### PR TITLE
[TENT] Validate sub-batch type in getTransferStatus

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/gds/gds_transport.cpp
@@ -315,6 +315,9 @@ Status GdsTransport::submitTransferTasks(
 Status GdsTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                        TransferStatus& status) {
     auto gds_batch = dynamic_cast<GdsSubBatch*>(batch);
+    if (!gds_batch) {
+        return Status::InvalidArgument("Invalid GDS sub-batch" LOC_MARK);
+    }
     unsigned num_tasks = gds_batch->io_param_ranges.size();
     if (task_id < 0 || task_id >= (int)num_tasks)
         return Status::InvalidArgument("Invalid task ID");

--- a/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/io_uring/io_uring_transport.cpp
@@ -235,6 +235,9 @@ Status IOUringTransport::submitTransferTasks(
 Status IOUringTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                            TransferStatus& status) {
     auto io_uring_batch = dynamic_cast<IOUringSubBatch*>(batch);
+    if (!io_uring_batch) {
+        return Status::InvalidArgument("Invalid io_uring sub-batch" LOC_MARK);
+    }
     if (task_id < 0 || task_id >= (int)io_uring_batch->task_list.size())
         return Status::InvalidArgument("Invalid task ID");
     auto& task = io_uring_batch->task_list[task_id];

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -374,6 +374,9 @@ void MnnvlTransport::startTransfer(std::vector<MnnvlTask *> &tasks,
 Status MnnvlTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                          TransferStatus &status) {
     auto mnnvl_batch = dynamic_cast<MnnvlSubBatch *>(batch);
+    if (!mnnvl_batch) {
+        return Status::InvalidArgument("Invalid MNNVL sub-batch" LOC_MARK);
+    }
     if (task_id < 0 || task_id >= (int)mnnvl_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -335,6 +335,9 @@ void NVLinkTransport::startTransfer(std::vector<NVLinkTask*>& tasks,
 Status NVLinkTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                           TransferStatus& status) {
     auto shm_batch = dynamic_cast<NVLinkSubBatch*>(batch);
+    if (!shm_batch) {
+        return Status::InvalidArgument("Invalid NVLink sub-batch" LOC_MARK);
+    }
     if (task_id < 0 || task_id >= (int)shm_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/shm/shm_transport.cpp
@@ -138,6 +138,9 @@ void ShmTransport::startTransfer(ShmTask *task, ShmSubBatch *batch) {
 Status ShmTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                        TransferStatus &status) {
     auto shm_batch = dynamic_cast<ShmSubBatch *>(batch);
+    if (!shm_batch) {
+        return Status::InvalidArgument("Invalid SHM sub-batch" LOC_MARK);
+    }
     if (task_id < 0 || task_id >= (int)shm_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -168,6 +168,9 @@ Status TcpTransport::submitTransferTasks(
 Status TcpTransport::getTransferStatus(SubBatchRef batch, int task_id,
                                        TransferStatus &status) {
     auto tcp_batch = dynamic_cast<TcpSubBatch *>(batch);
+    if (!tcp_batch) {
+        return Status::InvalidArgument("Invalid TCP sub-batch" LOC_MARK);
+    }
     if (task_id < 0 || task_id >= (int)tcp_batch->task_list.size()) {
         return Status::InvalidArgument("Invalid task id" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -22,6 +22,7 @@
 
 #include "tent/common/config.h"
 #include "tent/common/types.h"
+#include "tent/transport/shm/shm_transport.h"
 #include "tent/transport/tcp/tcp_transport.h"
 
 namespace mooncake {
@@ -183,6 +184,47 @@ TEST(TcpTaskTest, CrossThreadVisibility) {
     EXPECT_EQ(task.transferred_bytes.load(std::memory_order_acquire), 8192u);
 
     writer.join();
+}
+
+// ---------------------------------------------------------------------------
+// Sub-batch type mismatch regression test (#3129)
+// ---------------------------------------------------------------------------
+// getTransferStatus is a public Transport API. Handing it a sub-batch that
+// was allocated by a different transport used to dereference the result of a
+// failed dynamic_cast (UB). Neither allocateSubBatch nor getTransferStatus's
+// type check requires install(), so default-constructed transports suffice.
+
+TEST(TcpTransportSubBatchTest, RejectsForeignSubBatchInGetTransferStatus) {
+    TcpTransport tcp;
+    ShmTransport shm;
+
+    Transport::SubBatchRef shm_batch = nullptr;
+    ASSERT_TRUE(shm.allocateSubBatch(shm_batch, 8).ok());
+    ASSERT_NE(shm_batch, nullptr);
+
+    // An ShmSubBatch handed to TcpTransport must be rejected, not cast
+    // blindly. Without the null check this dereferences nullptr.
+    TransferStatus status;
+    EXPECT_TRUE(
+        tcp.getTransferStatus(shm_batch, 0, status).IsInvalidArgument());
+
+    // Same guard in the opposite direction.
+    Transport::SubBatchRef tcp_batch = nullptr;
+    ASSERT_TRUE(tcp.allocateSubBatch(tcp_batch, 8).ok());
+    ASSERT_NE(tcp_batch, nullptr);
+    EXPECT_TRUE(
+        shm.getTransferStatus(tcp_batch, 0, status).IsInvalidArgument());
+
+    // A matching sub-batch must still pass: the guard discriminates by
+    // type rather than rejecting everything.
+    auto* typed_tcp_batch = dynamic_cast<TcpSubBatch*>(tcp_batch);
+    ASSERT_NE(typed_tcp_batch, nullptr);
+    typed_tcp_batch->task_list.emplace_back();
+    ASSERT_TRUE(tcp.getTransferStatus(tcp_batch, 0, status).ok());
+    EXPECT_EQ(status.s, TransferStatusEnum::PENDING);
+
+    EXPECT_TRUE(shm.freeSubBatch(shm_batch).ok());
+    EXPECT_TRUE(tcp.freeSubBatch(tcp_batch).ok());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`getTransferStatus` is a public Transport API, but five transports dereferenced the result of `dynamic_cast<XxxSubBatch*>(batch)` without a null check: TCP, SHM, MNNVL, NVLink, and io_uring. SunriseLink's `getTransferStatus`, RDMA's `cancelTransferTask`, and (since #3280) GDS already validate — this PR applies the same guard to the remaining five for a uniform error surface.

The internal poll path is type-safe (`pollTaskStatus` indexes transport and sub-batch by the same `task.type`), so this is API hardening/consistency, not a reachable crash on current main.

Also adds a mismatch regression test (`TcpTransportSubBatchTest.RejectsForeignSubBatchInGetTransferStatus`, per review): hands an ShmSubBatch to TcpTransport (and the reverse) asserting InvalidArgument, plus a matching-type case. CPU-only, no install() required.

> Rebased on latest main: the GDS hunk from the original version was dropped — #3280 added an equivalent check upstream. `rdma_transport.cpp` remains out of scope (being reworked in #3016).

## Test plan

- [x] Regression test discriminates: reverting the guards makes it dereference nullptr
- [x] CI (all transports; tent-ci cuda-on/off)
