### PR TITLE
[tent] Support mixed DRAM+VRAM segments and multi-transport allocation in tebench

### DIFF
--- a/docs/source/design/tent/tebench.md
+++ b/docs/source/design/tent/tebench.md
@@ -243,6 +243,13 @@ Example:
 
 * `--seg_name` : local segment name (typically left empty)
 * `--seg_type` : `DRAM | VRAM` (default: `DRAM`)
+* `--seg_type_mix` : comma-separated segment types for mixed DRAM+VRAM runs,
+  e.g. `dram,vram`. When set, the target registers buffers of each listed
+  type in one segment, and initiator threads round-robin across them so a
+  single tebench process drives traffic over multiple memory types (and
+  thus multiple transports — SHM for DRAM, NVLink for VRAM) concurrently.
+  Empty falls back to `--seg_type` (single type, existing behavior). See
+  Section 5.8 for usage and the multi-transport configuration it requires.
 * `--target_seg_name` : target segment name (empty → Target mode)
 
 **Scan ranges**
@@ -282,7 +289,11 @@ gpu_id + thread_id
 
 **Transport (TENT only)**
 
-* `--xport_type` : `rdma | shm | mnnvl | gds | iouring`
+* `--xport_type` : `rdma | shm | mnnvl | gds | iouring`. Selects a single
+  transport to enable (all others are disabled). Empty means no transport
+  is explicitly enabled or disabled by tebench — the engine reads the
+  transport enable list from the `MC_TENT_CONF` config file (see Section
+  5.8 for multi-transport scenarios).
 * `--tent_intent_type` : attach a standard transfer intent to every request,
   such as `foreground_get`, `background_prefetch`, or `checkpoint`. This is
   useful for validating intent-specific transport and QoS policy selection.
@@ -304,3 +315,59 @@ gpu_id + thread_id
 QoS mode intentionally requires a fixed thread count. Sweep offered load by
 running explicit cases with different class thread allocations so every output
 record has an unambiguous workload contract.
+
+### 5.8 Mixed DRAM+VRAM and Multi-Transport
+
+By default, tebench allocates buffers of a single `--seg_type` and enables a
+single `--xport_type` per run. To exercise a mixed-transport workload where
+the engine's transport selector naturally picks SHM for DRAM→DRAM transfers
+and NVLink for VRAM→VRAM transfers within one process, combine
+`--seg_type_mix` with the `MC_TENT_CONF` environment variable:
+
+1. **Enable multiple transports via `MC_TENT_CONF`** — point it at a JSON
+   config file (or inline JSON string) that enables the transports you want
+   active:
+
+   ```json
+   {
+       "transports": {
+           "shm":    {"enable": true},
+           "nvlink": {"enable": true}
+       }
+   }
+   ```
+
+   Leave `--xport_type` empty so tebench does not override the config's
+   enable list. `MC_TENT_CONF` is read by the engine's `ConfigHelper` and
+   applies to both target and initiator.
+
+2. **Register a mixed DRAM+VRAM segment via `--seg_type_mix`**:
+
+   ```bash
+   # Target: mixed DRAM+VRAM segment, all GPUs
+   MC_TENT_CONF=/path/to/config.json ./tebench --backend=tent \
+     --metadata_type=p2p --seg_name=tgtmix --seg_type_mix=dram,vram \
+     --local_gpu_id=-1 &
+
+   # Initiator: mixed DRAM+VRAM, 8 threads (4 DRAM→SHM, 4 VRAM→NVLink)
+   MC_TENT_CONF=/path/to/config.json ./tebench --backend=tent \
+     --metadata_type=p2p --target_seg_name=<SEG> --seg_type_mix=dram,vram \
+     --local_gpu_id=-1 --op_type=write --duration=30 \
+     --start_num_threads=8 --max_num_threads=8
+   ```
+
+   Initiator threads round-robin across the listed seg_types by `thread_id`
+   (even→DRAM, odd→VRAM). The engine selects transport based on the target
+   buffer's location — SHM for `cpu:N` buffers, NVLink for `cuda:N` buffers —
+   so `/metrics` will show both `transport="shm"` and `transport="nvlink"`
+   labels with non-zero counts from a single metrics endpoint.
+
+3. **`--local_gpu_id=-1`** is recommended for VRAM so each worker thread
+   gets its own GPU buffer. With the default `--local_gpu_id=0`, all VRAM
+   threads share one GPU buffer and contend, which underrepresents NVLink
+   throughput.
+
+Mixed mode requires `--start_num_threads` ≥ 2 (at least one thread per
+seg_type) and a build with `USE_CUDA=ON` (for VRAM/NVLink support). When
+`--seg_type_mix` is empty, tebench falls back to `--seg_type` (single type)
+and `--xport_type` (single transport) — the existing behavior.

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -114,20 +114,16 @@ static IntentType getIntentType(const std::string& intent_type) {
     return it->second;
 }
 
