### PR TITLE
[Store] Scope capacity metric release to the serving MasterService

### DIFF
--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -452,12 +452,16 @@ class SegmentManager {
         : memory_allocator_(memory_allocator), enable_cxl_(enable_cxl) {}
 
     /**
-     * @brief Destructor. Releases the capacity metric contribution of
-     *        segments that are still mounted, since MasterMetricManager
-     *        outlives MasterService instances (e.g. across HA leadership
-     *        changes).
+     * @brief Releases the capacity metric contribution of segments that
+     *        are still mounted. Intended to be called when the owning
+     *        MasterService is torn down: MasterMetricManager outlives
+     *        MasterService instances (e.g. across HA leadership changes).
+     *        This is deliberately not done in the destructor, because other
+     *        SegmentManager instances (such as the temporary snapshot
+     *        readers) hold deserialized records that never contributed to
+     *        the metrics and must not release them.
      */
-    ~SegmentManager();
+    void releaseCapacityMetrics();
 
     /**
      * @brief Get RAII-style access to segment management operations

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -586,6 +586,12 @@ MasterService::~MasterService() {
         MasterMetricManager::instance().dec_allocated_mem_size(
             segment, static_cast<int64_t>(bytes));
     }
+
+    // Segments still mounted here never went through CommitUnmountSegment;
+    // release their capacity contribution so the process-lifetime
+    // MasterMetricManager stays consistent when the next leadership term
+    // constructs a fresh MasterService and the clients remount.
+    segment_manager_.releaseCapacityMetrics();
 }
 
 ErrorCode MasterService::SetBatchOpLogBackendForTesting(

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1557,13 +1557,13 @@ void NoFSegmentManager::GetMountedSegmentsSnapshot(
     }
 }
 
-SegmentManager::~SegmentManager() {
+void SegmentManager::releaseCapacityMetrics() {
     // Segments that are still mounted here never went through
     // CommitUnmountSegment, so their contribution to the capacity metrics
     // has not been released. MasterMetricManager outlives MasterService
-    // instances (a new one is constructed per HA leadership term), so
-    // release it here to keep the gauges consistent with the segments
-    // that are actually mounted.
+    // instances (a new one is constructed per HA leadership term), so the
+    // serving instance releases it at teardown to keep the gauges
+    // consistent with the segments that are actually mounted.
     for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
         const auto& segment = mounted_segment.segment;
         if (segment.protocol == "cxl") {

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -13,6 +13,7 @@
 #include "utils.h"
 #include "master_admin_service.h"
 #include "master_service.h"
+#include "segment.h"
 #include "rpc_service.h"
 #include "types.h"
 #include "master_config.h"
@@ -297,6 +298,54 @@ TEST_F(MasterMetricsTest, ServiceTeardownReleasesSegmentCapacity) {
     // when a master loses leadership) must release the segment's capacity
     // contribution; MasterMetricManager outlives the service instance.
     ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+}
+
+TEST_F(MasterMetricsTest, SnapshotReaderTeardownKeepsCapacityIntact) {
+    auto& metrics = MasterMetricManager::instance();
+
+    // Mount a segment through the accounted path so the gauge is non-zero.
+    SegmentManager source_manager(BufferAllocatorType::OFFSET);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "snapshot_reader_segment";
+    segment.base = 0x300000000;
+    segment.size = 1024 * 1024 * 16;
+    UUID client_id = generate_uuid();
+    ASSERT_EQ(
+        source_manager.getSegmentAccess().MountSegment(segment, client_id),
+        ErrorCode::OK);
+    const int64_t capacity_after_mount = metrics.get_total_mem_capacity();
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
+              static_cast<int64_t>(segment.size));
+
+    auto snapshot = SegmentSerializer(&source_manager).Serialize();
+    ASSERT_TRUE(snapshot.has_value());
+
+    {
+        // Deserialize into a temporary reader (as
+        // CatalogBackedSnapshotProvider does). The reader's records never
+        // contributed to the capacity metrics, so destroying it must leave
+        // the gauges untouched.
+        SegmentManager reader(BufferAllocatorType::OFFSET);
+        SegmentSerializer reader_serializer(&reader);
+        ASSERT_TRUE(
+            reader_serializer.Deserialize(snapshot.value()).has_value());
+    }
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_after_mount);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
+              static_cast<int64_t>(segment.size));
+
+    // Unmount to restore the gauges for the other tests.
+    {
+        auto access = source_manager.getSegmentAccess();
+        size_t dec_capacity = 0;
+        ASSERT_EQ(access.PrepareUnmountSegment(segment.id, dec_capacity),
+                  ErrorCode::OK);
+        ASSERT_EQ(
+            access.CommitUnmountSegment(segment.id, client_id, dec_capacity),
+            ErrorCode::OK);
+    }
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
 }
 


### PR DESCRIPTION
Follow-up to #3154, addressing the snapshot-reader lifecycle issue raised in https://github.com/kvcache-ai/Mooncake/pull/3154#issuecomment-5101860445.

## Problem

#3154 released mounted segments' `total_mem_capacity` contribution in `~SegmentManager`. However, `CatalogBackedSnapshotProvider` creates a temporary `SegmentManager` and populates `mounted_segments_` via `SegmentSerializer::Deserialize`, which inserts records directly without going through `MountSegment` — those records never incremented the gauge. Destroying the temporary reader therefore decrements capacity that was never added, leaving the gauge below the capacity actually accounted by the serving service (or negative on a standby with snapshot restore enabled).

## Fix

Move the release from `~SegmentManager` to the end of `~MasterService`, next to the existing `standby_accounted_memory_bytes_` cleanup, exposed as `SegmentManager::releaseCapacityMetrics()`. Only the serving instance releases its contribution; standalone and deserialized managers leave the gauges untouched.

The CXL `initializeCxlAllocator()` contribution discussed in the same comment is intentionally left for a separate follow-up.

## Testing

Added `MasterMetricsTest.SnapshotReaderTeardownKeepsCapacityIntact`: serializes a manager with an accounted mount, deserializes into a temporary `SegmentManager`, destroys it, and asserts the gauges are unchanged. The existing `ServiceTeardownReleasesSegmentCapacity` still covers the leadership-change leak. `master_metrics_test`, `segment_test`, `master_service_test`, and `serializer_test` pass locally.