### PR TITLE
[PG] Fix single-rank initialization and yalantinglibs dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,21 @@ if (WITH_EP)
     string(REPLACE ";" "|" _ep_torch_versions_pipe "${EP_TORCH_VERSIONS}")
     string(REPLACE ";" "|" _torch_cuda_arch_list_pipe "${TORCH_CUDA_ARCH_LIST}")
 
+    # PG is compiled by setup.py rather than as a native CMake target. Pass it
+    # the exact YLT include directories selected by find_package() so its
+    # header-only RPC types have the same ABI as engine.so.
+    get_target_property(
+      _pg_ylt_include_dirs
+      yalantinglibs::yalantinglibs
+      INTERFACE_INCLUDE_DIRECTORIES
+    )
+    if(NOT _pg_ylt_include_dirs)
+      message(FATAL_ERROR
+        "yalantinglibs::yalantinglibs has no INTERFACE_INCLUDE_DIRECTORIES")
+    endif()
+    string(REPLACE ";" "|" _pg_ylt_include_dirs_pipe
+           "${_pg_ylt_include_dirs}")
+
     add_custom_target(mooncake_ep_ext ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory "${EP_PG_STAGING_DIR}"
       COMMAND ${CMAKE_COMMAND}
@@ -172,12 +187,14 @@ if (WITH_EP)
         "-DTORCH_CUDA_ARCH_LIST=${_torch_cuda_arch_list_pipe}"
         "-DSTAGING_DIR=${EP_PG_STAGING_DIR}"
         "-DENGINE_SO_PATH=$<TARGET_FILE:engine>"
+        "-DASIO_SO_PATH=$<TARGET_FILE:asio_shared>"
+        "-DYLT_INCLUDE_DIRS=${_pg_ylt_include_dirs_pipe}"
         "-DPython3_EXECUTABLE=${Python3_EXECUTABLE}"
         "-DEP_USE_MUSA=$<IF:$<BOOL:${USE_MUSA}>,1,0>"
         "-DEP_USE_MACA=$<IF:$<BOOL:${USE_MACA}>,1,0>"
         -P "${CMAKE_CURRENT_SOURCE_DIR}/mooncake-pg/BuildPgExt.cmake"
       COMMENT "Building Mooncake PG Python extension(s)"
-      DEPENDS engine mooncake_ep_ext
+      DEPENDS engine asio_shared mooncake_ep_ext
       VERBATIM
     )
   endif ()

--- a/mooncake-pg/BuildPgExt.cmake
+++ b/mooncake-pg/BuildPgExt.cmake
@@ -11,6 +11,8 @@
 #   TORCH_CUDA_ARCH_LIST - pipe-separated CUDA arch list forwarded to torch
 #   STAGING_DIR         - destination directory for the built .so files
 #   ENGINE_SO_PATH      - absolute path to the built engine.cpython-XYZ.so
+#   ASIO_SO_PATH        - absolute path to the libasio.so used by engine.so
+#   YLT_INCLUDE_DIRS    - pipe-separated YLT include directories used by CMake
 #   EP_USE_MUSA         - set to "1" when building for MUSA (MTLink path)
 #   EP_USE_MACA         - set to "1" when building for MACA (MTLink path)
 
@@ -37,6 +39,14 @@ endif()
 set(ENV{MAKEFLAGS} "")
 set(ENV{MFLAGS} "")
 set(ENV{TORCH_CUDA_ARCH_LIST} "${TORCH_CUDA_ARCH_LIST}")
