### PR TITLE
[CI/Build] Deduplicate EFA and store CI workflows

### DIFF
--- a/.github/workflows/_build-efa-wheel.yaml
+++ b/.github/workflows/_build-efa-wheel.yaml
@@ -1,0 +1,203 @@
+name: _build-efa-wheel
+
+# Shared AWS EFA wheel build used by pull-request CI and release workflows.
+# EFA hardware is not required to build: the distro libfabric is used for
+# compilation, then auditwheel leaves libfabric/libefa to the system runtime.
+
+on:
+  workflow_call:
+    inputs:
+      variant:
+        # cuda | non-cuda
+        type: string
+        required: true
+      use-cuda:
+        type: boolean
+        required: true
+      python-versions:
+        # JSON array consumed by the called workflow's Python matrix.
+        type: string
+        required: true
+      build-profile:
+        # ci uses Ninja and CI diagnostics; release preserves the release make build.
+        type: string
+        required: true
+      cmake-args:
+        type: string
+        required: true
+      variant-flag:
+        # build_wheel.sh package variant, e.g. EFA_BUILD.
+        type: string
+        required: true
+      torch-cuda-arch-list:
+        type: string
+        default: ''
+      artifact-prefix:
+        type: string
+        required: true
+
+env:
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        python-version: ${{ fromJSON(inputs.python-versions) }}
+    env:
+      BUILD_PROFILE: ${{ inputs.build-profile }}
+      CMAKE_ARGS: ${{ inputs.cmake-args }}
+      EFA_VARIANT: ${{ inputs.variant }}
+      USE_CUDA: ${{ inputs.use-cuda }}
+      VARIANT_FLAG: ${{ inputs.variant-flag }}
+
+    steps:
+      - name: Validate build inputs
+        run: |
+          case "$BUILD_PROFILE" in
+            ci|release) ;;
+            *) echo "::error::Unknown EFA build profile: $BUILD_PROFILE"; exit 1 ;;
+          esac
+
+          case "$EFA_VARIANT:$USE_CUDA:$VARIANT_FLAG" in
+            cuda:true:EFA_BUILD|non-cuda:false:EFA_NON_CUDA_BUILD) ;;
+            *) echo "::error::Inconsistent EFA variant inputs"; exit 1 ;;
+          esac
+        shell: bash
+
+      - name: Configure CUDA architecture list
+        if: ${{ inputs.torch-cuda-arch-list != '' }}
+        env:
+          ARCH_LIST: ${{ inputs.torch-cuda-arch-list }}
+        run: echo "TORCH_CUDA_ARCH_LIST=$ARCH_LIST" >> "$GITHUB_ENV"
+        shell: bash
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: ${{ inputs.build-profile == 'release' }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Free up disk space
+        uses: ./.github/actions/free-disk-space
+
+      - name: Install CUDA Toolkit
+        if: ${{ inputs.use-cuda }}
+        uses: Jimver/cuda-toolkit@v0.2.24
+        with:
+          cuda: '12.8.1'
+          method: 'network'
+          sub-packages: '["nvcc", "nvrtc-dev"]'
+          non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Configure sccache
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: Install dependencies
+        run: |
+          sudo apt update -y
+          packages=(libfabric-dev libfabric1)
+          if [ "$BUILD_PROFILE" = ci ]; then
+            packages=(ninja-build "${packages[@]}")
+          fi
+          sudo apt install -y "${packages[@]}"
+          sudo bash -x dependencies.sh -y
+          if [ "$BUILD_PROFILE" = ci ]; then
+            df -h
+          fi
+        shell: bash
+
+      - name: Configure project
+        run: |
+          generator=()
+          if [ "$BUILD_PROFILE" = ci ]; then
+            generator=(-G Ninja)
+          fi
+
+          cuda_args=(-DUSE_CUDA=OFF)
+          if [ "$USE_CUDA" = true ]; then
+            cuda_args=(
+              -DUSE_CUDA=ON
+              -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/cuda/lib64/stubs
+            )
+          fi
+
+          read -r -a profile_args <<< "$CMAKE_ARGS"
+          mkdir build
+          cd build
+          cmake "${generator[@]}" .. \
+            -DUSE_EFA=ON \
+            -DLIBFABRIC_INCLUDE_DIR=/usr/include \
+            -DLIBFABRIC_LIBRARY=/usr/lib/x86_64-linux-gnu/libfabric.so \
+            -DENABLE_SCCACHE=ON \
+            -DCMAKE_BUILD_TYPE=Release \
+            "${profile_args[@]}" \
+            "${cuda_args[@]}"
+        shell: bash
+
+      - name: Build project
+        run: |
+          if [ "$USE_CUDA" = true ]; then
+            export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
+            export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
+          fi
+
+          cd build
+          if [ "$BUILD_PROFILE" = release ]; then
+            make -j3
+            sudo make install
+          else
+            cmake --build .
+            sudo cmake --install .
+            df -h
+          fi
+        shell: bash
+
+      - name: Run sccache stat for check
+        if: ${{ env.SCCACHE_PATH != '' }}
+        shell: bash
+        run: ${SCCACHE_PATH} --show-stats
+
+      - name: Generate Python version tag
+        id: python-tag
+        run: |
+          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> "$GITHUB_OUTPUT"
+        shell: bash
+
+      - name: Build Python wheel
+        run: |
+          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          export "$VARIANT_FLAG=1"
+          PYTHON_VERSION=${{ matrix.python-version }} \
+            OUTPUT_DIR=dist-py${{ steps.python-tag.outputs.python_version_tag }} \
+            ./scripts/build_wheel.sh
+        shell: bash
+
+      - name: Verify libfabric is excluded from the wheel
+        run: |
+          WHL=$(ls mooncake-wheel/dist-py${{ steps.python-tag.outputs.python_version_tag }}/*.whl | head -1)
+          echo "Inspecting $WHL"
+          if unzip -l "$WHL" | grep -iE 'libfabric|libefa'; then
+            echo "::error::libfabric/libefa must NOT be bundled in the EFA wheel"
+            exit 1
+          fi
+          echo "OK: libfabric/libefa correctly excluded (resolve to system EFA at runtime)"
+        shell: bash
+
+      - name: Upload Python wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact-prefix }}-py${{ steps.python-tag.outputs.python_version_tag }}
+          path: mooncake-wheel/dist-py${{ steps.python-tag.outputs.python_version_tag }}/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   build:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
+    if: &run-ci-for-source-changes >-
       (needs.check-paths.outputs.should-run-downstream == 'true' ||
        github.event_name == 'workflow_dispatch') &&
       (github.event_name == 'push' ||
@@ -136,57 +136,18 @@ jobs:
       shell: bash
 
     - name: Run Mooncake Store Rust smoke test and benchmark
-      run: |
-        $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
-          --eviction_high_watermark_ratio=0.95 \
-          --cluster_id=ci_rust_test_cluster \
-          --port 50051 &
-        MASTER_PID=$!
-        sleep 3
-        cd mooncake-store/rust
-        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:$LD_LIBRARY_PATH
-        export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
-        export MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src
-        export MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include
-        # This job builds Mooncake with -DENABLE_ASAN=ON, so the C++ libraries
-        # the Rust package links against carry undefined __asan_* references. Opt
-        # in to linking the ASan runtime; build.rs emits -lasan first, which
-        # keeps libasan first in the initial library list as ASan requires.
-        # Non-sanitized builds leave this unset and link without ASan.
-        export MOONCAKE_LINK_ASAN=1
-        export MC_METADATA_SERVER=http://127.0.0.1:8080/metadata
-        export MC_RUST_STORE_RUN_INTEGRATION=true
-        export MC_RUST_STORE_MASTER_ADDR=127.0.0.1:50051
-        export MC_RUST_STORE_LOCAL_HOSTNAME=127.0.0.1
-        export MC_RUST_STORE_PROTOCOL=tcp
-        export MC_RUST_STORE_DEVICE_NAME=
-        cargo test --test minimal_smoke -- --nocapture
-        MC_RUST_BENCH_ITERATIONS=4 \
-        MC_RUST_BENCH_VALUE_SIZE=4096 \
-        MC_RUST_BENCH_WARMUP=1 \
-          cargo run --release --example store_benchmark
-        kill $MASTER_PID 2>/dev/null || true
+      env:
+        MOONCAKE_STORE_CLUSTER_ID: ci_rust_test_cluster
+        MOONCAKE_STORE_RUST_LINK_ASAN: "1"
+      run: ./scripts/ci/run_store_rust_smoke.sh
       shell: bash
 
     - name: Run Go store binding integration tests
-      run: |
-        $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
-          --eviction_high_watermark_ratio=0.95 \
-          --cluster_id=ci_go_test_cluster \
-          --port 50051 &
-        MASTER_PID=$!
-        sleep 3
-        cd mooncake-store/go
-        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd
-        export CGO_ENABLED=1
-        export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
-        export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/build/mooncake-store/src -L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base -L$GITHUB_WORKSPACE/build/mooncake-common -L$GITHUB_WORKSPACE/build/mooncake-common/src -L$GITHUB_WORKSPACE/build/mooncake-common/etcd -Wl,--start-group -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lmooncake_common -Wl,--end-group -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -lmlx5 -ljsoncpp -lzstd -lcurl -luring -lasan -lm -lgcov -lxxhash -lyaml-cpp"
-        # Link cudart if CUDA is available (needed for D2H staging in mooncake_store)
-        if [ -d /usr/local/cuda/lib64 ]; then export CGO_LDFLAGS="$CGO_LDFLAGS -L/usr/local/cuda/lib64 -lcudart"; fi
-        # KV events publisher (optional; linked when libzmq is installed)
-        if ldconfig -p 2>/dev/null | grep -q libzmq; then export CGO_LDFLAGS="$CGO_LDFLAGS -lzmq"; fi
-        ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 MC_METADATA_SERVER=http://127.0.0.1:8080/metadata go test -v ./tests/...
-        kill $MASTER_PID 2>/dev/null || true
+      env:
+        MOONCAKE_STORE_CLUSTER_ID: ci_go_test_cluster
+        MOONCAKE_STORE_GO_LINK_COMMON: "1"
+        MOONCAKE_STORE_GO_SANITIZED: "1"
+      run: ./scripts/ci/run_store_go_integration.sh
       shell: bash
 
     - name: Test (in build env) with coverage
@@ -282,13 +243,7 @@ jobs:
 
   build-musa:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     runs-on: ubuntu-22.04
     container: registry.mthreads.com/mcconline/inference/pytorch:2.9.1.post1-py3.10-musa5.2.0-mp31-devel-ubuntu22.04-amd64
     steps:
@@ -320,13 +275,7 @@ jobs:
 
   build-arm64:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     runs-on: ubuntu-22.04-arm
     strategy:
       matrix:
@@ -593,13 +542,7 @@ jobs:
 
   build-flags:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -831,13 +774,7 @@ jobs:
   build-docker:
     name: Build Docker Image
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -860,7 +797,7 @@ jobs:
 
   spell-check:
     name: Spell Check with Typos
-    if: >-
+    if: &run-ci >-
       (github.event_name == 'push' ||
        github.event_name == 'workflow_dispatch' ||
        github.event.action == 'opened' ||
@@ -876,11 +813,7 @@ jobs:
 
   clang-format:
     name: Check code format
-    if: >-
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout Actions Repository
@@ -926,11 +859,7 @@ jobs:
 
   docs-check:
     name: Check Sphinx docs build
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.action == 'opened' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    if: *run-ci
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
@@ -967,11 +896,7 @@ jobs:
 
 
   check-paths:
-    if: >-
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.action == 'opened' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ci')
+    if: *run-ci
     runs-on: ubuntu-latest
     outputs:
       should-run-downstream: ${{ steps.dispatch-override.outputs.src || steps.filter.outputs.src }}
@@ -1011,25 +936,13 @@ jobs:
 
   build-wheel-cu13:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     uses: ./.github/workflows/ci_cu13.yml
     secrets: inherit
 
   build-wheel-efa:
     needs: [spell-check, clang-format, check-paths]
-    if: >-
-      (needs.check-paths.outputs.should-run-downstream == 'true' ||
-       github.event_name == 'workflow_dispatch') &&
-      (github.event_name == 'push' ||
-       github.event_name == 'workflow_dispatch' ||
-       github.event.action == 'opened' ||
-       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    if: *run-ci-for-source-changes
     uses: ./.github/workflows/ci_efa.yml
     secrets: inherit
 

--- a/.github/workflows/ci_efa.yml
+++ b/.github/workflows/ci_efa.yml
@@ -3,23 +3,10 @@ name: 'Build Wheel (AWS EFA)'
 on:
   workflow_call: {}
 
-# Builds the AWS EFA (libfabric) wheel variants on a stock ubuntu runner.
-# No EFA hardware is required to *build*: USE_EFA only needs the libfabric
-# headers/lib to compile and link. auditwheel later excludes libfabric/libefa
-# from the wheel so they resolve to the user's system EFA install
-# (/opt/amazon/efa/lib) at runtime. The distro libfabric (1.x) is ABI-forward-
-# compatible with the AWS EFA libfabric (2.x) that loads at runtime; the EFA
-# transport only uses long-stable fi_* core APIs.
-#
-# Two variants, since the EFA transport's memory path is CUDA-aware
-# (FI_HMEM_CUDA / GPUDirect under USE_CUDA=ON, FI_HMEM=system otherwise):
-#   efa            USE_CUDA=ON   (GPU)
-#   efa-non-cuda   USE_CUDA=OFF  (CPU/DRAM)
-# PR validation builds one python version per variant to keep CI cheap;
-# the release workflow builds the full python matrix.
+# No EFA hardware is required to build. PR validation covers the CUDA and
+# non-CUDA variants with one Python version each; releases use the full matrix.
 jobs:
   build-wheel-efa:
-    runs-on: ubuntu-22.04
     strategy:
       matrix:
         include:
@@ -31,119 +18,16 @@ jobs:
             use_cuda: "OFF"
             build_env: "EFA_NON_CUDA_BUILD"
             python-version: "3.10"
-    env:
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
-      SCCACHE_GHA_ENABLED: "true"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Free up disk space
-      uses: ./.github/actions/free-disk-space
-
-    - name: Install CUDA Toolkit
-      if: matrix.use_cuda == 'ON'
-      uses: Jimver/cuda-toolkit@v0.2.24
-      with:
-        cuda: '12.8.1'
-        method: 'network'
-        sub-packages: '["nvcc", "nvrtc-dev"]'
-        non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
-
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
-    - name: Configure sccache
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-    - name: Install dependencies
-      run: |
-        sudo apt update -y
-        sudo apt install -y ninja-build libfabric-dev libfabric1
-        sudo bash -x dependencies.sh -y
-        df -h
-      shell: bash
-
-    - name: Configure project
-      run: |
-        mkdir build
-        cd build
-        EXTRA_FLAGS=""
-        if [ "${{ matrix.use_cuda }}" = "ON" ]; then
-          EXTRA_FLAGS="-DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/cuda/lib64/stubs"
-        fi
-        cmake -G Ninja .. \
-          -DUSE_ETCD=ON \
-          -DUSE_HTTP=ON \
-          -DWITH_STORE=ON \
-          -DWITH_METRICS=ON \
-          -DBUILD_UNIT_TESTS=OFF \
-          -DBUILD_EXAMPLES=ON \
-          -DENABLE_SCCACHE=ON \
-          -DBUILD_BENCHMARK=ON \
-          -DUSE_EFA=ON \
-          -DUSE_CUDA=${{ matrix.use_cuda }} \
-          -DLIBFABRIC_INCLUDE_DIR=/usr/include \
-          -DLIBFABRIC_LIBRARY=/usr/lib/x86_64-linux-gnu/libfabric.so \
-          -DCMAKE_BUILD_TYPE=Release \
-          -DENABLE_DEBUG_SYMBOLS=OFF \
-          $EXTRA_FLAGS
-      shell: bash
-
-    - name: Build project
-      run: |
-        if [ "${{ matrix.use_cuda }}" = "ON" ]; then
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        fi
-        cd build
-        cmake --build .
-        sudo cmake --install .
-        df -h
-      shell: bash
-
-    - name: Run sccache stat for check
-      if: ${{ env.SCCACHE_PATH != '' }}
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
-    - name: Generate Python version tag
-      id: generate_tag
-      run: |
-        echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-      shell: bash
-
-    - name: Build Python wheel
-      run: |
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        export ${{ matrix.build_env }}=1
-        PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag.outputs.python_version_tag }} ./scripts/build_wheel.sh
-      shell: bash
-
-    - name: Verify libfabric is excluded from the wheel
-      run: |
-        WHL=$(ls mooncake-wheel/dist-py${{ steps.generate_tag.outputs.python_version_tag }}/*.whl | head -1)
-        echo "Inspecting $WHL"
-        if unzip -l "$WHL" | grep -iE 'libfabric|libefa'; then
-          echo "::error::libfabric/libefa must NOT be bundled in the EFA wheel"
-          exit 1
-        fi
-        echo "OK: libfabric/libefa correctly excluded (resolve to system EFA at runtime)"
-      shell: bash
-
-    - name: Upload Python wheel artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: mooncake-wheel-efa-${{ matrix.variant }}-ubuntu-py${{ steps.generate_tag.outputs.python_version_tag }}
-        path: mooncake-wheel/dist-py${{ steps.generate_tag.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-efa-wheel.yaml
+    with:
+      variant: ${{ matrix.variant }}
+      use-cuda: ${{ matrix.use_cuda == 'ON' }}
+      python-versions: ${{ format('["{0}"]', matrix.python-version) }}
+      build-profile: ci
+      cmake-args: >-
+        -DUSE_ETCD=ON -DUSE_HTTP=ON -DWITH_STORE=ON -DWITH_METRICS=ON
+        -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
+        -DENABLE_DEBUG_SYMBOLS=OFF
+      variant-flag: ${{ matrix.build_env }}
+      torch-cuda-arch-list: '8.0;9.0'
+      artifact-prefix: mooncake-wheel-efa-${{ matrix.variant }}-ubuntu

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -254,48 +254,17 @@ jobs:
             ctest --parallel $(nproc) --output-on-failure
 
       - name: Run Mooncake Store Rust smoke test
-        run: |
-          $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
-            --eviction_high_watermark_ratio=0.95 \
-            --cluster_id=nightly_rust_cluster \
-            --port 50051 &
-          MASTER_PID=$!
-          sleep 3
-          cd mooncake-store/rust
-          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:$LD_LIBRARY_PATH
-          export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
-          export MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src
-          export MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include
-          export MC_METADATA_SERVER=http://127.0.0.1:8080/metadata
-          export MC_RUST_STORE_RUN_INTEGRATION=true
-          export MC_RUST_STORE_MASTER_ADDR=127.0.0.1:50051
-          export MC_RUST_STORE_LOCAL_HOSTNAME=127.0.0.1
-          export MC_RUST_STORE_PROTOCOL=tcp
-          export MC_RUST_STORE_DEVICE_NAME=
-          cargo test --test minimal_smoke -- --nocapture
-          MC_RUST_BENCH_ITERATIONS=4 \
-          MC_RUST_BENCH_VALUE_SIZE=4096 \
-          MC_RUST_BENCH_WARMUP=1 \
-            cargo run --release --example store_benchmark
-          kill $MASTER_PID 2>/dev/null || true
+        env:
+          MOONCAKE_STORE_CLUSTER_ID: nightly_rust_cluster
+          MOONCAKE_STORE_RUST_LINK_ASAN: "0"
+        run: ./scripts/ci/run_store_rust_smoke.sh
 
       - name: Run Go store binding integration tests
-        run: |
-          $GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master \
-            --eviction_high_watermark_ratio=0.95 \
-            --cluster_id=nightly_go_cluster \
-            --port 50051 &
-          MASTER_PID=$!
-          sleep 3
-          cd mooncake-store/go
-          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd
-          export CGO_ENABLED=1
-          export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
-          export CGO_LDFLAGS="-L$GITHUB_WORKSPACE/build/mooncake-store/src -L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src -L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base -L$GITHUB_WORKSPACE/build/mooncake-common -L$GITHUB_WORKSPACE/build/mooncake-common/etcd -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -lmlx5 -ljsoncpp -lzstd -lcurl -luring -lm -lxxhash -lyaml-cpp"
-          if [ -d /usr/local/cuda/lib64 ]; then export CGO_LDFLAGS="$CGO_LDFLAGS -L/usr/local/cuda/lib64 -lcudart"; fi
-          if ldconfig -p 2>/dev/null | grep -q libzmq; then export CGO_LDFLAGS="$CGO_LDFLAGS -lzmq"; fi
-          MC_METADATA_SERVER=http://127.0.0.1:8080/metadata go test -v ./tests/...
-          kill $MASTER_PID 2>/dev/null || true
+        env:
+          MOONCAKE_STORE_CLUSTER_ID: nightly_go_cluster
+          MOONCAKE_STORE_GO_LINK_COMMON: "0"
+          MOONCAKE_STORE_GO_SANITIZED: "0"
+        run: ./scripts/ci/run_store_go_integration.sh
 
       - name: Build and install Python wheel for integration tests
         run: |

--- a/.github/workflows/release-efa-non-cuda.yaml
+++ b/.github/workflows/release-efa-non-cuda.yaml
@@ -5,147 +5,30 @@ on:
     tags:
       - 'v*'
 
-# Publishes the AWS EFA (libfabric) non-CUDA wheel variant:
-#   mooncake-transfer-engine-efa-non-cuda   USE_EFA=ON USE_CUDA=OFF (CPU/DRAM only)
-# The CUDA variant (mooncake-transfer-engine-efa) is built by release-efa.yaml
-# — split into its own workflow because each PyPI package publishes from a
-# dedicated release workflow (trusted publisher / artifact pattern is
-# per-package), mirroring release.yaml vs release-non-cuda.yaml.
-#
-# No EFA hardware is needed to build: USE_EFA only needs libfabric headers/lib
-# to compile/link. auditwheel excludes libfabric/libefa from the wheel so they
-# resolve to the user's system AWS EFA install (/opt/amazon/efa/lib) at
-# runtime. The distro libfabric (1.x) used to build is ABI-forward-compatible
-# with the AWS EFA libfabric (2.x) loaded at runtime; the EFA transport uses
-# only long-stable fi_* core APIs.
-env:
-  SCCACHE_GHA_ENABLED: "true"
+# Publishes mooncake-transfer-engine-efa-non-cuda, the CPU/DRAM AWS EFA wheel.
 jobs:
   build:
-    runs-on: ubuntu-22.04
     permissions:
       contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      EFA_NON_CUDA_BUILD: "1"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        uses: ./.github/actions/free-disk-space
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo apt install -y libfabric-dev libfabric1
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. \
-            -DUSE_HTTP=ON \
-            -DUSE_ETCD=ON \
-            -DUSE_CUDA=OFF \
-            -DWITH_EP=OFF \
-            -DSTORE_USE_ETCD=ON \
-            -DUSE_EFA=ON \
-            -DLIBFABRIC_INCLUDE_DIR=/usr/include \
-            -DLIBFABRIC_LIBRARY=/usr/lib/x86_64-linux-gnu/libfabric.so \
-            -DENABLE_SCCACHE=ON \
-            -DCMAKE_BUILD_TYPE=Release
-        shell: bash
-
-      - name: Build project
-        run: |
-          cd build
-          make -j3
-          sudo make install
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Verify libfabric is excluded from the wheel
-        run: |
-          WHL=$(ls mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl | head -1)
-          echo "Inspecting $WHL"
-          if unzip -l "$WHL" | grep -iE 'libfabric|libefa'; then
-            echo "::error::libfabric/libefa must NOT be bundled in the EFA wheel"
-            exit 1
-          fi
-          echo "OK: libfabric/libefa correctly excluded"
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-efa-non-cuda-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-efa-wheel.yaml
+    with:
+      variant: non-cuda
+      use-cuda: false
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      build-profile: release
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
+      variant-flag: EFA_NON_CUDA_BUILD
+      artifact-prefix: mooncake-wheel-efa-non-cuda
 
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: build
-    runs-on: ubuntu-22.04
     permissions:
       contents: write
       id-token: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: mooncake-wheel/dist-all
-          pattern: mooncake-wheel-efa-non-cuda-py*
-
-      - name: Prepare wheels for release
-        run: |
-          mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
-          echo "Collected wheels for release:"
-          ls -la mooncake-wheel/dist-release/
-
-      - name: Upload wheels to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: mooncake-wheel/dist-release/*.whl
-
-      - name: Publish package to PyPI
-        if: github.repository == 'kvcache-ai/Mooncake'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    uses: ./.github/workflows/_publish-wheel.yaml
+    with:
+      artifact-pattern: 'mooncake-wheel-efa-non-cuda-py*'
+    secrets:
+      pypi-token: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/release-efa.yaml
+++ b/.github/workflows/release-efa.yaml
@@ -5,158 +5,30 @@ on:
     tags:
       - 'v*'
 
-# Publishes the AWS EFA (libfabric) CUDA wheel variant:
-#   mooncake-transfer-engine-efa            USE_EFA=ON USE_CUDA=ON  (GPU, GPUDirect/FI_HMEM_CUDA)
-# The non-CUDA variant (mooncake-transfer-engine-efa-non-cuda) is built by
-# release-efa-non-cuda.yaml — split into its own workflow because each PyPI
-# package publishes from a dedicated release workflow (trusted publisher /
-# artifact pattern is per-package), mirroring release.yaml vs release-non-cuda.yaml.
-#
-# No EFA hardware is needed to build: USE_EFA only needs libfabric headers/lib
-# to compile/link. auditwheel excludes libfabric/libefa from the wheel so they
-# resolve to the user's system AWS EFA install (/opt/amazon/efa/lib) at
-# runtime. The distro libfabric (1.x) used to build is ABI-forward-compatible
-# with the AWS EFA libfabric (2.x) loaded at runtime; the EFA transport uses
-# only long-stable fi_* core APIs.
-env:
-  SCCACHE_GHA_ENABLED: "true"
+# Publishes mooncake-transfer-engine-efa, the CUDA-aware AWS EFA wheel.
 jobs:
   build:
-    runs-on: ubuntu-22.04
     permissions:
       contents: write
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-    env:
-      EFA_BUILD: "1"
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Free up disk space
-        uses: ./.github/actions/free-disk-space
-
-      - name: Install CUDA Toolkit
-        uses: Jimver/cuda-toolkit@v0.2.24
-        with:
-          cuda: '12.8.1'
-          method: 'network'
-          sub-packages: '["nvcc", "nvrtc-dev"]'
-          non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
-
-      - name: Run sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Configure sccache
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: Configure project
-        run: |
-          sudo apt update -y
-          sudo apt install -y libfabric-dev libfabric1
-          sudo bash -x dependencies.sh -y
-          mkdir build
-          cd build
-          cmake .. \
-            -DUSE_HTTP=ON \
-            -DUSE_ETCD=ON \
-            -DUSE_CUDA=ON \
-            -DWITH_EP=OFF \
-            -DSTORE_USE_ETCD=ON \
-            -DUSE_EFA=ON \
-            -DLIBFABRIC_INCLUDE_DIR=/usr/include \
-            -DLIBFABRIC_LIBRARY=/usr/lib/x86_64-linux-gnu/libfabric.so \
-            -DENABLE_SCCACHE=ON \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/cuda/lib64/stubs
-        shell: bash
-
-      - name: Build project
-        run: |
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-          cd build
-          make -j3
-          sudo make install
-        shell: bash
-
-      - name: Run sccache stat for check
-        if: ${{ env.SCCACHE_PATH != '' }}
-        shell: bash
-        run: ${SCCACHE_PATH} --show-stats
-
-      - name: Generate Python version tag
-        id: generate_tag_release
-        run: |
-          echo "python_version_tag=$(echo ${{ matrix.python-version }} | tr -d '.')" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Build Python wheel
-        run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-          PYTHON_VERSION=${{ matrix.python-version }} OUTPUT_DIR=dist-py${{ steps.generate_tag_release.outputs.python_version_tag }} ./scripts/build_wheel.sh
-        env:
-          VERSION: ${{ env.VERSION }}
-
-      - name: Verify libfabric is excluded from the wheel
-        run: |
-          WHL=$(ls mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl | head -1)
-          echo "Inspecting $WHL"
-          if unzip -l "$WHL" | grep -iE 'libfabric|libefa'; then
-            echo "::error::libfabric/libefa must NOT be bundled in the EFA wheel"
-            exit 1
-          fi
-          echo "OK: libfabric/libefa correctly excluded"
-        shell: bash
-
-      - name: Upload Python wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mooncake-wheel-efa-py${{ steps.generate_tag_release.outputs.python_version_tag }}
-          path: mooncake-wheel/dist-py${{ steps.generate_tag_release.outputs.python_version_tag }}/*.whl
+    uses: ./.github/workflows/_build-efa-wheel.yaml
+    with:
+      variant: cuda
+      use-cuda: true
+      python-versions: '["3.10", "3.11", "3.12", "3.13"]'
+      build-profile: release
+      cmake-args: >-
+        -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
+      variant-flag: EFA_BUILD
+      artifact-prefix: mooncake-wheel-efa
 
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
     needs: build
-    runs-on: ubuntu-22.04
     permissions:
       contents: write
       id-token: write
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-
-      - name: Download all wheel artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: mooncake-wheel/dist-all
-          pattern: mooncake-wheel-efa-py*
-
-      - name: Prepare wheels for release
-        run: |
-          mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
-          echo "Collected wheels for release:"
-          ls -la mooncake-wheel/dist-release/
-
-      - name: Upload wheels to GitHub Release
-        uses: softprops/action-gh-release@v1
-        with:
-          files: mooncake-wheel/dist-release/*.whl
-
-      - name: Publish package to PyPI
-        if: github.repository == 'kvcache-ai/Mooncake'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: mooncake-wheel/dist-release/
-          password: ${{ secrets.PYPI_API_TOKEN }}
+    uses: ./.github/workflows/_publish-wheel.yaml
+    with:
+      artifact-pattern: 'mooncake-wheel-efa-py*'
+    secrets:
+      pypi-token: ${{ secrets.PYPI_API_TOKEN }}

--- a/scripts/ci/run_store_go_integration.sh
+++ b/scripts/ci/run_store_go_integration.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
+: "${MOONCAKE_STORE_CLUSTER_ID:?MOONCAKE_STORE_CLUSTER_ID must be set}"
+
+case "${MOONCAKE_STORE_GO_SANITIZED:-0}" in
+    0) sanitized=false ;;
+    1) sanitized=true ;;
+    *)
+        echo "MOONCAKE_STORE_GO_SANITIZED must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
+
+case "${MOONCAKE_STORE_GO_LINK_COMMON:-0}" in
+    0) link_common=false ;;
+    1) link_common=true ;;
+    *)
+        echo "MOONCAKE_STORE_GO_LINK_COMMON must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
+
+"$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
+    --eviction_high_watermark_ratio=0.95 \
+    --cluster_id="$MOONCAKE_STORE_CLUSTER_ID" \
+    --port 50051 &
+master_pid=$!
+sleep 3
+
+cd "$GITHUB_WORKSPACE/mooncake-store/go"
+export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd"
+export CGO_ENABLED=1
+export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
+
+linker_flags=(
+    "-L$GITHUB_WORKSPACE/build/mooncake-store/src"
+    "-L$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator"
+    "-L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src"
+    "-L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base"
+    "-L$GITHUB_WORKSPACE/build/mooncake-common"
+)
+if $link_common; then
+    linker_flags+=("-L$GITHUB_WORKSPACE/build/mooncake-common/src")
+fi
+linker_flags+=("-L$GITHUB_WORKSPACE/build/mooncake-common/etcd")
+if $link_common; then
+    linker_flags+=(
+        -Wl,--start-group
+        -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase
+        -lmooncake_common
+        -Wl,--end-group
+    )
+else
+    linker_flags+=(
+        -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase
+    )
+fi
+linker_flags+=(
+    -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -lmlx5
+    -ljsoncpp -lzstd -lcurl -luring
+)
+if $sanitized; then
+    linker_flags+=(-lasan)
+fi
+linker_flags+=(-lm)
+if $sanitized; then
+    linker_flags+=(-lgcov)
+fi
+linker_flags+=(-lxxhash -lyaml-cpp)
+export CGO_LDFLAGS="${linker_flags[*]}"
+
+# Link cudart if CUDA is available (needed for D2H staging in mooncake_store).
+if [ -d /usr/local/cuda/lib64 ]; then
+    export CGO_LDFLAGS="$CGO_LDFLAGS -L/usr/local/cuda/lib64 -lcudart"
+fi
+# The KV events publisher is optional and linked when libzmq is installed.
+if ldconfig -p 2>/dev/null | grep -q libzmq; then
+    export CGO_LDFLAGS="$CGO_LDFLAGS -lzmq"
+fi
+
+test_env=(MC_METADATA_SERVER=http://127.0.0.1:8080/metadata)
+if $sanitized; then
+    test_env=(ASAN_OPTIONS=detect_leaks=0:verify_asan_link_order=0 "${test_env[@]}")
+fi
+env "${test_env[@]}" go test -v ./tests/...
+
+kill "$master_pid" 2>/dev/null || true

--- a/scripts/ci/run_store_rust_smoke.sh
+++ b/scripts/ci/run_store_rust_smoke.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+: "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE must be set}"
+: "${MOONCAKE_STORE_CLUSTER_ID:?MOONCAKE_STORE_CLUSTER_ID must be set}"
+
+# ASan-enabled CI libraries require the Rust package to link libasan first.
+# Release-style nightly builds intentionally leave the ASan runtime unlinked.
+case "${MOONCAKE_STORE_RUST_LINK_ASAN:-0}" in
+    0) unset MOONCAKE_LINK_ASAN ;;
+    1) export MOONCAKE_LINK_ASAN=1 ;;
+    *)
+        echo "MOONCAKE_STORE_RUST_LINK_ASAN must be 0 or 1" >&2
+        exit 2
+        ;;
+esac
+
+"$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
+    --eviction_high_watermark_ratio=0.95 \
+    --cluster_id="$MOONCAKE_STORE_CLUSTER_ID" \
+    --port 50051 &
+master_pid=$!
+sleep 3
+
+cd "$GITHUB_WORKSPACE/mooncake-store/rust"
+export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:${LD_LIBRARY_PATH:-}"
+export MOONCAKE_BUILD_DIR="$GITHUB_WORKSPACE/build"
+export MOONCAKE_STORE_LIB_DIR="$GITHUB_WORKSPACE/build/mooncake-store/src"
+export MOONCAKE_STORE_INCLUDE_DIR="$GITHUB_WORKSPACE/mooncake-store/include"
+export MC_METADATA_SERVER=http://127.0.0.1:8080/metadata
+export MC_RUST_STORE_RUN_INTEGRATION=true
+export MC_RUST_STORE_MASTER_ADDR=127.0.0.1:50051
+export MC_RUST_STORE_LOCAL_HOSTNAME=127.0.0.1
+export MC_RUST_STORE_PROTOCOL=tcp
+export MC_RUST_STORE_DEVICE_NAME=
+
+cargo test --test minimal_smoke -- --nocapture
+MC_RUST_BENCH_ITERATIONS=4 \
+    MC_RUST_BENCH_VALUE_SIZE=4096 \
+    MC_RUST_BENCH_WARMUP=1 \
+    cargo run --release --example store_benchmark
+
+kill "$master_pid" 2>/dev/null || true


### PR DESCRIPTION
## Description

Deduplicate the GitHub Actions implementation for AWS EFA wheel builds and the shared Mooncake Store binding tests while preserving the existing workflow behavior.

This change:

- adds `_build-efa-wheel.yaml` as the single implementation for CI and release EFA wheel builds
- makes `ci_efa.yml`, `release-efa.yaml`, and `release-efa-non-cuda.yaml` thin callers
- reuses the existing `_publish-wheel.yaml` for both EFA release workflows
- centralizes the repeated job-level `run-ci` conditions in `ci.yml` with YAML anchors
- moves the duplicated Rust smoke/benchmark and Go binding integration blocks into scripts under `scripts/ci/`
- preserves the CI/release Python matrices, CMake flags, CUDA installation, libfabric exclusion check, artifact names and patterns, permissions, secrets, and job dependencies

### Relationship to #3148

#3148 also changes `ci.yml` and `nightly.yml`, but has a different scope: it fixes the undefined nightly `build-with-ep` inputs and moves expensive platform and coverage jobs out of per-PR CI. This PR intentionally does neither. It is limited to the accepted workflow deduplication and script extraction, so any overlap is file-level rather than a duplicate implementation goal.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files \
  .github/workflows/_build-efa-wheel.yaml \
  .github/workflows/ci.yml \
  .github/workflows/ci_efa.yml \
  .github/workflows/nightly.yml \
  .github/workflows/release-efa.yaml \
  .github/workflows/release-efa-non-cuda.yaml \
  scripts/ci/run_store_go_integration.sh \
  scripts/ci/run_store_rust_smoke.sh
bash -n scripts/ci/run_store_rust_smoke.sh scripts/ci/run_store_go_integration.sh
git diff --check
```

A static parity audit also compared the pre- and post-refactor triggers, conditions, matrices, workflow-call inputs, CMake/CUDA flags, permissions, artifact names and patterns, publish secrets, and job dependencies. A repository-wide reusable-workflow contract check found only the two known pre-existing nightly `build-with-ep` mismatches.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (requires GitHub-hosted CUDA/EFA jobs)
- [x] Manual/static validation completed as described above
- [x] All touched-file pre-commit hooks pass
- [x] All 27 workflow files parse as YAML
- [x] `bash -n` and `git diff --check` pass

`actionlint` and `shellcheck` were not available locally. Full CUDA/EFA builds were not run.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (touched files pass)
- [x] I have updated the documentation (not applicable; workflow-only refactor)
- [ ] I have added tests to prove my changes are effective (static parity validation only)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex analyzed the workflow duplication, implemented the reusable workflow and scripts, and ran the static validation. This PR is intentionally opened as a draft so the human submitter can review every changed line and confirm they can defend the change end-to-end before marking it ready.