### PR TITLE
[wheel] preserve grouped writes for structured objects

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -356,7 +356,7 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
     if not is_dataproto_ref_handle(handle):
         raise ValueError("not a Mooncake DataProto ref handle")
     version = int(handle.get("version", -1))
-    if version != DATAPROTO_REF_HANDLE_VERSION:
+    if version not in (DATAPROTO_REF_HANDLE_VERSION, 2):
         raise ValueError(
             f"unsupported DataProto ref handle version: {handle.get('version')!r}"
         )
@@ -400,8 +400,9 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
             stage=stage, member=member, section=section
         )
     storage_group_id = handle.get(STORAGE_GROUP_ID)
-    if storage_group_id is not None and (
-        not isinstance(storage_group_id, str) or not storage_group_id
+    if (version == 2 and storage_group_id is None) or (
+        storage_group_id is not None
+        and (not isinstance(storage_group_id, str) or not storage_group_id)
     ):
         raise ValueError("DataProto ref handle has invalid storage_group_id")
     return MooncakeDataProtoRef(

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -8,6 +8,7 @@ import uuid
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any, Callable, Iterator, Literal, Mapping, Optional, Protocol, Sequence
 
 import numpy as np
@@ -128,6 +129,7 @@ class MooncakeDataProtoRef:
     partition: str = "default"
     global_indexes: list[int] | None = None
     encoded_non_tensor: dict[str, Any] = field(default_factory=dict)
+    _storage_group_id: str | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True)
@@ -306,7 +308,8 @@ class _DataProtoRowSelection:
 
 
 DATAPROTO_REF_HANDLE_TYPE = "mooncake_dataproto_ref"
-DATAPROTO_REF_HANDLE_VERSION = 1
+DATAPROTO_REF_HANDLE_VERSION = 2
+STORAGE_GROUP_ID = "storage_group_id"
 DataProtoRefLike = MooncakeDataProtoRef | Mapping[str, Any]
 
 
@@ -320,7 +323,7 @@ def export_dataproto_ref(ref: MooncakeDataProtoRef) -> dict[str, Any]:
         raise TypeError(f"expected MooncakeDataProtoRef, got {type(ref).__name__}")
     handle = {
         "type": DATAPROTO_REF_HANDLE_TYPE,
-        "version": DATAPROTO_REF_HANDLE_VERSION,
+        "version": DATAPROTO_REF_HANDLE_VERSION if ref._storage_group_id is not None else 1,
         "kind": "bundle_stages",
         "batch_size": int(ref.batch_size),
         "namespace": ref.namespace,
@@ -341,6 +344,8 @@ def export_dataproto_ref(ref: MooncakeDataProtoRef) -> dict[str, Any]:
         "meta_info": _json_safe_value(ref.meta_info),
         "encoded_non_tensor": _json_safe_value(ref.encoded_non_tensor),
     }
+    if ref._storage_group_id is not None:
+        handle[STORAGE_GROUP_ID] = ref._storage_group_id
     json.dumps(handle, ensure_ascii=False)
     return handle
 
@@ -349,7 +354,8 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
     """Import a JSON-safe DataProto transport handle into a lazy ref."""
     if not is_dataproto_ref_handle(handle):
         raise ValueError("not a Mooncake DataProto ref handle")
-    if int(handle.get("version", -1)) != DATAPROTO_REF_HANDLE_VERSION:
+    version = int(handle.get("version", -1))
+    if version not in (1, DATAPROTO_REF_HANDLE_VERSION):
         raise ValueError(
             f"unsupported DataProto ref handle version: {handle.get('version')!r}"
         )
@@ -392,6 +398,11 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
         field_index[name] = StructuredFieldLocation(
             stage=stage, member=member, section=section
         )
+    storage_group_id = handle.get(STORAGE_GROUP_ID) if version == 2 else None
+    if version == 2 and (
+        not isinstance(storage_group_id, str) or not storage_group_id
+    ):
+        raise ValueError("DataProto ref handle requires storage_group_id")
     return MooncakeDataProtoRef(
         batch_size=int(handle["batch_size"]),
         stage_refs=stage_refs,
@@ -403,6 +414,7 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
         encoded_non_tensor=dict(
             _require_mapping(handle.get("encoded_non_tensor", {}), "encoded_non_tensor")
         ),
+        _storage_group_id=storage_group_id,
     )
 
 
@@ -479,6 +491,35 @@ class MooncakeBundleTransfer:
             default_chunk_bytes=self.default_chunk_bytes,
         )
         self._structured_store = _StructuredObjectLayer(self._bundle_store)
+
+    def _new_storage_group_id(self, config: Any) -> str:
+        raw_group_ids = getattr(config, "group_ids", None)
+        if raw_group_ids is None:
+            group_id = None
+        elif isinstance(raw_group_ids, str):
+            group_id = raw_group_ids
+        else:
+            try:
+                group_ids = list(raw_group_ids)
+            except TypeError as error:
+                raise ValueError(
+                    "structured object store config.group_ids must contain strings"
+                ) from error
+            if len(group_ids) > 1:
+                raise ValueError(
+                    "structured object store config.group_ids must contain exactly one "
+                    "logical group id; it is expanded across internal Mooncake keys"
+                )
+            group_id = group_ids[0] if group_ids else None
+        if group_id is None:
+            return f"structured-{uuid.uuid4().hex}"
+        if not isinstance(group_id, str):
+            raise ValueError(
+                "structured object store config.group_ids must contain strings"
+            )
+        if not group_id:
+            return f"structured-{uuid.uuid4().hex}"
+        return group_id
 
     def put_bundle(
         self,
@@ -1599,7 +1640,9 @@ class MooncakeBundleTransfer:
                     partition=ref.partition,
                     global_indexes=ref.global_indexes,
                     encoded_non_tensor=dict(ref.encoded_non_tensor),
+                    _storage_group_id=ref._storage_group_id,
                 )
