### PR TITLE
feat(store): bootstrap P2P standby from peer snapshot

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -3,17 +3,22 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <csignal>
 #include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <vector>
+
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
 
 #include "ha/oplog/oplog_replicator.h"
 #include "ha/oplog/oplog_store_factory.h"
 #include "ha/oplog/p2p_oplog_applier.h"
 #include "ha/oplog/p2p_standby_metadata_store.h"
+#include "ha/oplog/p2p_standby_snapshot_service.h"
 #include "standby_state_machine.h"
 #include "types.h"
 
@@ -30,6 +35,11 @@ struct P2PHotStandbyConfig {
     int oplog_poll_interval_ms{kDefaultOpLogPollIntervalMs};
     int reconnect_initial_backoff_ms{100};
     int reconnect_max_backoff_ms{5000};
+    uint16_t snapshot_service_port{0};
+    // TODO: Discover alive snapshot sources from the Redis Master registry by
+    // default, while keeping explicit endpoints as an override.
+    std::vector<std::string> snapshot_source_endpoints;
+    uint32_t snapshot_chunk_size{256};
 };
 
 struct P2PStandbySyncStatus {
@@ -84,6 +94,8 @@ class P2PHotStandbyService {
     P2PStandbyMetadataStore* GetMetadataStore() const {
         return metadata_store_.get();
     }
+    const std::string& GetClusterId() const { return config_.cluster_id; }
+    bool IsReadyForSnapshot() const;
 
    private:
     ErrorCode StartOplogFollowingLocked(uint64_t baseline_sequence_id);
@@ -97,6 +109,13 @@ class P2PHotStandbyService {
     void RestoreRecoveryWorker();
     void RequestRecovery();
     void RecoveryLoop();
+    ErrorCode BootstrapFromSnapshotSources(uint64_t& baseline_sequence_id);
+    ErrorCode GetLatestOpLogSequenceId(uint64_t& sequence_id) const;
+    bool WaitForAppliedSequenceLocked(
+        uint64_t sequence_id,
+        std::chrono::milliseconds timeout = std::chrono::seconds(30)) const;
+    ErrorCode StartSnapshotServer();
+    void StopSnapshotServer();
 
     P2PHotStandbyConfig config_;
     ReaderStoreFactory reader_store_factory_;
@@ -117,6 +136,9 @@ class P2PHotStandbyService {
     std::thread recovery_thread_;
     bool recovery_requested_{false};
     bool recovery_stopping_{false};
+
+    std::unique_ptr<P2PStandbySnapshotService> snapshot_service_;
+    std::unique_ptr<coro_rpc::coro_rpc_server> snapshot_server_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include <boost/functional/hash.hpp>
+#include <ylt/reflection/user_reflect_macro.hpp>
 
 #include "ha/oplog/oplog_manager.h"
 #include "metadata_store.h"
@@ -25,6 +26,8 @@ struct P2PStandbyClientInfo {
     uint16_t rpc_port = 0;
     // Segments owned by this client.
     std::vector<Segment> segments;
+
+    YLT_REFL(P2PStandbyClientInfo, client_id, ip_address, rpc_port, segments);
 };
 
 /// P2P-specific standby metadata store.
@@ -111,6 +114,13 @@ class P2PStandbyMetadataStore : public MetadataStore {
     };
 
     ExportedMetadata ExportMetadata() const;
+
+    std::vector<std::string> ListObjectKeys() const;
+    std::vector<UUID> ListClientIds() const;
+    std::optional<P2PStandbyClientInfo> GetClientInfo(
+        const UUID& client_id) const;
+    void RestoreMetadata(const std::string& key,
+                         const StandbyObjectMetadata& metadata);
 
     // ========================================================================
     // Query helpers

--- a/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <ylt/reflection/user_reflect_macro.hpp>
+
+#include "ha/oplog/p2p_standby_metadata_store.h"
+#include "types.h"
+
+namespace mooncake {
+
+class P2PHotStandbyService;
+
+inline constexpr uint32_t kMaxStandbySnapshotChunkSize = 4096;
+inline constexpr size_t kMaxStandbySnapshotSessions = 16;
+
+struct BeginStandbySnapshotRequest {
+    std::string cluster_id;
+    YLT_REFL(BeginStandbySnapshotRequest, cluster_id);
+};
+
+struct BeginStandbySnapshotResponse {
+    int32_t error_code{toInt(ErrorCode::OK)};
+    std::string session_id;
+    uint64_t baseline_sequence_id{0};
+    uint64_t object_count{0};
+    uint64_t client_count{0};
+    YLT_REFL(BeginStandbySnapshotResponse, error_code, session_id,
+             baseline_sequence_id, object_count, client_count);
+};
+
+struct StandbySnapshotChunkRequest {
+    std::string session_id;
+    uint64_t object_offset{0};
+    uint64_t client_offset{0};
+    uint32_t limit{256};
+    YLT_REFL(StandbySnapshotChunkRequest, session_id, object_offset,
+             client_offset, limit);
+};
+
+struct StandbySnapshotObjectRecord {
+    std::string key;
+    StandbyObjectMetadata metadata;
+    YLT_REFL(StandbySnapshotObjectRecord, key, metadata);
+};
+
+struct StandbySnapshotClientRecord {
+    UUID client_id{0, 0};
+    P2PStandbyClientInfo info;
+    YLT_REFL(StandbySnapshotClientRecord, client_id, info);
+};
+
+struct StandbySnapshotChunkResponse {
+    int32_t error_code{toInt(ErrorCode::OK)};
+    uint64_t next_object_offset{0};
+    uint64_t next_client_offset{0};
+    bool done{false};
+    std::vector<StandbySnapshotObjectRecord> objects;
+    std::vector<StandbySnapshotClientRecord> clients;
+    YLT_REFL(StandbySnapshotChunkResponse, error_code, next_object_offset,
+             next_client_offset, done, objects, clients);
+};
+
+struct EndStandbySnapshotRequest {
+    std::string session_id;
+    YLT_REFL(EndStandbySnapshotRequest, session_id);
+};
+
+class P2PStandbySnapshotService {
+   public:
+    explicit P2PStandbySnapshotService(P2PHotStandbyService* standby);
+    ~P2PStandbySnapshotService();
+
+    P2PStandbySnapshotService(const P2PStandbySnapshotService&) = delete;
+    P2PStandbySnapshotService& operator=(const P2PStandbySnapshotService&) =
+        delete;
+
+    BeginStandbySnapshotResponse BeginSnapshot(
+        const BeginStandbySnapshotRequest& request);
+    StandbySnapshotChunkResponse GetSnapshotChunk(
+        const StandbySnapshotChunkRequest& request);
+    int32_t EndSnapshot(const EndStandbySnapshotRequest& request);
+
+   private:
+    struct Session {
+        uint64_t baseline_sequence_id{0};
+        std::vector<std::string> object_keys;
+        std::vector<UUID> client_ids;
+        std::chrono::steady_clock::time_point last_access;
+    };
+
+    void CleanupExpiredSessionsLocked();
+    void CleanupLoop();
+
+    P2PHotStandbyService* standby_;
+    std::mutex mutex_;
+    std::condition_variable cleanup_cv_;
+    std::unordered_map<std::string, Session> sessions_;
+    uint64_t next_session_id_{1};
+    bool stopping_{false};
+    std::thread cleanup_thread_;
+};
+
+class P2PStandbySnapshotClient {
+   public:
+    ErrorCode Bootstrap(const std::string& endpoint,
+                        const std::string& cluster_id,
+                        P2PStandbyMetadataStore* target,
+                        uint64_t& baseline_sequence_id,
+                        uint32_t chunk_size = 256);
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -35,6 +35,9 @@ struct MasterConfig {
     uint64_t oplog_async_queue_max_entries = 100000;
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
+    uint32_t standby_snapshot_service_port = 0;
+    std::string standby_snapshot_sources;
+    uint32_t standby_snapshot_chunk_size = 256;
     bool enable_offload;
     std::string etcd_endpoints;
 
@@ -133,6 +136,9 @@ class MasterServiceSupervisorConfig {
     uint64_t oplog_async_queue_max_entries = 100000;
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
+    uint32_t standby_snapshot_service_port = 0;
+    std::string standby_snapshot_sources;
+    uint32_t standby_snapshot_chunk_size = 256;
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
     uint32_t max_total_pending_tasks = DEFAULT_MAX_TOTAL_PENDING_TASKS;
     uint32_t max_total_processing_tasks = DEFAULT_MAX_TOTAL_PROCESSING_TASKS;
@@ -204,6 +210,9 @@ class MasterServiceSupervisorConfig {
         oplog_async_queue_overflow_mode =
             config.oplog_async_queue_overflow_mode;
         oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
+        standby_snapshot_service_port = config.standby_snapshot_service_port;
+        standby_snapshot_sources = config.standby_snapshot_sources;
+        standby_snapshot_chunk_size = config.standby_snapshot_chunk_size;
 
         max_total_finished_tasks = config.max_total_finished_tasks;
         max_total_pending_tasks = config.max_total_pending_tasks;

--- a/mooncake-store/include/metadata_store.h
+++ b/mooncake-store/include/metadata_store.h
@@ -34,6 +34,9 @@ struct StandbyObjectMetadata {
 
     // Check if this metadata has valid replicas
     bool HasReplicas() const { return !replicas.empty(); }
+
+    YLT_REFL(StandbyObjectMetadata, client_id, size, replicas,
+             last_sequence_id);
 };
 
 /**

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -78,6 +78,7 @@ set(MOONCAKE_STORE_SOURCES
     ha/oplog/p2p_oplog_applier.cpp
     ha/oplog/p2p_standby_metadata_store.cpp
     ha/oplog/p2p_hot_standby_service.cpp
+    ha/oplog/p2p_standby_snapshot_service.cpp
     standby_state_machine.cpp
     ha_metric_manager.cpp
 )

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <random>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -419,7 +420,13 @@ bool P2PHotStandbyService::WaitForAppliedSequence(
 ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
     uint64_t& baseline_sequence_id) {
     P2PStandbySnapshotClient client;
-    for (const auto& endpoint : config_.snapshot_source_endpoints) {
+    auto snapshot_source_endpoints = config_.snapshot_source_endpoints;
+    if (snapshot_source_endpoints.size() > 1) {
+        static thread_local std::mt19937 generator(std::random_device{}());
+        std::shuffle(snapshot_source_endpoints.begin(),
+                     snapshot_source_endpoints.end(), generator);
+    }
+    for (const auto& endpoint : snapshot_source_endpoints) {
         uint64_t source_sequence_id = 0;
         auto err = client.Bootstrap(endpoint, config_.cluster_id,
                                     metadata_store_.get(), source_sequence_id,
@@ -434,6 +441,9 @@ ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
         LOG(WARNING) << "P2PHotStandbyService: snapshot source failed"
                      << ", source=" << endpoint << ", error=" << toString(err);
     }
+    LOG(ERROR) << "P2PHotStandbyService: all snapshot sources failed"
+               << ", cluster_id=" << config_.cluster_id
+               << ", source_count=" << snapshot_source_endpoints.size();
     return ErrorCode::INTERNAL_ERROR;
 }
 
@@ -441,6 +451,9 @@ ErrorCode P2PHotStandbyService::GetLatestOpLogSequenceId(
     uint64_t& sequence_id) const {
     auto store = CreateReaderStore();
     if (!store) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to create OpLog reader "
+                      "store when fetching latest sequence id"
+                   << ", cluster_id=" << config_.cluster_id;
         return ErrorCode::INTERNAL_ERROR;
     }
     return store->GetLatestSequenceId(sequence_id);

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -41,6 +41,26 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
     metadata_store_->RemoveAllMetadata();
     oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
                                                        config_.cluster_id);
+
+    uint64_t initial_sync_target = baseline_sequence_id;
+    if (!config_.snapshot_source_endpoints.empty()) {
+        auto bootstrap_err = BootstrapFromSnapshotSources(baseline_sequence_id);
+        if (bootstrap_err != ErrorCode::OK) {
+            LOG(ERROR) << "P2PHotStandbyService: snapshot bootstrap failed";
+            state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+            return bootstrap_err;
+        }
+        bootstrap_err = GetLatestOpLogSequenceId(initial_sync_target);
+        if (bootstrap_err != ErrorCode::OK) {
+            LOG(ERROR) << "P2PHotStandbyService: failed to get initial sync "
+                          "target";
+            state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+            return bootstrap_err;
+        }
+        LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up started"
+                  << ", baseline_sequence_id=" << baseline_sequence_id
+                  << ", target_sequence_id=" << initial_sync_target;
+    }
     oplog_applier_->Recover(baseline_sequence_id);
 
     auto err = StartOplogFollowingLocked(baseline_sequence_id);
@@ -53,8 +73,30 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         return err;
     }
 
+    if (!WaitForAppliedSequenceLocked(initial_sync_target)) {
+        LOG(ERROR) << "P2PHotStandbyService: initial sync timed out"
+                   << ", target_sequence_id=" << initial_sync_target
+                   << ", applied_sequence_id="
+                   << GetLocalLastAppliedSequenceIdLocked();
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        ResetOplogFollowingLocked();
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (!config_.snapshot_source_endpoints.empty()) {
+        LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up completed"
+                  << ", applied_sequence_id="
+                  << GetLocalLastAppliedSequenceIdLocked();
+    }
+
     state_machine_.ProcessEvent(StandbyEvent::SYNC_COMPLETE);
     StartRecoveryWorker();
+    auto snapshot_server_err = StartSnapshotServer();
+    if (snapshot_server_err != ErrorCode::OK) {
+        StopRecoveryWorker();
+        ResetOplogFollowingLocked();
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        return snapshot_server_err;
+    }
     LOG(INFO) << "P2PHotStandbyService started"
               << ", cluster_id=" << config_.cluster_id
               << ", baseline_sequence_id=" << baseline_sequence_id;
@@ -130,6 +172,7 @@ void P2PHotStandbyService::ResetOplogFollowingLocked() {
 void P2PHotStandbyService::Stop() {
     std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
     StopRecoveryWorker();
+    StopSnapshotServer();
     std::lock_guard<std::mutex> lock(mutex_);
 
     ResetOplogFollowingLocked();
@@ -337,6 +380,11 @@ bool P2PHotStandbyService::IsReadyForPromotion() const {
     return state_machine_.IsReadyForPromotion();
 }
 
+bool P2PHotStandbyService::IsReadyForSnapshot() const {
+    return IsReadyForPromotion() && oplog_applier_ &&
+           oplog_applier_->IsHealthy();
+}
+
 uint64_t P2PHotStandbyService::GetLatestAppliedSequenceId() const {
     std::lock_guard<std::mutex> lock(mutex_);
     return GetLocalLastAppliedSequenceIdLocked();
@@ -366,6 +414,83 @@ bool P2PHotStandbyService::WaitForAppliedSequence(
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     return GetLatestAppliedSequenceId() >= sequence_id;
+}
+
+ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
+    uint64_t& baseline_sequence_id) {
+    P2PStandbySnapshotClient client;
+    for (const auto& endpoint : config_.snapshot_source_endpoints) {
+        uint64_t source_sequence_id = 0;
+        auto err = client.Bootstrap(endpoint, config_.cluster_id,
+                                    metadata_store_.get(), source_sequence_id,
+                                    config_.snapshot_chunk_size);
+        if (err == ErrorCode::OK) {
+            baseline_sequence_id = source_sequence_id;
+            LOG(INFO) << "P2PHotStandbyService: snapshot bootstrap succeeded"
+                      << ", source=" << endpoint
+                      << ", baseline_sequence_id=" << baseline_sequence_id;
+            return ErrorCode::OK;
+        }
+        LOG(WARNING) << "P2PHotStandbyService: snapshot source failed"
+                     << ", source=" << endpoint << ", error=" << toString(err);
+    }
+    return ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode P2PHotStandbyService::GetLatestOpLogSequenceId(
+    uint64_t& sequence_id) const {
+    auto store = CreateReaderStore();
+    if (!store) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return store->GetLatestSequenceId(sequence_id);
+}
+
+bool P2PHotStandbyService::WaitForAppliedSequenceLocked(
+    uint64_t sequence_id, std::chrono::milliseconds timeout) const {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (GetLocalLastAppliedSequenceIdLocked() >= sequence_id) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return GetLocalLastAppliedSequenceIdLocked() >= sequence_id;
+}
+
+ErrorCode P2PHotStandbyService::StartSnapshotServer() {
+    if (config_.snapshot_service_port == 0 || snapshot_server_) {
+        return ErrorCode::OK;
+    }
+    snapshot_service_ = std::make_unique<P2PStandbySnapshotService>(this);
+    snapshot_server_ = std::make_unique<coro_rpc::coro_rpc_server>(
+        1, config_.snapshot_service_port);
+    snapshot_server_
+        ->register_handler<&P2PStandbySnapshotService::BeginSnapshot>(
+            snapshot_service_.get());
+    snapshot_server_
+        ->register_handler<&P2PStandbySnapshotService::GetSnapshotChunk>(
+            snapshot_service_.get());
+    snapshot_server_->register_handler<&P2PStandbySnapshotService::EndSnapshot>(
+        snapshot_service_.get());
+
+    auto start_result = snapshot_server_->async_start();
+    if (start_result.hasResult()) {
+        snapshot_server_.reset();
+        snapshot_service_.reset();
+        LOG(ERROR) << "P2PHotStandbyService: snapshot RPC server failed"
+                   << ", port=" << config_.snapshot_service_port;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+void P2PHotStandbyService::StopSnapshotServer() {
+    if (snapshot_server_) {
+        snapshot_server_->stop();
+    }
+    snapshot_server_.reset();
+    snapshot_service_.reset();
 }
 
 void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -48,6 +48,12 @@ size_t P2PStandbyMetadataStore::GetKeyCount() const {
     return objects_.size();
 }
 
+void P2PStandbyMetadataStore::RestoreMetadata(
+    const std::string& key, const StandbyObjectMetadata& metadata) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    objects_[key] = metadata;
+}
+
 // ============================================================================
 // P2P-specific operations
 // ============================================================================
@@ -301,6 +307,36 @@ P2PStandbyMetadataStore::ExportMetadata() const {
     }
 
     return result;
+}
+
+std::vector<std::string> P2PStandbyMetadataStore::ListObjectKeys() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::string> keys;
+    keys.reserve(objects_.size());
+    for (const auto& [key, metadata] : objects_) {
+        keys.push_back(key);
+    }
+    return keys;
+}
+
+std::vector<UUID> P2PStandbyMetadataStore::ListClientIds() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<UUID> ids;
+    ids.reserve(clients_.size());
+    for (const auto& [id, client] : clients_) {
+        ids.push_back(id);
+    }
+    return ids;
+}
+
+std::optional<P2PStandbyClientInfo> P2PStandbyMetadataStore::GetClientInfo(
+    const UUID& client_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = clients_.find(client_id);
+    if (it == clients_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
 }
 
 // ============================================================================

--- a/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
@@ -1,0 +1,284 @@
+#include "ha/oplog/p2p_standby_snapshot_service.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <chrono>
+#include <csignal>
+
+#include <async_simple/coro/SyncAwait.h>
+#include <ylt/coro_rpc/coro_rpc_client.hpp>
+
+#include "ha/oplog/p2p_hot_standby_service.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr auto kSnapshotSessionIdleTimeout = std::chrono::minutes(5);
+constexpr auto kSnapshotSessionCleanupInterval = std::chrono::minutes(1);
+
+}  // namespace
+
+P2PStandbySnapshotService::P2PStandbySnapshotService(
+    P2PHotStandbyService* standby)
+    : standby_(standby), cleanup_thread_([this] { CleanupLoop(); }) {}
+
+P2PStandbySnapshotService::~P2PStandbySnapshotService() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopping_ = true;
+    }
+    cleanup_cv_.notify_all();
+    if (cleanup_thread_.joinable()) {
+        cleanup_thread_.join();
+    }
+}
+
+BeginStandbySnapshotResponse P2PStandbySnapshotService::BeginSnapshot(
+    const BeginStandbySnapshotRequest& request) {
+    BeginStandbySnapshotResponse response;
+    if (!standby_ || request.cluster_id != standby_->GetClusterId() ||
+        !standby_->IsReadyForSnapshot()) {
+        response.error_code = toInt(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+        return response;
+    }
+
+    Session session;
+    session.baseline_sequence_id = standby_->GetLatestAppliedSequenceId();
+    auto* store = standby_->GetMetadataStore();
+    session.object_keys = store->ListObjectKeys();
+    session.client_ids = store->ListClientIds();
+    session.last_access = std::chrono::steady_clock::now();
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    CleanupExpiredSessionsLocked();
+    if (sessions_.size() >= kMaxStandbySnapshotSessions) {
+        response.error_code = toInt(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+        return response;
+    }
+    response.session_id = std::to_string(next_session_id_++);
+    response.baseline_sequence_id = session.baseline_sequence_id;
+    response.object_count = session.object_keys.size();
+    response.client_count = session.client_ids.size();
+    sessions_.emplace(response.session_id, std::move(session));
+    LOG(INFO) << "Standby snapshot: session started"
+              << ", session_id=" << response.session_id
+              << ", baseline_sequence_id=" << response.baseline_sequence_id
+              << ", objects=" << response.object_count
+              << ", clients=" << response.client_count;
+    return response;
+}
+
+StandbySnapshotChunkResponse P2PStandbySnapshotService::GetSnapshotChunk(
+    const StandbySnapshotChunkRequest& request) {
+    StandbySnapshotChunkResponse response;
+    if (!standby_ || request.limit == 0 ||
+        request.limit > kMaxStandbySnapshotChunkSize) {
+        response.error_code = toInt(ErrorCode::INVALID_PARAMS);
+        return response;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    CleanupExpiredSessionsLocked();
+    auto session_it = sessions_.find(request.session_id);
+    if (session_it == sessions_.end()) {
+        response.error_code = toInt(ErrorCode::INVALID_PARAMS);
+        return response;
+    }
+
+    auto& session = session_it->second;
+    if (request.object_offset > session.object_keys.size() ||
+        request.client_offset > session.client_ids.size()) {
+        response.error_code = toInt(ErrorCode::INVALID_PARAMS);
+        return response;
+    }
+    session.last_access = std::chrono::steady_clock::now();
+    const size_t object_offset = static_cast<size_t>(request.object_offset);
+    const size_t client_offset = static_cast<size_t>(request.client_offset);
+    const size_t object_end =
+        object_offset +
+        std::min<size_t>(request.limit,
+                         session.object_keys.size() - object_offset);
+    for (size_t i = object_offset; i < object_end; ++i) {
+        auto metadata =
+            standby_->GetMetadataStore()->GetMetadata(session.object_keys[i]);
+        if (metadata) {
+            response.objects.push_back(
+                {session.object_keys[i], std::move(*metadata)});
+        }
+    }
+    response.next_object_offset = object_end;
+
+    const size_t client_end =
+        client_offset +
+        std::min<size_t>(request.limit,
+                         session.client_ids.size() - client_offset);
+    for (size_t i = client_offset; i < client_end; ++i) {
+        auto info =
+            standby_->GetMetadataStore()->GetClientInfo(session.client_ids[i]);
+        if (info) {
+            response.clients.push_back(
+                {session.client_ids[i], std::move(*info)});
+        }
+    }
+    response.next_client_offset = client_end;
+    response.done = object_end == session.object_keys.size() &&
+                    client_end == session.client_ids.size();
+    return response;
+}
+
+int32_t P2PStandbySnapshotService::EndSnapshot(
+    const EndStandbySnapshotRequest& request) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    CleanupExpiredSessionsLocked();
+    return sessions_.erase(request.session_id) == 1
+               ? toInt(ErrorCode::OK)
+               : toInt(ErrorCode::INVALID_PARAMS);
+}
+
+void P2PStandbySnapshotService::CleanupExpiredSessionsLocked() {
+    const auto now = std::chrono::steady_clock::now();
+    for (auto it = sessions_.begin(); it != sessions_.end();) {
+        if (now - it->second.last_access > kSnapshotSessionIdleTimeout) {
+            it = sessions_.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void P2PStandbySnapshotService::CleanupLoop() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (!stopping_) {
+        cleanup_cv_.wait_for(lock, kSnapshotSessionCleanupInterval,
+                             [this] { return stopping_; });
+        if (!stopping_) {
+            CleanupExpiredSessionsLocked();
+        }
+    }
+}
+
+namespace {
+
+bool ParseEndpoint(const std::string& endpoint, std::string& host,
+                   std::string& port) {
+    auto separator = endpoint.rfind(':');
+    if (separator == std::string::npos || separator == 0 ||
+        separator + 1 == endpoint.size()) {
+        return false;
+    }
+    host = endpoint.substr(0, separator);
+    port = endpoint.substr(separator + 1);
+    return true;
+}
+
+}  // namespace
+
+ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
+                                              const std::string& cluster_id,
+                                              P2PStandbyMetadataStore* target,
+                                              uint64_t& baseline_sequence_id,
+                                              uint32_t chunk_size) {
+    if (!target || chunk_size == 0 ||
+        chunk_size > kMaxStandbySnapshotChunkSize) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    std::string host;
+    std::string port;
+    if (!ParseEndpoint(endpoint, host, port)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    coro_rpc::coro_rpc_client client;
+    auto connect_error = async_simple::coro::syncAwait(
+        client.connect(host, port, std::chrono::seconds(5)));
+    if (connect_error) {
+        LOG(WARNING) << "Standby snapshot: connect failed"
+                     << ", endpoint=" << endpoint
+                     << ", error=" << connect_error.message();
+        return ErrorCode::RPC_FAIL;
+    }
+
+    auto begin = async_simple::coro::syncAwait(
+        client.call_for<&P2PStandbySnapshotService::BeginSnapshot>(
+            std::chrono::seconds(10), BeginStandbySnapshotRequest{cluster_id}));
+    if (!begin || fromInt(begin->error_code) != ErrorCode::OK) {
+        return begin ? fromInt(begin->error_code) : ErrorCode::RPC_FAIL;
+    }
+
+    const std::string session_id = begin->session_id;
+    uint64_t object_offset = 0;
+    uint64_t client_offset = 0;
+    uint64_t chunk_count = 0;
+    const auto started_at = std::chrono::steady_clock::now();
+    LOG(INFO) << "Standby snapshot: bootstrap started"
+              << ", endpoint=" << endpoint << ", session_id=" << session_id
+              << ", baseline_sequence_id=" << begin->baseline_sequence_id
+              << ", objects=" << begin->object_count
+              << ", clients=" << begin->client_count;
+    target->RemoveAllMetadata();
+
+    ErrorCode result = ErrorCode::OK;
+    while (true) {
+        StandbySnapshotChunkRequest request;
+        request.session_id = session_id;
+        request.object_offset = object_offset;
+        request.client_offset = client_offset;
+        request.limit = chunk_size;
+        auto chunk = async_simple::coro::syncAwait(
+            client.call_for<&P2PStandbySnapshotService::GetSnapshotChunk>(
+                std::chrono::seconds(30), request));
+        if (!chunk || fromInt(chunk->error_code) != ErrorCode::OK) {
+            result = chunk ? fromInt(chunk->error_code) : ErrorCode::RPC_FAIL;
+            break;
+        }
+        for (const auto& record : chunk->clients) {
+            target->RegisterClient(record.client_id, record.info.ip_address,
+                                   record.info.rpc_port, record.info.segments);
+        }
+        for (const auto& record : chunk->objects) {
+            target->RestoreMetadata(record.key, record.metadata);
+        }
+        object_offset = chunk->next_object_offset;
+        client_offset = chunk->next_client_offset;
+        ++chunk_count;
+        if (chunk->done || chunk_count % 100 == 0) {
+            LOG(INFO) << "Standby snapshot: bootstrap progress"
+                      << ", endpoint=" << endpoint
+                      << ", session_id=" << session_id
+                      << ", objects=" << object_offset << "/"
+                      << begin->object_count << ", clients=" << client_offset
+                      << "/" << begin->client_count;
+        }
+        if (chunk->done) {
+            baseline_sequence_id = begin->baseline_sequence_id;
+            break;
+        }
+    }
+
+    async_simple::coro::syncAwait(
+        client.call_for<&P2PStandbySnapshotService::EndSnapshot>(
+            std::chrono::seconds(5), EndStandbySnapshotRequest{session_id}));
+    if (result != ErrorCode::OK) {
+        LOG(ERROR) << "Standby snapshot: bootstrap failed"
+                   << ", endpoint=" << endpoint << ", session_id=" << session_id
+                   << ", object_offset=" << object_offset
+                   << ", client_offset=" << client_offset
+                   << ", error=" << toString(result);
+        target->RemoveAllMetadata();
+    } else {
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started_at);
+        LOG(INFO) << "Standby snapshot: bootstrap completed"
+                  << ", endpoint=" << endpoint << ", session_id=" << session_id
+                  << ", baseline_sequence_id=" << baseline_sequence_id
+                  << ", chunks=" << chunk_count
+                  << ", elapsed_ms=" << elapsed.count();
+    }
+    return result;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
@@ -38,12 +38,28 @@ P2PStandbySnapshotService::~P2PStandbySnapshotService() {
 BeginStandbySnapshotResponse P2PStandbySnapshotService::BeginSnapshot(
     const BeginStandbySnapshotRequest& request) {
     BeginStandbySnapshotResponse response;
-    if (!standby_ || request.cluster_id != standby_->GetClusterId() ||
-        !standby_->IsReadyForSnapshot()) {
+    const bool has_standby = standby_ != nullptr;
+    const std::string local_cluster_id =
+        has_standby ? standby_->GetClusterId() : "";
+    const bool snapshot_ready = has_standby &&
+                                request.cluster_id == local_cluster_id &&
+                                standby_->IsReadyForSnapshot();
+    if (!snapshot_ready) {
+        LOG(WARNING) << "Standby snapshot: BeginSnapshot rejected"
+                     << ", request_cluster_id=" << request.cluster_id
+                     << ", local_cluster_id=" << local_cluster_id
+                     << ", has_standby=" << has_standby;
         response.error_code = toInt(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
         return response;
     }
 
+    // NOTE: This snapshot is a bootstrap seed, not a consistent image of the
+    // source metadata at baseline_sequence_id. The source standby may keep
+    // applying OpLogs while chunks are fetched; entries deleted during the
+    // fetch can be absent from the restored state, while newly-created keys
+    // are not added unless they were already in the captured key set.
+    // Correctness depends on idempotent OpLog replay, and the restored node
+    // must catch up from baseline_sequence_id to converge to the final state.
     Session session;
     session.baseline_sequence_id = standby_->GetLatestAppliedSequenceId();
     auto* store = standby_->GetMetadataStore();
@@ -54,6 +70,10 @@ BeginStandbySnapshotResponse P2PStandbySnapshotService::BeginSnapshot(
     std::lock_guard<std::mutex> lock(mutex_);
     CleanupExpiredSessionsLocked();
     if (sessions_.size() >= kMaxStandbySnapshotSessions) {
+        LOG(WARNING) << "Standby snapshot: BeginSnapshot rejected, too many "
+                        "active sessions"
+                     << ", active_sessions=" << sessions_.size()
+                     << ", max_sessions=" << kMaxStandbySnapshotSessions;
         response.error_code = toInt(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
         return response;
     }
@@ -75,6 +95,12 @@ StandbySnapshotChunkResponse P2PStandbySnapshotService::GetSnapshotChunk(
     StandbySnapshotChunkResponse response;
     if (!standby_ || request.limit == 0 ||
         request.limit > kMaxStandbySnapshotChunkSize) {
+        LOG(WARNING) << "Standby snapshot: GetSnapshotChunk rejected, invalid "
+                        "request"
+                     << ", session_id=" << request.session_id
+                     << ", has_standby=" << (standby_ != nullptr)
+                     << ", limit=" << request.limit
+                     << ", max_limit=" << kMaxStandbySnapshotChunkSize;
         response.error_code = toInt(ErrorCode::INVALID_PARAMS);
         return response;
     }
@@ -83,6 +109,10 @@ StandbySnapshotChunkResponse P2PStandbySnapshotService::GetSnapshotChunk(
     CleanupExpiredSessionsLocked();
     auto session_it = sessions_.find(request.session_id);
     if (session_it == sessions_.end()) {
+        LOG(WARNING) << "Standby snapshot: GetSnapshotChunk rejected, unknown "
+                        "session"
+                     << ", session_id=" << request.session_id
+                     << ", active_sessions=" << sessions_.size();
         response.error_code = toInt(ErrorCode::INVALID_PARAMS);
         return response;
     }
@@ -90,6 +120,13 @@ StandbySnapshotChunkResponse P2PStandbySnapshotService::GetSnapshotChunk(
     auto& session = session_it->second;
     if (request.object_offset > session.object_keys.size() ||
         request.client_offset > session.client_ids.size()) {
+        LOG(WARNING) << "Standby snapshot: GetSnapshotChunk rejected, invalid "
+                        "offsets"
+                     << ", session_id=" << request.session_id
+                     << ", object_offset=" << request.object_offset
+                     << ", object_count=" << session.object_keys.size()
+                     << ", client_offset=" << request.client_offset
+                     << ", client_count=" << session.client_ids.size();
         response.error_code = toInt(ErrorCode::INVALID_PARAMS);
         return response;
     }
@@ -182,12 +219,21 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
                                               uint32_t chunk_size) {
     if (!target || chunk_size == 0 ||
         chunk_size > kMaxStandbySnapshotChunkSize) {
+        LOG(WARNING) << "Standby snapshot: bootstrap rejected, invalid "
+                        "request"
+                     << ", endpoint=" << endpoint
+                     << ", has_target=" << (target != nullptr)
+                     << ", chunk_size=" << chunk_size
+                     << ", max_chunk_size=" << kMaxStandbySnapshotChunkSize;
         return ErrorCode::INVALID_PARAMS;
     }
 
     std::string host;
     std::string port;
     if (!ParseEndpoint(endpoint, host, port)) {
+        LOG(WARNING) << "Standby snapshot: bootstrap rejected, invalid "
+                        "endpoint"
+                     << ", endpoint=" << endpoint;
         return ErrorCode::INVALID_PARAMS;
     }
 
@@ -205,6 +251,10 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
         client.call_for<&P2PStandbySnapshotService::BeginSnapshot>(
             std::chrono::seconds(10), BeginStandbySnapshotRequest{cluster_id}));
     if (!begin || fromInt(begin->error_code) != ErrorCode::OK) {
+        LOG(WARNING) << "Standby snapshot: BeginSnapshot RPC failed"
+                     << ", endpoint=" << endpoint << ", error="
+                     << (begin ? toString(fromInt(begin->error_code))
+                               : toString(ErrorCode::RPC_FAIL));
         return begin ? fromInt(begin->error_code) : ErrorCode::RPC_FAIL;
     }
 
@@ -232,6 +282,13 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
                 std::chrono::seconds(30), request));
         if (!chunk || fromInt(chunk->error_code) != ErrorCode::OK) {
             result = chunk ? fromInt(chunk->error_code) : ErrorCode::RPC_FAIL;
+            LOG(WARNING) << "Standby snapshot: GetSnapshotChunk RPC failed"
+                         << ", endpoint=" << endpoint
+                         << ", session_id=" << session_id
+                         << ", object_offset=" << object_offset
+                         << ", client_offset=" << client_offset
+                         << ", limit=" << request.limit
+                         << ", error=" << toString(result);
             break;
         }
         for (const auto& record : chunk->clients) {
@@ -258,9 +315,6 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
         }
     }
 
-    async_simple::coro::syncAwait(
-        client.call_for<&P2PStandbySnapshotService::EndSnapshot>(
-            std::chrono::seconds(5), EndStandbySnapshotRequest{session_id}));
     if (result != ErrorCode::OK) {
         LOG(ERROR) << "Standby snapshot: bootstrap failed"
                    << ", endpoint=" << endpoint << ", session_id=" << session_id
@@ -277,6 +331,19 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
                   << ", baseline_sequence_id=" << baseline_sequence_id
                   << ", chunks=" << chunk_count
                   << ", elapsed_ms=" << elapsed.count();
+    }
+
+    // EndSnapshot is best-effort; the server-side CleanupLoop removes idle
+    // sessions by timeout if this cleanup RPC fails.
+    auto end = async_simple::coro::syncAwait(
+        client.call_for<&P2PStandbySnapshotService::EndSnapshot>(
+            std::chrono::seconds(5), EndStandbySnapshotRequest{session_id}));
+    const ErrorCode end_result = end ? fromInt(*end) : ErrorCode::RPC_FAIL;
+    if (end_result != ErrorCode::OK) {
+        LOG(WARNING) << "Standby snapshot: EndSnapshot RPC failed"
+                     << ", endpoint=" << endpoint
+                     << ", session_id=" << session_id
+                     << ", error=" << toString(end_result);
     }
     return result;
 }

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -3,10 +3,12 @@
 #include "centralized_rpc_service.h"
 #include "ha/oplog/p2p_hot_standby_service.h"
 #include "p2p_rpc_service.h"
+#include "utils.h"
 #ifdef STORE_USE_REDIS
 #include "redis_master_view_helper.h"
 #endif
 
+#include <limits>
 #include <optional>
 
 namespace mooncake {
@@ -163,6 +165,17 @@ int MasterServiceSupervisor::Start() {
         std::unique_ptr<P2PHotStandbyService> p2p_standby;
         if (config_.deployment_mode == DeploymentMode::P2P &&
             config_.enable_oplog) {
+            if (config_.standby_snapshot_service_port >
+                    std::numeric_limits<uint16_t>::max() ||
+                config_.standby_snapshot_chunk_size == 0 ||
+                config_.standby_snapshot_chunk_size >
+                    kMaxStandbySnapshotChunkSize) {
+                LOG(ERROR) << "Invalid standby snapshot configuration"
+                           << ", port=" << config_.standby_snapshot_service_port
+                           << ", chunk_size="
+                           << config_.standby_snapshot_chunk_size;
+                return -1;
+            }
             P2PHotStandbyConfig standby_config;
             standby_config.cluster_id = config_.cluster_id;
             standby_config.oplog_store_type =
@@ -172,6 +185,14 @@ int MasterServiceSupervisor::Start() {
             standby_config.redis_username = config_.redis_username;
             standby_config.redis_password = config_.redis_password;
             standby_config.redis_db_index = config_.redis_db_index;
+            standby_config.snapshot_service_port =
+                static_cast<uint16_t>(config_.standby_snapshot_service_port);
+            standby_config.snapshot_chunk_size =
+                config_.standby_snapshot_chunk_size;
+            if (!config_.standby_snapshot_sources.empty()) {
+                standby_config.snapshot_source_endpoints = splitString(
+                    config_.standby_snapshot_sources, ',', /*trim=*/true);
+            }
 
             p2p_standby =
                 std::make_unique<P2PHotStandbyService>(standby_config);

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -139,6 +139,12 @@ DEFINE_string(oplog_async_queue_overflow_mode, "reject",
               "Async OpLog queue overflow mode: reject or bypass");
 DEFINE_uint64(oplog_best_effort_max_retries, 3,
               "Maximum Redis attempts for best-effort OpLogs");
+DEFINE_uint32(standby_snapshot_service_port, 0,
+              "RPC port used to serve Standby metadata snapshots; 0 disables");
+DEFINE_string(standby_snapshot_sources, "",
+              "Comma-separated explicit Standby snapshot source endpoints");
+DEFINE_uint32(standby_snapshot_chunk_size, 256,
+              "Maximum metadata records per Standby snapshot RPC chunk");
 
 // Redis election backend configuration
 DEFINE_string(election_backend, "etcd",
@@ -220,6 +226,15 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt64("oplog_best_effort_max_retries",
                              &master_config.oplog_best_effort_max_retries,
                              FLAGS_oplog_best_effort_max_retries);
+    default_config.GetUInt32("standby_snapshot_service_port",
+                             &master_config.standby_snapshot_service_port,
+                             FLAGS_standby_snapshot_service_port);
+    default_config.GetString("standby_snapshot_sources",
+                             &master_config.standby_snapshot_sources,
+                             FLAGS_standby_snapshot_sources);
+    default_config.GetUInt32("standby_snapshot_chunk_size",
+                             &master_config.standby_snapshot_chunk_size,
+                             FLAGS_standby_snapshot_chunk_size);
     default_config.GetBool("enable_offload", &master_config.enable_offload,
                            FLAGS_enable_offload);
     default_config.GetString("etcd_endpoints", &master_config.etcd_endpoints,
@@ -451,6 +466,24 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.oplog_best_effort_max_retries =
             FLAGS_oplog_best_effort_max_retries;
+    }
+    if ((google::GetCommandLineFlagInfo("standby_snapshot_service_port",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.standby_snapshot_service_port =
+            FLAGS_standby_snapshot_service_port;
+    }
+    if ((google::GetCommandLineFlagInfo("standby_snapshot_sources", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.standby_snapshot_sources = FLAGS_standby_snapshot_sources;
+    }
+    if ((google::GetCommandLineFlagInfo("standby_snapshot_chunk_size", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.standby_snapshot_chunk_size =
+            FLAGS_standby_snapshot_chunk_size;
     }
     if ((google::GetCommandLineFlagInfo("enable_offload", &info) &&
          !info.is_default) ||

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -258,6 +258,119 @@ TEST_F(P2PHotStandbyServiceTest, ReplicatesMasterWrittenP2POplog) {
     EXPECT_EQ(desc.rpc_port, 50051);
 }
 
+TEST_F(P2PHotStandbyServiceTest, BootstrapsFromStandbySnapshotSource) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{11, 11};
+    const UUID segment_id{12, 12};
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+    AddReplica(master, "snapshot-key", client_id, segment_id, 8192);
+
+    auto source_config = MakeStandbyConfig();
+    source_config.snapshot_service_port =
+        static_cast<uint16_t>(49000 + (::getpid() % 1000));
+    P2PHotStandbyService source(source_config);
+    ASSERT_EQ(source.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        source.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+
+    auto target_config = MakeStandbyConfig();
+    target_config.snapshot_source_endpoints = {
+        "127.0.0.1:" + std::to_string(source_config.snapshot_service_port)};
+    target_config.snapshot_chunk_size = 1;
+    P2PHotStandbyService target(target_config);
+    ASSERT_EQ(target.Start(), ErrorCode::OK);
+    ASSERT_GE(target.GetLatestAppliedSequenceId(), 2);
+
+    auto exported = target.ExportMetadata();
+    ASSERT_NE(exported.clients.find(client_id), exported.clients.end());
+    auto object = exported.objects.find("snapshot-key");
+    ASSERT_NE(object, exported.objects.end());
+    EXPECT_EQ(object->second.size, 8192);
+    ASSERT_EQ(object->second.replicas.size(), 1);
+
+    target.Stop();
+    source.Stop();
+}
+
+TEST_F(P2PHotStandbyServiceTest,
+       SnapshotKeepsFixedInventoryWhileSourceContinuesApplying) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{21, 21};
+    const UUID segment_id{22, 22};
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+    AddReplica(master, "before-snapshot", client_id, segment_id, 4096);
+
+    P2PHotStandbyService source(MakeStandbyConfig());
+    ASSERT_EQ(source.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        source.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+
+    P2PStandbySnapshotService snapshot(&source);
+    auto begin = snapshot.BeginSnapshot({kClusterId});
+    ASSERT_EQ(fromInt(begin.error_code), ErrorCode::OK);
+    EXPECT_EQ(begin.baseline_sequence_id, 2);
+
+    AddReplica(master, "after-snapshot", client_id, segment_id, 8192);
+    ASSERT_TRUE(
+        source.WaitForAppliedSequence(3, std::chrono::milliseconds(2000)));
+
+    auto chunk = snapshot.GetSnapshotChunk(
+        {begin.session_id, /*object_offset=*/0, /*client_offset=*/0,
+         /*limit=*/100});
+    ASSERT_EQ(fromInt(chunk.error_code), ErrorCode::OK);
+    ASSERT_TRUE(chunk.done);
+    ASSERT_EQ(chunk.objects.size(), 1);
+    EXPECT_EQ(chunk.objects.front().key, "before-snapshot");
+    EXPECT_EQ(snapshot.EndSnapshot({begin.session_id}), toInt(ErrorCode::OK));
+}
+
+TEST_F(P2PHotStandbyServiceTest,
+       SnapshotRejectsInvalidChunksAndLimitsSessions) {
+    P2PHotStandbyService source(MakeStandbyConfig());
+    ASSERT_EQ(source.Start(), ErrorCode::OK);
+
+    P2PStandbySnapshotService snapshot(&source);
+    std::vector<std::string> session_ids;
+    for (size_t i = 0; i < kMaxStandbySnapshotSessions; ++i) {
+        auto begin = snapshot.BeginSnapshot({kClusterId});
+        ASSERT_EQ(fromInt(begin.error_code), ErrorCode::OK);
+        session_ids.push_back(std::move(begin.session_id));
+    }
+
+    auto excess_session = snapshot.BeginSnapshot({kClusterId});
+    EXPECT_EQ(fromInt(excess_session.error_code),
+              ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+
+    auto oversized_chunk = snapshot.GetSnapshotChunk(
+        {session_ids.front(), 0, 0, kMaxStandbySnapshotChunkSize + 1});
+    EXPECT_EQ(fromInt(oversized_chunk.error_code), ErrorCode::INVALID_PARAMS);
+
+    auto invalid_offset =
+        snapshot.GetSnapshotChunk({session_ids.front(), 1, 0, 1});
+    EXPECT_EQ(fromInt(invalid_offset.error_code), ErrorCode::INVALID_PARAMS);
+
+    ASSERT_EQ(snapshot.EndSnapshot({session_ids.front()}),
+              toInt(ErrorCode::OK));
+    auto replacement_session = snapshot.BeginSnapshot({kClusterId});
+    EXPECT_EQ(fromInt(replacement_session.error_code), ErrorCode::OK);
+    source.Stop();
+}
+
+TEST_F(P2PHotStandbyServiceTest, SnapshotServerRejectsOccupiedPort) {
+    auto config = MakeStandbyConfig();
+    config.snapshot_service_port =
+        static_cast<uint16_t>(50000 + (::getpid() % 1000));
+
+    P2PHotStandbyService first(config);
+    ASSERT_EQ(first.Start(), ErrorCode::OK);
+
+    P2PHotStandbyService second(config);
+    EXPECT_EQ(second.Start(), ErrorCode::INTERNAL_ERROR);
+
+    second.Stop();
+    first.Stop();
+}
+
 TEST_F(P2PHotStandbyServiceTest, ReconnectsFromLastAppliedSequence) {
     std::mutex states_mutex;
     std::vector<std::shared_ptr<ControlledNotifierState>> states;


### PR DESCRIPTION
## Description

  Add peer snapshot bootstrap support for P2P Standby:

  - Serve paginated snapshots of object and client metadata.
  - Bootstrap a Standby from explicitly configured peer endpoints.
  - Continue replaying OpLog entries from the snapshot baseline before becoming ready.
  - Support configurable snapshot service port, source endpoints, and chunk size.
  - Add server-side chunk and offset validation.
  - Limit concurrent snapshot sessions and periodically clean up expired sessions.
  - Detect snapshot RPC server startup failures reliably.
  - Keep explicit endpoints as an override for future Redis-based source discovery.

  ## Module

  - [ ] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [x] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  The P2P OpLog test suite was compiled and run in the local development container. It covers snapshot bootstrap, concurrent source updates, invalid chunk requests, session limits, and occupied RPC ports.

  Test commands:
```
  docker exec mooncake-dev sh -lc \
    'cd /workspace &&
     cmake --build build-redis-oplog --target p2p_oplog_test -j$(nproc) &&
     ./build-redis-oplog/mooncake-store/tests/p2p_oplog_test'
```
  Test results:

  - [x] Unit tests pass — 90/90
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [ ] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex assisted with implementation, concurrency and lifecycle review, test coverage, formatting, and local build/test validation. The human submitter is responsible for reviewing, understanding, and defending the changes.