### PR TITLE
[Store] Add configurable persist mode for bucket data

### DIFF
--- a/docs/source/deployment/ssd/ssd-offload.md
+++ b/docs/source/deployment/ssd/ssd-offload.md
@@ -161,6 +161,47 @@ Applies when `MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR=bucket_storage_backend
 | `MOONCAKE_OFFLOAD_BUCKET_EVICTION_POLICY` | `fifo` | Eviction policy: `none` / `fifo` / `lru` |
 | `MOONCAKE_OFFLOAD_BUCKET_MAX_PHYSICAL_BYTES` | `0` (disabled) | Hard cap on **real on-disk** bytes (`du`-equivalent) under this backend's `ssd_offload_path`. `0` disables it. Its scope depends on the deployment — see below. |
 | `MOONCAKE_OFFLOAD_BUCKET_DISK_SCAN_CACHE_MS` | `500` | How long the directory-scan result is cached before re-scanning, to bound the cost of the physical-usage check. `<= 0` scans on every check. |
+| `MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE` | `disabled` | How bucket data is flushed before its metadata is committed: `disabled` / `relaxed` / `strict`. Costs offload throughput; see [Bucket data durability](#bucket-data-durability) for what each level does and does not guarantee |
+
+(bucket-data-durability)=
+#### Bucket data durability
+
+A bucket is written as two files: `<id>.bucket` holds the data and `<id>.meta` holds the metadata that restart recovery walks. Neither is flushed by default, so which of the two reaches the device first is decided by kernel writeback. If a crash lands after `.meta` is on the device but while part of `<id>.bucket` is still in the page cache, recovery finds metadata pointing at data that was never persisted, and those keys read back as corrupt.
+
+`MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE` chooses what the offload path does about that window. It applies to the **data** file only:
+
+| Value | After the data write | What it changes |
+|---|---|---|
+| `disabled` (default) | nothing | Nothing. Existing behavior |
+| `relaxed` | `sync_file_range(WAIT_BEFORE\|WRITE\|WAIT_AFTER)` on the data file | The bucket data is written back and waited for before `.meta` is written, instead of both files racing on writeback scheduling. On a filesystem whose metadata journal commits in order (ext4, xfs), that is enough to stop `.meta` from becoming durable ahead of the data |
+| `strict` | `fdatasync()` on the data file | The same, and additionally makes the bucket data itself durable: `fdatasync()` writes the file metadata needed to read the data back and flushes the device cache |
+
+Two limits are worth being explicit about, because they bound what any level can promise:
+
+- **`sync_file_range()` is not a data-integrity operation.** It does not write out file metadata; `sync_file_range(2)` warns that unless the application is strictly overwriting already-instantiated blocks — which this path is not, since each bucket is a freshly created file — there is no guarantee the data is available after a crash. `relaxed` buys ordering, not durability. It also adds nothing for a process crash: a dying process leaves the page cache intact, and the kernel still writes both files out.
+- **No level makes an offloaded object durable, because `.meta` is never flushed.** After `strict` returns, the bucket data is on the device but `.meta` is still only in the page cache. A crash in that window loses `.meta`, so restart recovery never sees the bucket and deletes the orphaned `.bucket` — the object is lost, exactly as it would be at `disabled`. What the setting removes is the *corrupt* outcome (metadata durable, data not), not the *lost* one. `strict`'s power-loss guarantee also assumes the device honors cache flushes and the filesystem is not mounted with barriers disabled, and it does not cover the directory entry.
+
+Both levels above `disabled` cost write throughput on the offload path. The cost is dominated by writing the bucket's own data out, so it grows with bucket size; `strict` adds a further roughly constant amount for what `fdatasync()` does beyond that (filesystem journal commit and device cache flush). Measured at the 62.5 MiB bucket that `MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=500` produces at 128 KiB values, on one Samsung 990 PRO NVMe with a dedicated ext4 partition, single-threaded, 5 repetitions of 60 offloads:
+
+| Value | Per bucket (p50) | Offload throughput (mean) |
+|---|---|---|
+| `disabled` | 10.55 ms | 5693 MiB/s |
+| `relaxed` | 20.15 ms | 3006 MiB/s |
+| `strict` | 25.56 ms | 2398 MiB/s |
+
+```bash
+./build/mooncake-store/benchmarks/storage_backend_bench \
+  --backend=bucket --test=offload --value_size=131072 --batch_size=500 \
+  --num_operations=60 --warmup_operations=6 --verify=false \
+  --storage_path=<directory on the target device> \
+  --bucket_persist_mode=disabled   # then relaxed, then strict
+```
+
+`--storage_path` matters: its default is under `/tmp`, which is often a different device, or a tmpfs. The two columns are not two views of the same statistic — the per-bucket figure is the p50 latency and the throughput is derived from mean latency — so they do not divide into each other. The ratios travel better than the absolute numbers; measure on the target device before choosing.
+
+`disabled` does not avoid the write, it defers it: the bucket data stays dirty in the page cache until kernel writeback picks it up, so its cost lands on whatever else is using the device at that moment rather than on the offload call. Its 5693 MiB/s is the rate of filling the page cache, not a device rate. For the same reason, benchmarking these levels against each other requires a `sync` between runs, or `disabled`'s deferred writeback is charged to whichever level runs next.
+
+This setting is independent of `MOONCAKE_OFFSET_PERSIST_MODE`, which controls the offset-allocator backend.
 
 ### File-per-key backend settings
 
@@ -306,6 +347,7 @@ mooncake_client \
 
 - `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` must be an absolute path to an existing, writable directory. Symbolic links and paths containing `..` are rejected.
 - On real client restart, `bucket_storage_backend` and `file_per_key_storage_backend` scan existing SSD metadata and report it to the master, so previously offloaded objects remain accessible. `offset_allocator_storage_backend` does not support restart recovery.
+- What `bucket_storage_backend` recovers after an unclean shutdown depends on `MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE`; see [Bucket data durability](#bucket-data-durability).
 - Eviction only notifies the master and deletes local files; objects replicated on other nodes are unaffected.
 - Each machine requires its own real client process. In multi-node deployments, ensure `--host` and `--port` are correctly set so nodes can reach each other.
 

--- a/mooncake-store/benchmarks/storage_backend_bench.cpp
+++ b/mooncake-store/benchmarks/storage_backend_bench.cpp
@@ -136,6 +136,9 @@ DEFINE_string(cache_mode, "buffered",
               "Cache mode: buffered (page cache), direct (O_DIRECT), "
               "fadvise_dontneed (evict after use), drop_cache_external (print "
               "instructions)");
+DEFINE_string(bucket_persist_mode, "disabled",
+              "Bucket backend only: flush level applied to bucket data before "
+              "its metadata is committed (disabled/relaxed/strict)");
 DEFINE_bool(flush_between_ops, false,
             "Call fdatasync after each write (NOT IMPLEMENTED - requires "
             "backend Flush API)");
@@ -200,6 +203,15 @@ enum class CacheMode {
     FADVISE_DONTNEED,    // Buffered + evict after use
     DROP_CACHE_EXTERNAL  // Print instructions for external cache drop
 };
+
+mooncake::BucketPersistMode StringToBucketPersistMode(const std::string& str) {
+    if (str == "disabled") return mooncake::BucketPersistMode::kDisabled;
+    if (str == "relaxed") return mooncake::BucketPersistMode::kRelaxed;
+    if (str == "strict") return mooncake::BucketPersistMode::kStrict;
+    LOG(WARNING) << "Unknown bucket persist mode: " << str
+                 << ", using disabled";
+    return mooncake::BucketPersistMode::kDisabled;
+}
 
 CacheMode StringToCacheMode(const std::string& str) {
     if (str == "buffered") return CacheMode::BUFFERED;
@@ -819,6 +831,8 @@ std::shared_ptr<mooncake::StorageBackendInterface> CreateBackend(
             mooncake::BucketBackendConfig bucket_config;
             bucket_config.bucket_size_limit = 256 * MB;
             bucket_config.bucket_keys_limit = 500;
+            bucket_config.persist_mode =
+                StringToBucketPersistMode(FLAGS_bucket_persist_mode);
             return std::make_shared<mooncake::BucketStorageBackend>(
                 config, bucket_config);
         }

--- a/mooncake-store/include/file_interface.h
+++ b/mooncake-store/include/file_interface.h
@@ -67,6 +67,48 @@ class StorageFile {
      */
     virtual tl::expected<void, ErrorCode> datasync() { return {}; }
 
+    // ---- Test-only fault injection ----
+    // Which sync call a test wants to fail. kAny matches both.
+    enum class SyncKind { kNone = 0, kWritebackWait, kDatasync, kAny };
+
+    // Makes the next matching sync call on any StorageFile report failure
+    // without issuing the syscall, so a test can verify that a caller which is
+    // supposed to flush actually issues that specific call and propagates the
+    // error. One-shot: consumed by the first matching call. Process-global
+    // because storage backends create their StorageFile instances internally,
+    // so a test has no handle to set it on. Pass kNone to disarm.
+    static void SetSyncFailureForTest(SyncKind kind) {
+        sync_failure_for_test_.store(static_cast<int>(kind),
+                                     std::memory_order_relaxed);
+    }
+
+    // Whether an injected failure is still waiting to be consumed. A test uses
+    // this to tell "the call was never issued" from "the call was issued and
+    // failed", which is how the ordering of two flushes can be observed.
+    static bool IsSyncFailureArmedForTest() {
+        return sync_failure_for_test_.load(std::memory_order_relaxed) !=
+               static_cast<int>(SyncKind::kNone);
+    }
+
+    /**
+     * @brief Writes this file's dirty pages back and waits for them, without
+     * flushing file metadata or the device's volatile write cache.
+     *
+     * sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER) over the whole file.
+     * Cheaper than datasync() because it neither writes out the inode nor
+     * issues a device cache flush -- which is also why it is not a
+     * data-integrity operation: after it returns, the data pages have been
+     * written back, but for a newly created file the metadata describing where
+     * they live need not be on the device yet. Use it to order this file's
+     * data against a later write to another file, not to make it durable; use
+     * datasync() for that. A file accessed only through O_DIRECT has no
+     * page-cache pages to write back, so this does nothing for it.
+     *
+     * Operates on the file descriptor, so the base implementation is correct
+     * for every StorageFile.
+     */
+    virtual tl::expected<void, ErrorCode> writeback_wait();
+
     // Prevent destructor from unlinking the arena file on write failure.
     void SetDeleteOnWriteFail(bool v) { delete_on_write_fail_ = v; }
 
@@ -155,6 +197,21 @@ class StorageFile {
     ErrorCode get_error_code() { return error_code_; }
 
    protected:
+    // Returns and clears the injected sync failure if it matches `kind`. Call
+    // from the sync implementations before doing any real work.
+    static bool ConsumeSyncFailureForTest(SyncKind kind) {
+        int armed = sync_failure_for_test_.load(std::memory_order_relaxed);
+        if (armed != static_cast<int>(SyncKind::kAny) &&
+            armed != static_cast<int>(kind)) {
+            return false;
+        }
+        return sync_failure_for_test_.compare_exchange_strong(
+            armed, static_cast<int>(SyncKind::kNone),
+            std::memory_order_relaxed);
+    }
+
+    static std::atomic<int> sync_failure_for_test_;
+
     bool delete_on_write_fail_ = true;
     std::string filename_;
     int fd_;

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -1148,6 +1148,11 @@ class BucketStorageBackend : public StorageBackendInterface {
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)
         ungrouped_offloading_objects_;
 
+    // Test-only fault injection: when set, the next WriteBucket data datasync()
+    // is treated as failed. Consumed (reset to false) on read. See
+    // SetDatasyncFailureForTest().
+    std::atomic<bool> test_datasync_failure_{false};
+
     // File handle cache for UringFile to avoid repeated open/close overhead
     mutable Mutex file_cache_mutex_;
     mutable std::unordered_map<std::string, std::shared_ptr<StorageFile>>
@@ -1159,6 +1164,15 @@ class BucketStorageBackend : public StorageBackendInterface {
 
     // Clear file cache (called on destruction or when needed)
     void ClearFileCache();
+
+   public:
+    // ---- Test accessors ----
+    // Force the next bucket-data datasync() in WriteBucket to be treated as
+    // failed, so tests can verify that a failed durability flush aborts the
+    // offload and does not commit metadata. One-shot (consumed on use).
+    void SetDatasyncFailureForTest() {
+        test_datasync_failure_.store(true, std::memory_order_relaxed);
+    }
 };
 
 class OffsetAllocatorStorageBackend : public StorageBackendInterface {

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -201,6 +201,43 @@ inline std::ostream& operator<<(std::ostream& os,
     }
 }
 
+// How BucketStorageBackend flushes a bucket's data file before committing the
+// bucket's metadata (.meta) file. Restart recovery walks .meta files, so this
+// setting decides what a crash can leave behind: metadata committed for data
+// that never reached the device. Separate from OffsetPersistMode so the two
+// backends can be configured independently.
+enum class BucketPersistMode {
+    kDisabled,  // No flush (default). Both files are left dirty and the order
+                // in which they reach the device is left to kernel writeback.
+    kRelaxed,   // sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER): write the
+                // bucket data back and wait for it before .meta is written.
+                // This buys ordering, not durability -- sync_file_range() does
+                // not write file metadata -- and it relies on the filesystem
+                // committing metadata in order (ext4, xfs).
+    kStrict,    // fdatasync(): as kRelaxed, and makes the bucket data itself
+                // durable, subject to the device honoring cache flushes.
+};
+
+// Note what none of these levels do: StoreBucketMetadata() does not flush
+// .meta, so a crash right after an offload still loses the bucket at every
+// level (recovery finds no .meta and drops the orphaned data file). What the
+// setting removes is the corrupt outcome -- durable metadata pointing at data
+// that was not persisted -- not the lost one.
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const BucketPersistMode& mode) {
+    switch (mode) {
+        case BucketPersistMode::kDisabled:
+            return os << "disabled";
+        case BucketPersistMode::kRelaxed:
+            return os << "relaxed";
+        case BucketPersistMode::kStrict:
+            return os << "strict";
+        default:
+            return os << "unknown";
+    }
+}
+
 struct BucketBackendConfig {
     int64_t bucket_size_limit =
         256 * kMB;  // Max total size of a single bucket (256 MB)
@@ -237,6 +274,10 @@ struct BucketBackendConfig {
     // more often. <=0 disables caching (scan every check). Only relevant when
     // max_physical_bytes > 0.
     int64_t disk_scan_cache_ms = 500;
+    // Ordering of a bucket's data against the metadata that points at it.
+    // Disabled by default: every level above kDisabled costs write throughput
+    // on the offload path.
+    BucketPersistMode persist_mode = BucketPersistMode::kDisabled;
 
     bool Validate() const;
 
@@ -1036,6 +1077,15 @@ class BucketStorageBackend : public StorageBackendInterface {
     tl::expected<void, ErrorCode> WriteBucket(
         int64_t bucket_id, std::shared_ptr<BucketMetadata> bucket_metadata,
         std::vector<iovec>& iovs);
+
+    /**
+     * @brief Flush a bucket's data file at the configured persist mode, before
+     * its metadata is committed.
+     * @param file The bucket data file, already written.
+     * @return Empty on success (including kDisabled, which flushes nothing),
+     * FILE_WRITE_FAIL if the flush failed.
+     */
+    tl::expected<void, ErrorCode> PersistBucketData(StorageFile& file);
 
     tl::expected<void, ErrorCode> StoreBucketMetadata(
         int64_t bucket_id, std::shared_ptr<BucketMetadata> bucket_metadata);

--- a/mooncake-store/src/posix_file.cpp
+++ b/mooncake-store/src/posix_file.cpp
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <fcntl.h>
 #include <string>
 #include <sys/uio.h>
 #include <unistd.h>
@@ -14,7 +15,37 @@ PosixFile::PosixFile(const std::string &filename, int fd)
     }
 }
 
+std::atomic<int> StorageFile::sync_failure_for_test_{
+    static_cast<int>(StorageFile::SyncKind::kNone)};
+
+tl::expected<void, ErrorCode> StorageFile::writeback_wait() {
+    if (ConsumeSyncFailureForTest(SyncKind::kWritebackWait)) {
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+    if (fd_ < 0) {
+        return tl::make_unexpected(ErrorCode::FILE_INVALID_HANDLE);
+    }
+    // Offsets 0/0 mean "the whole file". WAIT_BEFORE|WRITE|WAIT_AFTER is the
+    // combination sync_file_range(2) documents for writing out a range and
+    // waiting for it; without WAIT_BEFORE the kernel runs the writeback in
+    // WB_SYNC_NONE mode, which skips a folio that is already under writeback
+    // rather than waiting for it, so a page re-dirtied concurrently could be
+    // left behind.
+    if (sync_file_range(fd_, 0, 0,
+                        SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE |
+                            SYNC_FILE_RANGE_WAIT_AFTER) != 0) {
+        const int err = errno;
+        LOG(ERROR) << "sync_file_range failed for " << filename_ << ": "
+                   << strerror(err);
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+    return {};
+}
+
 tl::expected<void, ErrorCode> PosixFile::datasync() {
+    if (ConsumeSyncFailureForTest(SyncKind::kDatasync)) {
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
     if (fdatasync(fd_) != 0) {
         LOG(ERROR) << "fdatasync failed: " << strerror(errno);
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -136,6 +136,24 @@ BucketBackendConfig BucketBackendConfig::FromEnvironment() {
     config.disk_scan_cache_ms =
         Environ::GetInt64("MOONCAKE_OFFLOAD_BUCKET_DISK_SCAN_CACHE_MS",
                           config.disk_scan_cache_ms);
+    // Bucket data persistence before the metadata commit. Deliberately its own
+    // variable rather than MOONCAKE_OFFSET_PERSIST_MODE: a deployment may want
+    // different levels on the two backends, and changing one must not silently
+    // move the other's durability behaviour.
+    const char* persist = std::getenv("MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE");
+    if (persist) {
+        std::string s(persist);
+        if (AsciiCaseInsensitiveEquals(s, "disabled")) {
+            config.persist_mode = BucketPersistMode::kDisabled;
+        } else if (AsciiCaseInsensitiveEquals(s, "relaxed")) {
+            config.persist_mode = BucketPersistMode::kRelaxed;
+        } else if (AsciiCaseInsensitiveEquals(s, "strict")) {
+            config.persist_mode = BucketPersistMode::kStrict;
+        } else {
+            LOG(WARNING) << "Unknown MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE=" << s
+                         << "; using default (disabled)";
+        }
+    }
 
     const auto policy_str = Environ::GetString(
         "MOONCAKE_OFFLOAD_BUCKET_EVICTION_POLICY",
@@ -2329,6 +2347,11 @@ tl::expected<void, ErrorCode> BucketStorageBackend::Init() {
             LOG(INFO) << "Initialized BucketIdGenerator from existing state. "
                       << "Last used bucket ID was " << max_bucket_id;
         }
+        if (bucket_backend_config_.persist_mode !=
+            BucketPersistMode::kDisabled) {
+            LOG(INFO) << "Bucket data persist mode: "
+                      << bucket_backend_config_.persist_mode;
+        }
         initialized_.store(true, std::memory_order_release);
     } catch (const std::exception& e) {
         LOG(ERROR) << "Bucket storage backend initialize error: " << e.what()
@@ -2585,7 +2608,6 @@ BucketStorageBackend::BuildBucket(
 tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
     int64_t bucket_id, std::shared_ptr<BucketMetadata> bucket_metadata,
     std::vector<iovec>& iovs) {
-    namespace fs = std::filesystem;
     auto bucket_data_path_res = GetBucketDataPath(bucket_id);
     if (!bucket_data_path_res) {
         LOG(ERROR) << "Failed to get bucket data path, bucket_id=" << bucket_id;
@@ -2662,15 +2684,6 @@ tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
             return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
         }
 
-        // Flush bucket data to stable storage before writing metadata.
-        // This prevents a crash from leaving valid metadata pointing at
-        // incomplete data (write-ordering durability guarantee).
-        auto sync_result = uring_file->datasync();
-        if (!sync_result) {
-            LOG(ERROR) << "datasync failed for bucket: " << bucket_id;
-            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
-        }
-
         // Invalidate cache for this file since content changed
         {
             MutexLocker cache_locker(&file_cache_mutex_);
@@ -2700,27 +2713,45 @@ tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
             file_cache_.erase(bucket_data_path);
         }
     }
+    // Flush the bucket data before committing its metadata, at the level the
+    // deployment configured. Restart recovery walks .meta files, so metadata
+    // committed for data that never reached the device is what leaves a bucket
+    // unreadable after a crash. The flush runs on whichever file OpenFile()
+    // returned; for writes that is always the buffered PosixFile, since
+    // OpenFile() only returns a UringFile for FileMode::Read.
+    auto persist_result = PersistBucketData(*file);
+    if (!persist_result) {
+        LOG(ERROR) << "Failed to persist bucket data before metadata commit, "
+                      "bucket_id="
+                   << bucket_id << ", error: " << persist_result.error();
+        // The data file was written but not persisted at the configured level;
+        // drop it so no orphan remains (mirrors the metadata-write-failure
+        // cleanup below).
+        CleanupOrphanedBucket(bucket_id);
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+
     auto store_bucket_metadata_result =
         StoreBucketMetadata(bucket_id, bucket_metadata);
     if (!store_bucket_metadata_result) {
         LOG(ERROR) << "Failed to store bucket metadata, error: "
                    << store_bucket_metadata_result.error();
-
-        // Clean up the bucket file to prevent orphans
-        std::error_code ec;
-        if (fs::remove(bucket_data_path, ec)) {
-            LOG(WARNING) << "Cleaned up orphaned bucket file after metadata "
-                            "write failure: "
-                         << bucket_data_path;
-        } else if (ec) {
-            LOG(ERROR) << "Failed to clean up bucket file after metadata write "
-                          "failure: "
-                       << bucket_data_path << ", error: " << ec.message();
-        }
-
+        // Drop the just-written data file (and any partial metadata file) so no
+        // orphan remains; same cleanup as the datasync-failure path above.
+        CleanupOrphanedBucket(bucket_id);
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
     return {};
+}
+
+tl::expected<void, ErrorCode> BucketStorageBackend::PersistBucketData(
+    StorageFile& file) {
+    const auto mode = bucket_backend_config_.persist_mode;
+    if (mode == BucketPersistMode::kDisabled) {
+        return {};
+    }
+    return (mode == BucketPersistMode::kStrict) ? file.datasync()
+                                                : file.writeback_wait();
 }
 
 void BucketStorageBackend::CleanupOrphanedBucket(int64_t bucket_id) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2480,7 +2480,6 @@ BucketStorageBackend::BuildBucket(
 tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
     int64_t bucket_id, std::shared_ptr<BucketMetadata> bucket_metadata,
     std::vector<iovec>& iovs) {
-    namespace fs = std::filesystem;
     auto bucket_data_path_res = GetBucketDataPath(bucket_id);
     if (!bucket_data_path_res) {
         LOG(ERROR) << "Failed to get bucket data path, bucket_id=" << bucket_id;
@@ -2557,15 +2556,6 @@ tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
             return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
         }
 
-        // Flush bucket data to stable storage before writing metadata.
-        // This prevents a crash from leaving valid metadata pointing at
-        // incomplete data (write-ordering durability guarantee).
-        auto sync_result = uring_file->datasync();
-        if (!sync_result) {
-            LOG(ERROR) << "datasync failed for bucket: " << bucket_id;
-            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
-        }
-
         // Invalidate cache for this file since content changed
         {
             MutexLocker cache_locker(&file_cache_mutex_);
@@ -2595,24 +2585,33 @@ tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
             file_cache_.erase(bucket_data_path);
         }
     }
+    // Flush bucket data to stable storage before writing metadata, so a crash
+    // cannot leave committed metadata pointing at unpersisted data
+    // (write-ordering durability guarantee). This runs for both the O_DIRECT
+    // UringFile path and the buffered PosixFile path: OpenFile() only returns a
+    // UringFile for FileMode::Read, so bucket writes always take the PosixFile
+    // branch, where fdatasync() is what actually enforces the ordering.
+    auto sync_result = file->datasync();
+    if (test_datasync_failure_.exchange(false, std::memory_order_relaxed)) {
+        // Test-only fault injection (see SetDatasyncFailureForTest()).
+        sync_result = tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+    if (!sync_result) {
+        LOG(ERROR) << "datasync failed for bucket: " << bucket_id;
+        // The data file was written but not durably persisted; drop it so no
+        // orphan remains (mirrors the metadata-write-failure cleanup below).
+        CleanupOrphanedBucket(bucket_id);
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
+
     auto store_bucket_metadata_result =
         StoreBucketMetadata(bucket_id, bucket_metadata);
     if (!store_bucket_metadata_result) {
         LOG(ERROR) << "Failed to store bucket metadata, error: "
                    << store_bucket_metadata_result.error();
-
-        // Clean up the bucket file to prevent orphans
-        std::error_code ec;
-        if (fs::remove(bucket_data_path, ec)) {
-            LOG(WARNING) << "Cleaned up orphaned bucket file after metadata "
-                            "write failure: "
-                         << bucket_data_path;
-        } else if (ec) {
-            LOG(ERROR) << "Failed to clean up bucket file after metadata write "
-                          "failure: "
-                       << bucket_data_path << ", error: " << ec.message();
-        }
-
+        // Drop the just-written data file (and any partial metadata file) so no
+        // orphan remains; same cleanup as the datasync-failure path above.
+        CleanupOrphanedBucket(bucket_id);
         return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
     }
     return {};

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -843,6 +843,9 @@ tl::expected<size_t, ErrorCode> UringFile::vector_read(const iovec* iov,
 // ---------------------------------------------------------------------------
 
 tl::expected<void, ErrorCode> UringFile::datasync() {
+    if (ConsumeSyncFailureForTest(SyncKind::kDatasync)) {
+        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    }
     if (fd_ < 0) return make_error<void>(ErrorCode::FILE_NOT_FOUND);
     auto res = SharedUringRing::instance().fsync(fd_);
     if (!res) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -15,8 +15,9 @@
 #include <thread>
 #include <atomic>
 #include <algorithm>
-#include <cstring>
 #include <cstdlib>
+#include <cstring>
+#include <optional>
 #include <mutex>
 #include <fcntl.h>
 #include <unistd.h>
@@ -48,6 +49,8 @@ class ScopedEnvVar {
     }
 
     void Set(const char* value) { setenv(name_.c_str(), value, 1); }
+
+    void Unset() { unsetenv(name_.c_str()); }
 
    private:
     std::string name_;
@@ -205,6 +208,10 @@ class StorageBackendTest : public ::testing::Test {
     }
 
     void TearDown() override {
+        // The sync-failure injection is process-global and one-shot. A test
+        // that arms it and then fails a fatal assertion would otherwise leak it
+        // into an unrelated test in this binary.
+        StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kNone);
         google::ShutdownGoogleLogging();
         LOG(INFO) << "Clear test data...";
         // Clean up all test files and subdirectories
@@ -890,6 +897,278 @@ TEST_F(StorageBackendTest, BatchOffloadRollbackOnCompleteHandlerFailure) {
     }
     EXPECT_EQ(bucket_file_count, 0)
         << "No bucket data or metadata files should remain after rollback";
+}
+
+// Regression tests for the bucket write-ordering guarantee (issue #3089).
+// When a persist mode above kDisabled is configured, WriteBucket must flush the
+// bucket data before committing its metadata, and a failed flush must abort the
+// offload so metadata never points at data that was not persisted. This only
+// holds if the flush is actually issued on the (PosixFile) write path; if it is
+// skipped, the injected failure is never observed and the offload wrongly
+// succeeds.
+TEST_F(StorageBackendTest, BucketOffloadFailsWhenDataPersistFails) {
+    for (auto mode :
+         {BucketPersistMode::kRelaxed, BucketPersistMode::kStrict}) {
+        SCOPED_TRACE(::testing::Message() << "persist_mode=" << mode);
+
+        std::string test_dir = data_path + "/persist_fail_test_" +
+                               std::to_string(static_cast<int>(mode));
+        fs::create_directories(test_dir);
+
+        FileStorageConfig config;
+        config.storage_filepath = test_dir;
+        BucketBackendConfig bucket_config;
+        bucket_config.persist_mode = mode;
+        BucketStorageBackend storage_backend(config, bucket_config);
+        ASSERT_TRUE(storage_backend.Init());
+
+        const std::string key = "persist_fail_key";
+        std::string value = "durability_probe_value";
+        std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+        batched_slices.emplace(
+            key, std::vector<Slice>{Slice{value.data(), value.size()}});
+
+        // Fail the next flush issued by any StorageFile. If WriteBucket does
+        // not issue one, this is never consumed and the offload succeeds,
+        // which is what makes this a regression test for the flush being on
+        // the write path at all.
+        StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kAny);
+
+        auto offload_res = storage_backend.BatchOffload(
+            batched_slices,
+            [](const std::vector<std::string>&,
+               std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+
+        // The failed flush must surface as an offload failure...
+        EXPECT_FALSE(offload_res.has_value())
+            << "offload must fail when the bucket-data flush fails";
+
+        // ...and the key must not be committed (no metadata pointing at data
+        // that was not persisted).
+        auto exist_res = storage_backend.IsExist(key);
+        ASSERT_TRUE(exist_res.has_value());
+        EXPECT_FALSE(exist_res.value())
+            << "key must not be committed when its data flush failed";
+
+        // No orphaned bucket data/metadata files should remain.
+        int bucket_file_count = 0;
+        for (const auto& entry : fs::directory_iterator(test_dir)) {
+            if (!entry.is_regular_file()) continue;
+            std::string ext = entry.path().extension().string();
+            if (ext == ".bucket" || ext == ".meta") bucket_file_count++;
+        }
+        EXPECT_EQ(bucket_file_count, 0)
+            << "no bucket files should remain after a failed-flush offload";
+
+        // Sanity: with the failure no longer injected, the same offload
+        // succeeds and the value reads back unchanged, so the flush itself does
+        // not disturb the write path.
+        auto ok_res = storage_backend.BatchOffload(
+            batched_slices,
+            [](const std::vector<std::string>&,
+               std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+        ASSERT_TRUE(ok_res.has_value())
+            << "offload should succeed once the flush is no longer forced to "
+               "fail";
+
+        auto load_buffer = std::make_unique<char[]>(value.size());
+        std::unordered_map<std::string, Slice> load_slices;
+        load_slices.emplace(key, Slice{load_buffer.get(), value.size()});
+        auto load_res = storage_backend.BatchLoad(load_slices);
+        ASSERT_TRUE(load_res.has_value());
+        EXPECT_EQ(std::string(load_buffer.get(), value.size()), value);
+    }
+}
+
+// The default (kDisabled) keeps today's behaviour: no flush is issued on the
+// write path, so the injected failure is never consumed and the offload
+// succeeds. This pins the setting as purely additive for existing deployments.
+TEST_F(StorageBackendTest, BucketOffloadIgnoresPersistFailureWhenDisabled) {
+    std::string test_dir = data_path + "/persist_disabled_test";
+    fs::create_directories(test_dir);
+
+    FileStorageConfig config;
+    config.storage_filepath = test_dir;
+    BucketBackendConfig bucket_config;
+    ASSERT_EQ(bucket_config.persist_mode, BucketPersistMode::kDisabled)
+        << "kDisabled must stay the default";
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::string value = "no_flush_value";
+    std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+    batched_slices.emplace(
+        "persist_disabled_key",
+        std::vector<Slice>{Slice{value.data(), value.size()}});
+
+    StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kAny);
+
+    auto offload_res = storage_backend.BatchOffload(
+        batched_slices,
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    ASSERT_TRUE(offload_res.has_value())
+        << "no flush is issued when persist mode is disabled, so the injected "
+           "failure must not be reached";
+
+    auto exist_res = storage_backend.IsExist("persist_disabled_key");
+    ASSERT_TRUE(exist_res.has_value());
+    EXPECT_TRUE(exist_res.value());
+
+    // Nothing consumed the injection, which is the point of this test.
+    EXPECT_TRUE(StorageFile::IsSyncFailureArmedForTest())
+        << "no flush should be issued when the persist mode is disabled";
+    StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kNone);
+}
+
+// The flush must run BEFORE the metadata is committed -- that ordering is the
+// whole point of the setting, and it is not observable from the outcome of a
+// single offload, since both orders fail the same way and CleanupOrphanedBucket
+// removes both files either way. It is observable from whether the one-shot
+// injection was consumed: make the metadata write fail, and if the flush ran
+// first it has already consumed the injection.
+TEST_F(StorageBackendTest, BucketDataFlushPrecedesMetadataCommit) {
+    std::string test_dir = data_path + "/persist_order_test";
+    fs::create_directories(test_dir);
+
+    FileStorageConfig config;
+    config.storage_filepath = test_dir;
+    BucketBackendConfig bucket_config;
+    bucket_config.persist_mode = BucketPersistMode::kStrict;
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::string value = "order_probe_value";
+    auto offload = [&](const std::string& key) {
+        std::unordered_map<std::string, std::vector<Slice>> batch;
+        batch.emplace(key,
+                      std::vector<Slice>{Slice{value.data(), value.size()}});
+        return storage_backend.BatchOffload(
+            batch,
+            [](const std::vector<std::string>&,
+               std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    };
+
+    // BatchOffload returns the bucket id it used. Two warmups also confirm ids
+    // are consecutive, without which the blocked path below would target the
+    // wrong bucket and the test would pass vacuously.
+    auto warmup_first = offload("order_warmup_key_1");
+    ASSERT_TRUE(warmup_first.has_value());
+    auto warmup_second = offload("order_warmup_key_2");
+    ASSERT_TRUE(warmup_second.has_value());
+    ASSERT_EQ(warmup_second.value(), warmup_first.value() + 1)
+        << "bucket ids must be consecutive for this test to block the right "
+           "bucket";
+    const int64_t blocked_id = warmup_second.value() + 1;
+
+    // A directory at the .meta path makes StoreBucketMetadata's OpenFile fail
+    // with EISDIR; the file inside keeps CleanupOrphanedBucket's fs::remove
+    // from undoing it.
+    const auto meta_dir =
+        fs::path(test_dir) / (std::to_string(blocked_id) + ".meta");
+    ASSERT_TRUE(fs::create_directory(meta_dir));
+    {
+        std::ofstream blocker(meta_dir / "blocker");
+        ASSERT_TRUE(blocker.is_open());
+        blocker << "prevent directory removal";
+    }
+
+    StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kAny);
+    // Fails whichever order the two steps are in, so this is not what
+    // discriminates.
+    ASSERT_FALSE(offload("order_key").has_value());
+
+    EXPECT_FALSE(StorageFile::IsSyncFailureArmedForTest())
+        << "the injected flush failure was never consumed even though the "
+           "metadata write failed, so the flush is not issued before the "
+           "metadata commit";
+}
+
+// Each level must issue the call it advertises: kRelaxed writeback_wait(),
+// kStrict datasync(). Arming one kind and not the other separates them; with
+// a single "any sync" injection the two levels are indistinguishable and a
+// swapped or downgraded mapping would go unnoticed.
+TEST_F(StorageBackendTest, BucketPersistModeIssuesTheAdvertisedSyncCall) {
+    struct Case {
+        BucketPersistMode mode;
+        StorageFile::SyncKind armed;
+        bool expect_offload_failure;
+    };
+    const Case cases[] = {
+        {BucketPersistMode::kRelaxed, StorageFile::SyncKind::kWritebackWait,
+         true},
+        {BucketPersistMode::kRelaxed, StorageFile::SyncKind::kDatasync, false},
+        {BucketPersistMode::kStrict, StorageFile::SyncKind::kDatasync, true},
+        {BucketPersistMode::kStrict, StorageFile::SyncKind::kWritebackWait,
+         false},
+    };
+
+    int case_index = 0;
+    for (const auto& c : cases) {
+        SCOPED_TRACE(::testing::Message()
+                     << "persist_mode=" << c.mode
+                     << " armed=" << static_cast<int>(c.armed));
+        std::string test_dir =
+            data_path + "/persist_kind_test_" + std::to_string(case_index++);
+        fs::create_directories(test_dir);
+
+        FileStorageConfig config;
+        config.storage_filepath = test_dir;
+        BucketBackendConfig bucket_config;
+        bucket_config.persist_mode = c.mode;
+        BucketStorageBackend storage_backend(config, bucket_config);
+        ASSERT_TRUE(storage_backend.Init());
+
+        std::string value = "kind_probe_value";
+        std::unordered_map<std::string, std::vector<Slice>> batch;
+        batch.emplace("kind_probe_key",
+                      std::vector<Slice>{Slice{value.data(), value.size()}});
+
+        StorageFile::SetSyncFailureForTest(c.armed);
+        auto res = storage_backend.BatchOffload(
+            batch,
+            [](const std::vector<std::string>&,
+               std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+
+        if (c.expect_offload_failure) {
+            EXPECT_FALSE(res.has_value())
+                << "this level must issue the armed sync call";
+            EXPECT_FALSE(StorageFile::IsSyncFailureArmedForTest());
+        } else {
+            EXPECT_TRUE(res.has_value())
+                << "this level must not issue the other level's sync call";
+            EXPECT_TRUE(StorageFile::IsSyncFailureArmedForTest())
+                << "the other level's injection must still be armed";
+        }
+        StorageFile::SetSyncFailureForTest(StorageFile::SyncKind::kNone);
+    }
+}
+
+TEST_F(StorageBackendTest, BucketBackendConfigParsesPersistMode) {
+    struct Case {
+        const char* value;
+        BucketPersistMode expected;
+    };
+    const Case cases[] = {
+        {"disabled", BucketPersistMode::kDisabled},
+        {"relaxed", BucketPersistMode::kRelaxed},
+        {"strict", BucketPersistMode::kStrict},
+        {"STRICT", BucketPersistMode::kStrict},
+        // Unrecognized values fall back to the default rather than failing
+        // startup, matching MOONCAKE_OFFSET_PERSIST_MODE.
+        {"nonsense", BucketPersistMode::kDisabled},
+    };
+    ScopedEnvVar env("MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE");
+    for (const auto& c : cases) {
+        env.Set(c.value);
+        EXPECT_EQ(BucketBackendConfig::FromEnvironment().persist_mode,
+                  c.expected)
+            << "MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE=" << c.value;
+    }
+    env.Unset();
+    EXPECT_EQ(BucketBackendConfig::FromEnvironment().persist_mode,
+              BucketPersistMode::kDisabled)
+        << "unset must resolve to the default";
 }
 
 TEST_F(StorageBackendTest, AdaptorBatchOffloadAndBatchLoad) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -636,6 +636,66 @@ TEST_F(StorageBackendTest, BatchOffloadRollbackOnCompleteHandlerFailure) {
         << "No bucket data or metadata files should remain after rollback";
 }
 
+// Regression test for the bucket write-ordering durability guarantee:
+// WriteBucket must datasync() the bucket data before committing its metadata,
+// and a failed datasync must abort the offload so metadata never points at
+// unpersisted data. This only holds if datasync() is actually called on the
+// (PosixFile) write path; if the sync is skipped, the injected failure is never
+// observed and the offload wrongly succeeds. See issue #3089.
+TEST_F(StorageBackendTest, BucketOffloadFailsWhenDataDatasyncFails) {
+    std::string test_dir = data_path + "/datasync_fail_test";
+    fs::create_directories(test_dir);
+
+    FileStorageConfig config;
+    config.storage_filepath = test_dir;
+    BucketBackendConfig bucket_config;
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::string value = "durability_probe_value";
+    std::unordered_map<std::string, std::vector<Slice>> batched_slices;
+    batched_slices.emplace(
+        "datasync_fail_key",
+        std::vector<Slice>{Slice{value.data(), value.size()}});
+
+    // Force the bucket-data datasync to fail on the next WriteBucket.
+    storage_backend.SetDatasyncFailureForTest();
+
+    auto offload_res = storage_backend.BatchOffload(
+        batched_slices,
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+
+    // The failed durability flush must surface as an offload failure...
+    EXPECT_FALSE(offload_res.has_value())
+        << "offload must fail when the bucket-data datasync fails";
+
+    // ...and the key must not be committed (no metadata pointing at data that
+    // was never durably persisted).
+    auto exist_res = storage_backend.IsExist("datasync_fail_key");
+    ASSERT_TRUE(exist_res.has_value());
+    EXPECT_FALSE(exist_res.value())
+        << "key must not be committed when its data datasync failed";
+
+    // No orphaned bucket data/metadata files should remain.
+    int bucket_file_count = 0;
+    for (const auto& entry : fs::directory_iterator(test_dir)) {
+        if (!entry.is_regular_file()) continue;
+        std::string ext = entry.path().extension().string();
+        if (ext == ".bucket" || ext == ".meta") bucket_file_count++;
+    }
+    EXPECT_EQ(bucket_file_count, 0)
+        << "no bucket files should remain after a datasync-failed offload";
+
+    // Sanity: a subsequent offload without injected failure succeeds and syncs.
+    auto ok_res = storage_backend.BatchOffload(
+        batched_slices,
+        [](const std::vector<std::string>&,
+           std::vector<StorageObjectMetadata>&) { return ErrorCode::OK; });
+    EXPECT_TRUE(ok_res.has_value())
+        << "offload should succeed once datasync is no longer forced to fail";
+}
+
 TEST_F(StorageBackendTest, AdaptorBatchOffloadAndBatchLoad) {
     FileStorageConfig cfg;
 


### PR DESCRIPTION
## Description

Fixes #3089.

`BucketStorageBackend::WriteBucket` carries a comment saying it flushes bucket data to stable storage before committing the bucket metadata, and calls `datasync()` to do it. That call never runs: it sits inside a `dynamic_cast<UringFile*>` branch, but `OpenFile()` only returns a `UringFile` for `FileMode::Read`, so bucket writes always take the buffered `PosixFile` path. Both `.bucket` and `.meta` are left dirty and which one reaches the device first is decided by kernel writeback, so a crash can leave a committed `.meta` pointing at bucket data that was never persisted. Recovery walks `.meta` files, so those keys come back and read as corrupt.

The first version of this PR made the flush unconditional. Following review (@LujhCoconut, @he-yufeng in the thread below), it does not: the cost is real and what it buys depends on the deployment, so the level is now an explicit setting.

**`MOONCAKE_OFFLOAD_BUCKET_PERSIST_MODE` on `BucketBackendConfig`**, applying to the bucket **data** file:

| Level | After the data write | Per 62.5 MiB bucket (p50) | Offload throughput (mean) | What it changes |
|---|---|---|---|---|
| `disabled` (default) | nothing | 10.55 ms | 5693 MiB/s | nothing — today's behavior |
| `relaxed` | `sync_file_range(WAIT_BEFORE\|WRITE\|WAIT_AFTER)` | 20.15 ms | 3006 MiB/s | the data is written back and waited for before `.meta` is written, instead of both files racing on writeback scheduling |
| `strict` | `fdatasync()` | 25.56 ms | 2398 MiB/s | the same, and makes the bucket data itself durable, subject to the device honoring cache flushes |

Two limits are stated explicitly in the docs and in the header, because they bound what any level can promise:

- **`relaxed` buys ordering, not durability.** `sync_file_range()` does not write file metadata, and its man page is explicit that for anything other than overwrites of already-instantiated blocks — which a freshly created bucket file is not — the data is not guaranteed to be there after a crash. The ordering property then rests on the filesystem committing metadata in order (ext4, xfs). It also adds nothing for a process crash: a dying process leaves the page cache intact.
- **No level makes an offloaded object durable, because `StoreBucketMetadata()` does not flush `.meta`.** A crash in the window right after an offload loses that bucket at every level — recovery finds no `.meta` and drops the orphaned data file. The setting removes the *corrupt* outcome, not the *lost* one. That is what #3089 reports; making offload a durable operation is a larger change (it needs `.meta` and the directory entry too) and is not attempted here.

`disabled` is the default, so no existing deployment sees its offload throughput move. The mode is deliberately separate from `OffsetPersistMode`: a node may want different levels on the two backends, and changing one must not silently move the other's durability behavior.

**Also in this change:**
- The flush moves out of the dead `UringFile`-only branch into `PersistBucketData()`, so it runs on the path bucket writes actually take. A failed flush aborts the offload and drops the just-written data file via `CleanupOrphanedBucket()`; the adjacent metadata-write-failure path is switched to the same helper so both abort paths clean up identically.
- `StorageFile::writeback_wait()` for the `relaxed` level, implemented once on the file descriptor since `sync_file_range()` is the same operation for every implementation. `WAIT_BEFORE` is included because without it the kernel runs the writeback in `WB_SYNC_NONE` mode, which skips a folio already under writeback rather than waiting for it. It costs nothing measurable here, where `WriteBucket` is the only writer of a freshly truncated file.
- `storage_backend_bench --bucket_persist_mode`, so the table above can be reproduced with the tool this repo already ships for this backend.
- One trailing newline at the end of `posix_file.cpp`, which `end-of-file-fixer` requires once the file is touched.

Not in this change: the recovery-side check that `BucketMetadata::data_size` matches the actual `.bucket` size. It is worth doing regardless of the level chosen, but it belongs to `Init()` rather than the write path, so it will be a separate PR.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

Five new cases in `storage_backend_test`, each checked by making the corresponding mutation to the production code and confirming the case fails:

1. `BucketOffloadFailsWhenDataPersistFails` — at both `relaxed` and `strict`, an injected flush failure makes the offload fail, leaves the key uncommitted and no orphan `.bucket`/`.meta` behind; a retry without the injection succeeds and the value reads back unchanged.
2. `BucketDataFlushPrecedesMetadataCommit` — the flush is issued *before* the metadata commit. The outcome of a single offload cannot show this (both orders fail the same way and `CleanupOrphanedBucket` removes both files either way), so the test blocks the metadata write with a directory at the `.meta` path and checks that the one-shot fault was already consumed, which is only true if the flush ran first.
3. `BucketPersistModeIssuesTheAdvertisedSyncCall` — arming only one of the two sync kinds separates the levels, so a swapped or downgraded mapping (`strict` silently doing `relaxed`'s work) fails.
4. `BucketOffloadIgnoresPersistFailureWhenDisabled` — at the default the flush is never issued, so the injected failure is not reached and the offload succeeds. This pins the setting as additive.
5. `BucketBackendConfigParsesPersistMode` — the three values, case-insensitivity, the fallback to the default on an unrecognized value, and unset.

The fault is injected in `StorageFile`, not in the backend, so case 1 is a real regression test for the flush being on the write path: if `WriteBucket` does not issue a flush, the injection is never consumed and the offload wrongly succeeds. The injection is process-global, so the fixture clears it in `TearDown()` and the env-var case restores the previous value on scope exit.

**Test commands:**
```bash
cmake --build build --target storage_backend_test -j$(nproc)
ctest -R 'storage_backend_test|file_storage_test|file_storage_promotion_test|posix_file_test|file_util_test|offset_allocator_test|ssd_metrics_test|offload_on_evict_test|promotion_on_hit_test|nvme_kv_storage_backend_test|client_storage_backend_test'

# cost table above, per level
./build/mooncake-store/benchmarks/storage_backend_bench \
  --backend=bucket --test=offload --value_size=131072 --batch_size=500 \
  --num_operations=60 --warmup_operations=6 --verify=false \
  --storage_path=<directory on the target device> \
  --bucket_persist_mode=disabled   # then relaxed, then strict
```

`--storage_path` matters: its default is under `/tmp`, which is often a different device.

**Test results:**
- [x] Unit tests pass — `storage_backend_test` 95/95; the SSD-tier ctest set 11/11
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done — cost table measured on a Samsung 990 PRO NVMe, dedicated ext4 partition, buffered I/O, single-threaded, 5 repetitions of 60 offloads, device otherwise idle. Runs are separated by `sync`, since `disabled` leaves the whole run's data dirty and the kernel would otherwise write it back while the next level is being timed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (clang-format 20.1.8)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable) — `docs/source/deployment/ssd/ssd-offload.md`
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: N/A (~250 LOC excluding tests and docs)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code investigated the code paths, ran the measurements, and drafted the change, tests and documentation. The human submitter reviewed every changed line and can defend the change end to end.
