### PR TITLE
[CI] Fix nightly workflow: drop removed build-with-ep input

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -58,9 +58,8 @@ jobs:
       container: pytorch/manylinux2_28-builder:cuda12.8
       python-versions: '["3.10", "3.12"]'
       cuda: container
-      build-with-ep: '1'
       torch-cuda-arch-list: '8.0;9.0'
-      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1;2.13.0'
       build-nvlink-allocator: true
       cmake-args: >-
         -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON
@@ -91,10 +90,9 @@ jobs:
       container: pytorch/manylinux2_28-builder:cuda13.0
       python-versions: '["3.10", "3.12"]'
       cuda: container
-      build-with-ep: '1'
       variant-flag: CU13_BUILD
       torch-cuda-arch-list: '8.0;9.0'
-      ep-torch-versions: '2.11.0;2.12.0;2.12.1'
+      ep-torch-versions: '2.11.0;2.12.0;2.12.1;2.13.0'
       build-nvlink-allocator: true
       cmake-args: >-
         -DBUILD_UNIT_TESTS=OFF -DUSE_HTTP=ON -DUSE_ETCD=ON -DUSE_CUDA=ON


### PR DESCRIPTION
PR #3095 removed the build-with-ep workflow_call input from _build-wheel.yaml, but nightly.yml still passed it, which made the workflow file invalid. Align with release workflows by dropping the input and adding torch 2.13.0 to the EP matrix.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)