### PR TITLE
[Bugfix] Fix double free of UB/Barex slices on device-selection failure

### DIFF
--- a/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/barex_transport/barex_transport.cpp
@@ -1173,8 +1173,13 @@ Status BarexTransport::submitTransferTask(
             }
             if (!found_device) {
                 auto source_addr = slice->source_addr;
-                for (auto &entry : slices_to_post)
-                    for (auto s : entry.second) getSliceCache().deallocate(s);
+                // Do not deallocate slices already queued in slices_to_post
+                // here: every slice is also recorded in its owning
+                // TransferTask::slice_list right after allocation, and
+                // ~TransferTask() returns everything in slice_list to the
+                // cache exactly once. Deallocating here double-frees them
+                // into ThreadLocalSliceCache, letting a later allocate()
+                // hand the same Slice* to two unrelated transfers.
                 LOG(ERROR)
                     << "Memory region not registered by any active device(s): "
                     << source_addr;

--- a/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/kunpeng_transport/ub_transport.cpp
@@ -287,8 +287,13 @@ Status UbTransport::submitTransferTask(
             }
             if (device_id < 0) {
                 auto source_addr = slice->source_addr;
-                for (auto& entry : slices_to_post)
-                    for (auto s : entry.second) getSliceCache().deallocate(s);
+                // Do not deallocate slices already queued in slices_to_post
+                // here: every slice is also recorded in its owning
+                // TransferTask::slice_list right after allocation, and
+                // ~TransferTask() returns everything in slice_list to the
+                // cache exactly once. Deallocating here double-frees them
+                // into ThreadLocalSliceCache, letting a later allocate()
+                // hand the same Slice* to two unrelated transfers.
                 LOG(ERROR)
                     << "UbTransport: Address not registered by any device(s) "
                     << source_addr;


### PR DESCRIPTION
## Description

Sibling fix of #3125, which repaired this in `RdmaTransport`: on the device-selection failure path, `UbTransport::submitTransferTask` and `BarexTransport::submitTransferTask` both walk `slices_to_post` and deallocate every queued slice back into `ThreadLocalSliceCache`. Those slices are owned by their `TransferTask::slice_list` (pushed right after allocation), and `~TransferTask()` returns everything in `slice_list` to the cache exactly once when the failed task is torn down. The manual deallocate frees each slice a second time, so the same `Slice*` lands on the cache free list twice and a later `allocate()` can hand it to two unrelated transfers.

The fix mirrors #3125: drop the redundant deallocate and let the task destructor own cleanup.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Ownership audit only, no local build: `USE_UB` and `USE_BAREX` need the Kunpeng and Barex vendor SDKs, which I do not have on this machine. The change is a pure deletion of the redundant deallocate plus a comment, the identical fix #3125 shipped for `RdmaTransport` with a new gtest there; here every slice queued in `slices_to_post` was traced to its `task.slice_list.push_back(...)` right after `getSliceCache().allocate()` (main slice and the second/last fragment slices in Barex), and `~TransferTask()` in `transport.h` is the shared single-free owner.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`code_format.sh` needs clang-format-20, not available on this machine; the added lines are comments wrapped to match the file style. No new test: the vendor SDKs are required to compile either transport, and the behavior is already pinned by the ownership invariant `rdma_transport_submit_task_test.cpp` added in #3125.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Kimi Code (AI coding agent) helped locate the sibling sites and draft the edit. I verified the ownership chain by hand (allocation, slice_list registration, slices_to_post queueing, ~TransferTask teardown) and reviewed the final diff myself.