### PR TITLE
[TransferEngine] Reject peer segment descriptors with more keys than devices

### DIFF
--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -672,15 +672,20 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                 buffer.lkey.push_back(
                     static_cast<decltype(buffer.lkey)::value_type>(
                         lkeyJSON.asUInt64()));
+            // The same topology-derived device_id indexes both rkey and
+            // devices, and a publisher emits exactly one key per device, so a
+            // key vector longer than the device list lets that index run past
+            // the end of devices[]. See the comment in decodeSegmentDesc.
             if (buffer.name.empty() || !buffer.addr || !buffer.length ||
                 (!buffer.rkey.empty() &&
-                 buffer.rkey.size() != buffer.lkey.size())) {
+                 (buffer.rkey.size() != buffer.lkey.size() ||
+                  buffer.rkey.size() != desc->devices.size()))) {
                 LOG(WARNING)
                     << "Corrupted segment descriptor, name " << segment_name
                     << " buffer_protocol " << buffer_protocol << ", "
                     << buffer.name << ", " << buffer.addr << ", "
                     << buffer.length << ", " << buffer.rkey.size() << ", "
-                    << buffer.lkey.size();
+                    << buffer.lkey.size() << ", " << desc->devices.size();
                 return nullptr;
             }
             desc->buffers.push_back(buffer);
@@ -783,6 +788,19 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
             desc->devices.push_back(device);
         }
 
+        // rdma, efa and cxi pick a device with topology.selectDevice() and
+        // then use that one device_id to index both buffers[].rkey and
+        // devices[] (RdmaTransport::selectDevice / WorkerPool::selectPeerDevice
+        // and their efa/cxi counterparts). A publisher emits exactly one key
+        // per device, so a descriptor whose key vector is longer than its
+        // device list can drive device_id past the end of devices[]. barex is
+        // excluded: it hands the whole rkey vector to the peer rather than
+        // indexing it by device_id, and its key count comes from the mempool
+        // MR set rather than the device list.
+        const bool keys_indexed_by_device = desc->protocol == "rdma" ||
+                                            desc->protocol == "efa" ||
+                                            desc->protocol == "cxi";
+
         for (const auto &bufferJSON : segmentJSON["buffers"]) {
             BufferDesc buffer;
             buffer.name = bufferJSON["name"].asString();
@@ -798,12 +816,15 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                         lkeyJSON.asUInt64()));
             if (buffer.name.empty() || !buffer.addr || !buffer.length ||
                 (!buffer.rkey.empty() &&
-                 buffer.rkey.size() != buffer.lkey.size())) {
+                 (buffer.rkey.size() != buffer.lkey.size() ||
+                  (keys_indexed_by_device &&
+                   buffer.rkey.size() != desc->devices.size())))) {
                 LOG(WARNING)
                     << "Corrupted segment descriptor, name " << segment_name
                     << " protocol " << desc->protocol << ", " << buffer.name
                     << ", " << buffer.addr << ", " << buffer.length << ", "
-                    << buffer.rkey.size() << ", " << buffer.lkey.size();
+                    << buffer.rkey.size() << ", " << buffer.lkey.size() << ", "
+                    << desc->devices.size();
                 return nullptr;
             }
             desc->buffers.push_back(buffer);

--- a/mooncake-transfer-engine/src/transport/cxi_transport/cxi_context.cpp
+++ b/mooncake-transfer-engine/src/transport/cxi_transport/cxi_context.cpp
@@ -667,6 +667,20 @@ int CxiContext::submitPostSend(
             }
         }
 
+        // device_id comes from the peer-supplied topology, whose HCA list is
+        // independent of the peer 'devices' array, and selectDevice() bounds it
+        // against rkey only. decodeSegmentDesc() now rejects a descriptor whose
+        // key count and device count disagree; bound the value used to index
+        // devices[] locally as well.
+        if (static_cast<size_t>(device_id) >=
+            peer_segment_desc->devices.size()) {
+            LOG(ERROR) << "Peer device index out of range for target "
+                       << slice->target_id << ": device_id=" << device_id
+                       << " devices=" << peer_segment_desc->devices.size();
+            slice->markFailed();
+            continue;
+        }
+
         // no FI_VIRT_ADDR support on slingshot, must be offset of memory region
         slice->rdma.dest_addr -= peer_segment_desc->buffers[buffer_id].addr;
         slice->rdma.dest_rkey =

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -808,6 +808,20 @@ int EfaContext::submitPostSend(
             continue;
         }
 
