### PR TITLE
[store] Avoid staging copy for same node tensor put

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -652,7 +652,7 @@ config.preferred_segment = self.get_hostname()
 #### prefer_alloc_in_same_node
 **Type:** `bool`
 **Default:** `False`
-**Description:** Enables the preference for allocating data on the same node. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
+**Description:** Enables host-aware local-first allocation for this request, using the writer host identity and the normal ordered remote fallback. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
 
 ```python
 config = ReplicateConfig()

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -695,13 +695,13 @@ config.preferred_segment = self.get_hostname()
 ```
 
 #### prefer_alloc_in_same_node
-**Type:** `str`
-**Default:** `""` (empty string)
-**Description:** Enables the preference for allocating data on the same node. Currently, this only supports `batch_put_from_multi_buffers`. Additionally, it does not support disk segments, and the `replica_num` can only be set to 1.
+**Type:** `bool`
+**Default:** `False`
+**Description:** Enables the preference for allocating data on the same node. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
 
 ```python
 config = ReplicateConfig()
-config.prefer_alloc_in_same_node = "True"
+config.prefer_alloc_in_same_node = True
 ```
 
 #### group_ids

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -697,7 +697,7 @@ config.preferred_segment = self.get_hostname()
 #### prefer_alloc_in_same_node
 **Type:** `bool`
 **Default:** `False`
-**Description:** Enables the preference for allocating data on the same node. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
+**Description:** Enables host-aware local-first allocation for this request, using the writer host identity and the normal ordered remote fallback. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
 
 ```python
 config = ReplicateConfig()

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -650,13 +650,13 @@ config.preferred_segment = self.get_hostname()
 ```
 
 #### prefer_alloc_in_same_node
-**Type:** `str`
-**Default:** `""` (empty string)
-**Description:** Enables the preference for allocating data on the same node. Currently, this only supports `batch_put_from_multi_buffers`. Additionally, it does not support disk segments, and the `replica_num` can only be set to 1.
+**Type:** `bool`
+**Default:** `False`
+**Description:** Enables the preference for allocating data on the same node. This can be used with direct multi-buffer writes and tensor write APIs to avoid staging when the selected segment is local and local memcpy is enabled. It does not support disk segments, and the `replica_num` can only be set to 1. Tensor APIs keep their default staging behavior unless this flag is explicitly enabled.
 
 ```python
 config = ReplicateConfig()
-config.prefer_alloc_in_same_node = "True"
+config.prefer_alloc_in_same_node = True
 ```
 
 #### group_ids

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1045,6 +1045,10 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const std::vector<PyTensorInfo> &infos,
         const ReplicateConfig &config = ReplicateConfig{}) {
+        if (auto cuda_ipc_results = try_dummy_cuda_ipc_batch_upsert_tensor_impl(
+                keys, infos, config)) {
+            return *cuda_ipc_results;
+        }
         return batch_write_tensor_impl(
             keys, infos, config, "upsert",
             [this](const std::vector<std::string> &write_keys,

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -164,12 +164,6 @@ py::tuple tensor_shape_tuple(const TensorMetadata &metadata) {
     return py::cast(shape_vec);
 }
 
-void append_tensor_payload_span(std::vector<std::span<const char>> &values,
-                                uintptr_t data_ptr, size_t tensor_size) {
-    if (tensor_size == 0) return;
-    values.emplace_back(reinterpret_cast<const char *>(data_ptr), tensor_size);
-}
-
 pybind11::object buffer_to_tensor(BufferHandle *buffer_handle, char *usr_buffer,
                                   int64_t data_length,
                                   bool own_user_buffer = false) {
@@ -918,24 +912,7 @@ class MooncakeStorePyWrapper {
                         const ReplicateConfig &config) {
         // Validation & Metadata extraction (GIL Held)
         auto info = extract_tensor_info(tensor, key);
-        if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
-        if (use_dummy_client_) {
-            return put_tensor_info_impl(key, info, config);
-        }
-
-        // Prepare spans
-        std::vector<std::span<const char>> values;
-        values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
-                            sizeof(TensorMetadata));
-        append_tensor_payload_span(values, info.data_ptr, info.tensor_size);
-
-        // Store (GIL Released)
-        py::gil_scoped_release release_gil;
-        int ret = store_->put_parts(key, values, config);
-        if (ret != 0)
-            LOG(ERROR) << "put_parts failed for key " << key << " with code "
-                       << ret;
-        return ret;
+        return put_tensor_info_impl(key, info, config);
     }
 
     int put_tensor(const std::string &key, pybind11::object tensor) {
@@ -1287,17 +1264,15 @@ class MooncakeStorePyWrapper {
                                    : results[0];
         }
 
-        std::vector<std::span<const char>> values;
-        values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
-                            info.metadata.header.data_offset);
-        append_tensor_payload_span(values, info.data_ptr, info.tensor_size);
-
-        py::gil_scoped_release release_gil;
-        int ret = store_->put_parts(key, values, config);
-        if (ret != 0)
-            LOG(ERROR) << "put_parts failed for key " << key << " with code "
-                       << ret;
-        return ret;
+        auto results = batch_put_tensor_infos_impl(
+            std::vector<std::string>{key}, std::vector<PyTensorInfo>{info},
+            config);
+        if (results.size() != 1) {
+            LOG(ERROR) << "put returned unexpected result count for key "
+                       << key;
+            return to_py_ret(ErrorCode::RPC_FAIL);
+        }
+        return results[0];
     }
 
     int put_manifest_impl(const std::string &key,
@@ -1494,38 +1469,21 @@ class MooncakeStorePyWrapper {
                                    : results[0];
         }
 
-        std::vector<std::span<const char>> values;
-        values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
-                            info.metadata.header.data_offset);
-        append_tensor_payload_span(values, info.data_ptr, info.tensor_size);
-
-        py::gil_scoped_release release_gil;
-        int ret = store_->upsert_parts(key, values, config);
-        if (ret != 0)
-            LOG(ERROR) << "upsert_parts failed for key " << key << " with code "
-                       << ret;
-        return ret;
+        auto results = batch_upsert_tensor_infos_impl(
+            std::vector<std::string>{key}, std::vector<PyTensorInfo>{info},
+            config);
+        if (results.size() != 1) {
+            LOG(ERROR) << "upsert returned unexpected result count for key "
+                       << key;
+            return to_py_ret(ErrorCode::RPC_FAIL);
+        }
+        return results[0];
     }
 
     int upsert_tensor_impl(const std::string &key, pybind11::object tensor,
                            const ReplicateConfig &config) {
         auto info = extract_tensor_info(tensor, key);
-        if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
-        if (use_dummy_client_) {
-            return upsert_tensor_info_impl(key, info, config);
-        }
-
-        std::vector<std::span<const char>> values;
-        values.emplace_back(reinterpret_cast<const char *>(&info.metadata),
-                            sizeof(TensorMetadata));
-        append_tensor_payload_span(values, info.data_ptr, info.tensor_size);
-
-        py::gil_scoped_release release_gil;
-        int ret = store_->upsert_parts(key, values, config);
-        if (ret != 0)
-            LOG(ERROR) << "upsert_parts failed for key " << key << " with code "
-                       << ret;
-        return ret;
+        return upsert_tensor_info_impl(key, info, config);
     }
 
     int upsert_tensor(const std::string &key, pybind11::object tensor) {
@@ -1548,9 +1506,14 @@ class MooncakeStorePyWrapper {
                 return to_py_ret(ErrorCode::INVALID_PARAMS);
             }
 
+            std::vector<std::string> tp_keys;
+            tp_keys.reserve(tp_size);
             for (int rank = 0; rank < tp_size; ++rank) {
-                int ret = upsert_tensor_info_impl(get_tp_key_name(key, rank),
-                                                  (*infos)[rank], config);
+                tp_keys.push_back(get_tp_key_name(key, rank));
+            }
+            auto results =
+                batch_upsert_tensor_infos_impl(tp_keys, *infos, config);
+            for (int ret : results) {
                 if (ret != 0) return ret;
             }
             return 0;
@@ -1608,21 +1571,6 @@ class MooncakeStorePyWrapper {
         py::gil_scoped_release release_gil;
         return store_->batch_upsert_from(keys, buffers, sizes,
                                          ReplicateConfig{});
-    }
-
-    std::vector<int> batch_upsert_tensor_infos_impl(
-        const std::vector<std::string> &keys,
-        const std::vector<PyTensorInfo> &infos,
-        const ReplicateConfig &config = ReplicateConfig{}) {
-        return batch_write_tensor_impl(
-            keys, infos, config, "upsert",
-            [this](const std::vector<std::string> &write_keys,
-                   const std::vector<void *> &buffer_ptrs,
-                   const std::vector<size_t> &buffer_sizes,
-                   const ReplicateConfig &write_config) {
-                return store_->batch_upsert_from(write_keys, buffer_ptrs,
-                                                 buffer_sizes, write_config);
-            });
     }
 
     std::vector<int> batch_upsert_tensor_impl(

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1038,7 +1038,7 @@ class MooncakeStorePyWrapper {
                    const std::vector<std::vector<size_t>> &sizes,
                    const ReplicateConfig &write_config) {
                 return real_client_->batch_put_from_multi_buffers(
-                    write_keys, buffers, sizes, write_config);
+                    write_keys, buffers, sizes, write_config, true);
             });
     }
 
@@ -1064,7 +1064,7 @@ class MooncakeStorePyWrapper {
                    const std::vector<std::vector<size_t>> &sizes,
                    const ReplicateConfig &write_config) {
                 return real_client_->batch_upsert_from_multi_buffers(
-                    write_keys, buffers, sizes, write_config);
+                    write_keys, buffers, sizes, write_config, true);
             });
     }
 

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1058,7 +1058,7 @@ class MooncakeStorePyWrapper {
                    const std::vector<std::vector<void *>> &buffers,
                    const std::vector<std::vector<size_t>> &sizes,
                    const ReplicateConfig &write_config) {
-                return real_client_->batch_upsert_from_multi_buffers(
+                return store_->batch_upsert_from_multi_buffers(
                     write_keys, buffers, sizes, write_config);
             });
     }

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -912,6 +912,7 @@ class MooncakeStorePyWrapper {
                         const ReplicateConfig &config) {
         // Validation & Metadata extraction (GIL Held)
         auto info = extract_tensor_info(tensor, key);
+        if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
         return put_tensor_info_impl(key, info, config);
     }
 
@@ -1062,7 +1063,7 @@ class MooncakeStorePyWrapper {
                    const std::vector<std::vector<void *>> &buffers,
                    const std::vector<std::vector<size_t>> &sizes,
                    const ReplicateConfig &write_config) {
-                return store_->batch_upsert_from_multi_buffers(
+                return real_client_->batch_upsert_from_multi_buffers(
                     write_keys, buffers, sizes, write_config);
             });
     }