+            group_id = self._new_storage_group_id(config)
             return MooncakeDataProtoRef(
                 batch_size=batch_size,
                 stage_refs={},
@@ -1608,6 +1651,7 @@ class MooncakeBundleTransfer:
                 namespace=namespace,
                 partition=partition,
                 encoded_non_tensor={},
+                _storage_group_id=group_id,
             )
         duplicates = (
             sorted(set(ref.field_index) & set(field_updates)) if ref is not None else []
@@ -1624,6 +1668,16 @@ class MooncakeBundleTransfer:
                 raise ValueError(
                     f"DataProto overwrite for stage {stage!r} must include existing fields: {sorted(dangling)}"
                 )
+        if ref is None:
+            group_id = self._new_storage_group_id(config)
+            effective_config = _config_with_group_id(config, group_id)
+        else:
+            group_id = ref._storage_group_id
+            effective_config = (
+                config
+                if group_id is None
+                else _config_with_group_id(config, group_id)
+            )
         payload = StructuredObjectPayload(
             metadata={
                 "layout": "dataproto_stage",
@@ -1645,7 +1699,7 @@ class MooncakeBundleTransfer:
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
-                config=config,
+                config=effective_config,
             )
         else:
             stage_ref = self.put_structured_object(
@@ -1653,7 +1707,7 @@ class MooncakeBundleTransfer:
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
-                config=config,
+                config=effective_config,
             )
             if (
                 existing_stage_ref is not None
@@ -1686,6 +1740,7 @@ class MooncakeBundleTransfer:
             partition=partition,
             global_indexes=None if ref is None else ref.global_indexes,
             encoded_non_tensor=encoded_non_tensor,
+            _storage_group_id=group_id,
         )
 
 
@@ -6095,6 +6150,21 @@ def _copy_write_config(config: Any) -> Any:
                 f"structured object store config field {name!r} is not writable"
             ) from error
     return copied
+
+
+def _config_with_group_id(config: Any, group_id: str) -> Any:
+    configured_ids = getattr(_config_for_grouped_keys(config, 1), "group_ids", None)
+    if configured_ids and configured_ids[0] and configured_ids[0] != group_id:
+        raise ValueError(
+            "config.group_ids conflicts with the DataProto storage group"
+        )
+    grouped_config = (
+        getattr(_mooncake_store, "ReplicateConfig", SimpleNamespace)()
+        if config is None
+        else _copy_write_config(config)
+    )
+    grouped_config.group_ids = [group_id]
+    return grouped_config
 
 
 def _put_with_optional_config(

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -308,7 +308,8 @@ class _DataProtoRowSelection:
 
 
 DATAPROTO_REF_HANDLE_TYPE = "mooncake_dataproto_ref"
-DATAPROTO_REF_HANDLE_VERSION = 2
+DATAPROTO_REF_HANDLE_VERSION = 1
+# Optional v1 extension; older readers ignore unknown top-level fields.
 STORAGE_GROUP_ID = "storage_group_id"
 DataProtoRefLike = MooncakeDataProtoRef | Mapping[str, Any]
 
@@ -323,7 +324,7 @@ def export_dataproto_ref(ref: MooncakeDataProtoRef) -> dict[str, Any]:
         raise TypeError(f"expected MooncakeDataProtoRef, got {type(ref).__name__}")
     handle = {
         "type": DATAPROTO_REF_HANDLE_TYPE,
-        "version": DATAPROTO_REF_HANDLE_VERSION if ref._storage_group_id is not None else 1,
+        "version": DATAPROTO_REF_HANDLE_VERSION,
         "kind": "bundle_stages",
         "batch_size": int(ref.batch_size),
         "namespace": ref.namespace,
@@ -355,7 +356,7 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
     if not is_dataproto_ref_handle(handle):
         raise ValueError("not a Mooncake DataProto ref handle")
     version = int(handle.get("version", -1))
-    if version not in (1, DATAPROTO_REF_HANDLE_VERSION):
+    if version != DATAPROTO_REF_HANDLE_VERSION:
         raise ValueError(
             f"unsupported DataProto ref handle version: {handle.get('version')!r}"
         )
@@ -398,11 +399,11 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
         field_index[name] = StructuredFieldLocation(
             stage=stage, member=member, section=section
         )
-    storage_group_id = handle.get(STORAGE_GROUP_ID) if version == 2 else None
-    if version == 2 and (
+    storage_group_id = handle.get(STORAGE_GROUP_ID)
+    if storage_group_id is not None and (
         not isinstance(storage_group_id, str) or not storage_group_id
     ):
-        raise ValueError("DataProto ref handle requires storage_group_id")
+        raise ValueError("DataProto ref handle has invalid storage_group_id")
     return MooncakeDataProtoRef(
         batch_size=int(handle["batch_size"]),
         stage_refs=stage_refs,
@@ -492,7 +493,7 @@ class MooncakeBundleTransfer:
         )
         self._structured_store = _StructuredObjectLayer(self._bundle_store)
 
-    def _new_storage_group_id(self, config: Any) -> str:
+    def _new_storage_group_id(self, config: Any) -> str | None:
         raw_group_ids = getattr(config, "group_ids", None)
         if raw_group_ids is None:
             group_id = None
@@ -517,8 +518,8 @@ class MooncakeBundleTransfer:
             raise ValueError(
                 "structured object store config.group_ids must contain strings"
             )
-        if not group_id:
-            return f"structured-{uuid.uuid4().hex}"
+        if group_id == "":
+            return None
         return group_id
 
     def put_bundle(
@@ -1670,7 +1671,11 @@ class MooncakeBundleTransfer:
                 )
         if ref is None:
             group_id = self._new_storage_group_id(config)
-            effective_config = _config_with_group_id(config, group_id)
+            effective_config = (
+                config
+                if group_id is None
+                else _config_with_group_id(config, group_id)
+            )
         else:
             group_id = ref._storage_group_id
             effective_config = (

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import ctypes
 import io
 import json
@@ -6001,15 +6002,71 @@ def _call_write_with_optional_config(fn: Any, *args: Any, config: Any = None) ->
     return fn(*args, config=config)
 
 
+def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
+    """Return a write config whose group_ids match the physical key count."""
+    if config is None or key_count <= 0:
+        return config
+    group_ids = getattr(config, "group_ids", None)
+    if group_ids is None:
+        return config
+    normalize_to_list = isinstance(group_ids, str)
+    if normalize_to_list:
+        group_ids = [group_ids]
+    else:
+        group_ids = list(group_ids)
+    if len(group_ids) != 1:
+        raise ValueError(
+            "structured object store config.group_ids must contain exactly one "
+            "logical group id; it is expanded across internal Mooncake keys"
+        )
+    if key_count == 1 and not normalize_to_list:
+        return config
+    grouped_config = _copy_write_config(config)
+    grouped_config.group_ids = [group_ids[0]] * key_count
+    return grouped_config
+
+
+def _copy_write_config(config: Any) -> Any:
+    try:
+        return copy.copy(config)
+    except TypeError:
+        pass
+    try:
+        copied = type(config)()
+    except Exception as error:
+        raise TypeError(
+            "structured object store config must be copyable or default-constructible"
+        ) from error
+    for name in dir(config):
+        if name.startswith("_"):
+            continue
+        try:
+            value = getattr(config, name)
+        except Exception:
+            continue
+        if callable(value):
+            continue
+        try:
+            setattr(copied, name, value)
+        except Exception as error:
+            raise TypeError(
+                f"structured object store config field {name!r} is not writable"
+            ) from error
+    return copied
+
+
 def _put_with_optional_config(
     store: BundleStore, key: str, value: Any, config: Any = None
 ) -> int:
-    return _call_write_with_optional_config(store.put, key, value, config=config)
+    return _call_write_with_optional_config(
+        store.put, key, value, config=_config_for_grouped_keys(config, 1)
+    )
 
 
 def _put_from_with_optional_config(
     store: BundleStore, key: str, ptr: int, size: int, config: Any = None
 ) -> int:
+    config = _config_for_grouped_keys(config, 1)
     put_tensor_from = getattr(store, "put_tensor_from", None)
     if config is None and callable(put_tensor_from):
         return put_tensor_from(key, ptr, size)
@@ -6027,7 +6084,11 @@ def _batch_put_from_with_optional_config(
     config: Any = None,
 ) -> Sequence[int]:
     return _call_write_with_optional_config(
-        batch_put_from, list(keys), list(ptrs), list(sizes), config=config
+        batch_put_from,
+        list(keys),
+        list(ptrs),
+        list(sizes),
+        config=_config_for_grouped_keys(config, len(keys)),
     )
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3449,23 +3449,24 @@ class _BundleManifestStore:
                 config=config,
             )
             written_keys.extend(meta_keys)
+            cleanup_key_list = list(dict.fromkeys(cleanup_keys or []))
+            buffer_object_ids = {
+                self._object_id_from_bundle_key(str(payload_spec["key"]))
+                for payload_spec in buffers.values()
+            }
+            buffer_object_ids.update(
+                self._object_id_from_bundle_key(key) for key in cleanup_key_list
+            )
             manifest = {
                 "version": 1,
                 "layout": "bundle",
                 "object_id": object_id,
                 "meta": meta_spec,
                 "buffers": dict(buffers),
-                "buffer_object_ids": sorted(
-                    {
-                        str(payload_spec["key"])
-                        .removeprefix(f"{self._key_prefix}/")
-                        .split("/buffer/", 1)[0]
-                        for payload_spec in buffers.values()
-                    }
-                ),
+                "buffer_object_ids": sorted(item for item in buffer_object_ids if item),
             }
-            if cleanup_keys:
-                manifest["cleanup_keys"] = list(dict.fromkeys(cleanup_keys))
+            if cleanup_key_list:
+                manifest["cleanup_keys"] = cleanup_key_list
             self._validate_manifest(manifest)
             manifest_blob = _encode_manifest(manifest)
             _check_status(
@@ -3755,6 +3756,16 @@ class _BundleManifestStore:
         if result.copy_mode not in {"auto", "zero_copy", "copy"}:
             raise ValueError(f"unsupported copy_mode: {result.copy_mode}")
         return result
+
+    def _object_id_from_bundle_key(self, key: str) -> str | None:
+        prefix = f"{self._key_prefix}/"
+        if not key.startswith(prefix):
+            return None
+        suffix = key[len(prefix) :]
+        for marker in ("/manifest", "/meta", "/buffer/"):
+            if marker in suffix:
+                return suffix.split(marker, 1)[0]
+        return None
 
     def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
         if manifest.get("version") != 1 or manifest.get("layout") != "bundle":

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1479,16 +1479,20 @@ class MooncakeBundleTransfer:
             if collisions:
                 raise ValueError(f"structured members already exist: {collisions}")
             merged_buffers.update(new_manifest["buffers"])
+            cleanup_keys = [
+                *old_manifest.get("cleanup_keys", []),
+                self._bundle_store.manifest_key(old_stage_ref),
+                *self._bundle_store.payload_keys(old_manifest["meta"]),
+                self._bundle_store.manifest_key(new_stage_ref),
+                *self._bundle_store.payload_keys(new_manifest["meta"]),
+            ]
             merged_ref = self._bundle_store.put_bundle_manifest(
                 _encode_structured_metadata(merged_metadata),
                 merged_buffers,
                 partition=partition,
                 chunk_bytes=chunk_bytes,
                 policy=policy,
-                cleanup_keys=[
-                    self._bundle_store.manifest_key(old_stage_ref),
-                    *self._bundle_store.payload_keys(old_manifest["meta"]),
-                ],
+                cleanup_keys=cleanup_keys,
                 config=config,
             )
         except Exception:
@@ -3993,9 +3997,14 @@ class _BundleManifestStore:
         if not key.startswith(prefix):
             return None
         suffix = key[len(prefix) :]
-        for marker in ("/manifest", "/meta", "/buffer/"):
-            if marker in suffix:
-                return suffix.split(marker, 1)[0]
+        if suffix.endswith("/manifest"):
+            return suffix[: -len("/manifest")]
+        if suffix.endswith("/meta"):
+            return suffix[: -len("/meta")]
+        for marker in ("/meta/", "/buffer/"):
+            index = suffix.find(marker)
+            if index > 0:
+                return suffix[:index]
         return None
 
     def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
@@ -4422,6 +4431,8 @@ class _MooncakePayloadTransport:
         # Stream one chunk at a time: acquire -> memcpy -> put -> release.
         # This keeps pool pressure minimal and allows RDMA transfers to pipeline.
         for chunk_key, group, size in zip(chunk_keys, chunk_groups, sizes):
+            # Each pool lease maps to one physical key, so a single logical group id
+            # stays length-1 for each batch_put_from call in this path.
             lease = pool.acquire(size)
             try:
                 _copy_memoryviews_to_lease(group, lease)
@@ -6013,6 +6024,20 @@ def _call_write_with_optional_config(fn: Any, *args: Any, config: Any = None) ->
     return fn(*args, config=config)
 
 
+_WRITE_CONFIG_COPY_FIELDS = (
+    "data_type",
+    "group_ids",
+    "nof_replica_num",
+    "prefer_alloc_in_same_node",
+    "preferred_nof_segments",
+    "preferred_segment",
+    "preferred_segments",
+    "replica_num",
+    "with_hard_pin",
+    "with_soft_pin",
+)
+
+
 def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
     """Return a write config whose group_ids match the physical key count."""
     if config is None or key_count <= 0:
@@ -6025,6 +6050,8 @@ def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
         group_ids = [group_ids]
     else:
         group_ids = list(group_ids)
+    if not group_ids:
+        return config
     if len(group_ids) != 1:
         raise ValueError(
             "structured object store config.group_ids must contain exactly one "
@@ -6048,15 +6075,17 @@ def _copy_write_config(config: Any) -> Any:
         raise TypeError(
             "structured object store config must be copyable or default-constructible"
         ) from error
-    for name in dir(config):
-        if name.startswith("_"):
+    for name in _WRITE_CONFIG_COPY_FIELDS:
+        if not hasattr(config, name):
             continue
         try:
             value = getattr(config, name)
         except Exception:
             continue
-        if callable(value):
-            continue
+        if isinstance(value, list):
+            value = list(value)
+        elif isinstance(value, tuple):
+            value = tuple(value)
         try:
             setattr(copied, name, value)
         except Exception as error:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -6051,7 +6051,9 @@ def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
     else:
         group_ids = list(group_ids)
     if not group_ids:
-        return config
+        ungrouped_config = _copy_write_config(config)
+        ungrouped_config.group_ids = None
+        return ungrouped_config
     if len(group_ids) != 1:
         raise ValueError(
             "structured object store config.group_ids must contain exactly one "

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import ctypes
 import io
 import json
@@ -3385,6 +3386,7 @@ class _BundleManifestStore:
                         value,
                         target_chunk_bytes,
                         transfer_policy,
+                        config=config,
                     )
                 else:
                     payload_spec, payload_keys = self._put_payload(
@@ -3699,6 +3701,7 @@ class _BundleManifestStore:
         value: _MultiBufferPayload,
         chunk_bytes: int,
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> tuple[dict[str, Any], list[str]]:
         total_bytes = value.nbytes
         if total_bytes == 0:
@@ -3710,6 +3713,7 @@ class _BundleManifestStore:
                 chunk_bytes,
                 transfer_policy,
                 pre_registered=False,
+                config=config,
             )
         chunk_groups = _split_multi_buffer_payload(value.buffers, chunk_bytes)
         chunk_keys = [
@@ -3720,6 +3724,7 @@ class _BundleManifestStore:
             chunk_keys,
             chunk_groups,
             transfer_policy,
+            config=config,
         )
         payload_spec = {
             "key": key,
@@ -3923,10 +3928,11 @@ class _MooncakePayloadTransport:
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
         transfer_policy: BundleTransferPolicy,
+        config: Any = None,
     ) -> list[str]:
         def fallback_to_direct_put() -> list[str]:
             chunks = [memoryview(b"".join(group)) for group in chunk_groups]
-            return self._put_chunks_direct(chunk_keys, chunks)
+            return self._put_chunks_direct(chunk_keys, chunks, config=config)
 
         if transfer_policy.copy_mode == "zero_copy":
             # Joining one chunk group costs the same single copy the contiguous
@@ -3934,25 +3940,30 @@ class _MooncakePayloadTransport:
             # register-source-buffer zero-copy semantics of single-buffer puts.
             chunks = [memoryview(b"".join(group)) for group in chunk_groups]
             return self.put_payload_chunks(
-                chunk_keys, chunks, transfer_policy, pre_registered=False
+                chunk_keys,
+                chunks,
+                transfer_policy,
+                pre_registered=False,
+                config=config,
             )
         if transfer_policy.copy_mode == "copy" or self._ensure_buffer_pool() is None:
             return fallback_to_direct_put()
         if all(len(group) == 1 for group in chunk_groups):
             self.batch_put_buffer_groups_from(
-                chunk_keys, [[group[0]] for group in chunk_groups]
+                chunk_keys, [[group[0]] for group in chunk_groups], config=config
             )
             return list(chunk_keys)
         if not callable(self._batch_put_from):
             return fallback_to_direct_put()
         put_mode = self._resolve_buffer_group_put_mode(chunk_groups, transfer_policy)
         if put_mode == "batch":
-            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups)
+            self.batch_put_buffer_groups_from(chunk_keys, chunk_groups, config=config)
             return list(chunk_keys)
         return self._put_buffer_groups_parallel(
             list(chunk_keys),
             [list(group) for group in chunk_groups],
             transfer_policy.max_inflight_put,
+            config=config,
         )
 
     def read_payload(self, payload_spec: Mapping[str, Any]) -> bytes:
@@ -4195,6 +4206,7 @@ class _MooncakePayloadTransport:
         self,
         chunk_keys: Sequence[str],
         chunk_groups: Sequence[Sequence[memoryview]],
+        config: Any = None,
     ) -> None:
         batch_put_from = self._batch_put_from
         if not callable(batch_put_from):
@@ -4209,7 +4221,9 @@ class _MooncakePayloadTransport:
             lease = pool.acquire(size)
             try:
                 _copy_memoryviews_to_lease(group, lease)
-                results = batch_put_from([chunk_key], [lease.ptr], [size])
+                results = _batch_put_from_with_optional_config(
+                    batch_put_from, [chunk_key], [lease.ptr], [size], config
+                )
                 self._check_batch_put_results(results, [chunk_key], "batch_put_from")
             except Exception:
                 _cleanup_keys(self._store, chunk_keys, strict=False)
@@ -4344,6 +4358,7 @@ class _MooncakePayloadTransport:
         chunk_keys: list[str],
         chunk_groups: list[Sequence[memoryview]],
         max_inflight_put: int,
+        config: Any = None,
     ) -> list[str]:
         groups = self._group_buffer_group_ranges(
             chunk_keys, chunk_groups, max_inflight_put
@@ -4358,6 +4373,7 @@ class _MooncakePayloadTransport:
                         self.batch_put_buffer_groups_from,
                         group_keys,
                         group_chunks,
+                        config,
                     )
                     for group_keys, group_chunks in groups
                 ]
@@ -5538,15 +5554,71 @@ def _call_write_with_optional_config(fn: Any, *args: Any, config: Any = None) ->
     return fn(*args, config=config)
 
 
+def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
+    """Return a write config whose group_ids match the physical key count."""
+    if config is None or key_count <= 0:
+        return config
+    group_ids = getattr(config, "group_ids", None)
+    if group_ids is None:
+        return config
+    normalize_to_list = isinstance(group_ids, str)
+    if normalize_to_list:
+        group_ids = [group_ids]
+    else:
+        group_ids = list(group_ids)
+    if len(group_ids) != 1:
+        raise ValueError(
+            "structured object store config.group_ids must contain exactly one "
+            "logical group id; it is expanded across internal Mooncake keys"
+        )
+    if key_count == 1 and not normalize_to_list:
+        return config
+    grouped_config = _copy_write_config(config)
+    grouped_config.group_ids = [group_ids[0]] * key_count
+    return grouped_config
+
+
+def _copy_write_config(config: Any) -> Any:
+    try:
+        return copy.copy(config)
+    except TypeError:
+        pass
+    try:
+        copied = type(config)()
+    except Exception as error:
+        raise TypeError(
+            "structured object store config must be copyable or default-constructible"
+        ) from error
+    for name in dir(config):
+        if name.startswith("_"):
+            continue
+        try:
+            value = getattr(config, name)
+        except Exception:
+            continue
+        if callable(value):
+            continue
+        try:
+            setattr(copied, name, value)
+        except Exception as error:
+            raise TypeError(
+                f"structured object store config field {name!r} is not writable"
+            ) from error
+    return copied
+
+
 def _put_with_optional_config(
     store: BundleStore, key: str, value: Any, config: Any = None
 ) -> int:
-    return _call_write_with_optional_config(store.put, key, value, config=config)
+    return _call_write_with_optional_config(
+        store.put, key, value, config=_config_for_grouped_keys(config, 1)
+    )
 
 
 def _put_from_with_optional_config(
     store: BundleStore, key: str, ptr: int, size: int, config: Any = None
 ) -> int:
+    config = _config_for_grouped_keys(config, 1)
     put_tensor_from = getattr(store, "put_tensor_from", None)
     if config is None and callable(put_tensor_from):
         return put_tensor_from(key, ptr, size)
@@ -5564,7 +5636,11 @@ def _batch_put_from_with_optional_config(
     config: Any = None,
 ) -> Sequence[int]:
     return _call_write_with_optional_config(
-        batch_put_from, list(keys), list(ptrs), list(sizes), config=config
+        batch_put_from,
+        list(keys),
+        list(ptrs),
+        list(sizes),
+        config=_config_for_grouped_keys(config, len(keys)),
     )
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3762,9 +3762,14 @@ class _BundleManifestStore:
         if not key.startswith(prefix):
             return None
         suffix = key[len(prefix) :]
-        for marker in ("/manifest", "/meta", "/buffer/"):
-            if marker in suffix:
-                return suffix.split(marker, 1)[0]
+        if suffix.endswith("/manifest"):
+            return suffix[: -len("/manifest")]
+        if suffix.endswith("/meta"):
+            return suffix[: -len("/meta")]
+        for marker in ("/meta/", "/buffer/"):
+            index = suffix.find(marker)
+            if index > 0:
+                return suffix[:index]
         return None
 
     def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
@@ -4229,6 +4234,8 @@ class _MooncakePayloadTransport:
         # Stream one chunk at a time: acquire -> memcpy -> put -> release.
         # This keeps pool pressure minimal and allows RDMA transfers to pipeline.
         for chunk_key, group, size in zip(chunk_keys, chunk_groups, sizes):
+            # Each pool lease maps to one physical key, so a single logical group id
+            # stays length-1 for each batch_put_from call in this path.
             lease = pool.acquire(size)
             try:
                 _copy_memoryviews_to_lease(group, lease)
@@ -5565,6 +5572,20 @@ def _call_write_with_optional_config(fn: Any, *args: Any, config: Any = None) ->
     return fn(*args, config=config)
 
 
+_WRITE_CONFIG_COPY_FIELDS = (
+    "data_type",
+    "group_ids",
+    "nof_replica_num",
+    "prefer_alloc_in_same_node",
+    "preferred_nof_segments",
+    "preferred_segment",
+    "preferred_segments",
+    "replica_num",
+    "with_hard_pin",
+    "with_soft_pin",
+)
+
+
 def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
     """Return a write config whose group_ids match the physical key count."""
     if config is None or key_count <= 0:
@@ -5577,6 +5598,11 @@ def _config_for_grouped_keys(config: Any, key_count: int) -> Any:
         group_ids = [group_ids]
     else:
         group_ids = list(group_ids)
+    if not group_ids:
+        raise ValueError(
+            "structured object store config.group_ids must not be empty; "
+            "provide exactly one logical group id"
+        )
     if len(group_ids) != 1:
         raise ValueError(
             "structured object store config.group_ids must contain exactly one "
@@ -5600,15 +5626,17 @@ def _copy_write_config(config: Any) -> Any:
         raise TypeError(
             "structured object store config must be copyable or default-constructible"
         ) from error
-    for name in dir(config):
-        if name.startswith("_"):
+    for name in _WRITE_CONFIG_COPY_FIELDS:
+        if not hasattr(config, name):
             continue
         try:
             value = getattr(config, name)
         except Exception:
             continue
-        if callable(value):
-            continue
+        if isinstance(value, list):
+            value = list(value)
+        elif isinstance(value, tuple):
+            value = tuple(value)
         try:
             setattr(copied, name, value)
         except Exception as error:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -4415,16 +4415,25 @@ class _MooncakePayloadTransport:
         value: _TensorPayload,
         config: Any = None,
     ) -> dict[str, Any] | None:
-        if config is not None:
-            return None
-        put_tensor = getattr(self._store, "put_tensor", None)
+        put_tensor = getattr(
+            self._store, "put_tensor" if config is None else "pub_tensor", None
+        )
         if not callable(put_tensor):
             return None
         tensor = value.tensor
         nbytes = int(getattr(tensor, "nbytes", 0))
         metadata_bytes = _tensor_metadata_size()
         total_bytes = metadata_bytes + nbytes
-        _check_status(put_tensor(key, tensor), "put_tensor", key)
+        _check_status(
+            _call_write_with_optional_config(
+                put_tensor,
+                key,
+                tensor,
+                config=_config_for_grouped_keys(config, 1),
+            ),
+            "put_tensor",
+            key,
+        )
         return {
             "key": key,
             "kind": "tensor",

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3560,23 +3560,24 @@ class _BundleManifestStore:
                 config=config,
             )
             written_keys.extend(meta_keys)
+            cleanup_key_list = list(dict.fromkeys(cleanup_keys or []))
+            buffer_object_ids = {
+                self._object_id_from_bundle_key(str(payload_spec["key"]))
+                for payload_spec in buffers.values()
+            }
+            buffer_object_ids.update(
+                self._object_id_from_bundle_key(key) for key in cleanup_key_list
+            )
             manifest = {
                 "version": 1,
                 "layout": "bundle",
                 "object_id": object_id,
                 "meta": meta_spec,
                 "buffers": dict(buffers),
-                "buffer_object_ids": sorted(
-                    {
-                        str(payload_spec["key"])
-                        .removeprefix(f"{self._key_prefix}/")
-                        .split("/buffer/", 1)[0]
-                        for payload_spec in buffers.values()
-                    }
-                ),
+                "buffer_object_ids": sorted(item for item in buffer_object_ids if item),
             }
-            if cleanup_keys:
-                manifest["cleanup_keys"] = list(dict.fromkeys(cleanup_keys))
+            if cleanup_key_list:
+                manifest["cleanup_keys"] = cleanup_key_list
             self._validate_manifest(manifest)
             manifest_blob = _encode_manifest(manifest)
             _check_status(
@@ -3986,6 +3987,16 @@ class _BundleManifestStore:
         if result.copy_mode not in {"auto", "zero_copy", "copy"}:
             raise ValueError(f"unsupported copy_mode: {result.copy_mode}")
         return result
+
+    def _object_id_from_bundle_key(self, key: str) -> str | None:
+        prefix = f"{self._key_prefix}/"
+        if not key.startswith(prefix):
+            return None
+        suffix = key[len(prefix) :]
+        for marker in ("/manifest", "/meta", "/buffer/"):
+            if marker in suffix:
+                return suffix.split(marker, 1)[0]
+        return None
 
     def _validate_manifest(self, manifest: Mapping[str, Any]) -> None:
         if manifest.get("version") != 1 or manifest.get("layout") != "bundle":

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -554,6 +554,37 @@ def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
     assert all(group_ids == ["rollout-group"] for group_ids in batch_group_ids)
 
 
+def test_bundle_manifest_update_allows_meta_only_cleanup_keys() -> None:
+    store, transfer = make_transfer()
+    old_ref = transfer.put_structured_object(structured_payload({"kind": "old"}))
+    cleanup_keys = [
+        old_ref.manifest_key,
+        *transfer._bundle_store.payload_keys(old_ref.manifest["meta"]),
+    ]
+
+    merged_ref = transfer._bundle_store.put_bundle_manifest(
+        json.dumps({"kind": "merged"}, separators=(",", ":")).encode("utf-8"),
+        {},
+        partition="default",
+        chunk_bytes=None,
+        policy=None,
+        cleanup_keys=cleanup_keys,
+    )
+    result = transfer.materialize(transfer.read_spec(merged_ref))
+    manifest = sos._decode_manifest(store.objects[merged_ref.manifest_key])
+
+    assert result.metadata == {"kind": "merged"}
+    assert result.objects == {}
+    assert set(cleanup_keys).issubset(set(manifest["cleanup_keys"]))
+    assert old_ref.manifest["object_id"] in manifest["buffer_object_ids"]
+
+    transfer.remove_bundle(merged_ref)
+
+    assert old_ref.manifest_key not in store.objects
+    assert merged_ref.manifest_key not in store.objects
+    assert all(key not in store.objects for key in cleanup_keys)
+
+
 def test_dataproto_append_updates_manifest_with_grouped_config() -> None:
     store, transfer = make_transfer()
     config = GroupConfig(["rollout-group"])

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -73,8 +73,10 @@ class InMemoryStore:
         self.put_tensor_from_calls = 0
         self.batch_remove_calls = 0
         self.put_tensor_calls = 0
+        self.pub_tensor_calls = 0
         self.get_tensor_calls = 0
         self.put_configs: list[object] = []
+        self.pub_tensor_configs: list[object] = []
         self.batch_put_from_configs: list[object] = []
         self.events: list[tuple[str, str]] = []
 
@@ -126,6 +128,13 @@ class InMemoryStore:
 
     def put_tensor(self, key: str, value) -> int:
         self.put_tensor_calls += 1
+        with self.lock:
+            self.tensor_objects[key] = value.detach().clone()
+        return 0
+
+    def pub_tensor(self, key: str, value, config=None) -> int:
+        self.pub_tensor_calls += 1
+        self.pub_tensor_configs.append(config)
         with self.lock:
             self.tensor_objects[key] = value.detach().clone()
         return 0
@@ -318,6 +327,7 @@ class PutTensorOnlyStore(InMemoryStore):
 
 class NoTensorFastPathStore(InMemoryStore):
     put_tensor = None
+    pub_tensor = None
     get_tensor = None
 
 
@@ -831,6 +841,99 @@ def test_high_level_put_replaces_empty_group_id_without_mutating_config() -> Non
     )
     assert config.group_ids == [""]
     assert config.replica_num == 2
+
+
+@pytest.mark.parametrize("object_type", ["dict", "dataproto"])
+def test_high_level_put_preserves_grouped_tensor_fast_path(object_type) -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer()
+    tensor = torch.arange(12, dtype=torch.int64).reshape(4, 3)
+
+    if object_type == "dict":
+        ref = transfer.put({"input_ids": tensor}, type="dict", stage="rollout")
+        result = transfer.get(ref, type="dict")
+        actual = result["input_ids"]
+    else:
+        ref = transfer.put_dataproto(
+            SimpleDataProto(batch={"input_ids": tensor}),
+            stage="rollout",
+        )
+        result = transfer.get_dataproto(ref)
+        actual = result["batch"]["input_ids"]
+
+    group_id = _storage_group_id(ref)
+    payload = ref.stage_refs["rollout"].manifest["buffers"]["batch.input_ids"]
+    assert payload["kind"] == "tensor"
+    assert store.pub_tensor_calls == 1
+    assert store.put_tensor_calls == 0
+    assert store.batch_put_from_calls == 0
+    assert store.get_tensor_calls == 1
+    assert _seen_group_ids(store.pub_tensor_configs) == [[group_id]]
+    assert torch.equal(actual, tensor)
+
+
+def test_high_level_append_preserves_grouped_tensor_fast_path() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer()
+    input_ids = torch.arange(12, dtype=torch.int64).reshape(4, 3)
+    rewards = torch.arange(4, dtype=torch.float32)
+    ref = transfer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": input_ids}),
+        stage="rollout",
+    )
+    group_id = _storage_group_id(ref)
+    old_payload_key = ref.stage_refs["rollout"].manifest["buffers"][
+        "batch.input_ids"
+    ]["key"]
+
+    ref = transfer.append_dataproto_fields(
+        ref,
+        SimpleDataProto(batch={"rewards": rewards}),
+        stage="rollout",
+    )
+    result = transfer.get_dataproto(ref)
+    buffers = ref.stage_refs["rollout"].manifest["buffers"]
+
+    assert ref._storage_group_id == group_id
+    assert buffers["batch.input_ids"]["key"] == old_payload_key
+    assert buffers["batch.input_ids"]["kind"] == "tensor"
+    assert buffers["batch.rewards"]["kind"] == "tensor"
+    assert store.pub_tensor_calls == 2
+    assert store.put_tensor_calls == 0
+    assert store.batch_put_from_calls == 0
+    assert store.get_tensor_calls == 2
+    assert _seen_group_ids(store.pub_tensor_configs) == [[group_id], [group_id]]
+    assert torch.equal(result["batch"]["input_ids"], input_ids)
+    assert torch.equal(result["batch"]["rewards"], rewards)
+
+    transfer.cleanup_dataproto(ref)
+    assert store.objects == {}
+    assert store.tensor_objects == {}
+
+
+def test_grouped_tensor_falls_back_when_pub_tensor_is_unavailable() -> None:
+    torch = pytest.importorskip("torch")
+    store, transfer = make_transfer(NoTensorFastPathStore())
+    tensor = torch.arange(12, dtype=torch.int64).reshape(4, 3)
+
+    ref = transfer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": tensor}),
+        stage="rollout",
+    )
+    result = transfer.get_dataproto(ref)
+
+    group_id = _storage_group_id(ref)
+    payload = ref.stage_refs["rollout"].manifest["buffers"]["batch.input_ids"]
+    assert payload.get("kind") != "tensor"
+    assert store.put_tensor_calls == 0
+    assert store.pub_tensor_calls == 0
+    assert store.get_tensor_calls == 0
+    assert _seen_group_ids(store.put_configs) == [
+        [group_id],
+        [group_id],
+        [group_id],
+    ]
+    assert torch.equal(result["batch"]["input_ids"], tensor)
 
 
 @pytest.mark.parametrize(

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -505,6 +505,55 @@ def test_structured_object_expands_group_id_for_chunk_batch_put() -> None:
     assert manifest_group_ids == ["rollout-group"]
 
 
+def test_structured_object_normalizes_string_group_id() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig("rollout-group")
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "grouped"}, value=b"payload"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["value"] == b"payload"
+    assert _seen_group_ids(store.put_configs)[-1] == ["rollout-group"]
+    assert config.group_ids == "rollout-group"
+
+
+def test_structured_object_rejects_empty_group_ids() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        transfer.put_structured_object(
+            structured_payload({"kind": "bad"}, value=b"payload"),
+            config=GroupConfig([]),
+        )
+
+
+def test_structured_object_parallel_put_preserves_group_id() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(["rollout-group"])
+    payload = structured_payload(
+        {"kind": "parallel"},
+        large=np.arange(128, dtype=np.uint8),
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(max_inflight_put=4, put_mode="parallel"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    assert store.max_active_puts > 1
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert batch_group_ids
+    assert all(set(group_ids) == {"rollout-group"} for group_ids in batch_group_ids)
+    assert config.group_ids == ["rollout-group"]
+
+
 def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
     pool = FakeBufferPool()
     store, transfer = make_transfer(buffer_pool=pool)

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -809,7 +809,7 @@ def test_high_level_put_auto_creates_opaque_storage_group(payload_type) -> None:
     group_id = _storage_group_id(ref)
     handle = export_dataproto_ref(ref)
     assert group_id.startswith("structured-")
-    assert handle["version"] == 2
+    assert handle["version"] == 1
     assert handle["storage_group_id"] == group_id
     assert all(
         list(write_config.group_ids) == [group_id]
@@ -823,7 +823,7 @@ def test_high_level_put_auto_creates_opaque_storage_group(payload_type) -> None:
     assert config.replica_num == 2
 
 
-def test_high_level_put_replaces_empty_group_id_without_mutating_config() -> None:
+def test_high_level_put_preserves_explicit_ungrouped_config() -> None:
     store, transfer = make_transfer()
     config = GroupConfig([""], replica_num=2)
 
@@ -832,13 +832,32 @@ def test_high_level_put_replaces_empty_group_id_without_mutating_config() -> Non
         type="dict",
         config=config,
     )
-
-    group_id = _storage_group_id(ref)
-    assert group_id.startswith("structured-")
-    assert all(
-        list(write_config.group_ids) == [group_id]
-        for write_config in store.put_configs
+    handle = export_dataproto_ref(ref)
+    first_put_count = len(store.put_configs)
+    appended = MooncakeBundleTransfer(
+        store, key_prefix=transfer.key_prefix
+    ).append_dataproto_fields(
+        handle,
+        SimpleDataProto(batch={"values": np.arange(4) + 10}),
+        stage="value",
     )
+    result = transfer.get_dataproto(appended)
+
+    assert ref._storage_group_id is None
+    assert handle["version"] == 1
+    assert "storage_group_id" not in handle
+    assert all(
+        list(write_config.group_ids) == [""]
+        for write_config in store.put_configs
+        if write_config is not None
+    )
+    assert all(
+        seen_config is None
+        for seen_config in store.put_configs[first_put_count:]
+    )
+    assert appended._storage_group_id is None
+    assert np.array_equal(result["batch"]["input_ids"], np.arange(4))
+    assert np.array_equal(result["batch"]["values"], np.arange(4) + 10)
     assert config.group_ids == [""]
     assert config.replica_num == 2
 
@@ -2759,10 +2778,10 @@ def test_dataproto_ref_handle_roundtrip_materializes_and_cleans_up() -> None:
     legacy_handle["version"] = 1
     legacy_handle.pop("storage_group_id")
     assert import_dataproto_ref(legacy_handle)._storage_group_id is None
-    invalid_v2_handle = dict(handle)
-    invalid_v2_handle["storage_group_id"] = ""
+    invalid_handle = dict(handle)
+    invalid_handle["storage_group_id"] = ""
     with pytest.raises(ValueError, match="storage_group_id"):
-        import_dataproto_ref(invalid_v2_handle)
+        import_dataproto_ref(invalid_handle)
 
     result = transfer.get_dataproto(handle)
     assert np.array_equal(result["batch"]["input_ids"], input_ids)

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -2782,6 +2782,12 @@ def test_dataproto_ref_handle_roundtrip_materializes_and_cleans_up() -> None:
     invalid_handle["storage_group_id"] = ""
     with pytest.raises(ValueError, match="storage_group_id"):
         import_dataproto_ref(invalid_handle)
+    transitional_v2_handle = dict(handle)
+    transitional_v2_handle["version"] = 2
+    assert (
+        import_dataproto_ref(transitional_v2_handle)._storage_group_id
+        == ref._storage_group_id
+    )
 
     result = transfer.get_dataproto(handle)
     assert np.array_equal(result["batch"]["input_ids"], input_ids)

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -44,8 +44,14 @@ class BadDataProto:
 
 
 class GroupConfig:
-    def __init__(self, group_ids) -> None:
+    def __init__(self, group_ids, replica_num: int = 1) -> None:
         self.group_ids = group_ids
+        self.replica_num = replica_num
+
+
+class UncopyableGroupConfig(GroupConfig):
+    def __copy__(self):
+        raise TypeError("not copyable")
 
 
 class InMemoryStore:
@@ -70,6 +76,7 @@ class InMemoryStore:
         self.get_tensor_calls = 0
         self.put_configs: list[object] = []
         self.batch_put_from_configs: list[object] = []
+        self.events: list[tuple[str, str]] = []
 
     def _enter_put(self) -> None:
         with self.lock:
@@ -91,6 +98,7 @@ class InMemoryStore:
 
     def put(self, key: str, value, config=None) -> int:
         self.put_configs.append(config)
+        self.events.append(("put", key))
         self._enter_put()
         try:
             time.sleep(0.01)
@@ -101,6 +109,7 @@ class InMemoryStore:
             self._exit_put()
 
     def get(self, key: str) -> bytes:
+        self.events.append(("get", key))
         self._enter_get()
         try:
             time.sleep(0.01)
@@ -466,6 +475,12 @@ def _seen_group_ids(configs: list[object]) -> list[list[str]]:
     ]
 
 
+def _storage_group_id(ref) -> str:
+    group_id = ref._storage_group_id
+    assert group_id is not None
+    return group_id
+
+
 def _multi_buffer_payload(values: range) -> sos._MultiBufferPayload:
     arrays = tuple(np.asarray([value], dtype=np.int32) for value in values)
     return sos._MultiBufferPayload(
@@ -767,6 +782,258 @@ def test_structured_object_rejects_ambiguous_group_ids() -> None:
             structured_payload({"kind": "bad"}, value=b"payload"),
             config=GroupConfig(["group-a", "group-b"]),
         )
+
+
+@pytest.mark.parametrize("payload_type", ["dict", "dataproto"])
+def test_high_level_put_auto_creates_opaque_storage_group(payload_type) -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(None, replica_num=2)
+    data = (
+        {"input_ids": np.arange(4)}
+        if payload_type == "dict"
+        else SimpleDataProto(batch={"input_ids": np.arange(4)})
+    )
+
+    ref = transfer.put(data, type=payload_type, stage="rollout", config=config)
+
+    group_id = _storage_group_id(ref)
+    handle = export_dataproto_ref(ref)
+    assert group_id.startswith("structured-")
+    assert handle["version"] == 2
+    assert handle["storage_group_id"] == group_id
+    assert all(
+        list(write_config.group_ids) == [group_id]
+        for write_config in store.put_configs
+    )
+    assert all(
+        write_config.replica_num == 2
+        for write_config in store.put_configs
+    )
+    assert config.group_ids is None
+    assert config.replica_num == 2
+
+
+def test_high_level_put_replaces_empty_group_id_without_mutating_config() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig([""], replica_num=2)
+
+    ref = transfer.put(
+        {"input_ids": np.arange(4)},
+        type="dict",
+        config=config,
+    )
+
+    group_id = _storage_group_id(ref)
+    assert group_id.startswith("structured-")
+    assert all(
+        list(write_config.group_ids) == [group_id]
+        for write_config in store.put_configs
+    )
+    assert config.group_ids == [""]
+    assert config.replica_num == 2
+
+
+@pytest.mark.parametrize(
+    ("group_ids", "expected_group_id"),
+    [("metadata-group", "metadata-group"), ([], None)],
+)
+def test_metadata_only_initial_put_does_not_copy_config(
+    group_ids, expected_group_id
+) -> None:
+    store, transfer = make_transfer()
+    config = UncopyableGroupConfig(group_ids)
+
+    ref = transfer.put_dataproto(
+        SimpleDataProto(meta_info={"step": 1}),
+        config=config,
+    )
+
+    group_id = _storage_group_id(ref)
+    if expected_group_id is None:
+        assert group_id.startswith("structured-")
+    else:
+        assert group_id == expected_group_id
+    assert store.events == []
+    assert config.group_ids == group_ids
+
+
+def test_high_level_put_rejects_non_string_group_before_write() -> None:
+    store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="must contain strings"):
+        transfer.put_dataproto(
+            SimpleDataProto(batch={"input_ids": np.arange(4)}),
+            config=GroupConfig([123]),
+        )
+
+    assert store.put_configs == []
+
+
+def test_imported_handle_append_recovers_group_without_scanning_old_stage() -> None:
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="cross-instance")
+    reader = MooncakeBundleTransfer(store, key_prefix="cross-instance")
+    ref = writer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(4)}),
+        stage="rollout",
+    )
+    group_id = _storage_group_id(ref)
+    first_append_record = len(store.put_configs)
+    store.events.clear()
+
+    appended = reader.append_dataproto_fields(
+        export_dataproto_ref(ref),
+        SimpleDataProto(batch={"values": np.arange(4)}),
+        stage="value",
+    )
+
+    assert not any(event == "get" for event, _key in store.events)
+    assert appended._storage_group_id == group_id
+    assert all(
+        list(config.group_ids) == [group_id]
+        for config in store.put_configs[first_append_record:]
+    )
+    third = MooncakeBundleTransfer(store, key_prefix="cross-instance")
+    final = third.append_dataproto_fields(
+        export_dataproto_ref(appended),
+        SimpleDataProto(batch={"rewards": np.arange(4) + 10}),
+        stage="rollout",
+    )
+    result = third.get_dataproto(final)
+
+    assert final._storage_group_id == group_id
+    assert np.array_equal(result["batch"]["values"], np.arange(4))
+    assert np.array_equal(result["batch"]["rewards"], np.arange(4) + 10)
+    assert all(
+        list(config.group_ids) == [group_id]
+        for config in store.put_configs[first_append_record:]
+    )
+
+
+def test_legacy_v1_handle_append_get_and_cleanup_uses_caller_group() -> None:
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="legacy-v1")
+    reader = MooncakeBundleTransfer(store, key_prefix="legacy-v1")
+    ref = writer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(4)}),
+        stage="rollout",
+    )
+    legacy_handle = export_dataproto_ref(ref)
+    legacy_handle["version"] = 1
+    legacy_handle.pop("storage_group_id")
+    store.put_configs.clear()
+    store.batch_put_from_configs.clear()
+    config = GroupConfig(["legacy-group"], replica_num=2)
+
+    appended = reader.append_dataproto_fields(
+        legacy_handle,
+        SimpleDataProto(batch={"values": np.arange(4) + 10}),
+        stage="value",
+        config=config,
+    )
+    result = reader.get_dataproto(appended)
+    reader.cleanup_dataproto(appended)
+
+    assert np.array_equal(result["batch"]["input_ids"], np.arange(4))
+    assert np.array_equal(result["batch"]["values"], np.arange(4) + 10)
+    assert appended._storage_group_id is None
+    group_ids = _seen_group_ids(
+        [*store.put_configs, *store.batch_put_from_configs]
+    )
+    assert group_ids
+    assert all(
+        write_group_ids == ["legacy-group"] for write_group_ids in group_ids
+    )
+    assert config.group_ids == ["legacy-group"]
+    assert config.replica_num == 2
+    assert store.objects == {}
+
+
+def test_metadata_only_append_preserves_group_without_store_io() -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put_dataproto(SimpleDataProto(meta_info={"step": 1}))
+    group_id = _storage_group_id(ref)
+    store.events.clear()
+
+    appended = transfer.append_dataproto_fields(
+        export_dataproto_ref(ref),
+        SimpleDataProto(meta_info={"stage": "metadata"}),
+        stage="metadata",
+    )
+
+    assert appended._storage_group_id == group_id
+    assert store.events == []
+
+
+def test_concurrent_append_branches_inherit_group_without_merging_refs() -> None:
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="concurrent-append")
+    ref = writer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(4)}),
+        stage="rollout",
+    )
+    handle = export_dataproto_ref(ref)
+    group_id = _storage_group_id(ref)
+    barrier = threading.Barrier(3)
+    branches = {}
+    failures = []
+
+    def append(name: str) -> None:
+        try:
+            transfer = MooncakeBundleTransfer(
+                store, key_prefix="concurrent-append"
+            )
+            barrier.wait()
+            branches[name] = transfer.append_dataproto_fields(
+                handle,
+                SimpleDataProto(batch={name: np.arange(4)}),
+                stage="rollout",
+            )
+        except BaseException as error:
+            failures.append(error)
+
+    value_thread = threading.Thread(target=append, args=("values",))
+    reward_thread = threading.Thread(target=append, args=("rewards",))
+    store.put_configs.clear()
+    value_thread.start()
+    reward_thread.start()
+    barrier.wait()
+    value_thread.join(timeout=5)
+    reward_thread.join(timeout=5)
+
+    assert not value_thread.is_alive()
+    assert not reward_thread.is_alive()
+    assert failures == []
+    assert branches["values"]._storage_group_id == group_id
+    assert branches["rewards"]._storage_group_id == group_id
+    assert set(branches["values"].field_index) == {"input_ids", "values"}
+    assert set(branches["rewards"].field_index) == {"input_ids", "rewards"}
+    value_result = writer.get_dataproto(branches["values"])
+    reward_result = writer.get_dataproto(branches["rewards"])
+    assert set(value_result["batch"]) == {"input_ids", "values"}
+    assert set(reward_result["batch"]) == {"input_ids", "rewards"}
+    assert all(
+        list(config.group_ids) == [group_id]
+        for config in store.put_configs
+    )
+
+
+def test_append_rejects_conflicting_group_before_write() -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(4)})
+    )
+    before_puts = len(store.put_configs)
+
+    with pytest.raises(ValueError, match="conflicts"):
+        transfer.append_dataproto_fields(
+            export_dataproto_ref(ref),
+            SimpleDataProto(batch={"values": np.arange(4)}),
+            stage="value",
+            config=GroupConfig(["other-group"]),
+        )
+
+    assert len(store.put_configs) == before_puts
 
 
 def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:
@@ -2218,7 +2485,7 @@ def test_unified_put_rejects_unknown_type() -> None:
 )
 def test_unified_dict_put_passes_store_config_to_writes(policy, config_attr, use_pool) -> None:
     store, transfer = make_transfer(buffer_pool=FakeBufferPool() if use_pool else None)
-    config = object()
+    config = GroupConfig(None)
     data = {"input_ids": np.arange(12, dtype=np.int64).reshape(4, 3)}
     kwargs = {"config": config}
     if policy is not None:
@@ -2230,7 +2497,10 @@ def test_unified_dict_put_passes_store_config_to_writes(policy, config_attr, use
     assert np.array_equal(result["input_ids"], data["input_ids"])
     configs = getattr(store, config_attr)
     assert configs
-    assert all(item is config for item in configs)
+    group_ids = _seen_group_ids(configs)
+    assert group_ids
+    assert all(ids == group_ids[0] for ids in group_ids)
+    assert config.group_ids is None
 
 
 def test_unified_dict_put_accepts_field_schemas() -> None:
@@ -2378,8 +2648,18 @@ def test_dataproto_ref_handle_roundtrip_materializes_and_cleans_up() -> None:
     assert handle["stage_refs"] == {
         "rollout": {"manifest_key": ref.stage_refs["rollout"].manifest_key}
     }
+    assert handle["storage_group_id"] == ref._storage_group_id
     imported = import_dataproto_ref(handle)
     assert imported.stage_refs["rollout"].manifest == {}
+    assert imported._storage_group_id == ref._storage_group_id
+    legacy_handle = dict(handle)
+    legacy_handle["version"] = 1
+    legacy_handle.pop("storage_group_id")
+    assert import_dataproto_ref(legacy_handle)._storage_group_id is None
+    invalid_v2_handle = dict(handle)
+    invalid_v2_handle["storage_group_id"] = ""
+    with pytest.raises(ValueError, match="storage_group_id"):
+        import_dataproto_ref(invalid_v2_handle)
 
     result = transfer.get_dataproto(handle)
     assert np.array_equal(result["batch"]["input_ids"], input_ids)

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -43,6 +43,11 @@ class BadDataProto:
         pass
 
 
+class GroupConfig:
+    def __init__(self, group_ids) -> None:
+        self.group_ids = group_ids
+
+
 class InMemoryStore:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
@@ -451,6 +456,152 @@ def test_small_dict_sized_groups_enable_auto_parallel_put() -> None:
     groups = [[SizedBuffer(1024**2)] for _ in range(128)]
     policy = BundleTransferPolicy(max_inflight_put=8)
     assert transfer._transport._resolve_buffer_group_put_mode(groups, policy) == "parallel"
+
+
+def _seen_group_ids(configs: list[object]) -> list[list[str]]:
+    return [
+        list(config.group_ids)
+        for config in configs
+        if config is not None and hasattr(config, "group_ids")
+    ]
+
+
+def test_structured_object_expands_store_replicate_config() -> None:
+    mooncake_store = pytest.importorskip("mooncake.store")
+    store, transfer = make_transfer()
+    config = mooncake_store.ReplicateConfig()
+    config.replica_num = 2
+    config.group_ids = ["rollout-group"]
+    payload = structured_payload(
+        {"kind": "replicated"},
+        large=np.arange(64, dtype=np.uint8),
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    grouped_configs = [
+        seen_config
+        for seen_config in store.batch_put_from_configs
+        if seen_config is not None and hasattr(seen_config, "group_ids")
+    ]
+    assert any(len(seen_config.group_ids) > 1 for seen_config in grouped_configs)
+    assert all(
+        set(seen_config.group_ids) == {"rollout-group"}
+        for seen_config in grouped_configs
+    )
+    assert all(seen_config.replica_num == 2 for seen_config in grouped_configs)
+    assert config.group_ids == ["rollout-group"]
+
+
+def test_structured_object_expands_group_id_for_chunk_batch_put() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(["rollout-group"])
+    payload = structured_payload(
+        {"kind": "grouped"},
+        large=np.arange(64, dtype=np.uint8),
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert any(len(group_ids) > 1 for group_ids in batch_group_ids)
+    assert all(set(group_ids) == {"rollout-group"} for group_ids in batch_group_ids)
+    manifest_group_ids = _seen_group_ids(store.put_configs)[-1]
+    assert manifest_group_ids == ["rollout-group"]
+
+
+def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
+    pool = FakeBufferPool()
+    store, transfer = make_transfer(buffer_pool=pool)
+    config = GroupConfig(["rollout-group"])
+    first = np.arange(4, dtype=np.int32)
+    second = np.arange(4, 8, dtype=np.int32)
+    multi = sos._MultiBufferPayload(
+        buffers=(
+            memoryview(first.reshape(-1).data).cast("B"),
+            memoryview(second.reshape(-1).data).cast("B"),
+        ),
+        owners=(first, second),
+        dtype=first.dtype.str,
+        shape=(8,),
+    )
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "multi"}, values=multi),
+        chunk_bytes=64,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["values"].tolist() == list(range(8))
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert batch_group_ids
+    assert all(group_ids == ["rollout-group"] for group_ids in batch_group_ids)
+
+
+def test_dataproto_append_updates_manifest_with_grouped_config() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(["rollout-group"])
+    ref = transfer.put(
+        {"input_ids": np.arange(6, dtype=np.int64).reshape(3, 2)},
+        type="dict",
+        stage="rollout",
+        chunk_bytes=16,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    old_manifest_key = ref.stage_refs["rollout"].manifest_key
+
+    ref = transfer.append_dataproto_fields(
+        ref,
+        SimpleDataProto(batch={"rewards": np.arange(3, dtype=np.float32)}),
+        stage="rollout",
+        chunk_bytes=16,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.get(ref, type="dict")
+    view = transfer.dataproto_manifest_view(ref)
+
+    assert ref.stage_refs["rollout"].manifest_key != old_manifest_key
+    assert np.array_equal(
+        result["input_ids"], np.arange(6, dtype=np.int64).reshape(3, 2)
+    )
+    assert np.array_equal(result["rewards"], np.arange(3, dtype=np.float32))
+    assert set(view["batch_fields"]) == {"input_ids", "rewards"}
+    stage_manifest = store.objects[ref.stage_refs["rollout"].manifest_key]
+    manifest = sos._decode_manifest(stage_manifest)
+    assert set(manifest["buffers"]) == {"batch.input_ids", "batch.rewards"}
+    assert old_manifest_key in manifest["cleanup_keys"]
+    assert all(
+        set(group_ids) == {"rollout-group"}
+        for group_ids in _seen_group_ids(store.batch_put_from_configs)
+    )
+
+
+def test_structured_object_rejects_ambiguous_group_ids() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="config.group_ids"):
+        transfer.put_structured_object(
+            structured_payload({"kind": "bad"}, value=b"payload"),
+            config=GroupConfig(["group-a", "group-b"]),
+        )
 
 
 def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -535,6 +535,37 @@ def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
     assert all(group_ids == ["rollout-group"] for group_ids in batch_group_ids)
 
 
+def test_bundle_manifest_update_allows_meta_only_cleanup_keys() -> None:
+    store, transfer = make_transfer()
+    old_ref = transfer.put_structured_object(structured_payload({"kind": "old"}))
+    cleanup_keys = [
+        old_ref.manifest_key,
+        *transfer._bundle_store.payload_keys(old_ref.manifest["meta"]),
+    ]
+
+    merged_ref = transfer._bundle_store.put_bundle_manifest(
+        json.dumps({"kind": "merged"}, separators=(",", ":")).encode("utf-8"),
+        {},
+        partition="default",
+        chunk_bytes=None,
+        policy=None,
+        cleanup_keys=cleanup_keys,
+    )
+    result = transfer.materialize(transfer.read_spec(merged_ref))
+    manifest = sos._decode_manifest(store.objects[merged_ref.manifest_key])
+
+    assert result.metadata == {"kind": "merged"}
+    assert result.objects == {}
+    assert set(cleanup_keys).issubset(set(manifest["cleanup_keys"]))
+    assert old_ref.manifest["object_id"] in manifest["buffer_object_ids"]
+
+    transfer.remove_bundle(merged_ref)
+
+    assert old_ref.manifest_key not in store.objects
+    assert merged_ref.manifest_key not in store.objects
+    assert all(key not in store.objects for key in cleanup_keys)
+
+
 def test_dataproto_append_updates_manifest_with_grouped_config() -> None:
     store, transfer = make_transfer()
     config = GroupConfig(["rollout-group"])

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -43,6 +43,11 @@ class BadDataProto:
         pass
 
 
+class GroupConfig:
+    def __init__(self, group_ids) -> None:
+        self.group_ids = group_ids
+
+
 class InMemoryStore:
     def __init__(self) -> None:
         self.objects: dict[str, bytes] = {}
@@ -432,6 +437,152 @@ def write_manifest(
     store.objects[manifest_key] = json.dumps(manifest, separators=(",", ":")).encode(
         "utf-8"
     )
+
+
+def _seen_group_ids(configs: list[object]) -> list[list[str]]:
+    return [
+        list(config.group_ids)
+        for config in configs
+        if config is not None and hasattr(config, "group_ids")
+    ]
+
+
+def test_structured_object_expands_store_replicate_config() -> None:
+    mooncake_store = pytest.importorskip("mooncake.store")
+    store, transfer = make_transfer()
+    config = mooncake_store.ReplicateConfig()
+    config.replica_num = 2
+    config.group_ids = ["rollout-group"]
+    payload = structured_payload(
+        {"kind": "replicated"},
+        large=np.arange(64, dtype=np.uint8),
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    grouped_configs = [
+        seen_config
+        for seen_config in store.batch_put_from_configs
+        if seen_config is not None and hasattr(seen_config, "group_ids")
+    ]
+    assert any(len(seen_config.group_ids) > 1 for seen_config in grouped_configs)
+    assert all(
+        set(seen_config.group_ids) == {"rollout-group"}
+        for seen_config in grouped_configs
+    )
+    assert all(seen_config.replica_num == 2 for seen_config in grouped_configs)
+    assert config.group_ids == ["rollout-group"]
+
+
+def test_structured_object_expands_group_id_for_chunk_batch_put() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(["rollout-group"])
+    payload = structured_payload(
+        {"kind": "grouped"},
+        large=np.arange(64, dtype=np.uint8),
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert any(len(group_ids) > 1 for group_ids in batch_group_ids)
+    assert all(set(group_ids) == {"rollout-group"} for group_ids in batch_group_ids)
+    manifest_group_ids = _seen_group_ids(store.put_configs)[-1]
+    assert manifest_group_ids == ["rollout-group"]
+
+
+def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
+    pool = FakeBufferPool()
+    store, transfer = make_transfer(buffer_pool=pool)
+    config = GroupConfig(["rollout-group"])
+    first = np.arange(4, dtype=np.int32)
+    second = np.arange(4, 8, dtype=np.int32)
+    multi = sos._MultiBufferPayload(
+        buffers=(
+            memoryview(first.reshape(-1).data).cast("B"),
+            memoryview(second.reshape(-1).data).cast("B"),
+        ),
+        owners=(first, second),
+        dtype=first.dtype.str,
+        shape=(8,),
+    )
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "multi"}, values=multi),
+        chunk_bytes=64,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["values"].tolist() == list(range(8))
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert batch_group_ids
+    assert all(group_ids == ["rollout-group"] for group_ids in batch_group_ids)
+
+
+def test_dataproto_append_updates_manifest_with_grouped_config() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig(["rollout-group"])
+    ref = transfer.put(
+        {"input_ids": np.arange(6, dtype=np.int64).reshape(3, 2)},
+        type="dict",
+        stage="rollout",
+        chunk_bytes=16,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    old_manifest_key = ref.stage_refs["rollout"].manifest_key
+
+    ref = transfer.append_dataproto_fields(
+        ref,
+        SimpleDataProto(batch={"rewards": np.arange(3, dtype=np.float32)}),
+        stage="rollout",
+        chunk_bytes=16,
+        policy=BundleTransferPolicy(put_mode="batch"),
+        config=config,
+    )
+    result = transfer.get(ref, type="dict")
+    view = transfer.dataproto_manifest_view(ref)
+
+    assert ref.stage_refs["rollout"].manifest_key != old_manifest_key
+    assert np.array_equal(
+        result["input_ids"], np.arange(6, dtype=np.int64).reshape(3, 2)
+    )
+    assert np.array_equal(result["rewards"], np.arange(3, dtype=np.float32))
+    assert set(view["batch_fields"]) == {"input_ids", "rewards"}
+    stage_manifest = store.objects[ref.stage_refs["rollout"].manifest_key]
+    manifest = sos._decode_manifest(stage_manifest)
+    assert set(manifest["buffers"]) == {"batch.input_ids", "batch.rewards"}
+    assert old_manifest_key in manifest["cleanup_keys"]
+    assert all(
+        set(group_ids) == {"rollout-group"}
+        for group_ids in _seen_group_ids(store.batch_put_from_configs)
+    )
+
+
+def test_structured_object_rejects_ambiguous_group_ids() -> None:
+    _store, transfer = make_transfer()
+
+    with pytest.raises(ValueError, match="config.group_ids"):
+        transfer.put_structured_object(
+            structured_payload({"kind": "bad"}, value=b"payload"),
+            config=GroupConfig(["group-a", "group-b"]),
+        )
 
 
 def test_put_object_roundtrips_numpy_and_torch_tensor_fields() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -592,8 +592,15 @@ def test_structured_object_normalizes_string_group_id() -> None:
     assert config.group_ids == "rollout-group"
 
 
-def test_structured_object_preserves_empty_group_ids_as_ungrouped() -> None:
-    store, transfer = make_transfer()
+def test_structured_object_normalizes_empty_group_ids_as_ungrouped() -> None:
+    class StrictGroupStore(InMemoryStore):
+        def put(self, key: str, value, config=None) -> int:
+            group_ids = getattr(config, "group_ids", None)
+            if group_ids is not None and len(group_ids) != 1:
+                raise ValueError("group_ids must match the number of keys")
+            return super().put(key, value, config=config)
+
+    store, transfer = make_transfer(StrictGroupStore())
     config = GroupConfig([])
 
     ref = transfer.put_structured_object(
@@ -603,8 +610,9 @@ def test_structured_object_preserves_empty_group_ids_as_ungrouped() -> None:
     result = transfer.materialize(transfer.read_spec(ref))
 
     assert result.objects["value"] == b"payload"
-    assert _seen_group_ids(store.put_configs)
-    assert all(group_ids == [] for group_ids in _seen_group_ids(store.put_configs))
+    seen_configs = [seen for seen in store.put_configs if seen is not None]
+    assert seen_configs
+    assert all(seen.group_ids is None for seen in seen_configs)
     assert config.group_ids == []
 
 

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -466,15 +466,24 @@ def _seen_group_ids(configs: list[object]) -> list[list[str]]:
     ]
 
 
+def _multi_buffer_payload(values: range) -> sos._MultiBufferPayload:
+    arrays = tuple(np.asarray([value], dtype=np.int32) for value in values)
+    return sos._MultiBufferPayload(
+        buffers=tuple(memoryview(array.data).cast("B") for array in arrays),
+        owners=arrays,
+        dtype=arrays[0].dtype.str,
+        shape=(len(arrays),),
+    )
+
+
 def test_structured_object_expands_store_replicate_config() -> None:
     mooncake_store = pytest.importorskip("mooncake.store")
-    store, transfer = make_transfer()
+    store, transfer = make_transfer(buffer_pool=FakeBufferPool())
     config = mooncake_store.ReplicateConfig()
     config.replica_num = 2
     config.group_ids = ["rollout-group"]
     payload = structured_payload(
-        {"kind": "replicated"},
-        large=np.arange(64, dtype=np.uint8),
+        {"kind": "replicated"}, values=_multi_buffer_payload(range(8))
     )
 
     ref = transfer.put_structured_object(
@@ -485,27 +494,31 @@ def test_structured_object_expands_store_replicate_config() -> None:
     )
     result = transfer.materialize(transfer.read_spec(ref))
 
-    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    assert result.objects["values"].tolist() == list(range(8))
     grouped_configs = [
         seen_config
         for seen_config in store.batch_put_from_configs
         if seen_config is not None and hasattr(seen_config, "group_ids")
     ]
-    assert any(len(seen_config.group_ids) > 1 for seen_config in grouped_configs)
+    assert grouped_configs
     assert all(
-        set(seen_config.group_ids) == {"rollout-group"}
+        list(seen_config.group_ids) == ["rollout-group"]
         for seen_config in grouped_configs
     )
     assert all(seen_config.replica_num == 2 for seen_config in grouped_configs)
     assert config.group_ids == ["rollout-group"]
+    expanded = sos._config_for_grouped_keys(config, 2)
+    assert expanded is not config
+    assert list(expanded.group_ids) == ["rollout-group", "rollout-group"]
+    assert expanded.replica_num == 2
+    assert config.group_ids == ["rollout-group"]
 
 
-def test_structured_object_expands_group_id_for_chunk_batch_put() -> None:
-    store, transfer = make_transfer()
+def test_structured_object_preserves_group_id_for_streamed_batch_put() -> None:
+    store, transfer = make_transfer(buffer_pool=FakeBufferPool())
     config = GroupConfig(["rollout-group"])
     payload = structured_payload(
-        {"kind": "grouped"},
-        large=np.arange(64, dtype=np.uint8),
+        {"kind": "grouped"}, values=_multi_buffer_payload(range(8))
     )
 
     ref = transfer.put_structured_object(
@@ -516,29 +529,113 @@ def test_structured_object_expands_group_id_for_chunk_batch_put() -> None:
     )
     result = transfer.materialize(transfer.read_spec(ref))
 
-    assert np.array_equal(result.objects["large"], payload.buffers["large"])
+    assert result.objects["values"].tolist() == list(range(8))
     batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
-    assert any(len(group_ids) > 1 for group_ids in batch_group_ids)
-    assert all(set(group_ids) == {"rollout-group"} for group_ids in batch_group_ids)
+    assert batch_group_ids
+    assert all(group_ids == ["rollout-group"] for group_ids in batch_group_ids)
     manifest_group_ids = _seen_group_ids(store.put_configs)[-1]
     assert manifest_group_ids == ["rollout-group"]
+
+
+def test_structured_object_direct_copy_preserves_group_id(monkeypatch) -> None:
+    def copy_arrays(arrays, destination, expected_bytes, start, count):
+        payload = b"".join(
+            bytes(memoryview(array.data).cast("B"))
+            for array in arrays[start : start + count]
+        )
+        assert len(payload) == expected_bytes
+        ctypes.memmove(destination, payload, len(payload))
+        return len(payload)
+
+    monkeypatch.setattr(sos, "_concat_arrays_into", copy_arrays)
+    pool = FakeBufferPool()
+    store, transfer = make_transfer(buffer_pool=pool)
+    config = GroupConfig(["rollout-group"])
+    arrays = [
+        np.asarray([1, 2], dtype=np.int32),
+        np.asarray([3, 4], dtype=np.int32),
+    ]
+    values = sos._DirectCopyPayload.from_flat_arrays(
+        arrays, np.dtype(np.int32), total_elems=4
+    )
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "direct"}, values=values),
+        chunk_bytes=8,
+        config=config,
+    )
+    assert store.batch_put_from_calls > 0
+    assert pool.acquire_count == pool.release_count > 0
+    assert store.register_buffer_calls == store.unregister_buffer_calls == 0
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["values"].tolist() == [1, 2, 3, 4]
+    group_ids = _seen_group_ids(
+        [*store.put_configs, *store.batch_put_from_configs]
+    )
+    assert group_ids
+    assert all(ids == ["rollout-group"] for ids in group_ids)
+
+
+def test_structured_object_normalizes_string_group_id() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig("rollout-group")
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "grouped"}, value=b"payload"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["value"] == b"payload"
+    assert _seen_group_ids(store.put_configs)[-1] == ["rollout-group"]
+    assert config.group_ids == "rollout-group"
+
+
+def test_structured_object_preserves_empty_group_ids_as_ungrouped() -> None:
+    store, transfer = make_transfer()
+    config = GroupConfig([])
+
+    ref = transfer.put_structured_object(
+        structured_payload({"kind": "ungrouped"}, value=b"payload"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["value"] == b"payload"
+    assert _seen_group_ids(store.put_configs)
+    assert all(group_ids == [] for group_ids in _seen_group_ids(store.put_configs))
+    assert config.group_ids == []
+
+
+def test_structured_object_parallel_put_preserves_group_id() -> None:
+    store, transfer = make_transfer(buffer_pool=FakeBufferPool())
+    config = GroupConfig(["rollout-group"])
+    payload = structured_payload(
+        {"kind": "parallel"}, values=_multi_buffer_payload(range(8))
+    )
+
+    ref = transfer.put_structured_object(
+        payload,
+        chunk_bytes=8,
+        policy=BundleTransferPolicy(max_inflight_put=4, put_mode="parallel"),
+        config=config,
+    )
+    result = transfer.materialize(transfer.read_spec(ref))
+
+    assert result.objects["values"].tolist() == list(range(8))
+    assert store.max_active_puts > 1
+    batch_group_ids = _seen_group_ids(store.batch_put_from_configs)
+    assert batch_group_ids
+    assert all(set(group_ids) == {"rollout-group"} for group_ids in batch_group_ids)
+    assert config.group_ids == ["rollout-group"]
 
 
 def test_structured_object_multi_buffer_put_preserves_group_id() -> None:
     pool = FakeBufferPool()
     store, transfer = make_transfer(buffer_pool=pool)
     config = GroupConfig(["rollout-group"])
-    first = np.arange(4, dtype=np.int32)
-    second = np.arange(4, 8, dtype=np.int32)
-    multi = sos._MultiBufferPayload(
-        buffers=(
-            memoryview(first.reshape(-1).data).cast("B"),
-            memoryview(second.reshape(-1).data).cast("B"),
-        ),
-        owners=(first, second),
-        dtype=first.dtype.str,
-        shape=(8,),
-    )
+    multi = _multi_buffer_payload(range(8))
 
     ref = transfer.put_structured_object(
         structured_payload({"kind": "multi"}, values=multi),
@@ -619,10 +716,39 @@ def test_dataproto_append_updates_manifest_with_grouped_config() -> None:
     manifest = sos._decode_manifest(stage_manifest)
     assert set(manifest["buffers"]) == {"batch.input_ids", "batch.rewards"}
     assert old_manifest_key in manifest["cleanup_keys"]
-    assert all(
-        set(group_ids) == {"rollout-group"}
-        for group_ids in _seen_group_ids(store.batch_put_from_configs)
+    write_group_ids = _seen_group_ids(
+        [*store.put_configs, *store.batch_put_from_configs]
     )
+    assert write_group_ids
+    assert all(group_ids == ["rollout-group"] for group_ids in write_group_ids)
+
+
+def test_dataproto_repeated_same_stage_append_preserves_cleanup_lineage() -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(4, dtype=np.int64)}),
+        stage="rollout",
+    )
+    initial_manifest_key = ref.stage_refs["rollout"].manifest_key
+    ref = transfer.append_dataproto_fields(
+        ref,
+        SimpleDataProto(batch={"values": np.arange(4, dtype=np.float32)}),
+        stage="rollout",
+    )
+    first_merged_manifest_key = ref.stage_refs["rollout"].manifest_key
+    ref = transfer.append_dataproto_fields(
+        ref,
+        SimpleDataProto(batch={"rewards": np.arange(4, dtype=np.float32)}),
+        stage="rollout",
+    )
+    final_manifest = sos._decode_manifest(
+        store.objects[ref.stage_refs["rollout"].manifest_key]
+    )
+
+    assert initial_manifest_key in final_manifest["cleanup_keys"]
+    assert first_merged_manifest_key in final_manifest["cleanup_keys"]
+    transfer.cleanup_dataproto(ref)
+    assert store.objects == {}
 
 
 def test_structured_object_rejects_ambiguous_group_ids() -> None:


### PR DESCRIPTION
## Description

### Motivation

Structured object transfer may fan out one logical object into multiple physical Mooncake Store keys, including metadata, payload chunks, multi-buffer chunks, and the final manifest. When callers pass a `ReplicateConfig` with `group_ids`, Mooncake Store batch APIs require the number of group IDs to match the physical key count.

Before this change, structured object writes did not consistently preserve group semantics across all internal write paths, especially multi-buffer writes and manifest updates during append. This could make grouped placement/replication semantics incomplete for structured rollout-data transfer.

### Description

This PR adds grouped write support for structured objects.

- Expands one logical `config.group_ids` value across the physical keys written by structured object batch paths.
- Preserves `config` through multi-buffer PUT paths.
- Ensures structured object manifest writes, including append-generated manifests, are written with the same group semantics.
- Allows manifest updates to keep cleanup-only object IDs in `buffer_object_ids`, so append/merge manifests remain valid even when old stage keys are only cleanup targets.
- Supports real `mooncake.store.ReplicateConfig`, including the pybind object case where `copy.copy()` is not available.
- Rejects ambiguous structured object configs with multiple logical group IDs, since one structured object should map to one logical group.

This is a focused Python wheel change for structured object transfer semantics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
python3 -m py_compile mooncake-wheel/mooncake/structured_object_store.py mooncake-wheel/tests/test_structured_object_store.py

cd mooncake-wheel
PYTHONPATH=. python3 -m pytest tests/test_structured_object_store.py -q -k "group or replicate_config or appends_stage_fields_without_rewriting_existing or overwrite_replaces_encoded_metadata or cleanup_removes_all_stage_objects or typed_ragged_uses_multi_buffer_put"
PYTHONPATH=. python3 -m pytest tests/test_structured_object_store.py -q -k "not real_store"
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done

Result:
```text
12 passed, 101 deselected in 2.14s
88 passed, 15 skipped, 10 deselected, 14 warnings in 12.54s
```

Additional checks:
```text
git diff --check: passed
py_compile: passed
```

Note:
```text
The full test_structured_object_store.py run includes real-store setup tests that can hang in this test environment. The focused regression suite and the non-real-store structured object suite passed. The skipped tests are caused by the local torch/CUDA import environment.
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to implement the focused structured object group semantics patch, run targeted validation, perform self-review, and prepare this PR description.
