### PR TITLE
[CI] Fix TONE SGLang Qwen3.5 cache gating

### DIFF
--- a/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
+++ b/scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This test case is adapted from https://github.com/sgl-project/sglang/blob/main/test/registered/distributed/test_disaggregation_different_tp.py
-# The original test has been updated to use deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct as DEFAULT_MODEL_NAME_FOR_TEST_MLA 
+# The original test has been updated to use deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct as DEFAULT_MODEL_NAME_FOR_TEST_MLA
 # and meta-llama/Llama-3.2-3B-Instruct as DEFAULT_MODEL_NAME_FOR_TEST
 
 test_case_name="test_disaggregation_different_tp"
@@ -11,26 +11,44 @@ BASE_DIR=${BASE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}
 . ${BASE_DIR}/scripts/common.sh
 
 run_test()
-{ 
+{
     echo "===== Running pytest tests ====="
     local log_file="${BASE_DIR}/${TEST_CASE_RESULT_PATH}/${test_case_name}.log"
 
     echo "Running tests in container and saving output to: $log_file"
 
-    # Use local HF cache (offline) only when both models are already downloaded.
-    local off_mla=$(hf_offline_prefix "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
-    local off_llama=$(hf_offline_prefix "meta-llama/Llama-3.2-3B-Instruct")
     local offline_prefix=""
-    if [ -n "$off_mla" ] && [ -n "$off_llama" ]; then
-        offline_prefix="$off_mla"
+    local cache_diagnostic=""
+    if [ "${USE_MODELSCOPE}" = "true" ]; then
+        cache_diagnostic="Model cache policy: online (USE_MODELSCOPE=true)"
+    else
+        local off_mla
+        local off_llama
+        local off_qwen
+        off_mla=$(hf_offline_prefix "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
+        off_llama=$(hf_offline_prefix "meta-llama/Llama-3.2-3B-Instruct")
+        off_qwen=$(hf_offline_prefix "Qwen/Qwen3.5-4B")
+        if [ -z "$off_mla" ]; then
+            cache_diagnostic="Model cache policy: online (missing cache for deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct)"
+        elif [ -z "$off_llama" ]; then
+            cache_diagnostic="Model cache policy: online (missing cache for meta-llama/Llama-3.2-3B-Instruct)"
+        elif [ -z "$off_qwen" ]; then
+            cache_diagnostic="Model cache policy: online (missing cache for Qwen/Qwen3.5-4B)"
+        else
+            offline_prefix="$off_mla"
+            cache_diagnostic="Model cache policy: offline (all required models are cached)"
+        fi
     fi
 
-    ${docker_exec} "\
-        cd /sgl-workspace/sglang/test/registered/disaggregation && \
-        sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\nDEFAULT_MODEL_NAME_FOR_TEST = \"meta-llama/Llama-3.2-3B-Instruct\"\n&|' test_disaggregation_different_tp.py && \
-        echo 'Model override applied successfully' && \
-        ${offline_prefix}python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long" | tee "$log_file"
-    
+    {
+        echo "$cache_diagnostic"
+        ${docker_exec} "\
+            cd /sgl-workspace/sglang/test/registered/disaggregation && \
+            sed -i '0,/^class /s|^class |DEFAULT_MODEL_NAME_FOR_TEST_MLA = \"deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct\"\nDEFAULT_MODEL_NAME_FOR_TEST = \"meta-llama/Llama-3.2-3B-Instruct\"\n&|' test_disaggregation_different_tp.py && \
+            echo 'Model override applied successfully' && \
+            ${offline_prefix}python3 -m pytest test_disaggregation_different_tp.py -v -s --tb=long"
+    } 2>&1 | tee "$log_file"
+
     return ${PIPESTATUS[0]}
 }
 
@@ -55,7 +73,7 @@ if [ "${BASH_SOURCE[0]}" == "${0}" ]; then
     if ! run_test; then
         exit_code=1
     fi
-    
+
     parse $exit_code
     exit $?
 fi


### PR DESCRIPTION
## Description

Fix the TONE SGLang disaggregation test's global Hugging Face offline decision.

The upstream test now also uses `Qwen/Qwen3.5-4B`, but Mooncake enabled `HF_HUB_OFFLINE=1` and `TRANSFORMERS_OFFLINE=1` after checking only the cached DeepSeek and Llama models. When Qwen3.5 was missing, the entire pytest process remained offline and could not download it through the configured `HF_ENDPOINT`.

This change:
- requires the DeepSeek, Llama, and Qwen3.5 caches before enabling offline mode;
- keeps hub access online when any required model is missing;
- does not apply the Hugging Face cache decision when `USE_MODELSCOPE=true`;
- logs the selected cache policy and the missing model that caused online mode.

The upstream model choices, pytest command, result parsing, and artifact paths are unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
bash -n scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
# Mocked cache-policy cases: Qwen3.5 missing, all models cached, and USE_MODELSCOPE=true
pre-commit run --files scripts/tone_tests/scripts/test_disaggregation_different_tp.sh
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (GPU integration test not run locally)
- [x] Manual testing done with mocked cache decisions

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable; no user-facing documentation change)
- [x] I have added or run tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable; this change is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex helped inspect the upstream SGLang test, implement the cache gate, and run validation)

The human submitter reviewed the complete diff and confirmed they can defend the change end-to-end.