### PR TITLE
[TransferEngine] Refactor RDMA worker ownership to avoid endpoint UAF

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/endpoint_store.h
@@ -41,7 +41,7 @@ class EndpointStore {
     virtual std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr) = 0;
     virtual std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) = 0;
+        const std::string &peer_nic_path, RdmaContext *context, ibv_cq *cq) = 0;
     virtual int deleteEndpoint(const std::string &peer_nic_path) = 0;
     // Deletes the endpoint matching endpoint_ptr (by pointer identity, under
     // the store lock -- the pointer is never dereferenced, so a stale/freed
@@ -83,7 +83,8 @@ class FIFOEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) override;
+        const std::string &peer_nic_path, RdmaContext *context,
+        ibv_cq *cq) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
     int deleteEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr,
@@ -125,7 +126,8 @@ class SIEVEEndpointStore : public EndpointStore {
     std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr) override;
     std::shared_ptr<RdmaEndPoint> insertEndpoint(
-        const std::string &peer_nic_path, RdmaContext *context) override;
+        const std::string &peer_nic_path, RdmaContext *context,
+        ibv_cq *cq) override;
     int deleteEndpoint(const std::string &peer_nic_path) override;
     int deleteEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr,
@@ -143,6 +145,11 @@ class SIEVEEndpointStore : public EndpointStore {
     }
 
     void testOnlyInsertWaiting(std::shared_ptr<RdmaEndPoint> ep) override;
