### PR TITLE
[CI] Fix nightly Go path and gate publishing on tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -116,7 +116,7 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   publish-testpypi:
-    needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86]
+    needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, nightly-test]
     if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
     runs-on: ubuntu-22.04
     environment: nightly
@@ -217,6 +217,7 @@ jobs:
         run: |
           sudo apt update -y
           sudo bash -x dependencies.sh -y
+          echo "/usr/local/go/bin" >> "$GITHUB_PATH"
           mkdir build && cd build
           cmake -G Ninja .. \
             -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_UB=ON -DUSE_ETCD=ON -DUSE_CUDA=ON \


### PR DESCRIPTION
## Description

Fix the nightly workflow failure from [run 30561954622](https://github.com/kvcache-ai/Mooncake/actions/runs/30561954622/job/90936998409) and prevent untested nightly wheels from being published.

- Export `/usr/local/go/bin` through `GITHUB_PATH` after `dependencies.sh` installs Go, so the separate build step can compile `libetcd_wrapper.so`.
- Make `publish-testpypi` depend on `nightly-test`, so failed or cancelled tests skip publishing.

The build failed because `dependencies.sh` adds Go only to `~/.bashrc`, while subsequent GitHub Actions steps do not source that file. The reusable wheel workflow already uses the same `GITHUB_PATH` propagation and succeeded in the failing nightly run.

Related work: #3137 also touches the nightly wheel matrix, but does not change the Go toolchain path or gate TestPyPI publishing on `nightly-test`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/nightly.yml
bash -n scripts/ci/run_store_go_integration.sh scripts/ci/run_store_rust_smoke.sh scripts/run_tests.sh scripts/build_wheel.sh
git diff --check
```

**Test results:**
- [ ] Unit tests pass (not applicable to this workflow-only change)
- [ ] Integration tests pass (requires the GitHub-hosted nightly environment)
- [x] Manual testing done: reviewed the workflow dependency graph and verified the Go path export precedes the separate build step
- Targeted pre-commit hooks passed, including YAML validation.
- A full nightly build was not run locally.
- `actionlint` was unavailable; an attempted temporary download was blocked by GitHub release-assets returning HTTP 403.

## Checklist

- [ ] I have performed a human self-review of every changed line before marking this draft ready
- [x] I have formatted my code using `./scripts/code_format.sh` (not applicable to YAML; targeted pre-commit passed)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (touched-file run passed)
- [x] I have updated the documentation (not applicable; CI-only behavior)
- [ ] I have added tests to prove my changes are effective (workflow behavior requires a remote run)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 3 changed lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex inspected the failing Actions run and related workflows, implemented the scoped YAML fixes, ran targeted validation, and prepared this draft PR. The human submitter must review every changed line and be able to defend the change end-to-end before marking it ready.