### PR TITLE
[Bugfix] Fix double free of RDMA slice on device-selection failure

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -651,8 +651,14 @@ Status RdmaTransport::submitTransferTask(
             }
             if (!found_device) {
                 auto source_addr = slice->source_addr;
-                for (auto &entry : slices_to_post)
-                    for (auto s : entry.second) getSliceCache().deallocate(s);
+                // Do not deallocate slices already queued in slices_to_post
+                // here: every slice, including those, is already recorded in
+                // its owning TransferTask::slice_list (unconditionally,
+                // right after allocation above), and ~TransferTask() returns
+                // everything in slice_list to the cache exactly once.
+                // Deallocating them again here double-frees them into
+                // ThreadLocalSliceCache, letting a later allocate() hand out
+                // the same Slice* to two unrelated transfers.
                 LOG(ERROR)
                     << "Memory region not registered by any active device(s): "
                     << source_addr;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -293,6 +293,13 @@ target_link_libraries(rdma_context_reprobe_test PUBLIC transfer_engine gtest
                                                        gtest_main)
 add_test(NAME rdma_context_reprobe_test COMMAND rdma_context_reprobe_test)
 
+add_executable(rdma_transport_submit_task_test
+               ${WORKSPACE}/rdma_transport_submit_task_test.cpp)
+target_link_libraries(rdma_transport_submit_task_test PUBLIC transfer_engine
+                                                             gtest gtest_main)
+add_test(NAME rdma_transport_submit_task_test
+         COMMAND rdma_transport_submit_task_test)
+
 add_executable(topology_test ${WORKSPACE}/topology_test.cpp)
 target_link_libraries(topology_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME topology_test COMMAND topology_test)

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -25,6 +25,7 @@
 
 #include "common.h"
 #include "error.h"
+#include "rdma_test_peers.h"
 #include "transfer_metadata.h"
 #include "transport/rdma_transport/rdma_context.h"
 #include "transport/rdma_transport/rdma_transport.h"
@@ -141,42 +142,6 @@ int ibv_close_device(ibv_context *) { return 0; }
 
 }  // extern "C"
 #endif  // __linux__
