### PR TITLE
[TE] fix(efa): bind a CUDA context before registering GPU memory

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -344,6 +344,50 @@ int EfaContext::deconstruct() {
     return 0;
 }
 
+#if defined(USE_CUDA)
+// Bind `device_ordinal`'s primary context to the calling thread if it has no
+// current context.
+//
+// fi_mr_regattr() on FI_HMEM_CUDA memory reaches libfabric's
+// cuda_get_dmabuf_fd() (hmem_cuda.c), which calls the *driver* API
+// cuMemGetHandleForAddressRange() with no context management of its own -- it
+// assumes the caller already has a current context.  A std::thread that has
+// only ever touched the runtime API has none, so the export returns
+// CUDA_ERROR_INVALID_CONTEXT.  libfabric then takes the no-fallback path
+// (efa_hmem.c never sets dmabuf_fallback_enabled for FI_HMEM_CUDA), reaches
+// efa_mr.c's `if (!errno) errno = ENOTSUP; return -errno;` and reports a bare
+// "Operation not supported" that names neither the real cause nor the thread.
+//
+// Two callers reach us on such a thread: registerLocalMemoryBatch() runs one
+// std::async(std::launch::async) per buffer, and registerLocalMemory() can fan
+// out one std::thread per NIC.  The failure is a race -- it only hits threads
+// that register before any CUDA call has bound a context on them -- so it looks
+// intermittent and scales with how many buffers are registered at once.  It is
+// not benign: registerLocalMemory() calls rollbackChunks() on error, so an
+// affected buffer ends up registered on *no* NIC, and the first KV transfer
+// that touches it fails with a misleading "remote mooncake session ... is not
+// alive". Observed on p6-b300 with a large hybrid-attention KV pool: 8 of ~1456
+// registrations failed, exactly one per rank, all of them the earliest
+// registrations in the process.
+//
+// cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
+// uses, so this binds the thread to the process's existing context rather than
+// creating a new one.  The retain is intentionally not released: the primary
+// context outlives every registration, and dropping the last reference here
+// would tear down the context the rest of the process is using.
+static void bindCudaContextIfNeeded(int device_ordinal) {
+    CUcontext cur = nullptr;
+    if (cuCtxGetCurrent(&cur) == CUDA_SUCCESS && cur != nullptr) return;
+
+    CUdevice dev;
+    if (cuDeviceGet(&dev, device_ordinal) != CUDA_SUCCESS) return;
+
+    CUcontext primary = nullptr;
+    if (cuDevicePrimaryCtxRetain(&primary, dev) != CUDA_SUCCESS) return;
+    cuCtxSetCurrent(primary);
+}
+#endif
+
 int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
                                              int access,
                                              EfaMemoryRegionMeta& mrMeta) {
@@ -388,6 +432,12 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
 
     int ret;
     if (iface != FI_HMEM_SYSTEM) {
+#if defined(USE_CUDA)
+        // Registering GPU memory needs a current CUDA context on this
+        // thread, and our callers may reach us on a freshly spawned one.
+        // See bindCudaContextIfNeeded().
+        bindCudaContextIfNeeded(device_ordinal);
+#endif
         // GPU memory: use fi_mr_regattr with explicit iface and device
         struct iovec iov = {.iov_base = addr, .iov_len = length};
         struct fi_mr_attr attr = {};

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -345,46 +345,63 @@ int EfaContext::deconstruct() {
 }
 
 #if defined(USE_CUDA)
-// Bind `device_ordinal`'s primary context to the calling thread if it has no
-// current context.
+// A silent failure here resurfaces as the provider's opaque "Operation not
+// supported" from fi_mr_regattr(), which is the attribution problem this whole
+// helper exists to remove -- so name the driver call that actually failed.
+static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
+    const char* err = nullptr;
+    cuGetErrorString(ret, &err);
+    LOG(WARNING) << "EFA: " << call << " failed for CUDA device "
+                 << device_ordinal << ": " << (err ? err : "unknown") << " ("
+                 << ret
+                 << "); GPU memory registration may fail with a bare"
+                    " \"Operation not supported\"";
+}
+
+// Make `device_ordinal`'s primary context current on the calling thread, unless
+// a context for that same device already is.
 //
-// fi_mr_regattr() on FI_HMEM_CUDA memory reaches libfabric's
-// cuda_get_dmabuf_fd() (hmem_cuda.c), which calls the *driver* API
-// cuMemGetHandleForAddressRange() with no context management of its own -- it
-// assumes the caller already has a current context.  A std::thread that has
-// only ever touched the runtime API has none, so the export returns
-// CUDA_ERROR_INVALID_CONTEXT.  libfabric then takes the no-fallback path
-// (efa_hmem.c never sets dmabuf_fallback_enabled for FI_HMEM_CUDA), reaches
-// efa_mr.c's `if (!errno) errno = ENOTSUP; return -errno;` and reports a bare
-// "Operation not supported" that names neither the real cause nor the thread.
+// Why a context is needed at all: fi_mr_regattr() on FI_HMEM_CUDA memory
+// reaches libfabric's cuda_get_dmabuf_fd(), which calls the driver API
+// cuMemGetHandleForAddressRange() and does no context management of its own.
+// The export also runs against the CURRENT context, so a context belonging to
+// another device is no better than none -- both end up as a bare "Operation not
+// supported" from the provider.
 //
-// Two callers reach us on such a thread: registerLocalMemoryBatch() runs one
-// std::async(std::launch::async) per buffer, and registerLocalMemory() can fan
-// out one std::thread per NIC.  The failure is a race -- it only hits threads
-// that register before any CUDA call has bound a context on them -- so it looks
-// intermittent and scales with how many buffers are registered at once.  It is
-// not benign: registerLocalMemory() calls rollbackChunks() on error, so an
-// affected buffer ends up registered on *no* NIC, and the first KV transfer
-// that touches it fails with a misleading "remote mooncake session ... is not
-// alive". Observed on p6-b300 with a large hybrid-attention KV pool: 8 of ~1456
-// registrations failed, exactly one per rank, all of them the earliest
-// registrations in the process.
+// Who arrives here without the right context: registerLocalMemoryBatch() runs
+// one std::async(std::launch::async) per buffer and registerLocalMemory() can
+// fan out one std::thread per NIC, so a registering thread may have touched no
+// CUDA API at all; and since std::async may reuse threads, one thread can
+// register buffers on several devices in turn.
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
-// uses, so this binds the thread to the process's existing context rather than
-// creating a new one.  The retain is intentionally not released: the primary
-// context outlives every registration, and dropping the last reference here
-// would tear down the context the rest of the process is using.
+// uses, so this attaches to the process's existing context rather than creating
+// another.  The retain is intentionally not released: the primary context
+// outlives every registration, and dropping the last reference here would tear
+// down the context the rest of the process is using.
 static void bindCudaContextIfNeeded(int device_ordinal) {
-    CUcontext cur = nullptr;
-    if (cuCtxGetCurrent(&cur) == CUDA_SUCCESS && cur != nullptr) return;
+    CUdevice want;
+    CUresult ret = cuDeviceGet(&want, device_ordinal);
+    if (ret != CUDA_SUCCESS) {
+        logCudaFailure("cuDeviceGet", ret, device_ordinal);
+        return;
+    }
 
-    CUdevice dev;
-    if (cuDeviceGet(&dev, device_ordinal) != CUDA_SUCCESS) return;
+    CUcontext cur = nullptr;
+    CUdevice cur_dev;
+    if (cuCtxGetCurrent(&cur) == CUDA_SUCCESS && cur != nullptr &&
+        cuCtxGetDevice(&cur_dev) == CUDA_SUCCESS && cur_dev == want)
+        return;
 
     CUcontext primary = nullptr;
-    if (cuDevicePrimaryCtxRetain(&primary, dev) != CUDA_SUCCESS) return;
-    cuCtxSetCurrent(primary);
+    ret = cuDevicePrimaryCtxRetain(&primary, want);
+    if (ret != CUDA_SUCCESS) {
+        logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal);
+        return;
+    }
+    ret = cuCtxSetCurrent(primary);
+    if (ret != CUDA_SUCCESS)
+        logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
 }
 #endif
 
