### PR TITLE
[Bugfix][TE] Respect remote_accessible in RDMA verbs MR registration

### DIFF
--- a/docs/source/api-reference/cpp/transfer-engine.md
+++ b/docs/source/api-reference/cpp/transfer-engine.md
@@ -182,6 +182,8 @@ Registers a space starting at address `addr` with a length of `length` on the lo
 - `length`: The length of the registration space;
 - `location`: The `device` corresponding to this memory segment, such as `cuda:0` indicating the GPU device, `cpu:0` indicating the CPU socket, by matching with the network card priority order table (see `installTransport`), the preferred network card is identified. You can also use `*`, Transfer Engine will try to automatically recognize the `device` corresponding to `addr`, if it fails to recognize the device, it will print a `WARNING` level log and use all network cards, no preferred network cards.
 - `remote_accessible`: Indicates whether this memory can be accessed by remote nodes.
+  For RDMA, `false` registers the buffer for local transfer use only: remote
+  read/write permissions are not granted and no `rkey` is published.
 - `update_metadata`: Whether to publish the registration to the metadata service.
 - Return value: If successful, returns 0; otherwise, returns a negative value.
 

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -324,6 +324,8 @@ static int encodeMultiProtocolSegmentDesc(
 
     Json::Value buffersJSON(Json::arrayValue);
     for (const auto &buffer : desc.buffers) {
+        if (buffer.protocol == "rdma" && buffer.rkey.empty()) continue;
+
         Json::Value bufferJSON;
         bufferJSON["name"] = buffer.name;
         bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
@@ -414,6 +416,8 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
 
         Json::Value buffersJSON(Json::arrayValue);
         for (const auto &buffer : desc.buffers) {
+            if (desc.protocol == "rdma" && buffer.rkey.empty()) continue;
+
             Json::Value bufferJSON;
             bufferJSON["name"] = buffer.name;
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -324,8 +324,6 @@ static int encodeMultiProtocolSegmentDesc(
 
     Json::Value buffersJSON(Json::arrayValue);
     for (const auto &buffer : desc.buffers) {
-        if (buffer.protocol == "rdma" && buffer.rkey.empty()) continue;
-
         Json::Value bufferJSON;
         bufferJSON["name"] = buffer.name;
         bufferJSON["length"] = static_cast<Json::UInt64>(buffer.length);
@@ -416,8 +414,6 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
 
         Json::Value buffersJSON(Json::arrayValue);
         for (const auto &buffer : desc.buffers) {
-            if (desc.protocol == "rdma" && buffer.rkey.empty()) continue;
-
             Json::Value bufferJSON;
             bufferJSON["name"] = buffer.name;
             bufferJSON["addr"] = static_cast<Json::UInt64>(buffer.addr);
@@ -677,8 +673,8 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                     static_cast<decltype(buffer.lkey)::value_type>(
                         lkeyJSON.asUInt64()));
             if (buffer.name.empty() || !buffer.addr || !buffer.length ||
-                buffer.rkey.empty() ||
-                buffer.rkey.size() != buffer.lkey.size()) {
+                (!buffer.rkey.empty() &&
+                 buffer.rkey.size() != buffer.lkey.size())) {
                 LOG(WARNING)
                     << "Corrupted segment descriptor, name " << segment_name
                     << " buffer_protocol " << buffer_protocol << ", "
@@ -801,8 +797,8 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                     static_cast<decltype(buffer.lkey)::value_type>(
                         lkeyJSON.asUInt64()));
             if (buffer.name.empty() || !buffer.addr || !buffer.length ||
-                buffer.rkey.empty() ||
-                buffer.rkey.size() != buffer.lkey.size()) {
+                (!buffer.rkey.empty() &&
+                 buffer.rkey.size() != buffer.lkey.size())) {
                 LOG(WARNING)
                     << "Corrupted segment descriptor, name " << segment_name
                     << " protocol " << desc->protocol << ", " << buffer.name

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -214,7 +214,6 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
                                                bool remote_accessible,
                                                bool update_metadata,
                                                bool force_sequential) {
-    BufferDesc buffer_desc;
     int access_rights = IBV_ACCESS_LOCAL_WRITE;
     if (remote_accessible)
         access_rights |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -214,12 +214,10 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
                                                bool remote_accessible,
                                                bool update_metadata,
                                                bool force_sequential) {
-    (void)remote_accessible;
-    const int kBaseAccessRights = IBV_ACCESS_LOCAL_WRITE |
-                                  IBV_ACCESS_REMOTE_WRITE |
-                                  IBV_ACCESS_REMOTE_READ;
-
-    int access_rights = kBaseAccessRights;
+    BufferDesc buffer_desc;
+    int access_rights = IBV_ACCESS_LOCAL_WRITE;
+    if (remote_accessible)
+        access_rights |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ;
     if (MCIbRelaxedOrderingEnabled) {
         access_rights |= IBV_ACCESS_RELAXED_ORDERING;
     }
@@ -416,7 +414,8 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
         BufferDesc buffer_desc;
         for (auto &context : context_list_) {
             buffer_desc.lkey.push_back(context->lkey(chunk_addr));
-            buffer_desc.rkey.push_back(context->rkey(chunk_addr));
+            if (remote_accessible)
+                buffer_desc.rkey.push_back(context->rkey(chunk_addr));
         }
         buffer_desc.name = resolved_name;
         buffer_desc.addr = (uint64_t)chunk_addr;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -63,9 +63,9 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
         auto hint = config.enable_dest_device_affinity
                         ? std::string_view(local_hca)
                         : std::string_view();
-        ret = RdmaTransport::selectDevice(peer_segment_desc, offset, length,
-                                          hint, buffer_id, device_id,
-                                          retry_count);
+        ret =
+            RdmaTransport::selectDevice(peer_segment_desc, offset, length, hint,
+                                        buffer_id, device_id, retry_count);
     }
     if (ret) return ret;
 
@@ -74,6 +74,9 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
         device_id < 0 ||
         static_cast<size_t>(device_id) >=
             peer_segment_desc->buffers[buffer_id].rkey.size()) {
+        LOG(ERROR) << "[RDMA] No rkey for MR access: seg="
+                   << (peer_segment_desc ? peer_segment_desc->name : "null")
+                   << " addr=" << (void *)offset << " len=" << length;
         return ERR_ADDRESS_NOT_REGISTERED;
     }
     return 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -54,16 +54,29 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
                             const std::string &local_hca, int &buffer_id,
                             int &device_id, int retry_count = 0) {
     const auto &config = globalConfig();
+    int ret = 0;
     if (config.enable_hca_peer_affinity) {
-        return RdmaTransport::selectDeviceByLocalHca(
+        ret = RdmaTransport::selectDeviceByLocalHca(
             peer_segment_desc, offset, length, local_hca, buffer_id, device_id,
             retry_count);
+    } else {
+        auto hint = config.enable_dest_device_affinity
+                        ? std::string_view(local_hca)
+                        : std::string_view();
+        ret = RdmaTransport::selectDevice(peer_segment_desc, offset, length,
+                                          hint, buffer_id, device_id,
+                                          retry_count);
     }
+    if (ret) return ret;
 
-    auto hint = config.enable_dest_device_affinity ? std::string_view(local_hca)
-                                                   : std::string_view();
-    return RdmaTransport::selectDevice(peer_segment_desc, offset, length, hint,
-                                       buffer_id, device_id, retry_count);
+    if (buffer_id < 0 ||
+        static_cast<size_t>(buffer_id) >= peer_segment_desc->buffers.size() ||
+        device_id < 0 ||
+        static_cast<size_t>(device_id) >=
+            peer_segment_desc->buffers[buffer_id].rkey.size()) {
+        return ERR_ADDRESS_NOT_REGISTERED;
+    }
+    return 0;
 }
 
 static bool workerCanPost(int thread_id) {

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -192,6 +192,30 @@ TEST_F(RdmaContextConstructionTest,
 #endif
 }
 
+TEST(RdmaMemoryRegistrationPolicyTest, LocalOnlyBufferHasNoPublishedRkey) {
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    auto local_desc = std::make_shared<TransferMetadata::SegmentDesc>();
+    local_desc->name = "local-rdma-segment";
+    local_desc->protocol = "rdma";
+    ASSERT_EQ(metadata->addLocalSegment(LOCAL_SEGMENT_ID,
+                                        "local-rdma-segment",
+                                        std::move(local_desc)),
+              0);
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindMetadata(transport, metadata,
+                                        "local-rdma-segment");
+    std::array<char, 1> buffer{};
+    ASSERT_EQ(transport.registerLocalMemory(buffer.data(), buffer.size(),
+                                            "cpu:0", false, false),
+              0);
+
+    auto desc = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(desc, nullptr);
+    ASSERT_EQ(desc->buffers.size(), 1);
+    EXPECT_TRUE(desc->buffers[0].rkey.empty());
+}
+
 ibv_gid makeGid(const std::array<uint8_t, 16> &bytes) {
     ibv_gid gid = {};
     std::memcpy(gid.raw, bytes.data(), bytes.size());

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -197,8 +197,7 @@ TEST(RdmaMemoryRegistrationPolicyTest, LocalOnlyBufferHasNoPublishedRkey) {
     auto local_desc = std::make_shared<TransferMetadata::SegmentDesc>();
     local_desc->name = "local-rdma-segment";
     local_desc->protocol = "rdma";
-    ASSERT_EQ(metadata->addLocalSegment(LOCAL_SEGMENT_ID,
-                                        "local-rdma-segment",
+    ASSERT_EQ(metadata->addLocalSegment(LOCAL_SEGMENT_ID, "local-rdma-segment",
                                         std::move(local_desc)),
               0);
 

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -306,7 +306,7 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     FAIL() << "TE metadata refresh polling did not refresh cached descriptor";
 }
 
-TEST(TransferMetadataPublicationTest, OmitsBufferWithoutRkey) {
+TEST(TransferMetadataPublicationTest, PreservesLocalOnlyBufferWithoutRkey) {
     constexpr uint64_t kRemoteAddr = 0x1000;
     constexpr uint64_t kLocalOnlyAddr = 0x2000;
 
@@ -341,8 +341,10 @@ TEST(TransferMetadataPublicationTest, OmitsBufferWithoutRkey) {
     ASSERT_NE(segment_id, static_cast<TransferMetadata::SegmentID>(-1));
     auto remote_desc = client.getSegmentDescByID(segment_id, true);
     ASSERT_NE(remote_desc, nullptr);
-    ASSERT_EQ(remote_desc->buffers.size(), 1);
+    ASSERT_EQ(remote_desc->buffers.size(), 2);
     EXPECT_EQ(remote_desc->buffers[0].addr, kRemoteAddr);
+    EXPECT_EQ(remote_desc->buffers[1].addr, kLocalOnlyAddr);
+    EXPECT_TRUE(remote_desc->buffers[1].rkey.empty());
 }
 
 TEST(HandshakeFrameTest, ValidFrameRoundTrips) {

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -306,6 +306,47 @@ TEST(TransferMetadataPollingTest, PollingRefreshesCachedRemoteSegmentDesc) {
     FAIL() << "TE metadata refresh polling did not refresh cached descriptor";
 }
 
+TEST(TransferMetadataPublicationTest, OmitsBufferWithoutRkey) {
+    constexpr uint64_t kRemoteAddr = 0x1000;
+    constexpr uint64_t kLocalOnlyAddr = 0x2000;
+
+    TransferMetadata server(P2PHANDSHAKE);
+    TransferMetadata client(P2PHANDSHAKE);
+
+    int sockfd = -1;
+    const uint16_t port = findAvailableTcpPort(sockfd);
+    ASSERT_GT(port, 0);
+    const std::string remote_segment_name =
+        "127.0.0.1:" + std::to_string(port);
+
+    auto server_desc =
+        makeRdmaSegmentDesc(remote_segment_name, kRemoteAddr);
+    auto local_only_buffer = makeRdmaBufferDesc(kLocalOnlyAddr);
+    local_only_buffer.rkey.clear();
+    server_desc->buffers.push_back(local_only_buffer);
+    ASSERT_EQ(server.addLocalSegment(LOCAL_SEGMENT_ID, remote_segment_name,
+                                     std::move(server_desc)),
+              0);
+
+    TransferMetadata::RpcMetaDesc rpc_desc;
+    rpc_desc.ip_or_host_name = "127.0.0.1";
+    rpc_desc.rpc_port = port;
+    rpc_desc.sockfd = sockfd;
+    ASSERT_EQ(server.addRpcMetaEntry(remote_segment_name, rpc_desc), 0);
+
+    ASSERT_EQ(client.addLocalSegment(
+                  LOCAL_SEGMENT_ID, "127.0.0.1:0",
+                  makeRdmaSegmentDesc("127.0.0.1:0", 0x3000)),
+              0);
+
+    const auto segment_id = client.getSegmentID(remote_segment_name);
+    ASSERT_NE(segment_id, static_cast<TransferMetadata::SegmentID>(-1));
+    auto remote_desc = client.getSegmentDescByID(segment_id, true);
+    ASSERT_NE(remote_desc, nullptr);
+    ASSERT_EQ(remote_desc->buffers.size(), 1);
+    EXPECT_EQ(remote_desc->buffers[0].addr, kRemoteAddr);
+}
+
 TEST(HandshakeFrameTest, ValidFrameRoundTrips) {
     int fds[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -316,11 +316,9 @@ TEST(TransferMetadataPublicationTest, OmitsBufferWithoutRkey) {
     int sockfd = -1;
     const uint16_t port = findAvailableTcpPort(sockfd);
     ASSERT_GT(port, 0);
-    const std::string remote_segment_name =
-        "127.0.0.1:" + std::to_string(port);
+    const std::string remote_segment_name = "127.0.0.1:" + std::to_string(port);
 
-    auto server_desc =
-        makeRdmaSegmentDesc(remote_segment_name, kRemoteAddr);
+    auto server_desc = makeRdmaSegmentDesc(remote_segment_name, kRemoteAddr);
     auto local_only_buffer = makeRdmaBufferDesc(kLocalOnlyAddr);
     local_only_buffer.rkey.clear();
     server_desc->buffers.push_back(local_only_buffer);
@@ -334,10 +332,10 @@ TEST(TransferMetadataPublicationTest, OmitsBufferWithoutRkey) {
     rpc_desc.sockfd = sockfd;
     ASSERT_EQ(server.addRpcMetaEntry(remote_segment_name, rpc_desc), 0);
 
-    ASSERT_EQ(client.addLocalSegment(
-                  LOCAL_SEGMENT_ID, "127.0.0.1:0",
-                  makeRdmaSegmentDesc("127.0.0.1:0", 0x3000)),
-              0);
+    ASSERT_EQ(
+        client.addLocalSegment(LOCAL_SEGMENT_ID, "127.0.0.1:0",
+                               makeRdmaSegmentDesc("127.0.0.1:0", 0x3000)),
+        0);
 
     const auto segment_id = client.getSegmentID(remote_segment_name);
     ASSERT_NE(segment_id, static_cast<TransferMetadata::SegmentID>(-1));


### PR DESCRIPTION
## Description

`RdmaTransport::registerLocalMemoryInternal()` previously discarded the `remote_accessible` argument (`(void)remote_accessible;`) and unconditionally granted remote read/write permissions (`IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE`). This violated the API contract and exposed local-only memory to remote peers.

This PR fixes the issue by:
1. Setting `IBV_ACCESS_REMOTE_*` permissions only when `remote_accessible` is true. When `false`, registers with `IBV_ACCESS_LOCAL_WRITE` only and leaves the `rkey` vector empty.
2. Filtering out RDMA buffers with empty `rkey` vectors during metadata encoding so local-only memory is not advertised across the network.
3. Adding bounds checks in `selectPeerDevice()` for `buffer_id` and `device_id` against the `rkey` array size to prevent out-of-bounds indexing on local-only memory.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added unit tests in `rdma_context_reprobe_test.cpp` and `transfer_metadata_test.cpp`:
1. `RdmaMemoryRegistrationPolicyTest.LocalOnlyBufferHasNoPublishedRkey`: Verifies that registering local memory with `remote_accessible=false` keeps its `rkey` empty.
2. `TransferMetadataPublicationTest.OmitsBufferWithoutRkey`: Verifies that buffers with empty `rkey`s are excluded when encoding P2P segment descriptions for network transfer.

**Test commands:**
```bash
cmake --build build-ci-local --target rdma_context_reprobe_test transfer_metadata_test
./build-ci-local/mooncake-transfer-engine/tests/rdma_context_reprobe_test --gtest_filter='*RegistrationPolicy*'
./build-ci-local/mooncake-transfer-engine/tests/transfer_metadata_test --gtest_filter='TransferMetadataPublicationTest.*'