### PR TITLE
[Weight] Add placement and runtime binding manifest contracts

### DIFF
--- a/docs/source/design/index.md
+++ b/docs/source/design/index.md
@@ -23,6 +23,7 @@ distributed execution components.
 | [HiCache](hicache-design) | Hierarchical KV cache design. |
 | [Engram](engram) | Distributed serving and cache architecture. |
 | [Unified Parallel Tensor I/O](unified-parallel-tensor-io) | Parallel tensor storage and transfer model. |
+| [Weight Transfer Manifest](weight-transfer-manifest) | Logical weight placement, runtime binding, and lifecycle fencing contract. |
 | [SSD Offload](ssd-offload) | SSD-backed cache hierarchy design. |
 | [SSD Free-Ratio-First Allocation](ssd-free-ratio-first-allocation) | Capacity-aware replica placement strategy. |
 

--- a/docs/source/design/weight-transfer-manifest.md
+++ b/docs/source/design/weight-transfer-manifest.md
@@ -1,0 +1,102 @@
+# Weight Transfer Manifest Contract
+
+This document defines the framework-neutral contract used to describe model
+weight placement and live runtime locations. It is the foundation for future
+heterogeneous reshard planning; it does not implement planning, transfer
+execution, or weight storage.
+
+## Contract Split
+
+The contract separates logical placement from process-local state:
+
+| Contract | Contents | Lifetime |
+|----------|----------|----------|
+| `PlacementManifest` | tensor identity, global shape, dtype, logical boxes, shard dimensions, ownership coordinates, and layout fingerprint | serializable and reusable |
+| `RuntimeBindingManifest` | worker, endpoint, device, contiguous address range, lease, generation, and allocation owner | one live runtime snapshot |
+| `RuntimeManifest` | validated logical and physical runtime snapshot | one live runtime snapshot |
+
+`PlacementManifest` never contains GPU addresses, endpoints, leases, or owner
+objects. A runtime restart can therefore reuse the same logical placement and
+produce a new binding.
+
+## Logical Semantics
+
+Each tensor has a stable `tensor_id`, full `global_shape`, dtype, item size,
+layout fingerprint, and optional layer or expert identity. Each fragment is an
+N-D logical box described by `global_offset` and `local_shape`.
+
+`partition_dim` is the single-dimensional shorthand. `shard_dims` is the
+normalized N-D representation. When both are present they must describe the
+same single dimension.
+
+`ParallelRank` records the framework-provided owner coordinates for routing.
+It is not a second sharding model: logical coverage comes from the N-D box and
+`shard_dims`. Topology sizes and target-placement synthesis remain planner
+inputs, consistent with the unified parallel tensor I/O design.
+
+Mooncake does not infer layer, expert, layout, or partition semantics from
+model parameter names. Framework adapters must provide those facts.
+
+## Identity And Fencing
+
+A placement is serialized in canonical tensor and fragment order.
+`placement_id` is derived from that canonical logical content; a supplied ID
+must match the derived value. Runtime instance IDs, addresses, workers,
+endpoints, and leases never affect it. A second SHA-256 digest covers the
+complete serialized placement, including the derived placement ID.
+Canonical hashes use UTF-8 JSON with sorted keys, compact separators, and
+normalized single-axis `partition_dim`/`shard_dims` semantics.
+
+Every runtime binding carries that digest. `bind_runtime_manifest()` rejects a
+binding when any logical placement field has changed. Different
+`placement_fragment_id` values cannot describe the same tensor, owner rank,
+offset, and shape.
+
+The contract carries the lease and generation fence; the caller or control
+plane must verify liveness immediately before binding and transfer. Optional
+owner objects keep framework allocations alive and are never serialized.
+If a binding fragment provides its own lease generation, it must equal the
+binding's snapshot generation. Address ranges are validated within each
+`(instance, worker, device)` address space; endpoints are routing metadata, not
+independent memory spaces.
+
+Every runtime `address` points to the first transferable byte of the tensor
+view, not to the allocation base. Framework offsets are metadata that are
+already reflected in that address and must not be applied again. An inventory
+with a non-zero `storage_offset` or `byte_offset` must explicitly pass
+`address_semantics="view"`. Runtime bindings accept only an explicitly
+contiguous view. Its half-open address range must have a representable
+unsigned 64-bit exclusive end.
+
+`RuntimeManifest` can represent an address-bearing snapshot without a lease.
+It is not the safe consumer boundary: projection to `RuntimeBindingManifest`
+requires a lease and a known generation, and transfer consumers bind the
+placement and binding before using an address. Runtime inputs require an
+explicit layout fingerprint, a known generation, matching per-fragment lease
+generations, and canonical contiguous runtime views. Bindings are always
+content-attested.
+
+## Integration Flow
+
+1. A framework exports runtime tensor facts and model semantics.
+2. `RuntimeManifest.from_runtime_inventory()` validates the live snapshot.
+3. Projection produces a reusable `PlacementManifest` and an ephemeral
+   `RuntimeBindingManifest`.
+4. A consumer validates and binds both halves before planning or transfer.
+5. A new runtime generation creates a new binding while retaining the logical
+   placement identity.
+
+The inventory adapters accept mappings or attribute-based records and do not
+import SGLang, vLLM, PyTorch, or another model framework.
+
+## Non-Goals
+
+This contract does not:
+
+- generate source-to-target reshard regions;
+- infer model semantics from parameter names;
+- execute Transfer Engine operations;
+- persist weights in Mooncake Store;
+- define snapshot discovery, activation, rollback, or control-plane policy.
+
+Those capabilities build on this contract in separate changes.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -132,6 +132,7 @@ design/transfer-engine/index
 design/hicache-design
 design/engram
 design/unified-parallel-tensor-io
+design/weight-transfer-manifest
 design/tent/overview
 design/tent/tebench
 design/conductor/conductor-architecture-design

--- a/mooncake-wheel/mooncake/weight_transfer/__init__.py
+++ b/mooncake-wheel/mooncake/weight_transfer/__init__.py
@@ -1,0 +1,29 @@
+"""Public contracts for framework-neutral model weight transfer."""
+
+from .manifest import (
+    ParallelRank,
+    PlacementFragment,
+    PlacementManifest,
+    RuntimeBindingFragment,
+    RuntimeBindingManifest,
+    RuntimeFragment,
+    RuntimeManifest,
+    TensorDescriptor,
+    bind_runtime_manifest,
+    placement_manifest_from_runtime_manifest,
+    runtime_binding_from_runtime_manifest,
+)
+
+__all__ = [
+    "ParallelRank",
+    "PlacementFragment",
+    "PlacementManifest",
+    "RuntimeBindingFragment",
+    "RuntimeBindingManifest",
+    "RuntimeFragment",
+    "RuntimeManifest",
+    "TensorDescriptor",
+    "bind_runtime_manifest",
+    "placement_manifest_from_runtime_manifest",
+    "runtime_binding_from_runtime_manifest",
+]

--- a/mooncake-wheel/mooncake/weight_transfer/manifest.py
+++ b/mooncake-wheel/mooncake/weight_transfer/manifest.py
@@ -13,7 +13,7 @@ import hashlib
 import json
 from dataclasses import asdict, dataclass, field, replace
 from math import prod
-from typing import Any, Mapping, Optional, Sequence, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
 
 
 _MAX_U64 = (1 << 64) - 1
@@ -318,6 +318,98 @@ def _normalize_aliases(value: Any) -> tuple[str, ...]:
     return tuple(sorted(aliases))
 
 
+def _canonical_stride(shape: tuple[int, ...]) -> tuple[int, ...]:
+    stride = []
+    running = 1
+    for extent in reversed(shape):
+        stride.append(running)
+        running *= extent
+    return tuple(reversed(stride))
+
+
+def _validate_address_semantics(
+    address_semantics: Optional[str],
+    *,
+    has_nonzero_offset: bool,
+) -> None:
+    if address_semantics is not None and address_semantics != "view":
+        raise ValueError("address_semantics must be 'view'")
+    if has_nonzero_offset and address_semantics != "view":
+        raise ValueError("non-zero runtime offsets require address_semantics='view'")
+
+
+def _validate_runtime_view(
+    record: Any,
+    descriptor: TensorDescriptor,
+    address_semantics: Optional[str],
+) -> None:
+    is_contiguous = _read_field(record, "is_contiguous")
+    if type(is_contiguous) is not bool or not is_contiguous:
+        raise ValueError("runtime inventory tensor must be contiguous")
+
+    local_shape = _require_integer_tuple(
+        _read_field(record, "local_shape"), "local_shape", minimum=1
+    )
+    stride = _require_integer_tuple(_read_field(record, "stride"), "stride", minimum=0)
+    if len(stride) != len(local_shape):
+        raise ValueError("runtime inventory stride rank mismatch")
+    canonical_stride = _canonical_stride(local_shape)
+    if any(
+        extent != 1 and actual != canonical
+        for extent, actual, canonical in zip(local_shape, stride, canonical_stride)
+    ):
+        raise ValueError("runtime inventory tensor must use canonical stride")
+
+    storage_offset = _read_field(record, "storage_offset")
+    byte_offset = _read_field(record, "byte_offset")
+    _require_integer(storage_offset, "storage_offset", minimum=0)
+    _require_integer(byte_offset, "byte_offset", minimum=0)
+    if byte_offset % descriptor.itemsize != 0:
+        raise ValueError("runtime inventory byte_offset must be item-aligned")
+    _validate_address_semantics(
+        address_semantics,
+        has_nonzero_offset=storage_offset != 0 or byte_offset != 0,
+    )
+
+
+def _runtime_binding_fragment_from_record(
+    record: Any,
+    owner_resolver: Optional[Callable[[Any], Any]],
+    address_semantics: Optional[str],
+    expected_generation: int,
+) -> RuntimeBindingFragment:
+    is_contiguous = _read_field(record, "is_contiguous")
+    if type(is_contiguous) is not bool or not is_contiguous:
+        raise ValueError("runtime binding allocation must be contiguous")
+    fragment_generation = _read_optional_field(record, "lease_generation")
+    if fragment_generation is not None:
+        _require_u64(fragment_generation, "lease_generation")
+        if fragment_generation != expected_generation:
+            raise ValueError("runtime binding fragment lease generation mismatch")
+    storage_offset = _read_optional_field(record, "storage_offset")
+    byte_offset = _read_optional_field(record, "byte_offset")
+    if storage_offset is not None:
+        _require_integer(storage_offset, "storage_offset", minimum=0)
+    if byte_offset is not None:
+        _require_integer(byte_offset, "byte_offset", minimum=0)
+    _validate_address_semantics(
+        address_semantics,
+        has_nonzero_offset=(
+            storage_offset not in (None, 0) or byte_offset not in (None, 0)
+        ),
+    )
+    return RuntimeBindingFragment(
+        placement_fragment_id=_read_field(record, "placement_fragment_id"),
+        fragment_id=_read_field(record, "fragment_id"),
+        address=_read_field(record, "address"),
+        nbytes=_read_field(record, "nbytes"),
+        worker_id=_read_field(record, "worker_id"),
+        endpoint=_read_field(record, "endpoint"),
+        device=_read_field(record, "device"),
+        owner=(owner_resolver(record) if owner_resolver is not None else None),
+    )
+
+
 def _require_exact_fields(
     value: Any, expected: frozenset[str], label: str
 ) -> Mapping[str, Any]:
@@ -427,6 +519,20 @@ def _validate_fragment_geometry(
         )
 
 
+def _runtime_alias_descriptor_key(tensor: TensorDescriptor) -> tuple:
+    tensor = _canonical_tensor_descriptor(tensor)
+    return (
+        tensor.global_shape,
+        tensor.dtype,
+        tensor.itemsize,
+        tensor.partition_dim,
+        tensor.effective_shard_dims,
+        tensor.layer_id,
+        tensor.expert_id,
+        tensor.layout_fingerprint,
+    )
+
+
 def _canonical_tensor_descriptor(tensor: TensorDescriptor) -> TensorDescriptor:
     shard_dims = tensor.effective_shard_dims
     partition_dim = shard_dims[0] if len(shard_dims) == 1 else None
@@ -437,6 +543,62 @@ def _canonical_tensor_descriptor(tensor: TensorDescriptor) -> TensorDescriptor:
         partition_dim=partition_dim,
         shard_dims=shard_dims,
     )
