### PR TITLE
[Store][TE] fabric_mem best-effort alloc via percentile ladder

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -49,6 +49,9 @@
 #ifdef USE_INTRA_NVLINK
 #include "gpu_vendor/intra_nvlink.h"
 #endif
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+#include "ascend_allocator.h"
+#endif
 
 DEFINE_bool(enable_http_server, false,
             "Enable embedded HTTP server for health check and metrics.");
@@ -854,9 +857,6 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         while (global_segment_size > 0) {
             size_t segment_size = std::min(global_segment_size, max_mr_size);
             global_segment_size -= segment_size;
-            current_glbseg_size += segment_size;
-            LOG(INFO) << "Mounting segment: " << segment_size << " bytes, "
-                      << current_glbseg_size << " of " << total_glbseg_size;
 
             size_t mapped_size = segment_size;
             void *ptr = nullptr;
@@ -878,6 +878,16 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 ptr = allocate_buffer_mmap_memory(mapped_size,
                                                   get_hugepage_size_from_env(),
                                                   parallel_hugetlb_population);
+#if defined(USE_ASCEND_DIRECT) || defined(USE_UBSHMEM)
+            } else if ((protocol == "ascend" || protocol == "ubshmem") &&
+                       globalConfig().ascend_use_fabric_mem) {
+                size_t actual_size = 0;
+                ptr = ascend_allocate_memory_best_effort(
+                    segment_size, this->protocol, &actual_size);
+                if (ptr) {
+                    mapped_size = actual_size;
+                }
+#endif
             } else {
                 ptr = allocate_buffer_allocator_memory(segment_size,
                                                        this->protocol);
@@ -887,6 +897,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 LOG(ERROR) << "Failed to allocate segment memory";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
             }
