### PR TITLE
[CI/Build] Align Asio with yalantinglibs target

### DIFF
--- a/mooncake-common/src/CMakeLists.txt
+++ b/mooncake-common/src/CMakeLists.txt
@@ -1,27 +1,5 @@
 find_package(yaml-cpp REQUIRED)
 
-find_package(asio QUIET)
-
-if(asio_FOUND)
-    message(STATUS "Found ASIO via find_package")
-    set(ASIO_INCLUDE_DIR ${asio_INCLUDE_DIR})
-else()
-    find_path(ASIO_INCLUDE_DIR
-        NAMES asio.hpp
-        PATHS
-            /usr/local/include
-            /usr/include
-            ${CMAKE_INSTALL_PREFIX}/include
-        DOC "Path to ASIO headers"
-    )
-
-    if(NOT ASIO_INCLUDE_DIR)
-        message(FATAL_ERROR "ASIO not found. Please install ASIO or set ASIO_INCLUDE_DIR manually.")
-    endif()
-
-    message(STATUS "Found ASIO at: ${ASIO_INCLUDE_DIR}")
-endif()
-
 set(MOONCAKE_COMMON_SOURCES
     default_config.cpp
     environ.cpp
@@ -35,11 +13,6 @@ target_compile_definitions(asio_shared
         ASIO_DYN_LINK
 )
 
-target_include_directories(asio_shared
-    PUBLIC
-        ${ASIO_INCLUDE_DIR}
-)
-
 set_target_properties(asio_shared PROPERTIES
     POSITION_INDEPENDENT_CODE ON
     INSTALL_RPATH "$ORIGIN"
@@ -48,7 +21,10 @@ set_target_properties(asio_shared PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/mooncake-common"
 )
 
-target_link_libraries(asio_shared PUBLIC pthread)
+target_link_libraries(asio_shared PUBLIC
+    pthread
+    yalantinglibs::yalantinglibs
+)
 
 add_library(mooncake_common
     ${MOONCAKE_COMMON_SOURCES}
@@ -62,6 +38,7 @@ target_include_directories(mooncake_common PUBLIC
 target_link_libraries(mooncake_common PUBLIC
     yaml-cpp
     jsoncpp
+    yalantinglibs::yalantinglibs
 )
 
 if (BUILD_SHARED_LIBS)


### PR DESCRIPTION
## What changed

- make `mooncake_common` publicly depend on `yalantinglibs::yalantinglibs`
- make `asio_shared` consume Asio through the same yalantinglibs target
- remove the independent system Asio lookup

## Why

`mooncake-common/include/default_config.h` publicly includes
`<ylt/easylog.hpp>`, but `mooncake_common` did not propagate the corresponding
CMake target. Builds could therefore succeed only because yalantinglibs happened
to be installed in a compiler-default include path.

There was also an ABI consistency issue: Transfer Engine targets already consume
Asio headers transitively through yalantinglibs, while `asio_shared` independently
selected a system Asio installation. If those header versions differ,
`libtransfer_engine.so` can request Asio symbols that the generated `libasio.so`
does not export. Using one CMake target for both sides keeps their compile-time
Asio ABI aligned.

## Validation

- configured Mooncake from the current `main` branch
- built `asio_shared`, `mooncake_common`, `transfer_engine`, and `engine`
- verified that the Asio symbol required by `libtransfer_engine.so` is exported
  by the generated `libasio.so`
- imported `TransferEngine` from the generated Python extension
- ran whitespace and diff checks on the changed file
