### PR TITLE
[TransferEngine] Allow idempotent duplicate memory registration

### DIFF
--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -1250,14 +1250,13 @@ TEST_F(RealClientTest, ErrBufferRegistrationErrors) {
         EXPECT_EQ(py_client_->register_buffer(buf, sizeof(buf)), 0)
             << "First registration should succeed";
 
-        // Second registration of the same memory
-        {
-            GLogMuter muter;
-            EXPECT_NE(py_client_->register_buffer(buf, sizeof(buf)), 0)
-                << "Duplicate registration of the same buffer should fail.";
-        }
+        EXPECT_EQ(py_client_->register_buffer(buf, sizeof(buf)), 0)
+            << "Duplicate registration of the same buffer should succeed "
+               "and increment the registration refcount.";
 
         // Cleanup
+        EXPECT_EQ(py_client_->unregister_buffer(buf), 0)
+            << "First unregistration should decrement the refcount";
         EXPECT_EQ(py_client_->unregister_buffer(buf), 0)
             << "Unregistration should succeed";
     }

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -401,6 +401,7 @@ class TransferEngineImpl {
         uint64_t length;
         std::string location;
         bool remote_accessible;
+        uint64_t ref_count = 1;
     };
 
     using MemoryRegionMap = std::map<uintptr_t, MemoryRegion>;