+
+
+def _is_exact_declared_runtime_alias(
+    left: RuntimeFragment,
+    right: RuntimeFragment,
+    tensors: Mapping[str, TensorDescriptor],
+) -> bool:
+    return (
+        left.address == right.address
+        and left.nbytes == right.nbytes
+        and left.lease_generation == right.lease_generation
+        and len(left.aliases) >= 2
+        and left.aliases == right.aliases
+        and left.global_offset == right.global_offset
+        and left.local_shape == right.local_shape
+        and _runtime_alias_descriptor_key(tensors[left.tensor_id])
+        == _runtime_alias_descriptor_key(tensors[right.tensor_id])
+    )
+
+
+def _validate_runtime_address_ranges(
+    *,
+    instance_id: str,
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[RuntimeFragment],
+) -> None:
+    tensor_by_id = {tensor.tensor_id: tensor for tensor in tensors}
+    by_address_space: dict[tuple[str, str, str], list[RuntimeFragment]] = {}
+    for fragment in fragments:
+        address_space = (instance_id, fragment.worker_id, fragment.device)
+        by_address_space.setdefault(address_space, []).append(fragment)
+
+    for address_space, address_fragments in by_address_space.items():
+        ordered = sorted(address_fragments, key=lambda item: item.address)
+        active: list[RuntimeFragment] = []
+        for current in ordered:
+            active = [
+                previous
+                for previous in active
+                if previous.address + previous.nbytes > current.address
+            ]
+            for previous in active:
+                if _is_exact_declared_runtime_alias(
+                    previous,
+                    current,
+                    tensor_by_id,
+                ):
+                    continue
+                raise ValueError(
+                    "runtime manifest address ranges overlap: "
+                    f"{previous.fragment_id} and {current.fragment_id} "
+                    f"in {address_space}"
+                )
+            active.append(current)
+
+
 @dataclass(frozen=True)
 class PlacementManifest:
     """Serializable address-free placement with a canonical content ID."""
@@ -649,9 +811,266 @@ class PlacementManifest:
         )
 
 
