### PR TITLE
[Store] Fix segment capacity metric ownership

### DIFF
--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -3,6 +3,7 @@
 #include <boost/functional/hash.hpp>
 #include <chrono>
 #include <map>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <shared_mutex>
@@ -55,6 +56,10 @@ struct MountedSegment {
     Segment segment;
     SegmentStatus status;
     std::shared_ptr<BufferAllocatorBase> buf_allocator;
+    // Runtime-only ownership marker. Snapshot deserialization reconstructs
+    // segment state without registering capacity metrics, so this field is
+    // deliberately not serialized.
+    bool capacity_metric_accounted{false};
 };
 
 struct MountedNoFSegment {
@@ -152,6 +157,11 @@ class ScopedSegmentAccess {
                                      const UUID& client_id) const;
 
     bool GetSegment(const UUID& segment_id, Segment& segment) const;
+
+    /**
+     * @brief Register the capacity metric for an already-restored segment.
+     */
+    ErrorCode AccountSegmentCapacityMetric(const UUID& segment_id);
 
     struct AllocatorReplacement {
         UUID segment_id;
@@ -452,10 +462,10 @@ class SegmentManager {
         : memory_allocator_(memory_allocator), enable_cxl_(enable_cxl) {}
 
     /**
-     * @brief Destructor. Releases the capacity metric contribution of
-     *        segments that are still mounted, since MasterMetricManager
-     *        outlives MasterService instances (e.g. across HA leadership
-     *        changes).
+     * @brief Releases any capacity metric contributions still owned by this
+     *        manager. MasterService stops and joins its threads in its
+     *        destructor body before member destruction reaches this manager.
+     *        This also covers partial construction and standalone use.
      */
     ~SegmentManager();
 
@@ -500,6 +510,11 @@ class SegmentManager {
     // Used for unified allocation and recycling of CXL shared memory.
     const bool enable_cxl_;
     std::shared_ptr<BufferAllocatorBase> cxl_global_allocator_;
+    struct CapacityMetricContribution {
+        std::string segment_name;
+        int64_t bytes;
+    };
+    std::optional<CapacityMetricContribution> cxl_capacity_metric_contribution_;
     // allocator_manager_ only contains allocators whose segment status is OK.
     AllocatorManager allocator_manager_;
     std::unordered_map<UUID, MountedSegment, boost::hash<UUID>>
@@ -515,6 +530,12 @@ class SegmentManager {
     std::unordered_map<UUID, std::shared_ptr<LocalDiskSegment>,
                        boost::hash<UUID>>
         client_local_disk_segment_;  // client_id -> local_disk_segment
+
+    void AccountSegmentCapacityMetricLocked(MountedSegment& mounted_segment);
+    void ReleaseSegmentCapacityMetricLocked(MountedSegment& mounted_segment);
+    void ReleaseMountedCapacityMetricContributions();
+    void ReleaseMountedCapacityMetricContributionsLocked();
+    void ReleaseMetricContributions();
 
     friend class ScopedSegmentAccess;
     friend class SegmentTest;        // for unit tests

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7637,8 +7637,14 @@ tl::expected<void, SerializationError> MasterService::ApplySnapshotState(
             for (const auto& [segment, client_id] : all_segments) {
                 Ping(client_id);
                 total_size += static_cast<int64_t>(segment.size);
-                MasterMetricManager::instance().inc_total_mem_capacity(
-                    segment.name, segment.size);
+                auto account_err =
+                    segment_access.AccountSegmentCapacityMetric(segment.id);
+                if (account_err != ErrorCode::OK) {
+                    LOG(ERROR)
+                        << "[Restore] Failed to account segment capacity, "
+                        << "segment_name=" << segment.name
+                        << ", error=" << account_err;
+                }
             }
             LOG(INFO) << "[Restore] Total capacity size after restore: "
                       << total_size;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -214,7 +214,8 @@ ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
     segment_manager_->client_by_name_[segment.name] = client_id;
     segment_manager_->segment_id_by_name_[segment.name] = segment.id;
     AddHostSegment(segment_manager_->segments_by_host_, segment);
-    MasterMetricManager::instance().inc_total_mem_capacity(segment.name, size);
+    segment_manager_->AccountSegmentCapacityMetricLocked(
+        segment_manager_->mounted_segments_.at(segment.id));
 
     return ErrorCode::OK;
 }
@@ -298,6 +299,16 @@ bool ScopedSegmentAccess::GetSegment(const UUID& segment_id,
     }
     segment = mounted->second.segment;
     return true;
+}
+
+ErrorCode ScopedSegmentAccess::AccountSegmentCapacityMetric(
+    const UUID& segment_id) {
+    auto mounted = segment_manager_->mounted_segments_.find(segment_id);
+    if (mounted == segment_manager_->mounted_segments_.end()) {
+        return ErrorCode::SEGMENT_NOT_FOUND;
+    }
+    segment_manager_->AccountSegmentCapacityMetricLocked(mounted->second);
+    return ErrorCode::OK;
 }
 
 bool ScopedSegmentAccess::ReplaceAllocators(
@@ -440,7 +451,6 @@ ErrorCode ScopedSegmentAccess::CommitUnmountSegment(
 
     // segment_id -> segment_name
     std::string segment_name;
-    bool is_cxl = false;
     auto&& segment = segment_manager_->mounted_segments_.find(segment_id);
     if (segment != segment_manager_->mounted_segments_.end()) {
         segment_name = segment->second.segment.name;
@@ -454,16 +464,17 @@ ErrorCode ScopedSegmentAccess::CommitUnmountSegment(
             segment_manager_->segment_id_by_name_.erase(segment_id_by_name_it);
             segment_manager_->client_by_name_.erase(segment_name);
         }
-        is_cxl = (segment->second.segment.protocol == "cxl");
+        if (segment->second.capacity_metric_accounted &&
+            segment->second.segment.size != metrics_dec_capacity) {
+            LOG(WARNING) << "segment_id=" << segment_id
+                         << ", warn=capacity_metric_size_mismatch"
+                         << ", accounted_size=" << segment->second.segment.size
+                         << ", prepared_size=" << metrics_dec_capacity;
+        }
+        segment_manager_->ReleaseSegmentCapacityMetricLocked(segment->second);
     }
     // Remove from mounted_segments_
     segment_manager_->mounted_segments_.erase(segment_id);
-
-    // Decrease the total capacity
-    if (!is_cxl) {
-        MasterMetricManager::instance().dec_total_mem_capacity(
-            segment_name, metrics_dec_capacity);
-    }
 
     return ErrorCode::OK;
 }
@@ -822,6 +833,10 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
             ErrorCode::DESERIALIZE_FAIL,
             "deserialize SegmentManager segment_manager is null"));
     }
+
+    // Clear any live metric ownership before replacing the in-memory state.
+    // Deserialized entries themselves do not own metric contributions.
+    segment_manager_->ReleaseMountedCapacityMetricContributions();
 
     // Clear existing data
     segment_manager_->mounted_segments_.clear();
@@ -1183,6 +1198,7 @@ tl::expected<void, SerializationError> SegmentSerializer::Deserialize(
 }
 
 void SegmentSerializer::Reset() {
+    segment_manager_->ReleaseMountedCapacityMetricContributions();
     segment_manager_->mounted_segments_.clear();
     segment_manager_->client_segments_.clear();
     segment_manager_->client_by_name_.clear();
@@ -1557,21 +1573,50 @@ void NoFSegmentManager::GetMountedSegmentsSnapshot(
     }
 }
 
-SegmentManager::~SegmentManager() {
-    // Segments that are still mounted here never went through
-    // CommitUnmountSegment, so their contribution to the capacity metrics
-    // has not been released. MasterMetricManager outlives MasterService
-    // instances (a new one is constructed per HA leadership term), so
-    // release it here to keep the gauges consistent with the segments
-    // that are actually mounted.
-    for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
-        const auto& segment = mounted_segment.segment;
-        if (segment.protocol == "cxl") {
-            // CXL mounts do not contribute to total_mem_capacity.
-            continue;
-        }
-        MasterMetricManager::instance().dec_total_mem_capacity(segment.name,
-                                                               segment.size);
+SegmentManager::~SegmentManager() { ReleaseMetricContributions(); }
+
+void SegmentManager::AccountSegmentCapacityMetricLocked(
+    MountedSegment& mounted_segment) {
+    if (mounted_segment.capacity_metric_accounted ||
+        (enable_cxl_ && mounted_segment.segment.protocol == "cxl")) {
+        return;
+    }
+    MasterMetricManager::instance().inc_total_mem_capacity(
+        mounted_segment.segment.name,
+        static_cast<int64_t>(mounted_segment.segment.size));
+    mounted_segment.capacity_metric_accounted = true;
+}
+
+void SegmentManager::ReleaseSegmentCapacityMetricLocked(
+    MountedSegment& mounted_segment) {
+    if (!mounted_segment.capacity_metric_accounted) {
+        return;
+    }
+    MasterMetricManager::instance().dec_total_mem_capacity(
+        mounted_segment.segment.name,
+        static_cast<int64_t>(mounted_segment.segment.size));
+    mounted_segment.capacity_metric_accounted = false;
+}
+
+void SegmentManager::ReleaseMountedCapacityMetricContributionsLocked() {
+    for (auto& entry : mounted_segments_) {
+        ReleaseSegmentCapacityMetricLocked(entry.second);
+    }
+}
+
+void SegmentManager::ReleaseMountedCapacityMetricContributions() {
+    std::unique_lock<std::shared_mutex> lock(segment_mutex_);
+    ReleaseMountedCapacityMetricContributionsLocked();
+}
+
+void SegmentManager::ReleaseMetricContributions() {
+    std::unique_lock<std::shared_mutex> lock(segment_mutex_);
+    ReleaseMountedCapacityMetricContributionsLocked();
+    if (cxl_capacity_metric_contribution_) {
+        MasterMetricManager::instance().dec_total_mem_capacity(
+            cxl_capacity_metric_contribution_->segment_name,
+            cxl_capacity_metric_contribution_->bytes);
+        cxl_capacity_metric_contribution_.reset();
     }
 }
 
@@ -1586,7 +1631,10 @@ void SegmentManager::initializeCxlAllocator(const std::string& cxl_path,
 
     cxl_global_allocator_ = std::make_shared<CachelibBufferAllocator>(
         cxl_path, DEFAULT_CXL_BASE, cxl_size, cxl_path);
-    MasterMetricManager::instance().inc_total_mem_capacity(cxl_path, cxl_size);
+    MasterMetricManager::instance().inc_total_mem_capacity(
+        cxl_path, static_cast<int64_t>(cxl_size));
+    cxl_capacity_metric_contribution_ =
+        CapacityMetricContribution{cxl_path, static_cast<int64_t>(cxl_size)};
 }
 
 int64_t ScopedLocalDiskSegmentAccess::getSsdTotalCapacity(

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -300,6 +300,93 @@ TEST_F(MasterMetricsTest, ServiceTeardownReleasesSegmentCapacity) {
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
 }
 
+TEST_F(MasterMetricsTest, SegmentManagerDestructorReleasesOwnedCapacity) {
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t capacity_before = metrics.get_total_mem_capacity();
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "segment_manager_destructor_test_segment";
+    segment.base = 0x310000000;
+    segment.size = 1024 * 1024 * 16;
+
+    {
+        SegmentManager manager(BufferAllocatorType::OFFSET);
+        auto access = manager.getSegmentAccess();
+        ASSERT_EQ(access.MountSegment(segment, generate_uuid()), ErrorCode::OK);
+        ASSERT_EQ(metrics.get_total_mem_capacity(),
+                  capacity_before + static_cast<int64_t>(segment.size));
+    }
+
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+}
+
+TEST_F(MasterMetricsTest, CxlProtocolUsesRegularAccountingWhenCxlIsDisabled) {
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t capacity_before = metrics.get_total_mem_capacity();
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "disabled_cxl_accounting_test_segment";
+    segment.base = 0x320000000;
+    segment.size = 1024 * 1024 * 16;
+    segment.protocol = "cxl";
+
+    {
+        SegmentManager manager(BufferAllocatorType::OFFSET, false);
+        auto access = manager.getSegmentAccess();
+        ASSERT_EQ(access.MountSegment(segment, generate_uuid()), ErrorCode::OK);
+        ASSERT_EQ(metrics.get_total_mem_capacity(),
+                  capacity_before + static_cast<int64_t>(segment.size));
+        ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
+                  static_cast<int64_t>(segment.size));
+    }
+
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+}
+
+TEST_F(MasterMetricsTest,
+       SnapshotDeserializationDoesNotOwnSegmentCapacityMetrics) {
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t capacity_before = metrics.get_total_mem_capacity();
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "snapshot_metric_ownership_test_segment";
+    segment.base = 0x310000000;
+    segment.size = 1024 * 1024 * 16;
+    const UUID client_id = generate_uuid();
+
+    std::vector<uint8_t> serialized;
+    {
+        SegmentManager source(BufferAllocatorType::OFFSET);
+        {
+            auto access = source.getSegmentAccess();
+            ASSERT_EQ(access.MountSegment(segment, client_id), ErrorCode::OK);
+        }
+        SegmentSerializer serializer(&source);
+        auto result = serializer.Serialize();
+        ASSERT_TRUE(result.has_value()) << result.error().message;
+        serialized = std::move(result.value());
+    }
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+
+    {
+        SegmentManager restored(BufferAllocatorType::OFFSET);
+        SegmentSerializer serializer(&restored);
+        auto result = serializer.Deserialize(serialized);
+        ASSERT_TRUE(result.has_value()) << result.error().message;
+
+        // Destroying a deserialized container is a no-op for capacity metrics
+        // because deserialization did not register any contributions.
+    }
+    ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_before);
+    ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
+}
+
 TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     const uint64_t default_kv_lease_ttl = 100;
     auto& metrics = MasterMetricManager::instance();


### PR DESCRIPTION
## Description

Follow-up to #3154. The process-scoped master metrics outlive individual `MasterService` terms, but snapshot-deserialized `SegmentManager` instances do not own the capacity contributions represented by their restored segment metadata. Unconditionally reconciling every stored segment during destruction can therefore decrement capacity owned by another serving instance.

This change:

- records runtime ownership for each mounted segment capacity contribution;
- releases only owned contributions from `SegmentManager` destruction, after `MasterService` has joined its workers;
- explicitly assigns ownership when restored segments are activated by a serving master;
- tracks the shared global CXL allocator contribution separately from per-client CXL mounts; and
- preserves regular capacity accounting for `protocol == "cxl"` mounts when CXL mode is disabled.

This keeps memory-capacity gauges correct across HA leadership terms, constructor unwinding, normal unmounts, and snapshot-only `SegmentManager` lifecycles.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added regression coverage for service teardown, standalone `SegmentManager` destruction, snapshot-deserialized non-ownership, and CXL-protocol accounting when CXL mode is disabled.

**Test commands:**
```bash
clang-format --dry-run --Werror --lines=<changed-lines> <changed-file>
git diff --check
```

**Test results:**
- [ ] Unit tests pass — not run because CMake and an existing test binary are unavailable in the local environment
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: changed C++ ranges pass clang-format validation and the committed diff passes whitespace validation

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable (under 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex assisted with analyzing the metric ownership lifecycle, implementing the changes, adding tests, and reviewing the resulting diff. The human submitter remains responsible for reviewing and understanding every changed line before marking this PR ready for review.