+if(NOT YLT_INCLUDE_DIRS)
+  message(FATAL_ERROR "[PG] YLT_INCLUDE_DIRS was not provided by CMake")
+endif()
+if(NOT ASIO_SO_PATH OR NOT EXISTS "${ASIO_SO_PATH}")
+  message(FATAL_ERROR "[PG] ASIO_SO_PATH is missing or does not exist: ${ASIO_SO_PATH}")
+endif()
+set(ENV{MOONCAKE_YLT_INCLUDE_DIRS} "${YLT_INCLUDE_DIRS}")
+set(ENV{MOONCAKE_ASIO_SO_PATH} "${ASIO_SO_PATH}")
 if(EP_USE_MUSA)
   set(ENV{MOONCAKE_EP_USE_MUSA} "1")
 else()

--- a/mooncake-pg/include/control_plane/link_manager.h
+++ b/mooncake-pg/include/control_plane/link_manager.h
@@ -30,6 +30,8 @@ class LinkManager {
     LinkManager() = default;
 
     void init(GlobalRank rank, int max_world_size, TransferEngine* engine);
+    void start(uint64_t self_rank_epoch);
+    void stop();
 
     bool isInitialized() const {
         return initialized_.load(std::memory_order_acquire);
@@ -61,7 +63,8 @@ class LinkManager {
 
     void refreshPeerSegment(GlobalRank peer);
 
-    void publishLinkUp(GlobalRank peer, TransferMetadata::SegmentID target_id);
+    void publishLinkUp(GlobalRank peer, TransferMetadata::SegmentID target_id,
+                       uint64_t target_rank_epoch);
     void publishLinkDown(GlobalRank peer);
 
     ~LinkManager() { shutdown(); }
@@ -121,7 +124,7 @@ class LinkManager {
     std::string local_server_name_;
 
     // Warmup region
-    std::unique_ptr<int32_t[]> warmup_send_region_;
+    std::unique_ptr<int32_t> warmup_send_region_;
     std::unique_ptr<int32_t[]> warmup_recv_region_;
     bool skip_warmup_ = false;
 
@@ -135,6 +138,7 @@ class LinkManager {
     std::condition_variable wakeup_cv_;
 
     std::atomic<bool> initialized_{false};
+    std::atomic<bool> started_{false};
     std::atomic<bool> shutdown_{false};
 
     void pollerLoop();

--- a/mooncake-pg/setup.py
+++ b/mooncake-pg/setup.py
@@ -48,6 +48,21 @@ sysroot_library_dirs = existing_dirs(
 
 abi_define = f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}"
 
+ylt_include_dirs = existing_dirs(
+    *os.getenv("MOONCAKE_YLT_INCLUDE_DIRS", "").split("|")
+)
+if not ylt_include_dirs:
+    raise RuntimeError(
+        "MOONCAKE_YLT_INCLUDE_DIRS is unset or contains no existing directory"
+    )
+
+asio_so_path = os.getenv("MOONCAKE_ASIO_SO_PATH", "")
+if not os.path.isfile(asio_so_path):
+    raise RuntimeError(
+        "MOONCAKE_ASIO_SO_PATH is unset or does not name the libasio.so used "
+        "by engine.so"
+    )
+
 # Match the yalantinglibs configuration used by engine.so / store.so so that
 # header-only types like coro_io::socket_wrapper_t have the same layout across
 # all shared objects loaded in the same process.
@@ -58,14 +73,22 @@ abi_define = f"-D_GLIBCXX_USE_CXX11_ABI={abi_flag}"
 # etc.) diverges between the C++ targets and this file, template types
 # instantiated into both pg_*.so and store.so will have different layouts,
 #  leading to silent crashes. :(
-cxx_args = [abi_define, "-DYLT_ENABLE_IBV", "-std=c++20", "-O3", "-g0"]
+cxx_args = [
+    abi_define,
+    "-DYLT_ENABLE_IBV",
+    "-DASIO_SEPARATE_COMPILATION",
+    "-DASIO_DYN_LINK",
+    "-std=c++20",
+    "-O3",
+    "-g0",
+]
 
 cuda_libraries = ["ibverbs", "mlx5"]
 cuda_library_dirs = []
 include_dirs = [
     os.path.join(current_dir, "include"),
     os.path.join(current_dir, "../mooncake-transfer-engine/include"),
-    os.path.join(current_dir, "../extern/yalantinglibs/include"),
+    *ylt_include_dirs,
 ]
 use_maca = (
     os.getenv("MOONCAKE_EP_USE_MACA", "").upper() in {"1", "ON", "TRUE", "YES"}
@@ -139,6 +162,7 @@ setup(
                 "-L" + os.path.join(current_dir, "../mooncake-wheel/mooncake"),
                 "-Wl,--push-state,--no-as-needed",
                 "-l:engine.so",
+                asio_so_path,
                 "-Wl,--pop-state",
             ],
         )

--- a/mooncake-pg/src/control_plane/agent_host.cpp
+++ b/mooncake-pg/src/control_plane/agent_host.cpp
@@ -125,6 +125,7 @@ void AgentHost::shutdown() {
     // Finish operations that callers already submitted, including explicit
     // unregisterGroup calls, before releasing process-level rank ownership.
     executor_.shutdown();
+    link_manager_.stop();
     unregisterAgent();
     if (rpc_client_) {
         rpc_client_->shutdown();
@@ -490,6 +491,7 @@ void AgentHost::startAgentRegistration(bool start_new_session) {
         return;
     }
     if (start_new_session) {
+        link_manager_.stop();
         ++agent_session_id_;
         agent_session_initialized_ = false;
     }
@@ -546,6 +548,8 @@ void AgentHost::startAgentRegistration(bool start_new_session) {
                 if (agent_.getCoordinatorConnection() !=
                     AgentStateMachine::CoordinatorConnection::Connected)
                     return;
+
+                link_manager_.start(agent_.getRankEpoch());
 
                 if (!agent_registration_done_) {
                     agent_registration_done_ = true;

--- a/mooncake-pg/src/control_plane/coordinator.cpp
+++ b/mooncake-pg/src/control_plane/coordinator.cpp
@@ -24,7 +24,6 @@ CentralizedCoordinatorStateMachine::CentralizedCoordinatorStateMachine(
     endpoint_epochs_.assign(max_world_size_, 0);
     for (int r = 0; r < max_world_size_; ++r) {
         ranks_[r].link_status.assign(max_world_size_, 0);
-        ranks_[r].link_status[r] = 1;
     }
 }
 
@@ -87,7 +86,6 @@ CentralizedCoordinatorStateMachine::handleRegisterAgent(
     for (auto& peer : ranks_) {
         peer.link_status[req.rank] = 0;
     }
-    info.link_status[req.rank] = 1;
     info.last_link_event_report_id = 0;
 
     for (auto& [group_id, view] : group_views_) {
@@ -753,7 +751,6 @@ void CentralizedCoordinatorStateMachine::tryConfirmShutdown(
 bool CentralizedCoordinatorStateMachine::isMutuallyConnected(
     GlobalRank a, GlobalRank b) const {
     assert(rankInRange(a) && rankInRange(b));
-    if (a == b) return true;
     if (ranks_[a].state == RankState::Offline ||
         ranks_[b].state == RankState::Offline)
         return false;
@@ -767,7 +764,8 @@ std::vector<GlobalRank> CentralizedCoordinatorStateMachine::extendHealthySet()
     //  Collect current Healthy ranks.
     std::vector<GlobalRank> result;
     for (int i = 0; i < max_world_size_; ++i) {
-        if (ranks_[i].state == RankState::Healthy) {
+        if (ranks_[i].state == RankState::Healthy &&
+            isMutuallyConnected(i, i)) {
             result.push_back(i);
         }
     }
@@ -820,6 +818,9 @@ std::vector<GlobalRank> CentralizedCoordinatorStateMachine::extendHealthySet()
     // Extend with new mutually-connected candidates.
     for (int i = 0; i < max_world_size_; ++i) {
         if (ranks_[i].state == RankState::Offline) continue;
+        // The diagonal is local data-plane readiness. A registered Agent
+        // remains Synced until its LinkManager reports the self-link up.
+        if (!isMutuallyConnected(i, i)) continue;
         if (std::find(result.begin(), result.end(), i) != result.end())
             continue;
         bool connected_to_all = true;

--- a/mooncake-pg/src/control_plane/link_manager.cpp
+++ b/mooncake-pg/src/control_plane/link_manager.cpp
@@ -67,13 +67,9 @@ void LinkManager::init(GlobalRank rank, int max_world_size,
     read_state_ = std::vector<PeerReadState>(max_world_size_);
 
     if (!skip_warmup_) {
-        warmup_send_region_ = std::make_unique<int32_t[]>(max_world_size_);
-        std::memset(warmup_send_region_.get(), 0,
-                    max_world_size_ * sizeof(int32_t));
-        warmup_send_region_[0] = 1;
-        int rc = engine_->registerLocalMemory(warmup_send_region_.get(),
-                                              max_world_size_ * sizeof(int32_t),
-                                              kWildcardLocation);
+        warmup_send_region_ = std::make_unique<int32_t>(1);
+        int rc = engine_->registerLocalMemory(
+            warmup_send_region_.get(), sizeof(int32_t), kWildcardLocation);
         if (rc != 0) {
             LOG(FATAL) << "LinkManager: failed to register warmup send region";
         }
@@ -90,52 +86,58 @@ void LinkManager::init(GlobalRank rank, int max_world_size,
                 << rc;
         }
     }
+}
 
-    // Bootstrap self: open local segment, mark Connected.
+void LinkManager::start(uint64_t self_rank_epoch) {
+    if (!initialized_.load(std::memory_order_acquire)) {
+        LOG(ERROR) << "LinkManager: start() called before init()";
+        return;
+    }
+    if (shutdown_.load(std::memory_order_acquire)) return;
+    if (started_.exchange(true, std::memory_order_acq_rel)) return;
+
     TransferMetadata::SegmentID self_target_id{};
     {
         std::lock_guard<std::mutex> lock(peers_mutex_);
         auto& link = peers_[rank_];
         link.state = PeerLinkState::Connected;
         link.is_candidate = false;
+        link.target_rank_epoch = self_rank_epoch;
         link.target_id = engine_->openSegment(local_server_name_);
         self_target_id = link.target_id.value();
     }
 
-    // Write read model for self.
-    publishLinkUp(rank_, self_target_id);
+    publishLinkUp(rank_, self_target_id, self_rank_epoch);
 
-    // Start poller thread.
     poller_running_.store(true, std::memory_order_release);
     poller_thread_ = std::thread([this] { pollerLoop(); });
 }
 
-void LinkManager::shutdown() {
-    if (shutdown_.exchange(true, std::memory_order_acq_rel)) return;
+void LinkManager::stop() {
+    if (!initialized_.load(std::memory_order_acquire)) return;
 
+    started_.store(false, std::memory_order_release);
     poller_running_.store(false, std::memory_order_release);
     wakeup();
     if (poller_thread_.joinable()) {
         poller_thread_.join();
     }
 
-    // Tear down all peer links.
     std::lock_guard<std::mutex> lock(peers_mutex_);
-    for (int i = 0; i < max_world_size_; ++i) {
-        if (i == rank_) continue;
-        auto& link = peers_[i];
-        if (link.target_id.has_value()) {
-            engine_->closeSegment(link.target_id.value());
-            link.target_id = std::nullopt;
-        }
-        if (link.probe_batch_id.has_value()) {
-            engine_->freeBatchID(link.probe_batch_id.value());
-            link.probe_batch_id = std::nullopt;
-        }
-        link.health_check_requested = false;
-        link.state = PeerLinkState::Idle;
-        link.is_candidate = false;
+    for (int peer = 0; peer < max_world_size_; ++peer) {
+        tearDownPeerLink(peer);
+        peers_[peer] = PeerLink{};
     }
+    if (warmup_recv_region_) {
+        std::memset(warmup_recv_region_.get(), 0,
+                    max_world_size_ * sizeof(int32_t));
+    }
+}
+
+void LinkManager::shutdown() {
+    if (shutdown_.exchange(true, std::memory_order_acq_rel)) return;
+
+    stop();
 
     // Release warmup regions.
     if (warmup_send_region_) {
@@ -273,11 +275,16 @@ void LinkManager::refreshPeerSegment(GlobalRank peer) {
 }
 
 void LinkManager::publishLinkUp(GlobalRank peer,
-                                TransferMetadata::SegmentID target_id) {
+                                TransferMetadata::SegmentID target_id,
+                                uint64_t target_rank_epoch) {
     if (!rankInRange(peer)) return;
     read_state_[peer].target_id.store(target_id, std::memory_order_relaxed);
     read_state_[peer].link_connected.store(1, std::memory_order_release);
     read_state_[peer].version.fetch_add(1, std::memory_order_release);
+    emit(TELinkUpEvent{
+        .peer = peer,
+        .target_rank_epoch = target_rank_epoch,
+    });
 }
 
 void LinkManager::publishLinkDown(GlobalRank peer) {
@@ -445,11 +452,7 @@ bool LinkManager::advanceConnection(GlobalRank peer) {
             if (link.skip_warmup) {
                 link.state = PeerLinkState::Connected;
                 link.probe_backoff = PeerLink::kProbeBackoffMin;
-                publishLinkUp(peer, segment_id);
-                emit(TELinkUpEvent{
-                    .peer = peer,
-                    .target_rank_epoch = link.target_rank_epoch,
-                });
+                publishLinkUp(peer, segment_id, link.target_rank_epoch);
                 return true;
             }
 
@@ -492,11 +495,8 @@ bool LinkManager::advanceConnection(GlobalRank peer) {
                 link.probe_batch_id = std::nullopt;
                 link.state = PeerLinkState::Connected;
                 link.probe_backoff = PeerLink::kProbeBackoffMin;
-                publishLinkUp(peer, link.target_id.value());
-                emit(TELinkUpEvent{
-                    .peer = peer,
-                    .target_rank_epoch = link.target_rank_epoch,
-                });
+                publishLinkUp(peer, link.target_id.value(),
+                              link.target_rank_epoch);
                 return true;
             }
 
@@ -532,11 +532,8 @@ bool LinkManager::advanceConnection(GlobalRank peer) {
                 *warmup_flag = 0;
                 link.state = PeerLinkState::Connected;
                 link.probe_backoff = PeerLink::kProbeBackoffMin;
-                publishLinkUp(peer, link.target_id.value());
-                emit(TELinkUpEvent{
-                    .peer = peer,
-                    .target_rank_epoch = link.target_rank_epoch,
-                });
+                publishLinkUp(peer, link.target_id.value(),
+                              link.target_rank_epoch);
                 return true;
             }
             return false;

--- a/mooncake-pg/src/control_plane/link_manager.cpp
+++ b/mooncake-pg/src/control_plane/link_manager.cpp
@@ -125,8 +125,21 @@ void LinkManager::stop() {
 
     std::lock_guard<std::mutex> lock(peers_mutex_);
     for (int peer = 0; peer < max_world_size_; ++peer) {
-        tearDownPeerLink(peer);
-        peers_[peer] = PeerLink{};
+        if (peer == rank_) continue;
+        auto& link = peers_[peer];
+        if (link.target_id.has_value()) {
+            engine_->closeSegment(link.target_id.value());
+            link.target_id = std::nullopt;
+        }
+        if (link.probe_batch_id.has_value()) {
+            engine_->freeBatchID(link.probe_batch_id.value());
+            link.probe_batch_id = std::nullopt;
+        }
+        // Segment metadata belongs to the TransferEngine. removeLocalSegment
+        // is only valid while refreshing a live peer, not during shutdown.
+        link.health_check_requested = false;
+        link.state = PeerLinkState::Idle;
+        link.is_candidate = false;
     }
     if (warmup_recv_region_) {
         std::memset(warmup_recv_region_.get(), 0,

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -243,7 +243,24 @@ void setTransferEnginePy(pybind11::object engine_obj) {
     g_ctx.engine_initialized = true;
 }
 
+void shutdownProcessContext() {
+    if (g_ctx.agent_host) g_ctx.agent_host->shutdown();
+    // AgentHost::shutdown stops the control plane. Finish LinkManager's
+    // resource release before Python tears down an injected TransferEngine.
+    g_ctx.link_manager.shutdown();
+    g_ctx.agent_host.reset();
+    if (g_ctx.coordinator_host) g_ctx.coordinator_host->shutdown();
+    g_ctx.coordinator_host.reset();
+    g_ctx.external_engine = nullptr;
+    g_ctx.engine = nullptr;
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    // Python atexit handlers run while module globals still own an injected
+    // TransferEngine. Py_AtExit is too late: CPython may have already decref'd
+    // the Python TE wrapper before invoking its native exit handlers.
+    py::module_::import("atexit").attr("register")(
+        py::cpp_function(&shutdownProcessContext));
     m.def("createMooncakeBackend", &createMooncakeBackend);
     m.def("createMooncakeCpuBackend", &createMooncakeCpuBackend);
     m.def("set_host_ip", [](const std::string& host) { g_ctx.host_ip = host; });

--- a/mooncake-pg/tests/test_pg_init_functional.py
+++ b/mooncake-pg/tests/test_pg_init_functional.py
@@ -117,6 +117,13 @@ class _InitFunctionalMixin:
         for row in rows:
             self.assertEqual(row["sum"], expected_sum)
 
+    def test_world_size_one(self) -> None:
+        """Test a process group with world size 1 initializes and works."""
+        rows = self.spawn_backend_and_collect(_basic_init_worker, world_size=1)
+        self.assert_all_ok(rows)
+        for row in rows:
+            self.assertEqual(row["sum"], 1)
+
     def test_subgroup_create_destroy(self) -> None:
         """Test subgroup creation and destruction."""
         if self.world_size < 4:


### PR DESCRIPTION
## Description

This PR fixes single-rank ProcessGroup initialization and aligns the PG's YLT and Asio configuration with `engine.so`.

### Single-rank initialization

A single-rank group could remain stuck in `Synced` because it had no peer-link event to trigger the transition to `Healthy`. The Coordinator previously assumed that every rank was connected to itself, so the LinkManager never explicitly reported local data-plane readiness.

This PR:

- separates one-time `LinkManager` setup from per-session start and stop
- starts the `LinkManager` after Agent registration and reports self-link readiness, allowing single-rank groups to become `Ready`
- adds a test that initializes a single-rank group and verifies an `all_reduce`

### PG build consistency

PG is built through `setup.py`, outside the main CMake target graph, so it did not inherit the YLT and Asio usage requirements used to build `engine.so`. PG previously selected its YLT headers independently and compiled Asio in header-only mode, while `engine.so` used the YLT headers selected by CMake and the shared `asio_shared` implementation. If the selected YLT versions or configurations differed, loading both of them in the same process could result in a crash.

This change:

- forwards the YLT include directories from `yalantinglibs::yalantinglibs` to the PG build
- builds PG with `ASIO_SEPARATE_COMPILATION` and `ASIO_DYN_LINK`
- links PG directly against the same `asio_shared` library used by `engine.so`

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

- All unit tests passed.
- Manual e2e tests on recovery and scale-up passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

codex helped me to fix these bugs. All changes have been thoroughly reviewed and verified by me in person.