### PR TITLE
[Store] Add P2P standby oplog reconnect recovery

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -2,10 +2,13 @@
 #pragma once
 
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <thread>
 
 #include "ha/oplog/oplog_replicator.h"
 #include "ha/oplog/oplog_store_factory.h"
@@ -25,6 +28,8 @@ struct P2PHotStandbyConfig {
     std::string redis_password;
     int redis_db_index{0};
     int oplog_poll_interval_ms{kDefaultOpLogPollIntervalMs};
+    int reconnect_initial_backoff_ms{100};
+    int reconnect_max_backoff_ms{5000};
 };
 
 struct P2PStandbySyncStatus {
@@ -50,7 +55,10 @@ struct P2PStandbySyncStatus {
 // layer P2P-specific.
 class P2PHotStandbyService {
    public:
-    explicit P2PHotStandbyService(P2PHotStandbyConfig config);
+    using ReaderStoreFactory = std::function<std::unique_ptr<OpLogStore>()>;
+
+    explicit P2PHotStandbyService(P2PHotStandbyConfig config,
+                                  ReaderStoreFactory reader_store_factory = {});
     ~P2PHotStandbyService();
 
     P2PHotStandbyService(const P2PHotStandbyService&) = delete;
@@ -79,12 +87,19 @@ class P2PHotStandbyService {
 
    private:
     ErrorCode StartOplogFollowingLocked(uint64_t baseline_sequence_id);
+    std::unique_ptr<OpLogStore> CreateReaderStore() const;
     void ResetOplogFollowingLocked();
     ErrorCode FinalCatchUpForPromotionLocked(uint64_t current_applied_seq_id);
     uint64_t GetLocalLastAppliedSequenceIdLocked() const;
     void OnWatcherEvent(StandbyEvent event);
+    void StartRecoveryWorker();
+    void StopRecoveryWorker();
+    void RestoreRecoveryWorker();
+    void RequestRecovery();
+    void RecoveryLoop();
 
     P2PHotStandbyConfig config_;
+    ReaderStoreFactory reader_store_factory_;
 
     std::unique_ptr<P2PStandbyMetadataStore> metadata_store_;
     std::unique_ptr<P2POpLogApplier> oplog_applier_;
@@ -93,7 +108,15 @@ class P2PHotStandbyService {
     std::unique_ptr<OpLogReplicator> oplog_replicator_;
 
     StandbyStateMachine state_machine_;
+    // Serializes Start(), Stop(), and Promote().
+    std::mutex lifecycle_mutex_;
     mutable std::mutex mutex_;
+
+    std::mutex recovery_mutex_;
+    std::condition_variable recovery_cv_;
+    std::thread recovery_thread_;
+    bool recovery_requested_{false};
+    bool recovery_stopping_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -119,6 +119,9 @@ class HAMetricManager {
     void inc_oplog_queue_bypassed(int64_t val = 1);
     void inc_oplog_sync_wait_timeouts(int64_t val = 1);
     void inc_oplog_read_failures(int64_t val = 1);
+    void inc_oplog_reader_reconnect_attempts(int64_t val = 1);
+    void inc_oplog_reader_reconnect_failures(int64_t val = 1);
+    void inc_oplog_reader_reconnects(int64_t val = 1);
     void inc_oplog_apply_failures(int64_t val = 1);
     void inc_oplog_best_effort_apply_skipped(int64_t val = 1);
     void inc_oplog_confirmed_holes(int64_t val = 1);
@@ -240,6 +243,9 @@ class HAMetricManager {
     ylt::metric::counter_t oplog_queue_bypassed_total_;
     ylt::metric::counter_t oplog_sync_wait_timeouts_total_;
     ylt::metric::counter_t oplog_read_failures_total_;
+    ylt::metric::counter_t oplog_reader_reconnect_attempts_total_;
+    ylt::metric::counter_t oplog_reader_reconnect_failures_total_;
+    ylt::metric::counter_t oplog_reader_reconnects_total_;
     ylt::metric::counter_t oplog_apply_failures_total_;
     ylt::metric::counter_t oplog_best_effort_apply_skipped_total_;
     ylt::metric::counter_t oplog_confirmed_holes_total_;

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -2,6 +2,7 @@
 
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -10,8 +11,10 @@
 
 namespace mooncake {
 
-P2PHotStandbyService::P2PHotStandbyService(P2PHotStandbyConfig config)
-    : config_(std::move(config)) {
+P2PHotStandbyService::P2PHotStandbyService(
+    P2PHotStandbyConfig config, ReaderStoreFactory reader_store_factory)
+    : config_(std::move(config)),
+      reader_store_factory_(std::move(reader_store_factory)) {
     metadata_store_ = std::make_unique<P2PStandbyMetadataStore>();
     oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
                                                        config_.cluster_id);
@@ -20,6 +23,7 @@ P2PHotStandbyService::P2PHotStandbyService(P2PHotStandbyConfig config)
 P2PHotStandbyService::~P2PHotStandbyService() { Stop(); }
 
 ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
     std::lock_guard<std::mutex> lock(mutex_);
     if (state_machine_.IsRunning()) {
         LOG(WARNING) << "P2PHotStandbyService is already running";
@@ -50,6 +54,7 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
     }
 
     state_machine_.ProcessEvent(StandbyEvent::SYNC_COMPLETE);
+    StartRecoveryWorker();
     LOG(INFO) << "P2PHotStandbyService started"
               << ", cluster_id=" << config_.cluster_id
               << ", baseline_sequence_id=" << baseline_sequence_id;
@@ -60,13 +65,7 @@ ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
     uint64_t baseline_sequence_id) {
     ResetOplogFollowingLocked();
 
-    watcher_oplog_store_ = OpLogStoreFactory::Create(
-        config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
-        config_.oplog_store_type == OpLogStoreType::REDIS
-            ? config_.redis_endpoint
-            : config_.oplog_store_root_dir,
-        config_.oplog_poll_interval_ms, config_.redis_password,
-        config_.redis_username, config_.redis_db_index);
+    watcher_oplog_store_ = CreateReaderStore();
     if (!watcher_oplog_store_) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create reader store"
                    << ", cluster_id=" << config_.cluster_id;
@@ -103,6 +102,19 @@ ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
     return ErrorCode::INTERNAL_ERROR;
 }
 
+std::unique_ptr<OpLogStore> P2PHotStandbyService::CreateReaderStore() const {
+    if (reader_store_factory_) {
+        return reader_store_factory_();
+    }
+    return OpLogStoreFactory::Create(
+        config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
+        config_.oplog_store_type == OpLogStoreType::REDIS
+            ? config_.redis_endpoint
+            : config_.oplog_store_root_dir,
+        config_.oplog_poll_interval_ms, config_.redis_password,
+        config_.redis_username, config_.redis_db_index);
+}
+
 void P2PHotStandbyService::ResetOplogFollowingLocked() {
     if (oplog_replicator_) {
         oplog_replicator_->Stop();
@@ -116,6 +128,8 @@ void P2PHotStandbyService::ResetOplogFollowingLocked() {
 }
 
 void P2PHotStandbyService::Stop() {
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    StopRecoveryWorker();
     std::lock_guard<std::mutex> lock(mutex_);
 
     ResetOplogFollowingLocked();
@@ -131,6 +145,22 @@ void P2PHotStandbyService::Stop() {
 }
 
 ErrorCode P2PHotStandbyService::Promote(bool force) {
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const bool apply_failed =
+            oplog_applier_ != nullptr && !oplog_applier_->IsHealthy();
+        const bool force_apply_failure =
+            force && apply_failed && GetState() == StandbyState::FAILED;
+        if (!IsReadyForPromotion() && !force_apply_failure) {
+            LOG(ERROR) << "P2PHotStandbyService: not ready for promotion"
+                       << ", state=" << StandbyStateToString(GetState())
+                       << ", apply_healthy=" << !apply_failed;
+            return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+        }
+    }
+
+    StopRecoveryWorker();
     std::lock_guard<std::mutex> lock(mutex_);
     const bool apply_failed =
         oplog_applier_ != nullptr && !oplog_applier_->IsHealthy();
@@ -140,6 +170,7 @@ ErrorCode P2PHotStandbyService::Promote(bool force) {
         LOG(ERROR) << "P2PHotStandbyService: not ready for promotion"
                    << ", state=" << StandbyStateToString(GetState())
                    << ", apply_healthy=" << !apply_failed;
+        RestoreRecoveryWorker();
         return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
     }
 
@@ -149,6 +180,7 @@ ErrorCode P2PHotStandbyService::Promote(bool force) {
     if (!promote_result.allowed) {
         LOG(ERROR) << "P2PHotStandbyService: cannot promote: "
                    << promote_result.reason;
+        RestoreRecoveryWorker();
         return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
     }
 
@@ -207,13 +239,7 @@ ErrorCode P2PHotStandbyService::Promote(bool force) {
 
 ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
     uint64_t current_applied_seq_id) {
-    auto catch_up_store = OpLogStoreFactory::Create(
-        config_.oplog_store_type, config_.cluster_id, OpLogStoreRole::READER,
-        config_.oplog_store_type == OpLogStoreType::REDIS
-            ? config_.redis_endpoint
-            : config_.oplog_store_root_dir,
-        config_.oplog_poll_interval_ms, config_.redis_password,
-        config_.redis_username, config_.redis_db_index);
+    auto catch_up_store = CreateReaderStore();
     if (!catch_up_store) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create catch-up store";
         return ErrorCode::INTERNAL_ERROR;
@@ -349,8 +375,124 @@ void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {
                 << ", event=" << StandbyEventToString(event)
                 << ", reason=" << result.reason;
     }
-    // TODO: Add service-level recovery orchestration for RECONNECTING and
-    // RECOVERING states in the follow-up error handling PR.
+    if (result.allowed && result.new_state == StandbyState::RECONNECTING) {
+        RequestRecovery();
+    }
+}
+
+void P2PHotStandbyService::StartRecoveryWorker() {
+    std::lock_guard<std::mutex> lock(recovery_mutex_);
+    if (recovery_thread_.joinable()) {
+        return;
+    }
+    recovery_stopping_ = false;
+    recovery_thread_ = std::thread(&P2PHotStandbyService::RecoveryLoop, this);
+}
+
+void P2PHotStandbyService::StopRecoveryWorker() {
+    {
+        std::lock_guard<std::mutex> lock(recovery_mutex_);
+        recovery_stopping_ = true;
+        recovery_requested_ = false;
+    }
+    recovery_cv_.notify_all();
+    if (recovery_thread_.joinable()) {
+        recovery_thread_.join();
+    }
+}
+
+void P2PHotStandbyService::RestoreRecoveryWorker() {
+    StartRecoveryWorker();
+    if (state_machine_.GetState() == StandbyState::RECONNECTING) {
+        RequestRecovery();
+    }
+}
+
+void P2PHotStandbyService::RequestRecovery() {
+    {
+        std::lock_guard<std::mutex> lock(recovery_mutex_);
+        if (recovery_stopping_) {
+            return;
+        }
+        recovery_requested_ = true;
+    }
+    recovery_cv_.notify_one();
+}
+
+void P2PHotStandbyService::RecoveryLoop() {
+    std::unique_lock<std::mutex> recovery_lock(recovery_mutex_);
+    while (true) {
+        recovery_cv_.wait(recovery_lock, [this] {
+            return recovery_stopping_ || recovery_requested_;
+        });
+        if (recovery_stopping_) {
+            return;
+        }
+        recovery_requested_ = false;
+        const int max_backoff_ms =
+            std::max(1, config_.reconnect_max_backoff_ms);
+        int backoff_ms = std::min(
+            std::max(1, config_.reconnect_initial_backoff_ms), max_backoff_ms);
+
+        while (!recovery_stopping_) {
+            recovery_lock.unlock();
+
+            ErrorCode err = ErrorCode::INTERNAL_ERROR;
+            uint64_t resume_sequence_id = 0;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                if (state_machine_.GetState() != StandbyState::RECONNECTING) {
+                    recovery_lock.lock();
+                    break;
+                }
+                resume_sequence_id = GetLocalLastAppliedSequenceIdLocked();
+                HAMetricManager::instance()
+                    .inc_oplog_reader_reconnect_attempts();
+                err = StartOplogFollowingLocked(resume_sequence_id);
+                if (err == ErrorCode::OK) {
+                    const bool watching =
+                        state_machine_.GetState() == StandbyState::WATCHING;
+                    const bool healthy =
+                        oplog_replicator_ && oplog_replicator_->IsHealthy();
+                    if (!watching || !healthy) {
+                        if (watching) {
+                            state_machine_.ProcessEvent(
+                                StandbyEvent::WATCH_BROKEN);
+                        }
+                        LOG(ERROR)
+                            << "P2PHotStandbyService: recovered OpLog reader "
+                               "is not healthy"
+                            << ", state="
+                            << StandbyStateToString(state_machine_.GetState());
+                        err = ErrorCode::INTERNAL_ERROR;
+                    }
+                } else {
+                    state_machine_.ProcessEvent(StandbyEvent::RECOVERY_FAILED);
+                }
+            }
+
+            recovery_lock.lock();
+            if (recovery_stopping_) {
+                return;
+            }
+            if (err == ErrorCode::OK) {
+                HAMetricManager::instance().inc_oplog_reader_reconnects();
+                LOG(INFO) << "P2PHotStandbyService: OpLog reader reconnected"
+                          << ", resume_sequence_id=" << resume_sequence_id;
+                break;
+            }
+
+            HAMetricManager::instance().inc_oplog_reader_reconnect_failures();
+            LOG(WARNING) << "P2PHotStandbyService: OpLog reader reconnect "
+                            "failed"
+                         << ", resume_sequence_id=" << resume_sequence_id
+                         << ", retry_in_ms=" << backoff_ms;
+            recovery_cv_.wait_for(recovery_lock,
+                                  std::chrono::milliseconds(backoff_ms),
+                                  [this] { return recovery_stopping_; });
+            backoff_ms += std::min(backoff_ms, max_backoff_ms - backoff_ms);
+        }
+    }
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha_metric_manager.cpp
+++ b/mooncake-store/src/ha_metric_manager.cpp
@@ -87,6 +87,15 @@ HAMetricManager::HAMetricManager()
           "Total number of synchronous OpLog wait timeouts"),
       oplog_read_failures_total_("ha_oplog_read_failures_total",
                                  "Total number of Standby OpLog read failures"),
+      oplog_reader_reconnect_attempts_total_(
+          "ha_oplog_reader_reconnect_attempts_total",
+          "Total Standby OpLog reader reconnect attempts"),
+      oplog_reader_reconnect_failures_total_(
+          "ha_oplog_reader_reconnect_failures_total",
+          "Total failed Standby OpLog reader reconnect attempts"),
+      oplog_reader_reconnects_total_(
+          "ha_oplog_reader_reconnects_total",
+          "Total successful Standby OpLog reader reconnects"),
       oplog_apply_failures_total_(
           "ha_oplog_apply_failures_total",
           "Total number of critical Standby OpLog apply failures"),
@@ -312,6 +321,15 @@ void HAMetricManager::inc_oplog_sync_wait_timeouts(int64_t val) {
 void HAMetricManager::inc_oplog_read_failures(int64_t val) {
     oplog_read_failures_total_.inc(val);
 }
+void HAMetricManager::inc_oplog_reader_reconnect_attempts(int64_t val) {
+    oplog_reader_reconnect_attempts_total_.inc(val);
+}
+void HAMetricManager::inc_oplog_reader_reconnect_failures(int64_t val) {
+    oplog_reader_reconnect_failures_total_.inc(val);
+}
+void HAMetricManager::inc_oplog_reader_reconnects(int64_t val) {
+    oplog_reader_reconnects_total_.inc(val);
+}
 void HAMetricManager::inc_oplog_apply_failures(int64_t val) {
     oplog_apply_failures_total_.inc(val);
 }
@@ -452,6 +470,9 @@ std::string HAMetricManager::serialize_metrics() {
     serialize_metric(oplog_queue_bypassed_total_);
     serialize_metric(oplog_sync_wait_timeouts_total_);
     serialize_metric(oplog_read_failures_total_);
+    serialize_metric(oplog_reader_reconnect_attempts_total_);
+    serialize_metric(oplog_reader_reconnect_failures_total_);
+    serialize_metric(oplog_reader_reconnects_total_);
     serialize_metric(oplog_apply_failures_total_);
     serialize_metric(oplog_best_effort_apply_skipped_total_);
     serialize_metric(oplog_confirmed_holes_total_);

--- a/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
@@ -154,6 +154,9 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
     M().inc_oplog_queue_bypassed();
     M().inc_oplog_sync_wait_timeouts();
     M().inc_oplog_read_failures();
+    M().inc_oplog_reader_reconnect_attempts();
+    M().inc_oplog_reader_reconnect_failures();
+    M().inc_oplog_reader_reconnects();
     M().inc_oplog_apply_failures();
     M().inc_oplog_best_effort_apply_skipped();
     M().inc_oplog_confirmed_holes();
@@ -181,6 +184,9 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
              "ha_oplog_queue_bypassed_total",
              "ha_oplog_sync_wait_timeouts_total",
              "ha_oplog_read_failures_total",
+             "ha_oplog_reader_reconnect_attempts_total",
+             "ha_oplog_reader_reconnect_failures_total",
+             "ha_oplog_reader_reconnects_total",
              "ha_oplog_apply_failures_total",
              "ha_oplog_best_effort_apply_skipped_total",
              "ha_oplog_confirmed_holes_total",

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <filesystem>
@@ -14,12 +15,94 @@
 #include <xxhash.h>
 
 #include "ha/oplog/localfs_oplog_store.h"
+#include "mock_oplog_store.h"
 #include "p2p_master_service.h"
 #include "p2p_rpc_service.h"
 #include "p2p_rpc_types.h"
 
 namespace mooncake::test {
 namespace {
+
+struct ControlledNotifierState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    OpLogChangeNotifier::ErrorCallback on_error;
+    uint64_t start_sequence_id{0};
+    int active_callbacks{0};
+    bool healthy_on_start{true};
+    bool healthy{false};
+};
+
+class ControlledNotifier : public OpLogChangeNotifier {
+   public:
+    explicit ControlledNotifier(std::shared_ptr<ControlledNotifierState> state)
+        : state_(std::move(state)) {}
+
+    ErrorCode Start(uint64_t start_sequence_id, EntryCallback,
+                    ErrorCallback on_error, MaintenanceCallback = {}) override {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        state_->start_sequence_id = start_sequence_id;
+        state_->on_error = std::move(on_error);
+        state_->healthy = state_->healthy_on_start;
+        return ErrorCode::OK;
+    }
+
+    void Stop() override {
+        std::unique_lock<std::mutex> lock(state_->mutex);
+        state_->healthy = false;
+        state_->cv.wait(lock, [this] { return state_->active_callbacks == 0; });
+    }
+
+    bool IsHealthy() const override {
+        std::lock_guard<std::mutex> lock(state_->mutex);
+        return state_->healthy;
+    }
+
+   private:
+    std::shared_ptr<ControlledNotifierState> state_;
+};
+
+class ControlledReaderStore : public MockOpLogStore {
+   public:
+    explicit ControlledReaderStore(
+        std::shared_ptr<ControlledNotifierState> state)
+        : state_(std::move(state)) {}
+
+    std::unique_ptr<OpLogChangeNotifier> CreateChangeNotifier(
+        const std::string&) override {
+        return std::make_unique<ControlledNotifier>(state_);
+    }
+
+   private:
+    std::shared_ptr<ControlledNotifierState> state_;
+};
+
+void InjectNotifierErrors(const std::shared_ptr<ControlledNotifierState>& state,
+                          ErrorCode error, int count = 1) {
+    OpLogChangeNotifier::ErrorCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        callback = state->on_error;
+        ++state->active_callbacks;
+    }
+    if (!callback) {
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            --state->active_callbacks;
+        }
+        state->cv.notify_all();
+        ADD_FAILURE() << "Notifier error callback is not installed";
+        return;
+    }
+    for (int i = 0; i < count; ++i) {
+        callback(error);
+    }
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        --state->active_callbacks;
+    }
+    state->cv.notify_all();
+}
 
 class P2PHotStandbyServiceTest : public ::testing::Test {
    protected:
@@ -173,6 +256,186 @@ TEST_F(P2PHotStandbyServiceTest, ReplicatesMasterWrittenP2POplog) {
     EXPECT_EQ(desc.segment_id, segment_id);
     EXPECT_EQ(desc.ip_address, "127.0.0.1");
     EXPECT_EQ(desc.rpc_port, 50051);
+}
+
+TEST_F(P2PHotStandbyServiceTest, ReconnectsFromLastAppliedSequence) {
+    std::mutex states_mutex;
+    std::vector<std::shared_ptr<ControlledNotifierState>> states;
+    std::atomic<int> factory_calls{0};
+    auto factory = [&]() -> std::unique_ptr<OpLogStore> {
+        const int call = ++factory_calls;
+        auto state = std::make_shared<ControlledNotifierState>();
+        if (call == 2) {
+            state->healthy_on_start = false;
+        }
+        {
+            std::lock_guard<std::mutex> lock(states_mutex);
+            states.push_back(state);
+        }
+        return std::make_unique<ControlledReaderStore>(state);
+    };
+
+    auto config = MakeStandbyConfig();
+    config.reconnect_initial_backoff_ms = 1;
+    config.reconnect_max_backoff_ms = 5;
+    P2PHotStandbyService standby(config, factory);
+    ASSERT_EQ(standby.Start(/*baseline_sequence_id=*/7), ErrorCode::OK);
+    std::shared_ptr<ControlledNotifierState> first_state;
+    {
+        std::lock_guard<std::mutex> lock(states_mutex);
+        ASSERT_EQ(states.size(), 1);
+        first_state = states.front();
+    }
+    InjectNotifierErrors(first_state, ErrorCode::INTERNAL_ERROR);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        size_t state_count = 0;
+        {
+            std::lock_guard<std::mutex> lock(states_mutex);
+            state_count = states.size();
+        }
+        if (state_count >= 2 && standby.GetState() == StandbyState::WATCHING) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    std::shared_ptr<ControlledNotifierState> second_state;
+    {
+        std::lock_guard<std::mutex> lock(states_mutex);
+        ASSERT_GE(states.size(), 3);
+        second_state = states.back();
+    }
+    EXPECT_GE(factory_calls.load(), 3);
+    {
+        std::lock_guard<std::mutex> lock(second_state->mutex);
+        EXPECT_EQ(second_state->start_sequence_id, 7);
+        EXPECT_TRUE(second_state->healthy);
+    }
+    EXPECT_EQ(standby.GetState(), StandbyState::WATCHING);
+    standby.Stop();
+}
+
+TEST_F(P2PHotStandbyServiceTest, CoalescesRepeatedWatchErrors) {
+    std::mutex states_mutex;
+    std::vector<std::shared_ptr<ControlledNotifierState>> states;
+    std::atomic<int> factory_calls{0};
+    auto factory = [&]() -> std::unique_ptr<OpLogStore> {
+        ++factory_calls;
+        auto state = std::make_shared<ControlledNotifierState>();
+        {
+            std::lock_guard<std::mutex> lock(states_mutex);
+            states.push_back(state);
+        }
+        return std::make_unique<ControlledReaderStore>(state);
+    };
+
+    P2PHotStandbyService standby(MakeStandbyConfig(), factory);
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+
+    std::shared_ptr<ControlledNotifierState> first_state;
+    {
+        std::lock_guard<std::mutex> lock(states_mutex);
+        first_state = states.front();
+    }
+    InjectNotifierErrors(first_state, ErrorCode::INTERNAL_ERROR, 2);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline &&
+           (factory_calls.load() < 2 ||
+            standby.GetState() != StandbyState::WATCHING)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    EXPECT_EQ(factory_calls.load(), 2);
+    EXPECT_EQ(standby.GetState(), StandbyState::WATCHING);
+    standby.Stop();
+}
+
+TEST_F(P2PHotStandbyServiceTest, StopInterruptsReconnectBackoff) {
+    std::shared_ptr<ControlledNotifierState> first_state;
+    std::atomic<int> factory_calls{0};
+    auto factory = [&]() -> std::unique_ptr<OpLogStore> {
+        const int call = ++factory_calls;
+        if (call > 1) {
+            return nullptr;
+        }
+        first_state = std::make_shared<ControlledNotifierState>();
+        return std::make_unique<ControlledReaderStore>(first_state);
+    };
+
+    auto config = MakeStandbyConfig();
+    config.reconnect_initial_backoff_ms = 1000;
+    config.reconnect_max_backoff_ms = 1000;
+    P2PHotStandbyService standby(config, factory);
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    InjectNotifierErrors(first_state, ErrorCode::INTERNAL_ERROR);
+
+    const auto reconnect_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < reconnect_deadline &&
+           factory_calls.load() < 2) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_GE(factory_calls.load(), 2);
+
+    const auto stop_start = std::chrono::steady_clock::now();
+    standby.Stop();
+    const auto stop_elapsed =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - stop_start);
+
+    EXPECT_LT(stop_elapsed, std::chrono::milliseconds(250));
+    EXPECT_EQ(standby.GetState(), StandbyState::STOPPED);
+    const int calls_after_stop = factory_calls.load();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_EQ(factory_calls.load(), calls_after_stop);
+}
+
+TEST_F(P2PHotStandbyServiceTest, CapsInitialReconnectBackoffAtMaximum) {
+    std::shared_ptr<ControlledNotifierState> first_state;
+    std::atomic<int> factory_calls{0};
+    auto factory = [&]() -> std::unique_ptr<OpLogStore> {
+        if (++factory_calls > 1) {
+            return nullptr;
+        }
+        first_state = std::make_shared<ControlledNotifierState>();
+        return std::make_unique<ControlledReaderStore>(first_state);
+    };
+
+    auto config = MakeStandbyConfig();
+    config.reconnect_initial_backoff_ms = 1000;
+    config.reconnect_max_backoff_ms = 1;
+    P2PHotStandbyService standby(config, factory);
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    InjectNotifierErrors(first_state, ErrorCode::INTERNAL_ERROR);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(250);
+    while (std::chrono::steady_clock::now() < deadline &&
+           factory_calls.load() < 3) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_GE(factory_calls.load(), 3);
+    standby.Stop();
+}
+
+TEST_F(P2PHotStandbyServiceTest, SerializesConcurrentPromoteAndStop) {
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+
+    ErrorCode promote_result = ErrorCode::INTERNAL_ERROR;
+    std::thread promote_thread([&] { promote_result = standby.Promote(); });
+    std::thread stop_thread([&] { standby.Stop(); });
+    promote_thread.join();
+    stop_thread.join();
+
+    EXPECT_TRUE(promote_result == ErrorCode::OK ||
+                promote_result == ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    EXPECT_EQ(standby.GetState(), StandbyState::STOPPED);
 }
 
 TEST_F(P2PHotStandbyServiceTest, UnmountSegmentCascadeIsReplayed) {


### PR DESCRIPTION
## Description

  Add automatic recovery for P2P standby OpLog reader failures.

  - Recreate the reader and notifier after watch failures.
  - Resume replication from the latest applied sequence ID.
  - Retry failed reconnects with bounded exponential backoff.
  - Coalesce repeated watcher errors and allow shutdown to interrupt backoff.
  - Preserve recovery when promotion races with a watcher failure.
  - Add reconnect metrics and unit tests.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  The affected targets were built and tested in the local `mooncake-dev` container.

  **Test commands:**
  ```bash
  cmake --build /workspace/build-redis-oplog \
    --target p2p_oplog_test ha_metric_manager_test -j 8

  cd /workspace/build-redis-oplog
  ctest -R "^(p2p_oplog_test|ha_metric_manager_test)$" --output-on-failure
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Result: 2/2 tests passed.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex assisted with code review, race-condition analysis, implementation, and test execution. The changes were reviewed and validated by the human submitter.