@@ -1071,6 +1072,11 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
+        if (pybind11::len(tensors_list) != keys.size()) {
+            LOG(ERROR) << "batch_put_tensor keys and tensors size mismatch";
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
+        }
         std::vector<PyTensorInfo> infos(keys.size());
         for (size_t i = 0; i < keys.size(); ++i) {
             infos[i] = extract_tensor_info(tensors_list[i], keys[i]);
@@ -1487,6 +1493,7 @@ class MooncakeStorePyWrapper {
     int upsert_tensor_impl(const std::string &key, pybind11::object tensor,
                            const ReplicateConfig &config) {
         auto info = extract_tensor_info(tensor, key);
+        if (!info.valid()) return to_py_ret(ErrorCode::INVALID_PARAMS);
         return upsert_tensor_info_impl(key, info, config);
     }
 
@@ -1581,6 +1588,11 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
+        if (pybind11::len(tensors_list) != keys.size()) {
+            LOG(ERROR) << "batch_upsert_tensor keys and tensors size mismatch";
+            return std::vector<int>(keys.size(),
+                                    to_py_ret(ErrorCode::INVALID_PARAMS));
+        }
         std::vector<PyTensorInfo> infos(keys.size());
         for (size_t i = 0; i < keys.size(); ++i) {
             infos[i] = extract_tensor_info(tensors_list[i], keys[i]);

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1049,11 +1049,40 @@ class MooncakeStorePyWrapper {
         return batch_write_tensor_impl(
             keys, infos, config, "put",
             [this](const std::vector<std::string> &write_keys,
-                   const std::vector<void *> &buffer_ptrs,
-                   const std::vector<size_t> &buffer_sizes,
+                   const std::vector<void *> &buffers,
+                   const std::vector<size_t> &sizes,
                    const ReplicateConfig &write_config) {
-                return store_->batch_put_from(write_keys, buffer_ptrs,
-                                              buffer_sizes, write_config);
+                return store_->batch_put_from(write_keys, buffers, sizes,
+                                              write_config);
+            },
+            [this](const std::vector<std::string> &write_keys,
+                   const std::vector<std::vector<void *>> &buffers,
+                   const std::vector<std::vector<size_t>> &sizes,
+                   const ReplicateConfig &write_config) {
+                return real_client_->batch_put_from_multi_buffers(
+                    write_keys, buffers, sizes, write_config);
+            });
+    }
+
+    std::vector<int> batch_upsert_tensor_infos_impl(
+        const std::vector<std::string> &keys,
+        const std::vector<PyTensorInfo> &infos,
+        const ReplicateConfig &config = ReplicateConfig{}) {
+        return batch_write_tensor_impl(
+            keys, infos, config, "upsert",
+            [this](const std::vector<std::string> &write_keys,
+                   const std::vector<void *> &buffers,
+                   const std::vector<size_t> &sizes,
+                   const ReplicateConfig &write_config) {
+                return store_->batch_upsert_from(write_keys, buffers, sizes,
+                                                 write_config);
+            },
+            [this](const std::vector<std::string> &write_keys,
+                   const std::vector<std::vector<void *>> &buffers,
+                   const std::vector<std::vector<size_t>> &sizes,
+                   const ReplicateConfig &write_config) {
+                return real_client_->batch_upsert_from_multi_buffers(
+                    write_keys, buffers, sizes, write_config);
             });
     }
 
@@ -1600,12 +1629,6 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const pybind11::list &tensors_list,
         const ReplicateConfig &config = ReplicateConfig{}) {
-        auto group_ids_error = ValidateGroupIdsForBatchConfig(
-            config, keys.size(), "batch_upsert_tensor");
-        if (!group_ids_error.empty()) {
-            return group_ids_error;
-        }
-
         std::vector<PyTensorInfo> infos(keys.size());
         for (size_t i = 0; i < keys.size(); ++i) {
             infos[i] = extract_tensor_info(tensors_list[i], keys[i]);

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -156,12 +156,37 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
     return results;
 }
 
-template <typename BatchWriteFromFn>
-std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
-                                         const std::vector<PyTensorInfo> &infos,
-                                         const ReplicateConfig &config,
-                                         const char *operation_name,
-                                         BatchWriteFromFn &&batch_write_from) {
+inline void append_tensor_write_buffers(const PyTensorInfo &info,
+                                        std::vector<void *> &buffers,
+                                        std::vector<size_t> &sizes) {
+    buffers.push_back(const_cast<TensorMetadata *>(&info.metadata));
+    sizes.push_back(info.metadata.header.data_offset);
+    if (info.tensor_size > 0) {
+        buffers.push_back(reinterpret_cast<void *>(info.data_ptr));
+        sizes.push_back(info.tensor_size);
+    }
+}
+
+inline void apply_tensor_batch_results(
+    std::vector<int> &results, const std::vector<size_t> &original_indices,
+    const std::vector<int> &op_results, const char *operation_name) {
+    if (op_results.size() != original_indices.size()) {
+        LOG(ERROR) << operation_name << " returned unexpected result count";
+        for (size_t index : original_indices) {
+            results[index] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+        }
+        return;
+    }
+    for (size_t i = 0; i < op_results.size(); ++i)
+        results[original_indices[i]] = op_results[i];
+}
+
+template <typename StagedBatchWriteFn, typename DirectBatchWriteFn>
+std::vector<int> batch_write_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config,
+    const char *operation_name, StagedBatchWriteFn &&staged_batch_write,
+    DirectBatchWriteFn &&direct_batch_write) {
     if (keys.size() != infos.size()) {
         LOG(ERROR) << operation_name
                    << ": keys and tensor infos must have the same length";
@@ -176,23 +201,84 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
     }
 
     std::vector<int> results(keys.size(), 0);
-
     {
         py::gil_scoped_release release_gil;
-        if (!store_->client_buffer_allocator_ && !use_dummy_client_) {
-            LOG(ERROR) << operation_name
-                       << ": client buffer allocator is not available";
+        std::vector<std::string> valid_keys;
+        std::vector<size_t> original_indices;
+        valid_keys.reserve(infos.size());
+        original_indices.reserve(infos.size());
+
+        if (use_dummy_client_) {
+            auto runtime_accelerator =
+                mooncake::device::GetAcceleratorRegistry()
+                    .RuntimeAccelerators();
+            std::vector<void *> buffer_ptrs;
+            std::vector<size_t> buffer_sizes;
+            std::vector<std::unique_ptr<BufferHandle>> temp_allocations;
+            buffer_ptrs.reserve(infos.size());
+            buffer_sizes.reserve(infos.size());
+            temp_allocations.reserve(infos.size());
+
+            for (size_t i = 0; i < infos.size(); ++i) {
+                if (!infos[i].valid()) {
+                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                    continue;
+                }
+
+                size_t total_size =
+                    infos[i].metadata.header.data_offset + infos[i].tensor_size;
+                auto alloc_result = store_->allocate_client_buffer(total_size);
+                if (!alloc_result) {
+                    LOG(ERROR) << "Failed to allocate buffer for "
+                               << operation_name << " key: " << keys[i];
+                    results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
+                    continue;
+                }
+
+                char *dst = static_cast<char *>(alloc_result->ptr());
+                std::memcpy(dst, &infos[i].metadata,
+                            infos[i].metadata.header.data_offset);
+                if (infos[i].tensor_size > 0) {
+                    if (!runtime_accelerator.CopyToHost(
+                            dst + infos[i].metadata.header.data_offset,
+                            reinterpret_cast<const void *>(infos[i].data_ptr),
+                            infos[i].tensor_size)) {
+                        LOG(ERROR) << "Failed to copy tensor payload for "
+                                   << operation_name << " key: " << keys[i];
+                        results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                        continue;
+                    }
+                }
+
+                valid_keys.push_back(keys[i]);
+                buffer_ptrs.push_back(alloc_result->ptr());
+                buffer_sizes.push_back(total_size);
+                original_indices.push_back(i);
+                temp_allocations.push_back(
+                    std::make_unique<BufferHandle>(std::move(*alloc_result)));
+            }
+
+            if (!valid_keys.empty()) {
+                ReplicateConfig write_config =
+                    MakeIndexedConfig(config, original_indices);
+                std::vector<int> op_results = staged_batch_write(
+                    valid_keys, buffer_ptrs, buffer_sizes, write_config);
+                apply_tensor_batch_results(results, original_indices,
+                                           op_results, operation_name);
+            }
+            return results;
+        }
+
+        if (!real_client_) {
+            LOG(ERROR) << operation_name << ": real client is not available";
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
         }
-        auto runtime_accelerator =
-            mooncake::device::GetAcceleratorRegistry().RuntimeAccelerators();
 
-        std::vector<std::string> valid_keys;
-        std::vector<void *> buffer_ptrs;
-        std::vector<size_t> buffer_sizes;
-        std::vector<size_t> original_indices;
-        std::vector<std::unique_ptr<BufferHandle>> temp_allocations;
+        std::vector<std::vector<void *>> all_buffers;
+        std::vector<std::vector<size_t>> all_sizes;
+        all_buffers.reserve(infos.size());
+        all_sizes.reserve(infos.size());
 
         for (size_t i = 0; i < infos.size(); ++i) {
             if (!infos[i].valid()) {
@@ -200,49 +286,22 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                 continue;
             }
 
-            size_t total_size =
-                infos[i].metadata.header.data_offset + infos[i].tensor_size;
-            auto alloc_result = store_->allocate_client_buffer(total_size);
-
-            if (!alloc_result) {
-                LOG(ERROR) << "Failed to allocate buffer for " << operation_name
-                           << " key: " << keys[i];
-                results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
-                continue;
-            }
-
-            char *dst = static_cast<char *>(alloc_result->ptr());
-            std::memcpy(dst, &infos[i].metadata,
-                        infos[i].metadata.header.data_offset);
-            if (infos[i].tensor_size > 0) {
-                if (!runtime_accelerator.CopyToHost(
-                        dst + infos[i].metadata.header.data_offset,
-                        reinterpret_cast<const void *>(infos[i].data_ptr),
-                        infos[i].tensor_size)) {
-                    LOG(ERROR) << "Failed to copy tensor payload for "
-                               << operation_name << " key: " << keys[i];
-                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
-                    continue;
-                }
-            }
-
+            all_buffers.emplace_back();
+            all_sizes.emplace_back();
+            append_tensor_write_buffers(infos[i], all_buffers.back(),
+                                        all_sizes.back());
             valid_keys.push_back(keys[i]);
-            buffer_ptrs.push_back(alloc_result->ptr());
-            buffer_sizes.push_back(total_size);
             original_indices.push_back(i);
-            temp_allocations.push_back(
-                std::make_unique<BufferHandle>(std::move(*alloc_result)));
         }
 
         if (!valid_keys.empty()) {
             ReplicateConfig write_config =
                 MakeIndexedConfig(config, original_indices);
-            std::vector<int> op_results = batch_write_from(
-                valid_keys, buffer_ptrs, buffer_sizes, write_config);
-            if (!apply_indexed_results(operation_name, op_results,
-                                       original_indices, results)) {
-                return results;
-            }
+            std::vector<int> op_results =
+                direct_batch_write(valid_keys, all_buffers, all_sizes,
+                                   write_config);
+            apply_tensor_batch_results(results, original_indices, op_results,
+                                       operation_name);
         }
     }
 

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -153,7 +153,7 @@ std::vector<int> batch_write_tensor_impl(
         valid_keys.reserve(infos.size());
         original_indices.reserve(infos.size());
 
-        if (use_dummy_client_) {
+        auto run_staged_write = [&]() -> std::vector<int> {
             auto runtime_accelerator =
                 mooncake::device::GetAcceleratorRegistry()
                     .RuntimeAccelerators();
@@ -212,7 +212,10 @@ std::vector<int> batch_write_tensor_impl(
                                            op_results, operation_name);
             }
             return results;
-        }
+        };
+
+        if (use_dummy_client_ || !config.prefer_alloc_in_same_node)
+            return run_staged_write();
 
         if (!real_client_) {
             LOG(ERROR) << operation_name << ": real client is not available";

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -14,9 +14,11 @@ int write_manifest_impl(const std::string &key,
     return ret;
 }
 
-std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
+template <typename CudaIpcBatchWriteFn>
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_write_tensor_impl(
     const std::vector<std::string> &keys,
-    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config,
+    const char *operation_name, CudaIpcBatchWriteFn &&write_cuda_ipc) {
     if (!use_dummy_client_ || keys.size() != infos.size()) return std::nullopt;
 
     std::vector<int> results(keys.size(), 0);
@@ -68,13 +70,35 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
             MakeIndexedConfig(config, original_indices);
         auto dummy_client = std::static_pointer_cast<DummyClient>(store_);
         std::vector<int> op_results =
-            dummy_client->batch_put_from_cuda_ipc(write_requests, write_config);
-        if (!apply_indexed_results("put", op_results, original_indices,
+            write_cuda_ipc(dummy_client, write_requests, write_config);
+        if (!apply_indexed_results(operation_name, op_results, original_indices,
                                    results)) {
             return results;
         }
     }
     return results;
+}
+
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    return try_dummy_cuda_ipc_batch_write_tensor_impl(
+        keys, infos, config, "put",
+        [](auto dummy_client, const auto &requests, const auto &write_config) {
+            return dummy_client->batch_put_from_cuda_ipc(requests,
+                                                         write_config);
+        });
+}
+
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_upsert_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    return try_dummy_cuda_ipc_batch_write_tensor_impl(
+        keys, infos, config, "upsert",
+        [](auto dummy_client, const auto &requests, const auto &write_config) {
+            return dummy_client->batch_upsert_from_cuda_ipc(requests,
+                                                            write_config);
+        });
 }
 
 inline void append_tensor_write_buffers(const PyTensorInfo &info,

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -218,9 +218,8 @@ std::vector<int> batch_write_tensor_impl(
         if (!valid_keys.empty()) {
             ReplicateConfig write_config =
                 MakeIndexedConfig(config, original_indices);
-            std::vector<int> op_results =
-                direct_batch_write(valid_keys, all_buffers, all_sizes,
-                                   write_config);
+            std::vector<int> op_results = direct_batch_write(
+                valid_keys, all_buffers, all_sizes, write_config);
             apply_tensor_batch_results(results, original_indices, op_results,
                                        operation_name);
         }

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -293,8 +293,7 @@ std::vector<int> batch_write_tensor_impl(
             return results;
         };
 
-        if (use_dummy_client_ || !config.prefer_alloc_in_same_node)
-            return run_staged_write();
+        if (use_dummy_client_) return run_staged_write();
 
         if (!real_client_) {
             LOG(ERROR) << operation_name << ": real client is not available";

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -297,9 +297,8 @@ std::vector<int> batch_write_tensor_impl(
         if (!valid_keys.empty()) {
             ReplicateConfig write_config =
                 MakeIndexedConfig(config, original_indices);
-            std::vector<int> op_results =
-                direct_batch_write(valid_keys, all_buffers, all_sizes,
-                                   write_config);
+            std::vector<int> op_results = direct_batch_write(
+                valid_keys, all_buffers, all_sizes, write_config);
             apply_tensor_batch_results(results, original_indices, op_results,
                                        operation_name);
         }

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -14,9 +14,11 @@ int write_manifest_impl(const std::string &key,
     return ret;
 }
 
-std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
+template <typename CudaIpcBatchWriteFn>
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_write_tensor_impl(
     const std::vector<std::string> &keys,
-    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config,
+    const char *operation_name, CudaIpcBatchWriteFn &&write_cuda_ipc) {
     if (!use_dummy_client_ || keys.size() != infos.size()) return std::nullopt;
 
     struct CudaStreamContext {
@@ -147,13 +149,35 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
             }
         }
         std::vector<int> op_results =
-            dummy_client->batch_put_from_cuda_ipc(write_requests, write_config);
-        if (!apply_indexed_results("put", op_results, original_indices,
+            write_cuda_ipc(dummy_client, write_requests, write_config);
+        if (!apply_indexed_results(operation_name, op_results, original_indices,
                                    results)) {
             return results;
         }
     }
     return results;
+}
+
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    return try_dummy_cuda_ipc_batch_write_tensor_impl(
+        keys, infos, config, "put",
+        [](auto dummy_client, const auto &requests, const auto &write_config) {
+            return dummy_client->batch_put_from_cuda_ipc(requests,
+                                                         write_config);
+        });
+}
+
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_upsert_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    return try_dummy_cuda_ipc_batch_write_tensor_impl(
+        keys, infos, config, "upsert",
+        [](auto dummy_client, const auto &requests, const auto &write_config) {
+            return dummy_client->batch_upsert_from_cuda_ipc(requests,
+                                                            write_config);
+        });
 }
 
 inline void append_tensor_write_buffers(const PyTensorInfo &info,

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -77,12 +77,37 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
     return results;
 }
 
-template <typename BatchWriteFromFn>
-std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
-                                         const std::vector<PyTensorInfo> &infos,
-                                         const ReplicateConfig &config,
-                                         const char *operation_name,
-                                         BatchWriteFromFn &&batch_write_from) {
+inline void append_tensor_write_buffers(const PyTensorInfo &info,
+                                        std::vector<void *> &buffers,
+                                        std::vector<size_t> &sizes) {
+    buffers.push_back(const_cast<TensorMetadata *>(&info.metadata));
+    sizes.push_back(info.metadata.header.data_offset);
+    if (info.tensor_size > 0) {
+        buffers.push_back(reinterpret_cast<void *>(info.data_ptr));
+        sizes.push_back(info.tensor_size);
+    }
+}
+
+inline void apply_tensor_batch_results(
+    std::vector<int> &results, const std::vector<size_t> &original_indices,
+    const std::vector<int> &op_results, const char *operation_name) {
+    if (op_results.size() != original_indices.size()) {
+        LOG(ERROR) << operation_name << " returned unexpected result count";
+        for (size_t index : original_indices) {
+            results[index] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+        }
+        return;
+    }
+    for (size_t i = 0; i < op_results.size(); ++i)
+        results[original_indices[i]] = op_results[i];
+}
+
+template <typename StagedBatchWriteFn, typename DirectBatchWriteFn>
+std::vector<int> batch_write_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config,
+    const char *operation_name, StagedBatchWriteFn &&staged_batch_write,
+    DirectBatchWriteFn &&direct_batch_write) {
     if (keys.size() != infos.size()) {
         LOG(ERROR) << operation_name
                    << ": keys and tensor infos must have the same length";
@@ -97,23 +122,84 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
     }
 
     std::vector<int> results(keys.size(), 0);
-
     {
         py::gil_scoped_release release_gil;
-        if (!store_->client_buffer_allocator_ && !use_dummy_client_) {
-            LOG(ERROR) << operation_name
-                       << ": client buffer allocator is not available";
+        std::vector<std::string> valid_keys;
+        std::vector<size_t> original_indices;
+        valid_keys.reserve(infos.size());
+        original_indices.reserve(infos.size());
+
+        if (use_dummy_client_) {
+            auto runtime_accelerator =
+                mooncake::device::GetAcceleratorRegistry()
+                    .RuntimeAccelerators();
+            std::vector<void *> buffer_ptrs;
+            std::vector<size_t> buffer_sizes;
+            std::vector<std::unique_ptr<BufferHandle>> temp_allocations;
+            buffer_ptrs.reserve(infos.size());
+            buffer_sizes.reserve(infos.size());
+            temp_allocations.reserve(infos.size());
+
+            for (size_t i = 0; i < infos.size(); ++i) {
+                if (!infos[i].valid()) {
+                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                    continue;
+                }
+
+                size_t total_size =
+                    infos[i].metadata.header.data_offset + infos[i].tensor_size;
+                auto alloc_result = store_->allocate_client_buffer(total_size);
+                if (!alloc_result) {
+                    LOG(ERROR) << "Failed to allocate buffer for "
+                               << operation_name << " key: " << keys[i];
+                    results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
+                    continue;
+                }
+
+                char *dst = static_cast<char *>(alloc_result->ptr());
+                std::memcpy(dst, &infos[i].metadata,
+                            infos[i].metadata.header.data_offset);
+                if (infos[i].tensor_size > 0) {
+                    if (!runtime_accelerator.CopyToHost(
+                            dst + infos[i].metadata.header.data_offset,
+                            reinterpret_cast<const void *>(infos[i].data_ptr),
+                            infos[i].tensor_size)) {
+                        LOG(ERROR) << "Failed to copy tensor payload for "
+                                   << operation_name << " key: " << keys[i];
+                        results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+                        continue;
+                    }
+                }
+
+                valid_keys.push_back(keys[i]);
+                buffer_ptrs.push_back(alloc_result->ptr());
+                buffer_sizes.push_back(total_size);
+                original_indices.push_back(i);
+                temp_allocations.push_back(
+                    std::make_unique<BufferHandle>(std::move(*alloc_result)));
+            }
+
+            if (!valid_keys.empty()) {
+                ReplicateConfig write_config =
+                    MakeIndexedConfig(config, original_indices);
+                std::vector<int> op_results = staged_batch_write(
+                    valid_keys, buffer_ptrs, buffer_sizes, write_config);
+                apply_tensor_batch_results(results, original_indices,
+                                           op_results, operation_name);
+            }
+            return results;
+        }
+
+        if (!real_client_) {
+            LOG(ERROR) << operation_name << ": real client is not available";
             return std::vector<int>(keys.size(),
                                     to_py_ret(ErrorCode::INVALID_PARAMS));
         }
-        auto runtime_accelerator =
-            mooncake::device::GetAcceleratorRegistry().RuntimeAccelerators();
 
-        std::vector<std::string> valid_keys;
-        std::vector<void *> buffer_ptrs;
-        std::vector<size_t> buffer_sizes;
-        std::vector<size_t> original_indices;
-        std::vector<std::unique_ptr<BufferHandle>> temp_allocations;
+        std::vector<std::vector<void *>> all_buffers;
+        std::vector<std::vector<size_t>> all_sizes;
+        all_buffers.reserve(infos.size());
+        all_sizes.reserve(infos.size());
 
         for (size_t i = 0; i < infos.size(); ++i) {
             if (!infos[i].valid()) {
@@ -121,49 +207,22 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                 continue;
             }
 
-            size_t total_size =
-                infos[i].metadata.header.data_offset + infos[i].tensor_size;
-            auto alloc_result = store_->allocate_client_buffer(total_size);
-
-            if (!alloc_result) {
-                LOG(ERROR) << "Failed to allocate buffer for " << operation_name
-                           << " key: " << keys[i];
-                results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
-                continue;
-            }
-
-            char *dst = static_cast<char *>(alloc_result->ptr());
-            std::memcpy(dst, &infos[i].metadata,
-                        infos[i].metadata.header.data_offset);
-            if (infos[i].tensor_size > 0) {
-                if (!runtime_accelerator.CopyToHost(
-                        dst + infos[i].metadata.header.data_offset,
-                        reinterpret_cast<const void *>(infos[i].data_ptr),
-                        infos[i].tensor_size)) {
-                    LOG(ERROR) << "Failed to copy tensor payload for "
-                               << operation_name << " key: " << keys[i];
-                    results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
-                    continue;
-                }
-            }
-
+            all_buffers.emplace_back();
+            all_sizes.emplace_back();
+            append_tensor_write_buffers(infos[i], all_buffers.back(),
+                                        all_sizes.back());
             valid_keys.push_back(keys[i]);
-            buffer_ptrs.push_back(alloc_result->ptr());
-            buffer_sizes.push_back(total_size);
             original_indices.push_back(i);
-            temp_allocations.push_back(
-                std::make_unique<BufferHandle>(std::move(*alloc_result)));
         }
 
         if (!valid_keys.empty()) {
             ReplicateConfig write_config =
                 MakeIndexedConfig(config, original_indices);
-            std::vector<int> op_results = batch_write_from(
-                valid_keys, buffer_ptrs, buffer_sizes, write_config);
-            if (!apply_indexed_results(operation_name, op_results,
-                                       original_indices, results)) {
-                return results;
-            }
+            std::vector<int> op_results =
+                direct_batch_write(valid_keys, all_buffers, all_sizes,
+                                   write_config);
+            apply_tensor_batch_results(results, original_indices, op_results,
+                                       operation_name);
         }
     }
 

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -232,7 +232,7 @@ std::vector<int> batch_write_tensor_impl(
         valid_keys.reserve(infos.size());
         original_indices.reserve(infos.size());
 
-        if (use_dummy_client_) {
+        auto run_staged_write = [&]() -> std::vector<int> {
             auto runtime_accelerator =
                 mooncake::device::GetAcceleratorRegistry()
                     .RuntimeAccelerators();
@@ -291,7 +291,10 @@ std::vector<int> batch_write_tensor_impl(
                                            op_results, operation_name);
             }
             return results;
-        }
+        };
+
+        if (use_dummy_client_ || !config.prefer_alloc_in_same_node)
+            return run_staged_write();
 
         if (!real_client_) {
             LOG(ERROR) << operation_name << ": real client is not available";

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -70,6 +70,10 @@ class Client {
    public:
     virtual ~Client();
 
+    using WriteBufferStager =
+        std::function<tl::expected<std::vector<Slice>, ErrorCode>(
+            const std::vector<Slice>&)>;
+
     const UUID& getClientId() const { return client_id_; }
     const std::string& tenant_id() const { return master_client_.tenant_id(); }
 
@@ -227,6 +231,10 @@ class Client {
         const std::vector<ObjectKey>& keys,
         std::vector<std::vector<Slice>>& batched_slices,
         const ReplicateConfig& config);
+    std::vector<tl::expected<void, ErrorCode>> BatchPut(
+        const std::vector<ObjectKey>& keys,
+        std::vector<std::vector<Slice>>& batched_slices,
+        const ReplicateConfig& config, const WriteBufferStager& stager);
 
     /**
      * @brief Write slices into a memory replica at an object-byte offset.
@@ -280,6 +288,10 @@ class Client {
         const std::vector<ObjectKey>& keys,
         std::vector<std::vector<Slice>>& batched_slices,
         const ReplicateConfig& config);
+    std::vector<tl::expected<void, ErrorCode>> BatchUpsert(
+        const std::vector<ObjectKey>& keys,
+        std::vector<std::vector<Slice>>& batched_slices,
+        const ReplicateConfig& config, const WriteBufferStager& stager);
 
     /**
      * @brief Removes an object and all its replicas
@@ -856,6 +868,8 @@ class Client {
     void StartBatchPut(std::vector<PutOperation>& ops,
                        const ReplicateConfig& config);
     void ComputeBatchObjectChecksums(std::vector<PutOperation>& ops);
+    void StageWriteBuffersForRemoteReplicas(std::vector<PutOperation>& ops,
+                                            const WriteBufferStager& stager);
     void SubmitTransfers(std::vector<PutOperation>& ops);
     void WaitForTransfers(std::vector<PutOperation>& ops);
     void SubmitDfsWrites(std::vector<PutOperation>& ops);

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -871,8 +871,8 @@ class Client {
         const std::vector<const std::vector<Slice>*>& slice_lists,
         const std::vector<DistributedFSDescriptor>& descriptors);
 
-    std::vector<tl::expected<void, ErrorCode>> BatchPutWhenPreferSameNode(
-        std::vector<PutOperation>& ops);
+    std::vector<tl::expected<void, ErrorCode>> BatchWriteWhenPreferSameNode(
+        std::vector<PutOperation>& ops, bool is_upsert);
     std::vector<tl::expected<void, ErrorCode>> BatchGetWhenPreferSameNode(
         const std::vector<std::string>& object_keys,
         const std::vector<QueryResult>& query_results,

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -790,8 +790,8 @@ class Client {
     std::vector<tl::expected<void, ErrorCode>> CollectResults(
         const std::vector<PutOperation>& ops);
 
-    std::vector<tl::expected<void, ErrorCode>> BatchPutWhenPreferSameNode(
-        std::vector<PutOperation>& ops);
+    std::vector<tl::expected<void, ErrorCode>> BatchWriteWhenPreferSameNode(
+        std::vector<PutOperation>& ops, bool is_upsert);
     std::vector<tl::expected<void, ErrorCode>> BatchGetWhenPreferSameNode(
         const std::vector<std::string>& object_keys,
         const std::vector<QueryResult>& query_results,

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -107,6 +107,11 @@ class DummyClient : public PyClient {
         const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config = ReplicateConfig{});
 
+    std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config = ReplicateConfig{}) override;
     std::shared_ptr<BufferHandle> get_buffer(const std::string &key);
 
     std::vector<std::shared_ptr<BufferHandle>> batch_get_buffer(

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -107,6 +107,10 @@ class DummyClient : public PyClient {
         const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config = ReplicateConfig{});
 
+    std::vector<int> batch_upsert_from_cuda_ipc(
+        const std::vector<CudaIpcWriteRequest> &requests,
+        const ReplicateConfig &config = ReplicateConfig{});
+
     std::vector<int> batch_upsert_from_multi_buffers(
         const std::vector<std::string> &keys,
         const std::vector<std::vector<void *>> &all_buffers,

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -372,6 +372,12 @@ class PyClient {
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
         const ReplicateConfig &config = ReplicateConfig{}) = 0;
 
+    virtual std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config = ReplicateConfig{}) = 0;
+
     virtual int upsert_parts(
         const std::string &key, std::vector<std::span<const char>> values,
         const ReplicateConfig &config = ReplicateConfig{}) = 0;

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -321,6 +321,12 @@ class PyClient {
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
         const ReplicateConfig &config = ReplicateConfig{}) = 0;
 
+    virtual std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config = ReplicateConfig{}) = 0;
+
     virtual int upsert_parts(
         const std::string &key, std::vector<std::span<const char>> values,
         const ReplicateConfig &config = ReplicateConfig{}) = 0;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -286,10 +286,15 @@ class RealClient : public PyClient {
 
     int upsert_from(const std::string &key, void *buffer, size_t size,
                     const ReplicateConfig &config = ReplicateConfig{});
-
     std::vector<int> batch_upsert_from(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
+        const ReplicateConfig &config = ReplicateConfig{});
+
+    std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
 
     int upsert_parts(const std::string &key,
@@ -638,10 +643,16 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> upsert_from_internal(
         const std::string &key, void *buffer, size_t size,
         const ReplicateConfig &config = ReplicateConfig{});
-
     std::vector<tl::expected<void, ErrorCode>> batch_upsert_from_internal(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
+        const ReplicateConfig &config = ReplicateConfig{});
+
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_multi_buffers_internal(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
 
     tl::expected<void, ErrorCode> upsert_parts_internal(

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -488,6 +488,11 @@ class RealClient : public PyClient {
         const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config, const UUID &client_id);
 
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_cuda_ipc_dummy_helper(
+        const std::vector<CudaIpcWriteRequest> &requests,
+        const ReplicateConfig &config, const UUID &client_id);
+
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_cuda_ipc_dummy_helper(
         const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id);
@@ -832,6 +837,11 @@ class RealClient : public PyClient {
     };
 
     void FreeAllocatedStoreSegment(AllocatedSegmentRecord &record);
+
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_write_from_cuda_ipc_dummy_helper(
+        const std::vector<CudaIpcWriteRequest> &requests,
+        const ReplicateConfig &config, const UUID &client_id, bool is_upsert);
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -245,6 +245,11 @@ class RealClient : public PyClient {
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
+    std::vector<int> batch_put_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config, bool stage_nonlocal);
 
     std::vector<int> batch_get_session_start(
         const std::vector<std::string> &keys) override;
@@ -296,6 +301,11 @@ class RealClient : public PyClient {
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
+    std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config, bool stage_nonlocal);
 
     int upsert_parts(const std::string &key,
                      std::vector<std::span<const char>> values,
@@ -666,7 +676,8 @@ class RealClient : public PyClient {
         const std::vector<std::string> &keys,
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
-        const ReplicateConfig &config = ReplicateConfig{});
+        const ReplicateConfig &config = ReplicateConfig{},
+        bool stage_nonlocal = false);
 
     tl::expected<void, ErrorCode> upsert_parts_internal(
         const std::string &key, std::vector<std::span<const char>> values,
@@ -691,7 +702,8 @@ class RealClient : public PyClient {
         const std::vector<std::string> &keys,
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
-        const ReplicateConfig &config = ReplicateConfig{});
+        const ReplicateConfig &config = ReplicateConfig{},
+        bool stage_nonlocal = false);
 
     tl::expected<void, ErrorCode> put_parts_internal(
         const std::string &key,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -463,6 +463,14 @@ class RealClient : public PyClient {
     batch_get_into_cuda_ipc_dummy_helper(
         const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id);
 
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_multi_buffers_dummy_helper(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<uint64_t>> &dummy_all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config, int32_t device_id,
+        const UUID &client_id);
+
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_multi_buffers_dummy_helper(
         const std::vector<std::string> &keys,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -492,6 +492,14 @@ class RealClient : public PyClient {
     batch_get_into_cuda_ipc_dummy_helper(
         const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id);
 
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_multi_buffers_dummy_helper(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<uint64_t>> &dummy_all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config, int32_t device_id,
+        const UUID &client_id);
+
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_multi_buffers_dummy_helper(
         const std::vector<std::string> &keys,

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -257,10 +257,15 @@ class RealClient : public PyClient {
 
     int upsert_from(const std::string &key, void *buffer, size_t size,
                     const ReplicateConfig &config = ReplicateConfig{});
-
     std::vector<int> batch_upsert_from(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
+        const ReplicateConfig &config = ReplicateConfig{});
+
+    std::vector<int> batch_upsert_from_multi_buffers(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
 
     int upsert_parts(const std::string &key,
@@ -609,10 +614,16 @@ class RealClient : public PyClient {
     tl::expected<void, ErrorCode> upsert_from_internal(
         const std::string &key, void *buffer, size_t size,
         const ReplicateConfig &config = ReplicateConfig{});
-
     std::vector<tl::expected<void, ErrorCode>> batch_upsert_from_internal(
         const std::vector<std::string> &keys,
         const std::vector<void *> &buffers, const std::vector<size_t> &sizes,
+        const ReplicateConfig &config = ReplicateConfig{});
+
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_multi_buffers_internal(
+        const std::vector<std::string> &keys,
+        const std::vector<std::vector<void *>> &all_buffers,
+        const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config = ReplicateConfig{});
 
     tl::expected<void, ErrorCode> upsert_parts_internal(

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -459,6 +459,11 @@ class RealClient : public PyClient {
         const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config, const UUID &client_id);
 
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_upsert_from_cuda_ipc_dummy_helper(
+        const std::vector<CudaIpcWriteRequest> &requests,
+        const ReplicateConfig &config, const UUID &client_id);
+
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_cuda_ipc_dummy_helper(
         const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id);
@@ -792,6 +797,11 @@ class RealClient : public PyClient {
     };
 
     void FreeAllocatedStoreSegment(AllocatedSegmentRecord &record);
+
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_write_from_cuda_ipc_dummy_helper(
+        const std::vector<CudaIpcWriteRequest> &requests,
+        const ReplicateConfig &config, const UUID &client_id, bool is_upsert);
 
     std::unique_ptr<AutoPortBinder> port_binder_ = nullptr;
 

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -626,6 +626,12 @@ class TransferSubmitter {
     bool validateTransferParams(const AllocatedBuffer::Descriptor& handle,
                                 const std::vector<Slice>& slices) const;
 
+    void appendMemcpyOperations(const AllocatedBuffer::Descriptor& handle,
+                                const std::vector<Slice>& slices,
+                                TransferRequest::OpCode op_code,
+                                uint64_t buffer_offset,
+                                std::vector<MemcpyOperation>& operations);
+
     /**
      * @brief Submit memcpy operation asynchronously
      */

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -201,6 +201,22 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            summary.allocated_nof_replicas == config.nof_replica_num;
 }
 
+std::optional<ErrorCode> ValidatePreferSameNodeWriteConfig(
+    const ReplicateConfig& config) {
+    if (config.nof_replica_num > 0) {
+        LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
+                      "NoF replicas";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (config.replica_num != 1) {
+        LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
+                      "replica_num != 1";
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    return std::nullopt;
+}
+
 // success describes whether the overall put should succeed. Reliable modes
 // require all allocated replicas to complete. Flexible dual-replica mode only
 // requires one replica type to succeed, so success may be true while
@@ -1923,16 +1939,18 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
-    if (client_cfg.prefer_alloc_in_same_node) {
-        LOG(ERROR) << "prefer_alloc_in_same_node is not supported for upsert";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
     std::vector<PutOperation> ops = CreatePutOperations(keys, batched_slices);
     ComputeBatchObjectChecksums(ops);
-    StartBatchUpsert(ops, client_cfg);
+    if (client_cfg.prefer_alloc_in_same_node) {
+        if (auto err = ValidatePreferSameNodeWriteConfig(client_cfg)) {
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(*err));
+        }
+        StartBatchUpsert(ops, client_cfg);
+        return BatchWriteWhenPreferSameNode(ops, true);
+    }
 
+    StartBatchUpsert(ops, client_cfg);
     auto t0 = std::chrono::steady_clock::now();
     SubmitTransfers(ops);
     WaitForTransfers(ops);
@@ -2576,8 +2594,8 @@ void Client::FinalizeBatchUpsert(std::vector<PutOperation>& ops) {
     for (size_t i = 0; i < ops.size(); ++i) {
         auto& op = ops[i];
 
-        if (!op.IsResolved() && !op.replicas.empty() &&
-            !op.pending_transfers.empty()) {
+        if (!op.IsResolved() &&
+            op.transfer_summary.successful_memory_transfers > 0) {
             successful_object_metas.emplace_back(
                 ObjectMeta{op.key, op.object_checksum});
             successful_indices.emplace_back(i);
@@ -2712,8 +2730,8 @@ std::vector<tl::expected<void, ErrorCode>> Client::CollectResults(
     return results;
 }
 
-std::vector<tl::expected<void, ErrorCode>> Client::BatchPutWhenPreferSameNode(
-    std::vector<PutOperation>& ops) {
+std::vector<tl::expected<void, ErrorCode>> Client::BatchWriteWhenPreferSameNode(
+    std::vector<PutOperation>& ops, bool is_upsert) {
     auto t0 = std::chrono::steady_clock::now();
     std::unordered_map<std::string, PutOperation> seg_to_ops{};
     for (auto& op : ops) {
@@ -2808,7 +2826,11 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPutWhenPreferSameNode(
     if (metrics_) {
         metrics_->transfer_metric.batch_put_latency_us.observe(us);
     }
-    FinalizeBatchPut(ops);
+    if (is_upsert) {
+        FinalizeBatchUpsert(ops);
+    } else {
+        FinalizeBatchPut(ops);
+    }
     return CollectResults(ops);
 }
 
@@ -2823,20 +2845,12 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
     std::vector<PutOperation> ops = CreatePutOperations(keys, batched_slices);
     ComputeBatchObjectChecksums(ops);
     if (client_cfg.prefer_alloc_in_same_node) {
-        if (client_cfg.nof_replica_num > 0) {
-            LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
-                          "NoF replicas";
+        if (auto err = ValidatePreferSameNodeWriteConfig(client_cfg)) {
             return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-        }
-        if (client_cfg.replica_num != 1) {
-            LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
-                          "replica_num != 1";
-            return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+                keys.size(), tl::unexpected(*err));
         }
         StartBatchPut(ops, client_cfg);
-        return BatchPutWhenPreferSameNode(ops);
+        return BatchWriteWhenPreferSameNode(ops, false);
     }
     StartBatchPut(ops, client_cfg);
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2130,6 +2130,13 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
     const ReplicateConfig& config) {
+    return BatchUpsert(keys, batched_slices, config, {});
+}
+
+std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
+    const std::vector<ObjectKey>& keys,
+    std::vector<std::vector<Slice>>& batched_slices,
+    const ReplicateConfig& config, const WriteBufferStager& stager) {
     ReplicateConfig client_cfg = AttachHostId(config);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
@@ -2142,10 +2149,12 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
                 keys.size(), tl::unexpected(*err));
         }
         StartBatchUpsert(ops, client_cfg);
+        StageWriteBuffersForRemoteReplicas(ops, stager);
         return BatchWriteWhenPreferSameNode(ops, true);
     }
 
     StartBatchUpsert(ops, client_cfg);
+    StageWriteBuffersForRemoteReplicas(ops, stager);
     auto t0 = std::chrono::steady_clock::now();
     SubmitTransfers(ops);
     WaitForTransfers(ops);
@@ -3082,6 +3091,29 @@ std::vector<tl::expected<void, ErrorCode>> Client::CollectResults(
     return results;
 }
 
+void Client::StageWriteBuffersForRemoteReplicas(
+    std::vector<PutOperation>& ops, const WriteBufferStager& stager) {
+    if (!stager) return;
+
+    for (auto& op : ops) {
+        if (op.IsResolved() || op.replicas.empty() ||
+            std::all_of(op.replicas.begin(), op.replicas.end(),
+                        [this](const Replica::Descriptor& replica) {
+                            return CanUseLocalMemcpy(replica);
+                        })) {
+            continue;
+        }
+        auto staged_slices = stager(op.slices);
+        if (!staged_slices) {
+            op.SetError(staged_slices.error(),
+                        "Failed to stage non-local write buffers");
+            continue;
+        }
+        op.slices = std::move(*staged_slices);
+        VLOG(1) << "Staged write buffers for non-local replica, key=" << op.key;
+    }
+}
+
 std::vector<tl::expected<void, ErrorCode>> Client::BatchWriteWhenPreferSameNode(
     std::vector<PutOperation>& ops, bool is_upsert) {
     auto t0 = std::chrono::steady_clock::now();
@@ -3191,6 +3223,13 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
     const std::vector<ObjectKey>& keys,
     std::vector<std::vector<Slice>>& batched_slices,
     const ReplicateConfig& config) {
+    return BatchPut(keys, batched_slices, config, {});
+}
+
+std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
+    const std::vector<ObjectKey>& keys,
+    std::vector<std::vector<Slice>>& batched_slices,
+    const ReplicateConfig& config, const WriteBufferStager& stager) {
     ReplicateConfig client_cfg = AttachHostId(config);
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
@@ -3203,9 +3242,11 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
                 keys.size(), tl::unexpected(*err));
         }
         StartBatchPut(ops, client_cfg);
+        StageWriteBuffersForRemoteReplicas(ops, stager);
         return BatchWriteWhenPreferSameNode(ops, false);
     }
     StartBatchPut(ops, client_cfg);
+    StageWriteBuffersForRemoteReplicas(ops, stager);
 
     auto t0 = std::chrono::steady_clock::now();
     SubmitTransfers(ops);

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -291,6 +291,22 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
            summary.allocated_dfs_replicas == config.dfs_replica_num;
 }
 
+std::optional<ErrorCode> ValidatePreferSameNodeWriteConfig(
+    const ReplicateConfig& config) {
+    if (config.nof_replica_num > 0) {
+        LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
+                      "NoF replicas";
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (config.replica_num != 1) {
+        LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
+                      "replica_num != 1";
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    return std::nullopt;
+}
+
 // success describes whether the overall put should succeed. Reliable modes
 // require all allocated replicas to complete. Flexible dual-replica mode only
 // requires one replica type to succeed, so success may be true while
@@ -2118,16 +2134,18 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchUpsert(
     if (protocol_ == "cxl") {
         client_cfg.preferred_segment = local_hostname_;
     }
-    if (client_cfg.prefer_alloc_in_same_node) {
-        LOG(ERROR) << "prefer_alloc_in_same_node is not supported for upsert";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
     std::vector<PutOperation> ops = CreatePutOperations(keys, batched_slices);
     ComputeBatchObjectChecksums(ops);
-    StartBatchUpsert(ops, client_cfg);
+    if (client_cfg.prefer_alloc_in_same_node) {
+        if (auto err = ValidatePreferSameNodeWriteConfig(client_cfg)) {
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(*err));
+        }
+        StartBatchUpsert(ops, client_cfg);
+        return BatchWriteWhenPreferSameNode(ops, true);
+    }
 
+    StartBatchUpsert(ops, client_cfg);
     auto t0 = std::chrono::steady_clock::now();
     SubmitTransfers(ops);
     WaitForTransfers(ops);
@@ -3064,8 +3082,8 @@ std::vector<tl::expected<void, ErrorCode>> Client::CollectResults(
     return results;
 }
 
-std::vector<tl::expected<void, ErrorCode>> Client::BatchPutWhenPreferSameNode(
-    std::vector<PutOperation>& ops) {
+std::vector<tl::expected<void, ErrorCode>> Client::BatchWriteWhenPreferSameNode(
+    std::vector<PutOperation>& ops, bool is_upsert) {
     auto t0 = std::chrono::steady_clock::now();
     std::unordered_map<std::string, PutOperation> seg_to_ops{};
     for (auto& op : ops) {
@@ -3161,7 +3179,11 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPutWhenPreferSameNode(
     if (metrics_) {
         metrics_->transfer_metric.batch_put_latency_us.observe(us);
     }
-    FinalizeBatchPut(ops);
+    if (is_upsert) {
+        FinalizeBatchUpsert(ops);
+    } else {
+        FinalizeBatchPut(ops);
+    }
     return CollectResults(ops);
 }
 
@@ -3176,20 +3198,12 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchPut(
     std::vector<PutOperation> ops = CreatePutOperations(keys, batched_slices);
     ComputeBatchObjectChecksums(ops);
     if (client_cfg.prefer_alloc_in_same_node) {
-        if (client_cfg.nof_replica_num > 0) {
-            LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
-                          "NoF replicas";
+        if (auto err = ValidatePreferSameNodeWriteConfig(client_cfg)) {
             return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-        }
-        if (client_cfg.replica_num != 1) {
-            LOG(ERROR) << "prefer_alloc_in_same_node is not supported with "
-                          "replica_num != 1";
-            return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+                keys.size(), tl::unexpected(*err));
         }
         StartBatchPut(ops, client_cfg);
-        return BatchPutWhenPreferSameNode(ops);
+        return BatchWriteWhenPreferSameNode(ops, false);
     }
     StartBatchPut(ops, client_cfg);
 

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -1297,6 +1297,24 @@ std::vector<int> DummyClient::batch_put_from_cuda_ipc(
     return results;
 }
 
+std::vector<int> DummyClient::batch_upsert_from_cuda_ipc(
+    const std::vector<mooncake::CudaIpcWriteRequest>& requests,
+    const ReplicateConfig& config) {
+    const auto start_time = std::chrono::steady_clock::now();
+    auto internal_results =
+        invoke_batch_rpc<&RealClient::batch_upsert_from_cuda_ipc_dummy_helper,
+                         void>(requests.size(), requests, config, client_id_);
+    auto results = expected_results_to_py<int>(internal_results);
+    const size_t successful_bytes =
+        sum_successful_cuda_ipc_sizes(results, requests);
+    if (successful_bytes > 0) {
+        ObserveTransferMetric(TransferOperationKind::kWrite,
+                              "batch_upsert_from_cuda_ipc", successful_bytes,
+                              elapsed_us_since(start_time), true);
+    }
+    return results;
+}
+
 std::vector<int> DummyClient::batch_upsert_from_multi_buffers(
     const std::vector<std::string>& keys,
     const std::vector<std::vector<void*>>& all_buffer_ptrs,

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -1297,6 +1297,33 @@ std::vector<int> DummyClient::batch_put_from_cuda_ipc(
     return results;
 }
 
+std::vector<int> DummyClient::batch_upsert_from_multi_buffers(
+    const std::vector<std::string>& keys,
+    const std::vector<std::vector<void*>>& all_buffer_ptrs,
+    const std::vector<std::vector<size_t>>& all_sizes,
+    const ReplicateConfig& config) {
+    std::vector<std::vector<uint64_t>> dummy_nested =
+        void_ptr_rows_to_u64_nested(all_buffer_ptrs);
+    const auto start_time = std::chrono::steady_clock::now();
+    auto internal_results = invoke_batch_rpc<
+        &RealClient::batch_upsert_from_multi_buffers_dummy_helper, void>(
+        keys.size(), keys, dummy_nested, all_sizes, config, device_id_,
+        client_id_);
+    std::vector<int> results;
+    results.reserve(internal_results.size());
+    for (const auto& result : internal_results) {
+        results.push_back(to_py_ret(result));
+    }
+    const size_t successful_bytes =
+        sum_successful_nested_sizes(results, all_sizes);
+    if (successful_bytes > 0) {
+        ObserveTransferMetric(
+            TransferOperationKind::kWrite, "batch_upsert_from_multi_buffers",
+            successful_bytes, elapsed_us_since(start_time), true);
+    }
+    return results;
+}
+
 std::vector<int> DummyClient::batch_get_into_multi_buffers(
     const std::vector<std::string>& keys,
     const std::vector<std::vector<void*>>& all_buffer_ptrs,

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3725,7 +3725,8 @@ auto MasterService::AllocateAndInsertMetadata(
     size_t allocated_nof_replicas = 0;
     if (config.replica_num > 0) {
         const bool use_local_first =
-            allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST &&
+            (allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST ||
+             config.prefer_alloc_in_same_node) &&
             config.replica_num == 1;
         std::string writer_host_id;
         if (use_local_first) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3364,7 +3364,8 @@ auto MasterService::AllocateAndInsertMetadata(
     size_t allocated_nof_replicas = 0;
     if (config.replica_num > 0) {
         const bool use_local_first =
-            allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST &&
+            (allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST ||
+             config.prefer_alloc_in_same_node) &&
             config.replica_num == 1;
         std::string writer_host_id;
         if (use_local_first) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4577,6 +4577,22 @@ std::vector<tl::expected<void, ErrorCode>>
 RealClient::batch_put_from_cuda_ipc_dummy_helper(
     const std::vector<CudaIpcWriteRequest> &requests,
     const ReplicateConfig &config, const UUID &client_id) {
+    return batch_write_from_cuda_ipc_dummy_helper(requests, config, client_id,
+                                                  false);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_cuda_ipc_dummy_helper(
+    const std::vector<CudaIpcWriteRequest> &requests,
+    const ReplicateConfig &config, const UUID &client_id) {
+    return batch_write_from_cuda_ipc_dummy_helper(requests, config, client_id,
+                                                  true);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_write_from_cuda_ipc_dummy_helper(
+    const std::vector<CudaIpcWriteRequest> &requests,
+    const ReplicateConfig &config, const UUID &client_id, bool is_upsert) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
@@ -4638,6 +4654,10 @@ RealClient::batch_put_from_cuda_ipc_dummy_helper(
         }
     }
 
+    if (is_upsert) {
+        return batch_upsert_from_multi_buffers_internal(keys, all_buffers,
+                                                        all_sizes, config);
+    }
     return batch_put_from_multi_buffers_internal(keys, all_buffers, all_sizes,
                                                  config);
 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4689,6 +4689,22 @@ std::vector<tl::expected<void, ErrorCode>>
 RealClient::batch_put_from_cuda_ipc_dummy_helper(
     const std::vector<CudaIpcWriteRequest> &requests,
     const ReplicateConfig &config, const UUID &client_id) {
+    return batch_write_from_cuda_ipc_dummy_helper(requests, config, client_id,
+                                                  false);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_cuda_ipc_dummy_helper(
+    const std::vector<CudaIpcWriteRequest> &requests,
+    const ReplicateConfig &config, const UUID &client_id) {
+    return batch_write_from_cuda_ipc_dummy_helper(requests, config, client_id,
+                                                  true);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_write_from_cuda_ipc_dummy_helper(
+    const std::vector<CudaIpcWriteRequest> &requests,
+    const ReplicateConfig &config, const UUID &client_id, bool is_upsert) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
@@ -4750,6 +4766,10 @@ RealClient::batch_put_from_cuda_ipc_dummy_helper(
         }
     }
 
+    if (is_upsert) {
+        return batch_upsert_from_multi_buffers_internal(keys, all_buffers,
+                                                        all_sizes, config);
+    }
     return batch_put_from_multi_buffers_internal(keys, all_buffers, all_sizes,
                                                  config);
 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -104,6 +104,65 @@ bool ReleasePinnedRegionsForFree(
     return safe_to_free;
 }
 
+template <typename T>
+std::vector<int> ToPyResults(
+    const std::vector<tl::expected<T, ErrorCode>> &results) {
+    std::vector<int> converted;
+    converted.reserve(results.size());
+    for (const auto &result : results) converted.push_back(to_py_ret(result));
+    return converted;
+}
+
+tl::expected<std::vector<std::vector<Slice>>, ErrorCode>
+BuildNestedSlicesFromBuffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes) {
+    if (keys.size() != all_buffers.size() ||
+        all_buffers.size() != all_sizes.size()) {
+        LOG(ERROR) << "Mismatched sizes for keys, buffers, and sizes";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::vector<std::vector<Slice>> batched_slices(keys.size());
+    for (size_t i = 0; i < all_buffers.size(); ++i) {
+        const auto &buffers = all_buffers[i];
+        const auto &sizes = all_sizes[i];
+        if (buffers.size() != sizes.size()) {
+            LOG(ERROR) << "Mismatched buffers and sizes of key:" << keys[i];
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        batched_slices[i].reserve(buffers.size());
+        for (size_t j = 0; j < buffers.size(); ++j) {
+            batched_slices[i].emplace_back(Slice{buffers[j], sizes[j]});
+        }
+    }
+    return batched_slices;
+}
+
+using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
+    const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
+    const ReplicateConfig &);
+
+std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
+    const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config, BatchWriteMethod write) {
+    if (!client) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    auto batched_slices =
+        BuildNestedSlicesFromBuffers(keys, all_buffers, all_sizes);
+    if (!batched_slices) {
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(batched_slices.error()));
+    }
+    return ((*client).*write)(keys, batched_slices.value(), config);
+}
+
 #ifdef USE_ASCEND_DIRECT
 bool checkAcl(aclError result, const char *message) {
     if (result != ACL_ERROR_NONE) {
@@ -5220,13 +5279,7 @@ std::vector<int> RealClient::batch_put_from_multi_buffers(
                     "batch_put_from_multi_buffers",
                     sum_successful_nested_sizes(py_results, sizes), latency_us);
             });
-    std::vector<int> results;
-    results.reserve(internal_results.size());
-
-    for (const auto &result : internal_results) {
-        results.push_back(to_py_ret(result));
-    }
-    return results;
+    return ToPyResults(internal_results);
 }
 
 std::vector<int> RealClient::batch_get_session_start(
@@ -5812,41 +5865,46 @@ std::vector<int> RealClient::batch_put_session_revoke(
     return results;
 }
 
+std::vector<int> RealClient::batch_upsert_from_multi_buffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &sizes,
+    const ReplicateConfig &config) {
+    auto internal_results =
+        execute_timed_operation<std::vector<tl::expected<void, ErrorCode>>>(
+            [&]() {
+                return batch_upsert_from_multi_buffers_internal(
+                    keys, all_buffers, sizes, config);
+            },
+            [](const auto &) { return true; },
+            [&](uint64_t latency_us, const auto &ret) {
+                auto py_results = ToPyResults(ret);
+                client_->ObserveTransferOperation(
+                    TransferOperationKind::kWrite,
+                    "batch_upsert_from_multi_buffers",
+                    sum_successful_nested_sizes(py_results, sizes), latency_us);
+            });
+    return ToPyResults(internal_results);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_multi_buffers_internal(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config) {
+    return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
+                                      config, &Client::BatchUpsert);
+}
+
 std::vector<tl::expected<void, ErrorCode>>
 RealClient::batch_put_from_multi_buffers_internal(
     const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
     const ReplicateConfig &config) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    if ((keys.size() != all_buffers.size()) ||
-        (all_buffers.size() != all_sizes.size())) {
-        LOG(ERROR) << "Mismatched sizes for keys, buffers, and sizes";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    std::vector<std::vector<mooncake::Slice>> batched_slices(keys.size());
-    for (size_t i = 0; i < all_buffers.size(); ++i) {
-        const auto &buffers = all_buffers[i];
-        const auto &sizes = all_sizes[i];
-        if (buffers.size() != sizes.size()) {
-            LOG(ERROR) << "Mismatched buffers and sizes of key:" << keys[i];
-            return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-        }
-        batched_slices[i].reserve(buffers.size());
-        for (size_t j = 0; j < buffers.size(); ++j) {
-            batched_slices[i].emplace_back(Slice{buffers[j], sizes[j]});
-        }
-    }
-    // Call client BatchPut and return the vector<expected> directly
-    return client_->BatchPut(keys, batched_slices, config);
+    return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
+                                      config, &Client::BatchPut);
 }
 
 std::vector<int> RealClient::batch_get_into_multi_buffers(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -144,6 +144,16 @@ using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
     const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
     const ReplicateConfig &);
 
+ReplicateConfig PreferLocalWriteSegment(const std::shared_ptr<Client> &client,
+                                        const ReplicateConfig &config) {
+    ReplicateConfig write_config = config;
+    if (client && write_config.preferred_segment.empty() &&
+        write_config.preferred_segments.empty()) {
+        write_config.preferred_segment = client->GetSegmentEndpoint();
+    }
+    return write_config;
+}
+
 std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
     const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
@@ -160,7 +170,8 @@ std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(batched_slices.error()));
     }
-    return ((*client).*write)(keys, batched_slices.value(), config);
+    auto write_config = PreferLocalWriteSegment(client, config);
+    return ((*client).*write)(keys, batched_slices.value(), write_config);
 }
 
 #ifdef USE_ASCEND_DIRECT
@@ -4082,7 +4093,8 @@ std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
     }
 
     // Call client BatchPut and return the vector<expected> directly
-    return client_->BatchPut(keys, ordered_batched_slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    return client_->BatchPut(keys, ordered_batched_slices, write_config);
 }
 
 tl::expected<void, ErrorCode> RealClient::put_from_internal(
@@ -4107,7 +4119,8 @@ tl::expected<void, ErrorCode> RealClient::put_from_internal(
     // Create slices directly from the user buffer
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto put_result = client_->Put(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto put_result = client_->Put(key, slices, write_config);
     if (!put_result) {
         return tl::unexpected(put_result.error());
     }
@@ -4214,7 +4227,8 @@ tl::expected<void, ErrorCode> RealClient::upsert_from_internal(
 
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto result = client_->Upsert(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto result = client_->Upsert(key, slices, write_config);
     if (!result) {
         return tl::unexpected(result.error());
     }
@@ -4262,7 +4276,8 @@ RealClient::batch_upsert_from_internal(const std::vector<std::string> &keys,
             split_into_slices(buffers[i], sizes[i]));
     }
 
-    return client_->BatchUpsert(keys, ordered_batched_slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    return client_->BatchUpsert(keys, ordered_batched_slices, write_config);
 }
 
 std::vector<int> RealClient::batch_upsert_from(
@@ -4773,6 +4788,41 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
     return results;
 }
 
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_multi_buffers_dummy_helper(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<uint64_t>> &dummy_all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config, int32_t device_id, const UUID &client_id) {
+#ifdef USE_ASCEND_DIRECT
+    if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
+            device_id)) {
+        LOG(ERROR) << "Failed to set context for physical device " << device_id;
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+#endif
+
+    std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    auto it = shm_contexts_.find(client_id);
+    if (it == shm_contexts_.end()) {
+        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    auto &context = it->second;
+
+    auto real_buffers_result = map_dummy_nested_addrs_to_real_ptrs(
+        context, dummy_all_buffers, all_sizes, keys, client_id);
+    if (!real_buffers_result) {
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(real_buffers_result.error()));
+    }
+
+    return batch_upsert_from_multi_buffers_internal(
+        keys, real_buffers_result.value(), all_sizes, config);
+}
+
 std::vector<tl::expected<int64_t, ErrorCode>>
 RealClient::batch_get_into_multi_buffers_dummy_helper(
     const std::vector<std::string> &keys,
@@ -5243,7 +5293,8 @@ int RealClient::put_from_with_metadata(const std::string &key, void *buffer,
         split_into_slices(metadata_buffer, metadata_size);
     auto data_slices = split_into_slices(buffer, size);
     slices.insert(slices.end(), data_slices.begin(), data_slices.end());
-    auto put_result = client_->Put(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto put_result = client_->Put(key, slices, write_config);
     if (!put_result) {
         LOG(ERROR) << "Put operation failed with error: "
                    << toString(put_result.error());

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -144,16 +144,6 @@ using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
     const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
     const ReplicateConfig &);
 
-ReplicateConfig PreferLocalWriteSegment(const std::shared_ptr<Client> &client,
-                                        const ReplicateConfig &config) {
-    ReplicateConfig write_config = config;
-    if (client && write_config.preferred_segment.empty() &&
-        write_config.preferred_segments.empty()) {
-        write_config.preferred_segment = client->GetSegmentEndpoint();
-    }
-    return write_config;
-}
-
 std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
     const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
@@ -170,8 +160,7 @@ std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(batched_slices.error()));
     }
-    auto write_config = PreferLocalWriteSegment(client, config);
-    return ((*client).*write)(keys, batched_slices.value(), write_config);
+    return ((*client).*write)(keys, batched_slices.value(), config);
 }
 
 #ifdef USE_ASCEND_DIRECT
@@ -3981,8 +3970,7 @@ std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
     }
 
     // Call client BatchPut and return the vector<expected> directly
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    return client_->BatchPut(keys, ordered_batched_slices, write_config);
+    return client_->BatchPut(keys, ordered_batched_slices, config);
 }
 
 tl::expected<void, ErrorCode> RealClient::put_from_internal(
@@ -4007,8 +3995,7 @@ tl::expected<void, ErrorCode> RealClient::put_from_internal(
     // Create slices directly from the user buffer
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto put_result = client_->Put(key, slices, write_config);
+    auto put_result = client_->Put(key, slices, config);
     if (!put_result) {
         return tl::unexpected(put_result.error());
     }
@@ -4115,8 +4102,7 @@ tl::expected<void, ErrorCode> RealClient::upsert_from_internal(
 
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto result = client_->Upsert(key, slices, write_config);
+    auto result = client_->Upsert(key, slices, config);
     if (!result) {
         return tl::unexpected(result.error());
     }
@@ -4164,8 +4150,7 @@ RealClient::batch_upsert_from_internal(const std::vector<std::string> &keys,
             split_into_slices(buffers[i], sizes[i]));
     }
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    return client_->BatchUpsert(keys, ordered_batched_slices, write_config);
+    return client_->BatchUpsert(keys, ordered_batched_slices, config);
 }
 
 std::vector<int> RealClient::batch_upsert_from(
@@ -5242,8 +5227,7 @@ int RealClient::put_from_with_metadata(const std::string &key, void *buffer,
         split_into_slices(metadata_buffer, metadata_size);
     auto data_slices = split_into_slices(buffer, size);
     slices.insert(slices.end(), data_slices.begin(), data_slices.end());
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto put_result = client_->Put(key, slices, write_config);
+    auto put_result = client_->Put(key, slices, config);
     if (!put_result) {
         LOG(ERROR) << "Put operation failed with error: "
                    << toString(put_result.error());

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -140,15 +140,57 @@ BuildNestedSlicesFromBuffers(
     return batched_slices;
 }
 
+tl::expected<std::vector<Slice>, ErrorCode> StageWriteSlices(
+    const std::shared_ptr<ClientBufferAllocator> &allocator,
+    const std::vector<Slice> &slices,
+    std::vector<BufferHandle> &staging_handles) {
+    if (!allocator) {
+        LOG(ERROR) << "Client buffer allocator is not provided";
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    size_t total_size = 0;
+    for (const auto &slice : slices) {
+        if (slice.size > std::numeric_limits<size_t>::max() - total_size) {
+            return tl::unexpected(ErrorCode::BUFFER_OVERFLOW);
+        }
+        total_size += slice.size;
+    }
+    auto allocation = allocator->allocate(total_size);
+    if (!allocation) {
+        return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+
+    auto runtime_accelerator =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
+    char *destination = static_cast<char *>(allocation->ptr());
+    std::vector<Slice> staged_slices;
+    staged_slices.reserve(slices.size());
+    size_t offset = 0;
+    for (const auto &slice : slices) {
+        if (!runtime_accelerator.CopyToHost(destination + offset, slice.ptr,
+                                            slice.size)) {
+            LOG(ERROR) << "Failed to stage non-local write buffer";
+            return tl::unexpected(ErrorCode::TRANSFER_FAIL);
+        }
+        staged_slices.emplace_back(destination + offset, slice.size);
+        offset += slice.size;
+    }
+    staging_handles.emplace_back(std::move(*allocation));
+    return staged_slices;
+}
+
 using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
     const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
-    const ReplicateConfig &);
+    const ReplicateConfig &, const Client::WriteBufferStager &);
 
 std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
     const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
-    const ReplicateConfig &config, BatchWriteMethod write) {
+    const ReplicateConfig &config,
+    const std::shared_ptr<ClientBufferAllocator> &allocator,
+    bool stage_nonlocal, BatchWriteMethod write) {
     if (!client) {
         LOG(ERROR) << "Client is not initialized";
         return std::vector<tl::expected<void, ErrorCode>>(
@@ -160,7 +202,16 @@ std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(batched_slices.error()));
     }
-    return ((*client).*write)(keys, batched_slices.value(), config);
+
+    std::vector<BufferHandle> staging_handles;
+    staging_handles.reserve(stage_nonlocal ? keys.size() : 0);
+    Client::WriteBufferStager stager;
+    if (stage_nonlocal) {
+        stager = [&](const std::vector<Slice> &slices) {
+            return StageWriteSlices(allocator, slices, staging_handles);
+        };
+    }
+    return ((*client).*write)(keys, batched_slices.value(), config, stager);
 }
 
 #ifdef USE_ASCEND_DIRECT
@@ -4752,11 +4803,11 @@ RealClient::batch_write_from_cuda_ipc_dummy_helper(
     }
 
     if (is_upsert) {
-        return batch_upsert_from_multi_buffers_internal(keys, all_buffers,
-                                                        all_sizes, config);
+        return batch_upsert_from_multi_buffers_internal(
+            keys, all_buffers, all_sizes, config, true);
     }
     return batch_put_from_multi_buffers_internal(keys, all_buffers, all_sizes,
-                                                 config);
+                                                 config, true);
 }
 
 std::vector<tl::expected<int64_t, ErrorCode>>
@@ -5316,11 +5367,20 @@ std::vector<int> RealClient::batch_put_from_multi_buffers(
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &sizes,
     const ReplicateConfig &config) {
+    return batch_put_from_multi_buffers(keys, all_buffers, sizes, config,
+                                        false);
+}
+
+std::vector<int> RealClient::batch_put_from_multi_buffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &sizes,
+    const ReplicateConfig &config, bool stage_nonlocal) {
     auto internal_results =
         execute_timed_operation<std::vector<tl::expected<void, ErrorCode>>>(
             [&]() {
-                return batch_put_from_multi_buffers_internal(keys, all_buffers,
-                                                             sizes, config);
+                return batch_put_from_multi_buffers_internal(
+                    keys, all_buffers, sizes, config, stage_nonlocal);
             },
             [](const auto &) { return true; },
             [&](uint64_t latency_us, const auto &ret) {
@@ -5925,11 +5985,20 @@ std::vector<int> RealClient::batch_upsert_from_multi_buffers(
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &sizes,
     const ReplicateConfig &config) {
+    return batch_upsert_from_multi_buffers(keys, all_buffers, sizes, config,
+                                           false);
+}
+
+std::vector<int> RealClient::batch_upsert_from_multi_buffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &sizes,
+    const ReplicateConfig &config, bool stage_nonlocal) {
     auto internal_results =
         execute_timed_operation<std::vector<tl::expected<void, ErrorCode>>>(
             [&]() {
                 return batch_upsert_from_multi_buffers_internal(
-                    keys, all_buffers, sizes, config);
+                    keys, all_buffers, sizes, config, stage_nonlocal);
             },
             [](const auto &) { return true; },
             [&](uint64_t latency_us, const auto &ret) {
@@ -5947,9 +6016,10 @@ RealClient::batch_upsert_from_multi_buffers_internal(
     const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
-    const ReplicateConfig &config) {
+    const ReplicateConfig &config, bool stage_nonlocal) {
     return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
-                                      config, &Client::BatchUpsert);
+                                      config, client_buffer_allocator_,
+                                      stage_nonlocal, &Client::BatchUpsert);
 }
 
 std::vector<tl::expected<void, ErrorCode>>
@@ -5957,9 +6027,10 @@ RealClient::batch_put_from_multi_buffers_internal(
     const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
-    const ReplicateConfig &config) {
+    const ReplicateConfig &config, bool stage_nonlocal) {
     return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
-                                      config, &Client::BatchPut);
+                                      config, client_buffer_allocator_,
+                                      stage_nonlocal, &Client::BatchPut);
 }
 
 std::vector<int> RealClient::batch_get_into_multi_buffers(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -144,6 +144,16 @@ using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
     const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
     const ReplicateConfig &);
 
+ReplicateConfig PreferLocalWriteSegment(const std::shared_ptr<Client> &client,
+                                        const ReplicateConfig &config) {
+    ReplicateConfig write_config = config;
+    if (client && write_config.preferred_segment.empty() &&
+        write_config.preferred_segments.empty()) {
+        write_config.preferred_segment = client->GetSegmentEndpoint();
+    }
+    return write_config;
+}
+
 std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
     const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
@@ -160,7 +170,8 @@ std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(batched_slices.error()));
     }
-    return ((*client).*write)(keys, batched_slices.value(), config);
+    auto write_config = PreferLocalWriteSegment(client, config);
+    return ((*client).*write)(keys, batched_slices.value(), write_config);
 }
 
 #ifdef USE_ASCEND_DIRECT
@@ -3970,7 +3981,8 @@ std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
     }
 
     // Call client BatchPut and return the vector<expected> directly
-    return client_->BatchPut(keys, ordered_batched_slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    return client_->BatchPut(keys, ordered_batched_slices, write_config);
 }
 
 tl::expected<void, ErrorCode> RealClient::put_from_internal(
@@ -3995,7 +4007,8 @@ tl::expected<void, ErrorCode> RealClient::put_from_internal(
     // Create slices directly from the user buffer
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto put_result = client_->Put(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto put_result = client_->Put(key, slices, write_config);
     if (!put_result) {
         return tl::unexpected(put_result.error());
     }
@@ -4102,7 +4115,8 @@ tl::expected<void, ErrorCode> RealClient::upsert_from_internal(
 
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto result = client_->Upsert(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto result = client_->Upsert(key, slices, write_config);
     if (!result) {
         return tl::unexpected(result.error());
     }
@@ -4150,7 +4164,8 @@ RealClient::batch_upsert_from_internal(const std::vector<std::string> &keys,
             split_into_slices(buffers[i], sizes[i]));
     }
 
-    return client_->BatchUpsert(keys, ordered_batched_slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    return client_->BatchUpsert(keys, ordered_batched_slices, write_config);
 }
 
 std::vector<int> RealClient::batch_upsert_from(
@@ -4697,6 +4712,41 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
     return results;
 }
 
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_multi_buffers_dummy_helper(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<uint64_t>> &dummy_all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config, int32_t device_id, const UUID &client_id) {
+#ifdef USE_ASCEND_DIRECT
+    if (!ContextManager::getInstance().setCurrentContextByPhysicalId(
+            device_id)) {
+        LOG(ERROR) << "Failed to set context for physical device " << device_id;
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+#endif
+
+    std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    auto it = shm_contexts_.find(client_id);
+    if (it == shm_contexts_.end()) {
+        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    auto &context = it->second;
+
+    auto real_buffers_result = map_dummy_nested_addrs_to_real_ptrs(
+        context, dummy_all_buffers, all_sizes, keys, client_id);
+    if (!real_buffers_result) {
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(real_buffers_result.error()));
+    }
+
+    return batch_upsert_from_multi_buffers_internal(
+        keys, real_buffers_result.value(), all_sizes, config);
+}
+
 std::vector<tl::expected<int64_t, ErrorCode>>
 RealClient::batch_get_into_multi_buffers_dummy_helper(
     const std::vector<std::string> &keys,
@@ -5172,7 +5222,8 @@ int RealClient::put_from_with_metadata(const std::string &key, void *buffer,
         split_into_slices(metadata_buffer, metadata_size);
     auto data_slices = split_into_slices(buffer, size);
     slices.insert(slices.end(), data_slices.begin(), data_slices.end());
-    auto put_result = client_->Put(key, slices, config);
+    auto write_config = PreferLocalWriteSegment(client_, config);
+    auto put_result = client_->Put(key, slices, write_config);
     if (!put_result) {
         LOG(ERROR) << "Put operation failed with error: "
                    << toString(put_result.error());

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -104,6 +104,65 @@ bool ReleasePinnedRegionsForFree(
     return safe_to_free;
 }
 
+template <typename T>
+std::vector<int> ToPyResults(
+    const std::vector<tl::expected<T, ErrorCode>> &results) {
+    std::vector<int> converted;
+    converted.reserve(results.size());
+    for (const auto &result : results) converted.push_back(to_py_ret(result));
+    return converted;
+}
+
+tl::expected<std::vector<std::vector<Slice>>, ErrorCode>
+BuildNestedSlicesFromBuffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes) {
+    if (keys.size() != all_buffers.size() ||
+        all_buffers.size() != all_sizes.size()) {
+        LOG(ERROR) << "Mismatched sizes for keys, buffers, and sizes";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    std::vector<std::vector<Slice>> batched_slices(keys.size());
+    for (size_t i = 0; i < all_buffers.size(); ++i) {
+        const auto &buffers = all_buffers[i];
+        const auto &sizes = all_sizes[i];
+        if (buffers.size() != sizes.size()) {
+            LOG(ERROR) << "Mismatched buffers and sizes of key:" << keys[i];
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        batched_slices[i].reserve(buffers.size());
+        for (size_t j = 0; j < buffers.size(); ++j) {
+            batched_slices[i].emplace_back(Slice{buffers[j], sizes[j]});
+        }
+    }
+    return batched_slices;
+}
+
+using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
+    const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
+    const ReplicateConfig &);
+
+std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
+    const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config, BatchWriteMethod write) {
+    if (!client) {
+        LOG(ERROR) << "Client is not initialized";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+    auto batched_slices =
+        BuildNestedSlicesFromBuffers(keys, all_buffers, all_sizes);
+    if (!batched_slices) {
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(batched_slices.error()));
+    }
+    return ((*client).*write)(keys, batched_slices.value(), config);
+}
+
 #ifdef USE_ASCEND_DIRECT
 bool checkAcl(aclError result, const char *message) {
     if (result != ACL_ERROR_NONE) {
@@ -5149,14 +5208,39 @@ std::vector<int> RealClient::batch_put_from_multi_buffers(
                     "batch_put_from_multi_buffers",
                     sum_successful_nested_sizes(py_results, sizes), latency_us);
             });
-    std::vector<int> results;
-    results.reserve(internal_results.size());
+    return ToPyResults(internal_results);
+}
 
-    for (const auto &result : internal_results) {
-        results.push_back(to_py_ret(result));
-    }
+std::vector<int> RealClient::batch_upsert_from_multi_buffers(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &sizes,
+    const ReplicateConfig &config) {
+    auto internal_results =
+        execute_timed_operation<std::vector<tl::expected<void, ErrorCode>>>(
+            [&]() {
+                return batch_upsert_from_multi_buffers_internal(
+                    keys, all_buffers, sizes, config);
+            },
+            [](const auto &) { return true; },
+            [&](uint64_t latency_us, const auto &ret) {
+                auto py_results = ToPyResults(ret);
+                client_->ObserveTransferOperation(
+                    TransferOperationKind::kWrite,
+                    "batch_upsert_from_multi_buffers",
+                    sum_successful_nested_sizes(py_results, sizes), latency_us);
+            });
+    return ToPyResults(internal_results);
+}
 
-    return results;
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_upsert_from_multi_buffers_internal(
+    const std::vector<std::string> &keys,
+    const std::vector<std::vector<void *>> &all_buffers,
+    const std::vector<std::vector<size_t>> &all_sizes,
+    const ReplicateConfig &config) {
+    return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
+                                      config, &Client::BatchUpsert);
 }
 
 std::vector<tl::expected<void, ErrorCode>>
@@ -5165,35 +5249,8 @@ RealClient::batch_put_from_multi_buffers_internal(
     const std::vector<std::vector<void *>> &all_buffers,
     const std::vector<std::vector<size_t>> &all_sizes,
     const ReplicateConfig &config) {
-    if (!client_) {
-        LOG(ERROR) << "Client is not initialized";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    if ((keys.size() != all_buffers.size()) ||
-        (all_buffers.size() != all_sizes.size())) {
-        LOG(ERROR) << "Mismatched sizes for keys, buffers, and sizes";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    std::vector<std::vector<mooncake::Slice>> batched_slices(keys.size());
-    for (size_t i = 0; i < all_buffers.size(); ++i) {
-        const auto &buffers = all_buffers[i];
-        const auto &sizes = all_sizes[i];
-        if (buffers.size() != sizes.size()) {
-            LOG(ERROR) << "Mismatched buffers and sizes of key:" << keys[i];
-            return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-        }
-        batched_slices[i].reserve(buffers.size());
-        for (size_t j = 0; j < buffers.size(); ++j) {
-            batched_slices[i].emplace_back(Slice{buffers[j], sizes[j]});
-        }
-    }
-    // Call client BatchPut and return the vector<expected> directly
-    return client_->BatchPut(keys, batched_slices, config);
+    return BatchWriteFromMultiBuffers(client_, keys, all_buffers, all_sizes,
+                                      config, &Client::BatchPut);
 }
 
 std::vector<int> RealClient::batch_get_into_multi_buffers(

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -144,16 +144,6 @@ using BatchWriteMethod = std::vector<tl::expected<void, ErrorCode>> (Client::*)(
     const std::vector<ObjectKey> &, std::vector<std::vector<Slice>> &,
     const ReplicateConfig &);
 
-ReplicateConfig PreferLocalWriteSegment(const std::shared_ptr<Client> &client,
-                                        const ReplicateConfig &config) {
-    ReplicateConfig write_config = config;
-    if (client && write_config.preferred_segment.empty() &&
-        write_config.preferred_segments.empty()) {
-        write_config.preferred_segment = client->GetSegmentEndpoint();
-    }
-    return write_config;
-}
-
 std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
     const std::shared_ptr<Client> &client, const std::vector<std::string> &keys,
     const std::vector<std::vector<void *>> &all_buffers,
@@ -170,8 +160,7 @@ std::vector<tl::expected<void, ErrorCode>> BatchWriteFromMultiBuffers(
         return std::vector<tl::expected<void, ErrorCode>>(
             keys.size(), tl::unexpected(batched_slices.error()));
     }
-    auto write_config = PreferLocalWriteSegment(client, config);
-    return ((*client).*write)(keys, batched_slices.value(), write_config);
+    return ((*client).*write)(keys, batched_slices.value(), config);
 }
 
 #ifdef USE_ASCEND_DIRECT
@@ -4093,8 +4082,7 @@ std::vector<tl::expected<void, ErrorCode>> RealClient::batch_put_from_internal(
     }
 
     // Call client BatchPut and return the vector<expected> directly
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    return client_->BatchPut(keys, ordered_batched_slices, write_config);
+    return client_->BatchPut(keys, ordered_batched_slices, config);
 }
 
 tl::expected<void, ErrorCode> RealClient::put_from_internal(
@@ -4119,8 +4107,7 @@ tl::expected<void, ErrorCode> RealClient::put_from_internal(
     // Create slices directly from the user buffer
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto put_result = client_->Put(key, slices, write_config);
+    auto put_result = client_->Put(key, slices, config);
     if (!put_result) {
         return tl::unexpected(put_result.error());
     }
@@ -4227,8 +4214,7 @@ tl::expected<void, ErrorCode> RealClient::upsert_from_internal(
 
     std::vector<mooncake::Slice> slices = split_into_slices(buffer, size);
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto result = client_->Upsert(key, slices, write_config);
+    auto result = client_->Upsert(key, slices, config);
     if (!result) {
         return tl::unexpected(result.error());
     }
@@ -4276,8 +4262,7 @@ RealClient::batch_upsert_from_internal(const std::vector<std::string> &keys,
             split_into_slices(buffers[i], sizes[i]));
     }
 
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    return client_->BatchUpsert(keys, ordered_batched_slices, write_config);
+    return client_->BatchUpsert(keys, ordered_batched_slices, config);
 }
 
 std::vector<int> RealClient::batch_upsert_from(
@@ -5313,8 +5298,7 @@ int RealClient::put_from_with_metadata(const std::string &key, void *buffer,
         split_into_slices(metadata_buffer, metadata_size);
     auto data_slices = split_into_slices(buffer, size);
     slices.insert(slices.end(), data_slices.begin(), data_slices.end());
-    auto write_config = PreferLocalWriteSegment(client_, config);
-    auto put_result = client_->Put(key, slices, write_config);
+    auto put_result = client_->Put(key, slices, config);
     if (!put_result) {
         LOG(ERROR) << "Put operation failed with error: "
                    << toString(put_result.error());

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -49,6 +49,9 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
         &RealClient::batch_put_from_multi_buffers_dummy_helper>(&real_client);
     server.register_handler<&RealClient::batch_put_from_cuda_ipc_dummy_helper>(
         &real_client);
+    server
+        .register_handler<&RealClient::batch_upsert_from_cuda_ipc_dummy_helper>(
+            &real_client);
     server.register_handler<
         &RealClient::batch_upsert_from_multi_buffers_dummy_helper>(
         &real_client);

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -49,6 +49,9 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
         &RealClient::batch_put_from_multi_buffers_dummy_helper>(&real_client);
     server.register_handler<&RealClient::batch_put_from_cuda_ipc_dummy_helper>(
         &real_client);
+    server.register_handler<
+        &RealClient::batch_upsert_from_multi_buffers_dummy_helper>(
+        &real_client);
     server.register_handler<&RealClient::upsert_dummy_helper>(&real_client);
     server.register_handler<&RealClient::upsert_from_dummy_helper>(
         &real_client);

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1049,16 +1049,44 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
     const std::vector<Replica::Descriptor>& replicas,
     std::vector<std::vector<Slice>>& all_slices,
     TransferRequest::OpCode op_code) {
-    std::optional<TransferFuture> future;
-    std::vector<TransferRequest> requests;
+    if (replicas.size() != all_slices.size()) {
+        LOG(ERROR) << "Mismatched replicas and slice lists";
+        return std::nullopt;
+    }
+
+    bool use_local_memcpy =
+        op_code == TransferRequest::WRITE && !replicas.empty();
+    size_t operation_count = 0;
     for (size_t i = 0; i < replicas.size(); ++i) {
-        auto& replica = replicas[i];
-        auto& slices = all_slices[i];
-        auto& mem_desc = replica.get_memory_descriptor();
-        if (!validateTransferParams(mem_desc.buffer_descriptor, slices)) {
+        if (!replicas[i].is_memory_replica()) {
+            LOG(ERROR) << "Batch transfer only supports memory replicas";
             return std::nullopt;
         }
-        auto& handle = mem_desc.buffer_descriptor;
+        const auto& handle =
+            replicas[i].get_memory_descriptor().buffer_descriptor;
+        if (!validateTransferParams(handle, all_slices[i])) {
+            return std::nullopt;
+        }
+        use_local_memcpy =
+            use_local_memcpy && canUseLocalMemcpy(handle.transport_endpoint_);
+        operation_count += all_slices[i].size();
+    }
+
+    std::vector<TransferRequest> requests;
+    std::vector<MemcpyOperation> memcpy_operations;
+    if (use_local_memcpy)
+        memcpy_operations.reserve(operation_count);
+    else
+        requests.reserve(operation_count);
+    for (size_t i = 0; i < replicas.size(); ++i) {
+        auto& slices = all_slices[i];
+        const auto& handle =
+            replicas[i].get_memory_descriptor().buffer_descriptor;
+        if (use_local_memcpy) {
+            appendMemcpyOperations(handle, slices, op_code, 0,
+                                   memcpy_operations);
+            continue;
+        }
         uint64_t offset = 0;
         SegmentHandle seg = engine_.openSegment(handle.transport_endpoint_);
         if (seg == static_cast<uint64_t>(ERR_INVALID_ARGUMENT)) {
@@ -1066,7 +1094,7 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
                        << handle.transport_endpoint_;
             return std::nullopt;
         }
-        for (auto slice : slices) {
+        for (const auto& slice : slices) {
             TransferRequest request;
             request.opcode = op_code;
             request.source = static_cast<char*>(slice.ptr);
@@ -1077,7 +1105,9 @@ std::optional<TransferFuture> TransferSubmitter::submit_batch(
             offset += slice.size;
         }
     }
-    future = submitTransfer(requests);
+    auto future = use_local_memcpy
+                      ? submitMemcpyOperations(std::move(memcpy_operations))
+                      : submitTransfer(requests);
     // Update metrics on successful submission
     if (future.has_value()) {
         for (auto& slices : all_slices) {
@@ -1160,36 +1190,36 @@ TransferSubmitter::submit_batch_get_offload_object(
                             : submitTransfer(requests);
 }
 
+void TransferSubmitter::appendMemcpyOperations(
+    const AllocatedBuffer::Descriptor& handle, const std::vector<Slice>& slices,
+    const TransferRequest::OpCode op_code, uint64_t buffer_offset,
+    std::vector<MemcpyOperation>& operations) {
+    uint64_t base_address = static_cast<uint64_t>(handle.buffer_address_);
+    uint64_t offset = buffer_offset;
+
+    for (const auto& slice : slices) {
+        if (slice.ptr == nullptr) continue;
+
+        void* dest;
+        const void* src;
+        if (op_code == TransferRequest::READ) {
+            dest = slice.ptr;
+            src = reinterpret_cast<const void*>(base_address + offset);
+        } else {
+            dest = reinterpret_cast<void*>(base_address + offset);
+            src = slice.ptr;
+        }
+        offset += slice.size;
+        operations.emplace_back(dest, src, slice.size);
+    }
+}
+
 std::optional<TransferFuture> TransferSubmitter::submitMemcpyOperation(
     const AllocatedBuffer::Descriptor& handle, const std::vector<Slice>& slices,
     const TransferRequest::OpCode op_code, uint64_t src_offset) {
     std::vector<MemcpyOperation> operations;
     operations.reserve(slices.size());
-    uint64_t base_address = static_cast<uint64_t>(handle.buffer_address_);
-    uint64_t offset = src_offset;
-
-    for (size_t i = 0; i < slices.size(); ++i) {
-        const auto& slice = slices[i];
-
-        if (slice.ptr == nullptr) continue;
-
-        void* dest;
-        const void* src;
-
-        if (op_code == TransferRequest::READ) {
-            // READ: from handle (remote buffer) to slice (local buffer)
-            dest = slice.ptr;
-            src = reinterpret_cast<const void*>(base_address + offset);
-        } else {
-            // WRITE: from slice (local buffer) to handle (remote buffer)
-            dest = reinterpret_cast<void*>(base_address + offset);
-            src = slice.ptr;
-        }
-        offset += slice.size;
-
-        operations.emplace_back(dest, src, slice.size);
-    }
-
+    appendMemcpyOperations(handle, slices, op_code, src_offset, operations);
     return submitMemcpyOperations(std::move(operations));
 }
 

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -568,6 +568,78 @@ TEST_F(ClientIntegrationTest, LocalPreferredAllocationTest) {
         << "Remove operation failed: " << toString(remove_result2.error());
 }
 
+TEST_F(ClientIntegrationTest, BatchWriteStagesActualNonLocalAllocation) {
+    size_t stage_calls = 0;
+    std::vector<std::pair<void*, size_t>> staged_allocations;
+    Client::WriteBufferStager stager = [&](const std::vector<Slice>& slices)
+        -> tl::expected<std::vector<Slice>, ErrorCode> {
+        size_t total_size = 0;
+        for (const auto& slice : slices) total_size += slice.size;
+        void* buffer = client_buffer_allocator_->allocate(total_size);
+        if (!buffer) return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+
+        std::vector<Slice> staged_slices;
+        size_t offset = 0;
+        for (const auto& slice : slices) {
+            std::memcpy(static_cast<char*>(buffer) + offset, slice.ptr,
+                        slice.size);
+            staged_slices.emplace_back(static_cast<char*>(buffer) + offset,
+                                       slice.size);
+            offset += slice.size;
+        }
+        staged_allocations.emplace_back(buffer, total_size);
+        ++stage_calls;
+        return staged_slices;
+    };
+    auto write = [&](const std::string& key, std::string& value,
+                     const ReplicateConfig& config, bool upsert) {
+        std::vector<std::string> keys{key};
+        std::vector<std::vector<Slice>> slices{{{value.data(), value.size()}}};
+        return upsert ? test_client_->BatchUpsert(keys, slices, config, stager)
+                      : test_client_->BatchPut(keys, slices, config, stager);
+    };
+
+    ReplicateConfig config;
+    config.preferred_segment = "localhost:17813";
+    size_t expected_stage_calls =
+        test_client_->CanUseLocalMemcpy(test_client_->GetTransportEndpoint())
+            ? 0
+            : 1;
+    std::string local_value = "local direct write";
+    auto local_result =
+        write("batch_write_actual_local", local_value, config, false);
+    ASSERT_TRUE(local_result[0]);
+    EXPECT_EQ(stage_calls, expected_stage_calls);
+
+    config.prefer_alloc_in_same_node = true;
+    config.preferred_segment = "localhost:17812";
+    std::string remote_value = "remote staged write";
+    auto remote_result =
+        write("batch_write_actual_remote", remote_value, config, false);
+    ASSERT_TRUE(remote_result[0]);
+    ++expected_stage_calls;
+    EXPECT_EQ(stage_calls, expected_stage_calls);
+    auto query = test_client_->Query("batch_write_actual_remote");
+    ASSERT_TRUE(query);
+    EXPECT_EQ(query->replicas[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              segment_provider_client_->GetTransportEndpoint());
+
+    remote_value = "remote staged upsert";
+    auto upsert_result =
+        write("batch_write_actual_remote", remote_value, config, true);
+    ASSERT_TRUE(upsert_result[0]);
+    ++expected_stage_calls;
+    EXPECT_EQ(stage_calls, expected_stage_calls);
+
+    EXPECT_TRUE(test_client_->Remove("batch_write_actual_local", true));
+    EXPECT_TRUE(test_client_->Remove("batch_write_actual_remote", true));
+    for (const auto& [ptr, size] : staged_allocations) {
+        client_buffer_allocator_->deallocate(ptr, size);
+    }
+}
+
 // Test heavy workload operations
 TEST_F(ClientIntegrationTest, DISABLED_AllocateTest) {
     const size_t data_size = 1 * 1024 * 1024;  // 1MB

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -2463,6 +2463,30 @@ TEST_F(MasterServiceTest, LocalFirstPutPrefersWriterHost) {
               "segment_host1");
 }
 
+TEST_F(MasterServiceTest, PreferSameNodeUsesHostAwareLocalFirstPlacement) {
+    MasterService service;
+    const UUID writer_client_id = generate_uuid();
+
+    [[maybe_unused]] const auto host0 = PrepareSimpleSegment(
+        service, "segment_host0", 0x300000000, kDefaultSegmentSize, "host0");
+    [[maybe_unused]] const auto host1 = PrepareSimpleSegment(
+        service, "segment_host1", 0x400000000, kDefaultSegmentSize, "host1");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.prefer_alloc_in_same_node = true;
+    config.host_id = "host1";
+
+    auto put_start = service.PutStart(writer_client_id, "prefer_same_node_key",
+                                      TenantId::Default(), 1024, config);
+    ASSERT_TRUE(put_start.has_value());
+    ASSERT_EQ(put_start->size(), 1u);
+    EXPECT_EQ((*put_start)[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              "segment_host1");
+}
+
 TEST_F(MasterServiceTest, LocalFirstPutFallsBackToNextOrderedHost) {
     auto service_config =
         MasterServiceConfig::builder()

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -2105,6 +2105,30 @@ TEST_F(MasterServiceTest, LocalFirstPutPrefersWriterHost) {
               "segment_host1");
 }
 
+TEST_F(MasterServiceTest, PreferSameNodeUsesHostAwareLocalFirstPlacement) {
+    MasterService service;
+    const UUID writer_client_id = generate_uuid();
+
+    [[maybe_unused]] const auto host0 = PrepareSimpleSegment(
+        service, "segment_host0", 0x300000000, kDefaultSegmentSize, "host0");
+    [[maybe_unused]] const auto host1 = PrepareSimpleSegment(
+        service, "segment_host1", 0x400000000, kDefaultSegmentSize, "host1");
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.prefer_alloc_in_same_node = true;
+    config.host_id = "host1";
+
+    auto put_start = service.PutStart(writer_client_id, "prefer_same_node_key",
+                                      TenantId::Default(), 1024, config);
+    ASSERT_TRUE(put_start.has_value());
+    ASSERT_EQ(put_start->size(), 1u);
+    EXPECT_EQ((*put_start)[0]
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              "segment_host1");
+}
+
 TEST_F(MasterServiceTest, LocalFirstPutFallsBackToNextOrderedHost) {
     auto service_config =
         MasterServiceConfig::builder()

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -2,6 +2,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <barrier>
 #include <chrono>
 #include <cstdio>
@@ -747,6 +748,7 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
         0);
 
     std::string test_data(1000, '1');
+    std::string upsert_data(1000, '2');
     std::string dst_data(1000, '0');
 
     // Register buffers for zero-copy operations
@@ -758,26 +760,36 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
         py_client_->register_buffer(dst_data.data(), dst_data.size());
     ASSERT_EQ(reg_result_dst, 0)
         << "Dst data buffer registration should succeed";
+    int reg_result_upsert =
+        py_client_->register_buffer(upsert_data.data(), upsert_data.size());
+    ASSERT_EQ(reg_result_upsert, 0)
+        << "Upsert data buffer registration should succeed";
 
     std::vector<std::string> keys;
     std::vector<std::vector<void*>> all_ptrs;
+    std::vector<std::vector<void*>> all_upsert_ptrs;
     std::vector<std::vector<void*>> all_dst_ptrs;
     std::vector<std::vector<size_t>> all_sizes;
     auto ptr = test_data.data();
+    auto upsert_ptr = upsert_data.data();
     auto dst_ptr = dst_data.data();
     for (size_t i = 0; i < 10; i++) {
         keys.emplace_back("test_key_" + std::to_string(i));
         std::vector<void*> ptrs;
+        std::vector<void*> upsert_ptrs;
         std::vector<void*> dst_ptrs;
         std::vector<size_t> sizes;
         for (size_t j = 0; j < 10; j++) {
             ptrs.emplace_back(ptr);
+            upsert_ptrs.emplace_back(upsert_ptr);
             dst_ptrs.emplace_back(dst_ptr);
             sizes.emplace_back(10);
             ptr += 10;
+            upsert_ptr += 10;
             dst_ptr += 10;
         }
         all_ptrs.emplace_back(ptrs);
+        all_upsert_ptrs.emplace_back(upsert_ptrs);
         all_dst_ptrs.emplace_back(dst_ptrs);
         all_sizes.emplace_back(sizes);
     }
@@ -796,6 +808,21 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
     }
     EXPECT_EQ(dst_data, test_data) << "Retrieved data should match original";
 
+    std::vector<int> upsert_results =
+        py_client_->batch_upsert_from_multi_buffers(keys, all_upsert_ptrs,
+                                                    all_sizes, config);
+    for (auto result : upsert_results) {
+        EXPECT_EQ(result, 0) << "Upsert operation should succeed";
+    }
+    std::fill(dst_data.begin(), dst_data.end(), '0');
+    get_results = py_client_->batch_get_into_multi_buffers(keys, all_dst_ptrs,
+                                                           all_sizes, true);
+    for (auto result : get_results) {
+        EXPECT_EQ(result, 100) << "Get after upsert should succeed";
+    }
+    EXPECT_EQ(dst_data, upsert_data)
+        << "Retrieved data should match upserted data";
+
     // Unregister buffers
     int unreg_result_test = py_client_->unregister_buffer(test_data.data());
     ASSERT_EQ(unreg_result_test, 0)
@@ -803,6 +830,9 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
     int unreg_result_dst = py_client_->unregister_buffer(dst_data.data());
     ASSERT_EQ(unreg_result_dst, 0)
         << "Dst data buffer unregistration should succeed";
+    int unreg_result_upsert = py_client_->unregister_buffer(upsert_data.data());
+    ASSERT_EQ(unreg_result_upsert, 0)
+        << "Upsert data buffer unregistration should succeed";
 }
 
 TEST_F(RealClientTest, TestBatchAndNormalGetReplicaDesc) {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -2,6 +2,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <barrier>
 #include <chrono>
 #include <cstdio>
@@ -883,6 +884,7 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
         0);
 
     std::string test_data(1000, '1');
+    std::string upsert_data(1000, '2');
     std::string dst_data(1000, '0');
 
     // Register buffers for zero-copy operations
@@ -894,26 +896,36 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
         py_client_->register_buffer(dst_data.data(), dst_data.size());
     ASSERT_EQ(reg_result_dst, 0)
         << "Dst data buffer registration should succeed";
+    int reg_result_upsert =
+        py_client_->register_buffer(upsert_data.data(), upsert_data.size());
+    ASSERT_EQ(reg_result_upsert, 0)
+        << "Upsert data buffer registration should succeed";
 
     std::vector<std::string> keys;
     std::vector<std::vector<void*>> all_ptrs;
+    std::vector<std::vector<void*>> all_upsert_ptrs;
     std::vector<std::vector<void*>> all_dst_ptrs;
     std::vector<std::vector<size_t>> all_sizes;
     auto ptr = test_data.data();
+    auto upsert_ptr = upsert_data.data();
     auto dst_ptr = dst_data.data();
     for (size_t i = 0; i < 10; i++) {
         keys.emplace_back("test_key_" + std::to_string(i));
         std::vector<void*> ptrs;
+        std::vector<void*> upsert_ptrs;
         std::vector<void*> dst_ptrs;
         std::vector<size_t> sizes;
         for (size_t j = 0; j < 10; j++) {
             ptrs.emplace_back(ptr);
+            upsert_ptrs.emplace_back(upsert_ptr);
             dst_ptrs.emplace_back(dst_ptr);
             sizes.emplace_back(10);
             ptr += 10;
+            upsert_ptr += 10;
             dst_ptr += 10;
         }
         all_ptrs.emplace_back(ptrs);
+        all_upsert_ptrs.emplace_back(upsert_ptrs);
         all_dst_ptrs.emplace_back(dst_ptrs);
         all_sizes.emplace_back(sizes);
     }
@@ -932,6 +944,21 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
     }
     EXPECT_EQ(dst_data, test_data) << "Retrieved data should match original";
 
+    std::vector<int> upsert_results =
+        py_client_->batch_upsert_from_multi_buffers(keys, all_upsert_ptrs,
+                                                    all_sizes, config);
+    for (auto result : upsert_results) {
+        EXPECT_EQ(result, 0) << "Upsert operation should succeed";
+    }
+    std::fill(dst_data.begin(), dst_data.end(), '0');
+    get_results = py_client_->batch_get_into_multi_buffers(keys, all_dst_ptrs,
+                                                           all_sizes, true);
+    for (auto result : get_results) {
+        EXPECT_EQ(result, 100) << "Get after upsert should succeed";
+    }
+    EXPECT_EQ(dst_data, upsert_data)
+        << "Retrieved data should match upserted data";
+
     // Unregister buffers
     int unreg_result_test = py_client_->unregister_buffer(test_data.data());
     ASSERT_EQ(unreg_result_test, 0)
@@ -939,6 +966,9 @@ TEST_F(RealClientTest, TestBatchPutAndGetMultiBuffers) {
     int unreg_result_dst = py_client_->unregister_buffer(dst_data.data());
     ASSERT_EQ(unreg_result_dst, 0)
         << "Dst data buffer unregistration should succeed";
+    int unreg_result_upsert = py_client_->unregister_buffer(upsert_data.data());
+    ASSERT_EQ(unreg_result_upsert, 0)
+        << "Upsert data buffer unregistration should succeed";
 }
 
 TEST_F(RealClientTest, TestPutGetSessionRanges) {

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -455,6 +455,42 @@ TEST_F(TransferTaskTest, CanUseLocalMemcpyHonorsMemcpyEnv) {
     EXPECT_FALSE(submitter.canUseLocalMemcpy(engine.getLocalIpAndPort()));
 }
 
+TEST_F(TransferTaskTest, BatchWriteHonorsLocalMemcpySetting) {
+    ScopedEnvVar memcpy_enabled("MC_STORE_MEMCPY", "1");
+
+    TransferEngine engine(false);
+    ASSERT_EQ(
+        engine.init("P2PHANDSHAKE", "127.0.0.1:30995", "127.0.0.1", 30995), 0);
+
+    std::vector<char> source(512, 'A');
+    std::vector<char> destination(source.size(), 0);
+    MemoryDescriptor memory;
+    memory.buffer_descriptor.buffer_address_ =
+        reinterpret_cast<uintptr_t>(destination.data());
+    memory.buffer_descriptor.size_ = destination.size();
+    memory.buffer_descriptor.transport_endpoint_ = engine.getLocalIpAndPort();
+    memory.buffer_descriptor.protocol_ = "tcp";
+    Replica::Descriptor replica;
+    replica.descriptor_variant = memory;
+    replica.status = ReplicaStatus::PROCESSING;
+
+    std::shared_ptr<StorageBackend> storage_backend;
+    {
+        TransferSubmitter submitter(engine, storage_backend,
+                                    engine.getLocalIpAndPort());
+        std::vector<std::vector<Slice>> slices{
+            {{source.data(), source.size()}}};
+        auto future =
+            submitter.submit_batch({replica}, slices, TransferRequest::WRITE);
+
+        ASSERT_TRUE(future);
+        EXPECT_EQ(future->strategy(), TransferStrategy::LOCAL_MEMCPY);
+        EXPECT_EQ(future->get(), ErrorCode::OK);
+    }
+    EXPECT_EQ(destination, source);
+    EXPECT_EQ(engine.freeEngine(), 0);
+}
+
 // Test TransferStrategy enum and stream operator
 TEST_F(TransferTaskTest, TransferStrategyEnum) {
     // Test enum values

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -339,6 +339,7 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         key_from = f"{key}_from"
         batch_keys = [f"{key}_batch_{i}" for i in range(2)]
         upsert_key = f"{key}_upsert"
+        cuda_upsert_key = f"{key}_cuda_upsert"
         pub_key = f"{key}_pub"
         tp_key = f"{key}_tp"
         batch_tp_key = f"{key}_batch_tp"
@@ -347,7 +348,9 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         parallel_from_key = f"{key}_parallel_from"
         parallel_upsert_key = f"{key}_parallel_upsert"
         parallel_upsert_from_key = f"{key}_parallel_upsert_from"
-        cleanup_keys = [key, key_from, *batch_keys, upsert_key, pub_key]
+        cleanup_keys = [
+            key, key_from, *batch_keys, upsert_key, cuda_upsert_key, pub_key
+        ]
         cleanup_keys.extend(
             [
                 parallel_key,
@@ -405,6 +408,16 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
             updated = tensor + 2
             self.assertEqual(self.store.upsert_tensor(upsert_key, updated), 0)
             self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), updated))
+
+            if torch.cuda.is_available():
+                cuda_updated = updated.to("cuda")
+                torch.cuda.synchronize()
+                self.assertEqual(
+                    self.store.upsert_tensor(cuda_upsert_key, cuda_updated), 0
+                )
+                self.assertTrue(
+                    torch.equal(self.store.get_tensor(cuda_upsert_key), updated)
+                )
 
             self.assertEqual(self.store.pub_tensor(pub_key, tensor + 3), 0)
             self.assertTrue(torch.equal(self.store.get_tensor(pub_key), tensor + 3))

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -598,6 +598,7 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         key_from = f"{key}_from"
         batch_keys = [f"{key}_batch_{i}" for i in range(2)]
         upsert_key = f"{key}_upsert"
+        cuda_upsert_key = f"{key}_cuda_upsert"
         pub_key = f"{key}_pub"
         tp_key = f"{key}_tp"
         batch_tp_key = f"{key}_batch_tp"
@@ -606,7 +607,9 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
         parallel_from_key = f"{key}_parallel_from"
         parallel_upsert_key = f"{key}_parallel_upsert"
         parallel_upsert_from_key = f"{key}_parallel_upsert_from"
-        cleanup_keys = [key, key_from, *batch_keys, upsert_key, pub_key]
+        cleanup_keys = [
+            key, key_from, *batch_keys, upsert_key, cuda_upsert_key, pub_key
+        ]
         cleanup_keys.extend(
             [
                 parallel_key,
@@ -663,6 +666,16 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
             updated = tensor + 2
             self.assertEqual(self.store.upsert_tensor(upsert_key, updated), 0)
             self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), updated))
+
+            if torch.cuda.is_available():
+                cuda_updated = updated.to("cuda")
+                torch.cuda.synchronize()
+                self.assertEqual(
+                    self.store.upsert_tensor(cuda_upsert_key, cuda_updated), 0
+                )
+                self.assertTrue(
+                    torch.equal(self.store.get_tensor(cuda_upsert_key), updated)
+                )
 
             self.assertEqual(self.store.pub_tensor(pub_key, tensor + 3), 0)
             self.assertTrue(torch.equal(self.store.get_tensor(pub_key), tensor + 3))

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -152,7 +152,6 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
             self.store.remove(key)
 
-
     @unittest.skipUnless(cuda_available(), "CUDA is not available")
     def test_cuda_local_copy_paths(self):
         """Test CUDA source writes and CUDA destination reads."""
@@ -169,6 +168,28 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
         self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), tensor.cpu()))
 
+        batch_put_keys = [f"{prefix}_batch_put_{i}" for i in range(2)]
+        batch_upsert_keys = [f"{prefix}_batch_upsert_{i}" for i in range(2)]
+        batch_tensors = [
+            torch.arange(16, dtype=torch.float32, device="cuda").reshape(4, 4),
+            torch.arange(24, dtype=torch.int64, device="cuda").reshape(2, 3, 4),
+        ]
+        self.assertEqual(
+            self.store.batch_put_tensor(batch_put_keys, batch_tensors), [0, 0]
+        )
+        self.assertEqual(
+            self.store.batch_upsert_tensor(batch_upsert_keys, batch_tensors),
+            [0, 0],
+        )
+        for key, expected_tensor in zip(batch_put_keys, batch_tensors):
+            self.assertTrue(
+                torch.equal(self.store.get_tensor(key), expected_tensor.cpu())
+            )
+        for key, expected_tensor in zip(batch_upsert_keys, batch_tensors):
+            self.assertTrue(
+                torch.equal(self.store.get_tensor(key), expected_tensor.cpu())
+            )
+
         raw = bytes(range(32))
         self.assertEqual(self.store.put(raw_key, raw), 0)
 
@@ -179,6 +200,8 @@ class TestDistributedObjectStore(unittest.TestCase):
 
         self.store.remove(put_key)
         self.store.remove(upsert_key)
+        for key in batch_put_keys + batch_upsert_keys:
+            self.store.remove(key)
         self.store.remove(raw_key)
 
     def test_put_get_tensor_with_metadata(self):

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -126,6 +126,33 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.store.remove(key_bool)
         self.store.remove(key_rand)
 
+    def test_batch_tensor_default_config(self):
+        import torch
+
+        prefix = f"test_batch_tensor_default_{os.getpid()}"
+        keys = [f"{prefix}_{i}" for i in range(2)]
+        tensors = [
+            torch.arange(16, dtype=torch.float32).reshape(4, 4),
+            torch.arange(24, dtype=torch.int64).reshape(2, 3, 4),
+        ]
+        self.assertEqual(self.store.batch_put_tensor(keys, tensors), [0, 0])
+        for key, tensor in zip(keys, tensors):
+            self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
+            self.store.remove(key)
+
+        upsert_keys = [f"{prefix}_upsert_{i}" for i in range(2)]
+        upsert_tensors = [
+            torch.arange(8, dtype=torch.float32),
+            torch.arange(12, dtype=torch.int32),
+        ]
+        self.assertEqual(
+            self.store.batch_upsert_tensor(upsert_keys, upsert_tensors), [0, 0]
+        )
+        for key, tensor in zip(upsert_keys, upsert_tensors):
+            self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
+            self.store.remove(key)
+
+
     @unittest.skipUnless(cuda_available(), "CUDA is not available")
     def test_cuda_local_copy_paths(self):
         """Test CUDA source writes and CUDA destination reads."""
@@ -139,6 +166,8 @@ class TestDistributedObjectStore(unittest.TestCase):
         tensor = torch.arange(16, dtype=torch.float32, device="cuda")
         self.assertEqual(self.store.put_tensor(put_key, tensor), 0)
         self.assertEqual(self.store.upsert_tensor(upsert_key, tensor), 0)
+        self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
+        self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), tensor.cpu()))
 
         raw = bytes(range(32))
         self.assertEqual(self.store.put(raw_key, raw), 0)

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -165,6 +165,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         raw_key = f"{prefix}_raw"
 
         tensor = torch.arange(16, dtype=torch.float32, device="cuda")
+        torch.cuda.synchronize()
         self.assertEqual(self.store.put_tensor(put_key, tensor), 0)
         self.assertEqual(self.store.upsert_tensor(upsert_key, tensor), 0)
         self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
@@ -176,6 +177,7 @@ class TestDistributedObjectStore(unittest.TestCase):
             torch.arange(16, dtype=torch.float32, device="cuda").reshape(4, 4),
             torch.arange(24, dtype=torch.int64, device="cuda").reshape(2, 3, 4),
         ]
+        torch.cuda.synchronize()
         self.assertEqual(
             self.store.batch_put_tensor(batch_put_keys, batch_tensors), [0, 0]
         )

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -154,7 +154,6 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
             self.store.remove(key)
 
-
     @unittest.skipUnless(cuda_available(), "CUDA is not available")
     def test_cuda_local_copy_paths(self):
         """Test CUDA source writes and CUDA destination reads."""
@@ -171,6 +170,28 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
         self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), tensor.cpu()))
 
+        batch_put_keys = [f"{prefix}_batch_put_{i}" for i in range(2)]
+        batch_upsert_keys = [f"{prefix}_batch_upsert_{i}" for i in range(2)]
+        batch_tensors = [
+            torch.arange(16, dtype=torch.float32, device="cuda").reshape(4, 4),
+            torch.arange(24, dtype=torch.int64, device="cuda").reshape(2, 3, 4),
+        ]
+        self.assertEqual(
+            self.store.batch_put_tensor(batch_put_keys, batch_tensors), [0, 0]
+        )
+        self.assertEqual(
+            self.store.batch_upsert_tensor(batch_upsert_keys, batch_tensors),
+            [0, 0],
+        )
+        for key, expected_tensor in zip(batch_put_keys, batch_tensors):
+            self.assertTrue(
+                torch.equal(self.store.get_tensor(key), expected_tensor.cpu())
+            )
+        for key, expected_tensor in zip(batch_upsert_keys, batch_tensors):
+            self.assertTrue(
+                torch.equal(self.store.get_tensor(key), expected_tensor.cpu())
+            )
+
         raw = bytes(range(32))
         self.assertEqual(self.store.put(raw_key, raw), 0)
 
@@ -181,6 +202,8 @@ class TestDistributedObjectStore(unittest.TestCase):
 
         self.store.remove(put_key)
         self.store.remove(upsert_key)
+        for key in batch_put_keys + batch_upsert_keys:
+            self.store.remove(key)
         self.store.remove(raw_key)
 
     def test_put_get_tensor_with_metadata(self):

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -128,6 +128,33 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.store.remove(key_bool)
         self.store.remove(key_rand)
 
+    def test_batch_tensor_default_config(self):
+        import torch
+
+        prefix = f"test_batch_tensor_default_{os.getpid()}"
+        keys = [f"{prefix}_{i}" for i in range(2)]
+        tensors = [
+            torch.arange(16, dtype=torch.float32).reshape(4, 4),
+            torch.arange(24, dtype=torch.int64).reshape(2, 3, 4),
+        ]
+        self.assertEqual(self.store.batch_put_tensor(keys, tensors), [0, 0])
+        for key, tensor in zip(keys, tensors):
+            self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
+            self.store.remove(key)
+
+        upsert_keys = [f"{prefix}_upsert_{i}" for i in range(2)]
+        upsert_tensors = [
+            torch.arange(8, dtype=torch.float32),
+            torch.arange(12, dtype=torch.int32),
+        ]
+        self.assertEqual(
+            self.store.batch_upsert_tensor(upsert_keys, upsert_tensors), [0, 0]
+        )
+        for key, tensor in zip(upsert_keys, upsert_tensors):
+            self.assertTrue(torch.equal(self.store.get_tensor(key), tensor))
+            self.store.remove(key)
+
+
     @unittest.skipUnless(cuda_available(), "CUDA is not available")
     def test_cuda_local_copy_paths(self):
         """Test CUDA source writes and CUDA destination reads."""
@@ -141,6 +168,8 @@ class TestDistributedObjectStore(unittest.TestCase):
         tensor = torch.arange(16, dtype=torch.float32, device="cuda")
         self.assertEqual(self.store.put_tensor(put_key, tensor), 0)
         self.assertEqual(self.store.upsert_tensor(upsert_key, tensor), 0)
+        self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
+        self.assertTrue(torch.equal(self.store.get_tensor(upsert_key), tensor.cpu()))
 
         raw = bytes(range(32))
         self.assertEqual(self.store.put(raw_key, raw), 0)

--- a/mooncake-wheel/tests/test_put_get_tensor.py
+++ b/mooncake-wheel/tests/test_put_get_tensor.py
@@ -163,6 +163,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         raw_key = f"{prefix}_raw"
 
         tensor = torch.arange(16, dtype=torch.float32, device="cuda")
+        torch.cuda.synchronize()
         self.assertEqual(self.store.put_tensor(put_key, tensor), 0)
         self.assertEqual(self.store.upsert_tensor(upsert_key, tensor), 0)
         self.assertTrue(torch.equal(self.store.get_tensor(put_key), tensor.cpu()))
@@ -174,6 +175,7 @@ class TestDistributedObjectStore(unittest.TestCase):
             torch.arange(16, dtype=torch.float32, device="cuda").reshape(4, 4),
             torch.arange(24, dtype=torch.int64, device="cuda").reshape(2, 3, 4),
         ]
+        torch.cuda.synchronize()
         self.assertEqual(
             self.store.batch_put_tensor(batch_put_keys, batch_tensors), [0, 0]
         )


### PR DESCRIPTION
## Description

### Motivation

The Python tensor write path used to copy tensor payloads through a client-side staging buffer before the data reached the Mooncake Store segment.

For local same-node tensor writes, this staging copy is unnecessary when the target Store segment is local to the writer process. It is especially expensive for GPU tensor -> Store CPU segment writes, where the old path first copied the GPU tensor into a client local/staging buffer and then copied that buffer into the Store segment.

This PR removes the extra staging copy from the local tensor write path.

This PR is split from the broader local tensor/offload optimization work. The scope here is intentionally limited to same-node tensor write staging removal.

### Scenario

Before this PR:

```text
tensor payload
  -> client local/staging buffer
  -> Store segment
```

After this PR, when the write can safely use the local same-node path:

```text
tensor payload
  -> Store segment
```

### Changes

- Add a direct multi-buffer write path for tensor payloads.
- Let local same-node tensor writes pass tensor payload buffers directly into the Store write path.
- Extend the transfer task local-copy path to consume caller-provided source buffers for local writes.
- Route put/upsert tensor writes through the shared multi-buffer writer to avoid duplicate tensor staging logic.
- Route single `put_tensor` and `upsert_tensor` through the same no-staging multi-buffer path as batch tensor writes.

### Performance

#### Local write staging removal

Environment:

```text
Mode: local same-node tensor put
Protocol: rdma
RDMA device: erdma_0
Sizes: 64 MB, 256 MB, 512 MB
Warmup / iterations: 2 / 7
Baseline: f224dcaf
This PR: c378659e
Benchmark harness: external local script, not included in this PR
```

The benchmark log confirms `MC_STORE_MEMCPY` was auto-disabled under RDMA, so the baseline uses the old staging/TransferEngine path. The after case uses the same public tensor APIs and removes the local staging copy when the destination is the local Store segment.

Local CPU tensor -> Store CPU segment put:

| Size | Before | After | Improvement |
| --- | --- | --- | --- |
| 64 MB | 5.106 GB/s / 13.142 ms | 13.924 GB/s / 4.820 ms | +173% |
| 256 MB | 5.160 GB/s / 52.027 ms | 13.341 GB/s / 20.121 ms | +159% |
| 512 MB | 5.459 GB/s / 98.348 ms | 13.340 GB/s / 40.245 ms | +144% |

Local GPU tensor -> Store CPU segment put:

| Size | Before | After | Improvement |
| --- | --- | --- | --- |
| 64 MB | 2.515 GB/s / 26.689 ms | 7.595 GB/s / 8.836 ms | +202% |
| 256 MB | 2.586 GB/s / 103.820 ms | 7.752 GB/s / 34.626 ms | +200% |
| 512 MB | 2.752 GB/s / 195.109 ms | 7.776 GB/s / 69.038 ms | +183% |

The main performance gain comes from local same-node tensor writes where the extra staging copy is removed.

#### Pinned Store segment memory local CUDA write

Environment:

```text
Mode: local same-node CUDA tensor write into pinned Store CPU segment
Protocol: tcp
MC_STORE_MEMCPY: 1
Pinned Store segment memory: enabled
MC_STORE_PIN_MEMORY_MAX_BYTES: 4294967296
Store segment size: 4096 MB
Client local buffer size: 1024 MB
Sizes: 64 MB, 256 MB, 512 MB
Warmup / iterations: 3 / 8
Baseline: 6c721eea
This PR: 00230d8f
Benchmark harness: external local one-shot script, not included in this PR
```

This benchmark uses pinned Store segment memory and local memcpy. It validates that single tensor writes now reach the same no-staging multi-buffer path as batch tensor writes.

Local CUDA tensor -> pinned Store CPU segment `put_tensor`:

| Size | Base GB/s | PR GB/s | Speedup | Base median | PR median |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 64 MB | 3.363 | 24.923 | 7.41x | 19.955 ms | 2.693 ms |
| 256 MB | 3.333 | 25.824 | 7.75x | 80.532 ms | 10.395 ms |
| 512 MB | 3.345 | 25.921 | 7.75x | 160.483 ms | 20.712 ms |

Local CUDA tensor -> pinned Store CPU segment `upsert_tensor`:

| Size | Base GB/s | PR GB/s | Speedup | Base median | PR median |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 64 MB | 3.379 | 24.702 | 7.31x | 19.858 ms | 2.717 ms |
| 256 MB | 3.334 | 25.712 | 7.71x | 80.520 ms | 10.440 ms |
| 512 MB | 3.346 | 25.923 | 7.75x | 160.430 ms | 20.710 ms |

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
./scripts/code_format.sh --check -b origin/main

cmake --build build-tensor-staging-nocuda-notest -j8 --target store

cmake -S . -B build-tensor-staging-cuda \
  -DUSE_CUDA=ON \
  -DWITH_STORE_RUST=OFF \
  -DWITH_EP=OFF \
  -DBUILD_UNIT_TESTS=OFF \
  -DBUILD_TESTS=OFF \
  -DCMAKE_BUILD_TYPE=Release

cmake --build build-tensor-staging-cuda -j8 --target store mooncake_master
```

Manual validation was run with local benchmark/smoke harnesses that are not included in this PR:

- local CPU tensor -> Store CPU segment put
- local GPU tensor -> Store CPU segment put
- CPU tensor write smoke for `put_tensor`, `upsert_tensor`, `batch_put_tensor`, and `batch_upsert_tensor`
- CUDA duplicate `put_tensor` smoke to confirm the existing successful return behavior for an existing key
- CUDA tensor local write benchmark with pinned Store segment memory and local memcpy enabled

**Test results:**

- [x] Format check passes
- [x] Build passes without CUDA enabled
- [x] Build passes with CUDA enabled
- [x] Manual CPU tensor write smoke passes
- [x] Manual CUDA duplicate `put_tensor` smoke passes
- [x] Manual performance validation done

Manual test results:

- Local CPU tensor put improved from 5.1-5.5 GB/s to 13.3-13.9 GB/s.
- Local GPU tensor put improved from 2.5-2.8 GB/s to 7.6-7.8 GB/s.
- With pinned Store segment memory, local CUDA `put_tensor` improved from 3.33-3.36 GB/s to 24.92-25.92 GB/s.
- With pinned Store segment memory, local CUDA `upsert_tensor` improved from 3.33-3.38 GB/s to 24.70-25.92 GB/s.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex was used to help with implementation, benchmarking, and review)