+            current_glbseg_size += mapped_size;
+            LOG(INFO) << "Mounting segment: " << mapped_size << " bytes, "
+                      << current_glbseg_size << " of " << total_glbseg_size;
+
             if (this->protocol == "ascend" || this->protocol == "ubshmem") {
                 ascend_segment_ptrs_.emplace_back(
                     ptr, AscendSegmentDeleter{this->protocol});

--- a/mooncake-transfer-engine/include/ascend_allocator.h
+++ b/mooncake-transfer-engine/include/ascend_allocator.h
@@ -9,6 +9,13 @@
 namespace mooncake {
 void* ascend_allocate_memory(size_t total_size, const std::string& protocol);
 
+// Fabric-mem best-effort: try 100%/90%/.../50% of target (1G-aligned).
+// Sets *actual_size on success; returns nullptr if 50% also fails.
+// Non-fabric paths fall back to exact-size ascend_allocate_memory.
+void* ascend_allocate_memory_best_effort(size_t target_size,
+                                         const std::string& protocol,
+                                         size_t* actual_size);
+
 void ascend_free_memory(const std::string& protocol, void* ptr);
 
 // Check if [addr, addr+length) overlaps with any store memory range.

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_allocator.cpp
@@ -4,91 +4,21 @@
 #include <vector>
 
 #include <glog/logging.h>
+#include "ascend_allocator.h"
 #include "config.h"
 #include "acl/acl.h"
 #include "transport/ascend_transport/ascend_direct_transport/adxl_compat.h"
 
 namespace mooncake {
 namespace {
-constexpr size_t kFabricMemPageSize = 1024 * 1024 * 1024;  // 1G
-#ifdef ASCEND_SUPPORT_FABRIC_MEM
-struct AllocRecord {
-    aclrtDrvMemHandle handle;
-    bool is_direct_alloc;
-};
-std::mutex g_vmm_alloc_mutex;
-std::unordered_map<void *, AllocRecord> g_vmm_alloc_records;
+constexpr size_t kFabricMemPageSize = 1024ULL * 1024 * 1024;  // 1G
+constexpr int kBestEffortStartPercent = 100;
+constexpr int kBestEffortMinPercent = 50;
+constexpr int kBestEffortPercentStep = 10;
 
-int allocate_physical_memory(size_t total_size, aclrtDrvMemHandle &handle) {
-    int32_t user_dev_id;
-    auto ret = aclrtGetDevice(&user_dev_id);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "Failed to get device: " << ret;
-        return -1;
-    }
-    int32_t physical_dev_id;
-    ret = aclrtGetPhyDevIdByLogicDevId(user_dev_id, &physical_dev_id);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "Failed to get physical dev id: " << ret;
-        return -1;
-    }
-    aclrtPhysicalMemProp prop = {};
-    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
-    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
-    prop.memAttr = ACL_MEM_P2P_HUGE1G;
-    prop.location.type = ACL_MEM_LOCATION_TYPE_HOST_NUMA;
-    // Only 0 2 4 6 is available for fabric mem, map 4 device to one numa.
-    const int32_t kDevicesPerChip = 4;
-    const int32_t kNumaNodeStep = 2;
-    prop.location.id = (physical_dev_id / kDevicesPerChip) * kNumaNodeStep;
-    prop.reserve = 0;
-    LOG(INFO) << "Malloc host memory for numa:" << prop.location.id;
-    ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(INFO) << "Malloc host memory for numa:" << prop.location.id
-                  << " failed, try common allocate instead.";
-        prop.location.type = ACL_MEM_LOCATION_TYPE_HOST;
-        prop.location.id = 0;
-        ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
-        if (ret != ACL_ERROR_NONE) {
-            LOG(INFO) << "Malloc failed, try smaller page instead.";
-            prop.memAttr = ACL_MEM_P2P_HUGE;
-            ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
-            if (ret != ACL_ERROR_NONE) {
-                LOG(ERROR) << "Failed to allocate memory: " << ret;
-                return -1;
-            }
-        }
-    }
-    return 0;
+size_t align_down_1g(size_t n) {
+    return (n / kFabricMemPageSize) * kFabricMemPageSize;
 }
-
-// Direct ACL VMM allocation (always bypasses adxl MallocMem).
-// Used by shm_helper when ascend_agent_mode && ascend_use_fabric_mem.
-void *allocate_vmm_memory_direct_impl(size_t total_size) {
-    aclrtDrvMemHandle handle = nullptr;
-    if (allocate_physical_memory(total_size, handle) != 0) {
-        return nullptr;
-    }
-    void *va = nullptr;
-    auto ret = aclrtReserveMemAddress(&va, total_size, 0, nullptr, 1);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "Failed to reserve memory: " << ret;
-        (void)aclrtFreePhysical(handle);
-        return nullptr;
-    }
-    ret = aclrtMapMem(va, total_size, 0, handle, 0);
-    if (ret != ACL_ERROR_NONE) {
-        LOG(ERROR) << "Failed to map memory: " << ret;
-        (void)aclrtReleaseMemAddress(va);
-        (void)aclrtFreePhysical(handle);
-        return nullptr;
-    }
-    std::lock_guard<std::mutex> lock(g_vmm_alloc_mutex);
-    g_vmm_alloc_records.emplace(va, AllocRecord{handle, true});
-    return va;
-}
-#endif
 
 struct StoreMemRange {
     void *base;
@@ -104,6 +34,132 @@ void remove_store_memory_range(void *ptr) {
         [ptr](const StoreMemRange &range) { return range.base == ptr; });
     g_store_mem_ranges.erase(it, g_store_mem_ranges.end());
 }
+
+#ifdef ASCEND_SUPPORT_FABRIC_MEM
+struct AllocRecord {
+    aclrtDrvMemHandle handle;
+    bool is_direct_alloc;
+};
+std::mutex g_vmm_alloc_mutex;
+std::unordered_map<void *, AllocRecord> g_vmm_alloc_records;
+
+int allocate_physical_memory(size_t total_size, aclrtDrvMemHandle &handle,
+                             bool quiet) {
+    int32_t user_dev_id;
+    auto ret = aclrtGetDevice(&user_dev_id);
+    if (ret != ACL_ERROR_NONE) {
+        if (!quiet) {
+            LOG(ERROR) << "Failed to get device: " << ret;
+        }
+        return -1;
+    }
+    int32_t physical_dev_id;
+    ret = aclrtGetPhyDevIdByLogicDevId(user_dev_id, &physical_dev_id);
+    if (ret != ACL_ERROR_NONE) {
+        if (!quiet) {
+            LOG(ERROR) << "Failed to get physical dev id: " << ret;
+        }
+        return -1;
+    }
+    aclrtPhysicalMemProp prop = {};
+    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
+    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
+    prop.memAttr = ACL_MEM_P2P_HUGE1G;
+    prop.location.type = ACL_MEM_LOCATION_TYPE_HOST_NUMA;
+    // Only 0 2 4 6 is available for fabric mem, map 4 device to one numa.
+    const int32_t kDevicesPerChip = 4;
+    const int32_t kNumaNodeStep = 2;
+    prop.location.id = (physical_dev_id / kDevicesPerChip) * kNumaNodeStep;
+    prop.reserve = 0;
+    if (!quiet) {
+        LOG(INFO) << "Malloc host memory for numa:" << prop.location.id;
+    }
+    ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
+    if (ret != ACL_ERROR_NONE) {
+        if (!quiet) {
+            LOG(INFO) << "Malloc host memory for numa:" << prop.location.id
+                      << " failed, try common allocate instead.";
+        }
+        prop.location.type = ACL_MEM_LOCATION_TYPE_HOST;
+        prop.location.id = 0;
+        ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
+        if (ret != ACL_ERROR_NONE) {
+            if (!quiet) {
+                LOG(INFO) << "Malloc failed, try smaller page instead.";
+            }
+            prop.memAttr = ACL_MEM_P2P_HUGE;
+            ret = aclrtMallocPhysical(&handle, total_size, &prop, 0);
+            if (ret != ACL_ERROR_NONE) {
+                if (!quiet) {
+                    LOG(ERROR) << "Failed to allocate memory: " << ret;
+                }
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
+
+// Direct ACL VMM allocation (always bypasses adxl MallocMem).
+// Used by shm_helper when ascend_agent_mode && ascend_use_fabric_mem.
+void *allocate_vmm_memory_direct_impl(size_t total_size, bool quiet = false) {
+    aclrtDrvMemHandle handle = nullptr;
+    if (allocate_physical_memory(total_size, handle, quiet) != 0) {
+        return nullptr;
+    }
+    void *va = nullptr;
+    auto ret = aclrtReserveMemAddress(&va, total_size, 0, nullptr, 1);
+    if (ret != ACL_ERROR_NONE) {
+        if (!quiet) {
+            LOG(ERROR) << "Failed to reserve memory: " << ret;
+        }
+        (void)aclrtFreePhysical(handle);
+        return nullptr;
+    }
+    ret = aclrtMapMem(va, total_size, 0, handle, 0);
+    if (ret != ACL_ERROR_NONE) {
+        if (!quiet) {
+            LOG(ERROR) << "Failed to map memory: " << ret;
+        }
+        (void)aclrtReleaseMemAddress(va);
+        (void)aclrtFreePhysical(handle);
+        return nullptr;
+    }
+    std::lock_guard<std::mutex> lock(g_vmm_alloc_mutex);
+    g_vmm_alloc_records.emplace(va, AllocRecord{handle, true});
+    return va;
+}
+
+// Exact-size fabric alloc: use adxl when the weak symbol is present; otherwise
+// direct VMM. Matches original ascend_allocate_memory behavior — adxl failure
+// does not fall back to direct VMM. When quiet=true, skip failure ERROR logs
+// (used by best-effort percentile probes).
+void *allocate_fabric_exact(size_t total_size, bool quiet = false) {
+    void *va = nullptr;
+    if (&adxl::AdxlEngine::MallocMem != nullptr) {
+        auto status = adxl::AdxlEngine::MallocMem(adxl::MemType::MEM_HOST,
+                                                  total_size, &va);
+        if (status != adxl::SUCCESS) {
+            if (!quiet) {
+                LOG(ERROR) << "Failed to allocate fabric memory, errmsg: "
+                           << aclGetRecentErrMsg();
+            }
+            return nullptr;
+        }
+        LOG(INFO) << "Call adxl MallocMem suc, va:" << va
+                  << ", size:" << total_size;
+        std::lock_guard<std::mutex> lock(g_vmm_alloc_mutex);
+        g_vmm_alloc_records.emplace(va, AllocRecord{nullptr, false});
+        return va;
+    }
+    va = allocate_vmm_memory_direct_impl(total_size, quiet);
+    if (va) {
+        std::lock_guard<std::mutex> store_lock(g_store_mem_mutex);
+        g_store_mem_ranges.push_back({va, total_size});
+    }
+    return va;
+}
+#endif
 }  // namespace
 
 void *ascend_allocate_vmm_memory_direct(size_t total_size) {
@@ -131,31 +187,13 @@ aclrtDrvMemHandle ascend_get_physical_handle_from_va(void *va) {
 
 void *ascend_allocate_memory(size_t total_size, const std::string &protocol) {
     if (globalConfig().ascend_use_fabric_mem) {
-        void *va = nullptr;
 #ifdef ASCEND_SUPPORT_FABRIC_MEM
-        if (&adxl::AdxlEngine::MallocMem != nullptr) {
-            // Try to use adxl_engine's MallocMem
-            auto status = adxl::AdxlEngine::MallocMem(adxl::MemType::MEM_HOST,
-                                                      total_size, &va);
-            if (status != adxl::SUCCESS) {
-                LOG(ERROR) << "Failed to allocate fabric memory, errmsg: "
-                           << aclGetRecentErrMsg();
-                return nullptr;
-            }
-            LOG(INFO) << "Call adxl MallocMem suc, va:" << va;
-            std::lock_guard<std::mutex> lock(g_vmm_alloc_mutex);
-            g_vmm_alloc_records.emplace(va, AllocRecord{nullptr, false});
-            return va;
-        }
-        va = allocate_vmm_memory_direct_impl(total_size);
-        if (va) {
-            std::lock_guard<std::mutex> store_lock(g_store_mem_mutex);
-            g_store_mem_ranges.push_back({va, total_size});
-        }
-        return va;
+        return allocate_fabric_exact(total_size);
 #else
+        (void)total_size;
         LOG(ERROR) << "Fabric mem mode is not supported, please upgrade Ascend "
                       "HDK and CANN.";
+        return nullptr;
 #endif
     }
     if (protocol == "ubshmem") {
@@ -176,6 +214,64 @@ void *ascend_allocate_memory(size_t total_size, const std::string &protocol) {
         g_store_mem_ranges.push_back({buffer, total_size});
     }
     return buffer;
+}
+
+void *ascend_allocate_memory_best_effort(size_t target_size,
+                                         const std::string &protocol,
+                                         size_t *actual_size) {
+    if (actual_size == nullptr) {
+        LOG(ERROR) << "ascend_allocate_memory_best_effort: actual_size is null";
+        return nullptr;
+    }
+    *actual_size = 0;
+
+    if (!globalConfig().ascend_use_fabric_mem) {
+        void *ptr = ascend_allocate_memory(target_size, protocol);
+        if (ptr) {
+            *actual_size = target_size;
+        }
+        return ptr;
+    }
+
+#ifdef ASCEND_SUPPORT_FABRIC_MEM
+    (void)protocol;
+    // Try 100%, 90%, ... down to 50% of configured size (1G-aligned).
+    // Skip candidates that fall below the unaligned 50% floor after round-down
+    // (e.g. 2.1 GiB target → 50% is 1.05 GiB → 1 GiB must not be accepted).
+    // Probe attempts are quiet; only the final failure logs ERROR.
+    const size_t min_size =
+        target_size * static_cast<size_t>(kBestEffortMinPercent) / 100;
+    size_t last_tried = 0;
+    for (int pct = kBestEffortStartPercent; pct >= kBestEffortMinPercent;
+         pct -= kBestEffortPercentStep) {
+        size_t sz =
+            (pct == kBestEffortStartPercent)
+                ? align_down_1g(target_size)
+                : align_down_1g(target_size * static_cast<size_t>(pct) / 100);
+        if (sz == 0 || sz < min_size || sz == last_tried) {
+            continue;
+        }
+        last_tried = sz;
+        void *ptr = allocate_fabric_exact(sz, /*quiet=*/true);
+        if (ptr != nullptr) {
+            *actual_size = sz;
+            if (sz < target_size) {
+                LOG(WARNING) << "Fabric mem best-effort: target=" << target_size
+                             << ", actual=" << sz << " (" << pct << "%)";
+            }
+            return ptr;
+        }
+    }
+
+    LOG(ERROR) << "Fabric mem best-effort failed: cannot allocate at least "
+               << kBestEffortMinPercent << "% of target=" << target_size;
+    return nullptr;
+#else
+    (void)protocol;
+    LOG(ERROR) << "Fabric mem mode is not supported, please upgrade Ascend "
+                  "HDK and CANN.";
+    return nullptr;
+#endif
 }
 
 bool ascend_is_store_memory(void *addr, size_t length) {

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -54,6 +54,9 @@ static int g_set_device_call_count = 0;
 static std::set<int> g_set_device_ids;
 static std::map<const void*, aclrtMemLocation> g_memory_locations;
 static std::mutex g_acl_mutex;
+// 0 = no size limit; otherwise aclrtMallocPhysical fails when size > threshold.
+static size_t g_malloc_physical_max_success = 0;
+static int g_malloc_physical_call_count = 0;
 
 namespace mock_acl {
 void reset() {
@@ -67,6 +70,18 @@ void reset() {
     g_set_device_call_count = 0;
     g_set_device_ids.clear();
     g_memory_locations.clear();
+    g_malloc_physical_max_success = 0;
+    g_malloc_physical_call_count = 0;
+}
+
+void set_malloc_physical_max_success(size_t max_success) {
+    std::lock_guard<std::mutex> lock(g_acl_mutex);
+    g_malloc_physical_max_success = max_success;
+}
+
+int malloc_physical_call_count() {
+    std::lock_guard<std::mutex> lock(g_acl_mutex);
+    return g_malloc_physical_call_count;
 }
 
 void set_device_count(int count) {
@@ -256,9 +271,14 @@ aclError aclrtGetPhyDevIdByLogicDevId(int32_t logic_dev_id,
 
 aclError aclrtMallocPhysical(aclrtDrvMemHandle* handle, size_t size,
                              aclrtPhysicalMemProp* prop, uint32_t flags) {
-    (void)size;
     (void)prop;
     (void)flags;
+    std::lock_guard<std::mutex> lock(g_acl_mutex);
+    ++g_malloc_physical_call_count;
+    if (g_malloc_physical_max_success > 0 &&
+        size > g_malloc_physical_max_success) {
+        return ACL_ERROR_FAILURE;
+    }
     *handle = reinterpret_cast<aclrtDrvMemHandle>(malloc(1));
     return *handle ? ACL_ERROR_NONE : ACL_ERROR_FAILURE;
 }
@@ -268,7 +288,11 @@ aclError aclrtReserveMemAddress(void** va, size_t size, size_t alignment,
     (void)alignment;
     (void)hint_addr;
     (void)page_type;
-    *va = malloc(size);
+    // Stub VA only — do not malloc(size) (best-effort tests use multi-GB
+    // sizes).
+    (void)size;
+    constexpr size_t kStubVaBytes = 64;
+    *va = malloc(kStubVaBytes);
     return *va ? ACL_ERROR_NONE : ACL_ERROR_FAILURE;
 }
 
@@ -2001,6 +2025,85 @@ TEST_F(AscendDirectTransportTest,
 // -----------------------------------------------------------------------------
 // Roce mode detection (HCCL_INTRA_ROCE_ENABLE / ASCEND_GLOBAL_RESOURCE_CONFIG)
 // -----------------------------------------------------------------------------
+
+TEST(FabricMemBestEffortAllocTest, PercentileLadderFindsFeasibleSize) {
+    mock_acl::reset();
+    constexpr size_t kGiB = 1024ULL * 1024 * 1024;
+    constexpr size_t kTargetGiB = 40;
+    constexpr size_t kMaxOkGiB = 35;
+    constexpr size_t kExpectGiB = 32;  // 80% of 40GiB after 100%/90% fail
+    constexpr size_t kTarget = kTargetGiB * kGiB;
+    mock_acl::set_malloc_physical_max_success(kMaxOkGiB * kGiB);
+
+    globalConfig().ascend_use_fabric_mem = true;
+    size_t actual = 0;
+    void* ptr = ascend_allocate_memory_best_effort(kTarget, "ascend", &actual);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(actual, kExpectGiB * kGiB);
+    EXPECT_GT(mock_acl::malloc_physical_call_count(), 1);
+
+    ascend_free_memory("ascend", ptr);
+    globalConfig().ascend_use_fabric_mem = false;
+    mock_acl::reset();
+}
+
+TEST(FabricMemBestEffortAllocTest, BelowFiftyPercentReturnsNull) {
+    mock_acl::reset();
+    constexpr size_t kGiB = 1024ULL * 1024 * 1024;
+    constexpr size_t kTargetGiB = 40;
+    constexpr size_t kMaxOkGiB = 15;  // below 50% of 40GiB (=20GiB)
+    mock_acl::set_malloc_physical_max_success(kMaxOkGiB * kGiB);
+
+    globalConfig().ascend_use_fabric_mem = true;
+    size_t actual = 0;
+    void* ptr = ascend_allocate_memory_best_effort(kTargetGiB * kGiB, "ascend",
+                                                   &actual);
+    EXPECT_EQ(ptr, nullptr);
+    EXPECT_EQ(actual, 0);
+
+    globalConfig().ascend_use_fabric_mem = false;
+    mock_acl::reset();
+}
+
+// 2.1 GiB target: 50% = 1.05 GiB. Align-down of lower percentiles yields 1 GiB
+// (< 50%), which must be rejected even if physical alloc of 1 GiB would
+// succeed.
+TEST(FabricMemBestEffortAllocTest, AlignDownBelowMinPercentIsRejected) {
+    mock_acl::reset();
+    constexpr size_t kGiB = 1024ULL * 1024 * 1024;
+    constexpr size_t kTarget = (2 * kGiB) + (kGiB / 10);  // 2.1 GiB
+    mock_acl::set_malloc_physical_max_success(kGiB);  // 1 GiB ok, 2 GiB fails
+
+    globalConfig().ascend_use_fabric_mem = true;
+    size_t actual = 0;
+    void* ptr = ascend_allocate_memory_best_effort(kTarget, "ascend", &actual);
+    EXPECT_EQ(ptr, nullptr);
+    EXPECT_EQ(actual, 0);
+
+    globalConfig().ascend_use_fabric_mem = false;
+    mock_acl::reset();
+}
+
+TEST(FabricMemBestEffortAllocTest, FullTargetFirstSuccess) {
+    mock_acl::reset();
+    constexpr size_t kGiB = 1024ULL * 1024 * 1024;
+    constexpr size_t kTargetGiB = 40;
+    constexpr size_t kTarget = kTargetGiB * kGiB;
+    // Physical alloc is tried up to 3 attribute tiers per size.
+    constexpr int kMaxPhysicalTiersPerSize = 3;
+    mock_acl::set_malloc_physical_max_success(0);  // unlimited
+
+    globalConfig().ascend_use_fabric_mem = true;
+    size_t actual = 0;
+    void* ptr = ascend_allocate_memory_best_effort(kTarget, "ascend", &actual);
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_EQ(actual, kTarget);  // 100% first
+    EXPECT_LE(mock_acl::malloc_physical_call_count(), kMaxPhysicalTiersPerSize);
+
+    ascend_free_memory("ascend", ptr);
+    globalConfig().ascend_use_fabric_mem = false;
+    mock_acl::reset();
+}
 
 TEST(RoceModeDetectionTest, GlobalResourceConfig_StringRoceDesc) {
     EXPECT_TRUE(HasRoceProtocolDescInGlobalResourceConfig(


### PR DESCRIPTION
## Description

When Ascend Store mounts a fabric_mem segment (`ascend` / `ubshmem` + `ascend_use_fabric_mem`), allocation is now best-effort instead of hard-failing at the configured size.

- Try sizes on a percentile ladder: **100% → 90% → … → 50%** of the target, each attempt **1G-aligned**.
- On success with a smaller size, mount the **actual** allocated size and log a WARNING (`Fabric mem best-effort: target=..., actual=...`).
- Fail only if even 50% of the target cannot be allocated.
- Intermediate probe failures are quiet (no ERROR spam during retries).
- Exact-size fabric alloc keeps original semantics: prefer `adxl::MallocMem` when the weak symbol is present; **adxl failure does not fall back to direct VMM** (direct VMM only when the symbol is absent).
- No new config / env knobs; best-effort applies whenever the fabric_mem path is used.
- Non-Ascend builds: the best-effort call site is guarded by `USE_ASCEND_DIRECT` / `USE_UBSHMEM` so GPU/CPU-only CI stays clean.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Unit tests (Ascend / ACL mock path)
ctest -R ascend_direct_transport_test --output-on-failure

# Or focused gtest filter
./mooncake-transfer-engine/tests/ascend_direct_transport_test \
  --gtest_filter='FabricMemBestEffortAllocTest.*'
```

**Test results:**
- [x] Unit tests pass (`FabricMemBestEffortAllocTest`: percentile ladder / below 50% / full target)
- [x] Integration tests pass (if applicable) — CI Build & Test (Linux) green, including `ascend-test`, tent, arm64, Docker
- [x] Manual testing done (describe below)

Manual (optional on A3):
- Configure `global_segment_size` larger than available contiguous fabric mem → Store starts with WARNING and mounted capacity < configured
- With enough memory → 100% path succeeds (no shrink)
- With available fabric mem < 50% of configured → startup fails clearly

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor was used to implement the best-effort allocation ladder, wire Store mount to the actual size, add ACL-mock unit tests, and fix non-Ascend CI compile guards.
