### PR TITLE
[Bugfix][Store] Support JsonCpp header layouts across Linux distributions

### DIFF
--- a/mooncake-store/benchmarks/oplog_batch_bench.cpp
+++ b/mooncake-store/benchmarks/oplog_batch_bench.cpp
@@ -1,6 +1,10 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <jsoncpp/json/json.h>
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>  // Ubuntu
+#else
+#include <json/json.h>  // CentOS
+#endif
 
 #include <algorithm>
 #include <atomic>

--- a/mooncake-store/tests/ha/oplog/oplog_batch_auditor_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_auditor_test.cpp
@@ -1,6 +1,10 @@
 #include <gtest/gtest.h>
 
-#include <jsoncpp/json/json.h>
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>  // Ubuntu
+#else
+#include <json/json.h>  // CentOS
+#endif
 
 #include <algorithm>
 #include <sstream>

--- a/mooncake-store/tools/oplog_batch_auditor.cpp
+++ b/mooncake-store/tools/oplog_batch_auditor.cpp
@@ -6,7 +6,11 @@
 #include <map>
 #include <string_view>
 
-#include <jsoncpp/json/json.h>
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>  // Ubuntu
+#else
+#include <json/json.h>  // CentOS
+#endif
 
 #include "ha/oplog/oplog_batch_codec.h"
 #include "ha/oplog/oplog_types.h"

--- a/mooncake-store/tools/oplog_batch_inspector.cpp
+++ b/mooncake-store/tools/oplog_batch_inspector.cpp
@@ -1,6 +1,10 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include <jsoncpp/json/json.h>
+#if __has_include(<jsoncpp/json/json.h>)
+#include <jsoncpp/json/json.h>  // Ubuntu
+#else
+#include <json/json.h>  // CentOS
+#endif
 
 #include <chrono>
 #include <cstdint>


### PR DESCRIPTION
## Description

Fix the Mooncake Store build failure seen in the [x86 nightly manylinux job](https://github.com/kvcache-ai/Mooncake/actions/runs/30471153615/job/90644300155).

The build installs `jsoncpp-devel` and CMake successfully finds `JsonCpp::JsonCpp`, but AlmaLinux exposes the header as `<json/json.h>`. Several recently added OpLog files hard-coded the Ubuntu layout, `<jsoncpp/json/json.h>`, causing compilation to fail.

Use the repository's existing `__has_include` compatibility pattern to support both header layouts in the OpLog inspector, auditor, benchmark, and auditor test.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build  --target oplog_batch_inspector oplog_batch_bench oplog_batch_auditor_test  -j32

env LSAN_OPTIONS=detect_leaks=0  ./build/mooncake-store/tests/oplog_batch_auditor_test

env LSAN_OPTIONS=detect_leaks=0  ./build/mooncake-store/tools/oplog_batch_inspector --version

env LSAN_OPTIONS=detect_leaks=0  ./build/mooncake-store/benchmarks/oplog_batch_bench --version

pre-commit run --files \
  mooncake-store/benchmarks/oplog_batch_bench.cpp \
  mooncake-store/tests/ha/oplog/oplog_batch_auditor_test.cpp \
  mooncake-store/tools/oplog_batch_auditor.cpp \
  mooncake-store/tools/oplog_batch_inspector.cpp
```

**Test results:**

- [x] Unit tests pass: 8/8 `OpLogBatchAuditorTest` cases
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done: all three affected targets build and both binaries load

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] No AI tools were used
- [ ] AI tools were used