### PR TITLE
[Store] Fence stale put finalization with ReplicaID

### DIFF
--- a/mooncake-store/benchmarks/master_bench.cpp
+++ b/mooncake-store/benchmarks/master_bench.cpp
@@ -195,8 +195,14 @@ class BenchClient {
             return false;
         }
 
-        auto put_end_result =
-            master_client_.PutEnd(key, mooncake::ReplicaType::MEMORY);
+        std::vector<mooncake::ReplicaID> replica_ids;
+        for (const auto& replica : put_start_result.value()) {
+            if (replica.is_memory_replica()) {
+                replica_ids.emplace_back(replica.id);
+            }
+        }
+        auto put_end_result = master_client_.PutEnd(
+            key, replica_ids, mooncake::ReplicaType::MEMORY);
         if (!put_end_result.has_value()) {
             return false;
         }

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -698,7 +698,7 @@ class Client {
 
     void PutToLocalFile(const std::string& object_key,
                         const std::vector<Slice>& slices,
-                        const DiskDescriptor& disk_descriptor);
+                        const Replica::Descriptor& replica);
     /**
      * @brief Initialize local hot cache
      * @return ErrorCode::OK if use local hot cache,

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -211,11 +211,13 @@ class MasterClient {
     /**
      * @brief Ends a put operation
      * @param key Object key
+     * @param replica_ids IDs returned by the matching PutStart
      * @param replica_type Type of replica (memory or disk)
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
     [[nodiscard]] tl::expected<void, ErrorCode> PutEnd(
-        const std::string& key, ReplicaType replica_type);
+        const std::string& key, const std::vector<ReplicaID>& replica_ids,
+        ReplicaType replica_type);
 
     /**
      * @brief Ends a put operation for a batch of objects
@@ -229,11 +231,13 @@ class MasterClient {
     /**
      * @brief Revokes a put operation
      * @param key Object key
+     * @param replica_ids IDs returned by the matching PutStart
      * @param replica_type Type of replica (memory or disk)
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
     [[nodiscard]] tl::expected<void, ErrorCode> PutRevoke(
-        const std::string& key, ReplicaType replica_type);
+        const std::string& key, const std::vector<ReplicaID>& replica_ids,
+        ReplicaType replica_type);
 
     /**
      * @brief Revokes a put operation for a batch of objects
@@ -263,13 +267,15 @@ class MasterClient {
                      const ReplicateConfig& config);
 
     [[nodiscard]] tl::expected<void, ErrorCode> UpsertEnd(
-        const std::string& key, ReplicaType replica_type);
+        const std::string& key, const std::vector<ReplicaID>& replica_ids,
+        ReplicaType replica_type);
 
     [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchUpsertEnd(
         const std::vector<std::string>& keys);
 
     [[nodiscard]] tl::expected<void, ErrorCode> UpsertRevoke(
-        const std::string& key, ReplicaType replica_type);
+        const std::string& key, const std::vector<ReplicaID>& replica_ids,
+        ReplicaType replica_type);
 
     [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchUpsertRevoke(
         const std::vector<std::string>& keys);

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -422,7 +422,8 @@ class MasterService {
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
     auto PutEnd(const UUID& client_id, const std::string& key,
-                const TenantId& tenant_id, ReplicaType replica_type)
+                const TenantId& tenant_id, ReplicaType replica_type,
+                const std::vector<ReplicaID>& replica_ids = {})
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -439,7 +440,8 @@ class MasterService {
      * found, ErrorCode::INVALID_WRITE if replica status is invalid
      */
     auto PutRevoke(const UUID& client_id, const std::string& key,
-                   const TenantId& tenant_id, ReplicaType replica_type)
+                   const TenantId& tenant_id, ReplicaType replica_type,
+                   const std::vector<ReplicaID>& replica_ids = {})
         -> tl::expected<void, ErrorCode>;
 
     /**
@@ -478,14 +480,16 @@ class MasterService {
      * @brief Complete an upsert operation. Delegates to PutEnd.
      */
     auto UpsertEnd(const UUID& client_id, const std::string& key,
-                   const TenantId& tenant_id, ReplicaType replica_type)
+                   const TenantId& tenant_id, ReplicaType replica_type,
+                   const std::vector<ReplicaID>& replica_ids = {})
         -> tl::expected<void, ErrorCode>;
 
     /**
      * @brief Revoke an upsert operation. Delegates to PutRevoke.
      */
     auto UpsertRevoke(const UUID& client_id, const std::string& key,
-                      const TenantId& tenant_id, ReplicaType replica_type)
+                      const TenantId& tenant_id, ReplicaType replica_type,
+                      const std::vector<ReplicaID>& replica_ids = {})
         -> tl::expected<void, ErrorCode>;
 
     /**

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -82,11 +82,13 @@ class WrappedMasterService {
 
     tl::expected<void, ErrorCode> PutEnd(
         const UUID& client_id, const std::string& key,
+        const std::vector<ReplicaID>& replica_ids,
         ReplicaType replica_type = ReplicaType::ALL,
         const std::string& tenant_id = "default");
 
     tl::expected<void, ErrorCode> PutRevoke(
         const UUID& client_id, const std::string& key,
+        const std::vector<ReplicaID>& replica_ids,
         ReplicaType replica_type = ReplicaType::ALL,
         const std::string& tenant_id = "default");
 
@@ -113,11 +115,13 @@ class WrappedMasterService {
 
     tl::expected<void, ErrorCode> UpsertEnd(
         const UUID& client_id, const std::string& key,
+        const std::vector<ReplicaID>& replica_ids,
         ReplicaType replica_type = ReplicaType::ALL,
         const std::string& tenant_id = "default");
 
     tl::expected<void, ErrorCode> UpsertRevoke(
         const UUID& client_id, const std::string& key,
+        const std::vector<ReplicaID>& replica_ids,
         ReplicaType replica_type = ReplicaType::ALL,
         const std::string& tenant_id = "default");
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -126,6 +126,29 @@ std::optional<ContiguousSliceRange> GetContiguousSliceRange(
                                 .size = total_size};
 }
 
+std::vector<ReplicaID> GetReplicaIdsForType(
+    const std::vector<Replica::Descriptor>& replicas,
+    ReplicaType replica_type) {
+    std::vector<ReplicaID> replica_ids;
+    replica_ids.reserve(replicas.size());
+    for (const auto& replica : replicas) {
+        const bool matches =
+            (replica_type == ReplicaType::ALL &&
+             (replica.is_memory_replica() || replica.is_nof_replica())) ||
+            (replica_type == ReplicaType::MEMORY &&
+             replica.is_memory_replica()) ||
+            (replica_type == ReplicaType::NOF_SSD &&
+             replica.is_nof_replica()) ||
+            (replica_type == ReplicaType::DISK && replica.is_disk_replica()) ||
+            (replica_type == ReplicaType::LOCAL_DISK &&
+             replica.is_local_disk_replica());
+        if (matches) {
+            replica_ids.emplace_back(replica.id);
+        }
+    }
+    return replica_ids;
+}
+
 struct ReplicaTransferSummary {
     size_t allocated_memory_replicas = 0;
     size_t allocated_nof_replicas = 0;
@@ -181,7 +204,7 @@ bool HasExpectedReplicaAllocation(const ReplicateConfig& config,
 // success describes whether the overall put should succeed. Reliable modes
 // require all allocated replicas to complete. Flexible dual-replica mode only
 // requires one replica type to succeed, so success may be true while
-// revoke_type is also set for the failed side.
+// revoke_type is also set for an allocated but failed side.
 struct FinalizeDecision {
     std::optional<ReplicaType> end_type;
     std::optional<ReplicaType> revoke_type;
@@ -230,13 +253,17 @@ FinalizeDecision DetermineFinalizeDecision(
     }
     if (memory_succeeded) {
         return {.end_type = ReplicaType::MEMORY,
-                .revoke_type = ReplicaType::NOF_SSD,
+                .revoke_type = summary.allocated_nof_replicas > 0
+                                   ? std::make_optional(ReplicaType::NOF_SSD)
+                                   : std::optional<ReplicaType>{},
                 .success = true,
                 .error = ErrorCode::OK};
     }
     if (nof_succeeded) {
         return {.end_type = ReplicaType::NOF_SSD,
-                .revoke_type = ReplicaType::MEMORY,
+                .revoke_type = summary.allocated_memory_replicas > 0
+                                   ? std::make_optional(ReplicaType::MEMORY)
+                                   : std::optional<ReplicaType>{},
                 .success = true,
                 .error = ErrorCode::OK};
     }
@@ -1596,8 +1623,7 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
             const auto& replica = *it;
             if (replica.is_disk_replica()) {
                 // Store to local file if storage backend is available
-                auto disk_descriptor = replica.get_disk_descriptor();
-                PutToLocalFile(key, slices, disk_descriptor);
+                PutToLocalFile(key, slices, replica);
                 break;  // Only one disk replica is needed
             }
         }
@@ -1629,8 +1655,11 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
         DetermineFinalizeDecision(config, transfer_summary);
 
     if (finalize_decision.end_type.has_value()) {
-        auto end_result =
-            master_client_.PutEnd(key, *finalize_decision.end_type);
+        auto end_result = master_client_.PutEnd(
+            key,
+            GetReplicaIdsForType(start_result.value(),
+                                 *finalize_decision.end_type),
+            *finalize_decision.end_type);
         if (!end_result) {
             ErrorCode err = end_result.error();
             LOG(ERROR) << "Failed to end put operation: " << err;
@@ -1639,8 +1668,11 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
     }
 
     if (finalize_decision.revoke_type.has_value()) {
-        auto revoke_result =
-            master_client_.PutRevoke(key, *finalize_decision.revoke_type);
+        auto revoke_result = master_client_.PutRevoke(
+            key,
+            GetReplicaIdsForType(start_result.value(),
+                                 *finalize_decision.revoke_type),
+            *finalize_decision.revoke_type);
         if (!revoke_result) {
             LOG(ERROR) << "Failed to revoke put operation";
             return tl::unexpected(revoke_result.error());
@@ -1696,8 +1728,7 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
              it != start_result.value().rend(); ++it) {
             const auto& replica = *it;
             if (replica.is_disk_replica()) {
-                auto disk_descriptor = replica.get_disk_descriptor();
-                PutToLocalFile(key, slices, disk_descriptor);
+                PutToLocalFile(key, slices, replica);
                 break;
             }
         }
@@ -1708,8 +1739,11 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
         if (replica.is_memory_replica()) {
             ErrorCode transfer_err = TransferWrite(replica, slices);
             if (transfer_err != ErrorCode::OK) {
-                auto revoke_result =
-                    master_client_.UpsertRevoke(key, ReplicaType::MEMORY);
+                auto revoke_result = master_client_.UpsertRevoke(
+                    key,
+                    GetReplicaIdsForType(start_result.value(),
+                                         ReplicaType::MEMORY),
+                    ReplicaType::MEMORY);
                 if (!revoke_result) {
                     LOG(ERROR) << "Failed to revoke upsert operation";
                     return tl::unexpected(revoke_result.error());
@@ -1727,7 +1761,9 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
     }
 
     // End upsert operation
-    auto end_result = master_client_.UpsertEnd(key, ReplicaType::MEMORY);
+    auto end_result = master_client_.UpsertEnd(
+        key, GetReplicaIdsForType(start_result.value(), ReplicaType::MEMORY),
+        ReplicaType::MEMORY);
     if (!end_result) {
         ErrorCode err = end_result.error();
         LOG(ERROR) << "Failed to end upsert operation: " << err;
@@ -2051,8 +2087,7 @@ void Client::SubmitTransfers(std::vector<PutOperation>& ops) {
                  ++it) {
                 const auto& replica = *it;
                 if (replica.is_disk_replica()) {
-                    auto disk_descriptor = replica.get_disk_descriptor();
-                    PutToLocalFile(op.key, op.slices, disk_descriptor);
+                    PutToLocalFile(op.key, op.slices, replica);
                     break;  // Only one disk replica is needed
                 }
             }
@@ -3394,8 +3429,11 @@ ErrorCode Client::PrepareStorageBackend(const std::string& storage_root_dir,
 
 void Client::PutToLocalFile(const std::string& key,
                             const std::vector<Slice>& slices,
-                            const DiskDescriptor& disk_descriptor) {
+                            const Replica::Descriptor& replica) {
     if (!storage_backend_) return;
+
+    const auto& disk_descriptor = replica.get_disk_descriptor();
+    const std::vector<ReplicaID> replica_ids{replica.id};
 
     size_t total_size = 0;
     for (const auto& slice : slices) {
@@ -3425,8 +3463,8 @@ void Client::PutToLocalFile(const std::string& key,
                            << ", triggering PutRevoke for disk replica";
                 pinned_buffer_pool_->Release(std::move(buf));
                 // Must revoke to avoid phantom replica in master
-                auto revoke_result =
-                    master_client_.PutRevoke(key, ReplicaType::DISK);
+                auto revoke_result = master_client_.PutRevoke(
+                    key, replica_ids, ReplicaType::DISK);
                 if (!revoke_result) {
                     LOG(ERROR)
                         << "Failed to revoke put operation for key: " << key;
@@ -3442,7 +3480,7 @@ void Client::PutToLocalFile(const std::string& key,
 
     // Async StoreObject + PutEnd (unchanged from original)
     write_thread_pool_.enqueue([this, backend = storage_backend_, key,
-                                value = std::move(value), path] {
+                                value = std::move(value), path, replica_ids] {
         ReplicaType replica_type = ReplicaType::DISK;
         // Store the object
         auto store_result = backend->StoreObject(
@@ -3475,7 +3513,8 @@ void Client::PutToLocalFile(const std::string& key,
         if (!store_result) {
             // If storage failed, revoke the put operation
             LOG(ERROR) << "Failed to store object for key: " << key;
-            auto revoke_result = master_client_.PutRevoke(key, replica_type);
+            auto revoke_result =
+                master_client_.PutRevoke(key, replica_ids, replica_type);
             if (!revoke_result) {
                 LOG(ERROR) << "Failed to revoke put operation for key: " << key;
             }
@@ -3483,7 +3522,7 @@ void Client::PutToLocalFile(const std::string& key,
         }
 
         // If storage succeeded, end the put operation
-        auto end_result = master_client_.PutEnd(key, replica_type);
+        auto end_result = master_client_.PutEnd(key, replica_ids, replica_type);
         if (!end_result) {
             LOG(ERROR) << "Failed to end put operation for key: " << key;
         }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -602,13 +602,14 @@ MasterClient::BatchPutStart(
     return result;
 }
 
-tl::expected<void, ErrorCode> MasterClient::PutEnd(const std::string& key,
-                                                   ReplicaType replica_type) {
+tl::expected<void, ErrorCode> MasterClient::PutEnd(
+    const std::string& key, const std::vector<ReplicaID>& replica_ids,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::PutEnd");
     timer.LogRequest("key=", key);
 
     auto result = invoke_rpc<&WrappedMasterService::PutEnd, void>(
-        client_id_, key, replica_type, tenant_id_.value());
+        client_id_, key, replica_ids, replica_type, tenant_id_.value());
     timer.LogResponseExpected(result);
     return result;
 }
@@ -625,12 +626,13 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchPutEnd(
 }
 
 tl::expected<void, ErrorCode> MasterClient::PutRevoke(
-    const std::string& key, ReplicaType replica_type) {
+    const std::string& key, const std::vector<ReplicaID>& replica_ids,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::PutRevoke");
     timer.LogRequest("key=", key);
 
     auto result = invoke_rpc<&WrappedMasterService::PutRevoke, void>(
-        client_id_, key, replica_type, tenant_id_.value());
+        client_id_, key, replica_ids, replica_type, tenant_id_.value());
     timer.LogResponseExpected(result);
     return result;
 }
@@ -692,12 +694,13 @@ MasterClient::BatchUpsertStart(
 }
 
 tl::expected<void, ErrorCode> MasterClient::UpsertEnd(
-    const std::string& key, ReplicaType replica_type) {
+    const std::string& key, const std::vector<ReplicaID>& replica_ids,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::UpsertEnd");
     timer.LogRequest("key=", key);
 
     auto result = invoke_rpc<&WrappedMasterService::UpsertEnd, void>(
-        client_id_, key, replica_type, tenant_id_.value());
+        client_id_, key, replica_ids, replica_type, tenant_id_.value());
     timer.LogResponseExpected(result);
     return result;
 }
@@ -714,12 +717,13 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchUpsertEnd(
 }
 
 tl::expected<void, ErrorCode> MasterClient::UpsertRevoke(
-    const std::string& key, ReplicaType replica_type) {
+    const std::string& key, const std::vector<ReplicaID>& replica_ids,
+    ReplicaType replica_type) {
     ScopedVLogTimer timer(1, "MasterClient::UpsertRevoke");
     timer.LogRequest("key=", key);
 
     auto result = invoke_rpc<&WrappedMasterService::UpsertRevoke, void>(
-        client_id_, key, replica_type, tenant_id_.value());
+        client_id_, key, replica_ids, replica_type, tenant_id_.value());
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3733,7 +3733,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
 }
 
 auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
-                           const TenantId& tenant_id, ReplicaType replica_type)
+                           const TenantId& tenant_id, ReplicaType replica_type,
+                           const std::vector<ReplicaID>& replica_ids)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     const auto object_id = MakeObjectIdentityForRequest(key, tenant_id);
@@ -3750,25 +3751,40 @@ auto MasterService::PutEnd(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    metadata.VisitReplicas(
-        [replica_type](const Replica& replica) {
-            if (replica_type == ReplicaType::ALL) {
-                return (replica.is_memory_replica() &&
-                        !replica.has_invalid_mem_handle()) ||
-                       (replica.is_nof_replica() &&
-                        !replica.has_invalid_nof_handle());
-            }
-            if (replica_type == ReplicaType::MEMORY) {
-                return replica.is_memory_replica() &&
-                       !replica.has_invalid_mem_handle();
-            }
-            if (replica_type == ReplicaType::NOF_SSD) {
-                return replica.is_nof_replica() &&
-                       !replica.has_invalid_nof_handle();
-            }
-            return replica.type() == replica_type;
-        },
-        [](Replica& replica) { replica.mark_complete(); });
+    auto target_pred = [replica_type](const Replica& replica) {
+        if (replica_type == ReplicaType::ALL) {
+            return (replica.is_memory_replica() &&
+                    !replica.has_invalid_mem_handle()) ||
+                   (replica.is_nof_replica() &&
+                    !replica.has_invalid_nof_handle());
+        }
+        if (replica_type == ReplicaType::MEMORY) {
+            return replica.is_memory_replica() &&
+                   !replica.has_invalid_mem_handle();
+        }
+        if (replica_type == ReplicaType::NOF_SSD) {
+            return replica.is_nof_replica() &&
+                   !replica.has_invalid_nof_handle();
+        }
+        return replica.type() == replica_type;
+    };
+
+    if (!replica_ids.empty()) {
+        const std::unordered_set<ReplicaID> expected_ids(replica_ids.begin(),
+                                                         replica_ids.end());
+        std::unordered_set<ReplicaID> current_ids;
+        for (const auto& replica : metadata.GetAllReplicas()) {
+            if (target_pred(replica)) current_ids.insert(replica.id());
+        }
+        if (expected_ids.size() != replica_ids.size() ||
+            expected_ids != current_ids) {
+            LOG(WARNING) << "key=" << key << ", error=replica_id_mismatch";
+            return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+        }
+    }
+
+    metadata.VisitReplicas(target_pred,
+                           [](Replica& replica) { replica.mark_complete(); });
 
     const bool has_memory_replica = metadata.HasMemReplica();
     const bool should_settle_quota =
@@ -3948,7 +3964,8 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
 
 auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
                               const TenantId& tenant_id,
-                              ReplicaType replica_type)
+                              ReplicaType replica_type,
+                              const std::vector<ReplicaID>& replica_ids)
     -> tl::expected<void, ErrorCode> {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     const auto object_id = MakeObjectIdentityForRequest(key, tenant_id);
@@ -3965,26 +3982,36 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    auto processing_rep = metadata.GetFirstReplica([replica_type](
-                                                       const Replica& replica) {
+    auto target_pred = [replica_type](const Replica& replica) {
         if (replica_type == ReplicaType::ALL) {
-            return (replica.is_memory_replica() || replica.is_nof_replica()) &&
-                   !replica.is_processing();
+            return replica.is_memory_replica() || replica.is_nof_replica();
         }
-        return replica.type() == replica_type && !replica.is_processing();
-    });
+        return replica.type() == replica_type;
+    };
+
+    if (!replica_ids.empty()) {
+        const std::unordered_set<ReplicaID> expected_ids(replica_ids.begin(),
+                                                         replica_ids.end());
+        std::unordered_set<ReplicaID> current_ids;
+        for (const auto& replica : metadata.GetAllReplicas()) {
+            if (target_pred(replica)) current_ids.insert(replica.id());
+        }
+        if (expected_ids.size() != replica_ids.size() ||
+            expected_ids != current_ids) {
+            LOG(WARNING) << "key=" << key << ", error=replica_id_mismatch";
+            return tl::make_unexpected(ErrorCode::INVALID_REPLICA);
+        }
+    }
+
+    auto processing_rep =
+        metadata.GetFirstReplica([&target_pred](const Replica& replica) {
+            return target_pred(replica) && !replica.is_processing();
+        });
     if (processing_rep != nullptr) {
         LOG(ERROR) << "key=" << key << ", status=" << processing_rep->status()
                    << ", error=invalid_replica_status";
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
-
-    auto target_pred = [replica_type](const Replica& r) {
-        if (replica_type == ReplicaType::ALL) {
-            return r.is_memory_replica() || r.is_nof_replica();
-        }
-        return r.type() == replica_type;
-    };
 
     if (enable_oplog_ && ordered_oplog_writer_) {
         auto remaining =
@@ -4434,16 +4461,18 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
 
 auto MasterService::UpsertEnd(const UUID& client_id, const std::string& key,
                               const TenantId& tenant_id,
-                              ReplicaType replica_type)
+                              ReplicaType replica_type,
+                              const std::vector<ReplicaID>& replica_ids)
     -> tl::expected<void, ErrorCode> {
-    return PutEnd(client_id, key, tenant_id, replica_type);
+    return PutEnd(client_id, key, tenant_id, replica_type, replica_ids);
 }
 
 auto MasterService::UpsertRevoke(const UUID& client_id, const std::string& key,
                                  const TenantId& tenant_id,
-                                 ReplicaType replica_type)
+                                 ReplicaType replica_type,
+                                 const std::vector<ReplicaID>& replica_ids)
     -> tl::expected<void, ErrorCode> {
-    return PutRevoke(client_id, key, tenant_id, replica_type);
+    return PutRevoke(client_id, key, tenant_id, replica_type, replica_ids);
 }
 
 std::vector<tl::expected<std::vector<Replica::Descriptor>, ErrorCode>>

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -396,10 +396,10 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
                 master_service_.IsTenantQuotaEnabled()
                     ? std::string_view(tenant_id)
                     : TenantId::kDefaultValue,
-                [&](const TenantId& resolved_tenant_id) {
+                [&](const TenantId& resolved_tenant_id)
+                    -> tl::expected<void, ErrorCode> {
                     if (replica_ids.empty()) {
-                        return tl::expected<void, ErrorCode>(
-                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                        return tl::unexpected(ErrorCode::INVALID_REPLICA);
                     }
                     return master_service_.PutEnd(client_id, key,
                                                   resolved_tenant_id,
@@ -425,10 +425,10 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(
                 master_service_.IsTenantQuotaEnabled()
                     ? std::string_view(tenant_id)
                     : TenantId::kDefaultValue,
-                [&](const TenantId& resolved_tenant_id) {
+                [&](const TenantId& resolved_tenant_id)
+                    -> tl::expected<void, ErrorCode> {
                     if (replica_ids.empty()) {
-                        return tl::expected<void, ErrorCode>(
-                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                        return tl::unexpected(ErrorCode::INVALID_REPLICA);
                     }
                     return master_service_.PutRevoke(client_id, key,
                                                      resolved_tenant_id,
@@ -670,10 +670,10 @@ tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
                 master_service_.IsTenantQuotaEnabled()
                     ? std::string_view(tenant_id)
                     : TenantId::kDefaultValue,
-                [&](const TenantId& resolved_tenant_id) {
+                [&](const TenantId& resolved_tenant_id)
+                    -> tl::expected<void, ErrorCode> {
                     if (replica_ids.empty()) {
-                        return tl::expected<void, ErrorCode>(
-                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                        return tl::unexpected(ErrorCode::INVALID_REPLICA);
                     }
                     return master_service_.UpsertEnd(client_id, key,
                                                      resolved_tenant_id,
@@ -699,10 +699,10 @@ tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevoke(
                 master_service_.IsTenantQuotaEnabled()
                     ? std::string_view(tenant_id)
                     : TenantId::kDefaultValue,
-                [&](const TenantId& resolved_tenant_id) {
+                [&](const TenantId& resolved_tenant_id)
+                    -> tl::expected<void, ErrorCode> {
                     if (replica_ids.empty()) {
-                        return tl::expected<void, ErrorCode>(
-                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                        return tl::unexpected(ErrorCode::INVALID_REPLICA);
                     }
                     return master_service_.UpsertRevoke(
                         client_id, key, resolved_tenant_id, replica_type,

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -386,19 +386,25 @@ WrappedMasterService::PutStart(const UUID& client_id, const std::string& key,
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const UUID& client_id, const std::string& key,
+    const std::vector<ReplicaID>& replica_ids, ReplicaType replica_type,
     const std::string& tenant_id) {
     return execute_rpc(
         "PutEnd",
         [&] {
-            return WithRequestTenant(master_service_.IsTenantQuotaEnabled()
-                                         ? std::string_view(tenant_id)
-                                         : TenantId::kDefaultValue,
-                                     [&](const TenantId& resolved_tenant_id) {
-                                         return master_service_.PutEnd(
-                                             client_id, key, resolved_tenant_id,
-                                             replica_type);
-                                     });
+            return WithRequestTenant(
+                master_service_.IsTenantQuotaEnabled()
+                    ? std::string_view(tenant_id)
+                    : TenantId::kDefaultValue,
+                [&](const TenantId& resolved_tenant_id) {
+                    if (replica_ids.empty()) {
+                        return tl::expected<void, ErrorCode>(
+                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                    }
+                    return master_service_.PutEnd(client_id, key,
+                                                  resolved_tenant_id,
+                                                  replica_type, replica_ids);
+                });
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
@@ -409,19 +415,25 @@ tl::expected<void, ErrorCode> WrappedMasterService::PutEnd(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::PutRevoke(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const UUID& client_id, const std::string& key,
+    const std::vector<ReplicaID>& replica_ids, ReplicaType replica_type,
     const std::string& tenant_id) {
     return execute_rpc(
         "PutRevoke",
         [&] {
-            return WithRequestTenant(master_service_.IsTenantQuotaEnabled()
-                                         ? std::string_view(tenant_id)
-                                         : TenantId::kDefaultValue,
-                                     [&](const TenantId& resolved_tenant_id) {
-                                         return master_service_.PutRevoke(
-                                             client_id, key, resolved_tenant_id,
-                                             replica_type);
-                                     });
+            return WithRequestTenant(
+                master_service_.IsTenantQuotaEnabled()
+                    ? std::string_view(tenant_id)
+                    : TenantId::kDefaultValue,
+                [&](const TenantId& resolved_tenant_id) {
+                    if (replica_ids.empty()) {
+                        return tl::expected<void, ErrorCode>(
+                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                    }
+                    return master_service_.PutRevoke(client_id, key,
+                                                     resolved_tenant_id,
+                                                     replica_type, replica_ids);
+                });
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
@@ -648,19 +660,25 @@ WrappedMasterService::UpsertStart(const UUID& client_id, const std::string& key,
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const UUID& client_id, const std::string& key,
+    const std::vector<ReplicaID>& replica_ids, ReplicaType replica_type,
     const std::string& tenant_id) {
     return execute_rpc(
         "UpsertEnd",
         [&] {
-            return WithRequestTenant(master_service_.IsTenantQuotaEnabled()
-                                         ? std::string_view(tenant_id)
-                                         : TenantId::kDefaultValue,
-                                     [&](const TenantId& resolved_tenant_id) {
-                                         return master_service_.UpsertEnd(
-                                             client_id, key, resolved_tenant_id,
-                                             replica_type);
-                                     });
+            return WithRequestTenant(
+                master_service_.IsTenantQuotaEnabled()
+                    ? std::string_view(tenant_id)
+                    : TenantId::kDefaultValue,
+                [&](const TenantId& resolved_tenant_id) {
+                    if (replica_ids.empty()) {
+                        return tl::expected<void, ErrorCode>(
+                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                    }
+                    return master_service_.UpsertEnd(client_id, key,
+                                                     resolved_tenant_id,
+                                                     replica_type, replica_ids);
+                });
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,
@@ -671,19 +689,25 @@ tl::expected<void, ErrorCode> WrappedMasterService::UpsertEnd(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::UpsertRevoke(
-    const UUID& client_id, const std::string& key, ReplicaType replica_type,
+    const UUID& client_id, const std::string& key,
+    const std::vector<ReplicaID>& replica_ids, ReplicaType replica_type,
     const std::string& tenant_id) {
     return execute_rpc(
         "UpsertRevoke",
         [&] {
-            return WithRequestTenant(master_service_.IsTenantQuotaEnabled()
-                                         ? std::string_view(tenant_id)
-                                         : TenantId::kDefaultValue,
-                                     [&](const TenantId& resolved_tenant_id) {
-                                         return master_service_.UpsertRevoke(
-                                             client_id, key, resolved_tenant_id,
-                                             replica_type);
-                                     });
+            return WithRequestTenant(
+                master_service_.IsTenantQuotaEnabled()
+                    ? std::string_view(tenant_id)
+                    : TenantId::kDefaultValue,
+                [&](const TenantId& resolved_tenant_id) {
+                    if (replica_ids.empty()) {
+                        return tl::expected<void, ErrorCode>(
+                            tl::unexpect, ErrorCode::INVALID_REPLICA);
+                    }
+                    return master_service_.UpsertRevoke(
+                        client_id, key, resolved_tenant_id, replica_type,
+                        replica_ids);
+                });
         },
         [&](auto& timer) {
             timer.LogRequest("client_id=", client_id, ", key=", key,

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -16,6 +16,7 @@
 
 #include "allocator.h"
 #include "client_service.h"
+#include "master_client.h"
 #include "types.h"
 #include "utils.h"
 #include "test_server_helpers.h"
@@ -1537,6 +1538,68 @@ TEST_F(EvictionNotificationTest, DiskReplicaRemovedAfterEviction) {
     EXPECT_TRUE(unmount.has_value()) << "UnmountSegment failed";
     std::free(seg_ptr_);
     seg_ptr_ = nullptr;
+}
+
+TEST_F(ClientIntegrationTest, ReplicaIdsFenceStalePutFinalization) {
+    MasterClient client(generate_uuid());
+    ASSERT_EQ(ErrorCode::OK, client.Connect(master_address_));
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::vector<size_t> slice_lengths{1024};
+
+    const std::string end_key = "stale_put_end_over_rpc";
+    auto first_end_write = client.PutStart(end_key, slice_lengths, config);
+    ASSERT_TRUE(first_end_write.has_value());
+    ASSERT_EQ(1, first_end_write->size());
+
+    auto missing_ids = client.PutEnd(end_key, {}, ReplicaType::MEMORY);
+    ASSERT_FALSE(missing_ids.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_REPLICA, missing_ids.error());
+
+    auto second_end_write = client.UpsertStart(end_key, slice_lengths, config);
+    ASSERT_TRUE(second_end_write.has_value());
+    ASSERT_EQ(1, second_end_write->size());
+    ASSERT_NE(first_end_write->front().id, second_end_write->front().id);
+
+    auto stale_end = client.PutEnd(end_key, {first_end_write->front().id},
+                                   ReplicaType::MEMORY);
+    ASSERT_FALSE(stale_end.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_REPLICA, stale_end.error());
+
+    auto before_current_end = client.GetReplicaList(end_key);
+    ASSERT_FALSE(before_current_end.has_value());
+    EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, before_current_end.error());
+
+    ASSERT_TRUE(client
+                    .PutEnd(end_key, {second_end_write->front().id},
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(client.Remove(end_key, /*force=*/true).has_value());
+
+    const std::string revoke_key = "stale_put_revoke_over_rpc";
+    auto first_revoke_write =
+        client.PutStart(revoke_key, slice_lengths, config);
+    ASSERT_TRUE(first_revoke_write.has_value());
+    ASSERT_EQ(1, first_revoke_write->size());
+    auto second_revoke_write =
+        client.UpsertStart(revoke_key, slice_lengths, config);
+    ASSERT_TRUE(second_revoke_write.has_value());
+    ASSERT_EQ(1, second_revoke_write->size());
+    ASSERT_NE(first_revoke_write->front().id, second_revoke_write->front().id);
+
+    auto stale_revoke = client.PutRevoke(
+        revoke_key, {first_revoke_write->front().id}, ReplicaType::MEMORY);
+    ASSERT_FALSE(stale_revoke.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_REPLICA, stale_revoke.error());
+
+    ASSERT_TRUE(client
+                    .PutRevoke(revoke_key, {second_revoke_write->front().id},
+                               ReplicaType::MEMORY)
+                    .has_value());
+    auto exists_after_revoke = client.ExistKey(revoke_key);
+    ASSERT_TRUE(exists_after_revoke.has_value());
+    EXPECT_FALSE(exists_after_revoke.value());
 }
 
 // Test Upsert Case A: key does not exist — equivalent to Put

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -544,8 +544,8 @@ TEST_F(MasterAdminServerTest, TenantQuotaAdminLifecycleEndpoints) {
         service->PutStart(client_id, "quota_admin_key", 100, cfg, "tenant-a");
     ASSERT_TRUE(put.has_value()) << toString(put.error());
     ASSERT_TRUE(service
-                    ->PutEnd(client_id, "quota_admin_key", ReplicaType::MEMORY,
-                             "tenant-a")
+                    ->PutEnd(client_id, "quota_admin_key", {put->front().id},
+                             ReplicaType::MEMORY, "tenant-a")
                     .has_value());
 
     auto delete_non_empty =
@@ -661,7 +661,8 @@ class MasterAdminServerWithServiceTest : public ::testing::Test {
         cfg.replica_num = 1;
         auto ps = service_->PutStart(client_id, kDefaultKey, 1024, cfg);
         if (ps.has_value()) {
-            (void)service_->PutEnd(client_id, kDefaultKey, ReplicaType::MEMORY);
+            (void)service_->PutEnd(client_id, kDefaultKey, {ps->front().id},
+                                   ReplicaType::MEMORY);
         }
 
         port_ = getFreeTcpPort();
@@ -730,7 +731,8 @@ TEST_F(MasterAdminServerWithServiceTest, GetAllKeysExcludesRemovedKey) {
     cfg.replica_num = 1;
     auto ps = service_->PutStart(client_id, key, 1024, cfg);
     if (ps.has_value()) {
-        (void)service_->PutEnd(client_id, key, ReplicaType::MEMORY);
+        (void)service_->PutEnd(client_id, key, {ps->front().id},
+                               ReplicaType::MEMORY);
     }
     (void)service_->Remove(key, "default");
 
@@ -1002,7 +1004,8 @@ TEST_F(MasterAdminServerWithServiceTest, BatchQueryKeysMultipleKeys) {
     cfg.replica_num = 1;
     auto ps = service_->PutStart(client_id, "second_key", 512, cfg);
     if (ps.has_value()) {
-        (void)service_->PutEnd(client_id, "second_key", ReplicaType::MEMORY);
+        (void)service_->PutEnd(client_id, "second_key", {ps->front().id},
+                               ReplicaType::MEMORY);
     }
 
     auto resp = HttpGet("/batch_query_keys?keys=" + std::string(kDefaultKey) +
@@ -1146,11 +1149,13 @@ TEST_F(MasterAdminServerTest, MultipleSegmentsAndKeys) {
     cfg.replica_num = 1;
     auto ps1 = service->PutStart(client_id, "key_one", 1024, cfg);
     if (ps1.has_value()) {
-        (void)service->PutEnd(client_id, "key_one", ReplicaType::MEMORY);
+        (void)service->PutEnd(client_id, "key_one", {ps1->front().id},
+                              ReplicaType::MEMORY);
     }
     auto ps2 = service->PutStart(client_id, "key_two", 2048, cfg);
     if (ps2.has_value()) {
-        (void)service->PutEnd(client_id, "key_two", ReplicaType::MEMORY);
+        (void)service->PutEnd(client_id, "key_two", {ps2->front().id},
+                              ReplicaType::MEMORY);
     }
 
     int port = getFreeTcpPort();

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -183,8 +183,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
               value_length);
     ASSERT_EQ(metrics.get_put_start_requests(), 1);
     ASSERT_EQ(metrics.get_put_start_failures(), 0);
-    auto put_revoke_result =
-        service_.PutRevoke(client_id, key, ReplicaType::MEMORY);
+    auto put_revoke_result = service_.PutRevoke(
+        client_id, key, {put_start_result1->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_revoke_result.has_value());
     ASSERT_EQ(metrics.get_key_count(), 0);
     ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
@@ -202,7 +202,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
               value_length);
     ASSERT_EQ(metrics.get_put_start_requests(), 2);
     ASSERT_EQ(metrics.get_put_start_failures(), 0);
-    auto put_end_result = service_.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result = service_.PutEnd(
+        client_id, key, {put_start_result2->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
     ASSERT_EQ(metrics.get_key_count(), 1);
     ASSERT_EQ(metrics.get_allocated_mem_size(), value_length);
@@ -238,7 +239,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     auto put_start_result3 =
         service_.PutStart(client_id, key, value_length, config);
     ASSERT_TRUE(put_start_result3.has_value());
-    auto put_end_result2 = service_.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result2 = service_.PutEnd(
+        client_id, key, {put_start_result3->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result2.has_value());
     ASSERT_EQ(metrics.get_key_count(), 1);
     ASSERT_EQ(1, service_.RemoveAll());
@@ -252,7 +254,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     auto put_start_result4 =
         service_.PutStart(client_id, key, value_length, config);
     ASSERT_TRUE(put_start_result4.has_value());
-    auto put_end_result3 = service_.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result3 = service_.PutEnd(
+        client_id, key, {put_start_result4->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result3.has_value());
     auto unmount_result = service_.UnmountSegment(segment_id, client_id);
     ASSERT_TRUE(unmount_result.has_value());
@@ -391,7 +394,8 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     auto put_start_result1 =
         service_.PutStart(client_id, key, value_length, config);
     ASSERT_TRUE(put_start_result1.has_value());
-    auto put_end_result1 = service_.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result1 = service_.PutEnd(
+        client_id, key, {put_start_result1->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result1.has_value());
     auto stats_dict = metrics.calculate_cache_stats();
 
@@ -867,7 +871,8 @@ TEST_F(MasterMetricsTest, SsdOffloadCacheHitAndTotalConsistent) {
     auto put_start_result =
         service_.PutStart(client_id, key, value_length, config);
     ASSERT_TRUE(put_start_result.has_value());
-    auto put_end_result = service_.PutEnd(client_id, key, ReplicaType::MEMORY);
+    auto put_end_result = service_.PutEnd(
+        client_id, key, {put_start_result->front().id}, ReplicaType::MEMORY);
     ASSERT_TRUE(put_end_result.has_value());
 
     // After PutEnd: MEMORY_TOTAL should increment by 1.

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -4982,9 +4982,11 @@ TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
     auto default_put_start =
         service_.PutStart(client_id, default_only_key, 1024, config);
     ASSERT_TRUE(default_put_start.has_value());
-    ASSERT_TRUE(
-        service_.PutEnd(client_id, default_only_key, ReplicaType::MEMORY)
-            .has_value());
+    ASSERT_TRUE(service_
+                    .PutEnd(client_id, default_only_key,
+                            {default_put_start->front().id},
+                            ReplicaType::MEMORY)
+                    .has_value());
 
     auto& metrics = MasterMetricManager::instance();
     const auto base_requests = metrics.get_batch_exist_key_requests();


### PR DESCRIPTION
## Description

This PR addresses the first scenario in [#3030](https://github.com/kvcache-ai/Mooncake/issues/3030).

Previously, `PutEnd` and `PutRevoke` only checked `client_id`. If the same client started a new write before the old one finished, a delayed request from the old write could accidentally finalize or revoke the new write.

This PR passes the `ReplicaID` returned by `PutStart`/`UpsertStart` to the finalization RPCs. The master now checks that the IDs belong to the current write and rejects stale requests with `INVALID_REPLICA`.

The second scenario in #3030, which is about revalidating a read after the lease expires, is not included in this PR. If this approach is acceptable, ReplicaID-based validation can be used for that case separately.

The single-key RPC signatures changed, so mixed-version Client/Master compatibility needs reviewer confirmation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build-standard -j16
ctest --test-dir build-standard -j1 --output-on-failure

cmake --build build-nof -j16 \
  --target master_service_test client_integration_test

timeout 30m build-nof/mooncake-store/tests/master_service_test
timeout 30m build-nof/mooncake-store/tests/client_integration_test
```

**Test results:**

- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

The new `ClientIntegrationTest.ReplicaIdsFenceStalePutFinalization` test passed.

The `USE_NOF=ON` binaries passed:

- `master_service_test`: 149/149
- `client_integration_test`: 18/18, with 1 disabled test

The full standard CTest run passed 100/104 tests. The four failures were related to unavailable etcd metadata configuration, unavailable hugepages, and an intermittent hot-standby timing failure. No ReplicaID fencing or NoF flexible-path regression was observed.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used for code investigation, implementation assistance, test orchestration, and review. The submitter has reviewed and understands the changes.