### PR TITLE
[Store] Add multi-level parallel read via shared ThreadPool

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -1156,11 +1156,42 @@ class BucketStorageBackend : public StorageBackendInterface {
     int64_t GUARDED_BY(mutex_) next_bucket_ = -1;
     BucketBackendConfig bucket_backend_config_;
 
-    static int env_batch_load_threads();
-    static int env_bucket_read_threads();
+    // Read plan for a single key within a bucket. Built under lock in
+    // BatchLoad Step 1, then consumed by the I/O phase (Step 2) where
+    // per-bucket plans are dispatched to batch_read (URing) or
+    // vector_read (POSIX).
+    struct ReadPlan {
+        std::string key;
+        int64_t bucket_id;
+        int64_t offset;
+        int64_t key_size;
+        int64_t data_size;
+        Slice dest_slice;
+    };
+
+#ifdef USE_URING
+    // Issue one io_uring batch_read for all plans sharing a bucket file.
+    // Computes O_DIRECT alignment, submits the batch, and adjusts each
+    // dest_slice.ptr to skip the alignment padding on success.
+    static tl::expected<void, ErrorCode> UringBatchReadBucket(
+        UringFile* uf, const std::vector<ReadPlan>& plans,
+        std::unordered_map<std::string, Slice>& batch_object,
+        int64_t bucket_id);
+#endif
+
+    // Intra-bucket POSIX parallel read: split plans into chunks and
+    // dispatch to intra_bucket_pool_.  Returns ErrorCode::OK or the
+    // first error encountered.
+    ErrorCode IntraBucketReadChunked(StorageFile* sf,
+                                     const std::vector<ReadPlan>& plans,
+                                     int64_t bucket_id);
+
+    static int EnvBatchLoadThreads();
+    static int EnvBucketReadThreads();
     const int batch_threads_;
     const int bucket_threads_;
-    mutable std::unique_ptr<ThreadPool> batch_load_pool_;
+    std::unique_ptr<ThreadPool> batch_load_pool_;    // bucket-level
+    std::unique_ptr<ThreadPool> intra_bucket_pool_;  // intra-bucket (POSIX)
 
     mutable Mutex offloading_mutex_;
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -18,6 +18,7 @@
 #include "file_interface.h"
 #include "mutex.h"
 #include "offset_allocator/offset_allocator.h"
+#include "thread_pool.h"
 #include "types.h"
 
 namespace mooncake {
@@ -1154,6 +1155,12 @@ class BucketStorageBackend : public StorageBackendInterface {
     std::set<std::pair<int64_t, int64_t>> GUARDED_BY(mutex_) lru_index_;
     int64_t GUARDED_BY(mutex_) next_bucket_ = -1;
     BucketBackendConfig bucket_backend_config_;
+
+    // Lazy-init thread pool for parallel BatchLoad.
+    // Created on first use when MC_BATCH_LOAD_THREADS > 1.
+    static int batch_load_threads();
+    static int bucket_read_threads();
+    mutable std::unique_ptr<ThreadPool> batch_load_pool_;
 
     mutable Mutex offloading_mutex_;
     std::unordered_map<std::string, int64_t> GUARDED_BY(offloading_mutex_)

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -1156,10 +1156,10 @@ class BucketStorageBackend : public StorageBackendInterface {
     int64_t GUARDED_BY(mutex_) next_bucket_ = -1;
     BucketBackendConfig bucket_backend_config_;
 
-    // Lazy-init thread pool for parallel BatchLoad.
-    // Created on first use when MC_BATCH_LOAD_THREADS > 1.
-    static int batch_load_threads();
-    static int bucket_read_threads();
+    static int env_batch_load_threads();
+    static int env_bucket_read_threads();
+    const int batch_threads_;
+    const int bucket_threads_;
     mutable std::unique_ptr<ThreadPool> batch_load_pool_;
 
     mutable Mutex offloading_mutex_;

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -19,14 +19,13 @@
 #include <vector>
 #include <algorithm>
 #include <future>
-
-#include "thread_pool.h"
 #include <chrono>
 #include <unordered_set>
 
 #include <ylt/struct_pb.hpp>
 
 #include "mutex.h"
+#include "thread_pool.h"
 #include "utils.h"
 #include "crc32c.h"
 #include "ascii_string.h"
@@ -1680,7 +1679,9 @@ BucketStorageBackend::BucketStorageBackend(
     const BucketBackendConfig& bucket_backend_config_)
     : StorageBackendInterface(file_storage_config_),
       storage_path_(file_storage_config_.storage_filepath),
-      bucket_backend_config_(bucket_backend_config_) {
+      bucket_backend_config_(bucket_backend_config_),
+      batch_threads_(EnvBatchLoadThreads()),
+      bucket_threads_(EnvBucketReadThreads()) {
     // Allocate aligned buffer for O_DIRECT I/O operations
     void* buf = nullptr;
     int ret = posix_memalign(&buf, kDirectIOAlignment, kAlignedBufferSize);
@@ -1695,6 +1696,15 @@ BucketStorageBackend::BucketStorageBackend(
             buf, [](void* p) { free(p); });
         LOG(INFO) << "BucketStorageBackend: Allocated " << kAlignedBufferSize
                   << " bytes aligned buffer at " << buf;
+    }
+
+    if (batch_threads_ > 1) {
+        batch_load_pool_ =
+            std::make_unique<ThreadPool>(static_cast<size_t>(batch_threads_));
+    }
+    if (bucket_threads_ > 1) {
+        intra_bucket_pool_ =
+            std::make_unique<ThreadPool>(static_cast<size_t>(bucket_threads_));
     }
 }
 
@@ -1861,27 +1871,107 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchQuery(
     return {};
 }
 
-int BucketStorageBackend::env_batch_load_threads() {
-    const char* env = std::getenv("MC_BATCH_LOAD_THREADS");
-    return env ? std::max(0, std::atoi(env)) : 0;
+int BucketStorageBackend::EnvBatchLoadThreads() {
+    return GetEnvOr<int>("MC_BATCH_LOAD_THREADS", 0);
 }
 
-int BucketStorageBackend::env_bucket_read_threads() {
-    const char* env = std::getenv("MC_BUCKET_READ_THREADS");
-    return env ? std::max(0, std::atoi(env)) : 0;
+int BucketStorageBackend::EnvBucketReadThreads() {
+    return GetEnvOr<int>("MC_BUCKET_READ_THREADS", 0);
 }
 
-BucketStorageBackend::BucketStorageBackend(
-    const FileStorageConfig& file_storage_config,
-    const BucketBackendConfig& bucket_backend_config)
-    : StorageBackendInterface(file_storage_config),
-      bucket_backend_config_(bucket_backend_config),
-      batch_threads_(env_batch_load_threads()),
-      bucket_threads_(env_bucket_read_threads()) {
-    const int n = std::max(batch_threads_, bucket_threads_);
-    if (n > 1) {
-        batch_load_pool_ = std::make_unique<ThreadPool>(static_cast<size_t>(n));
+#ifdef USE_URING
+tl::expected<void, ErrorCode> BucketStorageBackend::UringBatchReadBucket(
+    UringFile* uf, const std::vector<ReadPlan>& plans,
+    std::unordered_map<std::string, Slice>& batch_object, int64_t bucket_id) {
+    std::vector<UringFile::ReadDesc> descs;
+    std::vector<int64_t> buf_offsets;
+    descs.reserve(plans.size());
+    buf_offsets.reserve(plans.size());
+    size_t expected_bytes = 0;
+
+    for (const auto& plan : plans) {
+        int64_t actual_offset = plan.offset + plan.key_size;
+        int64_t aligned_offset = align_down(actual_offset, kDirectIOAlignment);
+        int64_t data_end =
+            actual_offset + static_cast<int64_t>(plan.dest_slice.size);
+        int64_t aligned_end = static_cast<int64_t>(
+            align_up(static_cast<size_t>(data_end), kDirectIOAlignment));
+        size_t aligned_size = static_cast<size_t>(aligned_end - aligned_offset);
+        descs.push_back({plan.dest_slice.ptr, aligned_size, aligned_offset});
+        buf_offsets.push_back(actual_offset - aligned_offset);
+        expected_bytes += aligned_size;
     }
+
+    auto result = uf->batch_read(descs.data(), static_cast<int>(descs.size()));
+    if (!result) {
+        LOG(ERROR) << "batch_read failed for bucket_id=" << bucket_id
+                   << " error=" << result.error();
+        return tl::make_unexpected(result.error());
+    }
+
+    // Guard against silent short reads (community #3066/#3073): the
+    // underlying collect() only flags cqe->res < 0, so a short read
+    // returns fewer bytes without surfacing an error.  Verify the
+    // aggregated byte count covers every aligned descriptor before
+    // exposing the zero-copy pointers.
+    if (result.value() < expected_bytes) {
+        LOG(ERROR) << "batch_read short read for bucket_id=" << bucket_id
+                   << ", expected at least: " << expected_bytes
+                   << ", got: " << result.value();
+        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+    }
+
+    // Zero-copy: adjust ptrs to skip alignment padding.
+    for (size_t i = 0; i < plans.size(); ++i) {
+        batch_object.at(plans[i].key).ptr =
+            static_cast<char*>(plans[i].dest_slice.ptr) + buf_offsets[i];
+    }
+    return {};
+}
+#endif
+
+ErrorCode BucketStorageBackend::IntraBucketReadChunked(
+    StorageFile* sf, const std::vector<ReadPlan>& plans, int64_t bucket_id) {
+    ThreadPool& intra_pool = *intra_bucket_pool_;
+    const size_t chunk_size =
+        (plans.size() + bucket_threads_ - 1) / bucket_threads_;
+    std::vector<std::future<ErrorCode>> futures;
+    futures.reserve(bucket_threads_);
+
+    for (size_t start = 0; start < plans.size(); start += chunk_size) {
+        size_t end = std::min(start + chunk_size, plans.size());
+        auto task = std::make_shared<std::packaged_task<ErrorCode()>>(
+            [sf, &plans, start, end, bucket_id]() -> ErrorCode {
+                for (size_t j = start; j < end; ++j) {
+                    const auto& plan = plans[j];
+                    iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
+                    auto rr =
+                        sf->vector_read(&iov, 1, plan.offset + plan.key_size);
+                    if (!rr) {
+                        LOG(ERROR) << "vector_read failed: " << plan.key
+                                   << " bucket_id=" << bucket_id
+                                   << " error=" << rr.error();
+                        return rr.error();
+                    }
+                    if (rr.value() != plan.dest_slice.size) {
+                        LOG(ERROR) << "Read size mismatch: " << plan.key
+                                   << " expected=" << plan.dest_slice.size
+                                   << " got=" << rr.value();
+                        return ErrorCode::FILE_READ_FAIL;
+                    }
+                }
+                return ErrorCode::OK;
+            });
+        futures.push_back(task->get_future());
+        intra_pool.enqueue([task]() { (*task)(); });
+    }
+
+    ErrorCode first_err = ErrorCode::OK;
+    for (auto& f : futures) {
+        ErrorCode err = f.get();
+        if (first_err == ErrorCode::OK && err != ErrorCode::OK) first_err = err;
+    }
+    return first_err;
 }
 
 tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
@@ -1889,14 +1979,6 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
     // Step 1: Build read plan by copying metadata under lock
     // BucketReadGuard increments inflight_reads_ to prevent deletion during IO.
     // When the guard goes out of scope, it decrements the counter.
-    struct ReadPlan {
-        std::string key;
-        int64_t bucket_id;
-        int64_t offset;
-        int64_t key_size;
-        int64_t data_size;
-        Slice dest_slice;
-    };
 
     // Group by bucket for efficient file access
     // BucketReadGuard tracks inflight reads - one guard per bucket being read
@@ -1968,16 +2050,17 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
         for (auto& [bucket_id, read_plans] : bucket_read_plans) {
             using task_type = std::packaged_task<ErrorCode()>;
             auto task = std::make_shared<task_type>(
-                [this, bucket_id,
-                 plans = std::move(read_plans),
+                [this, bucket_id, plans = std::move(read_plans),
                  &batch_object]() -> ErrorCode {
                     auto filepath_res = GetBucketDataPath(bucket_id);
                     if (!filepath_res) {
-                        LOG(ERROR) << "Failed to get bucket data path, bucket_id="
-                                   << bucket_id;
+                        LOG(ERROR)
+                            << "Failed to get bucket data path, bucket_id="
+                            << bucket_id;
                         return ErrorCode::INTERNAL_ERROR;
                     }
-                    auto file_res = OpenFile(filepath_res.value(), FileMode::Read);
+                    auto file_res =
+                        OpenFile(filepath_res.value(), FileMode::Read);
                     if (!file_res) {
                         LOG(ERROR) << "Failed to open bucket file: "
                                    << filepath_res.value();
@@ -1985,74 +2068,42 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                     }
                     auto& file = file_res.value();
 
-                    for (const auto& plan : plans) {
-                        int64_t actual_offset = plan.offset + plan.key_size;
-                        tl::expected<size_t, ErrorCode> read_res;
 #ifdef USE_URING
-                        UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
-                        if (uring_file != nullptr) {
-                            int64_t aligned_offset =
-                                align_down(actual_offset, kDirectIOAlignment);
-                            int64_t data_end =
-                                actual_offset + static_cast<int64_t>(plan.dest_slice.size);
-                            int64_t aligned_end = static_cast<int64_t>(align_up(
-                                static_cast<size_t>(data_end), kDirectIOAlignment));
-                            size_t aligned_size =
-                                static_cast<size_t>(aligned_end - aligned_offset);
-                            int64_t offset_in_buffer = actual_offset - aligned_offset;
-                            read_res = uring_file->read_aligned(
-                                plan.dest_slice.ptr, aligned_size, aligned_offset);
-                            if (read_res) {
-                                // Verify the aligned read returned enough bytes
-                                // to cover the actual data region.  read_aligned
-                                // reads the full aligned range [aligned_offset,
-                                // aligned_end); the caller-visible data starts at
-                                // offset_in_buffer into that buffer and spans
-                                // plan.dest_slice.size bytes.
-                                size_t min_required =
-                                    static_cast<size_t>(offset_in_buffer) +
-                                    plan.dest_slice.size;
-                                if (read_res.value() < min_required) {
-                                    LOG(ERROR)
-                                        << "read_aligned short read for key: "
-                                        << plan.key
-                                        << ", bucket_id=" << plan.bucket_id
-                                        << ", expected at least: " << min_required
-                                        << " (aligned_size=" << aligned_size
-                                        << ", data_size=" << plan.dest_slice.size
-                                        << ")"
-                                        << ", got: " << read_res.value();
-                                    return tl::make_unexpected(
-                                        ErrorCode::FILE_READ_FAIL);
-                                }
-                                // Adjust ptr to point to actual data start
-                                // (zero-copy: no memcpy, buffer was oversized
-                                // by AllocateBatch to accommodate the aligned
-                                // read)
-                                batch_object.at(plan.key).ptr =
-                                    static_cast<char*>(plan.dest_slice.ptr) +
-                                    offset_in_buffer;
-                                // Normalize read_res so the common validation
-                                // below passes.  The real short-read check was
-                                // already done above (min_required).
-                                read_res = plan.dest_slice.size;
-                            }
-                        } else
+                    // When the file is backed by io_uring with O_DIRECT,
+                    // use batch_read(): a single io_uring submission with
+                    // queue depth up to 32 gives the NVMe device real
+                    // parallelism - cheaper than per-key read_aligned().
+                    UringFile* const uf = dynamic_cast<UringFile*>(file.get());
+                    if (uf != nullptr) {
+                        auto res = UringBatchReadBucket(uf, plans, batch_object,
+                                                        bucket_id);
+                        if (!res) return res.error();
+                        return ErrorCode::OK;
+                    }
 #endif
-                        {
-                            iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
-                            read_res = file->vector_read(&iov, 1, actual_offset);
-                        }
+
+                    // Non-URING (buffered-I/O) path.
+                    if (bucket_threads_ > 1 && plans.size() > 1) {
+                        StorageFile* sf = file.get();
+                        return IntraBucketReadChunked(sf, plans, bucket_id);
+                    }
+                    // Sequential pread fallback.
+                    for (const auto& plan : plans) {
+                        iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
+                        auto read_res = file->vector_read(
+                            &iov, 1, plan.offset + plan.key_size);
                         if (!read_res) {
-                            LOG(ERROR) << "vector_read failed for key: " << plan.key
-                                       << ", bucket_id=" << plan.bucket_id
-                                       << ", error: " << read_res.error();
+                            LOG(ERROR)
+                                << "vector_read failed for key: " << plan.key
+                                << ", bucket_id=" << plan.bucket_id
+                                << ", error: " << read_res.error();
                             return read_res.error();
                         }
                         if (read_res.value() != plan.dest_slice.size) {
-                            LOG(ERROR) << "Read size mismatch for key: " << plan.key
-                                       << ", expected: " << plan.dest_slice.size
-                                       << ", got: " << read_res.value();
+                            LOG(ERROR)
+                                << "Read size mismatch for key: " << plan.key
+                                << ", expected: " << plan.dest_slice.size
+                                << ", got: " << read_res.value();
                             return ErrorCode::FILE_READ_FAIL;
                         }
                     }
@@ -2069,8 +2120,7 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
             if (first_err == ErrorCode::OK && err != ErrorCode::OK)
                 first_err = err;
         }
-        if (first_err != ErrorCode::OK)
-            return tl::make_unexpected(first_err);
+        if (first_err != ErrorCode::OK) return tl::make_unexpected(first_err);
     } else {
         for (auto& [bucket_id, read_plans] : bucket_read_plans) {
             auto filepath_res = GetBucketDataPath(bucket_id);
@@ -2086,89 +2136,107 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                            << filepath_res.value();
                 return tl::make_unexpected(file_res.error());
             }
-            if (bucket_threads_ > 1 && read_plans.size() > 1) {
-                // Intra-bucket chunked reads via thread pool.
-                // All chunks share the same fd (pread is thread-safe).
-                StorageFile* file_ptr = file_res->get();
-                ThreadPool& pool = *batch_load_pool_;
-                const size_t chunk_size =
-                    (read_plans.size() + bucket_threads_ - 1) /
-                    bucket_threads_;
-                std::vector<std::future<ErrorCode>> futures;
-                for (size_t start = 0; start < read_plans.size();
-                     start += chunk_size) {
-                    size_t end =
-                        std::min(start + chunk_size, read_plans.size());
-                    auto task = std::make_shared<
-                        std::packaged_task<ErrorCode()>>(
-                        [file_ptr, &read_plans, start, end,
-                         &batch_object,
-                         bucket_id]() -> ErrorCode {
-                            for (size_t j = start; j < end; ++j) {
-                                const auto& plan = read_plans[j];
-                                iovec iov{plan.dest_slice.ptr,
-                                          plan.dest_slice.size};
-                                auto rr = file_ptr->vector_read(
-                                    &iov, 1,
-                                    plan.offset + plan.key_size);
-                                if (!rr) {
-                                    LOG(ERROR) << "vector_read failed: "
-                                               << plan.key << " bucket_id="
-                                               << bucket_id
-                                               << " error=" << rr.error();
-                                    return rr.error();
-                                }
-                                if (rr.value() != plan.dest_slice.size) {
-                                    LOG(ERROR) << "Read size mismatch: "
-                                               << plan.key << " expected="
-                                               << plan.dest_slice.size
-                                               << " got=" << rr.value();
-                                    return ErrorCode::FILE_READ_FAIL;
-                                }
-                            }
-                            return ErrorCode::OK;
-                        });
-                    futures.push_back(task->get_future());
-                    pool.enqueue([task]() { (*task)(); });
+            if (read_plans.size() > 1) {
+                StorageFile* const sf = file_res->get();
+                bool handled = false;
+
+#ifdef USE_URING
+                // When the file is backed by io_uring with O_DIRECT, use
+                // batch_read(): a single io_uring submission with queue depth
+                // up to 32 gives the NVMe device real parallelism from one
+                // thread — cheaper and faster than dispatching to a thread
+                // pool where each thread issues one read at a time.
+                UringFile* const uf = dynamic_cast<UringFile*>(sf);
+                // Only use batch_read when the caller has opted
+                // into concurrency (either env var > 0), otherwise
+                // fall through to sequential read_aligned.
+                if (uf != nullptr &&
+                    (batch_threads_ > 0 || bucket_threads_ > 0)) {
+                    auto res = UringBatchReadBucket(uf, read_plans,
+                                                    batch_object, bucket_id);
+                    if (!res) return tl::make_unexpected(res.error());
+                    handled = true;
                 }
-                ErrorCode first_err = ErrorCode::OK;
-                for (auto& f : futures) {
-                    ErrorCode err = f.get();
-                    if (first_err == ErrorCode::OK && err != ErrorCode::OK)
-                        first_err = err;
+#endif
+                if (!handled && bucket_threads_ > 1) {
+                    ErrorCode ec =
+                        IntraBucketReadChunked(sf, read_plans, bucket_id);
+                    if (ec != ErrorCode::OK) return tl::make_unexpected(ec);
+                    handled = true;
                 }
-                if (first_err != ErrorCode::OK)
-                    return tl::make_unexpected(first_err);
-            } else {
-                auto& file = file_res.value();
+
+                if (handled) continue;
+            }
+
+            // Sequential fallthrough or single plan: per-key read with
+            // URING zero-copy support when available.
+            auto& file = file_res.value();
+
+            // Hoist UringFile check outside the per-plan loop.
+            // The file type is invariant within a single bucket's read loop.
+#ifdef USE_URING
+            UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
+#else
+            [[maybe_unused]] UringFile* const uring_file = nullptr;
+#endif
 
             for (const auto& plan : read_plans) {
                 int64_t actual_offset = plan.offset + plan.key_size;
                 tl::expected<size_t, ErrorCode> read_res;
 
 #ifdef USE_URING
-                UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
                 if (uring_file != nullptr) {
                     int64_t aligned_offset =
                         align_down(actual_offset, kDirectIOAlignment);
                     int64_t data_end =
-                        actual_offset + static_cast<int64_t>(plan.dest_slice.size);
+                        actual_offset +
+                        static_cast<int64_t>(plan.dest_slice.size);
                     int64_t aligned_end = static_cast<int64_t>(align_up(
                         static_cast<size_t>(data_end), kDirectIOAlignment));
                     size_t aligned_size =
                         static_cast<size_t>(aligned_end - aligned_offset);
                     int64_t offset_in_buffer = actual_offset - aligned_offset;
+                    // Zero-copy path: read directly into the slice buffer.
+                    // dest_slice.ptr is 4096-aligned and oversized (from
+                    // AllocateBatch) to accommodate the full aligned read
+                    // range.
                     read_res = uring_file->read_aligned(
                         plan.dest_slice.ptr, aligned_size, aligned_offset);
                     if (read_res) {
+                        // Verify the aligned read returned enough bytes
+                        // to cover the actual data region.  read_aligned
+                        // reads the full aligned range [aligned_offset,
+                        // aligned_end); the caller-visible data starts at
+                        // offset_in_buffer into that buffer and spans
+                        // plan.dest_slice.size bytes.
+                        size_t min_required =
+                            static_cast<size_t>(offset_in_buffer) +
+                            plan.dest_slice.size;
+                        if (read_res.value() < min_required) {
+                            LOG(ERROR)
+                                << "read_aligned short read for key: " << plan.key
+                                << ", bucket_id=" << plan.bucket_id
+                                << ", expected at least: " << min_required
+                                << " (aligned_size=" << aligned_size
+                                << ", data_size=" << plan.dest_slice.size << ")"
+                                << ", got: " << read_res.value();
+                            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                        }
+                        // Adjust ptr to point to actual data start
+                        // (zero-copy: no memcpy, buffer was oversized by
+                        // AllocateBatch to accommodate the aligned read)
                         batch_object.at(plan.key).ptr =
                             static_cast<char*>(plan.dest_slice.ptr) +
                             offset_in_buffer;
+                        // Normalize read_res so the common validation
+                        // below passes.  The real short-read check was
+                        // already done above (min_required).
                         read_res = plan.dest_slice.size;
                     }
                 } else
 #endif
                 {
+                    // Fallback to vector_read for non-UringFile
                     iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
                     read_res = file->vector_read(&iov, 1, actual_offset);
                 }
@@ -2179,14 +2247,13 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                                << ", error: " << read_res.error();
                     return tl::make_unexpected(read_res.error());
                 }
-            }
 
-            if (read_res.value() != plan.dest_slice.size) {
-                LOG(ERROR) << "Read size mismatch for key: " << plan.key
-                           << ", expected: " << plan.dest_slice.size
-                           << ", got: " << read_res.value();
-                return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
-            }
+                if (read_res.value() != plan.dest_slice.size) {
+                    LOG(ERROR) << "Read size mismatch for key: " << plan.key
+                               << ", expected: " << plan.dest_slice.size
+                               << ", got: " << read_res.value();
+                    return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                }
             }
         }
     }

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1876,11 +1876,11 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchQuery(
 }
 
 int BucketStorageBackend::EnvBatchLoadThreads() {
-    return GetEnvOr<int>("MC_BATCH_LOAD_THREADS", 0);
+    return Environ::GetInt("MC_BATCH_LOAD_THREADS", 0);
 }
 
 int BucketStorageBackend::EnvBucketReadThreads() {
-    return GetEnvOr<int>("MC_BUCKET_READ_THREADS", 0);
+    return Environ::GetInt("MC_BUCKET_READ_THREADS", 0);
 }
 
 #ifdef USE_URING
@@ -1891,7 +1891,12 @@ tl::expected<void, ErrorCode> BucketStorageBackend::UringBatchReadBucket(
     std::vector<int64_t> buf_offsets;
     descs.reserve(plans.size());
     buf_offsets.reserve(plans.size());
-    size_t expected_bytes = 0;
+    // Minimum aggregated bytes that must be returned so every key's actual
+    // data region is present.  Mirrors #3066's per-key min_required: the
+    // aligned descriptor may extend past EOF (tail padding) when a bucket
+    // file is not 4096-padded, so the check must only require
+    // offset_in_buffer + data_size per key, not the full aligned_size.
+    size_t required_bytes = 0;
 
     for (const auto& plan : plans) {
         int64_t actual_offset = plan.offset + plan.key_size;
@@ -1902,8 +1907,10 @@ tl::expected<void, ErrorCode> BucketStorageBackend::UringBatchReadBucket(
             align_up(static_cast<size_t>(data_end), kDirectIOAlignment));
         size_t aligned_size = static_cast<size_t>(aligned_end - aligned_offset);
         descs.push_back({plan.dest_slice.ptr, aligned_size, aligned_offset});
-        buf_offsets.push_back(actual_offset - aligned_offset);
-        expected_bytes += aligned_size;
+        int64_t offset_in_buffer = actual_offset - aligned_offset;
+        buf_offsets.push_back(offset_in_buffer);
+        required_bytes +=
+            static_cast<size_t>(offset_in_buffer) + plan.dest_slice.size;
     }
 
     auto result = uf->batch_read(descs.data(), static_cast<int>(descs.size()));
@@ -1916,11 +1923,11 @@ tl::expected<void, ErrorCode> BucketStorageBackend::UringBatchReadBucket(
     // Guard against silent short reads (community #3066/#3073): the
     // underlying collect() only flags cqe->res < 0, so a short read
     // returns fewer bytes without surfacing an error.  Verify the
-    // aggregated byte count covers every aligned descriptor before
-    // exposing the zero-copy pointers.
-    if (result.value() < expected_bytes) {
+    // aggregated byte count covers every key's actual data region
+    // (offset_in_buffer + data_size) before exposing the pointers.
+    if (result.value() < required_bytes) {
         LOG(ERROR) << "batch_read short read for bucket_id=" << bucket_id
-                   << ", expected at least: " << expected_bytes
+                   << ", expected at least: " << required_bytes
                    << ", got: " << result.value();
         return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
     }
@@ -1972,8 +1979,16 @@ ErrorCode BucketStorageBackend::IntraBucketReadChunked(
 
     ErrorCode first_err = ErrorCode::OK;
     for (auto& f : futures) {
-        ErrorCode err = f.get();
-        if (first_err == ErrorCode::OK && err != ErrorCode::OK) first_err = err;
+        try {
+            ErrorCode err = f.get();
+            if (first_err == ErrorCode::OK && err != ErrorCode::OK)
+                first_err = err;
+        } catch (...) {
+            // Still wait on every future so no queued task keeps running
+            // against captured references after this function returns.
+            if (first_err == ErrorCode::OK)
+                first_err = ErrorCode::INTERNAL_ERROR;
+        }
     }
     return first_err;
 }
@@ -2117,12 +2132,19 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
             pool.enqueue([task]() { (*task)(); });
         }
 
-        // Wait for all bucket reads to complete.
+        // Wait for all bucket reads to complete.  Keep draining every
+        // future even if one throws, so no queued task keeps running
+        // against captured references after this function returns.
         ErrorCode first_err = ErrorCode::OK;
         for (auto& f : futures) {
-            ErrorCode err = f.get();
-            if (first_err == ErrorCode::OK && err != ErrorCode::OK)
-                first_err = err;
+            try {
+                ErrorCode err = f.get();
+                if (first_err == ErrorCode::OK && err != ErrorCode::OK)
+                    first_err = err;
+            } catch (...) {
+                if (first_err == ErrorCode::OK)
+                    first_err = ErrorCode::INTERNAL_ERROR;
+            }
         }
         if (first_err != ErrorCode::OK) return tl::make_unexpected(first_err);
     } else {
@@ -2218,13 +2240,14 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                             plan.dest_slice.size;
                         if (read_res.value() < min_required) {
                             LOG(ERROR)
-                                << "read_aligned short read for key: " << plan.key
-                                << ", bucket_id=" << plan.bucket_id
+                                << "read_aligned short read for key: "
+                                << plan.key << ", bucket_id=" << plan.bucket_id
                                 << ", expected at least: " << min_required
                                 << " (aligned_size=" << aligned_size
                                 << ", data_size=" << plan.dest_slice.size << ")"
                                 << ", got: " << read_res.value();
-                            return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                            return tl::make_unexpected(
+                                ErrorCode::FILE_READ_FAIL);
                         }
                         // Adjust ptr to point to actual data start
                         // (zero-copy: no memcpy, buffer was oversized by

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1861,25 +1861,27 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchQuery(
     return {};
 }
 
-BucketStorageBackend::BucketStorageBackend(
-    const FileStorageConfig& file_storage_config,
-    const BucketBackendConfig& bucket_backend_config)
-    : StorageBackendInterface(file_storage_config),
-      bucket_backend_config_(bucket_backend_config) {
-    const int n = std::max(batch_load_threads(), bucket_read_threads());
-    if (n > 1) {
-        batch_load_pool_ = std::make_unique<ThreadPool>(static_cast<size_t>(n));
-    }
-}
-
-int BucketStorageBackend::batch_load_threads() {
+int BucketStorageBackend::env_batch_load_threads() {
     const char* env = std::getenv("MC_BATCH_LOAD_THREADS");
     return env ? std::max(0, std::atoi(env)) : 0;
 }
 
-int BucketStorageBackend::bucket_read_threads() {
+int BucketStorageBackend::env_bucket_read_threads() {
     const char* env = std::getenv("MC_BUCKET_READ_THREADS");
     return env ? std::max(0, std::atoi(env)) : 0;
+}
+
+BucketStorageBackend::BucketStorageBackend(
+    const FileStorageConfig& file_storage_config,
+    const BucketBackendConfig& bucket_backend_config)
+    : StorageBackendInterface(file_storage_config),
+      bucket_backend_config_(bucket_backend_config),
+      batch_threads_(env_batch_load_threads()),
+      bucket_threads_(env_bucket_read_threads()) {
+    const int n = std::max(batch_threads_, bucket_threads_);
+    if (n > 1) {
+        batch_load_pool_ = std::make_unique<ThreadPool>(static_cast<size_t>(n));
+    }
 }
 
 tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
@@ -1958,10 +1960,7 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
     // Step 2: Perform IO without holding any locks.
     // When MC_BATCH_LOAD_THREADS > 1, dispatch each bucket's reads to a
     // thread pool for parallelism (buckets are independent files).
-    const int batch_threads = batch_load_threads();
-    const int bucket_threads = bucket_read_threads();
-
-    if (batch_threads > 1 && bucket_read_plans.size() > 1) {
+    if (batch_threads_ > 1 && bucket_read_plans.size() > 1) {
         ThreadPool& pool = *batch_load_pool_;
         std::vector<std::future<ErrorCode>> futures;
         futures.reserve(bucket_read_plans.size());
@@ -2087,14 +2086,14 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                            << filepath_res.value();
                 return tl::make_unexpected(file_res.error());
             }
-            if (bucket_threads > 1 && read_plans.size() > 1) {
+            if (bucket_threads_ > 1 && read_plans.size() > 1) {
                 // Intra-bucket chunked reads via thread pool.
                 // All chunks share the same fd (pread is thread-safe).
                 StorageFile* file_ptr = file_res->get();
                 ThreadPool& pool = *batch_load_pool_;
                 const size_t chunk_size =
-                    (read_plans.size() + bucket_threads - 1) /
-                    bucket_threads;
+                    (read_plans.size() + bucket_threads_ - 1) /
+                    bucket_threads_;
                 std::vector<std::future<ErrorCode>> futures;
                 for (size_t start = 0; start < read_plans.size();
                      start += chunk_size) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -18,6 +18,9 @@
 #include <thread>
 #include <vector>
 #include <algorithm>
+#include <future>
+
+#include "thread_pool.h"
 #include <chrono>
 #include <unordered_set>
 
@@ -1858,6 +1861,27 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchQuery(
     return {};
 }
 
+BucketStorageBackend::BucketStorageBackend(
+    const FileStorageConfig& file_storage_config,
+    const BucketBackendConfig& bucket_backend_config)
+    : StorageBackendInterface(file_storage_config),
+      bucket_backend_config_(bucket_backend_config) {
+    const int n = std::max(batch_load_threads(), bucket_read_threads());
+    if (n > 1) {
+        batch_load_pool_ = std::make_unique<ThreadPool>(static_cast<size_t>(n));
+    }
+}
+
+int BucketStorageBackend::batch_load_threads() {
+    const char* env = std::getenv("MC_BATCH_LOAD_THREADS");
+    return env ? std::max(0, std::atoi(env)) : 0;
+}
+
+int BucketStorageBackend::bucket_read_threads() {
+    const char* env = std::getenv("MC_BUCKET_READ_THREADS");
+    return env ? std::max(0, std::atoi(env)) : 0;
+}
+
 tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
     std::unordered_map<std::string, Slice>& batch_object) {
     // Step 1: Build read plan by copying metadata under lock
@@ -1931,94 +1955,231 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
     // which remain alive until this function returns (~line bucket_guards
     // destructor), keeping inflight_reads_ > 0 throughout the I/O phase.
 
-    // Step 2: Perform IO without holding any locks
-    for (auto& [bucket_id, read_plans] : bucket_read_plans) {
-        // Open file for this bucket (cheap syscall, no lock needed)
-        auto filepath_res = GetBucketDataPath(bucket_id);
-        if (!filepath_res) {
-            LOG(ERROR) << "Failed to get bucket data path, bucket_id="
-                       << bucket_id;
-            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-        }
+    // Step 2: Perform IO without holding any locks.
+    // When MC_BATCH_LOAD_THREADS > 1, dispatch each bucket's reads to a
+    // thread pool for parallelism (buckets are independent files).
+    const int batch_threads = batch_load_threads();
+    const int bucket_threads = bucket_read_threads();
 
-        auto file_res = OpenFile(filepath_res.value(), FileMode::Read);
-        if (!file_res) {
-            LOG(ERROR) << "Failed to open bucket file: "
-                       << filepath_res.value();
-            return tl::make_unexpected(file_res.error());
-        }
-        auto& file = file_res.value();
+    if (batch_threads > 1 && bucket_read_plans.size() > 1) {
+        ThreadPool& pool = *batch_load_pool_;
+        std::vector<std::future<ErrorCode>> futures;
+        futures.reserve(bucket_read_plans.size());
 
-        // Read each key's data
-        for (const auto& plan : read_plans) {
-            int64_t actual_offset = plan.offset + plan.key_size;
-            tl::expected<size_t, ErrorCode> read_res;
-
-#ifdef USE_URING
-            // Try to use read_aligned for O_DIRECT I/O if file is UringFile
-            UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
-            if (uring_file != nullptr) {
-                // Calculate aligned read range
-                int64_t aligned_offset =
-                    align_down(actual_offset, kDirectIOAlignment);
-                int64_t data_end =
-                    actual_offset + static_cast<int64_t>(plan.dest_slice.size);
-                int64_t aligned_end = static_cast<int64_t>(align_up(
-                    static_cast<size_t>(data_end), kDirectIOAlignment));
-                size_t aligned_size =
-                    static_cast<size_t>(aligned_end - aligned_offset);
-                int64_t offset_in_buffer = actual_offset - aligned_offset;
-
-                // Zero-copy path: read directly into the slice buffer.
-                // dest_slice.ptr is 4096-aligned and oversized (from
-                // AllocateBatch) to accommodate the full aligned read range.
-                read_res = uring_file->read_aligned(
-                    plan.dest_slice.ptr, aligned_size, aligned_offset);
-
-                if (read_res) {
-                    // Verify the aligned read returned enough bytes
-                    // to cover the actual data region.  read_aligned
-                    // reads the full aligned range [aligned_offset,
-                    // aligned_end); the caller-visible data starts at
-                    // offset_in_buffer into that buffer and spans
-                    // plan.dest_slice.size bytes.
-                    size_t min_required =
-                        static_cast<size_t>(offset_in_buffer) +
-                        plan.dest_slice.size;
-                    if (read_res.value() < min_required) {
-                        LOG(ERROR)
-                            << "read_aligned short read for key: " << plan.key
-                            << ", bucket_id=" << plan.bucket_id
-                            << ", expected at least: " << min_required
-                            << " (aligned_size=" << aligned_size
-                            << ", data_size=" << plan.dest_slice.size << ")"
-                            << ", got: " << read_res.value();
-                        return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+        for (auto& [bucket_id, read_plans] : bucket_read_plans) {
+            using task_type = std::packaged_task<ErrorCode()>;
+            auto task = std::make_shared<task_type>(
+                [this, bucket_id,
+                 plans = std::move(read_plans),
+                 &batch_object]() -> ErrorCode {
+                    auto filepath_res = GetBucketDataPath(bucket_id);
+                    if (!filepath_res) {
+                        LOG(ERROR) << "Failed to get bucket data path, bucket_id="
+                                   << bucket_id;
+                        return ErrorCode::INTERNAL_ERROR;
                     }
-                    // Adjust ptr to point to actual data start
-                    // (zero-copy: no memcpy, buffer was oversized by
-                    // AllocateBatch to accommodate the aligned read)
-                    batch_object.at(plan.key).ptr =
-                        static_cast<char*>(plan.dest_slice.ptr) +
-                        offset_in_buffer;
-                    // Normalize read_res so the common validation
-                    // below passes.  The real short-read check was
-                    // already done above (min_required).
-                    read_res = plan.dest_slice.size;
-                }
-            } else
+                    auto file_res = OpenFile(filepath_res.value(), FileMode::Read);
+                    if (!file_res) {
+                        LOG(ERROR) << "Failed to open bucket file: "
+                                   << filepath_res.value();
+                        return file_res.error();
+                    }
+                    auto& file = file_res.value();
+
+                    for (const auto& plan : plans) {
+                        int64_t actual_offset = plan.offset + plan.key_size;
+                        tl::expected<size_t, ErrorCode> read_res;
+#ifdef USE_URING
+                        UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
+                        if (uring_file != nullptr) {
+                            int64_t aligned_offset =
+                                align_down(actual_offset, kDirectIOAlignment);
+                            int64_t data_end =
+                                actual_offset + static_cast<int64_t>(plan.dest_slice.size);
+                            int64_t aligned_end = static_cast<int64_t>(align_up(
+                                static_cast<size_t>(data_end), kDirectIOAlignment));
+                            size_t aligned_size =
+                                static_cast<size_t>(aligned_end - aligned_offset);
+                            int64_t offset_in_buffer = actual_offset - aligned_offset;
+                            read_res = uring_file->read_aligned(
+                                plan.dest_slice.ptr, aligned_size, aligned_offset);
+                            if (read_res) {
+                                // Verify the aligned read returned enough bytes
+                                // to cover the actual data region.  read_aligned
+                                // reads the full aligned range [aligned_offset,
+                                // aligned_end); the caller-visible data starts at
+                                // offset_in_buffer into that buffer and spans
+                                // plan.dest_slice.size bytes.
+                                size_t min_required =
+                                    static_cast<size_t>(offset_in_buffer) +
+                                    plan.dest_slice.size;
+                                if (read_res.value() < min_required) {
+                                    LOG(ERROR)
+                                        << "read_aligned short read for key: "
+                                        << plan.key
+                                        << ", bucket_id=" << plan.bucket_id
+                                        << ", expected at least: " << min_required
+                                        << " (aligned_size=" << aligned_size
+                                        << ", data_size=" << plan.dest_slice.size
+                                        << ")"
+                                        << ", got: " << read_res.value();
+                                    return tl::make_unexpected(
+                                        ErrorCode::FILE_READ_FAIL);
+                                }
+                                // Adjust ptr to point to actual data start
+                                // (zero-copy: no memcpy, buffer was oversized
+                                // by AllocateBatch to accommodate the aligned
+                                // read)
+                                batch_object.at(plan.key).ptr =
+                                    static_cast<char*>(plan.dest_slice.ptr) +
+                                    offset_in_buffer;
+                                // Normalize read_res so the common validation
+                                // below passes.  The real short-read check was
+                                // already done above (min_required).
+                                read_res = plan.dest_slice.size;
+                            }
+                        } else
 #endif
-            {
-                // Fallback to vector_read for non-UringFile
-                iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
-                read_res = file->vector_read(&iov, 1, actual_offset);
+                        {
+                            iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
+                            read_res = file->vector_read(&iov, 1, actual_offset);
+                        }
+                        if (!read_res) {
+                            LOG(ERROR) << "vector_read failed for key: " << plan.key
+                                       << ", bucket_id=" << plan.bucket_id
+                                       << ", error: " << read_res.error();
+                            return read_res.error();
+                        }
+                        if (read_res.value() != plan.dest_slice.size) {
+                            LOG(ERROR) << "Read size mismatch for key: " << plan.key
+                                       << ", expected: " << plan.dest_slice.size
+                                       << ", got: " << read_res.value();
+                            return ErrorCode::FILE_READ_FAIL;
+                        }
+                    }
+                    return ErrorCode::OK;
+                });
+            futures.push_back(task->get_future());
+            pool.enqueue([task]() { (*task)(); });
+        }
+
+        // Wait for all bucket reads to complete.
+        ErrorCode first_err = ErrorCode::OK;
+        for (auto& f : futures) {
+            ErrorCode err = f.get();
+            if (first_err == ErrorCode::OK && err != ErrorCode::OK)
+                first_err = err;
+        }
+        if (first_err != ErrorCode::OK)
+            return tl::make_unexpected(first_err);
+    } else {
+        for (auto& [bucket_id, read_plans] : bucket_read_plans) {
+            auto filepath_res = GetBucketDataPath(bucket_id);
+            if (!filepath_res) {
+                LOG(ERROR) << "Failed to get bucket data path, bucket_id="
+                           << bucket_id;
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
 
-            if (!read_res) {
-                LOG(ERROR) << "vector_read failed for key: " << plan.key
-                           << ", bucket_id=" << plan.bucket_id
-                           << ", error: " << read_res.error();
-                return tl::make_unexpected(read_res.error());
+            auto file_res = OpenFile(filepath_res.value(), FileMode::Read);
+            if (!file_res) {
+                LOG(ERROR) << "Failed to open bucket file: "
+                           << filepath_res.value();
+                return tl::make_unexpected(file_res.error());
+            }
+            if (bucket_threads > 1 && read_plans.size() > 1) {
+                // Intra-bucket chunked reads via thread pool.
+                // All chunks share the same fd (pread is thread-safe).
+                StorageFile* file_ptr = file_res->get();
+                ThreadPool& pool = *batch_load_pool_;
+                const size_t chunk_size =
+                    (read_plans.size() + bucket_threads - 1) /
+                    bucket_threads;
+                std::vector<std::future<ErrorCode>> futures;
+                for (size_t start = 0; start < read_plans.size();
+                     start += chunk_size) {
+                    size_t end =
+                        std::min(start + chunk_size, read_plans.size());
+                    auto task = std::make_shared<
+                        std::packaged_task<ErrorCode()>>(
+                        [file_ptr, &read_plans, start, end,
+                         &batch_object,
+                         bucket_id]() -> ErrorCode {
+                            for (size_t j = start; j < end; ++j) {
+                                const auto& plan = read_plans[j];
+                                iovec iov{plan.dest_slice.ptr,
+                                          plan.dest_slice.size};
+                                auto rr = file_ptr->vector_read(
+                                    &iov, 1,
+                                    plan.offset + plan.key_size);
+                                if (!rr) {
+                                    LOG(ERROR) << "vector_read failed: "
+                                               << plan.key << " bucket_id="
+                                               << bucket_id
+                                               << " error=" << rr.error();
+                                    return rr.error();
+                                }
+                                if (rr.value() != plan.dest_slice.size) {
+                                    LOG(ERROR) << "Read size mismatch: "
+                                               << plan.key << " expected="
+                                               << plan.dest_slice.size
+                                               << " got=" << rr.value();
+                                    return ErrorCode::FILE_READ_FAIL;
+                                }
+                            }
+                            return ErrorCode::OK;
+                        });
+                    futures.push_back(task->get_future());
+                    pool.enqueue([task]() { (*task)(); });
+                }
+                ErrorCode first_err = ErrorCode::OK;
+                for (auto& f : futures) {
+                    ErrorCode err = f.get();
+                    if (first_err == ErrorCode::OK && err != ErrorCode::OK)
+                        first_err = err;
+                }
+                if (first_err != ErrorCode::OK)
+                    return tl::make_unexpected(first_err);
+            } else {
+                auto& file = file_res.value();
+
+            for (const auto& plan : read_plans) {
+                int64_t actual_offset = plan.offset + plan.key_size;
+                tl::expected<size_t, ErrorCode> read_res;
+
+#ifdef USE_URING
+                UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
+                if (uring_file != nullptr) {
+                    int64_t aligned_offset =
+                        align_down(actual_offset, kDirectIOAlignment);
+                    int64_t data_end =
+                        actual_offset + static_cast<int64_t>(plan.dest_slice.size);
+                    int64_t aligned_end = static_cast<int64_t>(align_up(
+                        static_cast<size_t>(data_end), kDirectIOAlignment));
+                    size_t aligned_size =
+                        static_cast<size_t>(aligned_end - aligned_offset);
+                    int64_t offset_in_buffer = actual_offset - aligned_offset;
+                    read_res = uring_file->read_aligned(
+                        plan.dest_slice.ptr, aligned_size, aligned_offset);
+                    if (read_res) {
+                        batch_object.at(plan.key).ptr =
+                            static_cast<char*>(plan.dest_slice.ptr) +
+                            offset_in_buffer;
+                        read_res = plan.dest_slice.size;
+                    }
+                } else
+#endif
+                {
+                    iovec iov{plan.dest_slice.ptr, plan.dest_slice.size};
+                    read_res = file->vector_read(&iov, 1, actual_offset);
+                }
+
+                if (!read_res) {
+                    LOG(ERROR) << "vector_read failed for key: " << plan.key
+                               << ", bucket_id=" << plan.bucket_id
+                               << ", error: " << read_res.error();
+                    return tl::make_unexpected(read_res.error());
+                }
             }
 
             if (read_res.value() != plan.dest_slice.size) {
@@ -2026,6 +2187,7 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
                            << ", expected: " << plan.dest_slice.size
                            << ", got: " << read_res.value();
                 return tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+            }
             }
         }
     }

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -1701,10 +1701,14 @@ BucketStorageBackend::BucketStorageBackend(
     if (batch_threads_ > 1) {
         batch_load_pool_ =
             std::make_unique<ThreadPool>(static_cast<size_t>(batch_threads_));
+        LOG(INFO) << "BucketStorageBackend: bucket-level read pool created, "
+                  << batch_threads_ << " threads";
     }
     if (bucket_threads_ > 1) {
         intra_bucket_pool_ =
             std::make_unique<ThreadPool>(static_cast<size_t>(bucket_threads_));
+        LOG(INFO) << "BucketStorageBackend: intra-bucket read pool created, "
+                  << bucket_threads_ << " threads";
     }
 }
 
@@ -2177,7 +2181,7 @@ tl::expected<void, ErrorCode> BucketStorageBackend::BatchLoad(
 #ifdef USE_URING
             UringFile* uring_file = dynamic_cast<UringFile*>(file.get());
 #else
-            [[maybe_unused]] UringFile* const uring_file = nullptr;
+            [[maybe_unused]] void* uring_file = nullptr;
 #endif
 
             for (const auto& plan : read_plans) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -11,6 +11,8 @@
 #include <thread>
 #include <atomic>
 #include <algorithm>
+#include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <mutex>
 #include <fcntl.h>
@@ -4723,6 +4725,83 @@ TEST_F(StorageBackendTest,
         << "record with unknown flags must be dropped on recovery";
     EXPECT_EQ(LoadOne(recovered, "key_b", value_b.size()),
               std::make_optional(value_b));
+}
+
+// Helper: run a BatchLoad test with specific concurrency settings.
+static void RunConcurrentBatchLoadTest(const std::string& data_path,
+                                       const std::string& batch_threads,
+                                       const std::string& bucket_threads) {
+    setenv("MC_BATCH_LOAD_THREADS", batch_threads.c_str(), 1);
+    setenv("MC_BUCKET_READ_THREADS", bucket_threads.c_str(), 1);
+
+    FileStorageConfig config;
+    BucketBackendConfig bucket_config;
+    config.storage_filepath = data_path;
+
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    std::vector<std::string> keys;
+    std::vector<int64_t> sizes;
+    std::unordered_map<std::string, std::string> test_data;
+    std::vector<int64_t> buckets;
+    ASSERT_TRUE(
+        BatchOffloadUtil(storage_backend, keys, sizes, test_data, buckets));
+
+    auto allocator = std::make_shared<SimpleAllocator>(128 * 1024 * 1024);
+    std::unordered_map<std::string, Slice> batch_object;
+    for (const auto& [key, data] : test_data) {
+        void* buf = allocator->allocate(data.size());
+        batch_object.emplace(key, Slice{buf, data.size()});
+    }
+
+    auto t0 = std::chrono::steady_clock::now();
+    auto result = storage_backend.BatchLoad(batch_object);
+    auto t1 = std::chrono::steady_clock::now();
+    ASSERT_TRUE(result.has_value());
+
+    LOG(INFO) << "BatchLoad batch=" << batch_threads
+              << " bucket=" << bucket_threads << " " << test_data.size()
+              << " keys in "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0)
+                     .count()
+              << " ms";
+
+    ASSERT_EQ(batch_object.size(), test_data.size());
+    for (const auto& [key, data] : test_data) {
+        auto it = batch_object.find(key);
+        ASSERT_NE(it, batch_object.end());
+        std::string loaded(static_cast<char*>(it->second.ptr), it->second.size);
+        ASSERT_EQ(loaded, data) << "Data mismatch for key: " << key;
+    }
+
+    unsetenv("MC_BATCH_LOAD_THREADS");
+    unsetenv("MC_BUCKET_READ_THREADS");
+}
+
+// Default: both env vars unset (0) — original sequential path.
+TEST_F(StorageBackendTest, BatchLoadConcurrentDefault) {
+    RunConcurrentBatchLoadTest(data_path, "0", "0");
+}
+
+// Only bucket-level parallelism (MC_BATCH_LOAD_THREADS=4).
+TEST_F(StorageBackendTest, BatchLoadConcurrentBucketOnly) {
+    RunConcurrentBatchLoadTest(data_path, "4", "0");
+}
+
+// Only intra-bucket parallelism (MC_BUCKET_READ_THREADS=4).
+TEST_F(StorageBackendTest, BatchLoadConcurrentIntraBucketOnly) {
+    RunConcurrentBatchLoadTest(data_path, "0", "4");
+}
+
+// Both pools active — true 2-level concurrency.
+TEST_F(StorageBackendTest, BatchLoadConcurrentTwoLevel) {
+    RunConcurrentBatchLoadTest(data_path, "4", "4");
+}
+
+// Uneven thread counts: bucket=2, intra-bucket=8.
+TEST_F(StorageBackendTest, BatchLoadConcurrentUneven) {
+    RunConcurrentBatchLoadTest(data_path, "2", "8");
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
## Description
- Add MC_BATCH_LOAD_THREADS env var for bucket-level parallelism. When > 1 and multiple buckets, dispatch each bucket to a thread.
- Add MC_BUCKET_READ_THREADS env var for intra-bucket POSIX read parallelism. When > 1, split read plans into chunks and dispatch to threads sharing the same fd (pread is thread-safe).

  MC_BATCH_LOAD_THREADS  — bucket-level pool (independent files)
  MC_BUCKET_READ_THREADS — intra-bucket pool (POSIX pread chunking)
     • Both 0 (default):  original sequential path, zero change.
     • Only batch > 1:    buckets dispatched to bucket pool; URing uses
                       batch_read() (one io_uring submission, queue
                       depth 32), POSIX stays sequential per-bucket.
     • Only bucket > 1:   buckets sequential, POSIX plans split across
                       intra-bucket pool.  URing uses batch_read().
     • Both > 1:          bucket pool dispatches buckets, within each
                       POSIX plans further split across intra-bucket
                       pool — true 2-level concurrency.
     • URing batch_read() is enabled when either env var > 0

- Extract UringBatchReadBucket (URing alignment + batch_read + zero-copy) and IntraBucketReadChunked (POSIX chunk-dispatch) to eliminate duplication

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)