+@dataclass(frozen=True)
+class RuntimeBindingManifest:
+    """Ephemeral physical locations and lifetime fence for one placement."""
+
+    model_id: str
+    revision: str
+    placement_id: str
+    placement_digest: str
+    instance_id: str
+    generation: int
+    lease_id: str
+    fragments: tuple[RuntimeBindingFragment, ...]
+
+    def __post_init__(self) -> None:
+        fragments = _require_manifest_items(
+            self.fragments,
+            "RuntimeBindingManifest fragments",
+            RuntimeBindingFragment,
+        )
+        object.__setattr__(
+            self,
+            "fragments",
+            tuple(
+                sorted(
+                    fragments,
+                    key=lambda item: item.placement_fragment_id,
+                )
+            ),
+        )
+        for name in (
+            "model_id",
+            "revision",
+            "placement_id",
+            "instance_id",
+            "lease_id",
+        ):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_sha256_digest(self.placement_digest, "placement_digest")
+        _require_u64(self.generation, "generation")
+        placement_ids = [item.placement_fragment_id for item in self.fragments]
+        if len(placement_ids) != len(set(placement_ids)):
+            raise ValueError("duplicate placement fragment in runtime binding")
+        fragment_ids = [item.fragment_id for item in self.fragments]
+        if len(fragment_ids) != len(set(fragment_ids)):
+            raise ValueError("duplicate runtime fragment_id in runtime binding")
+
+    @classmethod
+    def from_runtime_inventory(
+        cls,
+        inventory: Any,
+        *,
+        owner_resolver: Optional[Callable[[Any], Any]] = None,
+        address_semantics: Optional[str] = None,
+    ) -> RuntimeBindingManifest:
+        """Import framework runtime locations without importing the framework.
+
+        A non-zero framework storage or byte offset requires
+        ``address_semantics="view"`` to declare that each address is already
+        normalized to the first byte of the transferable view.
+        """
+
+        _validate_address_semantics(
+            address_semantics,
+            has_nonzero_offset=False,
+        )
+        generation = _read_field(inventory, "generation")
+        _require_u64(generation, "generation")
+        return cls(
+            model_id=_read_field(inventory, "model_id"),
+            revision=_read_field(inventory, "revision"),
+            placement_id=_read_field(inventory, "placement_id"),
+            placement_digest=_read_field(inventory, "placement_digest"),
+            instance_id=_read_field(inventory, "instance_id"),
+            generation=generation,
+            lease_id=_read_field(inventory, "lease_id"),
+            fragments=tuple(
+                _runtime_binding_fragment_from_record(
+                    record,
+                    owner_resolver,
+                    address_semantics,
+                    generation,
+                )
+                for record in _require_sequence(
+                    _read_field(inventory, "fragments"),
+                    "runtime binding fragments",
+                )
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class RuntimeManifest:
+    """A validated runtime snapshot containing logical and physical facts."""
+
+    model_id: str
+    revision: str
+    instance_id: str
+    tensors: tuple[TensorDescriptor, ...]
+    fragments: tuple[RuntimeFragment, ...]
+    lease_id: Optional[str] = None
+    placement_id: Optional[str] = None
+    generation: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "tensors",
+            _require_manifest_items(
+                self.tensors,
+                "RuntimeManifest tensors",
+                TensorDescriptor,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fragments",
+            _require_manifest_items(
+                self.fragments,
+                "RuntimeManifest fragments",
+                RuntimeFragment,
+            ),
+        )
+        for name in ("model_id", "revision", "instance_id"):
+            _require_nonempty_string(getattr(self, name), name)
+        if self.lease_id is not None:
+            _require_nonempty_string(self.lease_id, "lease_id")
+        if self.placement_id is not None:
+            _require_nonempty_string(self.placement_id, "placement_id")
+        if self.generation is not None:
+            _require_u64(self.generation, "generation")
+        fragment_generations = {
+            fragment.lease_generation for fragment in self.fragments
+        }
+        if len(fragment_generations) > 1:
+            raise ValueError("runtime manifest has inconsistent lease generations")
+        if fragment_generations:
+            fragment_generation = next(iter(fragment_generations))
+            if self.generation is None:
+                object.__setattr__(self, "generation", fragment_generation)
+            elif self.generation != fragment_generation:
+                raise ValueError(
+                    "runtime manifest generation does not match fragment generation"
+                )
+
+        _validate_fragments(self.tensors, self.fragments)
+        _validate_runtime_address_ranges(
+            instance_id=self.instance_id,
+            tensors=self.tensors,
+            fragments=self.fragments,
+        )
+
+    @classmethod
+    def from_runtime_inventory(
+        cls,
+        inventory: Any,
+        *,
+        owner_resolver: Optional[Callable[[Any], Any]] = None,
+        address_semantics: Optional[str] = None,
+    ) -> RuntimeManifest:
+        """Import and validate a framework runtime tensor inventory.
+
+        A non-zero framework view offset requires
+        ``address_semantics="view"`` to declare that ``address`` is already
+        normalized to the first byte of that view.
+        """
+
+        _validate_address_semantics(
+            address_semantics,
+            has_nonzero_offset=False,
+        )
+        generation = _read_field(inventory, "generation")
+        _require_integer(generation, "generation", minimum=0)
+        tensors: dict[str, TensorDescriptor] = {}
+        fragments = []
+        for record in _require_sequence(
+            _read_field(inventory, "tensors"), "runtime inventory tensors"
+        ):
+            shard_dims = _read_optional_field(record, "shard_dims")
+            descriptor = TensorDescriptor(
+                tensor_id=_read_field(record, "tensor_id"),
+                global_shape=_read_field(record, "global_shape"),
+                dtype=_read_field(record, "dtype"),
+                itemsize=_read_field(record, "itemsize"),
+                partition_dim=_read_field(record, "partition_dim"),
+                layer_id=_read_optional_field(record, "layer_id"),
+                expert_id=_read_optional_field(record, "expert_id"),
+                layout_fingerprint=_read_field(record, "layout_fingerprint"),
+                shard_dims=shard_dims,
+            )
+            descriptor = _canonical_tensor_descriptor(descriptor)
+            previous = tensors.setdefault(descriptor.tensor_id, descriptor)
+            if previous != descriptor:
+                raise ValueError(
+                    f"runtime inventory descriptor mismatch: {descriptor.tensor_id}"
+                )
+            _validate_runtime_view(record, descriptor, address_semantics)
+            rank = _read_field(record, "rank")
+            lease_generation = _read_field(record, "lease_generation")
+            _require_integer(lease_generation, "lease_generation", minimum=0)
+            if lease_generation != generation:
+                raise ValueError(
+                    "runtime inventory lease generation mismatch: "
+                    f"{lease_generation} != {generation}"
+                )
+            fragments.append(
+                RuntimeFragment(
+                    fragment_id=_read_field(record, "fragment_id"),
+                    tensor_id=descriptor.tensor_id,
+                    global_offset=_read_field(record, "global_offset"),
+                    local_shape=_read_field(record, "local_shape"),
+                    address=_read_field(record, "address"),
+                    nbytes=_read_field(record, "nbytes"),
+                    worker_id=_read_field(record, "worker_id"),
+                    endpoint=_read_field(record, "endpoint"),
+                    device=_read_field(record, "device"),
+                    rank=ParallelRank(
+                        dp=_read_field(rank, "dp"),
+                        tp=_read_field(rank, "tp"),
+                        pp=_read_field(rank, "pp"),
+                        ep=_read_field(rank, "ep"),
+                    ),
+                    lease_generation=lease_generation,
+                    owner=(
+                        owner_resolver(record) if owner_resolver is not None else None
+                    ),
+                    aliases=_read_aliases(record),
+                    placement_fragment_id=_read_optional_field(
+                        record, "placement_fragment_id"
+                    ),
+                )
+            )
+        return cls(
+            model_id=_read_field(inventory, "model_id"),
+            revision=_read_field(inventory, "revision"),
+            instance_id=_read_field(inventory, "instance_id"),
+            tensors=tuple(sorted(tensors.values(), key=lambda item: item.tensor_id)),
+            fragments=tuple(fragments),
+            lease_id=_read_optional_field(inventory, "lease_id"),
+            placement_id=_read_optional_field(inventory, "placement_id"),
+            generation=generation,
+        )
+
+
 def _canonical_json_digest(value: Any) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+def _logical_fragment_id(fragment: RuntimeFragment) -> str:
+    if fragment.placement_fragment_id is not None:
+        return fragment.placement_fragment_id
+    content = {
+        "tensor_id": fragment.tensor_id,
+        "global_offset": fragment.global_offset,
+        "local_shape": fragment.local_shape,
+        "nbytes": fragment.nbytes,
+        "rank": asdict(fragment.rank),
+        "aliases": fragment.aliases,
+    }
+    return f"logical:{_canonical_json_digest(content)}"
 
 
 def _logical_placement_id(
@@ -678,3 +1097,146 @@ def _logical_placement_id(
         ],
     }
     return f"sha256:{_canonical_json_digest(content)}"
+
+
+def placement_manifest_from_runtime_manifest(
+    manifest: RuntimeManifest,
+    *,
+    placement_id: Optional[str] = None,
+) -> PlacementManifest:
+    """Project a runtime snapshot into address-free placement semantics."""
+
+    fragments = tuple(
+        PlacementFragment(
+            placement_fragment_id=_logical_fragment_id(fragment),
+            tensor_id=fragment.tensor_id,
+            global_offset=fragment.global_offset,
+            local_shape=fragment.local_shape,
+            nbytes=fragment.nbytes,
+            rank=fragment.rank,
+            aliases=fragment.aliases,
+        )
+        for fragment in manifest.fragments
+    )
+    if placement_id is not None:
+        _require_nonempty_string(placement_id, "placement_id")
+    effective_placement_id = placement_id or manifest.placement_id
+    if effective_placement_id is None:
+        effective_placement_id = _logical_placement_id(
+            model_id=manifest.model_id,
+            revision=manifest.revision,
+            tensors=manifest.tensors,
+            fragments=fragments,
+        )
+    return PlacementManifest(
+        model_id=manifest.model_id,
+        revision=manifest.revision,
+        placement_id=effective_placement_id,
+        tensors=manifest.tensors,
+        fragments=fragments,
+    )
+
+
+def runtime_binding_from_runtime_manifest(
+    manifest: RuntimeManifest,
+    *,
+    placement_id: Optional[str] = None,
+) -> RuntimeBindingManifest:
+    """Project runtime locations into the ephemeral binding contract."""
+
+    if manifest.lease_id is None:
+        raise ValueError("runtime manifest has no lease_id for runtime binding")
+    if manifest.generation is None:
+        raise ValueError("runtime manifest has no generation for runtime binding")
+    placement = placement_manifest_from_runtime_manifest(
+        manifest,
+        placement_id=placement_id,
+    )
+    return RuntimeBindingManifest(
+        model_id=manifest.model_id,
+        revision=manifest.revision,
+        placement_id=placement.placement_id,
+        placement_digest=placement.digest,
+        instance_id=manifest.instance_id,
+        generation=manifest.generation,
+        lease_id=manifest.lease_id,
+        fragments=tuple(
+            RuntimeBindingFragment(
+                placement_fragment_id=_logical_fragment_id(fragment),
+                fragment_id=fragment.fragment_id,
+                address=fragment.address,
+                nbytes=fragment.nbytes,
+                worker_id=fragment.worker_id,
+                endpoint=fragment.endpoint,
+                device=fragment.device,
+                owner=fragment.owner,
+            )
+            for fragment in manifest.fragments
+        ),
+    )
+
+
+def bind_runtime_manifest(
+    placement: PlacementManifest,
+    binding: RuntimeBindingManifest,
+) -> RuntimeManifest:
+    """Bind physical runtime locations to an exact logical placement."""
+
+    if placement.model_id != binding.model_id:
+        raise ValueError("placement and runtime binding model_id differ")
+    if placement.revision != binding.revision:
+        raise ValueError("placement and runtime binding revision differ")
+    if placement.placement_id != binding.placement_id:
+        raise ValueError("placement_id and runtime binding placement_id differ")
+    if placement.digest != binding.placement_digest:
+        raise ValueError("placement digest and runtime binding placement digest differ")
+
+    placement_by_id = {
+        fragment.placement_fragment_id: fragment for fragment in placement.fragments
+    }
+    binding_by_id = {
+        fragment.placement_fragment_id: fragment for fragment in binding.fragments
+    }
+    unknown = sorted(binding_by_id.keys() - placement_by_id.keys())
+    if unknown:
+        raise ValueError(f"unknown placement fragment in runtime binding: {unknown[0]}")
+    missing = sorted(placement_by_id.keys() - binding_by_id.keys())
+    if missing:
+        raise ValueError(f"missing placement fragment in runtime binding: {missing[0]}")
+
+    fragments = []
+    for placement_fragment in placement.fragments:
+        runtime = binding_by_id[placement_fragment.placement_fragment_id]
+        if runtime.nbytes != placement_fragment.nbytes:
+            raise ValueError(
+                "runtime binding byte size does not match placement: "
+                f"{placement_fragment.placement_fragment_id}"
+            )
+        fragments.append(
+            RuntimeFragment(
+                fragment_id=runtime.fragment_id,
+                tensor_id=placement_fragment.tensor_id,
+                global_offset=placement_fragment.global_offset,
+                local_shape=placement_fragment.local_shape,
+                address=runtime.address,
+                nbytes=runtime.nbytes,
+                worker_id=runtime.worker_id,
+                endpoint=runtime.endpoint,
+                device=runtime.device,
+                rank=placement_fragment.rank,
+                lease_generation=binding.generation,
+                owner=runtime.owner,
+                aliases=placement_fragment.aliases,
+                placement_fragment_id=placement_fragment.placement_fragment_id,
+            )
+        )
+    return RuntimeManifest(
+        model_id=placement.model_id,
+        revision=placement.revision,
+        instance_id=binding.instance_id,
+        tensors=placement.tensors,
+        fragments=tuple(fragments),
+        lease_id=binding.lease_id,
+        placement_id=placement.placement_id,
+        generation=binding.generation,
+    )

--- a/mooncake-wheel/mooncake/weight_transfer/manifest.py
+++ b/mooncake-wheel/mooncake/weight_transfer/manifest.py
@@ -1,0 +1,680 @@
+"""Framework-neutral logical placement and ephemeral runtime binding contracts.
+
+The logical half of the contract is serializable and contains no process-local
+addresses. The runtime half carries addresses, endpoints, generations, leases,
+and optional owner objects that keep framework allocations alive. Model
+frameworks are responsible for supplying tensor semantics; this module does not
+infer them from tensor names.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field, replace
+from math import prod
+from typing import Any, Mapping, Optional, Sequence, Union
+
+
+_MAX_U64 = (1 << 64) - 1
+
+
+@dataclass(frozen=True)
+class ParallelRank:
+    """Framework-provided owner coordinates used only for routing.
+
+    Logical sharding is defined by ``global_offset``, ``local_shape``, and
+    ``shard_dims``. This coordinate is not a replacement for the topology and
+    axis metadata used to synthesize a target placement.
+    """
+
+    dp: int = 0
+    tp: int = 0
+    pp: int = 0
+    ep: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("dp", "tp", "pp", "ep"):
+            _require_integer(getattr(self, name), f"parallel rank {name}", minimum=0)
+
+
+@dataclass(frozen=True)
+class TensorDescriptor:
+    """Logical tensor identity, shape, dtype, and framework-supplied semantics."""
+
+    tensor_id: str
+    global_shape: tuple[int, ...]
+    dtype: str
+    itemsize: int
+    partition_dim: Optional[int]
+    layout_fingerprint: str
+    layer_id: Optional[int] = None
+    expert_id: Optional[int] = None
+    shard_dims: Optional[tuple[int, ...]] = None
+
+    def __post_init__(self) -> None:
+        shape = _require_integer_tuple(self.global_shape, "global_shape", minimum=1)
+        if not shape:
+            raise ValueError("global_shape must not be empty")
+        object.__setattr__(self, "global_shape", shape)
+        _require_nonempty_string(self.tensor_id, "tensor_id")
+        _require_nonempty_string(self.dtype, "dtype")
+        _require_integer(self.itemsize, "itemsize", minimum=1)
+        if self.partition_dim is not None:
+            _require_integer(self.partition_dim, "partition_dim", minimum=0)
+            if self.partition_dim >= len(shape):
+                raise ValueError("partition_dim is out of range")
+        if self.shard_dims is not None:
+            shard_dims = _require_integer_tuple(
+                self.shard_dims, "shard_dims", minimum=0
+            )
+            if len(shard_dims) != len(set(shard_dims)):
+                raise ValueError("shard_dims must not contain duplicates")
+            if tuple(sorted(shard_dims)) != shard_dims:
+                raise ValueError("shard_dims must be sorted")
+            if any(dim >= len(shape) for dim in shard_dims):
+                raise ValueError("shard_dims contains an out-of-range dimension")
+            if self.partition_dim is not None and shard_dims != (self.partition_dim,):
+                raise ValueError("partition_dim conflicts with shard_dims")
+            object.__setattr__(self, "shard_dims", shard_dims)
+        for name in ("layer_id", "expert_id"):
+            value = getattr(self, name)
+            if value is not None:
+                _require_integer(value, name, minimum=0)
+        _require_nonempty_string(self.layout_fingerprint, "layout_fingerprint")
+
+    @property
+    def effective_shard_dims(self) -> tuple[int, ...]:
+        """Return normalized shard dimensions for single-axis and N-D inputs."""
+
+        if self.shard_dims is not None:
+            return self.shard_dims
+        if self.partition_dim is None:
+            return ()
+        return (self.partition_dim,)
+
+
+@dataclass(frozen=True)
+class RuntimeFragment:
+    """One contiguous runtime view backing a logical tensor box.
+
+    ``address`` always points at the first byte of this view, not at the base
+    of the underlying framework storage.
+    """
+
+    fragment_id: str
+    tensor_id: str
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    address: int
+    nbytes: int
+    worker_id: str
+    endpoint: str
+    device: str
+    rank: ParallelRank
+    lease_generation: int
+    owner: Any = field(default=None, compare=False, repr=False)
+    aliases: tuple[str, ...] = ()
+    placement_fragment_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "global_offset",
+            _require_integer_tuple(self.global_offset, "global_offset", minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "local_shape",
+            _require_integer_tuple(self.local_shape, "local_shape", minimum=1),
+        )
+        for name in ("fragment_id", "tensor_id", "worker_id", "endpoint", "device"):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_address_range(self.address, self.nbytes)
+        _require_u64(self.lease_generation, "lease_generation")
+        if not isinstance(self.rank, ParallelRank):
+            raise ValueError("rank must be a ParallelRank")
+        # Aliases are an opaque, framework-authoritative tied-storage group.
+        # Shared addresses are still accepted only when geometry, dtype,
+        # generation, layout, and the complete alias group also match.
+        object.__setattr__(self, "aliases", _normalize_aliases(self.aliases))
+        if self.placement_fragment_id is not None:
+            _require_nonempty_string(
+                self.placement_fragment_id, "placement_fragment_id"
+            )
+
+
+@dataclass(frozen=True)
+class PlacementFragment:
+    """An address-free logical tensor box assigned to one parallel rank."""
+
+    placement_fragment_id: str
+    tensor_id: str
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    nbytes: int
+    rank: ParallelRank
+    aliases: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "global_offset",
+            _require_integer_tuple(self.global_offset, "global_offset", minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "local_shape",
+            _require_integer_tuple(self.local_shape, "local_shape", minimum=1),
+        )
+        for name in ("placement_fragment_id", "tensor_id"):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_u64(self.nbytes, "nbytes", minimum=1)
+        if not isinstance(self.rank, ParallelRank):
+            raise ValueError("rank must be a ParallelRank")
+        object.__setattr__(self, "aliases", _normalize_aliases(self.aliases))
+
+    @property
+    def fragment_id(self) -> str:
+        """Expose the common fragment identifier used by future planners."""
+
+        return self.placement_fragment_id
+
+
+@dataclass(frozen=True)
+class RuntimeBindingFragment:
+    """Contiguous physical runtime view for one placement fragment."""
+
+    placement_fragment_id: str
+    fragment_id: str
+    address: int
+    nbytes: int
+    worker_id: str
+    endpoint: str
+    device: str
+    owner: Any = field(default=None, compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "placement_fragment_id",
+            "fragment_id",
+            "worker_id",
+            "endpoint",
+            "device",
+        ):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_address_range(self.address, self.nbytes)
+
+
+ManifestFragment = Union[RuntimeFragment, PlacementFragment]
+
+
+def _require_nonempty_string(value: Any, name: str) -> None:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+
+
+def _require_integer(
+    value: Any,
+    name: str,
+    *,
+    minimum: Optional[int] = None,
+) -> None:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+
+
+def _require_u64(value: Any, name: str, *, minimum: int = 0) -> None:
+    _require_integer(value, name, minimum=minimum)
+    if value > _MAX_U64:
+        raise ValueError(f"{name} must fit in an unsigned 64-bit integer")
+
+
+def _require_address_range(address: Any, nbytes: Any) -> None:
+    _require_u64(address, "address", minimum=1)
+    _require_u64(nbytes, "nbytes", minimum=1)
+    if nbytes > _MAX_U64 - address:
+        raise ValueError("address range must fit in an unsigned 64-bit integer")
+
+
+def _require_sha256_digest(value: Any, name: str) -> None:
+    _require_nonempty_string(value, name)
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _require_integer_tuple(
+    value: Any,
+    name: str,
+    *,
+    minimum: int,
+) -> tuple[int, ...]:
+    if isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must contain integers")
+    try:
+        result = tuple(value)
+    except TypeError as error:
+        raise ValueError(f"{name} must contain integers") from error
+    for item in result:
+        _require_integer(item, name, minimum=minimum)
+    return result
+
+
+def _require_sequence(value: Any, name: str) -> Sequence[Any]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence")
+    return value
+
+
+def _require_manifest_items(
+    value: Any,
+    name: str,
+    item_type: type,
+) -> tuple[Any, ...]:
+    items = tuple(_require_sequence(value, name))
+    if not all(isinstance(item, item_type) for item in items):
+        raise ValueError(f"{name} must contain {item_type.__name__}")
+    return items
+
+
+def _read_field(value: Any, name: str) -> Any:
+    try:
+        if isinstance(value, Mapping):
+            return value[name]
+        return getattr(value, name)
+    except (KeyError, AttributeError) as error:
+        raise ValueError(f"missing required field: {name}") from error
+
+
+def _read_optional_field(value: Any, name: str) -> Optional[Any]:
+    if isinstance(value, Mapping):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _read_aliases(value: Any) -> tuple[str, ...]:
+    aliases = _read_optional_field(value, "aliases")
+    if aliases is None:
+        return ()
+    if isinstance(aliases, (str, bytes, bytearray)) or not isinstance(
+        aliases, Sequence
+    ):
+        raise ValueError("aliases must be a sequence of non-empty strings")
+    return tuple(aliases)
+
+
+def _normalize_aliases(value: Any) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise ValueError("aliases must contain non-empty strings")
+    aliases = tuple(value)
+    if any(type(alias) is not str or not alias for alias in aliases):
+        raise ValueError("aliases must contain non-empty strings")
+    if len(aliases) != len(set(aliases)):
+        raise ValueError("aliases must not contain duplicates")
+    return tuple(sorted(aliases))
+
+
+def _require_exact_fields(
+    value: Any, expected: frozenset[str], label: str
+) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != expected:
+        raise ValueError(f"{label} schema fields do not match contract")
+    return value
+
+
+def _load_json_object(value: str, label: str) -> Mapping[str, Any]:
+    def reject_constant(constant: str) -> None:
+        raise ValueError(f"non-finite JSON number is unsupported: {constant}")
+
+    def reject_duplicate_fields(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON field: {key}")
+            result[key] = item
+        return result
+
+    try:
+        raw = json.loads(
+            value,
+            parse_constant=reject_constant,
+            object_pairs_hook=reject_duplicate_fields,
+        )
+    except (TypeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{label} is not valid JSON") from error
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    return raw
+
+
+def _validate_fragments(
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[ManifestFragment],
+) -> None:
+    tensor_by_id: dict[str, TensorDescriptor] = {}
+    for tensor in tensors:
+        if tensor.tensor_id in tensor_by_id:
+            raise ValueError(f"duplicate tensor_id: {tensor.tensor_id}")
+        tensor_by_id[tensor.tensor_id] = tensor
+
+    fragment_ids: set[str] = set()
+    logical_fragments: set[tuple] = set()
+    for fragment in fragments:
+        if fragment.fragment_id in fragment_ids:
+            raise ValueError(f"duplicate fragment_id: {fragment.fragment_id}")
+        fragment_ids.add(fragment.fragment_id)
+        logical_fragment = (
+            fragment.tensor_id,
+            fragment.rank,
+            fragment.global_offset,
+            fragment.local_shape,
+        )
+        if logical_fragment in logical_fragments:
+            raise ValueError(
+                "duplicate logical fragment for tensor and parallel rank: "
+                f"{fragment.fragment_id}"
+            )
+        logical_fragments.add(logical_fragment)
+        tensor = tensor_by_id.get(fragment.tensor_id)
+        if tensor is None:
+            raise ValueError(f"unknown tensor_id: {fragment.tensor_id}")
+        _validate_fragment_geometry(tensor, fragment)
+
+
+def _validate_fragment_geometry(
+    tensor: TensorDescriptor,
+    fragment: ManifestFragment,
+) -> None:
+    ndim = len(tensor.global_shape)
+    if len(fragment.global_offset) != ndim or len(fragment.local_shape) != ndim:
+        raise ValueError(f"fragment rank mismatch: {fragment.fragment_id}")
+    for offset, extent, total in zip(
+        fragment.global_offset,
+        fragment.local_shape,
+        tensor.global_shape,
+    ):
+        if offset + extent > total:
+            raise ValueError(f"fragment is out of bounds: {fragment.fragment_id}")
+
+    shard_dims = frozenset(tensor.effective_shard_dims)
+    if not shard_dims:
+        if fragment.global_offset != (0,) * ndim:
+            raise ValueError(
+                f"replicated fragment has an offset: {fragment.fragment_id}"
+            )
+        if fragment.local_shape != tensor.global_shape:
+            raise ValueError(
+                f"replicated fragment is incomplete: {fragment.fragment_id}"
+            )
+    else:
+        for dim in range(ndim):
+            if dim in shard_dims:
+                continue
+            if fragment.global_offset[dim] != 0:
+                raise ValueError(f"fragment offset uses a non-shard axis: {dim}")
+            if fragment.local_shape[dim] != tensor.global_shape[dim]:
+                raise ValueError(f"fragment shape uses a non-shard axis: {dim}")
+
+    expected_nbytes = prod(fragment.local_shape) * tensor.itemsize
+    if fragment.nbytes != expected_nbytes:
+        raise ValueError(
+            f"fragment byte size mismatch: {fragment.fragment_id}: "
+            f"expected {expected_nbytes}, got {fragment.nbytes}"
+        )
+
+
+def _canonical_tensor_descriptor(tensor: TensorDescriptor) -> TensorDescriptor:
+    shard_dims = tensor.effective_shard_dims
+    partition_dim = shard_dims[0] if len(shard_dims) == 1 else None
+    if tensor.shard_dims == shard_dims and tensor.partition_dim == partition_dim:
+        return tensor
+    return replace(
+        tensor,
+        partition_dim=partition_dim,
+        shard_dims=shard_dims,
+    )
+@dataclass(frozen=True)
+class PlacementManifest:
+    """Serializable address-free placement with a canonical content ID."""
+
+    model_id: str
+    revision: str
+    tensors: tuple[TensorDescriptor, ...]
+    fragments: tuple[PlacementFragment, ...]
+    placement_id: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        tensors = _require_manifest_items(
+            self.tensors, "PlacementManifest tensors", TensorDescriptor
+        )
+        tensors = tuple(_canonical_tensor_descriptor(tensor) for tensor in tensors)
+        fragments = _require_manifest_items(
+            self.fragments, "PlacementManifest fragments", PlacementFragment
+        )
+        object.__setattr__(
+            self,
+            "tensors",
+            tuple(sorted(tensors, key=lambda item: item.tensor_id)),
+        )
+        object.__setattr__(
+            self,
+            "fragments",
+            tuple(
+                sorted(
+                    fragments,
+                    key=lambda item: item.placement_fragment_id,
+                )
+            ),
+        )
+        for name in ("model_id", "revision"):
+            _require_nonempty_string(getattr(self, name), name)
+        _validate_fragments(self.tensors, self.fragments)
+        canonical_placement_id = _logical_placement_id(
+            model_id=self.model_id,
+            revision=self.revision,
+            tensors=self.tensors,
+            fragments=self.fragments,
+        )
+        if self.placement_id is None:
+            object.__setattr__(self, "placement_id", canonical_placement_id)
+        else:
+            _require_nonempty_string(self.placement_id, "placement_id")
+            if self.placement_id != canonical_placement_id:
+                raise ValueError(
+                    "placement_id does not match canonical logical content"
+                )
+
+    @property
+    def digest(self) -> str:
+        """Return the stable SHA-256 digest of the canonical JSON form."""
+
+        return hashlib.sha256(self.to_json().encode()).hexdigest()
+
+    def to_json(self) -> str:
+        """Serialize logical placement without any runtime location."""
+
+        return json.dumps(asdict(self), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, value: str) -> PlacementManifest:
+        """Parse a strict placement manifest."""
+
+        manifest = _require_exact_fields(
+            _load_json_object(value, "placement manifest"),
+            frozenset(
+                {
+                    "model_id",
+                    "revision",
+                    "placement_id",
+                    "tensors",
+                    "fragments",
+                }
+            ),
+            "placement manifest",
+        )
+
+        tensor_fields = frozenset(
+            {
+                "tensor_id",
+                "global_shape",
+                "dtype",
+                "itemsize",
+                "partition_dim",
+                "layer_id",
+                "expert_id",
+                "layout_fingerprint",
+                "shard_dims",
+            }
+        )
+        tensors = []
+        for index, item in enumerate(
+            _require_sequence(manifest["tensors"], "placement tensors")
+        ):
+            tensor = _require_exact_fields(
+                item, tensor_fields, f"placement tensor {index}"
+            )
+            tensors.append(
+                TensorDescriptor(
+                    tensor_id=tensor["tensor_id"],
+                    global_shape=tensor["global_shape"],
+                    dtype=tensor["dtype"],
+                    itemsize=tensor["itemsize"],
+                    partition_dim=tensor["partition_dim"],
+                    layer_id=tensor["layer_id"],
+                    expert_id=tensor["expert_id"],
+                    layout_fingerprint=tensor["layout_fingerprint"],
+                    shard_dims=(
+                        tensor["shard_dims"]
+                        if tensor["shard_dims"] is not None
+                        else None
+                    ),
+                )
+            )
+
+        fragment_fields = frozenset(
+            {
+                "placement_fragment_id",
+                "tensor_id",
+                "global_offset",
+                "local_shape",
+                "nbytes",
+                "rank",
+                "aliases",
+            }
+        )
+        rank_fields = frozenset({"dp", "tp", "pp", "ep"})
+        fragments = []
+        for index, item in enumerate(
+            _require_sequence(manifest["fragments"], "placement fragments")
+        ):
+            fragment = _require_exact_fields(
+                item, fragment_fields, f"placement fragment {index}"
+            )
+            rank = _require_exact_fields(
+                fragment["rank"], rank_fields, f"placement rank {index}"
+            )
+            fragments.append(
+                PlacementFragment(
+                    placement_fragment_id=fragment["placement_fragment_id"],
+                    tensor_id=fragment["tensor_id"],
+                    global_offset=fragment["global_offset"],
+                    local_shape=fragment["local_shape"],
+                    nbytes=fragment["nbytes"],
+                    rank=ParallelRank(**rank),
+                    aliases=fragment["aliases"],
+                )
+            )
+        return cls(
+            model_id=manifest["model_id"],
+            revision=manifest["revision"],
+            placement_id=manifest["placement_id"],
+            tensors=tuple(tensors),
+            fragments=tuple(fragments),
+        )
+
+    @classmethod
+    def from_runtime_inventory(cls, inventory: Any) -> PlacementManifest:
+        """Import framework-provided logical placement records."""
+
+        tensors: dict[str, TensorDescriptor] = {}
+        fragments = []
+        for record in _require_sequence(
+            _read_field(inventory, "tensors"), "placement inventory tensors"
+        ):
+            shard_dims = _read_optional_field(record, "shard_dims")
+            descriptor = TensorDescriptor(
+                tensor_id=_read_field(record, "tensor_id"),
+                global_shape=_read_field(record, "global_shape"),
+                dtype=_read_field(record, "dtype"),
+                itemsize=_read_field(record, "itemsize"),
+                partition_dim=_read_field(record, "partition_dim"),
+                layer_id=_read_optional_field(record, "layer_id"),
+                expert_id=_read_optional_field(record, "expert_id"),
+                layout_fingerprint=_read_field(record, "layout_fingerprint"),
+                shard_dims=shard_dims,
+            )
+            descriptor = _canonical_tensor_descriptor(descriptor)
+            previous = tensors.setdefault(descriptor.tensor_id, descriptor)
+            if previous != descriptor:
+                raise ValueError(
+                    f"placement descriptor mismatch: {descriptor.tensor_id}"
+                )
+            rank = _read_field(record, "rank")
+            fragments.append(
+                PlacementFragment(
+                    placement_fragment_id=_read_field(record, "placement_fragment_id"),
+                    tensor_id=descriptor.tensor_id,
+                    global_offset=_read_field(record, "global_offset"),
+                    local_shape=_read_field(record, "local_shape"),
+                    nbytes=_read_field(record, "nbytes"),
+                    rank=ParallelRank(
+                        dp=_read_field(rank, "dp"),
+                        tp=_read_field(rank, "tp"),
+                        pp=_read_field(rank, "pp"),
+                        ep=_read_field(rank, "ep"),
+                    ),
+                    aliases=_read_aliases(record),
+                )
+            )
+        return cls(
+            model_id=_read_field(inventory, "model_id"),
+            revision=_read_field(inventory, "revision"),
+            tensors=tuple(sorted(tensors.values(), key=lambda item: item.tensor_id)),
+            fragments=tuple(fragments),
+            placement_id=_read_optional_field(inventory, "placement_id"),
+        )
+
+
+def _canonical_json_digest(value: Any) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _logical_placement_id(
+    *,
+    model_id: str,
+    revision: str,
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[PlacementFragment],
+) -> str:
+    content = {
+        "schema": "weight-placement",
+        "model_id": model_id,
+        "revision": revision,
+        "tensors": [
+            asdict(_canonical_tensor_descriptor(tensor))
+            for tensor in sorted(tensors, key=lambda item: item.tensor_id)
+        ],
+        "fragments": [
+            asdict(fragment)
+            for fragment in sorted(
+                fragments,
+                key=lambda item: item.placement_fragment_id,
+            )
+        ],
+    }
+    return f"sha256:{_canonical_json_digest(content)}"

--- a/mooncake-wheel/tests/test_weight_transfer_manifest.py
+++ b/mooncake-wheel/tests/test_weight_transfer_manifest.py
@@ -1,0 +1,937 @@
+from __future__ import annotations
+
+import inspect
+import json
+import typing
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+import mooncake.weight_transfer as weight_transfer
+from mooncake.weight_transfer import (
+    ParallelRank,
+    PlacementFragment,
+    PlacementManifest,
+    RuntimeBindingFragment,
+    RuntimeBindingManifest,
+    RuntimeFragment,
+    RuntimeManifest,
+    TensorDescriptor,
+    bind_runtime_manifest,
+    placement_manifest_from_runtime_manifest,
+    runtime_binding_from_runtime_manifest,
+)
+
+
+MODEL_ID = "model"
+REVISION = "revision"
+
+
+def test_public_api_is_minimal_and_explicit() -> None:
+    assert weight_transfer.__all__ == [
+        "ParallelRank",
+        "PlacementFragment",
+        "PlacementManifest",
+        "RuntimeBindingFragment",
+        "RuntimeBindingManifest",
+        "RuntimeFragment",
+        "RuntimeManifest",
+        "TensorDescriptor",
+        "bind_runtime_manifest",
+        "placement_manifest_from_runtime_manifest",
+        "runtime_binding_from_runtime_manifest",
+    ]
+
+
+def test_public_type_hints_resolve() -> None:
+    for name in weight_transfer.__all__:
+        value = getattr(weight_transfer, name)
+        targets = (value, value.__init__) if inspect.isclass(value) else (value,)
+        for target in targets:
+            typing.get_type_hints(target)
+
+
+def descriptor(**overrides) -> TensorDescriptor:
+    values = {
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_shape": (8, 4),
+        "dtype": "bfloat16",
+        "itemsize": 2,
+        "partition_dim": 0,
+        "layer_id": 2,
+        "expert_id": 3,
+        "layout_fingerprint": "test:qwen:bf16:v1",
+    }
+    values.update(overrides)
+    return TensorDescriptor(**values)
+
+
+def runtime_fragment(**overrides) -> RuntimeFragment:
+    values = {
+        "fragment_id": "runtime-0",
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_offset": (0, 0),
+        "local_shape": (4, 4),
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "worker-0",
+        "endpoint": "worker-0:12345",
+        "device": "cuda:0",
+        "rank": ParallelRank(dp=0, tp=0, pp=1, ep=1),
+        "lease_generation": 7,
+    }
+    values.update(overrides)
+    return RuntimeFragment(**values)
+
+
+def placement_fragment(**overrides) -> PlacementFragment:
+    values = {
+        "placement_fragment_id": "placement-0",
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_offset": (0, 0),
+        "local_shape": (4, 4),
+        "nbytes": 32,
+        "rank": ParallelRank(dp=0, tp=0, pp=1, ep=1),
+    }
+    values.update(overrides)
+    return PlacementFragment(**values)
+
+
+def placement_manifest(**overrides) -> PlacementManifest:
+    values = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": None,
+        "tensors": (descriptor(),),
+        "fragments": (placement_fragment(),),
+    }
+    values.update(overrides)
+    return PlacementManifest(**values)
+
+
+def binding_fragment(**overrides) -> RuntimeBindingFragment:
+    values = {
+        "placement_fragment_id": "placement-0",
+        "fragment_id": "runtime-0",
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "worker-0",
+        "endpoint": "worker-0:12345",
+        "device": "cuda:0",
+    }
+    values.update(overrides)
+    return RuntimeBindingFragment(**values)
+
+
+def binding_manifest(
+    *,
+    placement: PlacementManifest | None = None,
+    **overrides,
+) -> RuntimeBindingManifest:
+    logical = placement or placement_manifest()
+    values = {
+        "model_id": logical.model_id,
+        "revision": logical.revision,
+        "placement_id": logical.placement_id,
+        "placement_digest": logical.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (binding_fragment(),),
+    }
+    values.update(overrides)
+    return RuntimeBindingManifest(**values)
+
+
+def runtime_inventory_tensor(**overrides) -> dict:
+    values = {
+        "fragment_id": "runtime-0",
+        "placement_fragment_id": "placement-0",
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_shape": (8, 4),
+        "global_offset": (0, 0),
+        "local_shape": (4, 4),
+        "dtype": "bfloat16",
+        "itemsize": 2,
+        "partition_dim": 0,
+        "layer_id": 2,
+        "expert_id": 3,
+        "layout_fingerprint": "test:qwen:bf16:v1",
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "worker-0",
+        "endpoint": "worker-0:12345",
+        "device": "cuda:0",
+        "rank": {"dp": 0, "tp": 0, "pp": 1, "ep": 1},
+        "lease_generation": 7,
+        "aliases": (),
+        "is_contiguous": True,
+        "stride": (4, 1),
+        "storage_offset": 0,
+        "byte_offset": 0,
+    }
+    values.update(overrides)
+    return values
+
+
+def runtime_inventory(**overrides) -> dict:
+    values = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "instance_id": "instance",
+        "placement_id": None,
+        "generation": 7,
+        "lease_id": "lease-7",
+        "tensors": (runtime_inventory_tensor(),),
+    }
+    values.update(overrides)
+    return values
+
+
+def test_partition_dim_and_single_axis_shard_dims_are_normalized() -> None:
+    single_axis = descriptor()
+    nd_descriptor = descriptor(
+        partition_dim=None,
+        shard_dims=(0, 1),
+        global_shape=(8, 16, 32),
+    )
+
+    assert single_axis.effective_shard_dims == (0,)
+    assert nd_descriptor.effective_shard_dims == (0, 1)
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"global_shape": ()}, "global_shape"),
+        ({"global_shape": (8.0, 4)}, "integer"),
+        ({"itemsize": True}, "integer"),
+        ({"partition_dim": 2}, "out of range"),
+        ({"partition_dim": 0, "shard_dims": (1,)}, "conflicts"),
+        ({"partition_dim": None, "shard_dims": (0, 0)}, "duplicates"),
+        ({"partition_dim": None, "shard_dims": (1, 0)}, "sorted"),
+        ({"partition_dim": None, "shard_dims": (2,)}, "out-of-range"),
+        ({"partition_dim": None, "shard_dims": (True,)}, "integer"),
+        ({"layout_fingerprint": ""}, "layout_fingerprint"),
+    ],
+)
+def test_tensor_descriptor_rejects_invalid_schema(
+    overrides: dict, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        descriptor(**overrides)
+
+
+def test_tensor_descriptor_requires_explicit_layout_fingerprint() -> None:
+    values = {
+        "tensor_id": "weight",
+        "global_shape": (4, 4),
+        "dtype": "bfloat16",
+        "itemsize": 2,
+        "partition_dim": 0,
+    }
+
+    with pytest.raises(TypeError, match="layout_fingerprint"):
+        TensorDescriptor(**values)
+
+
+def test_runtime_inventory_is_framework_neutral_and_retains_owner() -> None:
+    inventory = runtime_inventory(
+        tensors=(runtime_inventory_tensor(device="cuda:0"),),
+    )
+    owner = object()
+
+    manifest = RuntimeManifest.from_runtime_inventory(
+        inventory,
+        owner_resolver=lambda record: owner if record["fragment_id"] else None,
+    )
+
+    assert manifest.model_id == MODEL_ID
+    assert manifest.revision == REVISION
+    assert manifest.instance_id == "instance"
+    assert manifest.placement_id is None
+    assert manifest.generation == 7
+    assert manifest.lease_id == "lease-7"
+    assert manifest.fragments[0].owner is owner
+    assert manifest.fragments[0].device == "cuda:0"
+    assert manifest.fragments[0].rank == ParallelRank(dp=0, tp=0, pp=1, ep=1)
+    assert not hasattr(manifest, "to_json")
+
+
+def test_runtime_inventory_accepts_object_records_and_optional_semantics() -> None:
+    tensor = runtime_inventory_tensor()
+    tensor.pop("layer_id")
+    tensor.pop("expert_id")
+    tensor.pop("aliases")
+    inventory = SimpleNamespace(
+        **{
+            **runtime_inventory(),
+            "tensors": (SimpleNamespace(**tensor),),
+        }
+    )
+
+    manifest = RuntimeManifest.from_runtime_inventory(inventory)
+
+    assert manifest.tensors[0].layer_id is None
+    assert manifest.tensors[0].expert_id is None
+    assert manifest.fragments[0].aliases == ()
+
+
+def test_runtime_inventory_imports_multi_axis_logical_box() -> None:
+    tensor = runtime_inventory_tensor(
+        tensor_id="layers.2.experts.w1",
+        global_shape=(8, 16, 32),
+        global_offset=(3, 8, 0),
+        local_shape=(1, 8, 32),
+        partition_dim=None,
+        shard_dims=(0, 1),
+        expert_id=None,
+        nbytes=512,
+        stride=(256, 32, 1),
+    )
+
+    manifest = RuntimeManifest.from_runtime_inventory(
+        runtime_inventory(tensors=(tensor,))
+    )
+
+    assert manifest.tensors[0].effective_shard_dims == (0, 1)
+    assert manifest.fragments[0].global_offset == (3, 8, 0)
+    assert manifest.fragments[0].local_shape == (1, 8, 32)
+
+
+def test_runtime_inventory_normalizes_equivalent_single_axis_descriptors() -> None:
+    first = runtime_inventory_tensor(
+        fragment_id="runtime-0",
+        placement_fragment_id="placement-0",
+        global_offset=(0, 0),
+        address=0x1000,
+        worker_id="worker-0",
+        endpoint="worker-0:12345",
+        rank={"dp": 0, "tp": 0, "pp": 1, "ep": 1},
+    )
+    second = runtime_inventory_tensor(
+        fragment_id="runtime-1",
+        placement_fragment_id="placement-1",
+        shard_dims=(0,),
+        global_offset=(4, 0),
+        address=0x2000,
+        worker_id="worker-1",
+        endpoint="worker-1:12345",
+        rank={"dp": 0, "tp": 1, "pp": 1, "ep": 1},
+    )
+
+    manifest = RuntimeManifest.from_runtime_inventory(
+        runtime_inventory(tensors=(first, second))
+    )
+
+    assert manifest.tensors[0].partition_dim == 0
+    assert manifest.tensors[0].shard_dims == (0,)
+    assert len(manifest.fragments) == 2
+
+
+@pytest.mark.parametrize(
+    "tensor_overrides, message",
+    [
+        ({"is_contiguous": False}, "contiguous"),
+        ({"is_contiguous": 1}, "contiguous"),
+        ({"stride": (1, 4)}, "canonical stride"),
+        ({"stride": (4, True)}, "stride"),
+        ({"storage_offset": -1}, "storage_offset"),
+        ({"storage_offset": 0.0}, "storage_offset"),
+        ({"byte_offset": 1}, "item-aligned"),
+        ({"byte_offset": 0.0}, "byte_offset"),
+        ({"nbytes": 31}, "byte size mismatch"),
+    ],
+)
+def test_runtime_inventory_rejects_unsafe_physical_views(
+    tensor_overrides: dict, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        RuntimeManifest.from_runtime_inventory(
+            runtime_inventory(tensors=(runtime_inventory_tensor(**tensor_overrides),))
+        )
+
+
+def test_runtime_inventory_requires_explicit_view_address_semantics() -> None:
+    inventory = runtime_inventory(
+        tensors=(
+            runtime_inventory_tensor(
+                storage_offset=7,
+                byte_offset=14,
+            ),
+        )
+    )
+
+    with pytest.raises(ValueError, match="address_semantics"):
+        RuntimeManifest.from_runtime_inventory(inventory)
+
+    manifest = RuntimeManifest.from_runtime_inventory(
+        inventory,
+        address_semantics="view",
+    )
+
+    assert manifest.fragments[0].address == 0x1000
+
+
+def test_runtime_inventory_rejects_unknown_address_semantics() -> None:
+    with pytest.raises(ValueError, match="address_semantics"):
+        RuntimeManifest.from_runtime_inventory(
+            runtime_inventory(),
+            address_semantics="storage",
+        )
+
+
+def test_runtime_inventory_accepts_arbitrary_singleton_stride() -> None:
+    tensor = runtime_inventory_tensor(
+        global_shape=(8, 1, 4),
+        global_offset=(0, 0, 0),
+        local_shape=(4, 1, 4),
+        stride=(4, 99, 1),
+        nbytes=32,
+    )
+
+    manifest = RuntimeManifest.from_runtime_inventory(
+        runtime_inventory(tensors=(tensor,))
+    )
+
+    assert manifest.fragments[0].local_shape == (4, 1, 4)
+
+
+def test_runtime_inventory_requires_snapshot_generation_match() -> None:
+    with pytest.raises(ValueError, match="lease generation mismatch"):
+        RuntimeManifest.from_runtime_inventory(
+            runtime_inventory(
+                generation=8,
+                tensors=(runtime_inventory_tensor(lease_generation=7),),
+            )
+        )
+
+
+def test_direct_runtime_manifest_requires_one_generation() -> None:
+    with pytest.raises(ValueError, match="inconsistent lease generations"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=(descriptor(),),
+            fragments=(
+                runtime_fragment(fragment_id="runtime-0", lease_generation=7),
+                runtime_fragment(
+                    fragment_id="runtime-1",
+                    global_offset=(4, 0),
+                    address=0x2000,
+                    lease_generation=8,
+                ),
+            ),
+        )
+
+
+def test_runtime_manifest_derives_generation_for_direct_construction() -> None:
+    manifest = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        tensors=(descriptor(),),
+        fragments=(runtime_fragment(),),
+    )
+
+    assert manifest.generation == 7
+
+
+def test_empty_runtime_manifest_retains_explicit_generation() -> None:
+    manifest = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        tensors=(),
+        fragments=(),
+        generation=9,
+        lease_id="lease-9",
+    )
+
+    assert runtime_binding_from_runtime_manifest(manifest).generation == 9
+
+
+@pytest.mark.parametrize("right_address", [0x1000, 0x1010])
+def test_runtime_manifest_rejects_overlapping_independent_ranges(
+    right_address: int,
+) -> None:
+    tensors = (
+        descriptor(tensor_id="a.weight"),
+        descriptor(tensor_id="b.weight"),
+    )
+
+    with pytest.raises(ValueError, match="address ranges overlap"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=tensors,
+            fragments=(
+                runtime_fragment(fragment_id="runtime-a", tensor_id="a.weight"),
+                runtime_fragment(
+                    fragment_id="runtime-b",
+                    tensor_id="b.weight",
+                    address=right_address,
+                ),
+            ),
+        )
+
+
+def test_runtime_manifest_rejects_nested_overlap() -> None:
+    tensors = (
+        descriptor(
+            tensor_id="large.weight",
+            global_shape=(16,),
+            dtype="uint8",
+            itemsize=1,
+            partition_dim=None,
+        ),
+        descriptor(
+            tensor_id="small.weight",
+            global_shape=(4,),
+            dtype="uint8",
+            itemsize=1,
+            partition_dim=None,
+        ),
+        descriptor(
+            tensor_id="nested.weight",
+            global_shape=(4,),
+            dtype="uint8",
+            itemsize=1,
+            partition_dim=None,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="address ranges overlap"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=tensors,
+            fragments=(
+                runtime_fragment(
+                    fragment_id="large",
+                    tensor_id="large.weight",
+                    global_offset=(0,),
+                    local_shape=(16,),
+                    nbytes=16,
+                ),
+                runtime_fragment(
+                    fragment_id="small",
+                    tensor_id="small.weight",
+                    global_offset=(0,),
+                    local_shape=(4,),
+                    address=0x1000,
+                    nbytes=4,
+                    aliases=("large.weight", "small.weight"),
+                ),
+                runtime_fragment(
+                    fragment_id="nested",
+                    tensor_id="nested.weight",
+                    global_offset=(0,),
+                    local_shape=(4,),
+                    address=0x1008,
+                    nbytes=4,
+                ),
+            ),
+        )
+
+
+def test_runtime_manifest_treats_endpoint_as_routing_not_address_space() -> None:
+    tensors = (
+        descriptor(tensor_id="a.weight"),
+        descriptor(tensor_id="b.weight"),
+    )
+
+    with pytest.raises(ValueError, match="address ranges overlap"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=tensors,
+            fragments=(
+                runtime_fragment(fragment_id="a", tensor_id="a.weight"),
+                runtime_fragment(
+                    fragment_id="b",
+                    tensor_id="b.weight",
+                    endpoint="worker-0:54321",
+                ),
+            ),
+        )
+
+
+def test_runtime_manifest_allows_same_address_on_different_workers() -> None:
+    tensors = (
+        descriptor(tensor_id="a.weight"),
+        descriptor(tensor_id="b.weight"),
+    )
+
+    manifest = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        tensors=tensors,
+        fragments=(
+            runtime_fragment(fragment_id="a", tensor_id="a.weight"),
+            runtime_fragment(
+                fragment_id="b",
+                tensor_id="b.weight",
+                worker_id="worker-1",
+                endpoint="worker-1:12345",
+            ),
+        ),
+    )
+
+    assert len(manifest.fragments) == 2
+
+
+def test_runtime_manifest_treats_device_as_address_space() -> None:
+    tensors = (
+        descriptor(tensor_id="a.weight"),
+        descriptor(tensor_id="b.weight"),
+    )
+
+    manifest = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        tensors=tensors,
+        fragments=(
+            runtime_fragment(fragment_id="a", tensor_id="a.weight"),
+            runtime_fragment(
+                fragment_id="b",
+                tensor_id="b.weight",
+                device="cuda:1",
+            ),
+        ),
+    )
+
+    assert len(manifest.fragments) == 2
+
+
+def test_runtime_manifest_rejects_duplicate_logical_box_for_same_rank() -> None:
+    with pytest.raises(ValueError, match="duplicate logical fragment"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            generation=7,
+            tensors=(descriptor(),),
+            fragments=(
+                runtime_fragment(fragment_id="runtime-0", address=0x1000),
+                runtime_fragment(fragment_id="runtime-1", address=0x2000),
+            ),
+        )
+
+
+def test_runtime_manifest_allows_only_exact_compatible_declared_aliases() -> None:
+    aliases = ("lm_head.weight", "model.embed_tokens.weight")
+    tensors = (
+        descriptor(tensor_id="embed.weight"),
+        descriptor(tensor_id="head.weight"),
+    )
+    fragments = tuple(
+        runtime_fragment(
+            fragment_id=f"runtime-{tensor.tensor_id}",
+            tensor_id=tensor.tensor_id,
+            aliases=aliases,
+        )
+        for tensor in tensors
+    )
+
+    manifest = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        tensors=tensors,
+        fragments=fragments,
+    )
+
+    assert len(manifest.fragments) == 2
+
+    with pytest.raises(ValueError, match="address ranges overlap"):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=(
+                tensors[0],
+                replace(tensors[1], layout_fingerprint="different"),
+            ),
+            fragments=fragments,
+        )
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        runtime_fragment(tensor_id="missing"),
+        runtime_fragment(global_offset=(6, 0)),
+        runtime_fragment(nbytes=31),
+    ],
+)
+def test_runtime_manifest_rejects_invalid_fragment(fragment: RuntimeFragment) -> None:
+    with pytest.raises(ValueError):
+        RuntimeManifest(
+            model_id=MODEL_ID,
+            revision=REVISION,
+            instance_id="instance",
+            tensors=(descriptor(),),
+            fragments=(fragment,),
+        )
+
+
+def test_runtime_fragment_requires_device() -> None:
+    with pytest.raises(ValueError, match="device"):
+        runtime_fragment(device="")
+
+
+def test_placement_round_trip_is_stable_and_address_free() -> None:
+    placement = placement_manifest()
+
+    encoded = placement.to_json()
+    decoded = PlacementManifest.from_json(encoded)
+
+    assert decoded == placement
+    assert decoded.digest == placement.digest
+    assert placement.placement_id == (
+        "sha256:c4f3bc2feed99a64ff156fd57cb5cf626ae8b38c1551c0fe2225e1921e14d73a"
+    )
+    assert placement.digest == (
+        "7320a5090dc88556c57e5d9e8cb316d05b3bf99b00f7a0c0da04198ca995e915"
+    )
+    assert encoded == placement.to_json()
+    for forbidden in (
+        "address",
+        "endpoint",
+        "worker_id",
+        "instance_id",
+        "generation",
+        "lease_id",
+        "owner",
+    ):
+        assert forbidden not in encoded
+
+
+def test_placement_digest_is_independent_of_inventory_order() -> None:
+    tensors = (
+        descriptor(tensor_id="b.weight"),
+        descriptor(tensor_id="a.weight"),
+    )
+    fragments = (
+        placement_fragment(
+            placement_fragment_id="b",
+            tensor_id="b.weight",
+            rank=ParallelRank(tp=1),
+        ),
+        placement_fragment(
+            placement_fragment_id="a",
+            tensor_id="a.weight",
+            rank=ParallelRank(tp=0),
+        ),
+    )
+
+    first = placement_manifest(tensors=tensors, fragments=fragments)
+    second = placement_manifest(
+        tensors=tuple(reversed(tensors)),
+        fragments=tuple(reversed(fragments)),
+    )
+
+    assert first == second
+    assert first.to_json() == second.to_json()
+    assert first.digest == second.digest
+
+
+def test_placement_normalizes_partition_dim_and_shard_dims() -> None:
+    partitioned = placement_manifest(
+        tensors=(descriptor(shard_dims=None),),
+    )
+    nd_placement = placement_manifest(
+        tensors=(descriptor(shard_dims=(0,)),),
+    )
+
+    assert partitioned == nd_placement
+    assert partitioned.tensors[0].shard_dims == (0,)
+    assert partitioned.digest == nd_placement.digest
+
+
+@pytest.mark.parametrize("mutation", ["missing", "unknown", "nan"])
+def test_placement_json_requires_strict_schema(mutation: str) -> None:
+    raw = json.loads(placement_manifest().to_json())
+    if mutation == "missing":
+        del raw["revision"]
+    elif mutation == "unknown":
+        raw["future_semantics"] = "required"
+    else:
+        raw["model_id"] = float("nan")
+
+    with pytest.raises(ValueError):
+        PlacementManifest.from_json(json.dumps(raw))
+
+
+@pytest.mark.parametrize(
+    ("path", "mutation"),
+    [
+        (("tensors", 0), ("pop", "dtype")),
+        (("tensors", 0), ("set", "future_semantics")),
+        (("fragments", 0), ("pop", "nbytes")),
+        (("fragments", 0), ("set", "future_semantics")),
+        (("fragments", 0, "rank"), ("pop", "tp")),
+        (("fragments", 0, "rank"), ("set", "future_semantics")),
+    ],
+)
+def test_placement_json_requires_strict_nested_schema(
+    path: tuple, mutation: tuple[str, str]
+) -> None:
+    raw = json.loads(placement_manifest().to_json())
+    target = raw
+    for component in path:
+        target = target[component]
+    operation, field = mutation
+    if operation == "pop":
+        target.pop(field)
+    else:
+        target[field] = "unsupported"
+
+    with pytest.raises(ValueError, match="schema"):
+        PlacementManifest.from_json(json.dumps(raw))
+
+
+@pytest.mark.parametrize("value", ["not-json", "[]", '"placement"'])
+def test_placement_json_rejects_invalid_document(value: str) -> None:
+    with pytest.raises(ValueError):
+        PlacementManifest.from_json(value)
+
+
+def test_placement_json_rejects_duplicate_object_keys() -> None:
+    encoded = placement_manifest().to_json()
+    duplicated = encoded.replace(
+        '"model_id":"model"',
+        '"model_id":"model","model_id":"other"',
+        1,
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON field"):
+        PlacementManifest.from_json(duplicated)
+
+
+@pytest.mark.parametrize("aliases", ["alias", {"alias": 1}, ["alias", "alias"]])
+def test_placement_json_rejects_invalid_aliases(aliases) -> None:
+    raw = json.loads(placement_manifest().to_json())
+    raw["fragments"][0]["aliases"] = aliases
+
+    with pytest.raises(ValueError, match="aliases"):
+        PlacementManifest.from_json(json.dumps(raw))
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("tensors",), {}),
+        (("fragments",), 1),
+        (("tensors", 0, "global_shape"), 8),
+        (("tensors", 0, "shard_dims"), "0"),
+        (("fragments", 0, "global_offset"), 0),
+        (("fragments", 0, "local_shape"), None),
+        (("fragments", 0, "rank"), []),
+    ],
+)
+def test_placement_json_rejects_wrong_container_types(
+    path: tuple, value: object
+) -> None:
+    raw = json.loads(placement_manifest().to_json())
+    target = raw
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = value
+
+    with pytest.raises(ValueError):
+        PlacementManifest.from_json(json.dumps(raw))
+
+
+def test_placement_inventory_is_framework_neutral() -> None:
+    tensor = runtime_inventory_tensor()
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "tensors": (
+            {
+                key: value
+                for key, value in tensor.items()
+                if key
+                in {
+                    "placement_fragment_id",
+                    "tensor_id",
+                    "global_shape",
+                    "global_offset",
+                    "local_shape",
+                    "dtype",
+                    "itemsize",
+                    "partition_dim",
+                    "layer_id",
+                    "expert_id",
+                    "layout_fingerprint",
+                    "nbytes",
+                    "rank",
+                    "aliases",
+                }
+            },
+        ),
+    }
+
+    placement = PlacementManifest.from_runtime_inventory(inventory)
+
+    assert placement.fragments[0].rank == ParallelRank(dp=0, tp=0, pp=1, ep=1)
+    assert placement.fragments[0].global_offset == (0, 0)
+
+
+def test_placement_inventory_normalizes_equivalent_single_axis_descriptors() -> None:
+    fields = {
+        "placement_fragment_id",
+        "tensor_id",
+        "global_shape",
+        "global_offset",
+        "local_shape",
+        "dtype",
+        "itemsize",
+        "partition_dim",
+        "layer_id",
+        "expert_id",
+        "layout_fingerprint",
+        "shard_dims",
+        "nbytes",
+        "rank",
+        "aliases",
+    }
+    first = runtime_inventory_tensor(
+        placement_fragment_id="placement-0",
+        global_offset=(0, 0),
+        rank={"dp": 0, "tp": 0, "pp": 1, "ep": 1},
+    )
+    second = runtime_inventory_tensor(
+        placement_fragment_id="placement-1",
+        shard_dims=(0,),
+        global_offset=(4, 0),
+        rank={"dp": 0, "tp": 1, "pp": 1, "ep": 1},
+    )
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "tensors": tuple(
+            {key: value for key, value in tensor.items() if key in fields}
+            for tensor in (first, second)
+        ),
+    }
+
+    placement = PlacementManifest.from_runtime_inventory(inventory)
+
+    assert placement.tensors[0].partition_dim == 0
+    assert placement.tensors[0].shard_dims == (0,)
+    assert len(placement.fragments) == 2
+
+
+def test_placement_id_must_match_canonical_logical_content() -> None:
+    with pytest.raises(ValueError, match="canonical logical content"):
+        placement_manifest(placement_id="opaque-placement-id")

--- a/mooncake-wheel/tests/test_weight_transfer_manifest.py
+++ b/mooncake-wheel/tests/test_weight_transfer_manifest.py
@@ -935,3 +935,691 @@ def test_placement_inventory_normalizes_equivalent_single_axis_descriptors() -> 
 def test_placement_id_must_match_canonical_logical_content() -> None:
     with pytest.raises(ValueError, match="canonical logical content"):
         placement_manifest(placement_id="opaque-placement-id")
+
+
+def test_runtime_binding_inventory_retains_owner() -> None:
+    placement = placement_manifest()
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": placement.placement_id,
+        "placement_digest": placement.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (
+            {
+                "placement_fragment_id": "placement-0",
+                "fragment_id": "runtime-0",
+                "address": 0x1000,
+                "nbytes": 32,
+                "worker_id": "worker-0",
+                "endpoint": "worker-0:12345",
+                "device": "cuda:0",
+                "is_contiguous": True,
+            },
+        ),
+    }
+    owner = object()
+
+    binding = RuntimeBindingManifest.from_runtime_inventory(
+        inventory,
+        owner_resolver=lambda record: owner if record["fragment_id"] else None,
+    )
+
+    assert binding.fragments[0].owner is owner
+    assert binding.fragments[0].device == "cuda:0"
+
+
+def test_runtime_binding_inventory_requires_contiguous_proof() -> None:
+    placement = placement_manifest()
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": placement.placement_id,
+        "placement_digest": placement.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (
+            {
+                "placement_fragment_id": "placement-0",
+                "fragment_id": "runtime-0",
+                "address": 0x1000,
+                "nbytes": 32,
+                "worker_id": "worker-0",
+                "endpoint": "worker-0:12345",
+                "device": "cuda:0",
+            },
+        ),
+    }
+
+    with pytest.raises(ValueError, match="is_contiguous"):
+        RuntimeBindingManifest.from_runtime_inventory(inventory)
+
+
+def test_runtime_binding_inventory_rejects_fragment_generation_mismatch() -> None:
+    placement = placement_manifest()
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": placement.placement_id,
+        "placement_digest": placement.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (
+            {
+                "placement_fragment_id": "placement-0",
+                "fragment_id": "runtime-0",
+                "address": 0x1000,
+                "nbytes": 32,
+                "worker_id": "worker-0",
+                "endpoint": "worker-0:12345",
+                "device": "cuda:0",
+                "is_contiguous": True,
+                "lease_generation": 6,
+            },
+        ),
+    }
+
+    with pytest.raises(ValueError, match="lease generation"):
+        RuntimeBindingManifest.from_runtime_inventory(inventory)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("is_contiguous", False, "contiguous"),
+        ("storage_offset", -1, "storage_offset"),
+        ("device", "", "device"),
+    ],
+)
+def test_runtime_binding_inventory_rejects_unsafe_views(
+    field: str, value: object, message: str
+) -> None:
+    placement = placement_manifest()
+    fragment = {
+        "placement_fragment_id": "placement-0",
+        "fragment_id": "runtime-0",
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "worker-0",
+        "endpoint": "worker-0:12345",
+        "device": "cuda:0",
+        "is_contiguous": True,
+        field: value,
+    }
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": placement.placement_id,
+        "placement_digest": placement.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (fragment,),
+    }
+
+    with pytest.raises(ValueError, match=message):
+        RuntimeBindingManifest.from_runtime_inventory(inventory)
+
+
+@pytest.mark.parametrize("offset_field", ["storage_offset", "byte_offset"])
+def test_runtime_binding_inventory_requires_explicit_view_address_semantics(
+    offset_field: str,
+) -> None:
+    placement = placement_manifest()
+    fragment = {
+        "placement_fragment_id": "placement-0",
+        "fragment_id": "runtime-0",
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "worker-0",
+        "endpoint": "worker-0:12345",
+        "device": "cuda:0",
+        "is_contiguous": True,
+        offset_field: 7,
+    }
+    inventory = {
+        "model_id": MODEL_ID,
+        "revision": REVISION,
+        "placement_id": placement.placement_id,
+        "placement_digest": placement.digest,
+        "instance_id": "instance",
+        "generation": 7,
+        "lease_id": "lease-7",
+        "fragments": (fragment,),
+    }
+
+    with pytest.raises(ValueError, match="address_semantics"):
+        RuntimeBindingManifest.from_runtime_inventory(inventory)
+
+    binding = RuntimeBindingManifest.from_runtime_inventory(
+        inventory,
+        address_semantics="view",
+    )
+
+    assert binding.fragments[0].address == 0x1000
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"placement_digest": ""}, "placement_digest"),
+        ({"placement_digest": "g" * 64}, "SHA-256"),
+        ({"placement_digest": "a" * 63}, "SHA-256"),
+    ],
+)
+def test_runtime_binding_requires_content_attestation(
+    overrides: dict, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        binding_manifest(**overrides)
+
+
+@pytest.mark.parametrize(
+    "overrides, message",
+    [
+        ({"model_id": "other"}, "model_id"),
+        ({"revision": "other"}, "revision"),
+        ({"placement_id": "other"}, "placement_id"),
+    ],
+)
+def test_binding_rejects_identity_mismatch(overrides: dict, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        bind_runtime_manifest(placement_manifest(), binding_manifest(**overrides))
+
+
+def test_binding_requires_exact_fragment_set_and_size() -> None:
+    placement = placement_manifest()
+
+    with pytest.raises(ValueError, match="missing placement fragment"):
+        bind_runtime_manifest(
+            placement,
+            binding_manifest(placement=placement, fragments=()),
+        )
+    with pytest.raises(ValueError, match="unknown placement fragment"):
+        bind_runtime_manifest(
+            placement,
+            binding_manifest(
+                placement=placement,
+                fragments=(binding_fragment(placement_fragment_id="unknown"),),
+            ),
+        )
+    with pytest.raises(ValueError, match="byte size"):
+        bind_runtime_manifest(
+            placement,
+            binding_manifest(
+                placement=placement,
+                fragments=(binding_fragment(nbytes=64),),
+            ),
+        )
+
+
+def test_binding_rejects_duplicate_fragment_ids() -> None:
+    fragment = binding_fragment()
+
+    with pytest.raises(ValueError, match="duplicate placement fragment"):
+        binding_manifest(fragments=(fragment, replace(fragment, fragment_id="other")))
+    with pytest.raises(ValueError, match="duplicate runtime fragment_id"):
+        binding_manifest(
+            fragments=(
+                fragment,
+                replace(
+                    fragment,
+                    placement_fragment_id="placement-other",
+                ),
+            )
+        )
+
+
+def test_binding_allows_one_rank_to_span_runtime_locations() -> None:
+    placement = placement_manifest(
+        fragments=(
+            placement_fragment(placement_fragment_id="left"),
+            placement_fragment(
+                placement_fragment_id="right",
+                global_offset=(4, 0),
+            ),
+        )
+    )
+    binding = binding_manifest(
+        placement=placement,
+        fragments=(
+            binding_fragment(placement_fragment_id="left"),
+            binding_fragment(
+                placement_fragment_id="right",
+                fragment_id="runtime-right",
+                address=0x2000,
+                worker_id="worker-1",
+                endpoint="worker-1:12345",
+            ),
+        ),
+    )
+
+    runtime = bind_runtime_manifest(placement, binding)
+
+    assert {fragment.worker_id for fragment in runtime.fragments} == {
+        "worker-0",
+        "worker-1",
+    }
+
+
+def test_binding_rejects_overlapping_runtime_ranges() -> None:
+    placement = placement_manifest(
+        tensors=(
+            descriptor(tensor_id="a.weight"),
+            descriptor(tensor_id="b.weight"),
+        ),
+        fragments=(
+            placement_fragment(
+                placement_fragment_id="a",
+                tensor_id="a.weight",
+                rank=ParallelRank(tp=0),
+            ),
+            placement_fragment(
+                placement_fragment_id="b",
+                tensor_id="b.weight",
+                rank=ParallelRank(tp=1),
+            ),
+        ),
+    )
+    binding = binding_manifest(
+        placement=placement,
+        fragments=(
+            binding_fragment(placement_fragment_id="a", fragment_id="runtime-a"),
+            binding_fragment(
+                placement_fragment_id="b",
+                fragment_id="runtime-b",
+                endpoint="worker-0:54321",
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="address ranges overlap"):
+        bind_runtime_manifest(placement, binding)
+
+
+def test_binding_preserves_logical_and_physical_halves() -> None:
+    placement = placement_manifest()
+    binding = binding_manifest(placement=placement)
+
+    runtime = bind_runtime_manifest(placement, binding)
+
+    assert runtime.model_id == placement.model_id
+    assert runtime.revision == placement.revision
+    assert runtime.placement_id == placement.placement_id
+    assert runtime.instance_id == binding.instance_id
+    assert runtime.generation == binding.generation
+    assert runtime.lease_id == binding.lease_id
+    assert runtime.fragments[0].global_offset == placement.fragments[0].global_offset
+    assert runtime.fragments[0].address == binding.fragments[0].address
+    assert runtime.fragments[0].placement_fragment_id == "placement-0"
+
+
+def test_binding_order_does_not_change_runtime_manifest() -> None:
+    tensors = (
+        descriptor(tensor_id="a.weight"),
+        descriptor(tensor_id="b.weight"),
+    )
+    fragments = (
+        placement_fragment(
+            placement_fragment_id="a",
+            tensor_id="a.weight",
+            rank=ParallelRank(tp=0),
+        ),
+        placement_fragment(
+            placement_fragment_id="b",
+            tensor_id="b.weight",
+            rank=ParallelRank(tp=1),
+        ),
+    )
+    placement = placement_manifest(tensors=tensors, fragments=fragments)
+    bindings = (
+        binding_fragment(
+            placement_fragment_id="a",
+            fragment_id="runtime-a",
+            address=0x1000,
+        ),
+        binding_fragment(
+            placement_fragment_id="b",
+            fragment_id="runtime-b",
+            address=0x2000,
+        ),
+    )
+
+    first = bind_runtime_manifest(
+        placement,
+        binding_manifest(placement=placement, fragments=bindings),
+    )
+    second = bind_runtime_manifest(
+        placement,
+        binding_manifest(
+            placement=placement,
+            fragments=tuple(reversed(bindings)),
+        ),
+    )
+
+    assert first == second
+
+
+def test_empty_placement_binds_to_generation_scoped_empty_runtime() -> None:
+    placement = placement_manifest(tensors=(), fragments=())
+    binding = binding_manifest(
+        placement=placement,
+        fragments=(),
+        generation=11,
+        lease_id="lease-11",
+    )
+
+    runtime = bind_runtime_manifest(placement, binding)
+
+    assert runtime.fragments == ()
+    assert runtime.generation == 11
+    assert runtime.lease_id == "lease-11"
+
+
+def test_runtime_projection_round_trip_supports_rebinding() -> None:
+    owner = object()
+    runtime = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        generation=7,
+        lease_id="lease-7",
+        tensors=(descriptor(),),
+        fragments=(runtime_fragment(owner=owner),),
+    )
+
+    placement = placement_manifest_from_runtime_manifest(runtime)
+    binding = runtime_binding_from_runtime_manifest(runtime)
+    rebound = bind_runtime_manifest(
+        placement,
+        replace(
+            binding,
+            instance_id="instance-2",
+            generation=8,
+            lease_id="lease-8",
+            fragments=(
+                replace(
+                    binding.fragments[0],
+                    address=0x2000,
+                    worker_id="worker-2",
+                    endpoint="worker-2:12345",
+                ),
+            ),
+        ),
+    )
+
+    assert binding.fragments[0].owner is owner
+    assert rebound.fragments[0].owner is owner
+    assert rebound.fragments[0].address == 0x2000
+    assert rebound.generation == 8
+    assert placement.digest == placement_manifest_from_runtime_manifest(rebound).digest
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda placement: replace(
+            placement,
+            fragments=(replace(placement.fragments[0], global_offset=(4, 0)),),
+        ),
+        lambda placement: replace(
+            placement,
+            fragments=(replace(placement.fragments[0], rank=ParallelRank(tp=1)),),
+        ),
+        lambda placement: replace(
+            placement,
+            fragments=(
+                replace(
+                    placement.fragments[0],
+                    aliases=("alias-a", "alias-b"),
+                ),
+            ),
+        ),
+        lambda placement: replace(
+            placement,
+            tensors=(replace(placement.tensors[0], dtype="float16"),),
+        ),
+        lambda placement: replace(
+            placement,
+            tensors=(
+                replace(
+                    placement.tensors[0],
+                    layout_fingerprint="test:qwen:packed:v2",
+                ),
+            ),
+        ),
+        lambda placement: replace(
+            placement,
+            tensors=(
+                replace(
+                    placement.tensors[0],
+                    partition_dim=None,
+                    shard_dims=(0, 1),
+                ),
+            ),
+            fragments=(
+                replace(
+                    placement.fragments[0],
+                    local_shape=(8, 2),
+                ),
+            ),
+        ),
+    ],
+)
+def test_placement_identity_attests_exact_logical_content(mutate) -> None:
+    placement = placement_manifest()
+
+    with pytest.raises(ValueError, match="canonical logical content"):
+        mutate(placement)
+
+
+def test_projection_identity_is_stable_across_runtime_restarts() -> None:
+    first = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance-a",
+        generation=7,
+        lease_id="lease-7",
+        tensors=(descriptor(),),
+        fragments=(runtime_fragment(fragment_id="runtime-a"),),
+    )
+    second = replace(
+        first,
+        instance_id="instance-b",
+        generation=8,
+        lease_id="lease-8",
+        fragments=(
+            replace(
+                first.fragments[0],
+                fragment_id="runtime-b",
+                address=0x2000,
+                worker_id="worker-b",
+                endpoint="worker-b:12345",
+                lease_generation=8,
+            ),
+        ),
+    )
+
+    first_placement = placement_manifest_from_runtime_manifest(first)
+    second_placement = placement_manifest_from_runtime_manifest(second)
+
+    assert first_placement.placement_id == second_placement.placement_id
+    assert first_placement.digest == second_placement.digest
+    assert (
+        first_placement.fragments[0].placement_fragment_id
+        == second_placement.fragments[0].placement_fragment_id
+    )
+
+
+def test_projection_identity_normalizes_single_axis_shard_representations() -> None:
+    partitioned = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        generation=7,
+        lease_id="lease-7",
+        tensors=(descriptor(shard_dims=None),),
+        fragments=(runtime_fragment(),),
+    )
+    nd_runtime = replace(
+        partitioned,
+        tensors=(descriptor(shard_dims=(0,)),),
+    )
+
+    partitioned_placement = placement_manifest_from_runtime_manifest(partitioned)
+    nd_placement = placement_manifest_from_runtime_manifest(nd_runtime)
+
+    assert partitioned_placement.placement_id == nd_placement.placement_id
+    assert partitioned_placement.digest == nd_placement.digest
+
+
+def test_runtime_projection_requires_lease_and_known_generation() -> None:
+    without_lease = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        generation=7,
+        tensors=(descriptor(),),
+        fragments=(runtime_fragment(),),
+    )
+    without_generation = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        lease_id="lease",
+        tensors=(),
+        fragments=(),
+    )
+
+    with pytest.raises(ValueError, match="lease_id"):
+        runtime_binding_from_runtime_manifest(without_lease)
+    with pytest.raises(ValueError, match="generation"):
+        runtime_binding_from_runtime_manifest(without_generation)
+
+
+@pytest.mark.parametrize(
+    "project",
+    [
+        placement_manifest_from_runtime_manifest,
+        runtime_binding_from_runtime_manifest,
+    ],
+)
+def test_runtime_projection_rejects_explicit_empty_placement_id(project) -> None:
+    runtime = RuntimeManifest(
+        model_id=MODEL_ID,
+        revision=REVISION,
+        instance_id="instance",
+        generation=7,
+        lease_id="lease-7",
+        tensors=(descriptor(),),
+        fragments=(runtime_fragment(),),
+    )
+
+    with pytest.raises(ValueError, match="placement_id"):
+        project(runtime, placement_id="")
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: ParallelRank(dp=True),
+        lambda: runtime_fragment(address=4096.0),
+        lambda: runtime_fragment(lease_generation=False),
+        lambda: binding_fragment(nbytes=32.0),
+        lambda: binding_manifest(generation=True),
+    ],
+)
+def test_contract_rejects_bool_and_float_integer_fields(factory) -> None:
+    with pytest.raises(ValueError, match="integer"):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: placement_manifest(tensors=(object(),)), "tensors"),
+        (lambda: placement_manifest(fragments=(object(),)), "fragments"),
+        (lambda: binding_manifest(fragments=(object(),)), "fragments"),
+        (
+            lambda: RuntimeManifest(
+                model_id=MODEL_ID,
+                revision=REVISION,
+                instance_id="instance",
+                tensors=(object(),),
+                fragments=(),
+            ),
+            "tensors",
+        ),
+    ],
+)
+def test_manifest_collections_reject_wrong_element_types(factory, message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: placement_manifest(tensors=None), "tensors"),
+        (lambda: placement_manifest(fragments=None), "fragments"),
+        (lambda: binding_manifest(fragments=None), "fragments"),
+        (
+            lambda: RuntimeManifest(
+                model_id=MODEL_ID,
+                revision=REVISION,
+                instance_id="instance",
+                tensors=None,
+                fragments=(),
+            ),
+            "tensors",
+        ),
+        (
+            lambda: RuntimeManifest(
+                model_id=MODEL_ID,
+                revision=REVISION,
+                instance_id="instance",
+                tensors=(),
+                fragments=None,
+            ),
+            "fragments",
+        ),
+    ],
+)
+def test_manifest_collections_reject_wrong_container_types(
+    factory, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: runtime_fragment(address=2**64),
+        lambda: runtime_fragment(address=2**64 - 16, nbytes=32),
+        lambda: runtime_fragment(nbytes=2**64),
+        lambda: binding_fragment(address=2**64),
+        lambda: binding_fragment(address=2**64 - 16, nbytes=32),
+        lambda: binding_manifest(generation=2**64),
+    ],
+)
+def test_physical_contract_rejects_values_outside_u64_abi(factory) -> None:
+    with pytest.raises(ValueError, match="64-bit"):
+        factory()
+
+
+def test_physical_contract_rejects_unrepresentable_exclusive_end() -> None:
+    with pytest.raises(ValueError, match="64-bit"):
+        runtime_fragment(address=2**64 - 4, nbytes=4)
+
+
+def test_inventory_missing_required_field_is_a_contract_error() -> None:
+    inventory = runtime_inventory()
+    del inventory["model_id"]
+
+    with pytest.raises(ValueError, match="missing required field: model_id"):
+        RuntimeManifest.from_runtime_inventory(inventory)

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -43,6 +43,10 @@ python tests/test_import_structure.py
 echo "Running mooncake config test..."
 python tests/test_mooncake_config.py
 
+echo "Running weight transfer manifest contract tests..."
+python -m pip install pytest
+python -m pytest tests/test_weight_transfer_manifest.py -q
+
 echo "Verifying mooncake_master entry point..."
 # Check if the mooncake_master entry point is installed and executable
 which mooncake_master || { echo "ERROR: mooncake_master entry point not found!"; exit 1; }


### PR DESCRIPTION
## Description

This PR introduces framework-neutral runtime weight manifest contracts in the
Mooncake Python wheel. These contracts provide the metadata foundation for
future heterogeneous weight planning, transfer execution, and weight storage.

The change introduces:

- `PlacementManifest` for reusable logical tensor placement without runtime
  addresses.
- `RuntimeBindingManifest` for ephemeral addresses, endpoints, allocation
  owners, leases, and generations.
- `RuntimeManifest` for validated logical and physical runtime snapshots.
- N-D logical tensor boxes, framework-provided TP/PP/EP/DP ownership
  coordinates, aliases, layer/expert identities, and layout fingerprints.
- Canonical placement IDs and digests used to bind runtime locations to the
  exact logical placement.
- Validation for tensor geometry, address bounds, overlapping allocations,
  contiguous runtime views, lease generations, aliases, and placement
  completeness.
- Framework-neutral inventory adapters supporting mapping-based and
  attribute-based records without importing SGLang, vLLM, PyTorch, or
  model-specific code.

Single-axis `partition_dim` and equivalent `shard_dims=(dim,)` inputs are
normalized before descriptor consistency checks. Conflicting representations
continue to fail closed.

This PR does not implement reshard planning, Transfer Engine execution, or
weight persistence. Those capabilities will build on these contracts in
follow-up changes.

Related RFC: **TODO: add RFC issue link**

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [x] Docs
- [x] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The manifest contract was tested for construction, inventory import, canonical
serialization, digest stability, placement/runtime binding, lease and
generation fencing, address bounds, alias validation, N-D shard semantics, and
mixed equivalent single-axis descriptor encodings.

**Test commands:**

```bash
PYTHONPATH=mooncake-wheel python -m pytest -q \
  mooncake-wheel/tests/test_weight_transfer_manifest.py

ruff check \
  mooncake-wheel/mooncake/weight_transfer \
  mooncake-wheel/tests/test_weight_transfer_manifest.py

ruff format --check \
  mooncake-wheel/mooncake/weight_transfer \
  mooncake-wheel/tests/test_weight_transfer_manifest.py

git diff --check HEAD^ HEAD