### PR TITLE
[Store] Validate durable oplog prefix at startup

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_storage.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_storage.h
@@ -24,6 +24,7 @@ class OpLogBatchStorage {
    private:
     bool IsValidClusterId() const;
     ErrorCode RejectLegacyLayout() const;
+    ErrorCode ValidateDurablePrefixAtStartup(const DurablePrefix& prefix);
 
     std::string cluster_id_;
     HaKvBackend& backend_;

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -209,6 +209,11 @@ ErrorCode OpLogBatchStorage::ReadBatch(uint64_t batch_id,
         LOG(ERROR) << "Failed to decode OpLog batch record: " << reason;
         return ErrorCode::INTERNAL_ERROR;
     }
+    if (batch.batch_id != batch_id) {
+        LOG(ERROR) << "OpLog batch id does not match key: requested="
+                   << batch_id << ", payload=" << batch.batch_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -69,7 +69,7 @@ ErrorCode OpLogBatchStorage::InitDurablePrefix(DurablePrefix& prefix) {
     }
     err = ReadDurablePrefix(prefix);
     if (err == ErrorCode::OK) {
-        return ErrorCode::OK;
+        return ValidateDurablePrefixAtStartup(prefix);
     }
     if (err != ErrorCode::ETCD_KEY_NOT_EXIST) {
         return err;
@@ -104,7 +104,11 @@ ErrorCode OpLogBatchStorage::InitDurablePrefix(DurablePrefix& prefix) {
         return ErrorCode::OK;
     }
     if (err == ErrorCode::ETCD_TRANSACTION_FAIL) {
-        return ReadDurablePrefix(prefix);
+        err = ReadDurablePrefix(prefix);
+        if (err != ErrorCode::OK) {
+            return err;
+        }
+        return ValidateDurablePrefixAtStartup(prefix);
     }
     return err;
 }
@@ -122,6 +126,51 @@ ErrorCode OpLogBatchStorage::ReadDurablePrefix(DurablePrefix& prefix) {
     std::string reason;
     if (!DecodeDurablePrefix(value, &prefix, &reason)) {
         LOG(ERROR) << "Failed to decode durable prefix: " << reason;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode OpLogBatchStorage::ValidateDurablePrefixAtStartup(
+    const DurablePrefix& prefix) {
+    if ((prefix.batch_id == 0) != (prefix.last_seq == 0)) {
+        LOG(ERROR) << "Durable prefix has inconsistent zero fields: cluster="
+                   << cluster_id_ << ", batch_id=" << prefix.batch_id
+                   << ", last_seq=" << prefix.last_seq;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (prefix.batch_id == 0) {
+        const auto range = BuildBatchRecordRange(cluster_id_, 0);
+        std::vector<KvPair> batches;
+        ErrorCode err =
+            backend_.Range(range.begin_key, range.end_key, 1, batches);
+        if (err != ErrorCode::OK) {
+            return err;
+        }
+        if (!batches.empty()) {
+            LOG(ERROR) << "Zero durable prefix has batch records: cluster="
+                       << cluster_id_;
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        return ErrorCode::OK;
+    }
+
+    OpLogBatchRecord batch;
+    ErrorCode err = ReadBatch(prefix.batch_id, batch);
+    if (err == ErrorCode::ETCD_KEY_NOT_EXIST) {
+        LOG(ERROR) << "Durable prefix terminal batch is missing: cluster="
+                   << cluster_id_ << ", batch_id=" << prefix.batch_id;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (batch.last_seq != prefix.last_seq) {
+        LOG(ERROR) << "Durable prefix last sequence does not match batch: "
+                   << "cluster=" << cluster_id_
+                   << ", batch_id=" << prefix.batch_id
+                   << ", prefix_last_seq=" << prefix.last_seq
+                   << ", batch_last_seq=" << batch.last_seq;
         return ErrorCode::INTERNAL_ERROR;
     }
     return ErrorCode::OK;

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -377,6 +377,17 @@ TEST(OpLogBatchStorageTest, ReadBatchRejectsCorruptedRecord) {
     EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.ReadBatch(1, out));
 }
 
+TEST(OpLogBatchStorageTest, ReadBatchRejectsMismatchedPayloadBatchId) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000001",
+                          EncodeOpLogBatchRecord(MakeBatch(2, 1, 1))));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    OpLogBatchRecord out;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.ReadBatch(1, out));
+}
+
 TEST(OpLogBatchStorageTest, ReadBatchesAfterReturnsOrderedBatches) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -208,18 +208,21 @@ TEST(OpLogBatchStorageTest, RereadsDurablePrefixWhenCreateIfAbsentLosesRace) {
     FakeHaKvBackend backend;
     backend.CreateBeforeNextTxn(
         "/oplog/clusterA/durable_prefix",
-        EncodeDurablePrefix({.batch_id = 7, .last_seq = 99}));
+        EncodeDurablePrefix({.batch_id = 0, .last_seq = 0}));
     OpLogBatchStorage storage("clusterA", backend);
 
     DurablePrefix prefix;
     EXPECT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
 
-    EXPECT_EQ(7u, prefix.batch_id);
-    EXPECT_EQ(99u, prefix.last_seq);
+    EXPECT_EQ(0u, prefix.batch_id);
+    EXPECT_EQ(0u, prefix.last_seq);
 }
 
-TEST(OpLogBatchStorageTest, UsesExistingDurablePrefixWithoutReadingLatest) {
+TEST(OpLogBatchStorageTest, ValidatesExistingDurablePrefix) {
     FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000003",
+                          EncodeOpLogBatchRecord(MakeBatch(3, 7, 3))));
     ASSERT_EQ(ErrorCode::OK,
               backend.Put("/oplog/clusterA/durable_prefix",
                           EncodeDurablePrefix({.batch_id = 3, .last_seq = 9})));
@@ -230,6 +233,111 @@ TEST(OpLogBatchStorageTest, UsesExistingDurablePrefixWithoutReadingLatest) {
 
     EXPECT_EQ(3u, prefix.batch_id);
     EXPECT_EQ(9u, prefix.last_seq);
+}
+
+TEST(OpLogBatchStorageTest, RejectsZeroPrefixWithExistingBatch) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000001",
+                          EncodeOpLogBatchRecord(MakeBatch(1, 1, 1))));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, RejectsInconsistentDurablePrefixZeroFields) {
+    for (const DurablePrefix stored :
+         {DurablePrefix{.batch_id = 0, .last_seq = 9},
+          DurablePrefix{.batch_id = 3, .last_seq = 0}}) {
+        SCOPED_TRACE("batch_id=" + std::to_string(stored.batch_id) +
+                     " last_seq=" + std::to_string(stored.last_seq));
+        FakeHaKvBackend backend;
+        ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/durable_prefix",
+                                             EncodeDurablePrefix(stored)));
+        OpLogBatchStorage storage("clusterA", backend);
+
+        DurablePrefix prefix;
+        EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+    }
+}
+
+TEST(OpLogBatchStorageTest, RejectsPrefixWithoutTerminalBatch) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 3, .last_seq = 9})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, RejectsTerminalBatchIdMismatch) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000003",
+                          EncodeOpLogBatchRecord(MakeBatch(2, 7, 3))));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 3, .last_seq = 9})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, RejectsTerminalBatchLastSequenceMismatch) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000003",
+                          EncodeOpLogBatchRecord(MakeBatch(3, 7, 3))));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put("/oplog/clusterA/durable_prefix",
+                    EncodeDurablePrefix({.batch_id = 3, .last_seq = 10})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, RejectsCorruptedTerminalBatch) {
+    FakeHaKvBackend backend;
+    std::string encoded = EncodeOpLogBatchRecord(MakeBatch(1, 1, 1));
+    const auto pos =
+        encoded.find_first_of("0123456789", encoded.rfind(',') + 1);
+    ASSERT_NE(std::string::npos, pos);
+    encoded[pos] = encoded[pos] == '0' ? '1' : '0';
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put("/oplog/clusterA/batches/00000000000000000001", encoded));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, RejectsInvalidTerminalBatchSequenceRange) {
+    FakeHaKvBackend backend;
+    auto batch = MakeBatch(1, 1, 1);
+    batch.last_seq = 2;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000001",
+                          EncodeOpLogBatchRecord(batch)));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 1, .last_seq = 2})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.InitDurablePrefix(prefix));
 }
 
 TEST(OpLogBatchStorageTest, WriteBatchAndAdvancePrefixCommitsAtomically) {

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -17,6 +17,13 @@ namespace {
 class FakeHaKvBackend : public HaKvBackend {
    public:
     ErrorCode Get(std::string_view key, std::string& value) override {
+        if (next_get_key_error_ != ErrorCode::OK &&
+            key == next_get_error_key_) {
+            ErrorCode err = next_get_key_error_;
+            next_get_key_error_ = ErrorCode::OK;
+            next_get_error_key_.clear();
+            return err;
+        }
         if (next_get_error_ != ErrorCode::OK) {
             ErrorCode err = next_get_error_;
             next_get_error_ = ErrorCode::OK;
@@ -93,6 +100,10 @@ class FakeHaKvBackend : public HaKvBackend {
         race_value_ = std::move(value);
     }
     void FailNextGet(ErrorCode err) { next_get_error_ = err; }
+    void FailNextGetForKey(std::string key, ErrorCode err) {
+        next_get_error_key_ = std::move(key);
+        next_get_key_error_ = err;
+    }
     void FailNextRange(ErrorCode err) { next_range_error_ = err; }
     void FailNextTxn(ErrorCode err) { next_txn_error_ = err; }
     const std::vector<size_t>& range_limits() const { return range_limits_; }
@@ -104,6 +115,8 @@ class FakeHaKvBackend : public HaKvBackend {
     std::string race_key_;
     std::string race_value_;
     ErrorCode next_get_error_{ErrorCode::OK};
+    std::string next_get_error_key_;
+    ErrorCode next_get_key_error_{ErrorCode::OK};
     ErrorCode next_range_error_{ErrorCode::OK};
     ErrorCode next_txn_error_{ErrorCode::OK};
     std::vector<size_t> range_limits_;
@@ -578,6 +591,39 @@ TEST(OpLogBatchStorageTest, ReadBatchesAfterHonorsLimit) {
 TEST(OpLogBatchStorageBackendErrorTest, PropagatesReadDurablePrefixError) {
     FakeHaKvBackend backend;
     backend.FailNextGet(ErrorCode::ETCD_OPERATION_ERROR);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
+              storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageBackendErrorTest,
+     PropagatesZeroPrefixValidationRangeError) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    backend.FailNextRange(ErrorCode::ETCD_OPERATION_ERROR);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
+              storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageBackendErrorTest,
+     PropagatesTerminalBatchReadErrorAtStartup) {
+    FakeHaKvBackend backend;
+    const std::string batch_key =
+        "/oplog/clusterA/batches/00000000000000000001";
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put(batch_key, EncodeOpLogBatchRecord(MakeBatch(1, 1, 1))));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
+    backend.FailNextGetForKey(batch_key, ErrorCode::ETCD_OPERATION_ERROR);
     OpLogBatchStorage storage("clusterA", backend);
 
     DurablePrefix prefix;

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -8,7 +8,6 @@
 #ifdef STORE_USE_ETCD
 #include "etcd_helper.h"
 #include "ha/kv/etcd_ha_kv_backend.h"
-#include "ha/oplog/oplog_batch_codec.h"
 #include "ha/oplog/oplog_batch_storage.h"
 #endif
 
@@ -773,7 +772,7 @@ TEST_F(SnapshotChildProcessTest,
     const std::string cluster_id =
         "snapshot-batch-boundary-" + UuidToString(generate_uuid());
     constexpr ViewVersionId kViewVersion = 19;
-    constexpr uint64_t kBatchLatest = 77;
+    constexpr uint64_t kBatchLatest = 1;
 
     auto backend = std::make_shared<EtcdHaKvBackend>();
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -783,10 +782,14 @@ TEST_F(SnapshotChildProcessTest,
         GTEST_SKIP() << "failed to initialize batch durable prefix: "
                      << toString(init_err);
     }
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id),
-                           EncodeDurablePrefix(
-                               {.batch_id = 3, .last_seq = kBatchLatest})));
+    OpLogBatchRecord batch{.batch_id = 1,
+                           .first_seq = kBatchLatest,
+                           .last_seq = kBatchLatest,
+                           .entries = {{.sequence_id = kBatchLatest,
+                                        .op_type = OpType::PUT_END,
+                                        .object_key = "snapshot-boundary",
+                                        .payload = {}}}};
+    ASSERT_EQ(ErrorCode::OK, storage.WriteBatchAndAdvancePrefix(batch, prefix));
 
     const std::string snapshot_id = "20240601_120000_789";
     CreateBatchEtcdHASnapshotService(cluster_id, etcd_endpoints, kViewVersion);


### PR DESCRIPTION
## Description

Validate the durable oplog prefix when `OpLogBatchStorage` starts, so inconsistent or corrupted metadata is rejected before recovery proceeds.

This PR:

- requires `batch_id` and `last_seq` to be either both zero or both nonzero;
- requires an empty batch namespace when the durable prefix is `{0, 0}`;
- verifies that a nonzero prefix references an existing, decodable terminal batch;
- verifies that the terminal batch ID and `last_seq` match the durable prefix;
- applies the same validation after losing the prefix initialization CAS race;
- propagates backend `Get` and `Range` errors without converting them into corruption errors;
- rejects batch records whose payload ID does not match the requested storage key.

The validation is intentionally limited to the durable-prefix boundary. It does not scan historical batches or repair inconsistent metadata.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added unit tests covering valid prefixes, inconsistent zero fields, missing or corrupted terminal batches, ID and sequence mismatches, CAS races, and backend error propagation.

**Test commands:**

```bash
env LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/oplog_batch_storage_test

env LSAN_OPTIONS=detect_leaks=0 \
  ctest --test-dir build \
  -R '^oplog_batch_storage_test$' \
  --output-on-failure

pre-commit run --files \
  mooncake-store/include/ha/oplog/oplog_batch_storage.h \
  mooncake-store/src/ha/oplog/oplog_batch_storage.cpp \
  mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
```

**Test results:**

- [x] Unit tests pass (34/34)
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (not applicable; no user-facing behavior changed)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with the design, implementation, test coverage, and verification. The human submitter reviewed the final changes and is responsible for the submitted code.