### PR TITLE
[Store] Add exponential backoff for ordered oplog writer retries

### DIFF
--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -286,6 +286,10 @@ void OrderedOpLogWriter::Start() {
                 batch.entries.push_back(std::move(entry.entry));
             }
 
+            constexpr auto kInitialRetryDelay = std::chrono::milliseconds(1);
+            constexpr auto kMaxRetryDelay = std::chrono::milliseconds(1000);
+            auto retry_delay = kInitialRetryDelay;
+
             while (true) {
                 TestFailPoint::Wait("batch_before_txn");
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
@@ -348,17 +352,20 @@ void OrderedOpLogWriter::Start() {
                 }
 
                 {
-                    std::lock_guard<std::mutex> lock(impl_->mutex);
+                    std::unique_lock<std::mutex> lock(impl_->mutex);
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS
                     HAMetricManager::instance().inc_batch_record_retries();
 #endif
                     impl_->last_error = err;
                     impl_->accepting = false;
-                    if (impl_->stop_requested) {
+                    if (impl_->stop_requested ||
+                        impl_->cv.wait_for(lock, retry_delay, [this] {
+                            return impl_->stop_requested;
+                        })) {
                         return;
                     }
                 }
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                retry_delay = std::min(retry_delay * 2, kMaxRetryDelay);
             }
         }
     });

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -765,6 +765,102 @@ TEST(OrderedOpLogWriterFailureTest, RetriesSameBatchUntilSuccess) {
     writer.Stop();
 }
 
