### PR TITLE
[Store] Fix EraseMetadata leaking stale entries in offloading_objects

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1888,6 +1888,17 @@ MasterService::EraseMetadata(
             source->dec_refcnt();
         }
         tenant_state.offloading_tasks.erase(offload_it);
+
+        // Mirror entry in local_disk_segment.offloading_objects must be
+        // dropped too, otherwise the next OffloadObjectHeartbeat drains a
+        // task-less key back to the client and produces an orphan bucket.
+        const std::string scoped_key = tenant_id.MakeScopedKey(key);
+        ScopedLocalDiskSegmentAccess ssd_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        for (auto& [_, segment] : ssd_access.getClientLocalDiskSegment()) {
+            MutexLocker locker(&segment->offloading_mutex_);
+            segment->offloading_objects.erase(scoped_key);
+        }
     }
     tenant_state.processing_keys.erase(key);
     tenant_state.replication_tasks.erase(key);

--- a/mooncake-store/tests/offload_on_evict_test.cpp
+++ b/mooncake-store/tests/offload_on_evict_test.cpp
@@ -389,6 +389,41 @@ TEST_F(OffloadOnEvictTest, ComboD_EvictionWorks) {
     service->RemoveAll();
 }
 
+// Regression: EraseMetadata must drop the mirror entry in
+// LocalDiskSegment::offloading_objects. Otherwise BatchRemove leaves a
+// task-less key in the offload queue which the next
+// OffloadObjectHeartbeat drains back to the client, producing an
+// orphan bucket on SSD.
+TEST_F(OffloadOnEvictTest, BatchRemoveDropsOffloadingObjectsMirror) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.default_kv_lease_ttl = 0;  // no lease so BatchRemove succeeds
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto ctx =
+        PrepareSegment(*service, "test_segment", kDefaultSegmentBase, seg_size);
+    auto mount_ld = service->MountLocalDiskSegment(ctx.client_id, true);
+    ASSERT_TRUE(mount_ld.has_value());
+
+    const std::vector<std::string> keys = {"key_r1", "key_r2", "key_r3"};
+    for (const auto& k : keys) {
+        PutObject(*service, ctx.client_id, k);
+    }
+
+    // Remove before heartbeat drains the offload queue.
+    auto rm = service->BatchRemove(keys, TenantId::Default(), /*force=*/true);
+    for (const auto& r : rm) {
+        EXPECT_TRUE(r.has_value());
+    }
+
+    auto queued = DrainOffloadQueue(*service, ctx.client_id);
+    EXPECT_TRUE(queued.empty())
+        << "OffloadObjectHeartbeat returned " << queued.size()
+        << " stale entries after BatchRemove; EraseMetadata failed to clean "
+           "offloading_objects.";
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

`MasterService::EraseMetadata` clears `tenant_state.offloading_tasks` but leaves the mirror entry in `LocalDiskSegment::offloading_objects` behind. When a `Remove` / `BatchRemove(force=true)` (or `BatchEvict`, `RemoveByRegex`, lease-expiry cleanup) interposes between `PushOffloadingQueue` and the next `OffloadObjectHeartbeat`, the heartbeat drains a task-less key back to the client. The client writes a bucket and calls `NotifyOffloadSuccess` — resurrecting a `LOCAL_DISK`-only metadata entry, or leaking an orphan bucket on disk.

This is the same "phantom metadata persists in steady state" pattern @LujhCoconut described in #2827, but on the per-key eraser side.

## Relation to open work

- **#2676** (@Colors-111) — same class of orphan, scoped to `RemoveAll`; the per-key paths (`Remove` / `BatchRemove` / `BatchEvict` / lease-expiry) all still leak. This PR closes that gap.
- **#2827** (@he-yufeng, @LujhCoconut) — this PR removes one concrete producer of `OBJECT_ALREADY_EXISTS` on re-offload of a just-removed key; the worker-side dedup path discussed there is complementary.
- **#3009** (@bestdo77) — orthogonal, targets the worker-side ungrouped pool. Both fixes are needed independently.

## Fix

11 lines in `EraseMetadata`: after `offloading_tasks.erase(...)`, erase the same key from every client's `offloading_objects` map. Iteration is bounded by mounted local-disk segments (typ. 1..64) and is a hash-map no-op on segments that don't hold the key.

## Regression test

`OffloadOnEvictTest.BatchRemoveDropsOffloadingObjectsMirror`:
- Without fix: heartbeat drains **3** stale entries after `BatchRemove`.
- With fix: **0**.

## Testing

- `offload_on_evict_test`: 10/10 ✅ (9 pre-existing + 1 new regression)
- `master_service_test`: 145/145 ✅
- `master_service_ssd_test`: 18/18 ✅
- `clang-format-20`: clean

+46 lines total. No API changes.
