### PR TITLE
[Store] Add producer view to durable oplog prefix

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_types.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_types.h
@@ -17,7 +17,7 @@ struct DurablePrefix {
     uint64_t last_seq{0};
     // Leadership view that produced this durable boundary. Zero means that
     // the prefix has no producer-view metadata (legacy or not yet assigned).
-    uint64_t producer_view_version{0};
+    ViewVersionId producer_view_version{0};
 
     friend bool operator==(const DurablePrefix&,
                            const DurablePrefix&) = default;

--- a/mooncake-store/include/ha/oplog/oplog_batch_types.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_types.h
@@ -15,6 +15,7 @@ static constexpr int kOpLogBatchIdWidth = 20;
 struct DurablePrefix {
     uint64_t batch_id{0};
     uint64_t last_seq{0};
+    uint64_t producer_view_version{0};
 };
 
 struct BatchRecordRange {

--- a/mooncake-store/include/ha/oplog/oplog_batch_types.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_types.h
@@ -15,7 +15,12 @@ static constexpr int kOpLogBatchIdWidth = 20;
 struct DurablePrefix {
     uint64_t batch_id{0};
     uint64_t last_seq{0};
+    // Leadership view that produced this durable boundary. Zero means that
+    // the prefix has no producer-view metadata (legacy or not yet assigned).
     uint64_t producer_view_version{0};
+
+    friend bool operator==(const DurablePrefix&,
+                           const DurablePrefix&) = default;
 };
 
 struct BatchRecordRange {

--- a/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
@@ -186,19 +186,19 @@ bool DecodeDurablePrefix(const std::string& value, DurablePrefix* prefix,
         SetReason(reason, "unsupported durable prefix schema_version");
         return false;
     }
-    uint64_t producer_view_version = 0;
+    DurablePrefix decoded;
     if (root.isMember("producer_view_version") &&
-        !GetUInt64Field(root, "producer_view_version", &producer_view_version,
-                        reason)) {
+        !GetUInt64Field(root, "producer_view_version",
+                        &decoded.producer_view_version, reason)) {
         return false;
     }
-    if (!GetUInt64Field(root, "batch_id", &prefix->batch_id, reason)) {
+    if (!GetUInt64Field(root, "batch_id", &decoded.batch_id, reason)) {
         return false;
     }
-    if (!GetUInt64Field(root, "last_seq", &prefix->last_seq, reason)) {
+    if (!GetUInt64Field(root, "last_seq", &decoded.last_seq, reason)) {
         return false;
     }
-    prefix->producer_view_version = producer_view_version;
+    *prefix = decoded;
     return true;
 }
 

--- a/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
@@ -153,6 +153,10 @@ std::string EncodeDurablePrefix(const DurablePrefix& prefix) {
         static_cast<Json::UInt>(kDurablePrefixSchemaVersion);
     root["batch_id"] = static_cast<Json::UInt64>(prefix.batch_id);
     root["last_seq"] = static_cast<Json::UInt64>(prefix.last_seq);
+    if (prefix.producer_view_version != 0) {
+        root["producer_view_version"] =
+            static_cast<Json::UInt64>(prefix.producer_view_version);
+    }
     return WriteJson(root);
 }
 
@@ -182,12 +186,19 @@ bool DecodeDurablePrefix(const std::string& value, DurablePrefix* prefix,
         SetReason(reason, "unsupported durable prefix schema_version");
         return false;
     }
+    uint64_t producer_view_version = 0;
+    if (root.isMember("producer_view_version") &&
+        !GetUInt64Field(root, "producer_view_version", &producer_view_version,
+                        reason)) {
+        return false;
+    }
     if (!GetUInt64Field(root, "batch_id", &prefix->batch_id, reason)) {
         return false;
     }
     if (!GetUInt64Field(root, "last_seq", &prefix->last_seq, reason)) {
         return false;
     }
+    prefix->producer_view_version = producer_view_version;
     return true;
 }
 

--- a/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
@@ -155,7 +155,7 @@ std::string EncodeDurablePrefix(const DurablePrefix& prefix) {
     root["last_seq"] = static_cast<Json::UInt64>(prefix.last_seq);
     if (prefix.producer_view_version != 0) {
         root["producer_view_version"] =
-            static_cast<Json::UInt64>(prefix.producer_view_version);
+            static_cast<Json::Int64>(prefix.producer_view_version);
     }
     return WriteJson(root);
 }
@@ -187,10 +187,15 @@ bool DecodeDurablePrefix(const std::string& value, DurablePrefix* prefix,
         return false;
     }
     DurablePrefix decoded;
-    if (root.isMember("producer_view_version") &&
-        !GetUInt64Field(root, "producer_view_version",
-                        &decoded.producer_view_version, reason)) {
-        return false;
+    if (root.isMember("producer_view_version")) {
+        const auto& producer_view = root["producer_view_version"];
+        if (!producer_view.isInt64() || producer_view.asInt64() < 0) {
+            SetReason(reason,
+                      "field must be a non-negative ViewVersionId: "
+                      "producer_view_version");
+            return false;
+        }
+        decoded.producer_view_version = producer_view.asInt64();
     }
     if (!GetUInt64Field(root, "batch_id", &decoded.batch_id, reason)) {
         return false;

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -219,11 +219,27 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
          .expected_value = EncodeDurablePrefix(expected_prefix)});
     txn.puts.push_back({.key = BuildBatchRecordKey(cluster_id_, batch.batch_id),
                         .value = encoded_batch});
-    txn.puts.push_back(
-        {.key = durable_key,
-         .value = EncodeDurablePrefix(
-             {.batch_id = batch.batch_id, .last_seq = batch.last_seq})});
+    txn.puts.push_back({.key = durable_key,
+                        .value = EncodeDurablePrefix(
+                            {.batch_id = batch.batch_id,
+                             .last_seq = batch.last_seq,
+                             .producer_view_version =
+                                 expected_prefix.producer_view_version})});
     ErrorCode err = backend_.Txn(txn);
+    if (err == ErrorCode::ETCD_TRANSACTION_FAIL) {
+        std::string raw_prefix;
+        DurablePrefix decoded_prefix;
+        if (backend_.Get(durable_key, raw_prefix) == ErrorCode::OK &&
+            raw_prefix != txn.compares[0].expected_value &&
+            DecodeDurablePrefix(raw_prefix, &decoded_prefix) &&
+            decoded_prefix.batch_id == expected_prefix.batch_id &&
+            decoded_prefix.last_seq == expected_prefix.last_seq &&
+            decoded_prefix.producer_view_version ==
+                expected_prefix.producer_view_version) {
+            txn.compares[0].expected_value = raw_prefix;
+            err = backend_.Txn(txn);
+        }
+    }
     if (err != ErrorCode::ETCD_TRANSACTION_FAIL) {
         return err;
     }
@@ -231,7 +247,9 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
     DurablePrefix current_prefix;
     if (ReadDurablePrefix(current_prefix) != ErrorCode::OK ||
         current_prefix.batch_id != batch.batch_id ||
-        current_prefix.last_seq != batch.last_seq) {
+        current_prefix.last_seq != batch.last_seq ||
+        current_prefix.producer_view_version !=
+            expected_prefix.producer_view_version) {
         return err;
     }
     OpLogBatchRecord current_batch;

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -104,8 +104,7 @@ ErrorCode OpLogBatchStorage::InitDurablePrefix(DurablePrefix& prefix) {
         return ErrorCode::OK;
     }
     if (err == ErrorCode::ETCD_TRANSACTION_FAIL) {
-        err = ReadDurablePrefix(prefix);
-        if (err != ErrorCode::OK) {
+        if ((err = ReadDurablePrefix(prefix)) != ErrorCode::OK) {
             return err;
         }
         return ValidateDurablePrefixAtStartup(prefix);
@@ -232,10 +231,7 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
         if (backend_.Get(durable_key, raw_prefix) == ErrorCode::OK &&
             raw_prefix != txn.compares[0].expected_value &&
             DecodeDurablePrefix(raw_prefix, &decoded_prefix) &&
-            decoded_prefix.batch_id == expected_prefix.batch_id &&
-            decoded_prefix.last_seq == expected_prefix.last_seq &&
-            decoded_prefix.producer_view_version ==
-                expected_prefix.producer_view_version) {
+            decoded_prefix == expected_prefix) {
             txn.compares[0].expected_value = raw_prefix;
             err = backend_.Txn(txn);
         }
@@ -246,10 +242,11 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
 
     DurablePrefix current_prefix;
     if (ReadDurablePrefix(current_prefix) != ErrorCode::OK ||
-        current_prefix.batch_id != batch.batch_id ||
-        current_prefix.last_seq != batch.last_seq ||
-        current_prefix.producer_view_version !=
-            expected_prefix.producer_view_version) {
+        current_prefix !=
+            DurablePrefix{.batch_id = batch.batch_id,
+                          .last_seq = batch.last_seq,
+                          .producer_view_version =
+                              expected_prefix.producer_view_version}) {
         return err;
     }
     OpLogBatchRecord current_batch;

--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -319,8 +319,11 @@ void OrderedOpLogWriter::Start() {
 #endif
                     {
                         std::lock_guard<std::mutex> lock(impl_->mutex);
-                        impl_->durable_prefix = {.batch_id = batch.batch_id,
-                                                 .last_seq = batch.last_seq};
+                        impl_->durable_prefix = {
+                            .batch_id = batch.batch_id,
+                            .last_seq = batch.last_seq,
+                            .producer_view_version =
+                                expected_prefix.producer_view_version};
                         impl_->last_error = ErrorCode::OK;
                         impl_->accepting = !impl_->stop_requested;
                         for (size_t i = 0; i < entries.size(); ++i) {

--- a/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
@@ -256,6 +256,19 @@ TEST(OpLogDurablePrefixCodecTest, InvalidProducerViewLeavesOutputUnchanged) {
     EXPECT_FALSE(reason.empty());
 }
 
+TEST(OpLogDurablePrefixCodecTest, InvalidLastSeqLeavesOutputUnchanged) {
+    DurablePrefix prefix{
+        .batch_id = 11, .last_seq = 22, .producer_view_version = 33};
+    std::string reason;
+    EXPECT_FALSE(DecodeDurablePrefix(
+        R"({"batch_id":9,"last_seq":"invalid","schema_version":1})", &prefix,
+        &reason));
+    EXPECT_EQ(11u, prefix.batch_id);
+    EXPECT_EQ(22u, prefix.last_seq);
+    EXPECT_EQ(33u, prefix.producer_view_version);
+    EXPECT_FALSE(reason.empty());
+}
+
 TEST(OpLogDurablePrefixCodecTest, RejectsMalformedPayload) {
     DurablePrefix out;
     std::string reason;

--- a/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 #include <xxhash.h>
 
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -190,9 +191,11 @@ TEST(OpLogDurablePrefixCodecTest, PreservesLegacyEncodingWithoutProducerView) {
     EXPECT_TRUE(reason.empty());
 }
 
-TEST(OpLogDurablePrefixCodecTest, RoundTripsNonZeroProducerView) {
+TEST(OpLogDurablePrefixCodecTest, RoundTripsMaxProducerView) {
     DurablePrefix in{
-        .batch_id = 9, .last_seq = 1024, .producer_view_version = UINT64_MAX};
+        .batch_id = 9,
+        .last_seq = 1024,
+        .producer_view_version = std::numeric_limits<ViewVersionId>::max()};
 
     DurablePrefix out;
     std::string reason;
@@ -228,8 +231,8 @@ TEST(OpLogDurablePrefixCodecTest, IgnoresUnknownFields) {
 }
 
 TEST(OpLogDurablePrefixCodecTest, RejectsInvalidProducerViews) {
-    const std::vector<std::string> invalid_values = {R"("1")", "-1", "1.5",
-                                                     "18446744073709551616"};
+    const std::vector<std::string> invalid_values = {
+        R"("1")", "-1", "1.5", "9223372036854775808", "18446744073709551616"};
 
     for (const auto& invalid_value : invalid_values) {
         DurablePrefix prefix;

--- a/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
@@ -178,6 +178,84 @@ TEST(OpLogDurablePrefixCodecTest, RoundTripsNonZeroPrefix) {
     EXPECT_TRUE(reason.empty());
 }
 
+TEST(OpLogDurablePrefixCodecTest, PreservesLegacyEncodingWithoutProducerView) {
+    const std::string legacy =
+        R"({"batch_id":9,"last_seq":1024,"schema_version":1})";
+
+    DurablePrefix prefix;
+    std::string reason;
+    ASSERT_TRUE(DecodeDurablePrefix(legacy, &prefix, &reason));
+    EXPECT_EQ(0u, prefix.producer_view_version);
+    EXPECT_EQ(legacy, EncodeDurablePrefix(prefix));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(OpLogDurablePrefixCodecTest, RoundTripsNonZeroProducerView) {
+    DurablePrefix in{
+        .batch_id = 9, .last_seq = 1024, .producer_view_version = UINT64_MAX};
+
+    DurablePrefix out;
+    std::string reason;
+    ASSERT_TRUE(DecodeDurablePrefix(EncodeDurablePrefix(in), &out, &reason));
+    EXPECT_EQ(in.producer_view_version, out.producer_view_version);
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(OpLogDurablePrefixCodecTest, OmitsExplicitZeroProducerViewOnReencode) {
+    const std::string with_explicit_zero =
+        R"({"batch_id":9,"last_seq":1024,"producer_view_version":0,"schema_version":1})";
+    const std::string without_view =
+        R"({"batch_id":9,"last_seq":1024,"schema_version":1})";
+
+    DurablePrefix prefix;
+    std::string reason;
+    ASSERT_TRUE(DecodeDurablePrefix(with_explicit_zero, &prefix, &reason));
+    EXPECT_EQ(0u, prefix.producer_view_version);
+    EXPECT_EQ(without_view, EncodeDurablePrefix(prefix));
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(OpLogDurablePrefixCodecTest, IgnoresUnknownFields) {
+    DurablePrefix prefix;
+    std::string reason;
+    ASSERT_TRUE(DecodeDurablePrefix(
+        R"({"batch_id":9,"last_seq":1024,"producer_view_version":7,"schema_version":1,"unknown":"ignored"})",
+        &prefix, &reason));
+    EXPECT_EQ(9u, prefix.batch_id);
+    EXPECT_EQ(1024u, prefix.last_seq);
+    EXPECT_EQ(7u, prefix.producer_view_version);
+    EXPECT_TRUE(reason.empty());
+}
+
+TEST(OpLogDurablePrefixCodecTest, RejectsInvalidProducerViews) {
+    const std::vector<std::string> invalid_values = {R"("1")", "-1", "1.5",
+                                                     "18446744073709551616"};
+
+    for (const auto& invalid_value : invalid_values) {
+        DurablePrefix prefix;
+        std::string reason;
+        const std::string encoded =
+            R"({"batch_id":9,"last_seq":1024,"producer_view_version":)" +
+            invalid_value + R"(,"schema_version":1})";
+        EXPECT_FALSE(DecodeDurablePrefix(encoded, &prefix, &reason))
+            << invalid_value;
+        EXPECT_FALSE(reason.empty()) << invalid_value;
+    }
+}
+
+TEST(OpLogDurablePrefixCodecTest, InvalidProducerViewLeavesOutputUnchanged) {
+    DurablePrefix prefix{
+        .batch_id = 11, .last_seq = 22, .producer_view_version = 33};
+    std::string reason;
+    EXPECT_FALSE(DecodeDurablePrefix(
+        R"({"batch_id":9,"last_seq":1024,"producer_view_version":"invalid","schema_version":1})",
+        &prefix, &reason));
+    EXPECT_EQ(11u, prefix.batch_id);
+    EXPECT_EQ(22u, prefix.last_seq);
+    EXPECT_EQ(33u, prefix.producer_view_version);
+    EXPECT_FALSE(reason.empty());
+}
+
 TEST(OpLogDurablePrefixCodecTest, RejectsMalformedPayload) {
     DurablePrefix out;
     std::string reason;

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -169,6 +169,20 @@ TEST(OpLogBatchStorageTest, InitializesEmptyNamespaceAtZero) {
     EXPECT_EQ(prefix.last_seq, stored.last_seq);
 }
 
+TEST(OpLogBatchStorageTest, AcceptsNonzeroViewAtEmptyBoundary) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 0,
+                                               .last_seq = 0,
+                                               .producer_view_version = 7})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
+    EXPECT_EQ(7u, prefix.producer_view_version);
+}
+
 TEST(OpLogBatchStorageTest, RejectsLegacyLatest) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/latest", "42"));
@@ -379,6 +393,58 @@ TEST(OpLogBatchStorageTest, WriteBatchAndAdvancePrefixCommitsAtomically) {
     EXPECT_EQ(5u, prefix.last_seq);
 }
 
+TEST(OpLogBatchStorageTest, PreservesProducerViewWhenAdvancingPrefix) {
+    FakeHaKvBackend backend;
+    const DurablePrefix expected_prefix{
+        .batch_id = 1, .last_seq = 3, .producer_view_version = 7};
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/durable_prefix",
+                                         EncodeDurablePrefix(expected_prefix)));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    auto batch = MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2);
+    ASSERT_EQ(ErrorCode::OK,
+              storage.WriteBatchAndAdvancePrefix(batch, expected_prefix));
+
+    std::string encoded_prefix;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Get("/oplog/clusterA/durable_prefix", encoded_prefix));
+    DurablePrefix prefix;
+    ASSERT_TRUE(DecodeDurablePrefix(encoded_prefix, &prefix));
+    EXPECT_EQ(2u, prefix.batch_id);
+    EXPECT_EQ(5u, prefix.last_seq);
+    EXPECT_EQ(7u, prefix.producer_view_version);
+}
+
+TEST(OpLogBatchStorageTest, ExplicitZeroProducerViewCanAdvancePrefix) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000001",
+                          EncodeOpLogBatchRecord(MakeBatch(
+                              /*batch_id=*/1, /*first_seq=*/1, /*count=*/3))));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put(
+            "/oplog/clusterA/durable_prefix",
+            R"({"schema_version":1,"batch_id":1,"last_seq":3,"producer_view_version":0})"));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    ASSERT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
+    ASSERT_EQ(0u, prefix.producer_view_version);
+    ASSERT_EQ(
+        ErrorCode::OK,
+        storage.WriteBatchAndAdvancePrefix(
+            MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2), prefix));
+
+    std::string encoded_prefix;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Get("/oplog/clusterA/durable_prefix", encoded_prefix));
+    ASSERT_TRUE(DecodeDurablePrefix(encoded_prefix, &prefix));
+    EXPECT_EQ(2u, prefix.batch_id);
+    EXPECT_EQ(5u, prefix.last_seq);
+    EXPECT_EQ(0u, prefix.producer_view_version);
+}
+
 TEST(OpLogBatchStorageTest, CompareFailureDoesNotWriteBatchOrAdvancePrefix) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
@@ -416,6 +482,27 @@ TEST(OpLogBatchStorageTest, CompareFailureIsOkWhenTargetBatchAlreadyDurable) {
 
     EXPECT_EQ(ErrorCode::OK, storage.WriteBatchAndAdvancePrefix(
                                  batch, {.batch_id = 1, .last_seq = 3}));
+}
+
+TEST(OpLogBatchStorageTest,
+     CompareFailureWithDifferentProducerViewIsNotIdempotentSuccess) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 2,
+                                               .last_seq = 5,
+                                               .producer_view_version = 8})));
+    auto batch = MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2);
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/batches/00000000000000000002",
+                          EncodeOpLogBatchRecord(batch)));
+    backend.FailNextTxn(ErrorCode::ETCD_TRANSACTION_FAIL);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(
+        ErrorCode::ETCD_TRANSACTION_FAIL,
+        storage.WriteBatchAndAdvancePrefix(
+            batch, {.batch_id = 1, .last_seq = 3, .producer_view_version = 7}));
 }
 
 TEST(OpLogBatchStorageTest, RejectsSkippedBatchId) {

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -57,6 +57,16 @@ class FakeBatchWriter {
         return batches;
     }
 
+    std::vector<DurablePrefix> ExpectedPrefixes() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::vector<DurablePrefix> prefixes;
+        prefixes.reserve(writes_.size());
+        for (const auto& write : writes_) {
+            prefixes.push_back(write.expected_prefix);
+        }
+        return prefixes;
+    }
+
     bool WaitForWrites(size_t count, std::chrono::milliseconds timeout =
                                          std::chrono::milliseconds(1000)) {
         std::unique_lock<std::mutex> lock(mutex_);
@@ -586,6 +596,39 @@ TEST(OrderedOpLogWriterLoopTest, ContinuesFromInitialDurablePrefix) {
     EXPECT_EQ(8u, batches[0].batch_id);
     EXPECT_EQ(43u, batches[0].first_seq);
     EXPECT_EQ(43u, batches[0].last_seq);
+    writer.Stop();
+}
+
+TEST(OrderedOpLogWriterLoopTest, PreservesProducerViewAcrossBatches) {
+    FakeBatchWriter storage;
+    OrderedOpLogWriter writer(
+        OrderedOpLogWriterConfig{
+            .max_entries_per_batch = 1,
+            .initial_durable_prefix = {.producer_view_version = 7}},
+        [&](const OpLogBatchRecord& batch,
+            const DurablePrefix& expected_prefix) {
+            return storage.Write(batch, expected_prefix);
+        });
+    writer.Start();
+
+    auto first = writer.Reserve();
+    ASSERT_TRUE(first.has_value());
+    ASSERT_TRUE(
+        writer.Commit(std::move(*first), MakeEntry("k1"), [](const auto&) {})
+            .has_value());
+    ASSERT_TRUE(storage.WaitForWrites(1));
+
+    auto second = writer.Reserve();
+    ASSERT_TRUE(second.has_value());
+    ASSERT_TRUE(
+        writer.Commit(std::move(*second), MakeEntry("k2"), [](const auto&) {})
+            .has_value());
+    ASSERT_TRUE(storage.WaitForWrites(2));
+
+    const auto prefixes = storage.ExpectedPrefixes();
+    ASSERT_EQ(2u, prefixes.size());
+    EXPECT_EQ(7u, prefixes[0].producer_view_version);
+    EXPECT_EQ(7u, prefixes[1].producer_view_version);
     writer.Stop();
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked on #3165 and must not be merged before #3165.
> After #3165 is merged, this branch will be rebased onto the updated `main`.

## Description

This PR adds a backward-compatible producer view field to the durable oplog prefix.

- Add `producer_view_version` to `DurablePrefix` while keeping schema version 1.
- Preserve byte-identical legacy encoding when the producer view is zero.
- Validate producer view values during decoding and leave the output unchanged on decode failure.
- Carry the producer view across atomic batch and durable-prefix commits.
- Include the producer view in compare-failure idempotency checks.
- Support exact-value CAS for valid non-canonical prefixes, such as an explicitly encoded zero producer view.

This PR only introduces the format and storage semantics needed by later HA work. It does not claim producer views, fence stale writers, or switch the production writer.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target \
  oplog_batch_codec_test \
  oplog_batch_storage_test \
  oplog_batch_standby_reader_test \
  ordered_oplog_writer_test -j32

LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_codec_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_storage_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_standby_reader_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/ordered_oplog_writer_test
```

**Test results:**

- `oplog_batch_codec_test`: 34/34 passed
- `oplog_batch_storage_test`: 38/38 passed
- `oplog_batch_standby_reader_test`: 20/20 passed
- `ordered_oplog_writer_test`: 28/28 passed
- Pre-commit hooks passed for all files changed by this PR

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done

## Checklist

- [x] I have performed a self-review of every changed line
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

Codex was used to refine the design, implement the code and tests, investigate review findings, and run verification. The human submitter is responsible for reviewing and defending every changed line.