+TEST(OrderedOpLogWriterFailureTest, RetryBackoffGrowsAndCaps) {
+    using namespace std::chrono_literals;
+
+    FakeBatchWriter storage;
+    OrderedOpLogWriter writer(
+        OrderedOpLogWriterConfig{.max_entries_per_batch = 2},
+        [&](const OpLogBatchRecord& batch,
+            const DurablePrefix& expected_prefix) {
+            return storage.Write(batch, expected_prefix);
+        });
+    writer.Start();
+
+    storage.FailNextWrites(12, ErrorCode::PERSISTENT_FAIL);
+    auto reservation = writer.Reserve();
+    ASSERT_TRUE(reservation.has_value());
+    ASSERT_TRUE(writer
+                    .Commit(std::move(*reservation), MakeEntry("k1"),
+                            [](const auto&) {})
+                    .has_value());
+
+    ASSERT_TRUE(storage.WaitForAttempts(13));
+    const auto attempts = storage.AttemptTimes();
+    ASSERT_GE(attempts.size(), 13u);
+    EXPECT_GE(attempts[9] - attempts[0], 400ms);
+    EXPECT_GE(attempts[11] - attempts[10], 800ms);
+    EXPECT_LT(attempts[12] - attempts[11], 1500ms);
+    writer.Stop();
+}
+
+TEST(OrderedOpLogWriterFailureTest, RetryBackoffResetsAfterSuccess) {
+    using namespace std::chrono_literals;
+
+    FakeBatchWriter storage;
+    OrderedOpLogWriter writer(
+        OrderedOpLogWriterConfig{.max_entries_per_batch = 2},
+        [&](const OpLogBatchRecord& batch,
+            const DurablePrefix& expected_prefix) {
+            return storage.Write(batch, expected_prefix);
+        });
+    writer.Start();
+
+    auto first = writer.Reserve();
+    auto second = writer.Reserve();
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(second.has_value());
+
+    storage.FailNextWrites(10, ErrorCode::PERSISTENT_FAIL);
+    ASSERT_TRUE(
+        writer.Commit(std::move(*first), MakeEntry("k1"), [](const auto&) {})
+            .has_value());
+    ASSERT_TRUE(storage.WaitForWrites(1, 5s));
+    const auto first_batch_attempts = storage.AttemptTimes();
+    ASSERT_GE(first_batch_attempts.size(), 11u);
+    EXPECT_GE(first_batch_attempts[9] - first_batch_attempts[0], 400ms);
+
+    storage.FailNextWrites(1, ErrorCode::PERSISTENT_FAIL);
+    ASSERT_TRUE(
+        writer.Commit(std::move(*second), MakeEntry("k2"), [](const auto&) {})
+            .has_value());
+    ASSERT_TRUE(storage.WaitForAttempts(13));
+
+    const auto attempts = storage.AttemptTimes();
+    ASSERT_GE(attempts.size(), 13u);
+    EXPECT_LT(attempts[12] - attempts[11], 250ms);
+    writer.Stop();
+}
+
+TEST(OrderedOpLogWriterFailureTest, StopInterruptsRetryBackoff) {
+    using namespace std::chrono_literals;
+
+    FakeBatchWriter storage;
+    OrderedOpLogWriter writer(
+        OrderedOpLogWriterConfig{.max_entries_per_batch = 1},
+        [&](const OpLogBatchRecord& batch,
+            const DurablePrefix& expected_prefix) {
+            return storage.Write(batch, expected_prefix);
+        });
+    writer.Start();
+
+    storage.FailNextWrites(100000, ErrorCode::PERSISTENT_FAIL);
+    auto reservation = writer.Reserve();
+    ASSERT_TRUE(reservation.has_value());
+    ASSERT_TRUE(writer
+                    .Commit(std::move(*reservation), MakeEntry("k1"),
+                            [](const auto&) {})
+                    .has_value());
+    ASSERT_TRUE(storage.WaitForAttempts(11));
+    const auto attempts = storage.AttemptTimes();
+    ASSERT_GE(attempts.size(), 11u);
+    EXPECT_GE(attempts[10] - attempts[0], 800ms);
+
+    const auto started_at = FakeBatchWriter::Clock::now();
+    writer.Stop();
+    EXPECT_LT(FakeBatchWriter::Clock::now() - started_at, 250ms);
+}
+
 TEST(OrderedOpLogWriterFailureTest, SuccessAfterRetryRestoresAccepting) {
     FakeBatchWriter storage;
     OrderedOpLogWriter writer(

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -20,9 +20,13 @@ namespace {
 
 class FakeBatchWriter {
    public:
+    using Clock = std::chrono::steady_clock;
+
     ErrorCode Write(const OpLogBatchRecord& batch,
                     const DurablePrefix& expected_prefix) {
         std::unique_lock<std::mutex> lock(mutex_);
+        attempt_times_.push_back(Clock::now());
+        attempt_cv_.notify_all();
         while (blocked_) {
             blocked_write_active_ = true;
             blocked_cv_.notify_all();
@@ -58,6 +62,18 @@ class FakeBatchWriter {
         std::unique_lock<std::mutex> lock(mutex_);
         return cv_.wait_for(lock, timeout,
                             [&] { return writes_.size() >= count; });
+    }
+
+    bool WaitForAttempts(size_t count, std::chrono::milliseconds timeout =
+                                           std::chrono::milliseconds(5000)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return attempt_cv_.wait_for(
+            lock, timeout, [&] { return attempt_times_.size() >= count; });
+    }
+
+    std::vector<Clock::time_point> AttemptTimes() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return attempt_times_;
     }
 
     void FailNextWrite(ErrorCode err) {
@@ -100,8 +116,10 @@ class FakeBatchWriter {
 
     mutable std::mutex mutex_;
     std::condition_variable cv_;
+    std::condition_variable attempt_cv_;
     std::condition_variable blocked_cv_;
     std::vector<WriteRecord> writes_;
+    std::vector<Clock::time_point> attempt_times_;
     ErrorCode next_error_{ErrorCode::OK};
     ErrorCode repeated_error_{ErrorCode::OK};
     size_t failures_remaining_{0};


### PR DESCRIPTION
## Description

Replace the fixed 1 ms retry interval in `OrderedOpLogWriter` with per-batch exponential backoff.

The retry delay starts at 1 ms, doubles after each failed write, and is capped at 1 second. A successful write resets the delay for the next batch. `Stop()` can interrupt an active backoff immediately through the existing condition variable.

This change preserves the current retryable error set, batch ordering, durable-prefix handling, and callback behavior. Error classification, retry deadlines, and terminal-state handling are intentionally left out of scope.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added unit tests covering:

- Exponential growth and the 1-second backoff cap
- Backoff reset after a successful batch
- Immediate interruption of a long backoff by `Stop()`
- Existing retry, ordering, and callback behavior

**Test commands:**

```bash
cmake --build build --target ordered_oplog_writer_test -j32
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/ordered_oplog_writer_test
pre-commit run --files \
  mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp \
  mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
```

**Test results:**

- [x] Unit tests pass (`31/31`)
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (not applicable; no user-facing API change)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with implementation, test development, and PR drafting. I reviewed the changes and test results and am responsible for the submitted code.