### PR TITLE
[Store] Fix segment capacity metric leak on master service teardown

### DIFF
--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -452,6 +452,14 @@ class SegmentManager {
         : memory_allocator_(memory_allocator), enable_cxl_(enable_cxl) {}
 
     /**
+     * @brief Destructor. Releases the capacity metric contribution of
+     *        segments that are still mounted, since MasterMetricManager
+     *        outlives MasterService instances (e.g. across HA leadership
+     *        changes).
+     */
+    ~SegmentManager();
+
+    /**
      * @brief Get RAII-style access to segment management operations
      * @return ScopedSegmentAccess object that holds the lock
      */

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1557,6 +1557,24 @@ void NoFSegmentManager::GetMountedSegmentsSnapshot(
     }
 }
 
+SegmentManager::~SegmentManager() {
+    // Segments that are still mounted here never went through
+    // CommitUnmountSegment, so their contribution to the capacity metrics
+    // has not been released. MasterMetricManager outlives MasterService
+    // instances (a new one is constructed per HA leadership term), so
+    // release it here to keep the gauges consistent with the segments
+    // that are actually mounted.
+    for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
+        const auto& segment = mounted_segment.segment;
+        if (segment.protocol == "cxl") {
+            // CXL mounts do not contribute to total_mem_capacity.
+            continue;
+        }
+        MasterMetricManager::instance().dec_total_mem_capacity(segment.name,
+                                                               segment.size);
+    }
+}
+
 void SegmentManager::initializeCxlAllocator(const std::string& cxl_path,
                                             const size_t cxl_size) {
     LOG(INFO) << "Init CXL global allocator.";

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -270,6 +270,36 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_DOUBLE_EQ(metrics.get_segment_mem_used_ratio("xxxxxx_segment"), 0.0);
 }
 
+TEST_F(MasterMetricsTest, ServiceTeardownReleasesSegmentCapacity) {
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t capacity_before = metrics.get_total_mem_capacity();
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "teardown_test_segment";
+    segment.base = 0x300000000;
+    segment.size = 1024 * 1024 * 16;
+    UUID client_id = generate_uuid();
+
+    {
+        WrappedMasterServiceConfig service_config;
+        service_config.default_kv_lease_ttl = 100;
+        service_config.enable_metric_reporting = false;
+        WrappedMasterService service(service_config);
+        ASSERT_TRUE(service.MountSegment(segment, client_id).has_value());
+        ASSERT_EQ(metrics.get_total_mem_capacity(),
+                  capacity_before + static_cast<int64_t>(segment.size));
+        ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
+                  static_cast<int64_t>(segment.size));
+    }
+
+    // Destroying the service while the segment is still mounted (as happens
+    // when a master loses leadership) must release the segment's capacity
+    // contribution; MasterMetricManager outlives the service instance.
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+}
+
 TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     const uint64_t default_kv_lease_ttl = 100;
     auto& metrics = MasterMetricManager::instance();


### PR DESCRIPTION
## Problem

`MasterMetricManager` is a process-lifetime singleton, but segment capacity is only decremented in `CommitUnmountSegment`. In HA mode the supervisor constructs a fresh `WrappedMasterService` for every leadership term and destroys the old one on demotion. If the service is destroyed while segments are still mounted, the records die with the instance and their `total_mem_capacity` contribution is never released.

The only path that unmounts segments of silent clients is the client-expiry sweep, which needs ~`client_live_ttl_sec` to fire, while a clean demotion tears the service down in milliseconds — so a demotion typically strands the full mounted capacity in the singleton. After the next promotion, clients remount into the fresh instance and the same capacity is counted again: each leadership change inflates reported capacity by one full fleet of segments (2x, 3x, ...).

We hit this in production during an etcd latency incident that caused repeated leadership swaps: both masters ended up reporting exactly 2x the real capacity. `global_mem_used_ratio` plateaued at ~0.47 and could never reach `eviction_high_watermark_ratio` (0.9), so proactive eviction stopped entirely and writes ran into continuous `NO_AVAILABLE_HANDLE` allocation failures at the real memory ceiling, with reactive eviction as the only relief.

## Fix

Release the remaining mounted segments' capacity contribution in `~SegmentManager()`. Any segment still in `mounted_segments_` at destruction has by definition not gone through `CommitUnmountSegment`, so the decrement is exact and cannot double-count. CXL segments are skipped, mirroring the mount/unmount paths.

## Testing

Added `MasterMetricsTest.ServiceTeardownReleasesSegmentCapacity`: mounts a segment, destroys the service without unmounting (as a demotion does), and asserts the gauges return to baseline. `master_metrics_test` (12), `segment_test` (14) and `master_service_test` (145) all pass locally.