### PR TITLE
[Store] Surface partial replica allocation in PutStart and document allocation semantics

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -140,6 +140,7 @@ class MasterMetricManager {
     void inc_put_start_requests(int64_t val = 1);
     void inc_put_start_failures(int64_t val = 1);
     void inc_put_start_alloc_failures(int64_t val = 1);
+    void inc_put_start_partial_allocations(int64_t val = 1);
     void inc_put_end_requests(int64_t val = 1);
     void inc_put_end_failures(int64_t val = 1);
     void inc_put_revoke_requests(int64_t val = 1);
@@ -203,6 +204,7 @@ class MasterMetricManager {
     int64_t get_put_start_requests();
     int64_t get_put_start_failures();
     int64_t get_put_start_alloc_failures();
+    int64_t get_put_start_partial_allocations();
     int64_t get_put_end_requests();
     int64_t get_put_end_failures();
     int64_t get_put_revoke_requests();
@@ -432,6 +434,7 @@ class MasterMetricManager {
         int64_t put_starts = 0;
         int64_t put_start_fails = 0;
         int64_t put_start_alloc_fails = 0;
+        int64_t put_start_partial_allocs = 0;
         int64_t put_ends = 0;
         int64_t put_end_fails = 0;
         int64_t put_revoke_requests = 0;
@@ -568,6 +571,7 @@ class MasterMetricManager {
     ylt::metric::counter_t put_start_requests_;
     ylt::metric::counter_t put_start_failures_;
     ylt::metric::counter_t put_start_alloc_failures_;
+    ylt::metric::counter_t put_start_partial_allocations_;
     ylt::metric::counter_t put_end_requests_;
     ylt::metric::counter_t put_end_failures_;
     ylt::metric::counter_t put_revoke_requests_;

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -71,6 +71,10 @@ MasterMetricManager::MasterMetricManager()
           "master_put_start_alloc_failures_total",
           "Total number of PutStart failures caused by replica allocation "
           "failure"),
+      put_start_partial_allocations_(
+          "master_put_start_partial_allocations_total",
+          "Total number of PutStart requests that succeeded with fewer "
+          "replicas than requested (best-effort degradation)"),
       put_end_requests_("master_put_end_requests_total",
                         "Total number of PutEnd requests received"),
       put_end_failures_("master_put_end_failures_total",
@@ -513,6 +517,7 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     put_start_requests_.inc(0);
     put_start_failures_.inc(0);
     put_start_alloc_failures_.inc(0);
+    put_start_partial_allocations_.inc(0);
     put_end_requests_.inc(0);
     put_end_failures_.inc(0);
     put_revoke_requests_.inc(0);
@@ -924,6 +929,9 @@ void MasterMetricManager::inc_put_start_failures(int64_t val) {
 void MasterMetricManager::inc_put_start_alloc_failures(int64_t val) {
     put_start_alloc_failures_.inc(val);
 }
+void MasterMetricManager::inc_put_start_partial_allocations(int64_t val) {
+    put_start_partial_allocations_.inc(val);
+}
 void MasterMetricManager::inc_put_end_requests(int64_t val) {
     put_end_requests_.inc(val);
 }
@@ -1224,6 +1232,10 @@ int64_t MasterMetricManager::get_put_start_failures() {
 
 int64_t MasterMetricManager::get_put_start_alloc_failures() {
     return put_start_alloc_failures_.value();
+}
+
+int64_t MasterMetricManager::get_put_start_partial_allocations() {
+    return put_start_partial_allocations_.value();
 }
 
 int64_t MasterMetricManager::get_put_end_requests() {
@@ -1799,6 +1811,7 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(put_start_requests_);
     serialize_metric(put_start_failures_);
     serialize_metric(put_start_alloc_failures_);
+    serialize_metric(put_start_partial_allocations_);
     serialize_metric(put_end_requests_);
     serialize_metric(put_end_failures_);
     serialize_metric(put_revoke_requests_);
@@ -2060,6 +2073,7 @@ std::string MasterMetricManager::get_summary_string(
     int64_t put_starts = put_start_requests_.value();
     int64_t put_start_fails = put_start_failures_.value();
     int64_t put_start_alloc_fails = put_start_alloc_failures_.value();
+    int64_t put_start_partial_allocs = put_start_partial_allocations_.value();
     int64_t put_ends = put_end_requests_.value();
     int64_t put_end_fails = put_end_failures_.value();
     int64_t put_revoke_requests = put_revoke_requests_.value();
@@ -2181,6 +2195,7 @@ std::string MasterMetricManager::get_summary_string(
     current_counters.put_starts = put_starts;
     current_counters.put_start_fails = put_start_fails;
     current_counters.put_start_alloc_fails = put_start_alloc_fails;
+    current_counters.put_start_partial_allocs = put_start_partial_allocs;
     current_counters.put_ends = put_ends;
     current_counters.put_end_fails = put_end_fails;
     current_counters.put_revoke_requests = put_revoke_requests;
@@ -2559,6 +2574,8 @@ std::string MasterMetricManager::get_summary_string(
        << "Success/Attempts=" << eviction_success << "/" << eviction_attempts
        << ", "
        << "AllocFail=" << delta(&SummaryCounters::put_start_alloc_fails) << ", "
+       << "PartialAlloc=" << delta(&SummaryCounters::put_start_partial_allocs)
+       << ", "
        << "keys=" << evicted_key_count << ", "
        << "size=" << byte_size_to_string(evicted_size);
     // mem eviction

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -107,6 +107,24 @@ uint64_t SaturatingMultiply(uint64_t lhs, uint64_t rhs) {
     return lhs * rhs;
 }
 
+// Decides whether PutStart may proceed with the replicas that were
+// actually allocated. Three deliberately different policies apply:
+//
+//  - Memory-only (nof_replica_num == 0): best-effort. Fewer than
+//    config.replica_num replicas (but at least one) still succeed, even
+//    though DetermineReplicaWriteMode() classifies such configs as
+//    RELIABLE_MULTI_REPLICA. The shortfall is surfaced via a WARNING log
+//    (action=put_start_partial_allocation) and the
+//    master_put_start_partial_allocations_total metric.
+//  - FLEXIBLE_DUAL_REPLICA (1 memory + 1 NoF): allocating either side
+//    alone is sufficient.
+//  - Any other config with nof_replica_num > 0: strict. Both replica
+//    types must match the requested counts exactly, otherwise PutStart
+//    fails with NO_AVAILABLE_HANDLE.
+//
+// The "reliable" guarantee of RELIABLE_MULTI_REPLICA is enforced at the
+// transfer stage (all allocated replicas must complete or the put is
+// revoked), not at the allocation stage for memory-only configs.
 bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
                                   size_t allocated_memory_replicas,
                                   size_t allocated_nof_replicas) {
@@ -3464,6 +3482,21 @@ auto MasterService::AllocateAndInsertMetadata(
                 << ", allocated_nof_replicas=" << allocated_nof_replicas;
         abort_reserved_quota();
         return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+
+    // Best-effort / flexible modes may pass the check above with fewer
+    // replicas than requested (see HasExpectedReplicaAllocation). Surface
+    // the degradation so callers and operators can detect the reduced
+    // redundancy instead of failing silently.
+    if (allocated_memory_replicas < config.replica_num ||
+        allocated_nof_replicas < config.nof_replica_num) {
+        MasterMetricManager::instance().inc_put_start_partial_allocations();
+        LOG(WARNING) << "key=" << key << ", action=put_start_partial_allocation"
+                     << ", requested_memory_replicas=" << config.replica_num
+                     << ", allocated_memory_replicas="
+                     << allocated_memory_replicas
+                     << ", requested_nof_replicas=" << config.nof_replica_num
+                     << ", allocated_nof_replicas=" << allocated_nof_replicas;
     }
 
     if (use_disk_replica_) {

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -64,6 +64,7 @@ TEST_F(MasterMetricsTest, InitialStatusTest) {
     ASSERT_EQ(metrics.get_put_start_requests(), 0);
     ASSERT_EQ(metrics.get_put_start_failures(), 0);
     ASSERT_EQ(metrics.get_put_start_alloc_failures(), 0);
+    ASSERT_EQ(metrics.get_put_start_partial_allocations(), 0);
     ASSERT_EQ(metrics.get_put_end_requests(), 0);
     ASSERT_EQ(metrics.get_put_end_failures(), 0);
     ASSERT_EQ(metrics.get_put_revoke_requests(), 0);
@@ -755,7 +756,7 @@ TEST_F(MasterMetricsTest, SummaryUsesWindowRatesAndCumulativeEviction) {
               std::string::npos);
     EXPECT_NE(
         window_summary.find("Eviction: Success/Attempts=1/2, AllocFail=0, "
-                            "keys=3, size=4.00 KB"),
+                            "PartialAlloc=0, keys=3, size=4.00 KB"),
         std::string::npos);
     EXPECT_NE(window_summary.find("Mem Eviction: Success/Attempts=1/2, "
                                   "keys=3, size=4.00 KB"),
@@ -768,7 +769,7 @@ TEST_F(MasterMetricsTest, SummaryUsesWindowRatesAndCumulativeEviction) {
         metrics.get_summary_string_and_update_snapshot();
     EXPECT_NE(
         reported_summary.find("Eviction: Success/Attempts=1/2, AllocFail=0, "
-                              "keys=3, size=4.00 KB"),
+                              "PartialAlloc=0, keys=3, size=4.00 KB"),
         std::string::npos);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
@@ -776,7 +777,8 @@ TEST_F(MasterMetricsTest, SummaryUsesWindowRatesAndCumulativeEviction) {
         metrics.get_summary_string_and_update_snapshot();
     EXPECT_NE(idle_summary.find("PutStart=0.00/0.00"), std::string::npos);
     EXPECT_NE(idle_summary.find("Eviction: Success/Attempts=1/2, "
-                                "AllocFail=0, keys=3, size=4.00 KB"),
+                                "AllocFail=0, PartialAlloc=0, keys=3, "
+                                "size=4.00 KB"),
               std::string::npos);
     EXPECT_NE(idle_summary.find("Mem Eviction: Success/Attempts=1/2, "
                                 "keys=3, size=4.00 KB"),

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -4092,6 +4092,43 @@ TEST_F(MasterServiceTest, ReadableAfterPartialUnmountWithReplication) {
         << "Object should remain accessible with surviving replica";
 }
 
+TEST_F(MasterServiceTest, PutStartPartialAllocationIsObservable) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+
+    // Mount two segments only
+    constexpr size_t buffer1 = 0x300000000;
+    constexpr size_t buffer2 = 0x400000000;
+    constexpr size_t segment_size = 1024 * 1024 * 64;  // 64MB
+
+    auto segment1 = MakeSegment("segment1", buffer1, segment_size);
+    auto segment2 = MakeSegment("segment2", buffer2, segment_size);
+    UUID client_id = generate_uuid();
+    ASSERT_TRUE(service_->MountSegment(segment1, client_id).has_value());
+    ASSERT_TRUE(service_->MountSegment(segment2, client_id).has_value());
+
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t partial_before = metrics.get_put_start_partial_allocations();
+
+    // Request more replicas than available segments: best-effort keeps the
+    // put successful but the degradation must be recorded.
+    ReplicateConfig config;
+    config.replica_num = 3;
+    auto put_start_result = service_->PutStart(
+        client_id, "partial_alloc_key", TenantId::Default(), 1024, config);
+    ASSERT_TRUE(put_start_result.has_value());
+    ASSERT_EQ(2u, put_start_result->size());
+    ASSERT_EQ(metrics.get_put_start_partial_allocations(), partial_before + 1);
+
+    // A fully satisfied allocation must not be counted as partial.
+    ReplicateConfig full_config;
+    full_config.replica_num = 2;
+    auto full_result = service_->PutStart(
+        client_id, "full_alloc_key", TenantId::Default(), 1024, full_config);
+    ASSERT_TRUE(full_result.has_value());
+    ASSERT_EQ(2u, full_result->size());
+    ASSERT_EQ(metrics.get_put_start_partial_allocations(), partial_before + 1);
+}
+
 TEST_F(MasterServiceTest, UnmountSegmentPerformance) {
     std::unique_ptr<MasterService> service_(new MasterService());
     constexpr size_t kBufferAddress = 0x300000000;


### PR DESCRIPTION
## Description

`PutStart` may legitimately return fewer replicas than requested and still succeed: with `nof_replica_num == 0` the allocation check only requires `allocated > 0` (best-effort), and `FLEXIBLE_DUAL_REPLICA` (1 memory + 1 NoF) only requires either side to be allocated (see `HasExpectedReplicaAllocation`, `master_service.cpp`).

Today this degradation is completely silent: PutStart returns success, no log line is emitted, and no metric is incremented — while the strict-mode failure path already has both (`master_put_start_alloc_failures_total` + VLOG). Callers believe they got N replicas of redundancy when they may have received a single one, and operators have no way to detect or alert on it.

This PR makes the degradation observable and the semantics explicit, without changing any allocation behavior:

- Emit a `WARNING` log when PutStart succeeds with fewer replicas than requested (`action=put_start_partial_allocation`, with requested/allocated counts for both memory and NoF replicas).
- Add a new counter `master_put_start_partial_allocations_total` ("PutStart succeeded with fewer replicas than requested"), wired into Prometheus serialization and the admin summary string (`PartialAlloc=` next to the existing `AllocFail=`).
- Document the three allocation-check policies in a comment on `HasExpectedReplicaAllocation`. Today the function has no comment at all, and its behavior is easy to misread: `DetermineReplicaWriteMode` classifies both `replica_num=3, nof=0` and `replica_num=2, nof=1` as `RELIABLE_MULTI_REPLICA`, yet the allocation check treats them oppositely — the memory-only config passes best-effort (`allocated > 0`) while the NoF config requires exact counts. The deciding factor is `nof_replica_num == 0`, not the mode name, and nothing in the code says this is intentional. The new comment states the three policies, cross-references the new metric, and clarifies that RELIABLE's strictness for memory-only configs lives in the  transfer stage rather than the allocation stage.

Example log line (from the new unit test):

```
W... master_service.cpp] key=partial_alloc_key, action=put_start_partial_allocation, requested_memory_replicas=3, allocated_memory_replicas=2, requested_nof_replicas=0, allocated_nof_replicas=0
```

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other (observability improvement, no behavior change)

## How Has This Been Tested?

Built and tested on WSL2 Ubuntu 22.04 (Debug, `USE_NOF=ON`, `STORE_USE_ETCD=OFF`, `USE_CUDA=OFF`), branch based on upstream main `7a938fb3`.

New unit test `PutStartPartialAllocationIsObservable`: mounts 2 segments, requests `replica_num=3` → PutStart succeeds with 2 replicas and the new counter increments by exactly 1; a fully satisfied `replica_num=2` put does not increment it. Existing summary-format assertions in `master_metrics_test` updated for the new `PartialAlloc=` field.

**Test commands:**
```bash
ninja -j2 master_service_test master_metrics_test

./mooncake-store/tests/master_service_test \
  --gtest_filter='*PartialAllocation*:*ReadableAfterPartial*:*PutStartInvalidParams*'
./mooncake-store/tests/master_service_test \
  --gtest_filter='MasterServiceTest.Put*:MasterServiceTest.*Replica*'
./mooncake-store/tests/master_metrics_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual verification: the WARNING line above is emitted exactly once for the partial-allocation put and not for the fully-satisfied put. Regression: `master_service_test` Put*/Replica* filters 28/28 passed; `master_metrics_test` 11/11 passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (96 LOC, not needed)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assisted with locating the silent-degradation paths in `HasExpectedReplicaAllocation`/`PutStart`, wiring the new counter through `MasterMetricManager`, and drafting the unit test. The human submitter reviewed every changed line, ran all builds/tests listed above, and can defend the change end-to-end.

---