-int TENTBenchRunner::allocateBuffers() {
-    const auto total_buffer_size = XferBenchConfig::total_buffer_size;
-    const auto& seg_type = XferBenchConfig::seg_type;
-    const auto& xport_type = XferBenchConfig::xport_type;
-
-    // Resolve device prefix, start index, and buffer count per seg_type
-    std::string device_prefix;
-    int start_idx = 0, num_buffers = 0;
-
-    if (seg_type == "DRAM") {
+// Resolve device prefix, start index, and buffer count for a single seg_type.
+// Returns 0 on success, -1 on failure.
+static int resolveSegTypeParams(const std::string& seg_type,
+                                std::string& device_prefix, int& start_idx,
+                                int& num_buffers) {
+    if (seg_type == "DRAM" || seg_type == "dram") {
         device_prefix = "cpu";
         num_buffers = numa_num_configured_nodes();
 #if defined(USE_CUDA) || defined(USE_SUNRISE)
-    } else if (seg_type == "VRAM") {
+    } else if (seg_type == "VRAM" || seg_type == "vram") {
         device_prefix = "cuda";
         int gpu_count = 0;
         auto err = cudaGetDeviceCount(&gpu_count);
@@ -143,7 +139,7 @@ int TENTBenchRunner::allocateBuffers() {
                 << gpu_count << ")";
         }
 #elif defined(USE_HIP)
-    } else if (seg_type == "VRAM") {
+    } else if (seg_type == "VRAM" || seg_type == "vram") {
         device_prefix = "rocm";
         int gpu_count = 0;
         hipGetDeviceCount(&gpu_count);
@@ -161,48 +157,123 @@ int TENTBenchRunner::allocateBuffers() {
         LOG(ERROR) << "Unknown seg_type: " << seg_type;
         return -1;
     }
+    return 0;
+}
 
-    pinned_buffer_list_.resize(num_buffers, nullptr);
-    uint64_t alloc_ns = 0, reg_ns = 0;
-    for (int i = 0; i < num_buffers; ++i) {
-        auto location = device_prefix + ":" + std::to_string(start_idx + i);
-        MemoryOptions options;
-        if (!xport_type.empty()) {
-            options.type = getTransportType(xport_type);
-            options.location = location;
-        }
+// Parse a comma-separated list (e.g. "dram,vram") into a vector of lowercased
+// seg_type names. Empty input returns an empty vector.
+static std::vector<std::string> parseSegTypeMix(const std::string& mix) {
+    std::vector<std::string> result;
+    if (mix.empty()) return result;
+    std::stringstream ss(mix);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        size_t b = token.find_first_not_of(" \t");
+        size_t e = token.find_last_not_of(" \t");
+        if (b == std::string::npos) continue;
+        std::string name = token.substr(b, e - b + 1);
+        for (auto& c : name) c = to_lower(c);
+        result.push_back(name);
+    }
+    return result;
+}
 
-        auto t0 = getCurrentTimeInNano();
-        if (!xport_type.empty()) {
-            options.location = location;
-            CHECK_FAIL(engine_->allocateLocalMemory(
-                &pinned_buffer_list_[i], total_buffer_size, options));
-        } else {
-            CHECK_FAIL(engine_->allocateLocalMemory(
-                &pinned_buffer_list_[i], total_buffer_size, location));
-        }
-        auto t1 = getCurrentTimeInNano();
+int TENTBenchRunner::allocateBuffers() {
+    const auto total_buffer_size = XferBenchConfig::total_buffer_size;
+    const auto& xport_type = XferBenchConfig::xport_type;
 
-#ifdef USE_SUNRISE
-        if (seg_type == "VRAM") {
-            auto err = cudaSetDevice(start_idx + i);
-            CHECK_FAIL(err == cudaSuccess ? Status::OK()
-                                          : Status::InternalError(
-                                                "Failed to set Sunrise device "
-                                                "before registerLocalMemory"));
-        }
-#endif
-        CHECK_FAIL(engine_->registerLocalMemory(pinned_buffer_list_[i],
-                                                total_buffer_size, options));
-        auto t2 = getCurrentTimeInNano();
-
-        alloc_ns += (t1 - t0);
-        reg_ns += (t2 - t1);
+    // Determine the list of seg_types to allocate. --seg_type_mix wins over
+    // --seg_type when set; otherwise fall back to --seg_type (single type).
+    seg_type_mix_ = parseSegTypeMix(XferBenchConfig::seg_type_mix);
+    std::vector<std::string> seg_types;
+    if (!seg_type_mix_.empty()) {
+        seg_types = seg_type_mix_;
+    } else {
+        std::string s = XferBenchConfig::seg_type;
+        for (auto& c : s) c = to_lower(c);
+        seg_types.push_back(s);
     }
 
-    LOG(INFO) << "Allocated " << total_buffer_size * num_buffers << " bytes "
-              << seg_type << " buffers in " << alloc_ns / 1e6
-              << " ms, registered in " << reg_ns / 1e6 << " ms";
+    pinned_buffer_list_.clear();
+    pinned_buffer_seg_type_.clear();
+    uint64_t alloc_ns = 0, reg_ns = 0;
+    uint64_t total_bytes = 0;
+
+    for (const auto& seg_type : seg_types) {
+        std::string device_prefix;
+        int start_idx = 0, num_buffers = 0;
+        if (resolveSegTypeParams(seg_type, device_prefix, start_idx,
+                                 num_buffers) != 0) {
+            return -1;
+        }
+
+        for (int i = 0; i < num_buffers; ++i) {
+            auto location = device_prefix + ":" + std::to_string(start_idx + i);
+            MemoryOptions options;
+            options.location = location;
+            if (!xport_type.empty()) {
+                // Explicit single transport: honor it for both allocate and
+                // register (existing behavior).
+                options.type = getTransportType(xport_type);
+            } else if (!seg_type_mix_.empty()) {
+                // Multi-transport mode (--seg_type_mix set, transports
+                // enabled via MC_TENT_CONF). Pick the allocate transport
+                // based on seg_type so the right transport-specific allocator
+                // runs (e.g. SHM sets shm_path, NVLink sets up GPU memory
+                // handle). registerLocalMemory below then resets options.type
+                // to UNSPEC so the buffer registers to ALL enabled transports,
+                // not just this one.
+                options.type = (seg_type == "vram") ? NVLINK : SHM;
+            }
+            // else: single-seg_type fallback (--seg_type without
+            // --seg_type_mix, no --xport_type). Leave options.type as UNSPEC
+            // so the engine picks the default transport (original behavior).
+
+            auto t0 = getCurrentTimeInNano();
+            void* buf = nullptr;
+            CHECK_FAIL(
+                engine_->allocateLocalMemory(&buf, total_buffer_size, options));
+            pinned_buffer_list_.push_back(buf);
+            pinned_buffer_seg_type_.push_back(seg_type);
+            auto t1 = getCurrentTimeInNano();
+
+#ifdef USE_SUNRISE
+            if (seg_type == "vram") {
+                auto err = cudaSetDevice(start_idx + i);
+                CHECK_FAIL(err == cudaSuccess
+                               ? Status::OK()
+                               : Status::InternalError("Failed to set Sunrise "
+                                                       "device before "
+                                                       "registerLocalMemory"));
+            }
+#endif
+            // Reset options.type to UNSPEC so registerLocalMemory registers
+            // the buffer to ALL enabled transports (via
+            // getSupportedTransports(UNSPEC)), not just the one that
+            // allocated it. This is what makes multi-transport work: the
+            // buffer ends up registered to both SHM (which has shm_path set
+            // by the allocate call above) and TCP/NVLink (which don't need
+            // it), so requests targeting this buffer resolve regardless of
+            // which transport the engine picks. Only applies in multi-transport
+            // mode (--seg_type_mix set, no --xport_type); single-seg_type
+            // fallback keeps options.type as set above (UNSPEC or explicit).
+            if (xport_type.empty() && !seg_type_mix_.empty()) {
+                options.type = UNSPEC;
+            }
+            CHECK_FAIL(
+                engine_->registerLocalMemory(buf, total_buffer_size, options));
+            auto t2 = getCurrentTimeInNano();
+
+            alloc_ns += (t1 - t0);
+            reg_ns += (t2 - t1);
+            total_bytes += total_buffer_size;
+        }
+    }
+
+    LOG(INFO) << "Allocated " << total_bytes << " bytes across "
+              << pinned_buffer_list_.size() << " buffers (" << seg_types.size()
+              << " seg_types) in " << alloc_ns / 1e6 << " ms, registered in "
+              << reg_ns / 1e6 << " ms";
     return 0;
 }
 

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -34,6 +34,7 @@
 #include "tent/transfer_engine.h"
 #include "tent/common/utils/random.h"
 #include "tent/common/utils/os.h"
+#include "tent/runtime/topology.h"  // LocationParser
 
 namespace mooncake {
 namespace tent {
@@ -59,15 +60,64 @@ class TENTBenchRunner : public BenchRunner {
 
     uint64_t getLocalBufferBase(int thread_id, uint64_t block_size,
                                 uint64_t batch_size) const {
-        const size_t num_buffers = pinned_buffer_list_.size();
-        return (uint64_t)pinned_buffer_list_[thread_id % num_buffers] +
-               block_size * batch_size * (thread_id / num_buffers);
+        if (seg_type_mix_.empty()) {
+            // Single seg_type mode: original behavior.
+            const size_t num_buffers = pinned_buffer_list_.size();
+            return (uint64_t)pinned_buffer_list_[thread_id % num_buffers] +
+                   block_size * batch_size * (thread_id / num_buffers);
+        }
+        // Mixed mode: pick this thread's seg_type by round-robin, then index
+        // into the subset of pinned_buffer_list_ matching that seg_type.
+        const std::string& seg_type =
+            seg_type_mix_[thread_id % seg_type_mix_.size()];
+        size_t base = 0, count = 0;
+        for (size_t i = 0; i < pinned_buffer_seg_type_.size(); ++i) {
+            if (pinned_buffer_seg_type_[i] == seg_type) {
+                if (count == 0) base = i;
+                ++count;
+            }
+        }
+        if (count == 0) {
+            LOG(FATAL) << "No local buffer of seg_type " << seg_type
+                       << " for thread " << thread_id;
+        }
+        size_t slot = (thread_id / seg_type_mix_.size()) % count;
+        return (uint64_t)pinned_buffer_list_[base + slot] +
+               block_size * batch_size *
+                   ((thread_id / seg_type_mix_.size()) / count);
     }
 
     uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,
                                  uint64_t batch_size) const {
-        return info_.buffers[thread_id % info_.buffers.size()].base +
-               block_size * batch_size * (thread_id / info_.buffers.size());
+        if (seg_type_mix_.empty()) {
+            // Single seg_type mode: original behavior.
+            return info_.buffers[thread_id % info_.buffers.size()].base +
+                   block_size * batch_size * (thread_id / info_.buffers.size());
+        }
+        // Mixed mode: pick this thread's seg_type, then index into the
+        // subset of target segment buffers matching that seg_type. Use
+        // LocationParser to classify each buffer as host (cpu) vs device
+        // (cuda/rocm/supa/...) rather than hard-coding a vendor prefix.
+        const std::string& seg_type =
+            seg_type_mix_[thread_id % seg_type_mix_.size()];
+        bool want_device = (seg_type == "vram");
+        std::vector<size_t> matches;
+        for (size_t i = 0; i < info_.buffers.size(); ++i) {
+            const auto& loc = info_.buffers[i].location;
+            bool is_device =
+                LocationParser(loc).type() != "cpu" && loc != kWildcardLocation;
+            if (is_device == want_device) {
+                matches.push_back(i);
+            }
+        }
+        if (matches.empty()) {
+            LOG(FATAL) << "No target buffer of seg_type " << seg_type
+                       << " for thread " << thread_id;
+        }
+        size_t slot = (thread_id / seg_type_mix_.size()) % matches.size();
+        return info_.buffers[matches[slot]].base +
+               block_size * batch_size *
+                   ((thread_id / seg_type_mix_.size()) / matches.size());
     }
 
     double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
@@ -85,6 +135,13 @@ class TENTBenchRunner : public BenchRunner {
    private:
     std::unique_ptr<TransferEngine> engine_;
     std::vector<void*> pinned_buffer_list_;
+    // Parallel to pinned_buffer_list_: the seg_type each buffer belongs to
+    // ("dram" or "vram"). Populated by allocateBuffers; used by
+    // getLocalBufferBase to pick the right buffer per thread.
+    std::vector<std::string> pinned_buffer_seg_type_;
+    // Parsed --seg_type_mix (e.g. ["dram", "vram"]). Empty when --seg_type_mix
+    // is not set → single-seg_type mode (existing behavior).
+    std::vector<std::string> seg_type_mix_;
     SegmentID handle_;
     SegmentInfo info_;
     TransportType transport_hint_{UNSPEC};

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -20,6 +20,15 @@
 DEFINE_string(seg_name, "", "Memory segment name for the local side");
 DEFINE_string(seg_type, "DRAM",
               "Memory segment type for the target side: DRAM|VRAM");
+DEFINE_string(
+    seg_type_mix, "",
+    "Comma-separated segment types for mixed DRAM+VRAM runs, e.g. "
+    "\"dram,vram\". When set, target registers buffers of each listed type "
+    "in one segment, and initiator threads round-robin across them so a "
+    "single tebench process drives traffic over multiple memory types (and "
+    "thus multiple transports — SHM for DRAM, NVLink for VRAM) "
+    "concurrently. Empty falls back to --seg_type (single type, existing "
+    "behavior). Requires transports to be enabled via MC_TENT_CONF.");
 DEFINE_string(target_seg_name, "", "Memory segment name for the target side");
 DEFINE_string(op_type, "read", "Operation type to benchmark: read|write|mix");
 DEFINE_bool(check_consistency, false,
@@ -88,6 +97,7 @@ namespace mooncake {
 namespace tent {
 std::string XferBenchConfig::seg_name;
 std::string XferBenchConfig::seg_type;
+std::string XferBenchConfig::seg_type_mix;
 std::string XferBenchConfig::target_seg_name;
 std::string XferBenchConfig::op_type;
 bool XferBenchConfig::check_consistency = false;
@@ -123,6 +133,7 @@ int XferBenchConfig::target_gpu_id = 0;
 
 void XferBenchConfig::loadFromFlags() {
     seg_type = FLAGS_seg_type;
+    seg_type_mix = FLAGS_seg_type_mix;
     seg_name = FLAGS_seg_name;
     target_seg_name = FLAGS_target_seg_name;
     op_type = FLAGS_op_type;

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -56,6 +56,9 @@ struct XferBenchConfig {
 
     static std::string seg_name;
     static std::string seg_type;
+    // Comma-separated segment types for mixed DRAM+VRAM runs, e.g.
+    // "dram,vram". Empty falls back to --seg_type (single type).
+    static std::string seg_type_mix;
     static std::string target_seg_name;
     static std::string op_type;
     static bool check_consistency;


### PR DESCRIPTION
## Description

tebench could only allocate buffers of a single `seg_type` (DRAM or VRAM) and only enable a single transport per run (`--xport_type`). This prevented exercising mixed-transport workloads where the engine's `transport_selector` naturally picks SHM for DRAM and NVLink for VRAM within one process.

This change adds `--seg_type_mix=dram,vram` so a single tebench process can register a mixed DRAM+VRAM segment and drive concurrent traffic over both memory types, letting the engine select transports based on buffer location (real production behavior, not an artificial `transport_hint` override).

It also fixes a latent bug in `allocateBuffers` where the `shm_path` set by `ShmTransport::allocateLocalMemory` was silently dropped before `registerLocalMemory`, causing SHM to install but never register its buffers — silently falling back to TCP.

### Changes

**1. `allocateBuffers()` (`benchmark/tent_backend.cpp`)**
- Use the `MemoryOptions&` overload of `allocateLocalMemory` so transports like SHM (which set `options.shm_path` inside `allocateLocalMemory`) have those fields carried into `registerLocalMemory`. The previous no-options overload silently dropped `shm_path`, causing SHM to install but never register its buffers — silently falling back to TCP.
- Reset `options.type` to `UNSPEC` before `registerLocalMemory` so the buffer registers to ALL enabled transports (via `getSupportedTransports(UNSPEC)`), not just the one that allocated it. This is what makes multi-transport work: a DRAM buffer ends up registered to both SHM (has `shm_path`) and TCP (does not need it), so requests resolve regardless of which transport the engine picks.
- Loop over `seg_type_mix` to allocate both DRAM and VRAM buffers into one `pinned_buffer_list_`, tracking seg_type per buffer in a new `pinned_buffer_seg_type_` vector.

**2. `allocateLocalMemory(MemoryOptions&)` (`tent/src/runtime/transfer_engine_impl.cpp`)**
- When `options.type` is `UNSPEC`, mirror the `Location`-based overload's preference: CPU memory picks SHM > RDMA > TCP; non-CPU (cuda/rocm) picks NVLink > MNNVL > RDMA > TCP. Previously this UNSPEC branch skipped SHM entirely and non-CPU skipped NVLink, which meant a caller passing `MemoryOptions{type=UNSPEC}` (e.g. tebench without `--xport_type`) would allocate via TCP even when SHM was enabled and preferred, and VRAM buffers could not be allocated via NVLink.

**3. New `--seg_type_mix` flag (`benchmark/utils.cpp` / `utils.h`)**
- Comma-separated list of segment types, e.g. `"dram,vram"`. When set, target registers buffers of each listed type in one segment, and initiator threads round-robin across them so a single tebench process drives traffic over multiple memory types (and thus multiple transports — SHM for DRAM, NVLink for VRAM) concurrently. Empty falls back to `--seg_type` (single type, existing behavior). Transports are enabled via `MC_TENT_CONF` config file.

**4. `getLocalBufferBase` / `getTargetBufferBase` (`benchmark/tent_backend.h`)**
- In mixed mode, select buffer by the thread's assigned seg_type (round-robin by `thread_id`), then index within the filtered subset. Target buffers are filtered by location prefix (`"cpu:"` vs `"cuda:"`).

**5. Documentation (`docs/source/design/tent/tebench.md`)**
- Added `--seg_type_mix` flag description to Section 5.4.
- Expanded `--xport_type` in Section 5.6 with `MC_TENT_CONF` multi-transport note.
- Added new Section 5.8 documenting the mixed DRAM+VRAM + multi-transport scenario with usage examples.

No related issue found; not overlapping with open PRs.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Unit test regression** (built with `-DTENT_METRICS_ENABLED=ON -DUSE_TENT=ON -DUSE_CUDA=ON`):
- Existing `tent_metrics_recording_test` and `metrics_config_loader_test` still pass (14/14 + 26/26).

**Manual / end-to-end testing done:**

1. **Mixed DRAM+VRAM + SHM+NVLink** (`--seg_type_mix=dram,vram --local_gpu_id=-1`, 8 threads, 30s): `/metrics` shows both `transport="shm"` (216 GB / 206k reqs) and `transport="nvlink"` (320 GB / 306k reqs). Engine selects transport by buffer location — NVLink for VRAM, SHM for DRAM. 0 failures, 0 failovers. `stage_queue_wait_us` correctly appears for both transports.

2. **Single-seg_type regression — TCP** (`--xport_type=tcp --seg_type=DRAM`, no `--seg_type_mix`): only `transport="tcp"` label, 6.28 GB / 5990 reqs, 0 failures. Behavior unchanged from before.

3. **Single-seg_type regression — SHM** (`--xport_type=shm --seg_type=DRAM`, no `--seg_type_mix`): only `transport="shm"` label, 311 GB / 296k reqs, 0 failures. Behavior unchanged from before.

**Test commands:**
```bash
cmake -S . -B build -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON -DUSE_CUDA=ON
cmake --build build --target tebench
# Mixed scenario (requires GPU + NVLink hardware):
MC_TENT_CONF=/path/to/tent_shm_nvlink.json ./build/.../tebench --backend=tent \
  --metadata_type=p2p --seg_name=tgt --seg_type_mix=dram,vram --local_gpu_id=-1
# Single-seg_type regression:
./build/.../tebench --backend=tent --xport_type=tcp --seg_type=DRAM
./build/.../tebench --backend=tent --xport_type=shm --seg_type=DRAM
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable) — added `--seg_type_mix` to `docs/source/design/tent/tebench.md` Section 5.4, expanded `--xport_type` in 5.6 with `MC_TENT_CONF` note, added new Section 5.8 with mixed DRAM+VRAM + multi-transport usage examples
- [x] I have added tests to prove my changes are effective — N/A, this is a tebench tooling change; existing engine unit tests still pass, and end-to-end verification is documented above
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (6 files, +288/-56)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI tools were used to: explore the codebase and transport selection logic, implement the `allocateBuffers` mixed-mode and `--seg_type_mix` flag, fix the `allocateLocalMemory` UNSPEC branch, update the tebench documentation, and run `tebench` end-to-end verification (mixed DRAM+VRAM, single-seg_type regression, NVLink vs SHM performance analysis). The human submitter reviewed every changed line and re-ran the tebench verification flow independently.