+        // device_id comes from the peer-supplied topology, whose HCA list is
+        // independent of the peer 'devices' array, and selectDevice() bounds it
+        // against rkey only. decodeSegmentDesc() now rejects a descriptor whose
+        // key count and device count disagree; bound the value used to index
+        // devices[] locally as well.
+        if (static_cast<size_t>(device_id) >=
+            peer_segment_desc->devices.size()) {
+            LOG(ERROR) << "Peer device index out of range for target "
+                       << slice->target_id << ": device_id=" << device_id
+                       << " devices=" << peer_segment_desc->devices.size();
+            slice->markFailed();
+            continue;
+        }
+
         slice->rdma.dest_rkey =
             peer_segment_desc->buffers[buffer_id].rkey[device_id];
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -79,6 +79,19 @@ static int selectPeerDevice(RdmaTransport::SegmentDesc *peer_segment_desc,
                    << " addr=" << (void *)offset << " len=" << length;
         return ERR_ADDRESS_NOT_REGISTERED;
     }
+
+    // device_id comes from the peer-supplied topology, whose HCA list is
+    // independent of the peer 'devices' array, so bound it against that array
+    // too before the devices[device_id] accesses below. decodeSegmentDesc()
+    // now rejects a descriptor whose key count and device count disagree, which
+    // makes this check redundant for descriptors that arrived through the
+    // metadata path; it is kept as a local bound on the value actually used.
+    if (static_cast<size_t>(device_id) >= peer_segment_desc->devices.size()) {
+        LOG(ERROR) << "[RDMA] Peer device index out of range: seg="
+                   << peer_segment_desc->name << " device_id=" << device_id
+                   << " devices=" << peer_segment_desc->devices.size();
+        return ERR_ADDRESS_NOT_REGISTERED;
+    }
     return 0;
 }
 

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -347,6 +347,98 @@ TEST(TransferMetadataPublicationTest, PreservesLocalOnlyBufferWithoutRkey) {
     EXPECT_TRUE(remote_desc->buffers[1].rkey.empty());
 }
 
