### PR TITLE
[Bugfix] Check free HugeTLB capacity

### DIFF
--- a/scripts/check_hicache_hugepage_requirements.py
+++ b/scripts/check_hicache_hugepage_requirements.py
@@ -26,6 +26,8 @@ _UNIT_MAP = {
     "tib": 1024**4,
 }
 
+_HUGEPAGE_SYSFS_ROOT = Path("/sys/kernel/mm/hugepages")
+
 
 @dataclass(frozen=True)
 class BudgetSummary:
@@ -66,12 +68,16 @@ def read_available_hugetlb(page_size_bytes: int) -> int | None:
         return None
 
     page_size_kib = page_size_bytes // 1024
-    path = Path(f"/sys/kernel/mm/hugepages/hugepages-{page_size_kib}kB/nr_hugepages")
+    path = (
+        _HUGEPAGE_SYSFS_ROOT
+        / f"hugepages-{page_size_kib}kB"
+        / "free_hugepages"
+    )
     try:
-        nr_hugepages = int(path.read_text(encoding="utf-8").strip())
+        free_hugepages = int(path.read_text(encoding="utf-8").strip())
     except (FileNotFoundError, PermissionError, ValueError, OSError):
         return None
-    return nr_hugepages * page_size_bytes
+    return free_hugepages * page_size_bytes
 
 
 def evaluate_budget(

--- a/scripts/test_hicache_hugepage_requirements.py
+++ b/scripts/test_hicache_hugepage_requirements.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import tempfile
 import unittest
+from unittest import mock
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -68,6 +70,20 @@ class EvaluateBudgetTest(unittest.TestCase):
         self.assertEqual(summary.status, "planning_only")
         self.assertEqual(summary.exit_code, 0)
 
+
+class ReadAvailableHugeTLBTest(unittest.TestCase):
+    def test_reads_free_instead_of_configured_hugepages(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            root = Path(root)
+            page_dir = root / "hugepages-2048kB"
+            page_dir.mkdir()
+            (page_dir / "nr_hugepages").write_text("11", encoding="utf-8")
+            (page_dir / "free_hugepages").write_text("7", encoding="utf-8")
+
+            with mock.patch.object(helper, "_HUGEPAGE_SYSFS_ROOT", root):
+                available = helper.read_available_hugetlb(2 * 1024**2)
+
+            self.assertEqual(available, 14 * 1024**2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Description

The HiCache HugeTLB sizing helper currently reads `nr_hugepages`, which is the configured pool size, when auto-detecting available capacity. If another process already holds HugeTLB pages, the preflight can overestimate capacity and report that a launch fits even though the required pages are not free.

Read `free_hugepages` instead, and add a regression test with different configured and free page counts. The sysfs root is kept as an internal constant so the behavior can be tested without touching host sysfs.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [x] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python -m unittest scripts/test_hicache_hugepage_requirements.py
python -m compileall -q scripts/check_hicache_hugepage_requirements.py scripts/test_hicache_hugepage_requirements.py
git diff --check
```

**Test results:**
- [x] Unit tests pass (7 focused tests)
- [ ] Integration tests pass (not run; no HugeTLB/CUDA/RDMA environment required for this helper change)
- [x] Manual testing done: reproduced that the previous implementation selected `nr_hugepages`; the regression fixture verifies `7` free pages are returned when `11` pages are configured.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (not applicable; CLI behavior and options are unchanged)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 25 insertions and 3 deletions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex assisted with repository inspection, the focused implementation, and test drafting. I reviewed every changed line and verified the behavior and remote diff.