### PR TITLE
[Doc] Document master KV event publisher flags

### DIFF
--- a/docs/source/api-reference/http/conductor-indexer.md
+++ b/docs/source/api-reference/http/conductor-indexer.md
@@ -361,6 +361,7 @@ Registration metadata supplies fields such as `modelname`, `tenant_id`,
 `instance_id`, `block_size`, and `additionalsalt` when the engine event does
 not carry the full standardized envelope.
 
+(mooncake-store-master-publisher)=
 ### Mooncake Store master publisher
 
 `mooncake_master` can optionally publish RFC #1527 events when

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -525,6 +525,46 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 | `--enable_metric_reporting` | `true` | Periodically log master metrics |
 | `--metrics_port` | `9003` | HTTP port for `/metrics` endpoints |
 
+### KV Cache Event Publisher
+
+The master can publish RFC #1527 KV cache events over a ZMQ PUB socket for
+cache-aware indexers such as Mooncake Conductor. This feature is compiled out
+by default. Install `libzmq3-dev` and configure Mooncake Store with
+`-DENABLE_KV_EVENTS=ON` before enabling it at runtime.
+
+Both `--kv_events_bind_endpoint` and `--kv_events_backend_id` are required when
+the publisher is enabled. If either value is empty, or the ZMQ socket cannot
+bind, the master logs an error and continues with event publishing disabled.
+
+```bash
+mooncake_master \
+  --enable_kv_events=true \
+  --kv_events_bind_endpoint=tcp://0.0.0.0:5557 \
+  --kv_events_backend_id=store-node-1
+```
+
+Register an address reachable by the indexer, rather than the wildcard bind
+address, through the indexer's `POST /register` endpoint. For the event format,
+registration fields, and object-key behavior, see the
+[Mooncake Store master publisher](../api-reference/http/conductor-indexer.md#mooncake-store-master-publisher)
+reference.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--enable_kv_events` | `false` | Enable the RFC #1527 ZMQ publisher; requires a build with `ENABLE_KV_EVENTS=ON` |
+| `--kv_events_bind_endpoint` | empty | ZMQ PUB bind endpoint, for example `tcp://0.0.0.0:5557`; required when enabled |
+| `--kv_events_backend_id` | empty | Cache-owner identity emitted as `backend_id`; required when enabled |
+| `--kv_events_emit_legacy_compat` | `true` | Include vLLM/SGLang-compatible aliases such as `type` and `block_hashes` |
+| `--kv_events_emit_object_key` | `true` | Include the Mooncake `object_key`; unparsable sequence hashes are still published when this is enabled |
+| `--kv_events_queue_capacity` | `65536` | Maximum pending events; the publisher drops the oldest event when the queue is full. Set to `0` for an unbounded queue |
+
+The legacy flags `--kv_events_model_name`, `--kv_events_tenant_id`,
+`--kv_events_additional_salt`, `--kv_events_lora_name`,
+`--kv_events_block_size`, and `--kv_events_dp_rank` are retained for config
+compatibility but are not emitted in event payloads. Supply model, block-size,
+hash-namespace, LoRA, and data-parallel metadata when registering the publisher
+with the indexer; each event carries its object's tenant ID.
+
 ### HTTP Metadata Server (Embedded)
 
 | Flag | Default | Description |

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -545,9 +545,8 @@ mooncake_master \
 
 Register an address reachable by the indexer, rather than the wildcard bind
 address, through the indexer's `POST /register` endpoint. For the event format,
-registration fields, and object-key behavior, see the
-[Mooncake Store master publisher](../api-reference/http/conductor-indexer.md#mooncake-store-master-publisher)
-reference.
+registration fields, and object-key behavior, see the {ref}`Mooncake Store
+master publisher <mooncake-store-master-publisher>` reference.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -527,7 +527,7 @@ glog's standard flags (`--log_dir`, `--max_log_size`, `--logtostderr`, ...) cont
 
 ### KV Cache Event Publisher
 
-The master can publish RFC #1527 KV cache events over a ZMQ PUB socket for
+The master can publish KV cache lifecycle events over a ZMQ PUB socket for
 cache-aware indexers such as Mooncake Conductor. This feature is compiled out
 by default. Install `libzmq3-dev` and configure Mooncake Store with
 `-DENABLE_KV_EVENTS=ON` before enabling it at runtime.
@@ -550,7 +550,7 @@ master publisher <mooncake-store-master-publisher>` reference.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--enable_kv_events` | `false` | Enable the RFC #1527 ZMQ publisher; requires a build with `ENABLE_KV_EVENTS=ON` |
+| `--enable_kv_events` | `false` | Enable the ZMQ KV cache event publisher; requires a build with `ENABLE_KV_EVENTS=ON` |
 | `--kv_events_bind_endpoint` | empty | ZMQ PUB bind endpoint, for example `tcp://0.0.0.0:5557`; required when enabled |
 | `--kv_events_backend_id` | empty | Cache-owner identity emitted as `backend_id`; required when enabled |
 | `--kv_events_emit_legacy_compat` | `true` | Include vLLM/SGLang-compatible aliases such as `type` and `block_hashes` |

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -248,7 +248,8 @@ DEFINE_bool(kv_events_emit_legacy_compat, true,
 DEFINE_bool(kv_events_emit_object_key, true,
             "Include Mooncake object_key in published KV events");
 DEFINE_uint32(kv_events_queue_capacity, 65536,
-              "Deprecated; ignored (event queue is unbounded)");
+              "Maximum pending KV events; oldest events are dropped when "
+              "the queue is full (0 = unbounded)");
 DEFINE_string(ha_backend_type, "etcd",
               "HA backend type, e.g. etcd | redis | k8s");
 DEFINE_string(ha_backend_connstring, "",


### PR DESCRIPTION
## Description

Documents the currently shipped `mooncake_master` KV cache event publisher so its build-time requirement and runtime flags no longer drift from the implementation.

- adds the `ENABLE_KV_EVENTS=ON` / `libzmq3-dev` prerequisite and a minimal startup example
- documents required, compatibility, object-key, and queue-capacity flags
- explains which legacy identity flags are retained but no longer emitted
- adds a stable cross-reference to the existing Conductor publisher contract
- corrects the `--kv_events_queue_capacity` help text: the implementation uses it to bound the queue and drops the oldest event when full; `0` is unbounded

Root cause: the publisher landed with API/design documentation, but the deployment guide's master flag reference was not updated. The queue implementation and its gflag help also diverged.

This does not duplicate #2663. That PR proposes a separate logical-block/group publisher with `worker_id` support and does not update the current master startup guide, Conductor anchor, or `master.cpp` flag help covered here.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cd docs
make html SPHINXBUILD=.venv/bin/sphinx-build

pre-commit run --files \
  docs/source/api-reference/http/conductor-indexer.md \
  docs/source/deployment/mooncake-store-deployment-guide.md \
  mooncake-store/src/master.cpp
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done: inspected generated HTML and verified the deployment-guide link resolves to the Conductor publisher section

The Sphinx build succeeds. It reports seven environment-only warnings because the local proxy returns HTTP 403 for external intersphinx inventories; there are no local document or cross-reference warnings.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex audited the implementation and documentation for drift, authored the documentation/help-text update, checked related open work, and ran the validation commands above. The human submitter should review every changed line before marking this draft ready for review.