@@ -410,11 +411,17 @@ class TransferEngineImpl {
     bool hasOverlapInMapLocked(const MemoryRegionMap& regions, uintptr_t addr,
                                uint64_t length) const;
 
+    bool tryBumpLocalMemoryRegionRefs(
+        const std::vector<MemoryRegion>& regions);
+
     bool tryReserveMemoryRegions(const std::vector<MemoryRegion>& regions);
 
     void commitMemoryRegions(const std::vector<MemoryRegion>& regions);
 
     void releaseMemoryRegions(const std::vector<MemoryRegion>& regions);
+
+    std::vector<void*> releaseLocalMemoryRegionRefs(
+        const std::vector<void*>& addr_list);
 
     void insertMemoryRegionLocked(const MemoryRegion& region);
 

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -411,8 +411,7 @@ class TransferEngineImpl {
     bool hasOverlapInMapLocked(const MemoryRegionMap& regions, uintptr_t addr,
                                uint64_t length) const;
 
-    bool tryBumpLocalMemoryRegionRefs(
-        const std::vector<MemoryRegion>& regions);
+    bool tryBumpLocalMemoryRegionRefs(const std::vector<MemoryRegion>& regions);
 
     bool tryReserveMemoryRegions(const std::vector<MemoryRegion>& regions);
 

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -595,6 +595,10 @@ int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
 
     std::vector<MemoryRegion> regions = {
         {addr, length, location, remote_accessible}};
+    if (tryBumpLocalMemoryRegionRefs(regions)) {
+        return 0;
+    }
+
     if (!tryReserveMemoryRegions(regions)) {
         LOG(ERROR)
             << "Transfer Engine does not support overlapped memory region";
@@ -632,6 +636,11 @@ int TransferEngineImpl::registerLocalMemory(void* addr, size_t length,
 
 int TransferEngineImpl::unregisterLocalMemory(void* addr,
                                               bool update_metadata) {
+    auto addr_list = releaseLocalMemoryRegionRefs({addr});
+    if (addr_list.empty()) {
+        return 0;
+    }
+
     for (auto& transport : multi_transports_->listTransports()) {
         int ret = transport->unregisterLocalMemory(addr, update_metadata);
         if (ret) return ret;
@@ -799,6 +808,10 @@ int TransferEngineImpl::registerLocalMemoryBatch(
         regions.push_back({buffer.addr, buffer.length, location, true});
         addr_list.push_back(buffer.addr);
     }
+    if (tryBumpLocalMemoryRegionRefs(regions)) {
+        return 0;
+    }
+
     if (!tryReserveMemoryRegions(regions)) {
         LOG(ERROR)
             << "Transfer Engine does not support overlapped memory region";
@@ -831,15 +844,20 @@ int TransferEngineImpl::registerLocalMemoryBatch(
 
 int TransferEngineImpl::unregisterLocalMemoryBatch(
     const std::vector<void*>& addr_list) {
+    auto pending_addr_list = releaseLocalMemoryRegionRefs(addr_list);
+    if (pending_addr_list.empty()) {
+        return 0;
+    }
+
     int first_error = 0;
     for (auto transport : multi_transports_->listTransports()) {
-        int ret = transport->unregisterLocalMemoryBatch(addr_list);
+        int ret = transport->unregisterLocalMemoryBatch(pending_addr_list);
         if (ret && !first_error) first_error = ret;
     }
     if (first_error) return first_error;
 
     std::unique_lock<std::shared_mutex> lock(mutex_);
-    for (auto& addr : addr_list) {
+    for (auto& addr : pending_addr_list) {
         eraseMemoryRegionLocked(addr);
     }
     return 0;
@@ -874,6 +892,42 @@ bool TransferEngineImpl::hasOverlapInMapLocked(const MemoryRegionMap& regions,
     }
 
     return false;
+}
+
+bool TransferEngineImpl::tryBumpLocalMemoryRegionRefs(
+    const std::vector<MemoryRegion>& regions) {
+    if (regions.empty()) {
+        return false;
+    }
+
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+
+    for (const auto& region : regions) {
+        auto addr = reinterpret_cast<uintptr_t>(region.addr);
+        if (hasOverlapInMapLocked(registering_memory_regions_, addr,
+                                  region.length)) {
+            return false;
+        }
+
+        auto it = local_memory_regions_.find(addr);
+        if (it == local_memory_regions_.end()) {
+            return false;
+        }
+
+        auto& existing = it->second;
+        if (existing.length != region.length ||
+            existing.location != region.location ||
+            existing.remote_accessible != region.remote_accessible) {
+            return false;
+        }
+    }
+
+    for (const auto& region : regions) {
+        ++local_memory_regions_[reinterpret_cast<uintptr_t>(region.addr)]
+              .ref_count;
+    }
+
+    return true;
 }
 
 bool TransferEngineImpl::tryReserveMemoryRegions(
@@ -913,6 +967,24 @@ void TransferEngineImpl::releaseMemoryRegions(
         registering_memory_regions_.erase(
             reinterpret_cast<uintptr_t>(region.addr));
     }
+}
+
+std::vector<void*> TransferEngineImpl::releaseLocalMemoryRegionRefs(
+    const std::vector<void*>& addr_list) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::vector<void*> pending_addr_list;
+    pending_addr_list.reserve(addr_list.size());
+
+    for (auto addr : addr_list) {
+        auto it = local_memory_regions_.find(reinterpret_cast<uintptr_t>(addr));
+        if (it != local_memory_regions_.end() && it->second.ref_count > 1) {
+            --it->second.ref_count;
+        } else {
+            pending_addr_list.push_back(addr);
+        }
+    }
+
+    return pending_addr_list;
 }
 
 void TransferEngineImpl::insertMemoryRegionLocked(const MemoryRegion& region) {

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -187,6 +187,47 @@ class BlockingRegistrationTransport : public Transport {
     bool release_first_registration_ = false;
 };
 
+class CountingRegistrationTransport : public Transport {
+   public:
+    int registrationCalls() const { return registration_calls_; }
+    int unregisterCalls() const { return unregister_calls_; }
+
+    Status submitTransfer(BatchID,
+                          const std::vector<TransferRequest>&) override {
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID, size_t, TransferStatus&) override {
+        return Status::OK();
+    }
+
+   private:
+    int registerLocalMemory(void*, size_t, const std::string&, bool,
+                            bool) override {
+        ++registration_calls_;
+        return 0;
+    }
+
+    int unregisterLocalMemory(void*, bool) override {
+        ++unregister_calls_;
+        return 0;
+    }
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>&,
+                                 const std::string&) override {
+        return 0;
+    }
+
+    int unregisterLocalMemoryBatch(const std::vector<void*>&) override {
+        return 0;
+    }
+
+    const char* getName() const override { return "counting"; }
+
+    int registration_calls_ = 0;
+    int unregister_calls_ = 0;
+};
+
 class TransportTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -368,6 +409,50 @@ TEST_F(TransportTest, RegisterLocalMemoryBatchAllowsAdjacentBuffers) {
     };
 
     EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"), 0);
+}
+
+TEST_F(TransportTest, RegisterLocalMemoryAllowsIdempotentDuplicate) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<CountingRegistrationTransport>();
+    TransferEngineImplTestPeer::replaceTransports(engine, transport);
+
+    std::array<char, 128> buffer{};
+    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(),
+                                         "cpu:0"),
+              0);
+    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(),
+                                         "cpu:0"),
+              0);
+    EXPECT_EQ(transport->registrationCalls(), 1);
+
+    EXPECT_EQ(engine.unregisterLocalMemory(buffer.data()), 0);
+    EXPECT_EQ(transport->unregisterCalls(), 0);
+    EXPECT_EQ(engine.unregisterLocalMemory(buffer.data()), 0);
+    EXPECT_EQ(transport->unregisterCalls(), 1);
+}
+
+TEST_F(TransportTest, RegisterLocalMemoryBatchAllowsIdempotentDuplicate) {
+    TransferEngineImpl engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<BatchResultTransport>();
+    TransferEngineImplTestPeer::replaceTransports(engine, transport);
+
+    std::array<char, 2> buffer{};
+    std::vector<BufferEntry> entries = {
+        {buffer.data(), 1},
+        {buffer.data() + 1, 1},
+    };
+    std::vector<void*> addrs = {buffer.data(), buffer.data() + 1};
+
+    EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"), 0);
+    EXPECT_EQ(engine.registerLocalMemoryBatch(entries, "cpu:0"), 0);
+    EXPECT_EQ(transport->registeredBufferCount(), entries.size());
+
+    EXPECT_EQ(engine.unregisterLocalMemoryBatch(addrs), 0);
+    EXPECT_EQ(transport->unregisterBatchCalls(), 0);
+    EXPECT_EQ(engine.unregisterLocalMemoryBatch(addrs), 0);
+    EXPECT_EQ(transport->unregisterBatchCalls(), 1);
 }
 
 TEST_F(TransportTest, ConcurrentRegisterLocalMemoryRejectsOverlap) {

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -418,11 +418,9 @@ TEST_F(TransportTest, RegisterLocalMemoryAllowsIdempotentDuplicate) {
     TransferEngineImplTestPeer::replaceTransports(engine, transport);
 
     std::array<char, 128> buffer{};
-    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(),
-                                         "cpu:0"),
+    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(), "cpu:0"),
               0);
-    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(),
-                                         "cpu:0"),
+    EXPECT_EQ(engine.registerLocalMemory(buffer.data(), buffer.size(), "cpu:0"),
               0);
     EXPECT_EQ(transport->registrationCalls(), 1);
 


### PR DESCRIPTION
## Description

Fixes #3153.

Mooncake 0.3.12 added engine-level memory-region reservation to reject overlapping registrations, including in-flight duplicates. That also made already-completed byte-identical registrations fail with `ERR_ADDRESS_OVERLAPPED`, which breaks callers that register the same buffer through repeated init/reload/reconnect paths.

This PR allows completed duplicate registrations of the exact same region to be idempotent:

- `registerLocalMemory(addr, length, location, remote_accessible)` returns success when the same completed region is registered again.
- `registerLocalMemoryBatch(...)` returns success when the same completed batch regions are registered again.
- Duplicate completed registrations bump an engine-level ref count.
- Unregister only calls the transport when the final reference is released.
- True overlaps and in-flight duplicate registrations remain rejected.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target transport_uint_test -j4
build/mooncake-transfer-engine/tests/transport_uint_test --gtest_color=no
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`transport_uint_test` passes: 20/20 tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with implementation, test updates, and PR description preparation. The human submitter is responsible for reviewing and defending all changed lines.