-
-namespace mooncake {
-
-class RdmaTransportTestPeer {
-   public:
-    static void bindMetadata(RdmaTransport &transport,
-                             std::shared_ptr<TransferMetadata> metadata,
-                             std::string local_server_name) {
-        transport.metadata_ = std::move(metadata);
-        transport.local_server_name_ = std::move(local_server_name);
-    }
-};
-
-class RdmaContextTestPeer {
-   public:
-    static bool hasEndpointStore(const RdmaContext &context) {
-        return context.endpoint_store_ != nullptr;
-    }
-
-    static void seedAutoGidState(RdmaContext &context, ibv_context *verbs_ctx,
-                                 uint8_t port, uint16_t lid, const ibv_gid &gid,
-                                 int gid_index) {
-        context.context_ = verbs_ctx;
-        context.port_ = port;
-        context.lid_ = lid;
-        context.gid_ = gid;
-        context.gid_index_ = gid_index;
-        context.auto_gid_selection_enabled_ = true;
-    }
-
-    static void disableContextForTeardown(RdmaContext &context) {
-        context.context_ = nullptr;
-    }
-};
-
-}  // namespace mooncake
 
 namespace {
 

--- a/mooncake-transfer-engine/tests/rdma_test_peers.h
+++ b/mooncake-transfer-engine/tests/rdma_test_peers.h
@@ -1,0 +1,72 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Shared test-only friend accessors for exercising RdmaTransport/RdmaContext
+// without a real RDMA device. Include this instead of redeclaring
+// RdmaTransportTestPeer/RdmaContextTestPeer in individual test files.
+
+#ifndef MOONCAKE_TESTS_RDMA_TEST_PEERS_H
+#define MOONCAKE_TESTS_RDMA_TEST_PEERS_H
+
+#include <memory>
+#include <string>
+
+#include "transfer_metadata.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_transport.h"
+
+namespace mooncake {
+
+class RdmaTransportTestPeer {
+   public:
+    static void bindMetadata(RdmaTransport &transport,
+                             std::shared_ptr<TransferMetadata> metadata,
+                             std::string local_server_name) {
+        transport.metadata_ = std::move(metadata);
+        transport.local_server_name_ = std::move(local_server_name);
+    }
+
+    // Registers a (possibly bare, unconstructed) RdmaContext as one of the
+    // transport's local devices, bypassing initializeRdmaResources().
+    static void addContext(RdmaTransport &transport,
+                           std::shared_ptr<RdmaContext> context) {
+        transport.context_list_.push_back(std::move(context));
+    }
+};
+
+class RdmaContextTestPeer {
+   public:
+    static bool hasEndpointStore(const RdmaContext &context) {
+        return context.endpoint_store_ != nullptr;
+    }
+
+    static void seedAutoGidState(RdmaContext &context, ibv_context *verbs_ctx,
+                                 uint8_t port, uint16_t lid, const ibv_gid &gid,
+                                 int gid_index) {
+        context.context_ = verbs_ctx;
+        context.port_ = port;
+        context.lid_ = lid;
+        context.gid_ = gid;
+        context.gid_index_ = gid_index;
+        context.auto_gid_selection_enabled_ = true;
+    }
+
+    static void disableContextForTeardown(RdmaContext &context) {
+        context.context_ = nullptr;
+    }
+};
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_TESTS_RDMA_TEST_PEERS_H

--- a/mooncake-transfer-engine/tests/rdma_transport_submit_task_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_submit_task_test.cpp
@@ -1,0 +1,179 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for RdmaTransport::submitTransferTask()'s
+// "memory region not registered" (!found_device) error path: a slice that
+// already succeeded device selection and was queued into the function-local
+// slices_to_post accumulator must not be deallocated a second time when a
+// later slice in the same call fails device selection, since it is already
+// owned (and will be freed exactly once) by its TransferTask::slice_list.
+//
+// This exercises the real, unmodified RdmaTransport::submitTransferTask()
+// entry point. It avoids needing a real RDMA device by using a bare
+// RdmaContext (construct() never called): submitTransferTask() only checks
+// RdmaContext::active(), which defaults to true, for slices that fail device
+// selection.
+//
+// Every request here is a *single* TransferTask whose length spans two
+// slice_size blocks: the first offset resolves inside the registered
+// buffer (succeeds, queued into slices_to_post), and the second offset
+// starts exactly at the buffer's end (fails every retry). This reproduces
+// the bug with a single task instead of a task pair, so the only slices
+// touching ThreadLocalSliceCache belong to the one task under test -- no
+// second task's own slice churns through the shared cache and disturbs the
+// recycling queue's ordering.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "config.h"
+#include "rdma_test_peers.h"
+#include "transfer_metadata.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_transport.h"
+
+using namespace mooncake;
+
+namespace {
+
+using SegmentDesc = TransferMetadata::SegmentDesc;
+using BufferDesc = TransferMetadata::BufferDesc;
+
+class SubmitTransferTaskTest : public ::testing::Test {
+   protected:
+    static constexpr uint64_t kBufferAddr = 0x10000;
+
+    std::shared_ptr<TransferMetadata> metadata_;
+    std::unique_ptr<RdmaTransport> transport_;
+    std::shared_ptr<RdmaContext> context_;
+    uint64_t block_size_ = 0;
+
+    void SetUp() override {
+        block_size_ = globalConfig().slice_size;
+
+        metadata_ = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+        transport_ = std::make_unique<RdmaTransport>();
+        RdmaTransportTestPeer::bindMetadata(*transport_, metadata_,
+                                            "unit-test-server:1234");
+
+        // construct() is never called: no real device is opened. active()
+        // defaults to true, which is all submitTransferTask() checks.
+        context_ = std::make_shared<RdmaContext>(*transport_, "mlx5_unit_test");
+        RdmaTransportTestPeer::addContext(*transport_, context_);
+
+        auto desc = std::make_shared<SegmentDesc>();
+        desc->name = "unit-test-server:1234";
+        desc->protocol = "rdma";
+        BufferDesc buffer;
+        buffer.name = "cpu:0";
+        buffer.addr = kBufferAddr;
+        // Exactly one slice_size: a request longer than this has its first
+        // slice land fully inside the buffer and its second slice start
+        // exactly at the (unregistered) byte past the end.
+        buffer.length = block_size_;
+        buffer.lkey = {1};
+        buffer.rkey = {1};
+        desc->buffers.push_back(buffer);
+        ASSERT_EQ(
+            desc->topology.parse(R"({"cpu:0": [["mlx5_unit_test"], []]})"), 0);
+        metadata_->addLocalSegment(LOCAL_SEGMENT_ID, desc->name,
+                                   std::move(desc));
+    }
+
+    // Submits one task whose request spans 2 slice_size blocks starting at
+    // kBufferAddr. The first slice (offset 0) resolves inside the
+    // registered buffer and succeeds; the second slice (offset
+    // block_size_) starts past the buffer's end and fails every retry, so
+    // the call always returns early via the !found_device branch -- before
+    // ever reaching the end-of-function flush that would otherwise call
+    // into the (unconstructed, null) WorkerPool.
+    //
+    // `req`/`task` are owned by the caller and deliberately left alive on
+    // return, so the caller controls exactly when (if ever) the task's
+    // slices are returned to ThreadLocalSliceCache.
+    void triggerBug(Transport::TransferRequest &req,
+                    Transport::TransferTask &task) {
+        req.opcode = Transport::TransferRequest::WRITE;
+        req.source = reinterpret_cast<void *>(kBufferAddr);
+        req.length = 2 * block_size_;
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = 0;
+        task.request = &req;
+
+        auto status = transport_->submitTransferTask({&task});
+        EXPECT_FALSE(status.ok());
+        EXPECT_TRUE(status.IsAddressNotRegistered());
+        // slice_list[0]: the first slice, in-buffer, succeeded and was
+        // queued into slices_to_post -- the victim of the bug.
+        // slice_list[1]: the second slice, out-of-buffer, failed and
+        // triggered the (buggy) cleanup; never added to slices_to_post,
+        // so it is not itself double-freed.
+        ASSERT_EQ(task.slice_list.size(), 2u);
+    }
+};
+
+// task1's first slice is queued for reuse twice in a row, with nothing else
+// touching the cache in between: once by the buggy manual deallocate()
+// inside submitTransferTask() (while task1 is still alive), and again by
+// task1's own ~TransferTask() moments later. The recycling cache now holds
+// two entries for that single object.
+//
+// task2's own call then draws from that corrupted cache twice in a row (its
+// offset-0 slice, then its offset-block_size slice): with a correctly
+// single-registered cache, task1's two slices (each freed exactly once)
+// supply exactly two distinct pool entries, so task2's two independent
+// draws come back as two distinct Slice objects -- one reusing task1's
+// first slice, the other reusing its second. With the duplicate
+// registration, both draws instead return task1's original object --
+// proving it was freed more than once, purely by pointer comparison, with
+// no forced crash or process teardown required. EXPECT_EQ(task2[0], original)
+// is not itself the bug signal (a *single* legitimate free of `original`
+// would also make the very next allocation reuse it); it exists to
+// document that task2 is
+// indeed the one hitting the corrupted state before the discriminating
+// check below.
+TEST_F(SubmitTransferTaskTest, FoundDeviceFailureFreesSliceTwice) {
+    Transport::Slice *original = nullptr;
+    {
+        Transport::TransferRequest req1;
+        Transport::TransferTask task1;
+        triggerBug(req1, task1);
+        original = task1.slice_list[0];
+        // task1 destroyed here: ~TransferTask() deallocate()s both of its
+        // slices, including `original` a second time -- immediately after
+        // the buggy manual deallocate() inside submitTransferTask() already
+        // did so once, with nothing else in between since this task's own
+        // second (failed) slice was never added to slices_to_post and so
+        // was never touched by the bug.
+    }
+
+    Transport::TransferRequest req2;
+    Transport::TransferTask task2;
+    triggerBug(req2, task2);
+
+    EXPECT_EQ(task2.slice_list[0], original)
+        << "sanity check: the cache should have at least one legitimate "
+           "reuse of `original` queued up regardless of the bug";
+    EXPECT_NE(task2.slice_list[0], task2.slice_list[1])
+        << "task2's two slices cover disjoint offsets of the same request "
+           "and must never be backed by the same Slice object; "
+           "submitTransferTask() double-freed task1's slice on its "
+           "!found_device error path, so the recycling cache handed the "
+           "exact same, still-conceptually-owned pointer out twice in a "
+           "row for what should have been two independent allocations";
+}
+
+}  // namespace


### PR DESCRIPTION
## Description

  `RdmaTransport::submitTransferTask()`'s `!found_device` error path manually
  deallocated every slice already queued in the function-local
  `slices_to_post` accumulator. Those slices are unconditionally recorded in
  their owning `TransferTask::slice_list` as soon as they are allocated, and
  `~TransferTask()` already returns every slice in `slice_list` to
  `ThreadLocalSliceCache` exactly once. Deallocating them a second time here
  double-frees them into the cache, so a later `allocate()` can hand the same
  `Slice*` out to two unrelated transfers, eventually crashing with glibc's
  "double free detected in tcache 2".

  Fix: drop the manual deallocation in the error path and let the caller's
  `TransferTask` destructor own the single free, as it already does for every
  other slice.

  Also extracts the pre-existing `RdmaTransportTestPeer` /
  `RdmaContextTestPeer` friend-accessor test helpers (previously duplicated
  inside `rdma_context_reprobe_test.cpp`) into a shared
  `rdma_test_peers.h`, reused by the new test file.

  ## Module
  
  - [x] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [ ] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other
  
  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Built and run inside a Linux (Ubuntu 22.04) Docker container with the
  project's `dependencies.sh`, since this macOS sandbox lacks libibverbs and
  other Linux-only APIs the transfer engine depends on.

  **Test commands:**
  ```bash
  cd build
  ninja rdma_transport_submit_task_test
  ./mooncake-transfer-engine/tests/rdma_transport_submit_task_test \
      --gtest_filter='*FoundDeviceFailureFreesSliceTwice*'

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  The new SubmitTransferTaskTest.FoundDeviceFailureFreesSliceTwice test
  drives the real, unmodified submitTransferTask() entry point (no RDMA
  hardware needed, via a bare/unconstructed RdmaContext) and proves the
  double free purely by pointer comparison: after one task hits the
  !found_device path and is destroyed, a second task's two independent
  slice allocations must come back as two distinct Slice*. Verified this
  test FAILS on the pre-fix code (reliably reproducing glibc's "free():
  double free detected in tcache 2" crash) and PASSES cleanly after the fix.
  Also re-ran the existing rdma_context_reprobe_test after extracting the
  shared test-peer helpers to confirm no regression.

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue (not applicable, ~10
  LOC in the actual source fix)

  AI Assistance Disclosure
  
  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Used Claude Code to write and iteratively verify the reproducing test
  in a Linux container, and implement the fix. All changes reviewed line by
  line before commit.