### PR TITLE
[Store] Avoid staging for same-process GPU reads

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -616,9 +616,9 @@ class Client {
     }
 
     bool CanUseLocalMemcpy(const Replica::Descriptor& replica) const {
-        return transfer_submitter_ && replica.is_memory_replica() &&
-               transfer_submitter_->CanUseLocalMemcpy(
-                   replica.get_memory_descriptor().buffer_descriptor);
+        if (!replica.is_memory_replica()) return false;
+        return CanUseLocalMemcpy(replica.get_memory_descriptor()
+                                     .buffer_descriptor.transport_endpoint_);
     }
 
     /**

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -610,6 +610,12 @@ class Client {
         return endpoints;
     }
 
+    bool CanUseLocalMemcpy(const Replica::Descriptor& replica) const {
+        return transfer_submitter_ && replica.is_memory_replica() &&
+               transfer_submitter_->CanUseLocalMemcpy(
+                   replica.get_memory_descriptor().buffer_descriptor);
+    }
+
     /**
      * @brief Check if local hot cache is enabled
      * @return true if hot cache is enabled, false otherwise

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -615,6 +615,12 @@ class Client {
         return endpoints;
     }
 
+    bool CanUseLocalMemcpy(const Replica::Descriptor& replica) const {
+        return transfer_submitter_ && replica.is_memory_replica() &&
+               transfer_submitter_->CanUseLocalMemcpy(
+                   replica.get_memory_descriptor().buffer_descriptor);
+    }
+
     /**
      * @brief Check if local hot cache is enabled
      * @return true if hot cache is enabled, false otherwise

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -587,6 +587,10 @@ class TransferSubmitter {
     static bool isSameProcessEndpoint(const std::string& handle_endpoint,
                                       const std::string& local_endpoint);
 
+    bool CanUseLocalMemcpy(const AllocatedBuffer::Descriptor& handle) const {
+        return memcpy_enabled_ && isLocalTransfer(handle);
+    }
+
    private:
     TransferEngine& engine_;
     // Cached at construction: the local transport endpoint never changes for

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -595,6 +595,10 @@ class TransferSubmitter {
     static bool isSameProcessEndpoint(const std::string& handle_endpoint,
                                       const std::string& local_endpoint);
 
+    bool CanUseLocalMemcpy(const AllocatedBuffer::Descriptor& handle) const {
+        return memcpy_enabled_ && isLocalTransfer(handle);
+    }
+
    private:
     TransferEngine& engine_;
     // Cached at construction: the local transport endpoint never changes for

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -595,10 +595,6 @@ class TransferSubmitter {
     static bool isSameProcessEndpoint(const std::string& handle_endpoint,
                                       const std::string& local_endpoint);
 
-    bool CanUseLocalMemcpy(const AllocatedBuffer::Descriptor& handle) const {
-        return memcpy_enabled_ && isLocalTransfer(handle);
-    }
-
    private:
     TransferEngine& engine_;
     // Cached at construction: the local transport endpoint never changes for

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3639,15 +3639,48 @@ RealClient::get_into_ranges_internal(
             if (metadata.replica.is_memory_replica()) {
                 if (client_->CanUseLocalMemcpy(metadata.replica) &&
                     runtime_accelerator.FindDeviceForPointer(buffers[i])) {
+                    // Planning cache entries may be close to expiry. Renew and
+                    // reselect the replica before copying into device memory.
+                    auto refresh_result = resolve_ranged_read_metadata(keys[j]);
+                    if (!refresh_result) {
+                        std::fill(range_results.begin(), range_results.end(),
+                                  tl::unexpected(refresh_result.error()));
+                        continue;
+                    }
+                    std::optional<RangedReadMetadata> refreshed_metadata;
+                    refreshed_metadata.emplace(std::move(*refresh_result));
+                    auto lease_refresh_at =
+                        [](const RangedReadMetadata &value) {
+                            const auto now = std::chrono::steady_clock::now();
+                            return now +
+                                   (value.query_result.lease_timeout - now) / 2;
+                        };
+                    auto refresh_at = lease_refresh_at(*refreshed_metadata);
                     for (size_t k = 0; k < range_results.size(); ++k) {
+                        // Renew halfway through the remaining lease in long
+                        // batches.
                         const size_t dst_offset = dst_offsets[k];
                         if (dst_offset > capacities[i] ||
                             sizes[k] > capacities[i] - dst_offset) {
                             continue;
                         }
+                        if (std::chrono::steady_clock::now() >= refresh_at) {
+                            auto next_refresh_result =
+                                resolve_ranged_read_metadata(keys[j]);
+                            if (!next_refresh_result) {
+                                std::fill(range_results.begin() + k,
+                                          range_results.end(),
+                                          tl::unexpected(
+                                              next_refresh_result.error()));
+                                break;
+                            }
+                            refreshed_metadata.emplace(
+                                std::move(*next_refresh_result));
+                            refresh_at = lease_refresh_at(*refreshed_metadata);
+                        }
                         range_results[k] = execute_ranged_read(
                             keys[j], buffers[i], dst_offset, src_offsets[k],
-                            sizes[k], metadata, false, false);
+                            sizes[k], *refreshed_metadata, false, false);
                     }
                     continue;
                 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3595,6 +3595,8 @@ RealClient::get_into_ranges_internal(
             .first->second;
     };
 
+    auto runtime_accelerator =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
     struct ScatterLease {
         std::chrono::steady_clock::time_point expires_at;
         std::optional<ErrorCode> error;
@@ -3633,6 +3635,20 @@ RealClient::get_into_ranges_internal(
 
             const auto &metadata = metadata_result.value();
             if (metadata.replica.is_memory_replica()) {
+                if (client_->CanUseLocalMemcpy(metadata.replica) &&
+                    runtime_accelerator.FindDeviceForPointer(buffers[i])) {
+                    for (size_t k = 0; k < range_results.size(); ++k) {
+                        const size_t dst_offset = dst_offsets[k];
+                        if (dst_offset > capacities[i] ||
+                            sizes[k] > capacities[i] - dst_offset) {
+                            continue;
+                        }
+                        range_results[k] = execute_ranged_read(
+                            keys[j], buffers[i], dst_offset, src_offsets[k],
+                            sizes[k], metadata, false, false);
+                    }
+                    continue;
+                }
                 const auto &handle =
                     metadata.replica.get_memory_descriptor().buffer_descriptor;
                 auto [lease_it, inserted] = scatter_leases.try_emplace(keys[j]);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4584,58 +4584,22 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
 
     std::vector<tl::expected<int64_t, ErrorCode>> results(
         requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    std::vector<device::CudaIpcBufferMapping> mappings;
-    std::vector<void *> buffers;
-    std::vector<std::vector<std::string>> all_keys;
-    std::vector<std::vector<std::vector<size_t>>> all_dst_offsets;
-    std::vector<std::vector<std::vector<size_t>>> all_src_offsets;
-    std::vector<std::vector<std::vector<size_t>>> all_sizes;
-    std::vector<size_t> buffer_capacities;
-    std::vector<size_t> original_indices;
-    mappings.reserve(requests.size());
-    buffers.reserve(requests.size());
-    all_keys.reserve(requests.size());
-    all_dst_offsets.reserve(requests.size());
-    all_src_offsets.reserve(requests.size());
-    all_sizes.reserve(requests.size());
-    buffer_capacities.reserve(requests.size());
-    original_indices.reserve(requests.size());
 
     for (size_t i = 0; i < requests.size(); ++i) {
         const auto &request = requests[i];
+        if (request.size == 0) {
+            results[i] = 0;
+            continue;
+        }
         auto mapping = device::CudaIpcBufferMapping::Open(request.destination);
         if (!mapping) {
             results[i] = tl::unexpected(mapping.error());
             continue;
         }
-        mappings.push_back(std::move(*mapping));
-        buffers.push_back(mappings.back().ptr());
-        all_keys.push_back({request.key});
-        all_dst_offsets.push_back({{0}});
-        all_src_offsets.push_back(
-            {{static_cast<size_t>(request.source_offset)}});
-        all_sizes.push_back({{static_cast<size_t>(request.size)}});
-        buffer_capacities.push_back(static_cast<size_t>(request.size));
-        original_indices.push_back(i);
-    }
-
-    if (buffers.empty()) {
-        return results;
-    }
-
-    auto range_results = get_into_ranges_internal(
-        buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,
-        &buffer_capacities, nullptr);
-    for (size_t i = 0; i < original_indices.size(); ++i) {
-        if (i < range_results.size() && range_results[i].size() == 1 &&
-            range_results[i][0].size() == 1) {
-            results[original_indices[i]] = range_results[i][0][0];
-        } else {
-            LOG(ERROR) << "Invalid cuda ipc tensor read result shape for key "
-                       << requests[original_indices[i]].key;
-            results[original_indices[i]] =
-                tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
+        results[i] = get_into_range_internal(
+            request.key, mapping->ptr(), 0,
+            static_cast<size_t>(request.source_offset),
+            static_cast<size_t>(request.size), false, false);
     }
     return results;
 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3355,7 +3355,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
         if (runtime_accelerator.FindDeviceForPointer(dst) &&
-            !client_->CanUseLocalMemcpy(replica)) {
+            (!client_->CanUseLocalMemcpy(replica) ||
+             client_->IsHotCacheEnabled())) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3492,6 +3493,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     auto runtime_accelerator =
         device::GetAcceleratorRegistry().RuntimeAccelerators();
     void *dst = static_cast<char *>(buffer) + dst_offset;
+    auto filtered_qr = FilterQueryResult(query_result, replica, false);
     if (runtime_accelerator.FindDeviceForPointer(dst) &&
         !client_->CanUseLocalMemcpy(replica)) {
         if (!client_buffer_allocator_) {
@@ -3509,7 +3511,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         tmp_slices.emplace_back(Slice{tmp_handle.ptr(), size});
 
         auto get_result =
-            client_->Get(key, query_result, tmp_slices, src_offset);
+            client_->Get(key, filtered_qr, tmp_slices, src_offset);
         if (!get_result) {
             return tl::unexpected(get_result.error());
         }
@@ -3524,7 +3526,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     std::vector<Slice> slices;
     slices.emplace_back(Slice{dst, size});
 
-    auto get_result = client_->Get(key, query_result, slices, src_offset);
+    auto get_result = client_->Get(key, filtered_qr, slices, src_offset);
     if (!get_result) {
         return tl::unexpected(get_result.error());
     }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3654,15 +3654,48 @@ RealClient::get_into_ranges_internal(
             if (metadata.replica.is_memory_replica()) {
                 if (client_->CanUseLocalMemcpy(metadata.replica) &&
                     runtime_accelerator.FindDeviceForPointer(buffers[i])) {
+                    // Planning cache entries may be close to expiry. Renew and
+                    // reselect the replica before copying into device memory.
+                    auto refresh_result = resolve_ranged_read_metadata(keys[j]);
+                    if (!refresh_result) {
+                        std::fill(range_results.begin(), range_results.end(),
+                                  tl::unexpected(refresh_result.error()));
+                        continue;
+                    }
+                    std::optional<RangedReadMetadata> refreshed_metadata;
+                    refreshed_metadata.emplace(std::move(*refresh_result));
+                    auto lease_refresh_at =
+                        [](const RangedReadMetadata &value) {
+                            const auto now = std::chrono::steady_clock::now();
+                            return now +
+                                   (value.query_result.lease_timeout - now) / 2;
+                        };
+                    auto refresh_at = lease_refresh_at(*refreshed_metadata);
                     for (size_t k = 0; k < range_results.size(); ++k) {
+                        // Renew halfway through the remaining lease in long
+                        // batches.
                         const size_t dst_offset = dst_offsets[k];
                         if (dst_offset > capacities[i] ||
                             sizes[k] > capacities[i] - dst_offset) {
                             continue;
                         }
+                        if (std::chrono::steady_clock::now() >= refresh_at) {
+                            auto next_refresh_result =
+                                resolve_ranged_read_metadata(keys[j]);
+                            if (!next_refresh_result) {
+                                std::fill(range_results.begin() + k,
+                                          range_results.end(),
+                                          tl::unexpected(
+                                              next_refresh_result.error()));
+                                break;
+                            }
+                            refreshed_metadata.emplace(
+                                std::move(*next_refresh_result));
+                            refresh_at = lease_refresh_at(*refreshed_metadata);
+                        }
                         range_results[k] = execute_ranged_read(
                             keys[j], buffers[i], dst_offset, src_offsets[k],
-                            sizes[k], metadata, false, false);
+                            sizes[k], *refreshed_metadata, false, false);
                     }
                     continue;
                 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3354,7 +3354,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         auto runtime_accelerator =
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
-        if (runtime_accelerator.FindDeviceForPointer(dst)) {
+        if (runtime_accelerator.FindDeviceForPointer(dst) &&
+            !client_->CanUseLocalMemcpy(replica)) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3491,7 +3492,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     auto runtime_accelerator =
         device::GetAcceleratorRegistry().RuntimeAccelerators();
     void *dst = static_cast<char *>(buffer) + dst_offset;
-    if (runtime_accelerator.FindDeviceForPointer(dst)) {
+    if (runtime_accelerator.FindDeviceForPointer(dst) &&
+        !client_->CanUseLocalMemcpy(replica)) {
         if (!client_buffer_allocator_) {
             LOG(ERROR) << "Client buffer allocator is not provided";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4599,58 +4599,22 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
 
     std::vector<tl::expected<int64_t, ErrorCode>> results(
         requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    std::vector<device::CudaIpcBufferMapping> mappings;
-    std::vector<void *> buffers;
-    std::vector<std::vector<std::string>> all_keys;
-    std::vector<std::vector<std::vector<size_t>>> all_dst_offsets;
-    std::vector<std::vector<std::vector<size_t>>> all_src_offsets;
-    std::vector<std::vector<std::vector<size_t>>> all_sizes;
-    std::vector<size_t> buffer_capacities;
-    std::vector<size_t> original_indices;
-    mappings.reserve(requests.size());
-    buffers.reserve(requests.size());
-    all_keys.reserve(requests.size());
-    all_dst_offsets.reserve(requests.size());
-    all_src_offsets.reserve(requests.size());
-    all_sizes.reserve(requests.size());
-    buffer_capacities.reserve(requests.size());
-    original_indices.reserve(requests.size());
 
     for (size_t i = 0; i < requests.size(); ++i) {
         const auto &request = requests[i];
+        if (request.size == 0) {
+            results[i] = 0;
+            continue;
+        }
         auto mapping = device::CudaIpcBufferMapping::Open(request.destination);
         if (!mapping) {
             results[i] = tl::unexpected(mapping.error());
             continue;
         }
-        mappings.push_back(std::move(*mapping));
-        buffers.push_back(mappings.back().ptr());
-        all_keys.push_back({request.key});
-        all_dst_offsets.push_back({{0}});
-        all_src_offsets.push_back(
-            {{static_cast<size_t>(request.source_offset)}});
-        all_sizes.push_back({{static_cast<size_t>(request.size)}});
-        buffer_capacities.push_back(static_cast<size_t>(request.size));
-        original_indices.push_back(i);
-    }
-
-    if (buffers.empty()) {
-        return results;
-    }
-
-    auto range_results = get_into_ranges_internal(
-        buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,
-        &buffer_capacities, nullptr);
-    for (size_t i = 0; i < original_indices.size(); ++i) {
-        if (i < range_results.size() && range_results[i].size() == 1 &&
-            range_results[i][0].size() == 1) {
-            results[original_indices[i]] = range_results[i][0][0];
-        } else {
-            LOG(ERROR) << "Invalid cuda ipc tensor read result shape for key "
-                       << requests[original_indices[i]].key;
-            results[original_indices[i]] =
-                tl::unexpected(ErrorCode::INTERNAL_ERROR);
-        }
+        results[i] = get_into_range_internal(
+            request.key, mapping->ptr(), 0,
+            static_cast<size_t>(request.source_offset),
+            static_cast<size_t>(request.size), false, false);
     }
     return results;
 }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3355,7 +3355,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
         if (runtime_accelerator.FindDeviceForPointer(dst) &&
-            !client_->CanUseLocalMemcpy(replica)) {
+            (!client_->CanUseLocalMemcpy(replica) ||
+             client_->IsHotCacheEnabled())) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3477,6 +3478,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     auto runtime_accelerator =
         device::GetAcceleratorRegistry().RuntimeAccelerators();
     void *dst = static_cast<char *>(buffer) + dst_offset;
+    auto filtered_qr = FilterQueryResult(query_result, replica, false);
     if (runtime_accelerator.FindDeviceForPointer(dst) &&
         !client_->CanUseLocalMemcpy(replica)) {
         if (!client_buffer_allocator_) {
@@ -3494,7 +3496,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         tmp_slices.emplace_back(Slice{tmp_handle.ptr(), size});
 
         auto get_result =
-            client_->Get(key, query_result, tmp_slices, src_offset);
+            client_->Get(key, filtered_qr, tmp_slices, src_offset);
         if (!get_result) {
             return tl::unexpected(get_result.error());
         }
@@ -3509,7 +3511,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     std::vector<Slice> slices;
     slices.emplace_back(Slice{dst, size});
 
-    auto get_result = client_->Get(key, query_result, slices, src_offset);
+    auto get_result = client_->Get(key, filtered_qr, slices, src_offset);
     if (!get_result) {
         return tl::unexpected(get_result.error());
     }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3610,6 +3610,8 @@ RealClient::get_into_ranges_internal(
             .first->second;
     };
 
+    auto runtime_accelerator =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
     struct ScatterLease {
         std::chrono::steady_clock::time_point expires_at;
         std::optional<ErrorCode> error;
@@ -3648,6 +3650,20 @@ RealClient::get_into_ranges_internal(
 
             const auto &metadata = metadata_result.value();
             if (metadata.replica.is_memory_replica()) {
+                if (client_->CanUseLocalMemcpy(metadata.replica) &&
+                    runtime_accelerator.FindDeviceForPointer(buffers[i])) {
+                    for (size_t k = 0; k < range_results.size(); ++k) {
+                        const size_t dst_offset = dst_offsets[k];
+                        if (dst_offset > capacities[i] ||
+                            sizes[k] > capacities[i] - dst_offset) {
+                            continue;
+                        }
+                        range_results[k] = execute_ranged_read(
+                            keys[j], buffers[i], dst_offset, src_offsets[k],
+                            sizes[k], metadata, false, false);
+                    }
+                    continue;
+                }
                 const auto &handle =
                     metadata.replica.get_memory_descriptor().buffer_descriptor;
                 auto [lease_it, inserted] = scatter_leases.try_emplace(keys[j]);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3354,7 +3354,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         auto runtime_accelerator =
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
-        if (runtime_accelerator.FindDeviceForPointer(dst)) {
+        if (runtime_accelerator.FindDeviceForPointer(dst) &&
+            !client_->CanUseLocalMemcpy(replica)) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3476,7 +3477,8 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     auto runtime_accelerator =
         device::GetAcceleratorRegistry().RuntimeAccelerators();
     void *dst = static_cast<char *>(buffer) + dst_offset;
-    if (runtime_accelerator.FindDeviceForPointer(dst)) {
+    if (runtime_accelerator.FindDeviceForPointer(dst) &&
+        !client_->CanUseLocalMemcpy(replica)) {
         if (!client_buffer_allocator_) {
             LOG(ERROR) << "Client buffer allocator is not provided";
             return tl::unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <memory>
 #include <numeric>
@@ -21,6 +22,34 @@ namespace mooncake {
 // Test fixture for TransferTask tests
 // TODO: Currently, this test does not cover TransferSubmitter and
 // TransferEngine integration. Will add more tests in the future.
+class ScopedEnvVar {
+   public:
+    ScopedEnvVar(const char* name, const char* value) : name_(name) {
+        if (const char* old_value = std::getenv(name)) {
+            had_old_value_ = true;
+            old_value_ = old_value;
+        }
+        if (value) {
+            setenv(name_.c_str(), value, 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    ~ScopedEnvVar() {
+        if (had_old_value_) {
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    bool had_old_value_ = false;
+    std::string old_value_;
+};
+
 class TransferTaskTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -310,6 +339,49 @@ TEST_F(TransferTaskTest, IsSameProcessEndpoint) {
     // Hostname endpoints (non-P2P metadata mode) compare as full strings.
     EXPECT_TRUE(TransferSubmitter::isSameProcessEndpoint("host-a", "host-a"));
     EXPECT_FALSE(TransferSubmitter::isSameProcessEndpoint("host-a", "host-b"));
+}
+
+TEST_F(TransferTaskTest, CanUseLocalMemcpyRequiresSameProcessEndpoint) {
+    ScopedEnvVar memcpy_enabled("MC_STORE_MEMCPY", "1");
+
+    TransferEngine engine(false);
+    ASSERT_EQ(
+        engine.init("P2PHANDSHAKE", "127.0.0.1:30991", "127.0.0.1", 30991), 0);
+    ASSERT_NE(engine.installTransport("tcp", nullptr), nullptr);
+
+    std::shared_ptr<StorageBackend> storage_backend;
+    TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30991");
+
+    AllocatedBuffer::Descriptor handle{};
+    handle.size_ = 4096;
+    handle.buffer_address_ = 0x1000;
+    handle.protocol_ = "tcp";
+
+    handle.transport_endpoint_ = engine.getLocalIpAndPort();
+    ASSERT_FALSE(handle.transport_endpoint_.empty());
+    EXPECT_TRUE(submitter.CanUseLocalMemcpy(handle));
+
+    handle.transport_endpoint_ = "127.0.0.1:30992";
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+
+    handle.transport_endpoint_.clear();
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+}
+
+TEST_F(TransferTaskTest, CanUseLocalMemcpyHonorsMemcpyEnv) {
+    ScopedEnvVar memcpy_disabled("MC_STORE_MEMCPY", "0");
+
+    TransferEngine engine(false);
+    ASSERT_EQ(
+        engine.init("P2PHANDSHAKE", "127.0.0.1:30993", "127.0.0.1", 30993), 0);
+    ASSERT_NE(engine.installTransport("tcp", nullptr), nullptr);
+
+    std::shared_ptr<StorageBackend> storage_backend;
+    TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30993");
+
+    AllocatedBuffer::Descriptor handle{4096, 0x1000, "tcp",
+                                       engine.getLocalIpAndPort()};
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
 }
 
 // Test TransferStrategy enum and stream operator

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <memory>
@@ -21,6 +22,36 @@
 namespace mooncake {
 
 // Test fixture for TransferTask tests
+// TODO: Currently, this test does not cover TransferSubmitter and
+// TransferEngine integration. Will add more tests in the future.
+class ScopedEnvVar {
+   public:
+    ScopedEnvVar(const char* name, const char* value) : name_(name) {
+        if (const char* old_value = std::getenv(name)) {
+            had_old_value_ = true;
+            old_value_ = old_value;
+        }
+        if (value) {
+            setenv(name_.c_str(), value, 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    ~ScopedEnvVar() {
+        if (had_old_value_) {
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    bool had_old_value_ = false;
+    std::string old_value_;
+};
+
 class TransferTaskTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -391,6 +422,48 @@ TEST_F(TransferTaskTest, BatchGetOffloadObjectCopiesPinnedHostToGpu) {
     EXPECT_EQ(cudaFree(gpu_destination), cudaSuccess);
 }
 #endif
+TEST_F(TransferTaskTest, CanUseLocalMemcpyRequiresSameProcessEndpoint) {
+    ScopedEnvVar memcpy_enabled("MC_STORE_MEMCPY", "1");
+
+    TransferEngine engine(false);
+    ASSERT_EQ(
+        engine.init("P2PHANDSHAKE", "127.0.0.1:30991", "127.0.0.1", 30991), 0);
+    ASSERT_NE(engine.installTransport("tcp", nullptr), nullptr);
+
+    std::shared_ptr<StorageBackend> storage_backend;
+    TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30991");
+
+    AllocatedBuffer::Descriptor handle{};
+    handle.size_ = 4096;
+    handle.buffer_address_ = 0x1000;
+    handle.protocol_ = "tcp";
+
+    handle.transport_endpoint_ = engine.getLocalIpAndPort();
+    ASSERT_FALSE(handle.transport_endpoint_.empty());
+    EXPECT_TRUE(submitter.CanUseLocalMemcpy(handle));
+
+    handle.transport_endpoint_ = "127.0.0.1:30992";
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+
+    handle.transport_endpoint_.clear();
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+}
+
+TEST_F(TransferTaskTest, CanUseLocalMemcpyHonorsMemcpyEnv) {
+    ScopedEnvVar memcpy_disabled("MC_STORE_MEMCPY", "0");
+
+    TransferEngine engine(false);
+    ASSERT_EQ(
+        engine.init("P2PHANDSHAKE", "127.0.0.1:30993", "127.0.0.1", 30993), 0);
+    ASSERT_NE(engine.installTransport("tcp", nullptr), nullptr);
+
+    std::shared_ptr<StorageBackend> storage_backend;
+    TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30993");
+
+    AllocatedBuffer::Descriptor handle{4096, 0x1000, "tcp",
+                                       engine.getLocalIpAndPort()};
+    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+}
 
 // Test TransferStrategy enum and stream operator
 TEST_F(TransferTaskTest, TransferStrategyEnum) {

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -433,20 +433,12 @@ TEST_F(TransferTaskTest, CanUseLocalMemcpyRequiresSameProcessEndpoint) {
     std::shared_ptr<StorageBackend> storage_backend;
     TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30991");
 
-    AllocatedBuffer::Descriptor handle{};
-    handle.size_ = 4096;
-    handle.buffer_address_ = 0x1000;
-    handle.protocol_ = "tcp";
+    const auto local_endpoint = engine.getLocalIpAndPort();
+    ASSERT_FALSE(local_endpoint.empty());
+    EXPECT_TRUE(submitter.canUseLocalMemcpy(local_endpoint));
 
-    handle.transport_endpoint_ = engine.getLocalIpAndPort();
-    ASSERT_FALSE(handle.transport_endpoint_.empty());
-    EXPECT_TRUE(submitter.CanUseLocalMemcpy(handle));
-
-    handle.transport_endpoint_ = "127.0.0.1:30992";
-    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
-
-    handle.transport_endpoint_.clear();
-    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+    EXPECT_FALSE(submitter.canUseLocalMemcpy("127.0.0.1:30992"));
+    EXPECT_FALSE(submitter.canUseLocalMemcpy(""));
 }
 
 TEST_F(TransferTaskTest, CanUseLocalMemcpyHonorsMemcpyEnv) {
@@ -460,9 +452,7 @@ TEST_F(TransferTaskTest, CanUseLocalMemcpyHonorsMemcpyEnv) {
     std::shared_ptr<StorageBackend> storage_backend;
     TransferSubmitter submitter(engine, storage_backend, "127.0.0.1:30993");
 
-    AllocatedBuffer::Descriptor handle{4096, 0x1000, "tcp",
-                                       engine.getLocalIpAndPort()};
-    EXPECT_FALSE(submitter.CanUseLocalMemcpy(handle));
+    EXPECT_FALSE(submitter.canUseLocalMemcpy(engine.getLocalIpAndPort()));
 }
 
 // Test TransferStrategy enum and stream operator


### PR DESCRIPTION
## Description

Avoid the extra CPU staging buffer for same-process GPU read destinations in the Store get path.

Before this change, `get_into(cuda_ptr)` always allocated a client-side CPU staging buffer when the destination pointer was a CUDA pointer, then copied the result from CPU staging to GPU. This is necessary for remote transfers, but it is unnecessary for same-process local memcpy: the transfer layer can copy directly from the local Store segment into the caller's CUDA destination.

This PR exposes the existing transfer-layer local memcpy decision through `Client::CanUseLocalMemcpy()` and uses it in `RealClient::execute_ranged_read()` to skip staging only when all of the following are true:

- the selected replica is a memory replica
- `MC_STORE_MEMCPY` allows local memcpy
- the replica endpoint is the same process endpoint
- the destination is a CUDA/device pointer
- the local hot cache is disabled

It also routes dummy-client CUDA IPC tensor reads through the same ranged get path instead of the scatter path. The dummy client still exports the destination CUDA tensor with CUDA IPC, and the real client opens the IPC handle; after that, the read uses `get_into_range_internal()`, so same-process memory replicas can use the local memcpy no-staging path and remote/disabled-local-memcpy cases keep the conservative staging behavior. This avoids requiring the CUDA IPC destination pointer to be registered with TransferEngine for the same-node local memcpy case.

For `get_into_ranges()`, same-process GPU memory reads now use the same ranged get path as well. CPU range reads and remote range reads keep the existing scatter path.

Remote transfers, disk replicas, non-memory replicas, hot-cache-enabled full-object reads, and `MC_STORE_MEMCPY=0` keep the existing staging behavior.

Base branch: latest `origin/main` (`a6b4db4cfa371a3fc7f189a19977c102e14c4dfc`)

Branch: `cruz/get_no_staging`

Related RFC: [#3229 [RFC] RL Training Weight Offload and Restore Paths for Mooncake Store](https://github.com/kvcache-ai/Mooncake/issues/3229)

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B build-get-no-staging-nocuda -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DUSE_CUDA=OFF
cmake --build build-get-no-staging-nocuda -j8 --target store

cmake -S . -B build-get-no-staging-cuda -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DUSE_CUDA=ON
cmake --build build-get-no-staging-cuda -j8 --target store mooncake_master

cmake -S . -B build-get-no-staging-tests -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARK=OFF -DUSE_CUDA=OFF
cmake --build build-get-no-staging-tests -j8 --target transfer_task_test
./build-get-no-staging-tests/mooncake-store/tests/transfer_task_test --gtest_filter=TransferTaskTest.IsSameProcessEndpoint:TransferTaskTest.CanUseLocalMemcpyRequiresSameProcessEndpoint:TransferTaskTest.CanUseLocalMemcpyHonorsMemcpyEnv

./scripts/code_format.sh --check -b origin/main
git diff --check
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Same-node `get_into(cuda_ptr)` benchmark, Store segment pinned memory enabled, `MC_STORE_MEMCPY=1`, `protocol=tcp`, `CUDA_VISIBLE_DEVICES=0`.

| Size | main GB/s | PR GB/s | Speedup | main median | PR median |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 64 MB | 5.784 | 23.558 | 4.07x | 11.603 ms | 2.849 ms |
| 256 MB | 5.659 | 24.053 | 4.25x | 47.434 ms | 11.160 ms |
| 512 MB | 5.709 | 24.122 | 4.23x | 94.044 ms | 22.256 ms |

Additional path validation:

- `MC_STORE_MEMCPY=1 + get_into(cuda_ptr)`: passed, direct same-process local memcpy path
- `MC_STORE_MEMCPY=0 + get_into(cuda_ptr)`: passed, existing staging path preserved
- `MC_STORE_MEMCPY=1 + get_into(cpu_ptr)`: passed, CPU destination path preserved
- dummy-client CUDA IPC read helper: build and code-path validation confirm it now reuses `get_into_range_internal()` instead of `SubmitScatter`, so same-node local memcpy does not require registering the IPC-opened CUDA destination pointer with TransferEngine
- `get_into_ranges()` memory reads: code-path validation confirms same-process GPU destination buffers now reuse ranged get/local memcpy; CPU and remote range reads keep the existing scatter path

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to inspect the existing Store/transfer paths, prepare the small code change, run validation, and draft this PR description. I am responsible for reviewing and defending the final change.
