### PR TITLE
[Store] Fix null-ptr crash in PrepareStorageBackend

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -661,6 +661,17 @@ class Client {
            const std::map<std::string, std::string>& labels = {},
            const std::string& tenant_id = "default");
 
+    /**
+     * @brief Prepare and use the storage backend for persisting data.
+     * Exposed to subclasses for testing only.
+     * @return ErrorCode::OK on success. On failure no storage backend is
+     * retained, so persistence stays disabled.
+     */
+    ErrorCode PrepareStorageBackend(const std::string& storage_root_dir,
+                                    const std::string& fsdir,
+                                    bool enable_eviction = true,
+                                    uint64_t quota_bytes = 0);
+
    private:
     /**
      * @brief Internal helper functions for initialization and data transfer
@@ -684,14 +695,6 @@ class Client {
     ErrorCode TransferReadRange(const Replica::Descriptor& replica_descriptor,
                                 std::vector<Slice>& slices,
                                 uint64_t src_offset);
-
-    /**
-     * @brief Prepare and use the storage backend for persisting data
-     */
-    void PrepareStorageBackend(const std::string& storage_root_dir,
-                               const std::string& fsdir,
-                               bool enable_eviction = true,
-                               uint64_t quota_bytes = 0);
 
     void PutToLocalFile(const std::string& object_key,
                         const std::vector<Slice>& slices,

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -427,28 +427,39 @@ class StorageBackend {
      * @param fsdir  subdirectory name
      * @param enable_eviction Whether to enable disk eviction feature (default:
      * true) Note: Eviction is controlled by the enable_eviction parameter
-     * @return shared_ptr to new instance or nullptr if directory is invalid
+     * @return shared_ptr to new instance, or INVALID_PARAMS if the
+     * configuration is invalid
      *
      * Performs validation of the root directory before creating the instance:
      * - Verifies directory exists
      * - Verifies path is actually a directory
+     * - Verifies fsdir is not empty
      */
-    static std::shared_ptr<StorageBackend> Create(const std::string& root_dir,
-                                                  const std::string& fsdir,
-                                                  bool enable_eviction = true) {
+    static tl::expected<std::shared_ptr<StorageBackend>, ErrorCode> Create(
+        const std::string& root_dir, const std::string& fsdir,
+        bool enable_eviction = true) {
         namespace fs = std::filesystem;
-        if (!fs::exists(root_dir)) {
-            LOG(INFO) << "Root directory does not exist: " << root_dir;
-            return nullptr;
-        } else if (!fs::is_directory(root_dir)) {
-            LOG(INFO) << "Root path is not a directory: " << root_dir;
-            return nullptr;
-        } else if (fsdir.empty()) {
-            LOG(INFO) << "FSDIR cannot be empty";
-            return nullptr;
+        std::error_code ec;
+        const auto root_status = fs::status(root_dir, ec);
+        if (ec) {
+            LOG(ERROR) << "Failed to access root directory: " << root_dir
+                       << " (error: " << ec.message() << ")";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-
-        fs::path root_path(root_dir);
+        if (!fs::exists(root_status)) {
+            LOG(ERROR) << "Root directory does not exist: " << root_dir
+                       << ". Please create it first or fix the configured "
+                          "storage root directory.";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        if (!fs::is_directory(root_status)) {
+            LOG(ERROR) << "Root path is not a directory: " << root_dir;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        if (fsdir.empty()) {
+            LOG(ERROR) << "FSDIR cannot be empty";
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
 
         std::string real_fsdir = "moon_" + fsdir;
         return std::make_shared<StorageBackend>(root_dir, real_fsdir,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -917,8 +917,15 @@ std::optional<std::shared_ptr<Client>> Client::Create(
                 LOG(INFO) << "Storage root directory is: " << storage_root_dir;
                 LOG(INFO) << "Fs subdir is: " << fs_subdir;
                 // Initialize storage backend with default eviction settings
-                client->PrepareStorageBackend(storage_root_dir, fs_subdir, true,
-                                              0);
+                auto prep_err = client->PrepareStorageBackend(
+                    storage_root_dir, fs_subdir, true, 0);
+                if (prep_err != ErrorCode::OK) {
+                    LOG(ERROR)
+                        << "Failed to initialize storage backend: " << prep_err
+                        << ". Persistence was requested via fsdir but is "
+                           "unavailable.";
+                    return std::nullopt;
+                }
             } else {
                 LOG(ERROR) << "Invalid fsdir format: " << dir_string;
             }
@@ -940,9 +947,16 @@ std::optional<std::shared_ptr<Client>> Client::Create(
                           << config.enable_disk_eviction;
                 LOG(INFO) << "Quota bytes: " << config.quota_bytes;
                 // Initialize storage backend with config from master
-                client->PrepareStorageBackend(storage_root_dir, fs_subdir,
-                                              config.enable_disk_eviction,
-                                              config.quota_bytes);
+                auto prep_err = client->PrepareStorageBackend(
+                    storage_root_dir, fs_subdir, config.enable_disk_eviction,
+                    config.quota_bytes);
+                if (prep_err != ErrorCode::OK) {
+                    LOG(ERROR)
+                        << "Failed to initialize storage backend: " << prep_err
+                        << ". Persistence was requested via storage config "
+                           "but is unavailable.";
+                    return std::nullopt;
+                }
             } else {
                 LOG(ERROR) << "Invalid fsdir format: " << config.fsdir;
             }
@@ -3348,20 +3362,32 @@ tl::expected<void, ErrorCode> Client::MarkTaskToComplete(
     return master_client_.MarkTaskToComplete(update_request);
 }
 
-void Client::PrepareStorageBackend(const std::string& storage_root_dir,
-                                   const std::string& fsdir,
-                                   bool enable_eviction, uint64_t quota_bytes) {
+ErrorCode Client::PrepareStorageBackend(const std::string& storage_root_dir,
+                                        const std::string& fsdir,
+                                        bool enable_eviction,
+                                        uint64_t quota_bytes) {
     // Initialize storage backend
-    storage_backend_ =
+    auto backend_result =
         StorageBackend::Create(storage_root_dir, fsdir, enable_eviction);
-    if (!storage_backend_) {
-        LOG(INFO) << "Failed to initialize storage backend";
+    if (!backend_result) {
+        LOG(ERROR) << "Failed to create storage backend: "
+                   << backend_result.error();
+        return backend_result.error();
     }
-    auto init_result = storage_backend_->Init(quota_bytes);
+    // Initialize into a local first and only publish to storage_backend_
+    // after a successful Init(): users of storage_backend_ only null-check
+    // it, so it must never point to a backend whose Init() failed (using it
+    // before successful Init() is undefined behavior). If Init() throws,
+    // stack unwinding destroys the local and storage_backend_ stays clean.
+    auto backend = std::move(backend_result.value());
+    auto init_result = backend->Init(quota_bytes);
     if (!init_result) {
         LOG(ERROR) << "Failed to initialize StorageBackend. Error: "
                    << init_result.error() << ". The backend will be unusable.";
+        return init_result.error();
     }
+    storage_backend_ = std::move(backend);
+    return ErrorCode::OK;
 }
 
 void Client::PutToLocalFile(const std::string& key,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -928,6 +928,7 @@ std::optional<std::shared_ptr<Client>> Client::Create(
                 }
             } else {
                 LOG(ERROR) << "Invalid fsdir format: " << dir_string;
+                return std::nullopt;
             }
         }
     } else {
@@ -959,6 +960,7 @@ std::optional<std::shared_ptr<Client>> Client::Create(
                 }
             } else {
                 LOG(ERROR) << "Invalid fsdir format: " << config.fsdir;
+                return std::nullopt;
             }
         }
     }

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1356,6 +1356,22 @@ StorageBackendAdaptor::StorageBackendAdaptor(
       total_size(0) {}
 
 tl::expected<void, ErrorCode> StorageBackendAdaptor::Init() {
+    namespace fs = std::filesystem;
+    // Validate obviously invalid configuration up front. A missing root
+    // directory is fine: StorageBackend::Init() creates it on demand.
+    std::error_code ec;
+    const auto root_status =
+        fs::status(file_storage_config_.storage_filepath, ec);
+    if (!ec && fs::exists(root_status) && !fs::is_directory(root_status)) {
+        LOG(ERROR) << "Storage path exists but is not a directory: "
+                   << file_storage_config_.storage_filepath;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (file_per_key_config_.fsdir.empty()) {
+        LOG(ERROR) << "FSDIR cannot be empty";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
     std::string storage_root =
         file_storage_config_.storage_filepath + file_per_key_config_.fsdir;
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
+add_store_test(client_storage_backend_test client_storage_backend_test.cpp)
 add_store_test(mutex_test mutex_test.cpp)
 add_store_test(file_storage_test file_storage_test.cpp)
 add_store_test(task_manager_test task_manager_test.cpp)

--- a/mooncake-store/tests/client_storage_backend_test.cpp
+++ b/mooncake-store/tests/client_storage_backend_test.cpp
@@ -1,0 +1,54 @@
+// Regression tests for Client::PrepareStorageBackend (issue #3134): an
+// invalid storage configuration must surface as an error instead of
+// dereferencing a null backend or leaving a half-initialized one behind.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "client_service.h"
+
+namespace mooncake {
+namespace {
+
+class TestableClient : public Client {
+   public:
+    TestableClient()
+        : Client(/*local_hostname=*/"localhost:9003",
+                 /*metadata_connstring=*/"",
+                 /*protocol=*/"tcp",
+                 /*labels=*/{}) {}
+
+    using Client::PrepareStorageBackend;
+};
+
+TEST(ClientPrepareStorageBackendTest, InvalidRootDirReturnsErrorWithoutCrash) {
+    TestableClient client;
+    // Before the fix this dereferenced a null StorageBackend and crashed.
+    ErrorCode err = client.PrepareStorageBackend(
+        "/nonexistent_mooncake_store_test_path/12345", "fsdir", true, 0);
+    EXPECT_NE(err, ErrorCode::OK);
+}
+
+TEST(ClientPrepareStorageBackendTest, EmptyFsdirReturnsErrorWithoutCrash) {
+    TestableClient client;
+    ErrorCode err = client.PrepareStorageBackend(
+        std::filesystem::current_path().string(), "", true, 0);
+    EXPECT_NE(err, ErrorCode::OK);
+}
+
+TEST(ClientPrepareStorageBackendTest, ValidRootDirSucceeds) {
+    std::string root = std::filesystem::current_path().string() +
+                       "/data/client_prepare_storage_backend_test";
+    std::filesystem::create_directories(root);
+
+    TestableClient client;
+    EXPECT_EQ(client.PrepareStorageBackend(root, "fsdir", true, 0),
+              ErrorCode::OK);
+
+    std::filesystem::remove_all(root);
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <limits>
 #include <ranges>
@@ -154,6 +155,85 @@ class StorageBackendTest : public ::testing::Test {
         }
     }
 };
+
+// Regression tests for StorageBackend::Create validation (issue #3134):
+// invalid configuration must be reported as INVALID_PARAMS instead of
+// producing a nullptr that callers may dereference.
+TEST_F(StorageBackendTest, CreateRejectsNonexistentRootDir) {
+    auto result = StorageBackend::Create(data_path + "/does/not/exist/12345",
+                                         "fsdir", true);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(StorageBackendTest, CreateRejectsRootDirThatIsAFile) {
+    std::string file_path = data_path + "/root_is_a_file";
+    {
+        std::ofstream ofs(file_path);
+        ofs << "not a directory";
+    }
+    auto result = StorageBackend::Create(file_path, "fsdir", true);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(StorageBackendTest, CreateRejectsEmptyFsdir) {
+    auto result = StorageBackend::Create(data_path, "", true);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(StorageBackendTest, CreateAcceptsValidConfig) {
+    auto result = StorageBackend::Create(data_path, "fsdir", true);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NE(result.value(), nullptr);
+}
+
+// Regression tests for StorageBackendAdaptor::Init validation (issue #3134
+// follow-up): obviously invalid configuration must be reported as
+// INVALID_PARAMS, while a missing root directory is still auto-created.
+TEST_F(StorageBackendTest, AdaptorInitRejectsStoragePathThatIsAFile) {
+    std::string file_path = data_path + "/storage_path_is_a_file";
+    {
+        std::ofstream ofs(file_path);
+        ofs << "not a directory";
+    }
+    FileStorageConfig cfg;
+    cfg.storage_filepath = file_path;
+    FilePerKeyConfig file_per_key_config;
+    file_per_key_config.fsdir = "file_per_key_dir";
+    file_per_key_config.enable_eviction = false;
+
+    StorageBackendAdaptor adaptor(cfg, file_per_key_config);
+    auto init_result = adaptor.Init();
+    ASSERT_FALSE(init_result.has_value());
+    EXPECT_EQ(init_result.error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(StorageBackendTest, AdaptorInitRejectsEmptyFsdir) {
+    FileStorageConfig cfg;
+    cfg.storage_filepath = data_path;
+    FilePerKeyConfig file_per_key_config;
+    file_per_key_config.fsdir = "";
+    file_per_key_config.enable_eviction = false;
+
+    StorageBackendAdaptor adaptor(cfg, file_per_key_config);
+    auto init_result = adaptor.Init();
+    ASSERT_FALSE(init_result.has_value());
+    EXPECT_EQ(init_result.error(), ErrorCode::INVALID_PARAMS);
+}
+
+TEST_F(StorageBackendTest, AdaptorInitCreatesMissingRootDir) {
+    FileStorageConfig cfg;
+    cfg.storage_filepath = data_path + "/auto_created_root";
+    FilePerKeyConfig file_per_key_config;
+    file_per_key_config.fsdir = "file_per_key_dir";
+    file_per_key_config.enable_eviction = true;
+
+    StorageBackendAdaptor adaptor(cfg, file_per_key_config);
+    ASSERT_TRUE(adaptor.Init().has_value());
+    EXPECT_TRUE(fs::is_directory(cfg.storage_filepath));
+}
 
 TEST_F(StorageBackendTest, StorageBackendAll) {
     std::shared_ptr<SimpleAllocator> client_buffer_allocator =


### PR DESCRIPTION
## Description

Fixes #3134: `Client::PrepareStorageBackend` null-pointer dereference that causes a segmentation fault when the storage root directory is invalid.

### Root Cause

`StorageBackend::Create()` returns `nullptr` when `root_dir` does not exist, is not a directory, or `fsdir` is empty. `PrepareStorageBackend` logged but did not return, then called `storage_backend_->Init()` on the null pointer.

### Changes

1. **`StorageBackend::Create()`**: return `tl::expected<std::shared_ptr<StorageBackend>, ErrorCode>` instead of raw nullable pointer. Validation failures return `INVALID_PARAMS` with descriptive `LOG(ERROR)` messages (including `std::error_code::message()` for permissions errors).

2. **`Client::PrepareStorageBackend()`**: return `ErrorCode` instead of `void`. On `Create()` or `Init()` failure, reset `storage_backend_` to `nullptr` (so all existing null-guards work) and propagate the error.

3. **`Client::Create()` two call sites**: check `PrepareStorageBackend` return value; fail fast with `LOG(ERROR)` and `return std::nullopt` when storage initialization fails. This is a behavioral change: a configured-but-broken `fsdir` now prevents client creation (fail-fast) instead of silently disabling persistence. When `fsdir` is empty (persistence not requested), behavior is unchanged.

4. **`StorageBackendAdaptor::Init()`**: reject `storage_filepath` that is a file (not a directory) and empty `fsdir` before constructing `StorageBackend`. A missing root directory is still auto-created (preserving `Init()`'s `create_directories` behavior).

### Behavioral Change

Before this PR: `Client::Create()` with an invalid `root_dir` causes a segmentation fault (null deref). After this PR: `Client::Create()` with an invalid `root_dir` returns `std::nullopt` with a logged error. Only affects deployments where `fsdir` was explicitly configured but the path is invalid.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix
- [x] Breaking change (see Behavioral Change above)

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-store/build
cmake .. -DBUILD_TESTS=ON && make -j storage_backend_test client_storage_backend_test
./tests/storage_backend_test
./tests/client_storage_backend_test
```

**New tests added:**

- `storage_backend_test.cpp`:
  - `CreateRejectsNonexistentRootDir`
  - `CreateRejectsRootDirThatIsAFile`
  - `CreateRejectsEmptyFsdir`
  - `CreateAcceptsValidConfig`
  - `AdaptorInitRejectsStoragePathThatIsAFile`
  - `AdaptorInitRejectsEmptyFsdir`
  - `AdaptorInitCreatesMissingRootDir`

- `client_storage_backend_test.cpp` (new file):
  - `InvalidRootDirReturnsErrorWithoutCrash`
  - `EmptyFsdirReturnsErrorWithoutCrash`
  - `ValidRootDirSucceeds`

**Test results:**
- [ ] Unit tests pass
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted with root cause analysis and code review. All code was written and reviewed by the human submitter.