@@ -433,9 +450,6 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int ret;
     if (iface != FI_HMEM_SYSTEM) {
 #if defined(USE_CUDA)
-        // Registering GPU memory needs a current CUDA context on this
-        // thread, and our callers may reach us on a freshly spawned one.
-        // See bindCudaContextIfNeeded().
         bindCudaContextIfNeeded(device_ordinal);
 #endif
         // GPU memory: use fi_mr_regattr with explicit iface and device


### PR DESCRIPTION
## Description

`fi_mr_regattr()` on `FI_HMEM_CUDA` memory intermittently fails with a bare `Operation not supported`, which leaves the buffer registered on **no NIC at all** because `registerLocalMemory()` calls `rollbackChunks()` on error. Startup and SGLang's PD warmup still pass, so the damage only surfaces later: the first KV transfer that touches such a buffer fails with the misleading `remote mooncake session ... is not alive`, which points the reader at the peer rather than at local registration.

```
efa_context.cpp  fi_mr_regattr failed for GPU memory 0x726d08000000 (device 3): Operation not supported
efa_transport.cpp Failed to register memory region chunk 0 with EFA context 0
```

### Root cause

A missing CUDA context on the registering thread — not an EFA capability limit.

libfabric's `cuda_get_dmabuf_fd()` (`src/hmem_cuda.c`) calls the **driver** API `cuMemGetHandleForAddressRange()` and does no context management of its own; it assumes the caller already has a current context. A thread that has only ever used the CUDA *runtime* API has none, so the dmabuf export returns `CUDA_ERROR_INVALID_CONTEXT`. The EFA provider has no dmabuf fallback for `FI_HMEM_CUDA` (`efa_hmem.c` never sets `dmabuf_fallback_enabled` on that branch), so it ends up at `efa_mr.c`:

```c
if (!errno) errno = ENOTSUP;
return -errno;
```

`ENOTSUP` renders as `Operation not supported`. That string is a catch-all which has already discarded the real cause, which is why this was hard to attribute.

Two callers reach `registerMemoryRegionInternal()` on such a thread:

- `registerLocalMemoryBatch()` — one `std::async(std::launch::async)` per buffer
- `registerLocalMemory()` — one `std::thread` per NIC when `parallel_reg_mr` is on

Because it is a race against whatever binds a context on that thread first, the failure looks intermittent and scales with how many buffers are registered at once. Frameworks registering a handful of buffers usually get lucky; a large KV pool does not.

### Fix

Before `fi_mr_regattr()` on device memory, make the buffer's device's primary context current on the calling thread. `cuDevicePrimaryCtxRetain()` returns the same context the CUDA runtime uses, so this attaches to the process's existing context rather than creating another one. The retain is deliberately not released — the primary context outlives every registration, and dropping the last reference here would tear down the context the rest of the process is using.

The check is by **device**, not merely by presence: the dmabuf export runs against the *current* context, and `std::async` may reuse a worker thread across buffers that live on different GPUs, so a context belonging to another device would otherwise be accepted. The helper resolves `device_ordinal` to a `CUdevice` and compares it against `cuCtxGetDevice()` of the current context, re-binding whenever they differ. Every driver-call failure is logged with the call name, the device ordinal and the decoded `cuGetErrorString()` text — a silent early return here would resurface as the provider's bare `Operation not supported`, i.e. exactly the attribution problem this helper exists to remove.

The fix sits in `EfaContext` rather than in the callers so that every registration path is covered.

### Why this only showed up on Kimi K3

The failure is a race that only hits threads which register *before* any CUDA call has bound a context on them, so its incidence scales with concurrent registration fan-out rather than with anything model-specific. K3's hybrid-attention KV pool registers ~1456 buffers per node and hit 8 failures — exactly one per rank, all of them the earliest registrations in the process. Smaller KV pools never reach that fan-out and so never lose a buffer, which is why no other model reproduced it.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Hardware: 2x AWS p6-b300 (8x B300 per node, 16 EFA NICs), libfabric 2.4.0amzn5.0, CUDA 13, SGLang PD disaggregation with a large hybrid-attention KV cache (~1456 GPU registrations per node).

**1. Minimal reproducer** — same buffer, same NIC, registered from threads that differ only in whether a CUDA context is current:

| caller | `cuCtxGetCurrent` | dmabuf export | `fi_mr_regattr` |
|---|---|---|---|
| main thread | non-null | ok | **0 (OK)** |
| fresh `std::thread` | **nil** | invalid device context | **-95 (ENOTSUP)** |
| fresh thread + `cudaSetDevice`+`cudaFree(0)` | non-null | ok | **0 (OK)** |
| fresh thread + `cuCtxSetCurrent` | non-null | ok | **0 (OK)** |

`-95` matches the production failure exactly.

**2. End-to-end PD disaggregation**, 1P1D, identical config before and after:

| | before | after |
|---|---|---|
| decode GPU registrations | 1448 ok / **8 failed** | **1456 ok / 0 failed** |
| prefill GPU registrations | 1456 ok / 0 failed | 1456 ok / 0 failed |
| KV transfer errors | `session ... is not alive` | **0** |
| single request | **fails in 6.9 s** | **succeeds in 2.9 s** |
| 8 sequential requests | — | **8 / 8 succeed** |

The 8 failures were exactly one per rank and were the earliest registrations in the process, consistent with the race described above. After the fix the count rises to 1456, i.e. precisely the previously-lost buffer per rank.

**3. Review follow-up validation** (device-aware bind + failure logging), on 2x AWS p5.48xlarge (8x H100, 32 EFA NICs, driver 595.71.05), CUDA build:

| check | result |
|---|---|
| build | clean, 0 errors |
| `dmabuf_export_test` | 8 / 8 pass |
| `efa_gpu_loopback_test` | 3 / 3 pass |
| `efa_transport_test` | 10 / 10 pass |
| `efa_c_api_test` | 4 / 4 pass |
| 8-GPU fan-out probe (192 buffers, each registered from a thread with no prior CUDA call) | **192 / 192 exports ok, 192 re-binds, 0 driver failures** |

One honest caveat on the cross-device case. A probe reproducing it directly — one reused thread registering a device-0 buffer and then a device-3 buffer, instrumented to print which device the current context belongs to — confirms the **mismatch is real** (old logic: *"ctx now belongs to device 0, buffer is on device 3"*), but `cuMemGetHandleForAddressRange()` **succeeded anyway** on this stack, under both the old and the new logic. So the dmabuf export appears to require *a* valid context rather than one owning the buffer's device. The device-aware check is kept regardless: that behaviour is undocumented and not something worth making load-bearing in the registration path, and the check costs two driver calls on a path that already does `fi_mr_regattr`.

**Test commands:**
```bash
# format / lint
./scripts/code_format.sh --check -b upstream/main
pre-commit run --files mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp

# end-to-end: SGLang 1P1D over Mooncake/EFA, then
curl -s $ROUTER/v1/chat/completions -H 'Content-Type: application/json' \
  -d '{"model":"...","messages":[{"role":"user","content":"hi"}],"max_tokens":32}'
# and confirm zero failures:
docker logs <prefill> 2>&1 | grep -c 'fi_mr_regattr failed'   # 0
docker logs <decode>  2>&1 | grep -c 'fi_mr_regattr failed'   # 0
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

No unit test is included: reproducing this requires a real EFA NIC plus a CUDA device, and the trigger is a thread-state race that a unit test cannot deterministically create. The reproducer above is the practical equivalent and can be shared if useful.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note on `pre-commit`: it also reformats three files unrelated to this change (`mooncake-store/tests/client_buffer_test.cpp`, `mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp`, `mooncake-transfer-engine/tests/rdma_endpoint_reestablish_test.cpp`) that are already unformatted on `main`. Those were reverted to keep this PR to a single file — worth a separate cleanup.

## Related

No conflict with #2063 (`feat/efa-stale-peer-eviction`), which touches the same file: verified by a trial merge, which auto-merges cleanly and leaves both changes intact and format-clean. They can land in either order.

Upstream libfabric also deserves a diagnosability fix — the `FI_HMEM_CUDA` init branch in `efa_hmem.c` never enables `dmabuf_fallback_enabled`, so a dmabuf-fd failure reaches `efa_mr.c` with `errno` unset and the real cause is replaced by `ENOTSUP`. Reporting that separately.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to instrument the failure path (logging allocation kind, dmabuf-export errno and `cuCtxGetCurrent` for failing buffers), which is what identified the missing context, and to draft the reproducer and this description. All conclusions were verified on real hardware by the runs tabulated above. The submitter understands and stands behind the change.