+    // Test-only: push a pre-constructed endpoint into the active map so
+    // pointer-identity lookup/delete paths can be exercised without standing up
+    // an RDMA device.
+    void testOnlyInsertEndpoint(const std::string &peer_nic_path,
+                                std::shared_ptr<RdmaEndPoint> ep);
 
    private:
     RWSpinlock endpoint_map_lock_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -173,6 +173,8 @@ class RdmaContext {
    public:
     // EndPoint Management
     std::shared_ptr<RdmaEndPoint> endpoint(const std::string &peer_nic_path);
+    std::shared_ptr<RdmaEndPoint> endpoint(const std::string &peer_nic_path,
+                                           int cq_index);
 
     std::shared_ptr<RdmaEndPoint> getEndpointByPtr(
         const RdmaEndPoint *endpoint_ptr);
@@ -261,6 +263,7 @@ class RdmaContext {
     int eventFd() const { return event_fd_; }
 
     ibv_cq *cq();
+    ibv_cq *cq(int cq_index);
 
     std::atomic<int> *cqOutstandingCount(int cq_index) {
         return &cq_list_[cq_index].outstanding;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -262,7 +262,6 @@ class RdmaContext {
 
     int eventFd() const { return event_fd_; }
 
-    ibv_cq *cq();
     ibv_cq *cq(int cq_index);
 
     std::atomic<int> *cqOutstandingCount(int cq_index) {
@@ -270,6 +269,9 @@ class RdmaContext {
     }
 
     int cqCount() const { return cq_list_.size(); }
+    int postingThreadForPeer(const std::string &peer_nic_path) const;
+    int cqIndexForPostingThread(int thread_id) const;
+    int cqIndexForPeer(const std::string &peer_nic_path) const;
 
     int poll(int num_entries, ibv_wc *wc, int cq_index = 0);
 
@@ -332,8 +334,6 @@ class RdmaContext {
 
     std::atomic<int> next_comp_channel_index_;
     std::atomic<int> next_comp_vector_index_;
-    std::atomic<int> next_cq_list_index_;
-
     std::shared_ptr<WorkerPool> worker_pool_;
 
     std::atomic<bool> active_;

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -197,9 +197,10 @@ class RdmaEndPoint {
     static constexpr uint32_t kWaitExistingHandshakeInitialSleepUs = 50;
     static constexpr uint32_t kWaitExistingHandshakeMaxSleepUs = 2000;
 
-    // Maximum time (in seconds) to wait for outstanding WRs to drain in
-    // finishDestroy before forcing QP destruction. This guards against
-    // ibv_modify_qp-to-ERR failures that prevent WR flushing.
+    // Maximum time (in seconds) to wait for outstanding WRs to drain before
+    // treating the endpoint as leaked. Timed-out endpoints stay in the
+    // EndpointStore waiting list so stale in-flight references cannot turn
+    // into UAF.
     static constexpr double kFinishDestroyTimeoutSec = 30.0;
 
     // Maximum number of deconstructLocked retries in finishDestroy before
@@ -224,8 +225,10 @@ class RdmaEndPoint {
     size_t max_inline_bytes_;
 
     std::atomic<bool> active_;
+    ibv_cq *cq_;
     std::atomic<int> *cq_outstanding_;
     std::atomic<uint64_t> inactive_time_;
+    bool finish_destroy_timeout_logged_ = false;
     int finish_destroy_retries_ = 0;
 };
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -197,9 +197,10 @@ class RdmaEndPoint {
     static constexpr uint32_t kWaitExistingHandshakeInitialSleepUs = 50;
     static constexpr uint32_t kWaitExistingHandshakeMaxSleepUs = 2000;
 
-    // Maximum time (in seconds) to wait for outstanding WRs to drain in
-    // finishDestroy before forcing QP destruction. This guards against
-    // ibv_modify_qp-to-ERR failures that prevent WR flushing.
+    // Maximum time (in seconds) to wait for outstanding WRs to drain before
+    // treating the endpoint as leaked. Timed-out endpoints stay in the
+    // EndpointStore waiting list so stale in-flight references cannot turn
+    // into UAF.
     static constexpr double kFinishDestroyTimeoutSec = 30.0;
 
     // Maximum number of deconstructLocked retries in finishDestroy before
@@ -225,8 +226,10 @@ class RdmaEndPoint {
     size_t max_inline_bytes_;
 
     std::atomic<bool> active_;
+    ibv_cq *cq_;
     std::atomic<int> *cq_outstanding_;
     std::atomic<uint64_t> inactive_time_;
+    bool finish_destroy_timeout_logged_ = false;
     int finish_destroy_retries_ = 0;
 };
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -132,6 +132,9 @@ class RdmaEndPoint {
     void beginDestroy();
     bool finishDestroy();
 
+    void beginCompletionBatch();
+    void endCompletionBatch();
+
    private:
     int disconnectUnlocked();
 
@@ -229,6 +232,7 @@ class RdmaEndPoint {
     ibv_cq *cq_;
     std::atomic<int> *cq_outstanding_;
     std::atomic<uint64_t> inactive_time_;
+    std::atomic<int> completion_batch_refs_{0};
     bool finish_destroy_timeout_logged_ = false;
     int finish_destroy_retries_ = 0;
 };

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -132,6 +132,9 @@ class RdmaEndPoint {
     void beginDestroy();
     bool finishDestroy();
 
+    void beginCompletionBatch();
+    void endCompletionBatch();
+
    private:
     int disconnectUnlocked();
 
@@ -228,6 +231,7 @@ class RdmaEndPoint {
     ibv_cq *cq_;
     std::atomic<int> *cq_outstanding_;
     std::atomic<uint64_t> inactive_time_;
+    std::atomic<int> completion_batch_refs_{0};
     bool finish_destroy_timeout_logged_ = false;
     int finish_destroy_retries_ = 0;
 };

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -15,8 +15,13 @@
 #ifndef WORKER_H
 #define WORKER_H
 
-#include <queue>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "config.h"
 #include "rdma_context.h"
@@ -41,7 +46,6 @@ class WorkerPool {
 
    private:
     using SliceList = std::vector<Transport::Slice *>;
-    const static int kShardCount = 8;
 
     // Enqueue slices that were prepared by another WorkerPool. Used for
     // local-NIC failure handoff: the original worker keeps the remote path
@@ -49,12 +53,16 @@ class WorkerPool {
     // worker queue.
     int submitPreparedPostSend(
         const std::vector<Transport::Slice *> &slice_list);
-    void enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+    void enqueuePreparedSlices(const SliceList &slice_list,
                                uint64_t submitted_slice_count);
+    void enqueueSliceToOwner(Transport::Slice *slice);
+    int postingThreadForPeer(const std::string &peer_nic_path) const;
+    int cqIndexForPostingThread(int thread_id) const;
 
     void performPostSend(int thread_id);
 
     void performPollCq(int thread_id);
+    void processCompletions(int thread_id, const std::vector<ibv_wc> &wc_list);
 
     void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id,
                     bool handoff_to_local_worker = false);
@@ -150,12 +158,10 @@ class WorkerPool {
     std::mutex cond_mutex_;
     std::condition_variable cond_var_;
 
-    std::unordered_map<std::string, SliceList> slice_queue_[kShardCount];
-    std::atomic<uint64_t> slice_queue_count_[kShardCount];
-    TicketLock slice_queue_lock_[kShardCount];
-
     std::vector<std::unordered_map<std::string, SliceList>>
         collective_slice_queue_;
+    std::vector<std::unordered_map<std::string, SliceList>> worker_slice_queue_;
+    std::vector<std::mutex> worker_slice_queue_lock_;
 
     std::atomic<uint64_t> submitted_slice_count_, processed_slice_count_;
     std::atomic<uint64_t> recovery_activate_after_ns_{0};

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -62,7 +62,7 @@ class WorkerPool {
     void performPostSend(int thread_id);
 
     void performPollCq(int thread_id);
-    void processCompletions(int thread_id, const std::vector<ibv_wc> &wc_list);
+    void processCompletions(int thread_id, const ibv_wc *wc_list, int count);
 
     void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id,
                     bool handoff_to_local_worker = false);

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -15,8 +15,13 @@
 #ifndef WORKER_H
 #define WORKER_H
 
-#include <queue>
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "config.h"
 #include "rdma_context.h"
@@ -41,7 +46,6 @@ class WorkerPool {
 
    private:
     using SliceList = std::vector<Transport::Slice *>;
-    const static int kShardCount = 8;
 
     // Enqueue slices that were prepared by another WorkerPool. Used for
     // local-NIC failure handoff: the original worker keeps the remote path
@@ -49,12 +53,16 @@ class WorkerPool {
     // worker queue.
     int submitPreparedPostSend(
         const std::vector<Transport::Slice *> &slice_list);
-    void enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+    void enqueuePreparedSlices(const SliceList &slice_list,
                                uint64_t submitted_slice_count);
+    void enqueueSliceToOwner(Transport::Slice *slice);
+    int postingThreadForPeer(const std::string &peer_nic_path) const;
+    int cqIndexForPostingThread(int thread_id) const;
 
     void performPostSend(int thread_id);
 
     void performPollCq(int thread_id);
+    void processCompletions(int thread_id, const std::vector<ibv_wc> &wc_list);
 
     void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id,
                     bool handoff_to_local_worker = false);
@@ -151,12 +159,10 @@ class WorkerPool {
     std::mutex cond_mutex_;
     std::condition_variable cond_var_;
 
-    std::unordered_map<std::string, SliceList> slice_queue_[kShardCount];
-    std::atomic<uint64_t> slice_queue_count_[kShardCount];
-    TicketLock slice_queue_lock_[kShardCount];
-
     std::vector<std::unordered_map<std::string, SliceList>>
         collective_slice_queue_;
+    std::vector<std::unordered_map<std::string, SliceList>> worker_slice_queue_;
+    std::vector<std::mutex> worker_slice_queue_lock_;
 
     std::atomic<uint64_t> submitted_slice_count_, processed_slice_count_;
     std::atomic<uint64_t> recovery_activate_after_ns_{0};

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -21,6 +21,7 @@
 #include <cstddef>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "config.h"
 #include "transport/rdma_transport/rdma_context.h"
@@ -53,6 +54,14 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
         LOG(INFO) << "Endpoint " << peer_nic_path
                   << " already exists in FIFOEndpointStore";
         return endpoint_map_[peer_nic_path];
+    }
+    if (max_size_ > 0 &&
+        waiting_list_len_.load(std::memory_order_relaxed) >= max_size_) {
+        LOG(WARNING) << "Endpoint waiting list reached limit on "
+                     << context->deviceName()
+                     << "; continuing endpoint creation"
+                     << ", waiting_endpoints="
+                     << waiting_list_len_.load(std::memory_order_relaxed);
     }
     if (!cq) {
         LOG(ERROR) << "Cannot insert endpoint " << peer_nic_path
@@ -188,6 +197,9 @@ size_t FIFOEndpointStore::getTotalQPNumber() {
     for (const auto &kv : endpoint_map_) {
         total_qps += kv.second->getQPNumber();
     }
+    for (const auto &endpoint : waiting_list_) {
+        total_qps += endpoint->getQPNumber();
+    }
     return total_qps;
 }
 
@@ -231,6 +243,14 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
         LOG(INFO) << "Endpoint " << peer_nic_path
                   << " already exists in SIEVEEndpointStore";
         return endpoint_map_[peer_nic_path].first;
+    }
+    if (max_size_ > 0 &&
+        waiting_list_len_.load(std::memory_order_relaxed) >= max_size_) {
+        LOG(WARNING) << "Endpoint waiting list reached limit on "
+                     << context->deviceName()
+                     << "; continuing endpoint creation"
+                     << ", waiting_endpoints="
+                     << waiting_list_len_.load(std::memory_order_relaxed);
     }
     if (!cq) {
         LOG(ERROR) << "Cannot insert endpoint " << peer_nic_path

--- a/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/endpoint_store.cpp
@@ -47,12 +47,17 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::getEndpointByPtr(
 }
 
 std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
-    const std::string &peer_nic_path, RdmaContext *context) {
+    const std::string &peer_nic_path, RdmaContext *context, ibv_cq *cq) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     if (endpoint_map_.find(peer_nic_path) != endpoint_map_.end()) {
         LOG(INFO) << "Endpoint " << peer_nic_path
                   << " already exists in FIFOEndpointStore";
         return endpoint_map_[peer_nic_path];
+    }
+    if (!cq) {
+        LOG(ERROR) << "Cannot insert endpoint " << peer_nic_path
+                   << ": completion queue is null";
+        return nullptr;
     }
     auto endpoint = std::make_shared<RdmaEndPoint>(*context);
     if (!endpoint) {
@@ -60,9 +65,8 @@ std::shared_ptr<RdmaEndPoint> FIFOEndpointStore::insertEndpoint(
         return nullptr;
     }
     auto &config = globalConfig();
-    int ret =
-        endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
-                            config.max_wr, config.max_inline);
+    int ret = endpoint->construct(cq, config.num_qp_per_ep, config.max_sge,
+                                  config.max_wr, config.max_inline);
     if (ret) return nullptr;
 
     while (this->getSize() >= max_size_) evictEndpoint();
@@ -80,8 +84,9 @@ int FIFOEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     auto iter = endpoint_map_.find(peer_nic_path);
     // Begin two-phase destruction: mark endpoint as destroying and move QPs
     // to ERR state so inflight WRs are flushed to CQ. The endpoint is moved
-    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() once
-    // all outstanding WRs have been drained.
+    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() only
+    // after all outstanding WRs have been drained. Timed-out endpoints remain
+    // retired in waiting_list_ rather than being force-freed.
     if (iter != endpoint_map_.end()) {
         waiting_list_len_++;
         iter->second->beginDestroy();
@@ -220,12 +225,17 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::getEndpointByPtr(
 }
 
 std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
-    const std::string &peer_nic_path, RdmaContext *context) {
+    const std::string &peer_nic_path, RdmaContext *context, ibv_cq *cq) {
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     if (endpoint_map_.find(peer_nic_path) != endpoint_map_.end()) {
         LOG(INFO) << "Endpoint " << peer_nic_path
                   << " already exists in SIEVEEndpointStore";
         return endpoint_map_[peer_nic_path].first;
+    }
+    if (!cq) {
+        LOG(ERROR) << "Cannot insert endpoint " << peer_nic_path
+                   << ": completion queue is null";
+        return nullptr;
     }
     auto endpoint = std::make_shared<RdmaEndPoint>(*context);
     if (!endpoint) {
@@ -233,9 +243,8 @@ std::shared_ptr<RdmaEndPoint> SIEVEEndpointStore::insertEndpoint(
         return nullptr;
     }
     auto &config = globalConfig();
-    int ret =
-        endpoint->construct(context->cq(), config.num_qp_per_ep, config.max_sge,
-                            config.max_wr, config.max_inline);
+    int ret = endpoint->construct(cq, config.num_qp_per_ep, config.max_sge,
+                                  config.max_wr, config.max_inline);
     if (ret) return nullptr;
 
     while (this->getSize() >= max_size_) evictEndpoint();
@@ -252,8 +261,9 @@ int SIEVEEndpointStore::deleteEndpoint(const std::string &peer_nic_path) {
     auto iter = endpoint_map_.find(peer_nic_path);
     // Begin two-phase destruction: mark endpoint as destroying and move QPs
     // to ERR state so inflight WRs are flushed to CQ. The endpoint is moved
-    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() once
-    // all outstanding WRs have been drained.
+    // to waiting_list_ and will be fully destroyed by reclaimEndpoint() only
+    // after all outstanding WRs have been drained. Timed-out endpoints remain
+    // retired in waiting_list_ rather than being force-freed.
     if (iter != endpoint_map_.end()) {
         iter->second.first->beginDestroy();
         waiting_list_len_++;
@@ -375,6 +385,14 @@ void SIEVEEndpointStore::testOnlyInsertWaiting(
     RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     waiting_list_.insert(ep);
     waiting_list_len_++;
+}
+
+void SIEVEEndpointStore::testOnlyInsertEndpoint(
+    const std::string &peer_nic_path, std::shared_ptr<RdmaEndPoint> ep) {
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    endpoint_map_[peer_nic_path] = std::make_pair(ep, true);
+    fifo_list_.push_front(peer_nic_path);
+    fifo_map_[peer_nic_path] = fifo_list_.begin();
 }
 
 size_t SIEVEEndpointStore::getTotalQPNumber() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -167,7 +167,6 @@ RdmaContext::RdmaContext(RdmaTransport &engine, const std::string &device_name)
           [] { return static_cast<uint64_t>(getCurrentTimeInNano()); }),
       next_comp_channel_index_(0),
       next_comp_vector_index_(0),
-      next_cq_list_index_(0),
       worker_pool_(nullptr),
       active_(true) {
     static std::once_flag g_once_flag;
@@ -194,8 +193,21 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
         return ERR_INVALID_ARGUMENT;
     }
 
-    // Create endpoint store based on configuration
     auto &config = globalConfig();
+    if (config.workers_per_ctx <= 0) {
+        LOG(ERROR) << "Invalid workers_per_ctx=" << config.workers_per_ctx
+                   << " for device " << device_name_;
+        return ERR_INVALID_ARGUMENT;
+    }
+    const auto worker_count = static_cast<size_t>(config.workers_per_ctx);
+    if (num_cq_list < worker_count) {
+        LOG(INFO) << "Increasing RDMA CQ count for " << device_name_
+                  << " from " << num_cq_list << " to " << worker_count
+                  << " to keep each transfer worker on a dedicated CQ";
+        num_cq_list = worker_count;
+    }
+
+    // Create endpoint store based on configuration
     switch (config.endpoint_store_type) {
         case EndpointStoreType::FIFO:
             endpoint_store_ =
@@ -725,21 +737,8 @@ RdmaContext::findMemoryRegionContaining(uintptr_t addr) const {
 
 std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
     const std::string &peer_nic_path) {
-    if (cq_list_.empty()) {
-        LOG(ERROR) << "No CQ available for endpoint on " << deviceName();
-        return nullptr;
-    }
-
-    const auto &config = globalConfig();
-    if (config.workers_per_ctx <= 0) {
-        LOG(ERROR) << "Invalid workers_per_ctx=" << config.workers_per_ctx
-                   << " for endpoint on " << deviceName();
-        return nullptr;
-    }
-    int owner_thread =
-        static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
-                         static_cast<size_t>(config.workers_per_ctx));
-    int cq_index = owner_thread % static_cast<int>(cq_list_.size());
+    int cq_index = cqIndexForPeer(peer_nic_path);
+    if (cq_index < 0) return nullptr;
     return endpoint(peer_nic_path, cq_index);
 }
 
@@ -765,6 +764,7 @@ std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
         return endpoint;
     }
 
+    endpoint_store_->reclaimEndpoint();
     endpoint =
         endpoint_store_->insertEndpoint(peer_nic_path, this, cq(cq_index));
     endpoint_store_->reclaimEndpoint();
@@ -849,15 +849,33 @@ int RdmaContext::gidIndex() const {
     return gid_index_;
 }
 
-ibv_cq *RdmaContext::cq() {
-    int index = (next_cq_list_index_++) % cq_list_.size();
-    return cq_list_[index].native;
-}
-
 ibv_cq *RdmaContext::cq(int cq_index) {
     if (cq_list_.empty()) return nullptr;
-    if (cq_index < 0) return cq();
+    if (cq_index < 0) return nullptr;
     return cq_list_[static_cast<size_t>(cq_index) % cq_list_.size()].native;
+}
+
+int RdmaContext::postingThreadForPeer(
+    const std::string &peer_nic_path) const {
+    const auto &config = globalConfig();
+    if (config.workers_per_ctx <= 0) {
+        LOG(ERROR) << "Invalid workers_per_ctx=" << config.workers_per_ctx
+                   << " for endpoint on " << deviceName();
+        return -1;
+    }
+    return static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
+                            static_cast<size_t>(config.workers_per_ctx));
+}
+
+int RdmaContext::cqIndexForPostingThread(int thread_id) const {
+    const int cq_count = cqCount();
+    if (cq_count <= 0 || thread_id < 0) return -1;
+    if (thread_id >= 0 && thread_id < cq_count) return thread_id;
+    return thread_id % cq_count;
+}
+
+int RdmaContext::cqIndexForPeer(const std::string &peer_nic_path) const {
+    return cqIndexForPostingThread(postingThreadForPeer(peer_nic_path));
 }
 
 ibv_comp_channel *RdmaContext::compChannel() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <exception>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <thread>
 
@@ -724,6 +725,31 @@ RdmaContext::findMemoryRegionContaining(uintptr_t addr) const {
 
 std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
     const std::string &peer_nic_path) {
+    if (cq_list_.empty()) {
+        LOG(ERROR) << "No CQ available for endpoint on " << deviceName();
+        return nullptr;
+    }
+
+    const auto &config = globalConfig();
+    if (config.workers_per_ctx <= 0) {
+        LOG(ERROR) << "Invalid workers_per_ctx=" << config.workers_per_ctx
+                   << " for endpoint on " << deviceName();
+        return nullptr;
+    }
+    int owner_thread =
+        static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
+                         static_cast<size_t>(config.workers_per_ctx));
+    int cq_index = owner_thread % static_cast<int>(cq_list_.size());
+    return endpoint(peer_nic_path, cq_index);
+}
+
+std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
+    const std::string &peer_nic_path, int cq_index) {
+    if (cq_list_.empty()) {
+        LOG(ERROR) << "No CQ available for endpoint on " << deviceName();
+        return nullptr;
+    }
+
     if (!active_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "Context is not active: " << deviceName();
         return nullptr;
@@ -739,7 +765,8 @@ std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
         return endpoint;
     }
 
-    endpoint = endpoint_store_->insertEndpoint(peer_nic_path, this);
+    endpoint =
+        endpoint_store_->insertEndpoint(peer_nic_path, this, cq(cq_index));
     endpoint_store_->reclaimEndpoint();
     return endpoint;
 }
@@ -825,6 +852,12 @@ int RdmaContext::gidIndex() const {
 ibv_cq *RdmaContext::cq() {
     int index = (next_cq_list_index_++) % cq_list_.size();
     return cq_list_[index].native;
+}
+
+ibv_cq *RdmaContext::cq(int cq_index) {
+    if (cq_list_.empty()) return nullptr;
+    if (cq_index < 0) return cq();
+    return cq_list_[static_cast<size_t>(cq_index) % cq_list_.size()].native;
 }
 
 ibv_comp_channel *RdmaContext::compChannel() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -26,6 +26,7 @@
 #include <cassert>
 #include <exception>
 #include <fstream>
+#include <functional>
 #include <memory>
 #include <thread>
 
@@ -712,6 +713,31 @@ RdmaContext::findMemoryRegionContaining(uintptr_t addr) const {
 
 std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
     const std::string &peer_nic_path) {
+    if (cq_list_.empty()) {
+        LOG(ERROR) << "No CQ available for endpoint on " << deviceName();
+        return nullptr;
+    }
+
+    const auto &config = globalConfig();
+    if (config.workers_per_ctx <= 0) {
+        LOG(ERROR) << "Invalid workers_per_ctx=" << config.workers_per_ctx
+                   << " for endpoint on " << deviceName();
+        return nullptr;
+    }
+    int owner_thread =
+        static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
+                         static_cast<size_t>(config.workers_per_ctx));
+    int cq_index = owner_thread % static_cast<int>(cq_list_.size());
+    return endpoint(peer_nic_path, cq_index);
+}
+
+std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
+    const std::string &peer_nic_path, int cq_index) {
+    if (cq_list_.empty()) {
+        LOG(ERROR) << "No CQ available for endpoint on " << deviceName();
+        return nullptr;
+    }
+
     if (!active_.load(std::memory_order_acquire)) {
         LOG(ERROR) << "Context is not active: " << deviceName();
         return nullptr;
@@ -727,7 +753,8 @@ std::shared_ptr<RdmaEndPoint> RdmaContext::endpoint(
         return endpoint;
     }
 
-    endpoint = endpoint_store_->insertEndpoint(peer_nic_path, this);
+    endpoint =
+        endpoint_store_->insertEndpoint(peer_nic_path, this, cq(cq_index));
     endpoint_store_->reclaimEndpoint();
     return endpoint;
 }
@@ -813,6 +840,12 @@ int RdmaContext::gidIndex() const {
 ibv_cq *RdmaContext::cq() {
     int index = (next_cq_list_index_++) % cq_list_.size();
     return cq_list_[index].native;
+}
+
+ibv_cq *RdmaContext::cq(int cq_index) {
+    if (cq_list_.empty()) return nullptr;
+    if (cq_index < 0) return cq();
+    return cq_list_[static_cast<size_t>(cq_index) % cq_list_.size()].native;
 }
 
 ibv_comp_channel *RdmaContext::compChannel() {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -96,6 +96,7 @@ RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
       ready_wait_start_ts_(0),
       wr_depth_list_(nullptr),
       active_(true),
+      cq_(nullptr),
       cq_outstanding_(nullptr) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
@@ -117,6 +118,7 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     }
 
     qp_list_.resize(num_qp_list);
+    cq_ = cq;
     cq_outstanding_ = static_cast<std::atomic<int> *>(cq->cq_context);
 
     max_wr_depth_ = (int)max_wr_depth;
@@ -167,9 +169,7 @@ int RdmaEndPoint::reconstruct() {
         return ret;
     }
 
-    // Get CQ from context for reconstruction
-    ibv_cq *cq = context_.cq();
-    if (!cq) {
+    if (!cq_) {
         LOG(ERROR) << "No CQ available for endpoint reconstruction";
         return ERR_ENDPOINT;
     }
@@ -179,7 +179,7 @@ int RdmaEndPoint::reconstruct() {
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
     active_.store(true, std::memory_order_release);
 
-    return construct(cq, num_qp, max_sge_per_wr, max_wr_depth,
+    return construct(cq_, num_qp, max_sge_per_wr, max_wr_depth,
                      max_inline_bytes);
 }
 
@@ -213,7 +213,8 @@ int RdmaEndPoint::deconstructLocked() {
         if (!qp_list_[i]) continue;  // already destroyed in a previous call
         int ret = ibv_destroy_qp(qp_list_[i]);
         if (ret) {
-            LOG(ERROR) << "Failed to destroy QP[" << i << "]: " << strerror(ret);
+            LOG(ERROR) << "Failed to destroy QP[" << i
+                       << "]: " << strerror(ret);
             result = ERR_ENDPOINT;
         } else {
             qp_list_[i] = nullptr;
@@ -294,8 +295,9 @@ bool RdmaEndPoint::finishDestroy() {
         // Fall through to the unified destroy path.
     } else {
         // Gate 3: two-phase path. Wait for inflight WRs to drain via CQ
-        // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
-        // never be flushed; enforce a timeout to avoid leaking forever.
+        // polling. If they never drain, keep the retired endpoint alive in
+        // the waiting list. Leaking this object is safer than forcing QP
+        // destruction while stale slice references may still exist.
         bool has_outstanding = false;
         for (size_t i = 0; i < qp_list_.size(); ++i) {
             if (wr_depth_list_[i].load(std::memory_order_relaxed) != 0) {
@@ -308,8 +310,13 @@ bool RdmaEndPoint::finishDestroy() {
                               inactive_time_.load(std::memory_order_relaxed)) /
                              1e9;
             if (elapsed < kFinishDestroyTimeoutSec) return false;
-            LOG(WARNING) << "finishDestroy timed out after " << elapsed
-                         << "s with outstanding WRs, forcing destruction";
+            if (!finish_destroy_timeout_logged_) {
+                LOG(ERROR) << "finishDestroy timed out after " << elapsed
+                           << "s with outstanding WRs; keeping retired "
+                              "endpoint alive to avoid UAF";
+                finish_destroy_timeout_logged_ = true;
+            }
+            return false;
         }
     }
 
@@ -1194,8 +1201,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
         LOG(ERROR) << "[Handshake] " << message
                    << ": local=" << context_.nicPath()
                    << ", peer=" << peer_nic_path_ << ", qp_index=" << qp_index
-                   << ", local_qp=" << qp->qp_num
-                   << ", peer_qp=" << peer_qp_num
+                   << ", local_qp=" << qp->qp_num << ", peer_qp=" << peer_qp_num
                    << ", local_gid=" << context_.gid()
                    << ", local_gid_index=" << local_gid_index
                    << ", peer_gid=" << gidToString(peer_gid)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -97,6 +97,7 @@ RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
       ready_wait_start_ts_(0),
       wr_depth_list_(nullptr),
       active_(true),
+      cq_(nullptr),
       cq_outstanding_(nullptr) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
@@ -118,6 +119,7 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     }
 
     qp_list_.resize(num_qp_list);
+    cq_ = cq;
     cq_outstanding_ = static_cast<std::atomic<int> *>(cq->cq_context);
 
     max_wr_depth_ = (int)max_wr_depth;
@@ -172,9 +174,7 @@ int RdmaEndPoint::reconstruct() {
         return ret;
     }
 
-    // Get CQ from context for reconstruction
-    ibv_cq *cq = context_.cq();
-    if (!cq) {
+    if (!cq_) {
         LOG(ERROR) << "No CQ available for endpoint reconstruction";
         return ERR_ENDPOINT;
     }
@@ -184,7 +184,7 @@ int RdmaEndPoint::reconstruct() {
     ready_wait_start_ts_.store(0, std::memory_order_relaxed);
     active_.store(true, std::memory_order_release);
 
-    return construct(cq, num_qp, max_sge_per_wr, max_wr_depth,
+    return construct(cq_, num_qp, max_sge_per_wr, max_wr_depth,
                      max_inline_bytes);
 }
 
@@ -218,7 +218,8 @@ int RdmaEndPoint::deconstructLocked() {
         if (!qp_list_[i]) continue;  // already destroyed in a previous call
         int ret = ibv_destroy_qp(qp_list_[i]);
         if (ret) {
-            LOG(ERROR) << "Failed to destroy QP[" << i << "]: " << strerror(ret);
+            LOG(ERROR) << "Failed to destroy QP[" << i
+                       << "]: " << strerror(ret);
             result = ERR_ENDPOINT;
         } else {
             qp_list_[i] = nullptr;
@@ -299,8 +300,9 @@ bool RdmaEndPoint::finishDestroy() {
         // Fall through to the unified destroy path.
     } else {
         // Gate 3: two-phase path. Wait for inflight WRs to drain via CQ
-        // polling. If ibv_modify_qp-to-ERR failed in beginDestroy, WRs may
-        // never be flushed; enforce a timeout to avoid leaking forever.
+        // polling. If they never drain, keep the retired endpoint alive in
+        // the waiting list. Leaking this object is safer than forcing QP
+        // destruction while stale slice references may still exist.
         bool has_outstanding = false;
         for (size_t i = 0; i < qp_list_.size(); ++i) {
             if (wr_depth_list_[i].load(std::memory_order_relaxed) != 0) {
@@ -313,8 +315,13 @@ bool RdmaEndPoint::finishDestroy() {
                               inactive_time_.load(std::memory_order_relaxed)) /
                              1e9;
             if (elapsed < kFinishDestroyTimeoutSec) return false;
-            LOG(WARNING) << "finishDestroy timed out after " << elapsed
-                         << "s with outstanding WRs, forcing destruction";
+            if (!finish_destroy_timeout_logged_) {
+                LOG(ERROR) << "finishDestroy timed out after " << elapsed
+                           << "s with outstanding WRs; keeping retired "
+                              "endpoint alive to avoid UAF";
+                finish_destroy_timeout_logged_ = true;
+            }
+            return false;
         }
     }
 
@@ -1245,8 +1252,7 @@ int RdmaEndPoint::doSetupConnection(int qp_index, const ibv_gid &peer_gid,
         LOG(ERROR) << "[Handshake] " << message
                    << ": local=" << context_.nicPath()
                    << ", peer=" << peer_nic_path_ << ", qp_index=" << qp_index
-                   << ", local_qp=" << qp->qp_num
-                   << ", peer_qp=" << peer_qp_num
+                   << ", local_qp=" << qp->qp_num << ", peer_qp=" << peer_qp_num
                    << ", local_gid=" << context_.gid()
                    << ", local_gid_index=" << local_gid_index
                    << ", peer_gid=" << gidToString(peer_gid)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -287,6 +287,9 @@ bool RdmaEndPoint::finishDestroy() {
     // inactive endpoints are eligible for reclaim; active ones must stay.
     if (current_status != DESTROYING) {
         if (active_.load(std::memory_order_acquire)) return false;
+        if (completion_batch_refs_.load(std::memory_order_acquire) != 0) {
+            return false;
+        }
         // Endpoints that never reached construct() own no RDMA resources
         // and have wr_depth_list_ uninitialized; deconstructLocked() would
         // delete[] a wild pointer. Drop them directly.
@@ -310,7 +313,8 @@ bool RdmaEndPoint::finishDestroy() {
                 break;
             }
         }
-        if (has_outstanding) {
+        if (has_outstanding ||
+            completion_batch_refs_.load(std::memory_order_acquire) != 0) {
             double elapsed = (getCurrentTimeInNano() -
                               inactive_time_.load(std::memory_order_relaxed)) /
                              1e9;
@@ -340,6 +344,14 @@ bool RdmaEndPoint::finishDestroy() {
     }
     status_.store(DESTROYED, std::memory_order_relaxed);
     return true;
+}
+
+void RdmaEndPoint::beginCompletionBatch() {
+    completion_batch_refs_.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void RdmaEndPoint::endCompletionBatch() {
+    completion_batch_refs_.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -282,6 +282,9 @@ bool RdmaEndPoint::finishDestroy() {
     // inactive endpoints are eligible for reclaim; active ones must stay.
     if (current_status != DESTROYING) {
         if (active_.load(std::memory_order_acquire)) return false;
+        if (completion_batch_refs_.load(std::memory_order_acquire) != 0) {
+            return false;
+        }
         // Endpoints that never reached construct() own no RDMA resources
         // and have wr_depth_list_ uninitialized; deconstructLocked() would
         // delete[] a wild pointer. Drop them directly.
@@ -305,7 +308,8 @@ bool RdmaEndPoint::finishDestroy() {
                 break;
             }
         }
-        if (has_outstanding) {
+        if (has_outstanding ||
+            completion_batch_refs_.load(std::memory_order_acquire) != 0) {
             double elapsed = (getCurrentTimeInNano() -
                               inactive_time_.load(std::memory_order_relaxed)) /
                              1e9;
@@ -335,6 +339,14 @@ bool RdmaEndPoint::finishDestroy() {
     }
     status_.store(DESTROYED, std::memory_order_relaxed);
     return true;
+}
+
+void RdmaEndPoint::beginCompletionBatch() {
+    completion_batch_refs_.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void RdmaEndPoint::endCompletionBatch() {
+    completion_batch_refs_.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -1106,15 +1106,8 @@ int RdmaTransport::initializeRdmaResources() {
     for (auto &device_name : hca_list) {
         auto context = std::make_shared<RdmaContext>(*this, device_name);
         auto &config = globalConfig();
-        size_t cq_per_ctx = config.num_cq_per_ctx;
-        if (cq_per_ctx < static_cast<size_t>(config.workers_per_ctx)) {
-            cq_per_ctx = static_cast<size_t>(config.workers_per_ctx);
-            LOG(INFO) << "Increasing RDMA CQ count for " << device_name
-                      << " to match workers_per_ctx=" << config.workers_per_ctx
-                      << " for worker-owned endpoint polling";
-        }
         int ret = context->construct(
-            cq_per_ctx, config.num_comp_channels_per_ctx, config.port,
+            config.num_cq_per_ctx, config.num_comp_channels_per_ctx, config.port,
             config.gid_index, config.max_cqe, config.max_ep_per_ctx);
         if (ret) {
             local_topology_->disableDevice(device_name);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -1106,10 +1106,16 @@ int RdmaTransport::initializeRdmaResources() {
     for (auto &device_name : hca_list) {
         auto context = std::make_shared<RdmaContext>(*this, device_name);
         auto &config = globalConfig();
-        int ret = context->construct(config.num_cq_per_ctx,
-                                     config.num_comp_channels_per_ctx,
-                                     config.port, config.gid_index,
-                                     config.max_cqe, config.max_ep_per_ctx);
+        size_t cq_per_ctx = config.num_cq_per_ctx;
+        if (cq_per_ctx < static_cast<size_t>(config.workers_per_ctx)) {
+            cq_per_ctx = static_cast<size_t>(config.workers_per_ctx);
+            LOG(INFO) << "Increasing RDMA CQ count for " << device_name
+                      << " to match workers_per_ctx=" << config.workers_per_ctx
+                      << " for worker-owned endpoint polling";
+        }
+        int ret = context->construct(
+            cq_per_ctx, config.num_comp_channels_per_ctx, config.port,
+            config.gid_index, config.max_cqe, config.max_ep_per_ctx);
         if (ret) {
             local_topology_->disableDevice(device_name);
             LOG(WARNING) << "Disable device " << device_name;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -1104,10 +1104,16 @@ int RdmaTransport::initializeRdmaResources() {
     for (auto &device_name : hca_list) {
         auto context = std::make_shared<RdmaContext>(*this, device_name);
         auto &config = globalConfig();
-        int ret = context->construct(config.num_cq_per_ctx,
-                                     config.num_comp_channels_per_ctx,
-                                     config.port, config.gid_index,
-                                     config.max_cqe, config.max_ep_per_ctx);
+        size_t cq_per_ctx = config.num_cq_per_ctx;
+        if (cq_per_ctx < static_cast<size_t>(config.workers_per_ctx)) {
+            cq_per_ctx = static_cast<size_t>(config.workers_per_ctx);
+            LOG(INFO) << "Increasing RDMA CQ count for " << device_name
+                      << " to match workers_per_ctx=" << config.workers_per_ctx
+                      << " for worker-owned endpoint polling";
+        }
+        int ret = context->construct(
+            cq_per_ctx, config.num_comp_channels_per_ctx, config.port,
+            config.gid_index, config.max_cqe, config.max_ep_per_ctx);
         if (ret) {
             local_topology_->disableDevice(device_name);
             LOG(WARNING) << "Disable device " << device_name;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -115,15 +115,11 @@ WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
 }
 
 int WorkerPool::postingThreadForPeer(const std::string &peer_nic_path) const {
-    return static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
-                            static_cast<size_t>(kTransferWorkerCount));
+    return context_.postingThreadForPeer(peer_nic_path);
 }
 
 int WorkerPool::cqIndexForPostingThread(int thread_id) const {
-    const int cq_count = context_.cqCount();
-    if (cq_count <= 0) return 0;
-    if (thread_id >= 0 && thread_id < cq_count) return thread_id;
-    return thread_id >= 0 ? thread_id % cq_count : 0;
+    return context_.cqIndexForPostingThread(thread_id);
 }
 
 void WorkerPool::enqueueSliceToOwner(Transport::Slice *slice) {
@@ -541,7 +537,6 @@ void WorkerPool::performPollCq(int thread_id) {
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     std::unordered_set<RdmaEndPoint *> pinned_endpoints;
-    std::vector<ibv_wc> wc_list;
     const int cq_index = cqIndexForPostingThread(thread_id);
     ibv_wc wc[kPollCount];
     int nr_poll = context_.poll(kPollCount, wc, cq_index);
@@ -570,7 +565,6 @@ void WorkerPool::performPollCq(int thread_id) {
             pinned_endpoints.insert(slice->rdma.endpoint).second) {
             slice->rdma.endpoint->beginCompletionBatch();
         }
-        wc_list.push_back(wc[i]);
     }
     if (nr_poll)
         context_.cqOutstandingCount(cq_index)->fetch_sub(
@@ -579,15 +573,15 @@ void WorkerPool::performPollCq(int thread_id) {
     for (auto &entry : qp_depth_set)
         entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
-    if (!wc_list.empty()) processCompletions(thread_id, wc_list);
+    if (nr_poll > 0) processCompletions(thread_id, wc, nr_poll);
 
     for (auto *endpoint : pinned_endpoints) {
         endpoint->endCompletionBatch();
     }
 }
 
-void WorkerPool::processCompletions(int thread_id,
-                                    const std::vector<ibv_wc> &wc_list) {
+void WorkerPool::processCompletions(int thread_id, const ibv_wc *wc_list,
+                                    int count) {
     // Slices this call drove to a terminal state, successes and
     // retry-exhausted failures alike; folded into processed_slice_count_,
     // which gates worker parking. Every terminal outcome below goes through
@@ -617,15 +611,16 @@ void WorkerPool::processCompletions(int thread_id,
     SliceList failed_slice_list;
     SliceList local_failed_slice_list;
 
-    for (const auto &wc : wc_list) {
-        Transport::Slice *slice = (Transport::Slice *)wc.wr_id;
+    for (int i = 0; i < count; ++i) {
+        const ibv_wc &entry = wc_list[i];
+        Transport::Slice *slice = (Transport::Slice *)entry.wr_id;
         assert(slice);
-        if (wc.status != IBV_WC_SUCCESS) {
+        if (entry.status != IBV_WC_SUCCESS) {
             // Flush errors are generated when QPs transition to ERR state
             // during normal endpoint destruction (beginDestroy). They are not
             // real network errors and should not trigger rail failure handling
             // or endpoint deletion.
-            if (wc.status == IBV_WC_WR_FLUSH_ERR) {
+            if (entry.status == IBV_WC_WR_FLUSH_ERR) {
                 if (!context_.active()) {
                     if (globalConfig().trace)
                         LOG(INFO) << "Worker: WR flush error on inactive "
@@ -662,9 +657,9 @@ void WorkerPool::processCompletions(int thread_id,
                        << ", dest_rkey: " << slice->rdma.dest_rkey
                        << ", retry_cnt: " << slice->rdma.retry_cnt
                        << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
-                       << "): " << ibv_wc_status_str(wc.status);
+                       << "): " << ibv_wc_status_str(entry.status);
             auto *retry_list = &failed_slice_list;
-            const bool local_wc_failure = isLocalWcFailure(wc);
+            const bool local_wc_failure = isLocalWcFailure(entry);
             if (!context_.active() || local_wc_failure) {
                 // A local completion fault retires the endpoint, and the slice
                 // is handed to another local RNIC that rebuilds its own

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <functional>
+#include <unordered_set>
 
 #include "config.h"
 #include "memory_location.h"
@@ -539,6 +540,7 @@ void WorkerPool::performPollCq(int thread_id) {
 
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
+    std::unordered_set<RdmaEndPoint *> pinned_endpoints;
     std::vector<ibv_wc> wc_list;
     const int cq_index = cqIndexForPostingThread(thread_id);
     ibv_wc wc[kPollCount];
@@ -564,6 +566,10 @@ void WorkerPool::performPollCq(int thread_id) {
             qp_depth_set[slice->rdma.qp_depth]++;
         else
             qp_depth_set[slice->rdma.qp_depth] = 1;
+        if (slice->rdma.endpoint &&
+            pinned_endpoints.insert(slice->rdma.endpoint).second) {
+            slice->rdma.endpoint->beginCompletionBatch();
+        }
         wc_list.push_back(wc[i]);
     }
     if (nr_poll)
@@ -574,6 +580,10 @@ void WorkerPool::performPollCq(int thread_id) {
         entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
     if (!wc_list.empty()) processCompletions(thread_id, wc_list);
+
+    for (auto *endpoint : pinned_endpoints) {
+        endpoint->endCompletionBatch();
+    }
 }
 
 void WorkerPool::processCompletions(int thread_id,
@@ -657,17 +667,18 @@ void WorkerPool::processCompletions(int thread_id,
             const bool local_wc_failure = isLocalWcFailure(wc);
             if (!context_.active() || local_wc_failure) {
                 // A local completion fault retires the endpoint, and the slice
-                // is handed to another local RNIC that rebuilds its own endpoint
-                // to the same peer NIC. If the fault keeps recurring nothing
-                // throttles that cycle: the rail is deliberately not paused on
-                // the local path, and the context failure counter is cleared by
-                // any concurrent success, so both RNICs re-handshake the same
-                // peer as fast as the workers spin. Charge the path an error
-                // instead -- without an immediate pause, so a one-off fault
-                // still costs nothing -- and let kRailErrorThreshold stop the
-                // rebuild loop from this context. See issue #3299.
+                // is handed to another local RNIC that rebuilds its own
+                // endpoint to the same peer NIC. If the fault keeps recurring
+                // nothing throttles that cycle: the rail is deliberately not
+                // paused on the local path, and the context failure counter is
+                // cleared by any concurrent success, so both RNICs re-handshake
+                // the same peer as fast as the workers spin. Charge the path an
+                // error instead -- without an immediate pause, so a one-off
+                // fault still costs nothing -- and let kRailErrorThreshold stop
+                // the rebuild loop from this context. See issue #3299.
                 if (local_wc_failure &&
-                    local_failed_peer_paths.insert(slice->peer_nic_path).second) {
+                    local_failed_peer_paths.insert(slice->peer_nic_path)
+                        .second) {
                     markRailFailed(slice->peer_nic_path);
                 }
                 if (!recorded_local_context_failure) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -993,6 +993,7 @@ int WorkerPool::doProcessContextEvents() {
                      << context_.deviceName();
         if (event.event_type == IBV_EVENT_QP_FATAL) {
             auto endpoint_ptr = (RdmaEndPoint *)event.element.qp->qp_context;
+            auto endpoint = context_.getEndpointByPtr(endpoint_ptr);
 
             /**
              * There might be a deadlock if we call endpoint->set_active(false)
@@ -1010,13 +1011,16 @@ int WorkerPool::doProcessContextEvents() {
             event_acked = true;
 
             /**
-             * After ack the event, the endpoint might be destroyed if it
-             * happened to be destroying event.element.qp. Therefore, we cannot
-             * just dereference endpoint_ptr. Instead, we need to get the
-             * shared_ptr of the endpoint from context_ and use that shared_ptr
-             * to access the endpoint.
+             * After ack the event, the endpoint can otherwise be reclaimed
+             * before deleteEndpointByPtr() takes the store lock. Keep the
+             * shared_ptr acquired before ack alive through deletion so pointer
+             * identity cannot ABA-match a newly allocated endpoint.
              */
-            context_.deleteEndpointByPtr(endpoint_ptr);
+            if (endpoint) {
+                context_.deleteEndpointByPtr(endpoint.get());
+            } else {
+                LOG(WARNING) << "QP fatal event endpoint is no longer tracked";
+            }
         } else if (handleContextEvent(event.event_type, false, &event)) {
             event_acked = true;
         }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -95,42 +95,44 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
     return 0;
 }
 
-static bool workerCanPost(int thread_id) {
-    return kTransferWorkerCount == 1 || thread_id != 0;
-}
-
-static bool workerCanPoll(int thread_id) {
-    return kTransferWorkerCount == 1 || thread_id == 0;
-}
-
-static void getPostingShardAssignment(int thread_id, int &post_tid,
-                                      int &post_count) {
-    assert(workerCanPost(thread_id));
-    if (kTransferWorkerCount > 1) {
-        post_tid = thread_id - 1;
-        post_count = kTransferWorkerCount - 1;
-    } else {
-        post_tid = thread_id;
-        post_count = kTransferWorkerCount;
-    }
-}
-
 WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
       workers_running_(true),
       parked_worker_count_(0),
       redispatch_counter_(0),
+      worker_slice_queue_(kTransferWorkerCount),
+      worker_slice_queue_lock_(kTransferWorkerCount),
       submitted_slice_count_(0),
       processed_slice_count_(0) {
-    for (int i = 0; i < kShardCount; ++i)
-        slice_queue_count_[i].store(0, std::memory_order_relaxed);
     collective_slice_queue_.resize(kTransferWorkerCount);
     for (int i = 0; i < kTransferWorkerCount; ++i)
         worker_thread_.emplace_back(
             std::thread(std::bind(&WorkerPool::transferWorker, this, i)));
     worker_thread_.emplace_back(
         std::thread(std::bind(&WorkerPool::monitorWorker, this)));
+}
+
+int WorkerPool::postingThreadForPeer(const std::string &peer_nic_path) const {
+    return static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
+                            static_cast<size_t>(kTransferWorkerCount));
+}
+
+int WorkerPool::cqIndexForPostingThread(int thread_id) const {
+    const int cq_count = context_.cqCount();
+    if (cq_count <= 0) return 0;
+    if (thread_id >= 0 && thread_id < cq_count) return thread_id;
+    return thread_id >= 0 ? thread_id % cq_count : 0;
+}
+
+void WorkerPool::enqueueSliceToOwner(Transport::Slice *slice) {
+    const int owner_thread = postingThreadForPeer(slice->peer_nic_path);
+    {
+        std::lock_guard<std::mutex> lock(
+            worker_slice_queue_lock_[owner_thread]);
+        worker_slice_queue_[owner_thread][slice->peer_nic_path].push_back(
+            slice);
+    }
 }
 
 WorkerPool::~WorkerPool() {
@@ -179,7 +181,7 @@ int WorkerPool::submitPostSend(
     }
 #endif  // CONFIG_CACHE_SEGMENT_DESC
 
-    SliceList slice_list_map[kShardCount];
+    SliceList prepared_slice_list;
     uint64_t submitted_slice_count = 0;
     int all_rails_failed_count = 0;
     thread_local std::unordered_map<int, uint64_t> failed_target_ids;
@@ -272,12 +274,11 @@ int WorkerPool::submitPostSend(
                     << reinterpret_cast<void *>(slice->rdma.dest_addr)
                     << ", length=" << slice->length;
         }
-        int shard_id = (slice->target_id * 10007 + device_id) % kShardCount;
-        slice_list_map[shard_id].push_back(slice);
+        prepared_slice_list.push_back(slice);
         submitted_slice_count++;
     }
 
-    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
+    enqueuePreparedSlices(prepared_slice_list, submitted_slice_count);
 
     // Context-level health tracking: if all slices failed due to no available
     // rails, increment the context failure counter. This detects catastrophic
@@ -290,17 +291,9 @@ int WorkerPool::submitPostSend(
     return 0;
 }
 
-void WorkerPool::enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+void WorkerPool::enqueuePreparedSlices(const SliceList &slice_list,
                                        uint64_t submitted_slice_count) {
-    for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
-        if (slice_list_map[shard_id].empty()) continue;
-        slice_queue_lock_[shard_id].lock();
-        for (auto &slice : slice_list_map[shard_id])
-            slice_queue_[shard_id][slice->peer_nic_path].push_back(slice);
-        slice_queue_count_[shard_id].fetch_add(slice_list_map[shard_id].size(),
-                                               std::memory_order_relaxed);
-        slice_queue_lock_[shard_id].unlock();
-    }
+    for (auto &slice : slice_list) enqueueSliceToOwner(slice);
 
     submitted_slice_count_.fetch_add(submitted_slice_count);
     if (submitted_slice_count &&
@@ -315,7 +308,7 @@ int WorkerPool::submitPreparedPostSend(
     // Called by a different local RNIC's worker during local failover. The
     // slice already carries the chosen peer_nic_path and refreshed local lkey,
     // so enqueue it directly instead of running remote-path selection again.
-    SliceList slice_list_map[kShardCount];
+    SliceList prepared_slice_list;
     uint64_t submitted_slice_count = 0;
 
     for (auto &slice : slice_list) {
@@ -323,13 +316,11 @@ int WorkerPool::submitPreparedPostSend(
             slice->markFailed();
             continue;
         }
-        auto shard_id = static_cast<int>(
-            std::hash<std::string>{}(slice->peer_nic_path) % kShardCount);
-        slice_list_map[shard_id].push_back(slice);
+        prepared_slice_list.push_back(slice);
         submitted_slice_count++;
     }
 
-    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
+    enqueuePreparedSlices(prepared_slice_list, submitted_slice_count);
 
     return 0;
 }
@@ -355,10 +346,17 @@ void WorkerPool::untrackPostedSlices(
 }
 
 void WorkerPool::performPostSend(int thread_id) {
-    int post_tid = 0;
-    int post_count = 0;
-    getPostingShardAssignment(thread_id, post_tid, post_count);
     auto &local_slice_queue = collective_slice_queue_[thread_id];
+    {
+        std::lock_guard<std::mutex> lock(worker_slice_queue_lock_[thread_id]);
+        for (auto &entry : worker_slice_queue_[thread_id]) {
+            if (entry.second.empty()) continue;
+            auto &local_entry = local_slice_queue[entry.first];
+            local_entry.insert(local_entry.end(), entry.second.begin(),
+                               entry.second.end());
+        }
+        worker_slice_queue_[thread_id].clear();
+    }
 
     // If this local RNIC is inactive/unhealthy, the remote rail is not the
     // problem. Move queued work to another local RNIC while preserving the
@@ -368,36 +366,7 @@ void WorkerPool::performPostSend(int thread_id) {
         local_slice_queue.clear();
         for (auto &entry : local_slice_queue_clone)
             redispatch(entry.second, thread_id, true);
-
-        for (int shard_id = post_tid; shard_id < kShardCount;
-             shard_id += post_count) {
-            if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) ==
-                0)
-                continue;
-            slice_queue_lock_[shard_id].lock();
-            auto slice_queue_clone = slice_queue_[shard_id];
-            slice_queue_[shard_id].clear();
-            slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
-            slice_queue_lock_[shard_id].unlock();
-            for (auto &entry : slice_queue_clone)
-                redispatch(entry.second, thread_id, true);
-        }
         return;
-    }
-
-    for (int shard_id = post_tid; shard_id < kShardCount;
-         shard_id += post_count) {
-        if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) == 0)
-            continue;
-
-        slice_queue_lock_[shard_id].lock();
-        for (auto &entry : slice_queue_[shard_id]) {
-            for (auto &slice : entry.second)
-                local_slice_queue[entry.first].push_back(slice);
-            entry.second.clear();
-        }
-        slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
-        slice_queue_lock_[shard_id].unlock();
     }
 
     // Redispatch slices to other endpoints, for temporary failures
@@ -449,9 +418,11 @@ void WorkerPool::performPostSend(int thread_id) {
 #ifdef CONFIG_CACHE_ENDPOINT
         auto &endpoint = endpoint_map[entry.first];
         if (endpoint == nullptr || !endpoint->active())
-            endpoint = context_.endpoint(entry.first);
+            endpoint = context_.endpoint(entry.first,
+                                         cqIndexForPostingThread(thread_id));
 #else
-        auto endpoint = context_.endpoint(entry.first);
+        auto endpoint =
+            context_.endpoint(entry.first, cqIndexForPostingThread(thread_id));
 #endif
         if (!endpoint) {
             for (auto &slice : entry.second) failed_slice_list.push_back(slice);
@@ -550,6 +521,8 @@ void WorkerPool::performPostSend(int thread_id) {
 }
 
 void WorkerPool::performPollCq(int thread_id) {
+    if (context_.cqCount() <= 0) return;
+
     const uint64_t poll_ts = getCurrentTimeInNano();
     const uint64_t previous_poll_ts =
         last_poll_ts_ns_.exchange(poll_ts, std::memory_order_relaxed);
@@ -564,7 +537,48 @@ void WorkerPool::performPollCq(int thread_id) {
         }
     }
 
-    // Slices this loop drove to a terminal state, successes and
+    const static size_t kPollCount = 64;
+    std::unordered_map<std::atomic<int> *, int> qp_depth_set;
+    std::vector<ibv_wc> wc_list;
+    const int cq_index = cqIndexForPostingThread(thread_id);
+    ibv_wc wc[kPollCount];
+    int nr_poll = context_.poll(kPollCount, wc, cq_index);
+    if (nr_poll < 0) {
+        LOG(ERROR) << "Worker: Failed to poll completion queues";
+        return;
+    }
+
+    if (nr_poll > 0 && globalConfig().track_rdma_posted_slices) {
+        std::lock_guard<std::mutex> lock(posted_slices_mutex_);
+        for (int i = 0; i < nr_poll; ++i) {
+            auto *slice = reinterpret_cast<Transport::Slice *>(wc[i].wr_id);
+            posted_slices_.erase(slice);
+        }
+    }
+
+    for (int i = 0; i < nr_poll; ++i) {
+        Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
+        assert(slice);
+        assert(postingThreadForPeer(slice->peer_nic_path) == thread_id);
+        if (qp_depth_set.count(slice->rdma.qp_depth))
+            qp_depth_set[slice->rdma.qp_depth]++;
+        else
+            qp_depth_set[slice->rdma.qp_depth] = 1;
+        wc_list.push_back(wc[i]);
+    }
+    if (nr_poll)
+        context_.cqOutstandingCount(cq_index)->fetch_sub(
+            nr_poll, std::memory_order_acq_rel);
+
+    for (auto &entry : qp_depth_set)
+        entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
+
+    if (!wc_list.empty()) processCompletions(thread_id, wc_list);
+}
+
+void WorkerPool::processCompletions(int thread_id,
+                                    const std::vector<ibv_wc> &wc_list) {
+    // Slices this call drove to a terminal state, successes and
     // retry-exhausted failures alike; folded into processed_slice_count_,
     // which gates worker parking. Every terminal outcome below goes through
     // finalize_slice() so it is counted exactly once. Slices handed to
@@ -572,8 +586,8 @@ void WorkerPool::performPollCq(int thread_id) {
     int processed_slice_count = 0;
     // Successful completions only, kept apart because it clears the context
     // health counter. A completion error is no evidence that this RNIC can
-    // still move data -- including IBV_WC_WR_FLUSH_ERR, which only reports
-    // WRs the hardware discarded after the QP had already entered ERR.
+    // still move data, including IBV_WC_WR_FLUSH_ERR, which only reports WRs
+    // the hardware discarded after the QP had already entered ERR.
     int succeeded_slice_count = 0;
     auto finalize_slice = [&](Transport::Slice *slice, bool success) {
         if (success) {
@@ -584,8 +598,6 @@ void WorkerPool::performPollCq(int thread_id) {
         }
         processed_slice_count++;
     };
-    const static size_t kPollCount = 64;
-    std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     std::unordered_set<RdmaEndPoint *> local_failed_endpoints;
     // Peer NIC paths already charged a local-fault error this pass. A QP that
     // takes a local fault completes every WR it still holds, so one burst must
@@ -594,132 +606,102 @@ void WorkerPool::performPollCq(int thread_id) {
     bool recorded_local_context_failure = false;
     SliceList failed_slice_list;
     SliceList local_failed_slice_list;
-    for (int cq_index = 0; cq_index < context_.cqCount(); cq_index++) {
-        ibv_wc wc[kPollCount];
-        int nr_poll = context_.poll(kPollCount, wc, cq_index);
-        if (nr_poll < 0) {
-            LOG(ERROR) << "Worker: Failed to poll completion queues";
-            continue;
-        }
 
-        if (nr_poll > 0 && globalConfig().track_rdma_posted_slices) {
-            std::lock_guard<std::mutex> lock(posted_slices_mutex_);
-            for (int i = 0; i < nr_poll; ++i) {
-                auto *slice = reinterpret_cast<Transport::Slice *>(wc[i].wr_id);
-                posted_slices_.erase(slice);
-            }
-        }
-
-        for (int i = 0; i < nr_poll; ++i) {
-            Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
-            assert(slice);
-            if (qp_depth_set.count(slice->rdma.qp_depth))
-                qp_depth_set[slice->rdma.qp_depth]++;
-            else
-                qp_depth_set[slice->rdma.qp_depth] = 1;
-            // __sync_fetch_and_sub(slice->rdma.qp_depth, 1);
-            if (wc[i].status != IBV_WC_SUCCESS) {
-                // Flush errors are generated when QPs transition to ERR state
-                // during normal endpoint destruction (beginDestroy). They are
-                // not real network errors and should not trigger rail failure
-                // handling or endpoint deletion.
-                if (wc[i].status == IBV_WC_WR_FLUSH_ERR) {
-                    if (!context_.active()) {
-                        if (globalConfig().trace)
-                            LOG(INFO)
-                                << "Worker: WR flush error on inactive "
-                                << "local context " << context_.deviceName()
-                                << " (peer_nic: " << slice->peer_nic_path
-                                << "), handing off if retry allows";
-                        if (shouldRetrySlice(slice))
-                            local_failed_slice_list.push_back(slice);
-                        else
-                            finalize_slice(slice, false);
-                    } else {
-                        if (globalConfig().trace)
-                            LOG(INFO) << "Worker: WR flush error (peer_nic: "
-                                      << slice->peer_nic_path
-                                      << "), redispatching if retry allows";
-                        if (shouldRetrySlice(slice))
-                            failed_slice_list.push_back(slice);
-                        else
-                            finalize_slice(slice, false);
-                    }
-                    continue;
+    for (const auto &wc : wc_list) {
+        Transport::Slice *slice = (Transport::Slice *)wc.wr_id;
+        assert(slice);
+        if (wc.status != IBV_WC_SUCCESS) {
+            // Flush errors are generated when QPs transition to ERR state
+            // during normal endpoint destruction (beginDestroy). They are not
+            // real network errors and should not trigger rail failure handling
+            // or endpoint deletion.
+            if (wc.status == IBV_WC_WR_FLUSH_ERR) {
+                if (!context_.active()) {
+                    if (globalConfig().trace)
+                        LOG(INFO) << "Worker: WR flush error on inactive "
+                                  << "local context " << context_.deviceName()
+                                  << " (peer_nic: " << slice->peer_nic_path
+                                  << "), handing off if retry allows";
+                    if (shouldRetrySlice(slice))
+                        local_failed_slice_list.push_back(slice);
+                    else
+                        finalize_slice(slice, false);
+                } else {
+                    if (globalConfig().trace)
+                        LOG(INFO) << "Worker: WR flush error (peer_nic: "
+                                  << slice->peer_nic_path
+                                  << "), redispatching if retry allows";
+                    if (shouldRetrySlice(slice))
+                        failed_slice_list.push_back(slice);
+                    else
+                        finalize_slice(slice, false);
                 }
+                continue;
+            }
 
-                // Completion errors are split by local context health. Local
-                // faults hand off to another local RNIC; remote/default faults
-                // keep this local context and switch peer rails.
-                LOG(ERROR) << "Worker: Process failed for slice (opcode: "
-                           << slice->opcode
-                           << ", source_addr: " << slice->source_addr
-                           << ", length: " << slice->length
-                           << ", dest_addr: " << (void *)slice->rdma.dest_addr
-                           << ", local_nic: " << context_.deviceName()
-                           << ", peer_nic: " << slice->peer_nic_path
-                           << ", dest_rkey: " << slice->rdma.dest_rkey
-                           << ", retry_cnt: " << slice->rdma.retry_cnt
-                           << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
-                           << "): " << ibv_wc_status_str(wc[i].status);
-                auto *retry_list = &failed_slice_list;
-                const bool local_wc_failure = isLocalWcFailure(wc[i]);
-                if (!context_.active() || local_wc_failure) {
-                    // A local completion fault retires the endpoint, and the
-                    // slice is handed to another local RNIC that rebuilds its
-                    // own endpoint to the same peer NIC. If the fault keeps
-                    // recurring nothing throttles that cycle: the rail is
-                    // deliberately not paused on the local path, and the
-                    // context failure counter is cleared by any concurrent
-                    // success, so both RNICs re-handshake the same peer as fast
-                    // as the workers spin. Charge the path an error instead --
-                    // without an immediate pause, so a one-off fault still
-                    // costs nothing -- and let kRailErrorThreshold stop the
-                    // rebuild loop from this context. See issue #3299.
-                    if (local_wc_failure &&
-                        local_failed_peer_paths.insert(slice->peer_nic_path)
-                            .second) {
-                        markRailFailed(slice->peer_nic_path);
-                    }
-                    if (!recorded_local_context_failure) {
-                        handleLocalFailure(slice->peer_nic_path,
-                                           slice->rdma.endpoint);
-                        recorded_local_context_failure = true;
-                        if (slice->rdma.endpoint)
-                            local_failed_endpoints.insert(slice->rdma.endpoint);
-                    } else if (slice->rdma.endpoint &&
-                               !local_failed_endpoints.count(
-                                   slice->rdma.endpoint)) {
-                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
+            // Completion errors are split by local context health. Local faults
+            // hand off to another local RNIC; remote/default faults keep this
+            // local context and switch peer rails.
+            LOG(ERROR) << "Worker: Process failed for slice (opcode: "
+                       << slice->opcode
+                       << ", source_addr: " << slice->source_addr
+                       << ", length: " << slice->length
+                       << ", dest_addr: " << (void *)slice->rdma.dest_addr
+                       << ", local_nic: " << context_.deviceName()
+                       << ", peer_nic: " << slice->peer_nic_path
+                       << ", dest_rkey: " << slice->rdma.dest_rkey
+                       << ", retry_cnt: " << slice->rdma.retry_cnt
+                       << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
+                       << "): " << ibv_wc_status_str(wc.status);
+            auto *retry_list = &failed_slice_list;
+            const bool local_wc_failure = isLocalWcFailure(wc);
+            if (!context_.active() || local_wc_failure) {
+                // A local completion fault retires the endpoint, and the slice
+                // is handed to another local RNIC that rebuilds its own endpoint
+                // to the same peer NIC. If the fault keeps recurring nothing
+                // throttles that cycle: the rail is deliberately not paused on
+                // the local path, and the context failure counter is cleared by
+                // any concurrent success, so both RNICs re-handshake the same
+                // peer as fast as the workers spin. Charge the path an error
+                // instead -- without an immediate pause, so a one-off fault
+                // still costs nothing -- and let kRailErrorThreshold stop the
+                // rebuild loop from this context. See issue #3299.
+                if (local_wc_failure &&
+                    local_failed_peer_paths.insert(slice->peer_nic_path).second) {
+                    markRailFailed(slice->peer_nic_path);
+                }
+                if (!recorded_local_context_failure) {
+                    handleLocalFailure(slice->peer_nic_path,
+                                       slice->rdma.endpoint);
+                    recorded_local_context_failure = true;
+                    if (slice->rdma.endpoint)
                         local_failed_endpoints.insert(slice->rdma.endpoint);
-                    }
-                    retry_list = &local_failed_slice_list;
-                } else {
-                    if (hasAvailablePeerRailAlternative(slice,
-                                                        slice->peer_nic_path)) {
-                        markRailFailed(slice->peer_nic_path, true);
-                        redispatch_counter_++;
-                    }
-                    if (slice->rdma.endpoint) {
-                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
-                    }
+                } else if (slice->rdma.endpoint &&
+                           !local_failed_endpoints.count(
+                               slice->rdma.endpoint)) {
+                    context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                    local_failed_endpoints.insert(slice->rdma.endpoint);
                 }
-                if (shouldRetrySlice(slice)) {
-                    retry_list->push_back(slice);
-                } else {
-                    finalize_slice(slice, false);
-                }
+                retry_list = &local_failed_slice_list;
             } else {
-                finalize_slice(slice, true);
+                if (hasAvailablePeerRailAlternative(slice,
+                                                    slice->peer_nic_path)) {
+                    markRailFailed(slice->peer_nic_path, true);
+                    redispatch_counter_++;
+                }
+                if (slice->rdma.endpoint) {
+                    context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                }
             }
+            if (shouldRetrySlice(slice)) {
+                retry_list->push_back(slice);
+            } else {
+                finalize_slice(slice, false);
+            }
+        } else {
+            finalize_slice(slice, true);
         }
-        if (nr_poll)
-            context_.cqOutstandingCount(cq_index)->fetch_sub(
-                nr_poll, std::memory_order_acq_rel);
     }
-
-    for (auto &entry : qp_depth_set)
-        entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
     if (processed_slice_count)
         processed_slice_count_.fetch_add(processed_slice_count);
@@ -740,7 +722,6 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                             int thread_id, bool handoff_to_local_worker) {
     std::unordered_map<SegmentID, std::shared_ptr<Transport::SegmentDesc>>
         segment_desc_map;
-    const bool use_local_queue = workerCanPost(thread_id);
     int shared_redispatch_count = 0;
     // Remote redispatch needs target metadata to choose a new peer RNIC.
     // Local handoff keeps the peer RNIC fixed and only switches source RNIC, so
@@ -851,17 +832,12 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                         << ", retry_cnt=" << slice->rdma.retry_cnt;
             }
             slice->ts = 0;
-            if (use_local_queue) {
+            const int owner_thread = postingThreadForPeer(peer_nic_path);
+            if (owner_thread == thread_id) {
                 collective_slice_queue_[thread_id][peer_nic_path].push_back(
                     slice);
             } else {
-                int shard_id =
-                    (slice->target_id * 10007 + device_id) % kShardCount;
-                slice_queue_lock_[shard_id].lock();
-                slice_queue_[shard_id][peer_nic_path].push_back(slice);
-                slice_queue_count_[shard_id].fetch_add(
-                    1, std::memory_order_relaxed);
-                slice_queue_lock_[shard_id].unlock();
+                enqueueSliceToOwner(slice);
                 shared_redispatch_count++;
             }
         }
@@ -945,21 +921,15 @@ bool WorkerPool::tryHandoffToAnotherLocalWorker(Transport::Slice *slice) {
 }
 
 bool WorkerPool::hasOutstandingCq(int thread_id) {
-    if (!workerCanPoll(thread_id)) return false;
-    for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
-        if (context_.cqOutstandingCount(cq_index)->load(
-                std::memory_order_relaxed) > 0)
-            return true;
-    }
-    return false;
+    if (context_.cqCount() <= 0) return false;
+    return context_.cqOutstandingCount(cqIndexForPostingThread(thread_id))
+               ->load(std::memory_order_relaxed) > 0;
 }
 
 void WorkerPool::transferWorker(int thread_id) {
     bindToSocket(numa_socket_id_);
     const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
     uint64_t last_wait_ts = getCurrentTimeInNano();
-    const bool can_post = workerCanPost(thread_id);
-    const bool can_poll = workerCanPoll(thread_id);
     while (workers_running_.load(std::memory_order_relaxed)) {
         auto processed_slice_count =
             processed_slice_count_.load(std::memory_order_relaxed);
@@ -984,13 +954,9 @@ void WorkerPool::transferWorker(int thread_id) {
             }
             continue;
         }
-        if (can_post) {
-            performPostSend(thread_id);
-        }
+        performPostSend(thread_id);
 #ifndef USE_FAKE_POST_SEND
-        if (can_poll) {
-            performPollCq(thread_id);
-        }
+        performPollCq(thread_id);
 #endif
         last_wait_ts = getCurrentTimeInNano();
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <functional>
+#include <unordered_set>
 
 #include "config.h"
 #include "memory_location.h"
@@ -539,6 +540,7 @@ void WorkerPool::performPollCq(int thread_id) {
 
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
+    std::unordered_set<RdmaEndPoint *> pinned_endpoints;
     std::vector<ibv_wc> wc_list;
     const int cq_index = cqIndexForPostingThread(thread_id);
     ibv_wc wc[kPollCount];
@@ -564,6 +566,10 @@ void WorkerPool::performPollCq(int thread_id) {
             qp_depth_set[slice->rdma.qp_depth]++;
         else
             qp_depth_set[slice->rdma.qp_depth] = 1;
+        if (slice->rdma.endpoint &&
+            pinned_endpoints.insert(slice->rdma.endpoint).second) {
+            slice->rdma.endpoint->beginCompletionBatch();
+        }
         wc_list.push_back(wc[i]);
     }
     if (nr_poll)
@@ -574,6 +580,10 @@ void WorkerPool::performPollCq(int thread_id) {
         entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
     if (!wc_list.empty()) processCompletions(thread_id, wc_list);
+
+    for (auto *endpoint : pinned_endpoints) {
+        endpoint->endCompletionBatch();
+    }
 }
 
 void WorkerPool::processCompletions(int thread_id,

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -95,42 +95,44 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
     return 0;
 }
 
-static bool workerCanPost(int thread_id) {
-    return kTransferWorkerCount == 1 || thread_id != 0;
-}
-
-static bool workerCanPoll(int thread_id) {
-    return kTransferWorkerCount == 1 || thread_id == 0;
-}
-
-static void getPostingShardAssignment(int thread_id, int &post_tid,
-                                      int &post_count) {
-    assert(workerCanPost(thread_id));
-    if (kTransferWorkerCount > 1) {
-        post_tid = thread_id - 1;
-        post_count = kTransferWorkerCount - 1;
-    } else {
-        post_tid = thread_id;
-        post_count = kTransferWorkerCount;
-    }
-}
-
 WorkerPool::WorkerPool(RdmaContext &context, int numa_socket_id)
     : context_(context),
       numa_socket_id_(numa_socket_id),
       workers_running_(true),
       parked_worker_count_(0),
       redispatch_counter_(0),
+      worker_slice_queue_(kTransferWorkerCount),
+      worker_slice_queue_lock_(kTransferWorkerCount),
       submitted_slice_count_(0),
       processed_slice_count_(0) {
-    for (int i = 0; i < kShardCount; ++i)
-        slice_queue_count_[i].store(0, std::memory_order_relaxed);
     collective_slice_queue_.resize(kTransferWorkerCount);
     for (int i = 0; i < kTransferWorkerCount; ++i)
         worker_thread_.emplace_back(
             std::thread(std::bind(&WorkerPool::transferWorker, this, i)));
     worker_thread_.emplace_back(
         std::thread(std::bind(&WorkerPool::monitorWorker, this)));
+}
+
+int WorkerPool::postingThreadForPeer(const std::string &peer_nic_path) const {
+    return static_cast<int>(std::hash<std::string>{}(peer_nic_path) %
+                            static_cast<size_t>(kTransferWorkerCount));
+}
+
+int WorkerPool::cqIndexForPostingThread(int thread_id) const {
+    const int cq_count = context_.cqCount();
+    if (cq_count <= 0) return 0;
+    if (thread_id >= 0 && thread_id < cq_count) return thread_id;
+    return thread_id >= 0 ? thread_id % cq_count : 0;
+}
+
+void WorkerPool::enqueueSliceToOwner(Transport::Slice *slice) {
+    const int owner_thread = postingThreadForPeer(slice->peer_nic_path);
+    {
+        std::lock_guard<std::mutex> lock(
+            worker_slice_queue_lock_[owner_thread]);
+        worker_slice_queue_[owner_thread][slice->peer_nic_path].push_back(
+            slice);
+    }
 }
 
 WorkerPool::~WorkerPool() {
@@ -179,7 +181,7 @@ int WorkerPool::submitPostSend(
     }
 #endif  // CONFIG_CACHE_SEGMENT_DESC
 
-    SliceList slice_list_map[kShardCount];
+    SliceList prepared_slice_list;
     uint64_t submitted_slice_count = 0;
     int all_rails_failed_count = 0;
     thread_local std::unordered_map<int, uint64_t> failed_target_ids;
@@ -272,12 +274,11 @@ int WorkerPool::submitPostSend(
                     << reinterpret_cast<void *>(slice->rdma.dest_addr)
                     << ", length=" << slice->length;
         }
-        int shard_id = (slice->target_id * 10007 + device_id) % kShardCount;
-        slice_list_map[shard_id].push_back(slice);
+        prepared_slice_list.push_back(slice);
         submitted_slice_count++;
     }
 
-    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
+    enqueuePreparedSlices(prepared_slice_list, submitted_slice_count);
 
     // Context-level health tracking: if all slices failed due to no available
     // rails, increment the context failure counter. This detects catastrophic
@@ -290,17 +291,9 @@ int WorkerPool::submitPostSend(
     return 0;
 }
 
-void WorkerPool::enqueuePreparedSlices(SliceList (&slice_list_map)[kShardCount],
+void WorkerPool::enqueuePreparedSlices(const SliceList &slice_list,
                                        uint64_t submitted_slice_count) {
-    for (int shard_id = 0; shard_id < kShardCount; ++shard_id) {
-        if (slice_list_map[shard_id].empty()) continue;
-        slice_queue_lock_[shard_id].lock();
-        for (auto &slice : slice_list_map[shard_id])
-            slice_queue_[shard_id][slice->peer_nic_path].push_back(slice);
-        slice_queue_count_[shard_id].fetch_add(slice_list_map[shard_id].size(),
-                                               std::memory_order_relaxed);
-        slice_queue_lock_[shard_id].unlock();
-    }
+    for (auto &slice : slice_list) enqueueSliceToOwner(slice);
 
     submitted_slice_count_.fetch_add(submitted_slice_count);
     if (submitted_slice_count &&
@@ -315,7 +308,7 @@ int WorkerPool::submitPreparedPostSend(
     // Called by a different local RNIC's worker during local failover. The
     // slice already carries the chosen peer_nic_path and refreshed local lkey,
     // so enqueue it directly instead of running remote-path selection again.
-    SliceList slice_list_map[kShardCount];
+    SliceList prepared_slice_list;
     uint64_t submitted_slice_count = 0;
 
     for (auto &slice : slice_list) {
@@ -323,13 +316,11 @@ int WorkerPool::submitPreparedPostSend(
             slice->markFailed();
             continue;
         }
-        auto shard_id = static_cast<int>(
-            std::hash<std::string>{}(slice->peer_nic_path) % kShardCount);
-        slice_list_map[shard_id].push_back(slice);
+        prepared_slice_list.push_back(slice);
         submitted_slice_count++;
     }
 
-    enqueuePreparedSlices(slice_list_map, submitted_slice_count);
+    enqueuePreparedSlices(prepared_slice_list, submitted_slice_count);
 
     return 0;
 }
@@ -355,10 +346,17 @@ void WorkerPool::untrackPostedSlices(
 }
 
 void WorkerPool::performPostSend(int thread_id) {
-    int post_tid = 0;
-    int post_count = 0;
-    getPostingShardAssignment(thread_id, post_tid, post_count);
     auto &local_slice_queue = collective_slice_queue_[thread_id];
+    {
+        std::lock_guard<std::mutex> lock(worker_slice_queue_lock_[thread_id]);
+        for (auto &entry : worker_slice_queue_[thread_id]) {
+            if (entry.second.empty()) continue;
+            auto &local_entry = local_slice_queue[entry.first];
+            local_entry.insert(local_entry.end(), entry.second.begin(),
+                               entry.second.end());
+        }
+        worker_slice_queue_[thread_id].clear();
+    }
 
     // If this local RNIC is inactive/unhealthy, the remote rail is not the
     // problem. Move queued work to another local RNIC while preserving the
@@ -368,36 +366,7 @@ void WorkerPool::performPostSend(int thread_id) {
         local_slice_queue.clear();
         for (auto &entry : local_slice_queue_clone)
             redispatch(entry.second, thread_id, true);
-
-        for (int shard_id = post_tid; shard_id < kShardCount;
-             shard_id += post_count) {
-            if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) ==
-                0)
-                continue;
-            slice_queue_lock_[shard_id].lock();
-            auto slice_queue_clone = slice_queue_[shard_id];
-            slice_queue_[shard_id].clear();
-            slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
-            slice_queue_lock_[shard_id].unlock();
-            for (auto &entry : slice_queue_clone)
-                redispatch(entry.second, thread_id, true);
-        }
         return;
-    }
-
-    for (int shard_id = post_tid; shard_id < kShardCount;
-         shard_id += post_count) {
-        if (slice_queue_count_[shard_id].load(std::memory_order_relaxed) == 0)
-            continue;
-
-        slice_queue_lock_[shard_id].lock();
-        for (auto &entry : slice_queue_[shard_id]) {
-            for (auto &slice : entry.second)
-                local_slice_queue[entry.first].push_back(slice);
-            entry.second.clear();
-        }
-        slice_queue_count_[shard_id].store(0, std::memory_order_relaxed);
-        slice_queue_lock_[shard_id].unlock();
     }
 
     // Redispatch slices to other endpoints, for temporary failures
@@ -449,9 +418,11 @@ void WorkerPool::performPostSend(int thread_id) {
 #ifdef CONFIG_CACHE_ENDPOINT
         auto &endpoint = endpoint_map[entry.first];
         if (endpoint == nullptr || !endpoint->active())
-            endpoint = context_.endpoint(entry.first);
+            endpoint = context_.endpoint(entry.first,
+                                         cqIndexForPostingThread(thread_id));
 #else
-        auto endpoint = context_.endpoint(entry.first);
+        auto endpoint =
+            context_.endpoint(entry.first, cqIndexForPostingThread(thread_id));
 #endif
         if (!endpoint) {
             for (auto &slice : entry.second) failed_slice_list.push_back(slice);
@@ -550,6 +521,8 @@ void WorkerPool::performPostSend(int thread_id) {
 }
 
 void WorkerPool::performPollCq(int thread_id) {
+    if (context_.cqCount() <= 0) return;
+
     const uint64_t poll_ts = getCurrentTimeInNano();
     const uint64_t previous_poll_ts =
         last_poll_ts_ns_.exchange(poll_ts, std::memory_order_relaxed);
@@ -564,7 +537,48 @@ void WorkerPool::performPollCq(int thread_id) {
         }
     }
 
-    // Slices this loop drove to a terminal state, successes and
+    const static size_t kPollCount = 64;
+    std::unordered_map<std::atomic<int> *, int> qp_depth_set;
+    std::vector<ibv_wc> wc_list;
+    const int cq_index = cqIndexForPostingThread(thread_id);
+    ibv_wc wc[kPollCount];
+    int nr_poll = context_.poll(kPollCount, wc, cq_index);
+    if (nr_poll < 0) {
+        LOG(ERROR) << "Worker: Failed to poll completion queues";
+        return;
+    }
+
+    if (nr_poll > 0 && globalConfig().track_rdma_posted_slices) {
+        std::lock_guard<std::mutex> lock(posted_slices_mutex_);
+        for (int i = 0; i < nr_poll; ++i) {
+            auto *slice = reinterpret_cast<Transport::Slice *>(wc[i].wr_id);
+            posted_slices_.erase(slice);
+        }
+    }
+
+    for (int i = 0; i < nr_poll; ++i) {
+        Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
+        assert(slice);
+        assert(postingThreadForPeer(slice->peer_nic_path) == thread_id);
+        if (qp_depth_set.count(slice->rdma.qp_depth))
+            qp_depth_set[slice->rdma.qp_depth]++;
+        else
+            qp_depth_set[slice->rdma.qp_depth] = 1;
+        wc_list.push_back(wc[i]);
+    }
+    if (nr_poll)
+        context_.cqOutstandingCount(cq_index)->fetch_sub(
+            nr_poll, std::memory_order_acq_rel);
+
+    for (auto &entry : qp_depth_set)
+        entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
+
+    if (!wc_list.empty()) processCompletions(thread_id, wc_list);
+}
+
+void WorkerPool::processCompletions(int thread_id,
+                                    const std::vector<ibv_wc> &wc_list) {
+    // Slices this call drove to a terminal state, successes and
     // retry-exhausted failures alike; folded into processed_slice_count_,
     // which gates worker parking. Every terminal outcome below goes through
     // finalize_slice() so it is counted exactly once. Slices handed to
@@ -572,8 +586,8 @@ void WorkerPool::performPollCq(int thread_id) {
     int processed_slice_count = 0;
     // Successful completions only, kept apart because it clears the context
     // health counter. A completion error is no evidence that this RNIC can
-    // still move data -- including IBV_WC_WR_FLUSH_ERR, which only reports
-    // WRs the hardware discarded after the QP had already entered ERR.
+    // still move data, including IBV_WC_WR_FLUSH_ERR, which only reports WRs
+    // the hardware discarded after the QP had already entered ERR.
     int succeeded_slice_count = 0;
     auto finalize_slice = [&](Transport::Slice *slice, bool success) {
         if (success) {
@@ -584,121 +598,91 @@ void WorkerPool::performPollCq(int thread_id) {
         }
         processed_slice_count++;
     };
-    const static size_t kPollCount = 64;
-    std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     std::unordered_set<RdmaEndPoint *> local_failed_endpoints;
     bool recorded_local_context_failure = false;
     SliceList failed_slice_list;
     SliceList local_failed_slice_list;
-    for (int cq_index = 0; cq_index < context_.cqCount(); cq_index++) {
-        ibv_wc wc[kPollCount];
-        int nr_poll = context_.poll(kPollCount, wc, cq_index);
-        if (nr_poll < 0) {
-            LOG(ERROR) << "Worker: Failed to poll completion queues";
-            continue;
-        }
 
-        if (nr_poll > 0 && globalConfig().track_rdma_posted_slices) {
-            std::lock_guard<std::mutex> lock(posted_slices_mutex_);
-            for (int i = 0; i < nr_poll; ++i) {
-                auto *slice = reinterpret_cast<Transport::Slice *>(wc[i].wr_id);
-                posted_slices_.erase(slice);
-            }
-        }
-
-        for (int i = 0; i < nr_poll; ++i) {
-            Transport::Slice *slice = (Transport::Slice *)wc[i].wr_id;
-            assert(slice);
-            if (qp_depth_set.count(slice->rdma.qp_depth))
-                qp_depth_set[slice->rdma.qp_depth]++;
-            else
-                qp_depth_set[slice->rdma.qp_depth] = 1;
-            // __sync_fetch_and_sub(slice->rdma.qp_depth, 1);
-            if (wc[i].status != IBV_WC_SUCCESS) {
-                // Flush errors are generated when QPs transition to ERR state
-                // during normal endpoint destruction (beginDestroy). They are
-                // not real network errors and should not trigger rail failure
-                // handling or endpoint deletion.
-                if (wc[i].status == IBV_WC_WR_FLUSH_ERR) {
-                    if (!context_.active()) {
-                        if (globalConfig().trace)
-                            LOG(INFO)
-                                << "Worker: WR flush error on inactive "
-                                << "local context " << context_.deviceName()
-                                << " (peer_nic: " << slice->peer_nic_path
-                                << "), handing off if retry allows";
-                        if (shouldRetrySlice(slice))
-                            local_failed_slice_list.push_back(slice);
-                        else
-                            finalize_slice(slice, false);
-                    } else {
-                        if (globalConfig().trace)
-                            LOG(INFO) << "Worker: WR flush error (peer_nic: "
-                                      << slice->peer_nic_path
-                                      << "), redispatching if retry allows";
-                        if (shouldRetrySlice(slice))
-                            failed_slice_list.push_back(slice);
-                        else
-                            finalize_slice(slice, false);
-                    }
-                    continue;
+    for (const auto &wc : wc_list) {
+        Transport::Slice *slice = (Transport::Slice *)wc.wr_id;
+        assert(slice);
+        if (wc.status != IBV_WC_SUCCESS) {
+            // Flush errors are generated when QPs transition to ERR state
+            // during normal endpoint destruction (beginDestroy). They are not
+            // real network errors and should not trigger rail failure handling
+            // or endpoint deletion.
+            if (wc.status == IBV_WC_WR_FLUSH_ERR) {
+                if (!context_.active()) {
+                    if (globalConfig().trace)
+                        LOG(INFO) << "Worker: WR flush error on inactive "
+                                  << "local context " << context_.deviceName()
+                                  << " (peer_nic: " << slice->peer_nic_path
+                                  << "), handing off if retry allows";
+                    if (shouldRetrySlice(slice))
+                        local_failed_slice_list.push_back(slice);
+                    else
+                        finalize_slice(slice, false);
+                } else {
+                    if (globalConfig().trace)
+                        LOG(INFO) << "Worker: WR flush error (peer_nic: "
+                                  << slice->peer_nic_path
+                                  << "), redispatching if retry allows";
+                    if (shouldRetrySlice(slice))
+                        failed_slice_list.push_back(slice);
+                    else
+                        finalize_slice(slice, false);
                 }
+                continue;
+            }
 
-                // Completion errors are split by local context health. Local
-                // faults hand off to another local RNIC; remote/default faults
-                // keep this local context and switch peer rails.
-                LOG(ERROR) << "Worker: Process failed for slice (opcode: "
-                           << slice->opcode
-                           << ", source_addr: " << slice->source_addr
-                           << ", length: " << slice->length
-                           << ", dest_addr: " << (void *)slice->rdma.dest_addr
-                           << ", local_nic: " << context_.deviceName()
-                           << ", peer_nic: " << slice->peer_nic_path
-                           << ", dest_rkey: " << slice->rdma.dest_rkey
-                           << ", retry_cnt: " << slice->rdma.retry_cnt
-                           << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
-                           << "): " << ibv_wc_status_str(wc[i].status);
-                auto *retry_list = &failed_slice_list;
-                if (!context_.active() || isLocalWcFailure(wc[i])) {
-                    if (!recorded_local_context_failure) {
-                        handleLocalFailure(slice->peer_nic_path,
-                                           slice->rdma.endpoint);
-                        recorded_local_context_failure = true;
-                        if (slice->rdma.endpoint)
-                            local_failed_endpoints.insert(slice->rdma.endpoint);
-                    } else if (slice->rdma.endpoint &&
-                               !local_failed_endpoints.count(
-                                   slice->rdma.endpoint)) {
-                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
+            // Completion errors are split by local context health. Local faults
+            // hand off to another local RNIC; remote/default faults keep this
+            // local context and switch peer rails.
+            LOG(ERROR) << "Worker: Process failed for slice (opcode: "
+                       << slice->opcode
+                       << ", source_addr: " << slice->source_addr
+                       << ", length: " << slice->length
+                       << ", dest_addr: " << (void *)slice->rdma.dest_addr
+                       << ", local_nic: " << context_.deviceName()
+                       << ", peer_nic: " << slice->peer_nic_path
+                       << ", dest_rkey: " << slice->rdma.dest_rkey
+                       << ", retry_cnt: " << slice->rdma.retry_cnt
+                       << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
+                       << "): " << ibv_wc_status_str(wc.status);
+            auto *retry_list = &failed_slice_list;
+            if (!context_.active() || isLocalWcFailure(wc)) {
+                if (!recorded_local_context_failure) {
+                    handleLocalFailure(slice->peer_nic_path,
+                                       slice->rdma.endpoint);
+                    recorded_local_context_failure = true;
+                    if (slice->rdma.endpoint)
                         local_failed_endpoints.insert(slice->rdma.endpoint);
-                    }
-                    retry_list = &local_failed_slice_list;
-                } else {
-                    if (hasAvailablePeerRailAlternative(slice,
-                                                        slice->peer_nic_path)) {
-                        markRailFailed(slice->peer_nic_path, true);
-                        redispatch_counter_++;
-                    }
-                    if (slice->rdma.endpoint) {
-                        context_.deleteEndpointByPtr(slice->rdma.endpoint);
-                    }
+                } else if (slice->rdma.endpoint &&
+                           !local_failed_endpoints.count(
+                               slice->rdma.endpoint)) {
+                    context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                    local_failed_endpoints.insert(slice->rdma.endpoint);
                 }
-                if (shouldRetrySlice(slice)) {
-                    retry_list->push_back(slice);
-                } else {
-                    finalize_slice(slice, false);
-                }
+                retry_list = &local_failed_slice_list;
             } else {
-                finalize_slice(slice, true);
+                if (hasAvailablePeerRailAlternative(slice,
+                                                    slice->peer_nic_path)) {
+                    markRailFailed(slice->peer_nic_path, true);
+                    redispatch_counter_++;
+                }
+                if (slice->rdma.endpoint) {
+                    context_.deleteEndpointByPtr(slice->rdma.endpoint);
+                }
             }
+            if (shouldRetrySlice(slice)) {
+                retry_list->push_back(slice);
+            } else {
+                finalize_slice(slice, false);
+            }
+        } else {
+            finalize_slice(slice, true);
         }
-        if (nr_poll)
-            context_.cqOutstandingCount(cq_index)->fetch_sub(
-                nr_poll, std::memory_order_acq_rel);
     }
-
-    for (auto &entry : qp_depth_set)
-        entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
     if (processed_slice_count)
         processed_slice_count_.fetch_add(processed_slice_count);
@@ -719,7 +703,6 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                             int thread_id, bool handoff_to_local_worker) {
     std::unordered_map<SegmentID, std::shared_ptr<Transport::SegmentDesc>>
         segment_desc_map;
-    const bool use_local_queue = workerCanPost(thread_id);
     int shared_redispatch_count = 0;
     // Remote redispatch needs target metadata to choose a new peer RNIC.
     // Local handoff keeps the peer RNIC fixed and only switches source RNIC, so
@@ -830,17 +813,12 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                         << ", retry_cnt=" << slice->rdma.retry_cnt;
             }
             slice->ts = 0;
-            if (use_local_queue) {
+            const int owner_thread = postingThreadForPeer(peer_nic_path);
+            if (owner_thread == thread_id) {
                 collective_slice_queue_[thread_id][peer_nic_path].push_back(
                     slice);
             } else {
-                int shard_id =
-                    (slice->target_id * 10007 + device_id) % kShardCount;
-                slice_queue_lock_[shard_id].lock();
-                slice_queue_[shard_id][peer_nic_path].push_back(slice);
-                slice_queue_count_[shard_id].fetch_add(
-                    1, std::memory_order_relaxed);
-                slice_queue_lock_[shard_id].unlock();
+                enqueueSliceToOwner(slice);
                 shared_redispatch_count++;
             }
         }
@@ -924,21 +902,15 @@ bool WorkerPool::tryHandoffToAnotherLocalWorker(Transport::Slice *slice) {
 }
 
 bool WorkerPool::hasOutstandingCq(int thread_id) {
-    if (!workerCanPoll(thread_id)) return false;
-    for (int cq_index = 0; cq_index < context_.cqCount(); ++cq_index) {
-        if (context_.cqOutstandingCount(cq_index)->load(
-                std::memory_order_relaxed) > 0)
-            return true;
-    }
-    return false;
+    if (context_.cqCount() <= 0) return false;
+    return context_.cqOutstandingCount(cqIndexForPostingThread(thread_id))
+               ->load(std::memory_order_relaxed) > 0;
 }
 
 void WorkerPool::transferWorker(int thread_id) {
     bindToSocket(numa_socket_id_);
     const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
     uint64_t last_wait_ts = getCurrentTimeInNano();
-    const bool can_post = workerCanPost(thread_id);
-    const bool can_poll = workerCanPoll(thread_id);
     while (workers_running_.load(std::memory_order_relaxed)) {
         auto processed_slice_count =
             processed_slice_count_.load(std::memory_order_relaxed);
@@ -963,13 +935,9 @@ void WorkerPool::transferWorker(int thread_id) {
             }
             continue;
         }
-        if (can_post) {
-            performPostSend(thread_id);
-        }
+        performPostSend(thread_id);
 #ifndef USE_FAKE_POST_SEND
-        if (can_poll) {
-            performPollCq(thread_id);
-        }
+        performPollCq(thread_id);
 #endif
         last_wait_ts = getCurrentTimeInNano();
     }

--- a/mooncake-transfer-engine/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_test.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "transport/rdma_transport/endpoint_store.h"
 #include "transport/rdma_transport/rdma_context.h"
@@ -173,6 +175,40 @@ TEST_F(EndpointStoreTest, ReclaimDoesNotRequireActiveMap) {
 
     store.reclaimEndpoint();
     EXPECT_EQ(store.waitingListSize(), 0u);
+}
+
+TEST_F(EndpointStoreTest,
+       StaleRawPointerLookupAndDeleteStressDoesNotDereference) {
+    SIEVEEndpointStore store(4);
+    std::vector<RdmaEndPoint*> stale_ptrs;
+    stale_ptrs.reserve(1000);
+
+    for (size_t i = 0; i < 1000; ++i) {
+        auto endpoint = makeQuiescentEndpoint(*ctx_);
+        const std::string peer_nic_path = "peer@" + std::to_string(i);
+        store.testOnlyInsertEndpoint(peer_nic_path, endpoint);
+        stale_ptrs.push_back(endpoint.get());
+        EXPECT_EQ(endpoint, store.getEndpointByPtr(endpoint.get()));
+        EXPECT_EQ(0, store.deleteEndpointByPtr(endpoint.get()));
+    }
+
+    EXPECT_EQ(store.getSize(), 0u);
+    EXPECT_EQ(store.waitingListSize(), 1000u);
+    auto sentinel = makeQuiescentEndpoint(*ctx_);
+    store.testOnlyInsertEndpoint("sentinel@peer", sentinel);
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u);
+    EXPECT_EQ(store.getSize(), 1u);
+
+    // The endpoints were live in the store, deleted by raw pointer, then
+    // reclaimed. The raw pointers are now stale while the sentinel keeps the
+    // active map non-empty. Store APIs must compare pointer identity only;
+    // dereferencing would be caught by ASan builds.
+    for (auto* stale_ptr : stale_ptrs) {
+        EXPECT_EQ(nullptr, store.getEndpointByPtr(stale_ptr));
+        EXPECT_EQ(-1, store.deleteEndpointByPtr(stale_ptr));
+    }
+    EXPECT_EQ(sentinel, store.getEndpointByPtr(sentinel.get()));
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/endpoint_store_test.cpp
+++ b/mooncake-transfer-engine/tests/endpoint_store_test.cpp
@@ -116,6 +116,24 @@ TEST_F(EndpointStoreTest, ReclaimLeavesActiveEntries) {
            "active ones";
 }
 
+TEST_F(EndpointStoreTest, ReclaimLeavesCompletionPinnedEntries) {
+    SIEVEEndpointStore store(4);
+
+    auto endpoint = makeQuiescentEndpoint(*ctx_);
+    endpoint->beginCompletionBatch();
+    store.testOnlyInsertWaiting(endpoint);
+    EXPECT_EQ(store.waitingListSize(), 1u);
+
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 1u)
+        << "reclaim must not free an endpoint while a CQ completion batch "
+           "still holds raw slice endpoint pointers";
+
+    endpoint->endCompletionBatch();
+    store.reclaimEndpoint();
+    EXPECT_EQ(store.waitingListSize(), 0u);
+}
+
 TEST_F(EndpointStoreTest, ReclaimIsIdempotentWhenEmpty) {
     SIEVEEndpointStore store(4);
 


### PR DESCRIPTION
## Description

This PR addresses a correctness issue reported after #2696. The previous RDMA polling/worker changes exposed an endpoint lifetime race when multiple worker threads are enabled: different workers could concurrently operate on the same RDMA endpoint lifecycle, including post-send, completion failure handling, retry, redispatch, and endpoint deletion. That could lead to use-after-free risks when one worker was still using an endpoint while another worker retired or deleted it.

This PR refactors RDMA worker dispatch around a stable owner model:

```text
peer_nic_path -> owner worker -> owner CQ -> endpoint lifecycle
```

Main changes:
- Replace the shared RDMA slice shard queues with per-worker owner queues.
- Route submitted and redispatched slices to the stable owner worker for their `peer_nic_path`.
- Bind endpoint creation to the owner worker’s CQ.
- Make each worker poll only its owned CQ and process completions locally.
- Keep endpoint completion handling, retry, redispatch, and endpoint deletion on the owner worker path.
- Ensure RDMA contexts have at least one CQ per worker for worker-owned endpoint polling.
- Change endpoint reclaim timeout behavior: if an endpoint still has outstanding WRs after the timeout, keep the retired endpoint alive in the waiting list instead of force-freeing it. This trades a bounded retired-resource leak for avoiding stale in-flight reference UAF.
- Add endpoint store stress coverage for stale raw pointer lookup/delete APIs to ensure they compare pointer identity without dereferencing stale pointers.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
git diff --check
cmake --build build --target endpoint_store_test rdma_endpoint_state_test
build/mooncake-transfer-engine/tests/endpoint_store_test --gtest_color=no
build/mooncake-transfer-engine/tests/rdma_endpoint_state_test --gtest_color=no
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (not run; RDMA integration requires suitable RDMA devices/environment)
- [ ] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI assistance was used to analyze the RDMA worker concurrency model, draft the owner-based refactor, and prepare this PR description. The human submitter is responsible for reviewing and validating every changed line.