+// A peer descriptor whose key vector is longer than its device list lets the
+// topology-selected device_id pass the rkey bound in selectPeerDevice() and
+// still index devices[] out of bounds. Such a descriptor must be rejected at
+// decode time.
+TEST(TransferMetadataValidationTest, RejectsMoreKeysThanDevices) {
+    constexpr uint64_t kRemoteAddr = 0x1000;
+    constexpr size_t kKeyCount = 64;
+
+    TransferMetadata server(P2PHANDSHAKE);
+    TransferMetadata client(P2PHANDSHAKE);
+
+    int sockfd = -1;
+    const uint16_t port = findAvailableTcpPort(sockfd);
+    ASSERT_GT(port, 0);
+    const std::string remote_segment_name = "127.0.0.1:" + std::to_string(port);
+
+    auto server_desc = makeRdmaSegmentDesc(remote_segment_name, kRemoteAddr);
+    ASSERT_EQ(server_desc->devices.size(), 1u);
+    auto& buffer = server_desc->buffers[0];
+    while (buffer.rkey.size() < kKeyCount) {
+        buffer.lkey.push_back(1);
+        buffer.rkey.push_back(2);
+    }
+    ASSERT_EQ(server.addLocalSegment(LOCAL_SEGMENT_ID, remote_segment_name,
+                                     std::move(server_desc)),
+              0);
+
+    TransferMetadata::RpcMetaDesc rpc_desc;
+    rpc_desc.ip_or_host_name = "127.0.0.1";
+    rpc_desc.rpc_port = port;
+    rpc_desc.sockfd = sockfd;
+    ASSERT_EQ(server.addRpcMetaEntry(remote_segment_name, rpc_desc), 0);
+
+    ASSERT_EQ(
+        client.addLocalSegment(LOCAL_SEGMENT_ID, "127.0.0.1:0",
+                               makeRdmaSegmentDesc("127.0.0.1:0", 0x3000)),
+        0);
+
+    EXPECT_EQ(client.getSegmentID(remote_segment_name),
+              static_cast<TransferMetadata::SegmentID>(-1));
+}
+
+// The multi-NIC case a real publisher produces: one key per device. It must
+// still decode.
+TEST(TransferMetadataValidationTest, AcceptsOneKeyPerDevice) {
+    constexpr uint64_t kRemoteAddr = 0x1000;
+    constexpr size_t kDeviceCount = 4;
+
+    TransferMetadata server(P2PHANDSHAKE);
+    TransferMetadata client(P2PHANDSHAKE);
+
+    int sockfd = -1;
+    const uint16_t port = findAvailableTcpPort(sockfd);
+    ASSERT_GT(port, 0);
+    const std::string remote_segment_name = "127.0.0.1:" + std::to_string(port);
+
+    auto server_desc = makeRdmaSegmentDesc(remote_segment_name, kRemoteAddr);
+    auto& buffer = server_desc->buffers[0];
+    while (server_desc->devices.size() < kDeviceCount) {
+        TransferMetadata::DeviceDesc device_desc;
+        device_desc.name =
+            "mlx5_" + std::to_string(server_desc->devices.size());
+        device_desc.lid = 1;
+        device_desc.gid = "00000000000000000000ffff7f000001";
+        server_desc->devices.push_back(device_desc);
+        buffer.lkey.push_back(1);
+        buffer.rkey.push_back(2);
+    }
+    ASSERT_EQ(buffer.rkey.size(), kDeviceCount);
+    ASSERT_EQ(server.addLocalSegment(LOCAL_SEGMENT_ID, remote_segment_name,
+                                     std::move(server_desc)),
+              0);
+
+    TransferMetadata::RpcMetaDesc rpc_desc;
+    rpc_desc.ip_or_host_name = "127.0.0.1";
+    rpc_desc.rpc_port = port;
+    rpc_desc.sockfd = sockfd;
+    ASSERT_EQ(server.addRpcMetaEntry(remote_segment_name, rpc_desc), 0);
+
+    ASSERT_EQ(
+        client.addLocalSegment(LOCAL_SEGMENT_ID, "127.0.0.1:0",
+                               makeRdmaSegmentDesc("127.0.0.1:0", 0x3000)),
+        0);
+
+    const auto segment_id = client.getSegmentID(remote_segment_name);
+    ASSERT_NE(segment_id, static_cast<TransferMetadata::SegmentID>(-1));
+    auto remote_desc = client.getSegmentDescByID(segment_id, true);
+    ASSERT_NE(remote_desc, nullptr);
+    EXPECT_EQ(remote_desc->devices.size(), kDeviceCount);
+    EXPECT_EQ(remote_desc->buffers[0].rkey.size(), kDeviceCount);
+}
+
 TEST(HandshakeFrameTest, ValidFrameRoundTrips) {
     int fds[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);


### PR DESCRIPTION
## Description

A peer segment descriptor carries `devices[]`, `buffers[].rkey[]` and `priority_matrix` as three independent fields, and `decodeSegmentDesc()` never checks them against each other. The rdma, efa and cxi transports pick a device with `Topology::selectDevice()`, whose HCA list is built from the distinct HCA names in that `priority_matrix`, and use the resulting `device_id` to index both `buffers[buffer_id].rkey` and `devices[]`. Its range is therefore decoupled from `devices.size()`.

A descriptor with a short `devices` array, a longer `rkey` vector and many distinct HCAs drives `device_id` past the end of `devices[]`. The rkey bound (in `WorkerPool::selectPeerDevice` for rdma, inside `selectDevice` itself for efa and cxi) still passes, and the subsequent `devices[device_id].name` accesses read a `DeviceDesc` out of bounds and copy a wild `std::string`. In the RDMA transport those are `worker_pool.cpp:216` and `:256`, running in a transfer worker thread with no enclosing try/catch, so the resulting SIGSEGV is an uncaught process crash.

This change:

- Requires `rkey.size() == devices.size()` for a non-empty rkey vector in `decodeSegmentDesc()`, on both the single-protocol and multi-protocol paths. A publisher emits exactly one key per device (one per context in `context_list_`), so this extends the existing rkey/lkey consistency check, rejects the malformed peer once at decode time instead of per-slice, and covers all three transports. barex is excluded because it hands the whole rkey vector to the peer rather than indexing it by `device_id`, and its key count comes from the mempool MR set rather than the device list. Buffers with an empty rkey (registered local-only) stay valid.
- Keeps a `device_id < devices.size()` bound as defense in depth on the value actually used to index the array, in all three submit paths: `WorkerPool::selectPeerDevice()` for rdma, and the per-slice resolve loops in `efa_context.cpp` and `cxi_context.cpp`.
- Adds two tests over the real decode path: a peer publishing 64 keys for 1 device is rejected, and a well-formed 4-key/4-device descriptor still resolves.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two new unit tests in `transfer_metadata_test.cpp` exercise the real P2P-handshake decode path:

- `TransferMetadataValidationTest.RejectsMoreKeysThanDevices` — a peer descriptor with 64 keys and 1 device is rejected at decode time (`getSegmentID` returns -1).
- `TransferMetadataValidationTest.AcceptsOneKeyPerDevice` — the legitimate multi-NIC shape (4 devices, 4 keys) still decodes, with device and key counts preserved.

**Test commands:**
```bash
cmake --build build --target transfer_metadata_test
./build/mooncake-transfer-engine/tests/transfer_metadata_test
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted with reviewing the change and drafting this PR description. The human submitter is responsible for understanding and defending all changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)