### PR TITLE
[Bugfix][TE] Split RDMA slices at MR boundaries and handle submit errors

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -54,6 +54,78 @@ static std::string resolveBufferLocation(
     return location;
 }
 
+// Calculate remaining bytes in buffer for 'address'.
+// Caches 'last_buffer_idx' across sequential slices to avoid rescanning
+// buffers.
+static uint64_t bytesUntilBufferEnd(
+    const TransferMetadata::SegmentDesc *segment_desc, uint64_t address,
+    bool require_remote_key, size_t *last_buffer_idx = nullptr) {
+    if (!segment_desc || segment_desc->buffers.empty()) return 0;
+
+    auto is_valid_buffer = [&](const TransferMetadata::BufferDesc &buffer) {
+#ifdef ENABLE_MULTI_PROTOCOL
+        if (!buffer.protocol.empty() && buffer.protocol != "rdma") return false;
+#endif
+        if (require_remote_key ? buffer.rkey.empty() : buffer.lkey.empty())
+            return false;
+        if (address < buffer.addr || address - buffer.addr >= buffer.length)
+            return false;
+        return true;
+    };
+
+    if (last_buffer_idx && *last_buffer_idx < segment_desc->buffers.size()) {
+        const auto &buffer = segment_desc->buffers[*last_buffer_idx];
+        if (is_valid_buffer(buffer)) {
+            return buffer.length - (address - buffer.addr);
+        }
+    }
+
+    uint64_t max_remaining = 0;
+    for (size_t i = 0; i < segment_desc->buffers.size(); ++i) {
+        const auto &buffer = segment_desc->buffers[i];
+        if (is_valid_buffer(buffer)) {
+            uint64_t remaining = buffer.length - (address - buffer.addr);
+            if (remaining > max_remaining) {
+                max_remaining = remaining;
+                if (last_buffer_idx) *last_buffer_idx = i;
+            }
+        }
+    }
+    return max_remaining;
+}
+
+// Calculate slice length capped at MR boundary to avoid multi-MR WRs.
+// Caches source and target buffer indices across slices for a single request.
+struct SliceLengthCalculator {
+    const Transport::TransferRequest &request;
+    size_t block_size;
+    size_t fragment_size;
+    const TransferMetadata::SegmentDesc *local_desc;
+    const TransferMetadata::SegmentDesc *target_desc;
+
+    size_t src_buffer_idx = 0;
+    size_t tgt_buffer_idx = 0;
+
+    inline size_t calculate(uint64_t offset) {
+        const size_t remaining = request.length - offset;
+        size_t slice_length =
+            remaining <= block_size + fragment_size ? remaining : block_size;
+
+        const uint64_t src_rem = bytesUntilBufferEnd(
+            local_desc, reinterpret_cast<uint64_t>(request.source) + offset,
+            false, &src_buffer_idx);
+        if (src_rem > 0)
+            slice_length = std::min<uint64_t>(slice_length, src_rem);
+
+        const uint64_t tgt_rem = bytesUntilBufferEnd(
+            target_desc, request.target_offset + offset, true, &tgt_buffer_idx);
+        if (tgt_rem > 0)
+            slice_length = std::min<uint64_t>(slice_length, tgt_rem);
+
+        return slice_length;
+    }
+};
+
 // Mode definition for MC_IB_PCI_RELAXED_ORDERING env.
 // 0 - disabled, 1 - enabled if supported, 2 - auto (default, same as 1 today).
 static int getIbRelaxedOrderingMode() {
@@ -746,6 +818,8 @@ Status RdmaTransport::submitTransferTask(
     const std::vector<TransferTask *> &task_list) {
     std::unordered_map<std::shared_ptr<RdmaContext>, std::vector<Slice *>>
         slices_to_post;
+    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
+        target_segment_descs;
     auto local_segment_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
     assert(local_segment_desc.get());
     const size_t kBlockSize = globalConfig().slice_size;
@@ -753,6 +827,38 @@ Status RdmaTransport::submitTransferTask(
     const size_t kFragmentSize = globalConfig().fragment_limit;
     const size_t kSubmitWatermark =
         globalConfig().max_wr * globalConfig().num_qp_per_ep;
+    auto fail_unposted_slices = [&]() {
+        for (auto &entry : slices_to_post)
+            for (auto *slice : entry.second) slice->markFailed();
+        slices_to_post.clear();
+    };
+
+    // Fabricate a zero-length failed slice for unstarted tasks so that the
+    // existing success + failed == slice_count terminal check can drive the
+    // task to FAILED without special-casing, and ~TransferTask reclaims the
+    // slice.
+    auto fail_unstarted_tasks = [&](size_t first_task_index) {
+        for (size_t i = first_task_index; i < task_list.size(); ++i) {
+            auto &task = *task_list[i];
+            Slice *slice = getSliceCache().allocate();
+            assert(slice);
+            slice->source_addr = nullptr;
+            slice->length = 0;
+            slice->task = &task;
+            slice->status = Slice::PENDING;
+            task.slice_list.push_back(slice);
+            __sync_fetch_and_add(&task.slice_count, 1);
+            slice->markFailed();
+        }
+    };
+    auto fail_task_and_cleanup = [&](TransferTask &task, Slice *slice,
+                                     size_t task_index) {
+        task.total_bytes += slice->length;
+        __sync_fetch_and_add(&task.slice_count, 1);
+        slice->markFailed();
+        fail_unposted_slices();
+        fail_unstarted_tasks(task_index + 1);
+    };
     uint64_t nr_slices;
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
@@ -760,6 +866,15 @@ Status RdmaTransport::submitTransferTask(
         nr_slices = 0;
         assert(task.request);
         auto &request = *task.request;
+        auto target_desc_it = target_segment_descs.find(request.target_id);
+        if (target_desc_it == target_segment_descs.end()) {
+            target_desc_it =
+                target_segment_descs
+                    .emplace(request.target_id,
+                             metadata_->getSegmentDescByID(request.target_id))
+                    .first;
+        }
+        const auto &target_segment_desc = target_desc_it->second;
 
         auto request_buffer_id = -1, request_device_id = -1;
         if (selectDevice(local_segment_desc.get(), (uint64_t)request.source,
@@ -769,20 +884,20 @@ Status RdmaTransport::submitTransferTask(
             request_device_id = -1;
         }
 
-        for (uint64_t offset = 0; offset < request.length;
-             offset += kBlockSize) {
+        SliceLengthCalculator slice_calc{request, kBlockSize, kFragmentSize,
+                                         local_segment_desc.get(),
+                                         target_segment_desc.get()};
+        for (uint64_t offset = 0; offset < request.length;) {
+            size_t slice_length = slice_calc.calculate(offset);
+
             Slice *slice = getSliceCache().allocate();
             assert(slice);
             if (!slice->from_cache) {
                 nr_slices++;
             }
 
-            bool merge_final_slice =
-                request.length - offset <= kBlockSize + kFragmentSize;
-
             slice->source_addr = (char *)request.source + offset;
-            slice->length =
-                merge_final_slice ? request.length - offset : kBlockSize;
+            slice->length = slice_length;
             slice->source_location.clear();
             slice->opcode = request.opcode;
             slice->rdma.dest_addr = request.target_offset + offset;
@@ -825,14 +940,7 @@ Status RdmaTransport::submitTransferTask(
             }
             if (!found_device) {
                 auto source_addr = slice->source_addr;
-                // Do not deallocate slices already queued in slices_to_post
-                // here: every slice, including those, is already recorded in
-                // its owning TransferTask::slice_list (unconditionally,
-                // right after allocation above), and ~TransferTask() returns
-                // everything in slice_list to the cache exactly once.
-                // Deallocating them again here double-frees them into
-                // ThreadLocalSliceCache, letting a later allocate() hand out
-                // the same Slice* to two unrelated transfers.
+                fail_task_and_cleanup(task, slice, index);
                 LOG(ERROR)
                     << "Memory region not registered by any active device(s): "
                     << source_addr;
@@ -842,6 +950,7 @@ Status RdmaTransport::submitTransferTask(
             } else {
                 auto &context = context_list_[device_id];
                 if (!context->active()) {
+                    fail_task_and_cleanup(task, slice, index);
                     LOG(ERROR) << "Device " << device_id << " is not active";
                     return Status::InvalidArgument("Device " +
                                                    std::to_string(device_id) +
@@ -866,9 +975,7 @@ Status RdmaTransport::submitTransferTask(
                 nr_slices = 0;
             }
 
-            if (merge_final_slice) {
-                break;
-            }
+            offset += slice->length;
         }
     }
 

--- a/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
@@ -40,7 +40,12 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <vector>
 
+#if defined(USE_CUDA) || defined(USE_HIP)
+#include "cuda_alike.h"
+#endif
+#include "config.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
 
@@ -64,11 +69,12 @@ class RDMALargeMrTest : public ::testing::Test {
 
    protected:
     void SetUp() override {
-        // Force a small device max_mr_size cap (config caps to min(env,
-        // device)).
-        setenv("MC_MAX_MR_SIZE", std::to_string(kMaxMrSize).c_str(), 1);
         engine = std::make_unique<TransferEngine>(true);
-        engine->init(FLAGS_metadata_server, "test_node_large_mr");
+        const char *env_meta = std::getenv("MC_METADATA_SERVER");
+        std::string metadata_server = env_meta ? env_meta : "P2PHANDSHAKE";
+        ASSERT_EQ(engine->init(metadata_server, "test_node_large_mr"), 0);
+        ASSERT_EQ(globalConfig().max_mr_size, kMaxMrSize)
+            << "Launch this test process with MC_MAX_MR_SIZE=" << kMaxMrSize;
         addr = numa_alloc_onnode(kBufferSize, 0);
         ASSERT_NE(addr, nullptr);
         // Register a buffer LARGER than max_mr_size. Pre-fix this silently
@@ -136,9 +142,10 @@ TEST_F(RDMALargeMrTest, WriteStraddlesChunkBoundary) {
     const size_t kDataLength = 1ull << 20;  // 1 MiB
     // Center the target on the first chunk boundary: half in chunk 0, half in
     // chunk 1.
-    const size_t kTargetOffset = kMaxMrSize - kDataLength / 2;
+    const size_t kTargetOffset = kMaxMrSize - kDataLength / 2 + 1;
     ASSERT_LT(kTargetOffset, kMaxMrSize);                // starts in chunk 0
     ASSERT_GT(kTargetOffset + kDataLength, kMaxMrSize);  // ends in chunk 1
+    ASSERT_NE(kTargetOffset % globalConfig().slice_size, 0u);
 
     // Distinct source bytes, and poison the destination so a dropped/partial
     // write past the seam is caught by the memcmp below.
@@ -173,6 +180,39 @@ TEST_F(RDMALargeMrTest, WriteStraddlesChunkBoundary) {
         << "RDMA WRITE straddling a chunk boundary failed -- a cross-chunk "
            "transfer was not split across the two chunks' MRs (issue #2017).";
     ASSERT_EQ(0, memcmp(addr, (char *)addr + kTargetOffset, kDataLength));
+}
+
+// Verify RDMA WRITE when local source buffer range straddles an MR boundary.
+TEST_F(RDMALargeMrTest, WriteWithSourceStraddlingChunkBoundary) {
+    const size_t kDataLength = 1ull << 20;
+    const size_t kSourceOffset = kMaxMrSize - kDataLength / 2 + 1;
+    const size_t kTargetOffset = 2 * kMaxMrSize;
+    ASSERT_NE(kSourceOffset % globalConfig().slice_size, 0u);
+
+    for (size_t i = 0; i < kDataLength; ++i)
+        *((char *)addr + kSourceOffset + i) = (char)('A' + (lrand48() % 26));
+    memset((char *)addr + kTargetOffset, 0, kDataLength);
+
+    auto batch_id = engine->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = (uint8_t *)addr + kSourceOffset;
+    entry.target_id = LOCAL_SEGMENT_ID;
+    entry.target_offset = (uint64_t)addr + kTargetOffset;
+
+    Status s = engine->submitTransfer(batch_id, {entry});
+    ASSERT_TRUE(s.ok());
+
+    TransferStatus status;
+    while (true) {
+        ASSERT_EQ(engine->getTransferStatus(batch_id, 0, status), Status::OK());
+        if (status.s != TransferStatusEnum::WAITING) break;
+    }
+    ASSERT_EQ(engine->freeBatchID(batch_id), Status::OK());
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(0, memcmp((char *)addr + kSourceOffset,
+                        (char *)addr + kTargetOffset, kDataLength));
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/rdma_transport_submit_task_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_submit_task_test.cpp
@@ -12,27 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Regression test for RdmaTransport::submitTransferTask()'s
-// "memory region not registered" (!found_device) error path: a slice that
+// Regression tests for RdmaTransport::submitTransferTask()'s
+// "memory region not registered" (!found_device) error path. A slice that
 // already succeeded device selection and was queued into the function-local
-// slices_to_post accumulator must not be deallocated a second time when a
-// later slice in the same call fails device selection, since it is already
-// owned (and will be freed exactly once) by its TransferTask::slice_list.
-//
-// This exercises the real, unmodified RdmaTransport::submitTransferTask()
-// entry point. It avoids needing a real RDMA device by using a bare
-// RdmaContext (construct() never called): submitTransferTask() only checks
-// RdmaContext::active(), which defaults to true, for slices that fail device
-// selection.
-//
-// Every request here is a *single* TransferTask whose length spans two
-// slice_size blocks: the first offset resolves inside the registered
-// buffer (succeeds, queued into slices_to_post), and the second offset
-// starts exactly at the buffer's end (fails every retry). This reproduces
-// the bug with a single task instead of a task pair, so the only slices
-// touching ThreadLocalSliceCache belong to the one task under test -- no
-// second task's own slice churns through the shared cache and disturbs the
-// recycling queue's ordering.
+// slices_to_post accumulator remains owned by TransferTask::slice_list. It
+// must not be deallocated twice, and it must reach a terminal FAILED state if
+// a later slice causes submitTransferTask() to return an error.
 
 #include <gtest/gtest.h>
 
@@ -80,9 +65,6 @@ class SubmitTransferTaskTest : public ::testing::Test {
         BufferDesc buffer;
         buffer.name = "cpu:0";
         buffer.addr = kBufferAddr;
-        // Exactly one slice_size: a request longer than this has its first
-        // slice land fully inside the buffer and its second slice start
-        // exactly at the (unregistered) byte past the end.
         buffer.length = block_size_;
         buffer.lkey = {1};
         buffer.rkey = {1};
@@ -93,19 +75,8 @@ class SubmitTransferTaskTest : public ::testing::Test {
                                    std::move(desc));
     }
 
-    // Submits one task whose request spans 2 slice_size blocks starting at
-    // kBufferAddr. The first slice (offset 0) resolves inside the
-    // registered buffer and succeeds; the second slice (offset
-    // block_size_) starts past the buffer's end and fails every retry, so
-    // the call always returns early via the !found_device branch -- before
-    // ever reaching the end-of-function flush that would otherwise call
-    // into the (unconstructed, null) WorkerPool.
-    //
-    // `req`/`task` are owned by the caller and deliberately left alive on
-    // return, so the caller controls exactly when (if ever) the task's
-    // slices are returned to ThreadLocalSliceCache.
-    void triggerBug(Transport::TransferRequest &req,
-                    Transport::TransferTask &task) {
+    void triggerError(Transport::TransferRequest &req,
+                      Transport::TransferTask &task) {
         req.opcode = Transport::TransferRequest::WRITE;
         req.source = reinterpret_cast<void *>(kBufferAddr);
         req.length = 2 * block_size_;
@@ -113,67 +84,85 @@ class SubmitTransferTaskTest : public ::testing::Test {
         req.target_offset = 0;
         task.request = &req;
 
+        // markFailed() needs a valid BatchDesc in event-driven builds. The
+        // direct task is deliberately not inserted into that BatchDesc; the ID
+        // is only used by Slice::check_batch_completion().
+        task.batch_id = transport_->allocateBatchID(1);
         auto status = transport_->submitTransferTask({&task});
         EXPECT_FALSE(status.ok());
         EXPECT_TRUE(status.IsAddressNotRegistered());
-        // slice_list[0]: the first slice, in-buffer, succeeded and was
-        // queued into slices_to_post -- the victim of the bug.
-        // slice_list[1]: the second slice, out-of-buffer, failed and
-        // triggered the (buggy) cleanup; never added to slices_to_post,
-        // so it is not itself double-freed.
         ASSERT_EQ(task.slice_list.size(), 2u);
+        EXPECT_EQ(transport_->freeBatchID(task.batch_id), Status::OK());
     }
 };
 
-// task1's first slice is queued for reuse twice in a row, with nothing else
-// touching the cache in between: once by the buggy manual deallocate()
-// inside submitTransferTask() (while task1 is still alive), and again by
-// task1's own ~TransferTask() moments later. The recycling cache now holds
-// two entries for that single object.
-//
-// task2's own call then draws from that corrupted cache twice in a row (its
-// offset-0 slice, then its offset-block_size slice): with a correctly
-// single-registered cache, task1's two slices (each freed exactly once)
-// supply exactly two distinct pool entries, so task2's two independent
-// draws come back as two distinct Slice objects -- one reusing task1's
-// first slice, the other reusing its second. With the duplicate
-// registration, both draws instead return task1's original object --
-// proving it was freed more than once, purely by pointer comparison, with
-// no forced crash or process teardown required. EXPECT_EQ(task2[0], original)
-// is not itself the bug signal (a *single* legitimate free of `original`
-// would also make the very next allocation reuse it); it exists to
-// document that task2 is
-// indeed the one hitting the corrupted state before the discriminating
-// check below.
-TEST_F(SubmitTransferTaskTest, FoundDeviceFailureFreesSliceTwice) {
+TEST_F(SubmitTransferTaskTest, NoDuplicateSlice) {
     Transport::Slice *original = nullptr;
     {
-        Transport::TransferRequest req1;
-        Transport::TransferTask task1;
-        triggerBug(req1, task1);
-        original = task1.slice_list[0];
-        // task1 destroyed here: ~TransferTask() deallocate()s both of its
-        // slices, including `original` a second time -- immediately after
-        // the buggy manual deallocate() inside submitTransferTask() already
-        // did so once, with nothing else in between since this task's own
-        // second (failed) slice was never added to slices_to_post and so
-        // was never touched by the bug.
+        Transport::TransferRequest req;
+        Transport::TransferTask task;
+        triggerError(req, task);
+        original = task.slice_list[0];
     }
 
-    Transport::TransferRequest req2;
-    Transport::TransferTask task2;
-    triggerBug(req2, task2);
+    Transport::TransferRequest req;
+    Transport::TransferTask task;
+    triggerError(req, task);
 
-    EXPECT_EQ(task2.slice_list[0], original)
-        << "sanity check: the cache should have at least one legitimate "
-           "reuse of `original` queued up regardless of the bug";
-    EXPECT_NE(task2.slice_list[0], task2.slice_list[1])
-        << "task2's two slices cover disjoint offsets of the same request "
-           "and must never be backed by the same Slice object; "
-           "submitTransferTask() double-freed task1's slice on its "
-           "!found_device error path, so the recycling cache handed the "
-           "exact same, still-conceptually-owned pointer out twice in a "
-           "row for what should have been two independent allocations";
+    EXPECT_EQ(task.slice_list[0], original)
+        << "the cache should legitimately reuse the first released slice";
+    EXPECT_NE(task.slice_list[0], task.slice_list[1])
+        << "two independent slices must never share the same Slice object";
+}
+
+TEST_F(SubmitTransferTaskTest, PartialSubmitFailsBatch) {
+    auto batch_id = transport_->allocateBatchID(1);
+    Transport::TransferRequest request;
+    request.opcode = Transport::TransferRequest::WRITE;
+    request.source = reinterpret_cast<void *>(kBufferAddr);
+    request.length = 2 * block_size_;
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = 0;
+
+    auto submit_status = transport_->submitTransfer(batch_id, {request});
+    ASSERT_FALSE(submit_status.ok());
+    ASSERT_TRUE(submit_status.IsAddressNotRegistered());
+
+    Transport::TransferStatus transfer_status;
+    ASSERT_EQ(transport_->getTransferStatus(batch_id, 0, transfer_status),
+              Status::OK());
+    EXPECT_EQ(transfer_status.s, Transport::TransferStatusEnum::FAILED);
+    EXPECT_EQ(transport_->freeBatchID(batch_id), Status::OK());
+}
+
+TEST_F(SubmitTransferTaskTest, PartialSubmitFailsAllTasks) {
+    auto batch_id = transport_->allocateBatchID(2);
+    Transport::TransferRequest failing_request;
+    failing_request.opcode = Transport::TransferRequest::WRITE;
+    failing_request.source = reinterpret_cast<void *>(kBufferAddr);
+    failing_request.length = 2 * block_size_;
+    failing_request.target_id = LOCAL_SEGMENT_ID;
+    failing_request.target_offset = 0;
+
+    Transport::TransferRequest unstarted_request;
+    unstarted_request.opcode = Transport::TransferRequest::WRITE;
+    unstarted_request.source = reinterpret_cast<void *>(kBufferAddr);
+    unstarted_request.length = block_size_;
+    unstarted_request.target_id = LOCAL_SEGMENT_ID;
+    unstarted_request.target_offset = kBufferAddr;
+
+    auto submit_status = transport_->submitTransfer(
+        batch_id, {failing_request, unstarted_request});
+    ASSERT_FALSE(submit_status.ok());
+    ASSERT_TRUE(submit_status.IsAddressNotRegistered());
+
+    std::vector<Transport::TransferStatus> transfer_status;
+    ASSERT_EQ(transport_->getTransferStatus(batch_id, transfer_status),
+              Status::OK());
+    ASSERT_EQ(transfer_status.size(), 2u);
+    EXPECT_EQ(transfer_status[0].s, Transport::TransferStatusEnum::FAILED);
+    EXPECT_EQ(transfer_status[1].s, Transport::TransferStatusEnum::FAILED);
+    EXPECT_EQ(transport_->freeBatchID(batch_id), Status::OK());
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
Fixes two critical RDMA transfer bugs in `RdmaTransport`:

1. **MR Boundary Straddling**:
   - **Problem**: When a transfer request straddles two adjacent MRs, a fixed-size slice could span across the MR boundary. Since a single Verbs WR cannot span multiple MRs, this led to `AddressNotRegistered` or transfer failures.
   - **Fix**: Dynamically adjust `slice_length` at MR boundaries so that no single slice crosses into a neighboring MR.

2. **Submit Error Handling**:
   - **Problem**: When `submitTransferTask` encounters a failure mid-submission (e.g. `!found_device`), previously queued slices and unstarted tasks were left unhandled. As a result, the transfer batch hung in `WAITING` state permanently, causing `freeBatchID` to fail with `BatchBusy`.
   - **Fix**: Mark all unposted slices and remaining unstarted tasks as `FAILED` upon submission errors, ensuring the batch completes and resources are safely reclaimed.

## Module
- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

### Test Cases & Covered Issues:
1. **MR Boundary Straddling**:
   - `RDMALargeMrTest.WriteStraddlesChunkBoundary`: Triggered by target buffer straddling across two 64MB MR chunks.
   - `RDMALargeMrTest.WriteWithSourceStraddlingChunkBoundary`: Triggered by source buffer straddling across two 64MB MR chunks.

2. **Submit Error Handling**:
   - `SubmitTransferTaskTest.PartialSubmitFailsBatch`: Triggered when slice 0 succeeds but slice 1 fails device selection mid-submission, verifying batch status transitions to `FAILED` instead of hanging in `WAITING`.
   - `SubmitTransferTaskTest.PartialSubmitFailsAllTasks`: Triggered when task 0 fails mid-submission, verifying subsequent unstarted tasks in the batch are marked `FAILED`.

### Execution:
Verified test failure on pre-fix commits and 100% pass on post-fix:

```bash
MC_MAX_MR_SIZE=67108864 ./mooncake-transfer-engine/tests/rdma_large_mr_test
./mooncake-transfer-engine/tests/rdma_transport_submit_task_test