### PR TITLE
[Store] Add Fast-Fail for Impossible OffsetAllocator Requests

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -3,6 +3,12 @@ add_executable(allocator_bench allocator_bench.cpp)
 target_link_libraries(allocator_bench PRIVATE cachelib_memory_allocator
                                               mooncake_store)
 
+# Add focused OffsetAllocator concurrency benchmark
+add_executable(offset_allocator_concurrency_bench
+               offset_allocator_concurrency_bench.cpp)
+target_link_libraries(offset_allocator_concurrency_bench
+                      PRIVATE mooncake_store gflags::gflags pthread)
+
 # Add master benchmark executable
 add_executable(master_bench master_bench.cpp)
 target_link_libraries(master_bench PRIVATE cachelib_memory_allocator

--- a/mooncake-store/benchmarks/offset_allocator_concurrency_bench.cpp
+++ b/mooncake-store/benchmarks/offset_allocator_concurrency_bench.cpp
@@ -1,0 +1,150 @@
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "offset_allocator/offset_allocator.h"
+
+DEFINE_uint32(threads, 16, "Number of allocator worker threads");
+DEFINE_uint64(iterations, 100000, "Operations per worker thread");
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+using mooncake::offset_allocator::OffsetAllocator;
+
+constexpr uint64_t kMiB = 1024ULL * 1024;
+constexpr uint64_t kPoolSize = 1024 * kMiB;
+constexpr uint64_t kHighWaterFillSize = 960 * kMiB;
+constexpr uint64_t kFailedRequestSize = 128 * kMiB;
+constexpr uint64_t kSuccessfulRequestSize = 4 * 1024;
+
+struct Result {
+    std::string name;
+    uint64_t operations;
+    uint64_t unexpected_results;
+    double seconds;
+    std::vector<uint64_t> latencies_ns;
+};
+
+template <typename Operation>
+Result runConcurrentBenchmark(const std::string& name, Operation operation) {
+    std::atomic<uint32_t> ready{0};
+    std::atomic<bool> start{false};
+    std::atomic<uint64_t> unexpected_results{0};
+    std::vector<std::vector<uint64_t>> per_thread_latencies(FLAGS_threads);
+    std::vector<std::thread> workers;
+    workers.reserve(FLAGS_threads);
+
+    for (uint32_t thread_index = 0; thread_index < FLAGS_threads;
+         ++thread_index) {
+        workers.emplace_back([&, thread_index] {
+            auto& latencies = per_thread_latencies[thread_index];
+            latencies.reserve(FLAGS_iterations);
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+
+            for (uint64_t i = 0; i < FLAGS_iterations; ++i) {
+                const auto begin = Clock::now();
+                if (!operation()) {
+                    unexpected_results.fetch_add(1, std::memory_order_relaxed);
+                }
+                const auto end = Clock::now();
+                latencies.push_back(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(end -
+                                                                         begin)
+                        .count());
+            }
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != FLAGS_threads) {
+        std::this_thread::yield();
+    }
+    const auto begin = Clock::now();
+    start.store(true, std::memory_order_release);
+    for (auto& worker : workers) {
+        worker.join();
+    }
+    const auto end = Clock::now();
+
+    Result result{
+        .name = name,
+        .operations = FLAGS_iterations * FLAGS_threads,
+        .unexpected_results =
+            unexpected_results.load(std::memory_order_relaxed),
+        .seconds = std::chrono::duration<double>(end - begin).count(),
+        .latencies_ns = {},
+    };
+    result.latencies_ns.reserve(result.operations);
+    for (auto& latencies : per_thread_latencies) {
+        result.latencies_ns.insert(result.latencies_ns.end(), latencies.begin(),
+                                   latencies.end());
+    }
+    return result;
+}
+
+uint64_t percentile(const std::vector<uint64_t>& values, double percentile) {
+    const size_t index = static_cast<size_t>(
+        percentile * static_cast<double>(values.size() - 1));
+    return values[index];
+}
+
+void printResult(Result result) {
+    std::sort(result.latencies_ns.begin(), result.latencies_ns.end());
+    const double qps = static_cast<double>(result.operations) / result.seconds;
+
+    std::cout << std::fixed << std::setprecision(2) << result.name
+              << ": operations=" << result.operations << ", qps=" << qps
+              << ", p50_ns=" << percentile(result.latencies_ns, 0.50)
+              << ", p99_ns=" << percentile(result.latencies_ns, 0.99)
+              << ", max_ns=" << result.latencies_ns.back()
+              << ", unexpected_results=" << result.unexpected_results
+              << std::endl;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    if (FLAGS_threads == 0 || FLAGS_iterations == 0) {
+        std::cerr << "threads and iterations must be greater than zero"
+                  << std::endl;
+        return 1;
+    }
+
+    auto high_water_allocator = OffsetAllocator::create(
+        0, kPoolSize, FLAGS_threads + 16, FLAGS_threads + 16);
+    auto high_water_fill = high_water_allocator->allocate(kHighWaterFillSize);
+    if (!high_water_fill.has_value()) {
+        std::cerr << "failed to prepare high-water allocator" << std::endl;
+        return 1;
+    }
+    std::cout << "threads=" << FLAGS_threads
+              << ", iterations_per_thread=" << FLAGS_iterations
+              << ", high_water_percent="
+              << 100.0 * static_cast<double>(kHighWaterFillSize) / kPoolSize
+              << ", largest_free_region="
+              << high_water_allocator->storageReport().largestFreeRegion
+              << ", failed_request_size=" << kFailedRequestSize << std::endl;
+
+    printResult(runConcurrentBenchmark("high_water_failed_allocate", [&] {
+        return !high_water_allocator->allocate(kFailedRequestSize).has_value();
+    }));
+
+    auto success_allocator = OffsetAllocator::create(
+        0, kPoolSize, FLAGS_threads + 16, FLAGS_threads + 16);
+    printResult(runConcurrentBenchmark("successful_allocate_free", [&] {
+        return success_allocator->allocate(kSuccessfulRequestSize).has_value();
+    }));
+    return 0;
+}

--- a/mooncake-store/benchmarks/offset_allocator_concurrency_bench.cpp
+++ b/mooncake-store/benchmarks/offset_allocator_concurrency_bench.cpp
@@ -1,41 +1,91 @@
+// Benchmarks allocator and PutStart allocation stages for concurrent puts to
+// one segment. QPS and latency use separate phases; RPC, metadata, and transfer
+// work are intentionally excluded.
+
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <iomanip>
 #include <iostream>
+#include <limits>
+#include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
 
 #include <gflags/gflags.h>
 
+#include "allocation_strategy.h"
+#include "allocator.h"
 #include "offset_allocator/offset_allocator.h"
 
-DEFINE_uint32(threads, 16, "Number of allocator worker threads");
-DEFINE_uint64(iterations, 100000, "Operations per worker thread");
+DEFINE_uint32(threads, 16, "Number of concurrent worker threads");
+DEFINE_uint64(iterations, 100000, "Measured operations per worker and phase");
+DEFINE_uint64(warmup_iterations, 1000,
+              "Warmup operations per worker before each measured phase");
+DEFINE_uint64(pool_size_mb, 1024, "Allocator capacity in MiB");
+DEFINE_double(high_water_ratio, 0.90,
+              "Used-space ratio for the capacity-exhaustion scenario");
+DEFINE_uint64(failed_request_mb, 128,
+              "Request size in MiB for expected-failure scenarios");
+DEFINE_uint64(success_request_kb, 4,
+              "Request size in KiB for the successful allocate/free scenario");
+DEFINE_uint64(fragmentation_block_mb, 4,
+              "Block size in MiB used to create deterministic fragmentation");
+DEFINE_uint32(fragmentation_stride, 5,
+              "Free every Nth block; 5 leaves approximately 80% used");
+DEFINE_double(mixed_failure_ratio, 0.05,
+              "Expected-failure ratio for the high-water mixed scenario");
+DEFINE_string(layer, "all",
+              "Benchmark layer: all, offset_allocator, or put_allocation");
+DEFINE_string(scenario, "all",
+              "Scenario: all, capacity, fragmentation, mixed, or success");
 
 namespace {
 
 using Clock = std::chrono::steady_clock;
+using mooncake::AllocatedBuffer;
+using mooncake::AllocatorManager;
+using mooncake::OffsetBufferAllocator;
+using mooncake::RandomAllocationStrategy;
+using mooncake::ReplicaType;
+using mooncake::offset_allocator::OffsetAllocationHandle;
 using mooncake::offset_allocator::OffsetAllocator;
+using mooncake::offset_allocator::OffsetAllocStorageReport;
 
-constexpr uint64_t kMiB = 1024ULL * 1024;
-constexpr uint64_t kPoolSize = 1024 * kMiB;
-constexpr uint64_t kHighWaterFillSize = 960 * kMiB;
-constexpr uint64_t kFailedRequestSize = 128 * kMiB;
-constexpr uint64_t kSuccessfulRequestSize = 4 * 1024;
+constexpr uint64_t kKiB = 1024;
+constexpr uint64_t kMiB = 1024 * kKiB;
+constexpr uint64_t kMixedPatternSize = 10000;
+constexpr uintptr_t kBenchmarkBaseAddress = 0x100000000ULL;
+constexpr char kSegmentName[] = "benchmark-segment";
 
-struct Result {
-    std::string name;
-    uint64_t operations;
-    uint64_t unexpected_results;
-    double seconds;
+struct PhaseResult {
+    uint64_t operations = 0;
+    uint64_t unexpected_results = 0;
+    double seconds = 0;
     std::vector<uint64_t> latencies_ns;
 };
 
+struct Result {
+    std::string layer;
+    std::string scenario;
+    uint64_t operations = 0;
+    uint64_t throughput_unexpected_results = 0;
+    uint64_t latency_unexpected_results = 0;
+    double seconds = 0;
+    std::vector<uint64_t> latencies_ns;
+    uint64_t capacity = 0;
+    uint64_t total_free_space = 0;
+    uint64_t largest_free_region = 0;
+    uint64_t request_size = 0;
+    uint64_t success_request_size = 0;
+    double expected_failure_ratio = 0;
+};
+
 template <typename Operation>
-Result runConcurrentBenchmark(const std::string& name, Operation operation) {
+PhaseResult runConcurrentPhase(Operation& operation, bool collect_latency) {
     std::atomic<uint32_t> ready{0};
     std::atomic<bool> start{false};
     std::atomic<uint64_t> unexpected_results{0};
@@ -47,22 +97,40 @@ Result runConcurrentBenchmark(const std::string& name, Operation operation) {
          ++thread_index) {
         workers.emplace_back([&, thread_index] {
             auto& latencies = per_thread_latencies[thread_index];
-            latencies.reserve(FLAGS_iterations);
+            if (collect_latency) {
+                latencies.reserve(FLAGS_iterations);
+            }
+
+            for (uint64_t i = 0; i < FLAGS_warmup_iterations; ++i) {
+                operation(thread_index, i);
+            }
+
             ready.fetch_add(1, std::memory_order_release);
             while (!start.load(std::memory_order_acquire)) {
                 std::this_thread::yield();
             }
 
-            for (uint64_t i = 0; i < FLAGS_iterations; ++i) {
-                const auto begin = Clock::now();
-                if (!operation()) {
-                    unexpected_results.fetch_add(1, std::memory_order_relaxed);
+            if (collect_latency) {
+                for (uint64_t i = 0; i < FLAGS_iterations; ++i) {
+                    const auto begin = Clock::now();
+                    const bool expected_result = operation(thread_index, i);
+                    const auto end = Clock::now();
+                    if (!expected_result) {
+                        unexpected_results.fetch_add(1,
+                                                     std::memory_order_relaxed);
+                    }
+                    latencies.push_back(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            end - begin)
+                            .count());
                 }
-                const auto end = Clock::now();
-                latencies.push_back(
-                    std::chrono::duration_cast<std::chrono::nanoseconds>(end -
-                                                                         begin)
-                        .count());
+            } else {
+                for (uint64_t i = 0; i < FLAGS_iterations; ++i) {
+                    if (!operation(thread_index, i)) {
+                        unexpected_results.fetch_add(1,
+                                                     std::memory_order_relaxed);
+                    }
+                }
             }
         });
     }
@@ -77,74 +145,362 @@ Result runConcurrentBenchmark(const std::string& name, Operation operation) {
     }
     const auto end = Clock::now();
 
-    Result result{
-        .name = name,
-        .operations = FLAGS_iterations * FLAGS_threads,
-        .unexpected_results =
-            unexpected_results.load(std::memory_order_relaxed),
-        .seconds = std::chrono::duration<double>(end - begin).count(),
-        .latencies_ns = {},
-    };
-    result.latencies_ns.reserve(result.operations);
-    for (auto& latencies : per_thread_latencies) {
-        result.latencies_ns.insert(result.latencies_ns.end(), latencies.begin(),
-                                   latencies.end());
+    PhaseResult result;
+    result.operations = FLAGS_iterations * FLAGS_threads;
+    result.unexpected_results =
+        unexpected_results.load(std::memory_order_relaxed);
+    result.seconds = std::chrono::duration<double>(end - begin).count();
+    if (collect_latency) {
+        result.latencies_ns.reserve(result.operations);
+        for (auto& latencies : per_thread_latencies) {
+            result.latencies_ns.insert(result.latencies_ns.end(),
+                                       latencies.begin(), latencies.end());
+        }
     }
     return result;
 }
 
-uint64_t percentile(const std::vector<uint64_t>& values, double percentile) {
-    const size_t index = static_cast<size_t>(
-        percentile * static_cast<double>(values.size() - 1));
+template <typename Operation>
+Result runConcurrentBenchmark(const std::string& layer,
+                              const std::string& scenario,
+                              const OffsetAllocStorageReport& report,
+                              uint64_t capacity, uint64_t request_size,
+                              uint64_t success_request_size,
+                              double expected_failure_ratio,
+                              Operation operation) {
+    auto throughput = runConcurrentPhase(operation, false);
+    auto latency = runConcurrentPhase(operation, true);
+
+    Result result;
+    result.layer = layer;
+    result.scenario = scenario;
+    result.operations = throughput.operations;
+    result.throughput_unexpected_results = throughput.unexpected_results;
+    result.latency_unexpected_results = latency.unexpected_results;
+    result.seconds = throughput.seconds;
+    result.latencies_ns = std::move(latency.latencies_ns);
+    result.capacity = capacity;
+    result.total_free_space = report.totalFreeSpace;
+    result.largest_free_region = report.largestFreeRegion;
+    result.request_size = request_size;
+    result.success_request_size = success_request_size;
+    result.expected_failure_ratio = expected_failure_ratio;
+    return result;
+}
+
+uint64_t percentile(const std::vector<uint64_t>& values, double quantile) {
+    const size_t index =
+        static_cast<size_t>(quantile * static_cast<double>(values.size() - 1));
     return values[index];
+}
+
+void printCsvHeader() {
+    std::cout
+        << "layer,scenario,threads,iterations_per_thread,operations,"
+           "throughput_seconds,qps,p50_ns,p99_ns,"
+           "throughput_unexpected_results,latency_unexpected_results,"
+           "capacity_bytes,used_percent,total_free_bytes,"
+           "largest_free_region_bytes,request_bytes,success_request_bytes,"
+           "expected_failure_ratio"
+        << std::endl;
 }
 
 void printResult(Result result) {
     std::sort(result.latencies_ns.begin(), result.latencies_ns.end());
     const double qps = static_cast<double>(result.operations) / result.seconds;
+    const double used_percent =
+        100.0 * static_cast<double>(result.capacity - result.total_free_space) /
+        static_cast<double>(result.capacity);
 
-    std::cout << std::fixed << std::setprecision(2) << result.name
-              << ": operations=" << result.operations << ", qps=" << qps
-              << ", p50_ns=" << percentile(result.latencies_ns, 0.50)
-              << ", p99_ns=" << percentile(result.latencies_ns, 0.99)
-              << ", max_ns=" << result.latencies_ns.back()
-              << ", unexpected_results=" << result.unexpected_results
-              << std::endl;
+    std::cout << result.layer << ',' << result.scenario << ',' << FLAGS_threads
+              << ',' << FLAGS_iterations << ',' << result.operations << ','
+              << std::fixed << std::setprecision(6) << result.seconds << ','
+              << std::setprecision(2) << qps << ','
+              << percentile(result.latencies_ns, 0.50) << ','
+              << percentile(result.latencies_ns, 0.99) << ','
+              << result.throughput_unexpected_results << ','
+              << result.latency_unexpected_results << ',' << result.capacity
+              << ',' << used_percent << ',' << result.total_free_space << ','
+              << result.largest_free_region << ',' << result.request_size << ','
+              << result.success_request_size << ','
+              << result.expected_failure_ratio << std::endl;
+}
+
+bool isSelected(const std::string& selected, const std::string& value) {
+    return selected == "all" || selected == value;
+}
+
+template <typename Allocation, typename Allocate>
+bool fillCapacityPressure(uint64_t capacity, double used_ratio,
+                          Allocate allocate, std::vector<Allocation>& held) {
+    auto allocation = allocate(
+        static_cast<uint64_t>(static_cast<double>(capacity) * used_ratio));
+    if (!allocation) {
+        return false;
+    }
+    held.emplace_back(std::move(allocation));
+    return true;
+}
+
+template <typename Allocation, typename Allocate>
+bool createFragmentation(uint64_t block_size, uint32_t stride,
+                         Allocate allocate, std::vector<Allocation>& held) {
+    while (auto allocation = allocate(block_size)) {
+        held.emplace_back(std::move(allocation));
+    }
+    if (held.size() < stride) {
+        return false;
+    }
+    for (size_t i = 0; i < held.size(); i += stride) {
+        held[i].reset();
+    }
+    return true;
+}
+
+class OffsetAllocatorFixture {
+   public:
+    OffsetAllocatorFixture(uint64_t capacity, uint64_t /* unused */)
+        : capacity_(capacity),
+          allocator_(OffsetAllocator::create(0, capacity)) {}
+
+    bool prepareCapacityPressure(double used_ratio) {
+        return fillCapacityPressure(
+            capacity_, used_ratio,
+            [&](uint64_t size) { return allocator_->allocate(size); }, held_);
+    }
+
+    bool prepareFragmentation(uint64_t block_size, uint32_t stride) {
+        return createFragmentation(
+            block_size, stride,
+            [&](uint64_t size) { return allocator_->allocate(size); }, held_);
+    }
+
+    bool expectAllocationFailure(uint64_t request_size) {
+        return !allocator_->allocate(request_size).has_value();
+    }
+
+    bool allocateAndFree(uint64_t request_size) {
+        return allocator_->allocate(request_size).has_value();
+    }
+
+    OffsetAllocStorageReport report() const {
+        return allocator_->storageReport();
+    }
+
+   private:
+    uint64_t capacity_;
+    std::shared_ptr<OffsetAllocator> allocator_;
+    std::vector<std::optional<OffsetAllocationHandle>> held_;
+};
+
+class PutAllocationFixture {
+   public:
+    PutAllocationFixture(uint64_t capacity, uint64_t /* unused */)
+        : capacity_(capacity),
+          allocator_(std::make_shared<OffsetBufferAllocator>(
+              kSegmentName, kBenchmarkBaseAddress, capacity,
+              "benchmark-endpoint", ReplicaType::MEMORY)) {
+        allocator_manager_.addAllocator(kSegmentName, allocator_);
+    }
+
+    bool prepareCapacityPressure(double used_ratio) {
+        return fillCapacityPressure(
+            capacity_, used_ratio,
+            [&](uint64_t size) { return allocator_->allocate(size); }, held_);
+    }
+
+    bool prepareFragmentation(uint64_t block_size, uint32_t stride) {
+        return createFragmentation(
+            block_size, stride,
+            [&](uint64_t size) { return allocator_->allocate(size); }, held_);
+    }
+
+    bool expectAllocationFailure(uint64_t request_size) {
+        auto result = strategy_.Allocate(allocator_manager_, request_size, 1);
+        return !result.has_value();
+    }
+
+    bool allocateAndFree(uint64_t request_size) {
+        auto result = strategy_.Allocate(allocator_manager_, request_size, 1);
+        return result.has_value();
+    }
+
+    OffsetAllocStorageReport report() const {
+        return allocator_->getOffsetAllocator()->storageReport();
+    }
+
+   private:
+    uint64_t capacity_;
+    std::shared_ptr<OffsetBufferAllocator> allocator_;
+    AllocatorManager allocator_manager_;
+    RandomAllocationStrategy strategy_;
+    std::vector<std::unique_ptr<AllocatedBuffer>> held_;
+};
+
+template <typename Fixture>
+bool runFixtureScenarios(const std::string& layer, uint64_t capacity,
+                         uint64_t failed_request_size,
+                         uint64_t success_request_size,
+                         uint64_t fragmentation_block_size) {
+    if (isSelected(FLAGS_scenario, "capacity")) {
+        Fixture fixture(capacity, fragmentation_block_size);
+        if (!fixture.prepareCapacityPressure(FLAGS_high_water_ratio)) {
+            std::cerr << "failed to prepare capacity-pressure fixture for "
+                      << layer << std::endl;
+            return false;
+        }
+        const auto report = fixture.report();
+        if (report.largestFreeRegion >= failed_request_size) {
+            std::cerr << "capacity scenario request must exceed the largest "
+                         "free region"
+                      << std::endl;
+            return false;
+        }
+        auto operation = [&](uint32_t, uint64_t) {
+            return fixture.expectAllocationFailure(failed_request_size);
+        };
+        printResult(runConcurrentBenchmark(layer, "capacity_failed", report,
+                                           capacity, failed_request_size, 0,
+                                           1.0, operation));
+    }
+
+    if (isSelected(FLAGS_scenario, "fragmentation")) {
+        Fixture fixture(capacity, fragmentation_block_size);
+        if (!fixture.prepareFragmentation(fragmentation_block_size,
+                                          FLAGS_fragmentation_stride)) {
+            std::cerr << "failed to prepare fragmented fixture for " << layer
+                      << std::endl;
+            return false;
+        }
+        const auto report = fixture.report();
+        if (report.totalFreeSpace < failed_request_size ||
+            report.largestFreeRegion >= failed_request_size) {
+            std::cerr << "fragmentation scenario requires total free space >= "
+                         "request size and largest free region < request size"
+                      << std::endl;
+            return false;
+        }
+        auto operation = [&](uint32_t, uint64_t) {
+            return fixture.expectAllocationFailure(failed_request_size);
+        };
+        printResult(runConcurrentBenchmark(
+            layer, "fragmentation_failed", report, capacity,
+            failed_request_size, 0, 1.0, operation));
+    }
+
+    if (isSelected(FLAGS_scenario, "mixed")) {
+        Fixture fixture(capacity, fragmentation_block_size);
+        if (!fixture.prepareCapacityPressure(FLAGS_high_water_ratio)) {
+            std::cerr << "failed to prepare mixed high-water fixture for "
+                      << layer << std::endl;
+            return false;
+        }
+        const auto report = fixture.report();
+        if (report.largestFreeRegion >= failed_request_size) {
+            std::cerr << "mixed scenario failure request must exceed the "
+                         "largest free region"
+                      << std::endl;
+            return false;
+        }
+
+        const uint64_t failure_slots = static_cast<uint64_t>(
+            FLAGS_mixed_failure_ratio * static_cast<double>(kMixedPatternSize) +
+            0.5);
+        auto operation = [&](uint32_t thread_index, uint64_t operation_index) {
+            const uint64_t pattern_slot =
+                (operation_index * 7919 +
+                 static_cast<uint64_t>(thread_index) * 104729) %
+                kMixedPatternSize;
+            if (pattern_slot < failure_slots) {
+                return fixture.expectAllocationFailure(failed_request_size);
+            }
+            return fixture.allocateAndFree(success_request_size);
+        };
+        printResult(
+            runConcurrentBenchmark(layer, "high_water_mixed", report, capacity,
+                                   failed_request_size, success_request_size,
+                                   static_cast<double>(failure_slots) /
+                                       static_cast<double>(kMixedPatternSize),
+                                   operation));
+    }
+
+    if (isSelected(FLAGS_scenario, "success")) {
+        Fixture fixture(capacity, fragmentation_block_size);
+        const auto report = fixture.report();
+        auto operation = [&](uint32_t, uint64_t) {
+            return fixture.allocateAndFree(success_request_size);
+        };
+        printResult(runConcurrentBenchmark(
+            layer, "successful_allocate_free", report, capacity,
+            success_request_size, success_request_size, 0.0, operation));
+    }
+    return true;
+}
+
+bool validateFlags() {
+    const bool valid_layer = FLAGS_layer == "all" ||
+                             FLAGS_layer == "offset_allocator" ||
+                             FLAGS_layer == "put_allocation";
+    const bool valid_scenario =
+        FLAGS_scenario == "all" || FLAGS_scenario == "capacity" ||
+        FLAGS_scenario == "fragmentation" || FLAGS_scenario == "mixed" ||
+        FLAGS_scenario == "success";
+    if (!valid_layer || !valid_scenario || FLAGS_threads == 0 ||
+        FLAGS_iterations == 0 || FLAGS_pool_size_mb == 0 ||
+        FLAGS_failed_request_mb == 0 || FLAGS_success_request_kb == 0 ||
+        FLAGS_fragmentation_block_mb == 0 || FLAGS_fragmentation_stride < 2 ||
+        FLAGS_high_water_ratio <= 0.0 || FLAGS_high_water_ratio >= 1.0) {
+        return false;
+    }
+    const uint64_t mixed_failure_slots = static_cast<uint64_t>(
+        FLAGS_mixed_failure_ratio * static_cast<double>(kMixedPatternSize) +
+        0.5);
+    if (mixed_failure_slots == 0 || mixed_failure_slots >= kMixedPatternSize) {
+        return false;
+    }
+    constexpr uint64_t max_size = std::numeric_limits<size_t>::max();
+    return FLAGS_pool_size_mb <= max_size / kMiB &&
+           FLAGS_failed_request_mb <= max_size / kMiB &&
+           FLAGS_success_request_kb <= max_size / kKiB &&
+           FLAGS_fragmentation_block_mb <= max_size / kMiB;
 }
 
 }  // namespace
 
 int main(int argc, char** argv) {
     gflags::ParseCommandLineFlags(&argc, &argv, true);
-    if (FLAGS_threads == 0 || FLAGS_iterations == 0) {
-        std::cerr << "threads and iterations must be greater than zero"
+    if (!validateFlags()) {
+        std::cerr << "invalid benchmark flags; use --help for valid values"
                   << std::endl;
         return 1;
     }
 
-    auto high_water_allocator = OffsetAllocator::create(
-        0, kPoolSize, FLAGS_threads + 16, FLAGS_threads + 16);
-    auto high_water_fill = high_water_allocator->allocate(kHighWaterFillSize);
-    if (!high_water_fill.has_value()) {
-        std::cerr << "failed to prepare high-water allocator" << std::endl;
+    const uint64_t capacity = FLAGS_pool_size_mb * kMiB;
+    const uint64_t failed_request_size = FLAGS_failed_request_mb * kMiB;
+    const uint64_t success_request_size = FLAGS_success_request_kb * kKiB;
+    const uint64_t fragmentation_block_size =
+        FLAGS_fragmentation_block_mb * kMiB;
+    if (failed_request_size >= capacity || success_request_size >= capacity ||
+        fragmentation_block_size >= capacity) {
+        std::cerr << "request and fragmentation block sizes must be smaller "
+                     "than the allocator capacity"
+                  << std::endl;
         return 1;
     }
-    std::cout << "threads=" << FLAGS_threads
-              << ", iterations_per_thread=" << FLAGS_iterations
-              << ", high_water_percent="
-              << 100.0 * static_cast<double>(kHighWaterFillSize) / kPoolSize
-              << ", largest_free_region="
-              << high_water_allocator->storageReport().largestFreeRegion
-              << ", failed_request_size=" << kFailedRequestSize << std::endl;
 
-    printResult(runConcurrentBenchmark("high_water_failed_allocate", [&] {
-        return !high_water_allocator->allocate(kFailedRequestSize).has_value();
-    }));
+    printCsvHeader();
 
-    auto success_allocator = OffsetAllocator::create(
-        0, kPoolSize, FLAGS_threads + 16, FLAGS_threads + 16);
-    printResult(runConcurrentBenchmark("successful_allocate_free", [&] {
-        return success_allocator->allocate(kSuccessfulRequestSize).has_value();
-    }));
+    if (isSelected(FLAGS_layer, "offset_allocator") &&
+        !runFixtureScenarios<OffsetAllocatorFixture>(
+            "offset_allocator", capacity, failed_request_size,
+            success_request_size, fragmentation_block_size)) {
+        return 1;
+    }
+    if (isSelected(FLAGS_layer, "put_allocation") &&
+        !runFixtureScenarios<PutAllocationFixture>(
+            "put_allocation", capacity, failed_request_size,
+            success_request_size, fragmentation_block_size)) {
+        return 1;
+    }
     return 0;
 }

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -171,7 +171,10 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // the request cannot be represented by this allocator.
     [[nodiscard]] uint64_t normalizedAllocationSize(size_t size) const;
 
-    // Returns a lock-free snapshot of the largest allocatable free region.
+    // Returns a mutex-free atomic upper-bound hint for the largest allocatable
+    // free region. The hint may be larger than the current value after a
+    // successful allocation and is tightened on a locked allocation failure
+    // or after free.
     [[nodiscard]] uint64_t getLargestFreeRegion() const noexcept {
         return m_largest_free_region.load(std::memory_order_relaxed);
     }

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -173,8 +173,8 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
 
     // Returns a mutex-free atomic upper-bound hint for the largest allocatable
     // free region. The hint may be larger than the current value after a
-    // successful allocation and is tightened on a locked allocation failure
-    // or after free.
+    // successful allocation, is tightened on a locked allocation failure, and
+    // is raised when free creates a larger region.
     [[nodiscard]] uint64_t getLargestFreeRegion() const noexcept {
         return m_largest_free_region.load(std::memory_order_relaxed);
     }
@@ -223,6 +223,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     uint64_t m_allocated_size GUARDED_BY(m_mutex) = 0;
     uint64_t m_allocated_num GUARDED_BY(m_mutex) = 0;
     std::atomic<uint64_t> m_largest_free_region{0};
+    bool m_largest_free_region_tightened GUARDED_BY(m_mutex) = false;
 
     // Private constructor - use create() factory method instead
     OffsetAllocator(uint64_t base, size_t size, uint32 init_capacity,
@@ -251,7 +252,9 @@ class __Allocator {
     void reset();
 
     OffsetAllocation allocate(uint32 size);
-    void free(OffsetAllocation allocation);
+    // Returns the size of the newly merged free region, or zero if allocator
+    // metadata capacity still prevents another allocation.
+    uint32 free(OffsetAllocation allocation);
 
     uint32 allocationSize(OffsetAllocation allocation) const;
     OffsetAllocStorageReport storageReport() const;

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -2,6 +2,7 @@
 // (C) Sebastian Aaltonen 2023
 // MIT License (see file: LICENSE)
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -170,6 +171,11 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // the request cannot be represented by this allocator.
     [[nodiscard]] uint64_t normalizedAllocationSize(size_t size) const;
 
+    // Returns a lock-free snapshot of the largest allocatable free region.
+    [[nodiscard]] uint64_t getLargestFreeRegion() const noexcept {
+        return m_largest_free_region.load(std::memory_order_relaxed);
+    }
+
     // Get storage report (thread-safe)
     [[nodiscard]]
     OffsetAllocStorageReport storageReport() const;
@@ -200,6 +206,8 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     [[nodiscard]]
     OffsetAllocatorMetrics get_metrics_internal() const REQUIRES(m_mutex);
 
+    void refreshLargestFreeRegion() REQUIRES(m_mutex);
+
     std::unique_ptr<__Allocator> m_allocator GUARDED_BY(m_mutex);
     uint64_t m_base;
     // The real offset and size of the allocated memory need to be multiplied by
@@ -211,6 +219,7 @@ class OffsetAllocator : public std::enable_shared_from_this<OffsetAllocator> {
     // Lightweight metrics maintained during allocation/deallocation
     uint64_t m_allocated_size GUARDED_BY(m_mutex) = 0;
     uint64_t m_allocated_num GUARDED_BY(m_mutex) = 0;
+    std::atomic<uint64_t> m_largest_free_region{0};
 
     // Private constructor - use create() factory method instead
     OffsetAllocator(uint64_t base, size_t size, uint32 init_capacity,
@@ -330,6 +339,9 @@ OffsetAllocator::OffsetAllocator(T& serializer) {
                 "Deserializing OffsetAllocator failed: corrupt header");
         }
         m_allocator = std::make_unique<__Allocator>(serializer);
+        m_largest_free_region.store(
+            m_allocator->storageReport().largestFreeRegion << m_multiplier_bits,
+            std::memory_order_relaxed);
     } catch (const std::exception& e) {
         LOG(ERROR) << "Deserializing OffsetAllocator failed, error="
                    << e.what();

--- a/mooncake-store/include/offset_allocator/offset_allocator.h
+++ b/mooncake-store/include/offset_allocator/offset_allocator.h
@@ -345,9 +345,14 @@ OffsetAllocator::OffsetAllocator(T& serializer) {
                 "Deserializing OffsetAllocator failed: corrupt header");
         }
         m_allocator = std::make_unique<__Allocator>(serializer);
-        m_largest_free_region.store(
-            m_allocator->storageReport().largestFreeRegion << m_multiplier_bits,
-            std::memory_order_relaxed);
+        const uint64_t largest_free_region =
+            m_allocator->storageReport().largestFreeRegion << m_multiplier_bits;
+        m_largest_free_region.store(largest_free_region,
+                                    std::memory_order_relaxed);
+        const uint64_t allocator_capacity =
+            static_cast<uint64_t>(m_allocator->m_size) << m_multiplier_bits;
+        m_largest_free_region_tightened =
+            largest_free_region < allocator_capacity;
     } catch (const std::exception& e) {
         LOG(ERROR) << "Deserializing OffsetAllocator failed, error="
                    << e.what();

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -377,7 +377,19 @@ size_t OffsetBufferAllocator::getLargestFreeRegion() const {
     if (!offset_allocator_) {
         return 0;
     }
-    return offset_allocator_->getLargestFreeRegion();
+
+    try {
+        auto report = offset_allocator_->storageReport();
+        return report.largestFreeRegion;
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to get storage report: " << e.what()
+                   << " segment=" << segment_name_;
+        return 0;
+    } catch (...) {
+        LOG(ERROR) << "Unknown error getting storage report"
+                   << " segment=" << segment_name_;
+        return 0;
+    }
 }
 
 std::optional<RestoredOffsetBufferAllocator> RestoreOffsetBufferAllocator(

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -377,19 +377,7 @@ size_t OffsetBufferAllocator::getLargestFreeRegion() const {
     if (!offset_allocator_) {
         return 0;
     }
-
-    try {
-        auto report = offset_allocator_->storageReport();
-        return report.largestFreeRegion;
-    } catch (const std::exception& e) {
-        LOG(ERROR) << "Failed to get storage report: " << e.what()
-                   << " segment=" << segment_name_;
-        return 0;
-    } catch (...) {
-        LOG(ERROR) << "Unknown error getting storage report"
-                   << " segment=" << segment_name_;
-        return 0;
-    }
+    return offset_allocator_->getLargestFreeRegion();
 }
 
 std::optional<RestoredOffsetBufferAllocator> RestoreOffsetBufferAllocator(

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -602,6 +602,10 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
 
     OffsetAllocation allocation = m_allocator->allocate(fake_size);
     if (allocation.isNoSpace()) {
+        // A request can pass the conservative hint but still fail because
+        // the allocator state changed concurrently. Tighten the hint after
+        // observing the authoritative state under the mutex.
+        refreshLargestFreeRegion();
         // Log metrics to help understand why allocation failed
         // Note: We're already holding m_mutex, so use internal method
         OffsetAllocatorMetrics metrics = get_metrics_internal();
@@ -609,8 +613,6 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
                 << ", fake_size=" << fake_size << ", " << metrics;
         return std::nullopt;
     }
-
-    refreshLargestFreeRegion();
 
     // Update lightweight metrics
     m_allocated_size += size;

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -555,6 +555,9 @@ OffsetAllocator::OffsetAllocator(uint64_t base, size_t size,
       m_capacity(size) {
     m_allocator = std::make_unique<__Allocator>(size >> m_multiplier_bits,
                                                 init_capacity, max_capacity);
+    m_largest_free_region.store(
+        m_allocator->storageReport().largestFreeRegion << m_multiplier_bits,
+        std::memory_order_relaxed);
 }
 
 OffsetAllocator::OffsetAllocator(uint64_t base, size_t size,
@@ -563,10 +566,22 @@ OffsetAllocator::OffsetAllocator(uint64_t base, size_t size,
     : m_allocator(std::move(allocator)),
       m_base(base),
       m_multiplier_bits(multiplier_bits),
-      m_capacity(size) {}
+      m_capacity(size) {
+    m_largest_free_region.store(
+        m_allocator->storageReport().largestFreeRegion << m_multiplier_bits,
+        std::memory_order_relaxed);
+}
 
 std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
     if (size == 0) {
+        return std::nullopt;
+    }
+
+    // Free regions are grouped into size bins. A request larger than the
+    // highest free-bin boundary rounds up to a higher bin and cannot fit. The
+    // cached value is only a fast-fail hint: a stale larger value merely falls
+    // through to the mutex-protected allocator.
+    if (size > getLargestFreeRegion()) {
         return std::nullopt;
     }
 
@@ -594,6 +609,8 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
                 << ", fake_size=" << fake_size << ", " << metrics;
         return std::nullopt;
     }
+
+    refreshLargestFreeRegion();
 
     // Update lightweight metrics
     m_allocated_size += size;
@@ -669,11 +686,20 @@ OffsetAllocatorMetrics OffsetAllocator::get_metrics() const {
     return get_metrics_internal();
 }
 
+void OffsetAllocator::refreshLargestFreeRegion() {
+    const uint64_t largest_free_region =
+        m_allocator ? m_allocator->storageReport().largestFreeRegion
+                          << m_multiplier_bits
+                    : 0;
+    m_largest_free_region.store(largest_free_region, std::memory_order_relaxed);
+}
+
 void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation,
                                      uint64_t size) {
     MutexLocker lock(&m_mutex);
     if (m_allocator) {
         m_allocator->free(allocation);
+        refreshLargestFreeRegion();
         // Update lightweight metrics.  Saturate instead of wrapping:
         // recovery may free nodes whose exact requested size is unknown
         // (corrupt record), and an unsigned underflow would poison the

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -284,9 +284,9 @@ OffsetAllocation __Allocator::allocate(uint32 size) {
     return OffsetAllocation(node.dataOffset, nodeIndex);
 }
 
-void __Allocator::free(OffsetAllocation allocation) {
+uint32 __Allocator::free(OffsetAllocation allocation) {
     ASSERT(allocation.metadata != OffsetAllocation::NO_SPACE);
-    if (m_nodes.empty()) return;
+    if (m_nodes.empty()) return 0;
 
     uint32 nodeIndex = allocation.metadata;
     Node& node = m_nodes[nodeIndex];
@@ -348,6 +348,8 @@ void __Allocator::free(OffsetAllocation allocation) {
         m_nodes[combinedNodeIndex].neighborPrev = neighborPrev;
         m_nodes[neighborPrev].neighborNext = combinedNodeIndex;
     }
+
+    return m_freeOffset < m_max_capacity ? size : 0;
 }
 
 uint32 __Allocator::insertNodeIntoBin(uint32 size, uint32 dataOffset) {
@@ -585,12 +587,7 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
         return std::nullopt;
     }
 
-    MutexLocker guard(&m_mutex);
-    if (!m_allocator) {
-        return std::nullopt;
-    }
-
-    size_t fake_size =
+    const size_t fake_size =
         m_multiplier_bits > 0
             ? ((size + (static_cast<uint64_t>(1) << m_multiplier_bits) - 1u) >>
                m_multiplier_bits)
@@ -600,17 +597,23 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
         return std::nullopt;
     }
 
+    MutexLocker guard(&m_mutex);
+    if (!m_allocator) {
+        return std::nullopt;
+    }
+
     OffsetAllocation allocation = m_allocator->allocate(fake_size);
     if (allocation.isNoSpace()) {
         // A request can pass the conservative hint but still fail because
         // the allocator state changed concurrently. Tighten the hint after
         // observing the authoritative state under the mutex.
         refreshLargestFreeRegion();
-        // Log metrics to help understand why allocation failed
-        // Note: We're already holding m_mutex, so use internal method
-        OffsetAllocatorMetrics metrics = get_metrics_internal();
-        VLOG(1) << "OffsetAllocator allocation failed: size=" << size
-                << ", fake_size=" << fake_size << ", " << metrics;
+        if (VLOG_IS_ON(1)) {
+            // We're already holding m_mutex, so use the internal method.
+            const OffsetAllocatorMetrics metrics = get_metrics_internal();
+            VLOG(1) << "OffsetAllocator allocation failed: size=" << size
+                    << ", fake_size=" << fake_size << ", " << metrics;
+        }
         return std::nullopt;
     }
 
@@ -618,10 +621,14 @@ std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {
     m_allocated_size += size;
     m_allocated_num++;
 
-    // Use shared_from_this to get a shared_ptr to this OffsetAllocator
-    return OffsetAllocationHandle(
-        shared_from_this(), allocation,
-        m_base + (allocation.getOffset() << m_multiplier_bits), size);
+    const uint64_t real_base =
+        m_base + (allocation.getOffset() << m_multiplier_bits);
+    guard.unlock();
+
+    // Handle construction and shared_ptr reference-counting do not access
+    // allocator state and should not extend the serialized critical section.
+    return OffsetAllocationHandle(shared_from_this(), allocation, real_base,
+                                  size);
 }
 
 uint64_t OffsetAllocator::normalizedAllocationSize(size_t size) const {
@@ -694,14 +701,36 @@ void OffsetAllocator::refreshLargestFreeRegion() {
                           << m_multiplier_bits
                     : 0;
     m_largest_free_region.store(largest_free_region, std::memory_order_relaxed);
+    const uint64_t allocator_capacity =
+        m_allocator
+            ? static_cast<uint64_t>(m_allocator->m_size) << m_multiplier_bits
+            : 0;
+    m_largest_free_region_tightened =
+        m_allocator && largest_free_region < allocator_capacity;
 }
 
 void OffsetAllocator::freeAllocation(const OffsetAllocation& allocation,
                                      uint64_t size) {
     MutexLocker lock(&m_mutex);
     if (m_allocator) {
-        m_allocator->free(allocation);
-        refreshLargestFreeRegion();
+        const uint64_t freed_region =
+            static_cast<uint64_t>(m_allocator->free(allocation))
+            << m_multiplier_bits;
+        if (m_largest_free_region_tightened) {
+            // Before free, the hint is an upper bound for every existing free
+            // region. Only the newly merged region can raise that bound.
+            const uint64_t current_hint =
+                m_largest_free_region.load(std::memory_order_relaxed);
+            if (freed_region > current_hint) {
+                m_largest_free_region.store(freed_region,
+                                            std::memory_order_relaxed);
+            }
+            const uint64_t allocator_capacity =
+                static_cast<uint64_t>(m_allocator->m_size) << m_multiplier_bits;
+            if (freed_region >= allocator_capacity) {
+                m_largest_free_region_tightened = false;
+            }
+        }
         // Update lightweight metrics.  Saturate instead of wrapping:
         // recovery may free nodes whose exact requested size is unknown
         // (corrupt record), and an unsigned underflow would poison the

--- a/mooncake-store/src/offset_allocator.cpp
+++ b/mooncake-store/src/offset_allocator.cpp
@@ -569,9 +569,12 @@ OffsetAllocator::OffsetAllocator(uint64_t base, size_t size,
       m_base(base),
       m_multiplier_bits(multiplier_bits),
       m_capacity(size) {
-    m_largest_free_region.store(
-        m_allocator->storageReport().largestFreeRegion << m_multiplier_bits,
-        std::memory_order_relaxed);
+    const uint64_t largest_free_region =
+        m_allocator->storageReport().largestFreeRegion << m_multiplier_bits;
+    m_largest_free_region.store(largest_free_region, std::memory_order_relaxed);
+    const uint64_t allocator_capacity =
+        static_cast<uint64_t>(m_allocator->m_size) << m_multiplier_bits;
+    m_largest_free_region_tightened = largest_free_region < allocator_capacity;
 }
 
 std::optional<OffsetAllocationHandle> OffsetAllocator::allocate(size_t size) {

--- a/mooncake-store/tests/buffer_allocator_test.cpp
+++ b/mooncake-store/tests/buffer_allocator_test.cpp
@@ -111,6 +111,29 @@ TEST_F(BufferAllocatorTest, AllocateMultiple) {
     }
 }
 
+TEST_F(BufferAllocatorTest, OffsetLargestFreeRegionRemainsExact) {
+    constexpr size_t CAPACITY = 16 * 1024 * 1024;
+    auto allocator = std::make_shared<OffsetBufferAllocator>(
+        "exact-largest-free-region", 0x140000000ULL, CAPACITY,
+        "exact-largest-free-region");
+
+    EXPECT_EQ(allocator->getLargestFreeRegion(), CAPACITY);
+
+    auto buffer = allocator->allocate(CAPACITY / 2);
+    ASSERT_NE(buffer, nullptr);
+    const auto internal_allocator = allocator->getOffsetAllocator();
+
+    // Successful allocations intentionally leave the fast-fail hint high, but
+    // the segment-selection query must still return the authoritative value.
+    EXPECT_GT(internal_allocator->getLargestFreeRegion(),
+              allocator->getLargestFreeRegion());
+    EXPECT_EQ(allocator->getLargestFreeRegion(),
+              internal_allocator->storageReport().largestFreeRegion);
+
+    buffer.reset();
+    EXPECT_EQ(allocator->getLargestFreeRegion(), CAPACITY);
+}
+
 TEST_F(BufferAllocatorTest, RestoreOffsetAllocationsAtOriginalAddresses) {
     constexpr uintptr_t kBase = 0x180000000ULL;
     constexpr size_t kCapacity = 16 * 1024 * 1024;

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -1653,6 +1653,29 @@ TEST_F(OffsetAllocatorTest, SerializationOneElementAllocator) {
     testSerializeAllocator(alloc_a, handles);
 }
 
+TEST_F(OffsetAllocatorTest, DeserializedHintRaisesWhenAllocationsAreFreed) {
+    constexpr size_t ALLOCATOR_SIZE = 1024;
+    constexpr size_t BLOCK_SIZE = ALLOCATOR_SIZE / 2;
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto original =
+        OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+
+    auto handle = original->allocate(BLOCK_SIZE);
+    ASSERT_TRUE(handle.has_value());
+
+    std::vector<SerializedByte> buffer;
+    ASSERT_EQ(serialize_to(original, buffer), ErrorCode::OK);
+    auto restored = deserialize_from<OffsetAllocator>(buffer);
+    ASSERT_NE(restored, nullptr);
+
+    std::optional<OffsetAllocationHandle> restored_handle(
+        copyHandleWithNewAllocator(*handle, restored));
+    restored_handle.reset();
+
+    EXPECT_EQ(restored->getLargestFreeRegion(), ALLOCATOR_SIZE);
+    EXPECT_TRUE(restored->allocate(ALLOCATOR_SIZE).has_value());
+}
+
 TEST_F(OffsetAllocatorTest, SerializationRandomAllocatedAllocator) {
     // The size multiplier is larger than 1 when the allocator size is larger
     // than MAX_BIN_SIZE.

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -294,6 +294,12 @@ class OffsetAllocatorTest : public ::testing::Test {
         allocator->m_mutex.unlock();
     }
 
+    bool isLargestFreeRegionHintTightened(
+        const std::shared_ptr<OffsetAllocator>& allocator) {
+        MutexLocker lock(&allocator->m_mutex);
+        return allocator->m_largest_free_region_tightened;
+    }
+
     bool canAllocateWithoutFastFail(
         const std::shared_ptr<OffsetAllocator>& allocator, size_t size) {
         MutexLocker lock(&allocator->m_mutex);
@@ -565,8 +571,41 @@ TEST_F(OffsetAllocatorTest, AllocationFailure) {
     EXPECT_FALSE(handle.has_value());
 }
 
+TEST_F(OffsetAllocatorTest, FreeReturnsMergedRegionSize) {
+    constexpr uint32 ALLOCATOR_SIZE = 1024;
+    constexpr uint32 MAX_ALLOCS = 8;
+    constexpr uint32 BLOCK_SIZE = 128;
+    __Allocator allocator(ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+
+    const auto first = allocator.allocate(BLOCK_SIZE);
+    const auto second = allocator.allocate(BLOCK_SIZE);
+    const auto third = allocator.allocate(BLOCK_SIZE);
+    ASSERT_FALSE(first.isNoSpace());
+    ASSERT_FALSE(second.isNoSpace());
+    ASSERT_FALSE(third.isNoSpace());
+
+    EXPECT_EQ(allocator.free(first), BLOCK_SIZE);
+    EXPECT_EQ(allocator.free(third), ALLOCATOR_SIZE - 2 * BLOCK_SIZE);
+    EXPECT_EQ(allocator.free(second), ALLOCATOR_SIZE);
+}
+
+TEST_F(OffsetAllocatorTest, FreeReturnsZeroWhenMetadataCapacityIsExhausted) {
+    constexpr uint32 ALLOCATOR_SIZE = 384;
+    constexpr uint32 MAX_ALLOCS = 3;
+    constexpr uint32 BLOCK_SIZE = 128;
+    __Allocator allocator(ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+
+    const auto first = allocator.allocate(BLOCK_SIZE);
+    const auto second = allocator.allocate(BLOCK_SIZE);
+    ASSERT_FALSE(first.isNoSpace());
+    ASSERT_FALSE(second.isNoSpace());
+
+    EXPECT_EQ(allocator.free(first), 0);
+    EXPECT_EQ(allocator.storageReport().largestFreeRegion, 0);
+}
+
 TEST_F(OffsetAllocatorTest,
-       LargestFreeRegionHintTightensOnFailureAndRefreshesOnFree) {
+       LargestFreeRegionHintTightensOnFailureAndRaisesOnFree) {
     constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;
     constexpr uint32 MAX_ALLOCS = 1000;
     auto allocator =
@@ -594,6 +633,50 @@ TEST_F(OffsetAllocatorTest,
     EXPECT_EQ(allocator->getLargestFreeRegion(),
               allocator->storageReport().largestFreeRegion);
     EXPECT_EQ(allocator->getLargestFreeRegion(), ALLOCATOR_SIZE);
+}
+
+TEST_F(OffsetAllocatorTest, HintMaintenanceActivatesOnlyAfterFailure) {
+    constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto allocator =
+        OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+
+    EXPECT_FALSE(isLargestFreeRegionHintTightened(allocator));
+    auto handle = allocator->allocate(ALLOCATOR_SIZE / 2);
+    ASSERT_TRUE(handle.has_value());
+    EXPECT_FALSE(isLargestFreeRegionHintTightened(allocator));
+
+    const uint64_t actual_largest =
+        allocator->storageReport().largestFreeRegion;
+    ASSERT_FALSE(allocator->allocate(actual_largest + 1).has_value());
+    EXPECT_TRUE(isLargestFreeRegionHintTightened(allocator));
+
+    handle.reset();
+    EXPECT_FALSE(isLargestFreeRegionHintTightened(allocator));
+    EXPECT_EQ(allocator->getLargestFreeRegion(), ALLOCATOR_SIZE);
+}
+
+TEST_F(OffsetAllocatorTest,
+       HintMaintenanceUsesScaledAllocatorCapacityWhenFullyFreed) {
+    const uint64_t internal_capacity = bin_sizes[NUM_BINS - 1];
+    const uint64_t allocator_size = 2 * internal_capacity + 1;
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto allocator =
+        OffsetAllocator::create(0, allocator_size, MAX_ALLOCS, MAX_ALLOCS);
+
+    const uint64_t maximum_free_region = allocator->getLargestFreeRegion();
+    ASSERT_LT(maximum_free_region, allocator_size);
+    auto handle = allocator->allocate(maximum_free_region / 2);
+    ASSERT_TRUE(handle.has_value());
+
+    const uint64_t actual_largest =
+        allocator->storageReport().largestFreeRegion;
+    ASSERT_FALSE(allocator->allocate(actual_largest + 1).has_value());
+    ASSERT_TRUE(isLargestFreeRegionHintTightened(allocator));
+
+    handle.reset();
+    EXPECT_FALSE(isLargestFreeRegionHintTightened(allocator));
+    EXPECT_EQ(allocator->getLargestFreeRegion(), maximum_free_region);
 }
 
 TEST_F(OffsetAllocatorTest, ImpossibleAllocationDoesNotAcquireMutex) {

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <future>
 #include <map>
 #include <memory>
 #include <random>
@@ -283,6 +285,14 @@ class OffsetAllocatorTest : public ::testing::Test {
 
     void TearDown() override {}
 
+    void lockAllocator(const std::shared_ptr<OffsetAllocator>& allocator) {
+        allocator->m_mutex.lock();
+    }
+
+    void unlockAllocator(const std::shared_ptr<OffsetAllocator>& allocator) {
+        allocator->m_mutex.unlock();
+    }
+
     OffsetAllocationHandle copyHandleWithNewAllocator(
         const OffsetAllocationHandle& handle,
         const std::shared_ptr<OffsetAllocator>& new_allocator) {
@@ -306,6 +316,7 @@ class OffsetAllocatorTest : public ::testing::Test {
         ASSERT_EQ(a->m_capacity, b->m_capacity);
         ASSERT_EQ(a->m_allocated_size, b->m_allocated_size);
         ASSERT_EQ(a->m_allocated_num, b->m_allocated_num);
+        ASSERT_EQ(a->getLargestFreeRegion(), b->getLargestFreeRegion());
 
         // Compare __Allocator member variables
         ASSERT_EQ(a->m_allocator->m_size, b->m_allocator->m_size);
@@ -514,6 +525,50 @@ TEST_F(OffsetAllocatorTest, AllocationFailure) {
     auto handle =
         allocator->allocate(2 * ALLOCATOR_SIZE);  // 2GB > 1GB available
     EXPECT_FALSE(handle.has_value());
+}
+
+TEST_F(OffsetAllocatorTest, LargestFreeRegionCacheTracksMutations) {
+    constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto allocator =
+        OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+
+    EXPECT_EQ(allocator->getLargestFreeRegion(),
+              allocator->storageReport().largestFreeRegion);
+
+    auto handle = allocator->allocate(ALLOCATOR_SIZE / 2);
+    ASSERT_TRUE(handle.has_value());
+    EXPECT_EQ(allocator->getLargestFreeRegion(),
+              allocator->storageReport().largestFreeRegion);
+
+    handle.reset();
+    EXPECT_EQ(allocator->getLargestFreeRegion(),
+              allocator->storageReport().largestFreeRegion);
+    EXPECT_EQ(allocator->getLargestFreeRegion(), ALLOCATOR_SIZE);
+}
+
+TEST_F(OffsetAllocatorTest, ImpossibleAllocationDoesNotAcquireMutex) {
+    constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;
+    constexpr uint32 MAX_ALLOCS = 1000;
+    auto allocator =
+        OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
+    auto full_handle = allocator->allocate(ALLOCATOR_SIZE);
+    ASSERT_TRUE(full_handle.has_value());
+    ASSERT_EQ(allocator->getLargestFreeRegion(), 0);
+
+    lockAllocator(allocator);
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto result = std::async(std::launch::async, [&] {
+        started.set_value();
+        return allocator->allocate(1);
+    });
+    started_future.wait();
+    const auto status = result.wait_for(std::chrono::seconds(1));
+    unlockAllocator(allocator);
+
+    EXPECT_EQ(status, std::future_status::ready);
+    EXPECT_FALSE(result.get().has_value());
 }
 
 // Test multiple allocations

--- a/mooncake-store/tests/offset_allocator_test.cpp
+++ b/mooncake-store/tests/offset_allocator_test.cpp
@@ -7,6 +7,7 @@
 
 #include <chrono>
 #include <future>
+#include <limits>
 #include <map>
 #include <memory>
 #include <random>
@@ -293,6 +294,35 @@ class OffsetAllocatorTest : public ::testing::Test {
         allocator->m_mutex.unlock();
     }
 
+    bool canAllocateWithoutFastFail(
+        const std::shared_ptr<OffsetAllocator>& allocator, size_t size) {
+        MutexLocker lock(&allocator->m_mutex);
+        const uint64_t quantum = uint64_t{1} << allocator->m_multiplier_bits;
+        if (size == 0 ||
+            size > std::numeric_limits<uint64_t>::max() - (quantum - 1)) {
+            return false;
+        }
+        const uint64_t normalized_size = (size + quantum - 1) / quantum;
+        if (!allocator->m_allocator ||
+            normalized_size > allocator->m_allocator->m_size) {
+            return false;
+        }
+
+        auto allocation = allocator->m_allocator->allocate(
+            static_cast<uint32>(normalized_size));
+        if (allocation.isNoSpace()) {
+            return false;
+        }
+        allocator->m_allocator->free(allocation);
+        allocator->refreshLargestFreeRegion();
+        return true;
+    }
+
+    uint64_t multiplierBits(
+        const std::shared_ptr<OffsetAllocator>& allocator) const {
+        return allocator->m_multiplier_bits;
+    }
+
     OffsetAllocationHandle copyHandleWithNewAllocator(
         const OffsetAllocationHandle& handle,
         const std::shared_ptr<OffsetAllocator>& new_allocator) {
@@ -316,7 +346,15 @@ class OffsetAllocatorTest : public ::testing::Test {
         ASSERT_EQ(a->m_capacity, b->m_capacity);
         ASSERT_EQ(a->m_allocated_size, b->m_allocated_size);
         ASSERT_EQ(a->m_allocated_num, b->m_allocated_num);
-        ASSERT_EQ(a->getLargestFreeRegion(), b->getLargestFreeRegion());
+        const uint64_t actual_largest_a =
+            a->m_allocator->storageReport().largestFreeRegion
+            << a->m_multiplier_bits;
+        const uint64_t actual_largest_b =
+            b->m_allocator->storageReport().largestFreeRegion
+            << b->m_multiplier_bits;
+        ASSERT_EQ(actual_largest_a, actual_largest_b);
+        ASSERT_GE(a->getLargestFreeRegion(), actual_largest_a);
+        ASSERT_GE(b->getLargestFreeRegion(), actual_largest_b);
 
         // Compare __Allocator member variables
         ASSERT_EQ(a->m_allocator->m_size, b->m_allocator->m_size);
@@ -527,19 +565,30 @@ TEST_F(OffsetAllocatorTest, AllocationFailure) {
     EXPECT_FALSE(handle.has_value());
 }
 
-TEST_F(OffsetAllocatorTest, LargestFreeRegionCacheTracksMutations) {
+TEST_F(OffsetAllocatorTest,
+       LargestFreeRegionHintTightensOnFailureAndRefreshesOnFree) {
     constexpr uint32 ALLOCATOR_SIZE = 1024 * 1024;
     constexpr uint32 MAX_ALLOCS = 1000;
     auto allocator =
         OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
 
-    EXPECT_EQ(allocator->getLargestFreeRegion(),
-              allocator->storageReport().largestFreeRegion);
+    const uint64_t initial_largest = allocator->getLargestFreeRegion();
+    EXPECT_EQ(initial_largest, allocator->storageReport().largestFreeRegion);
 
     auto handle = allocator->allocate(ALLOCATOR_SIZE / 2);
     ASSERT_TRUE(handle.has_value());
-    EXPECT_EQ(allocator->getLargestFreeRegion(),
-              allocator->storageReport().largestFreeRegion);
+    const uint64_t actual_largest =
+        allocator->storageReport().largestFreeRegion;
+    ASSERT_LT(actual_largest, initial_largest);
+
+    // A successful allocation can leave the hint conservatively high so the
+    // success path does not need to publish a new atomic value.
+    EXPECT_EQ(allocator->getLargestFreeRegion(), initial_largest);
+
+    // The first request that passes the hint but fails in the allocator
+    // tightens it for subsequent requests.
+    EXPECT_FALSE(allocator->allocate(actual_largest + 1).has_value());
+    EXPECT_EQ(allocator->getLargestFreeRegion(), actual_largest);
 
     handle.reset();
     EXPECT_EQ(allocator->getLargestFreeRegion(),
@@ -554,6 +603,10 @@ TEST_F(OffsetAllocatorTest, ImpossibleAllocationDoesNotAcquireMutex) {
         OffsetAllocator::create(0, ALLOCATOR_SIZE, MAX_ALLOCS, MAX_ALLOCS);
     auto full_handle = allocator->allocate(ALLOCATOR_SIZE);
     ASSERT_TRUE(full_handle.has_value());
+
+    // The first failed request observes the exact allocator state and tightens
+    // the conservative hint.
+    ASSERT_FALSE(allocator->allocate(1).has_value());
     ASSERT_EQ(allocator->getLargestFreeRegion(), 0);
 
     lockAllocator(allocator);
@@ -569,6 +622,46 @@ TEST_F(OffsetAllocatorTest, ImpossibleAllocationDoesNotAcquireMutex) {
 
     EXPECT_EQ(status, std::future_status::ready);
     EXPECT_FALSE(result.get().has_value());
+}
+
+TEST_F(OffsetAllocatorTest, FastFailMatchesAllocatorAcrossBinBoundaries) {
+    constexpr uint32 MAX_ALLOCS = 8;
+    for (uint32 i = 16; i + 1 < NUM_BINS; ++i) {
+        const uint64_t capacity = static_cast<uint64_t>(bin_sizes[i + 1]) - 1;
+        const uint64_t request_size = static_cast<uint64_t>(bin_sizes[i]) + 1;
+        auto allocator =
+            OffsetAllocator::create(0, capacity, MAX_ALLOCS, MAX_ALLOCS);
+
+        ASSERT_EQ(allocator->getLargestFreeRegion(), bin_sizes[i])
+            << "bin index=" << i;
+        ASSERT_FALSE(canAllocateWithoutFastFail(allocator, request_size))
+            << "bin index=" << i;
+        EXPECT_FALSE(allocator->allocate(request_size).has_value())
+            << "bin index=" << i;
+    }
+}
+
+TEST_F(OffsetAllocatorTest, FastFailMatchesAllocatorWithMultipliers) {
+    constexpr uint32 MAX_ALLOCS = 8;
+    constexpr uint32 PREVIOUS_BIN_INDEX = NUM_BINS - 2;
+    const uint64_t INTERNAL_CAPACITY =
+        static_cast<uint64_t>(bin_sizes[NUM_BINS - 1]) - 1;
+
+    for (uint64_t multiplier_bits = 1; multiplier_bits <= 4;
+         ++multiplier_bits) {
+        const uint64_t capacity = INTERNAL_CAPACITY << multiplier_bits;
+        auto allocator =
+            OffsetAllocator::create(0, capacity, MAX_ALLOCS, MAX_ALLOCS);
+        const uint64_t largest_free_region =
+            static_cast<uint64_t>(bin_sizes[PREVIOUS_BIN_INDEX])
+            << multiplier_bits;
+        const uint64_t request_size = largest_free_region + 1;
+
+        ASSERT_EQ(multiplierBits(allocator), multiplier_bits);
+        ASSERT_EQ(allocator->getLargestFreeRegion(), largest_free_region);
+        ASSERT_FALSE(canAllocateWithoutFastFail(allocator, request_size));
+        EXPECT_FALSE(allocator->allocate(request_size).has_value());
+    }
 }
 
 // Test multiple allocations


### PR DESCRIPTION
## Description

Cache a conservative upper-bound hint for the largest allocatable free region in `OffsetAllocator` and use it to reject impossible requests before acquiring the allocator mutex.

The main changes are:

- Initialize the atomic hint from allocator state during construction and deserialization.
- Check the requested size against the hint before entering the mutex-protected allocation path.
- Keep successful allocations off the hint-update path. Allocation can only reduce the largest free region, so the previous value remains a safe upper bound.
- Tighten the hint after a request passes the hint but fails in the mutex-protected allocator.
- Enable free-side hint maintenance only after a locked allocation failure has tightened the hint. While maintenance is active, have the internal allocator return the region produced by deallocation and neighbor merging so the hint can be raised incrementally without scanning allocator bins through `storageReport()` after every free. Maintenance is disabled again after the allocator becomes fully free.
- Collect the detailed failure metrics only when `VLOG(1)` is enabled, avoiding another `storageReport()` call in the locked failure path by default.
- Keep `OffsetBufferAllocator::getLargestFreeRegion()` authoritative for segment selection; the conservative atomic value remains an internal allocation filter only.
- Reconstruct both the hint and its maintenance state from authoritative allocator metadata after deserialization, while keeping the serialized format unchanged.
- Add a reusable multithreaded benchmark covering direct `OffsetAllocator` calls and the same-segment Put allocation stage, including capacity pressure, deterministic fragmentation, configurable mixed success/failure ratios, and a successful allocate/free control.

The mutex-protected allocator remains authoritative. A stale larger hint can only allow a request to fall through to the existing locked path; it cannot make an invalid allocation succeed. The first locked failure tightens the hint for later requests. `memory_order_relaxed` is sufficient because the atomic value is only a filtering hint and does not publish or protect allocator metadata.

This change is complementary to #2445 and #2797, which use the largest free region to rank segments but do not modify `OffsetAllocator` internals. It also avoids replacing the current mutex with a shared mutex, as discussed in the closed PR #2695.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build \
  --target offset_allocator_test buffer_allocator_test \
           offset_allocator_concurrency_bench \
  -j8

./build/mooncake-store/tests/offset_allocator_test
./build/mooncake-store/tests/offset_allocator_test \
  --gtest_filter=OffsetAllocatorTest.LargestFreeRegionHintTightensOnFailureAndRaisesOnFree \
  --v=1
./build/mooncake-store/tests/buffer_allocator_test

for ratio in 0.05 0.30 0.60; do
  taskset -c 0-15 \
    ./build/mooncake-store/benchmarks/offset_allocator_concurrency_bench \
    --threads=16 \
    --iterations=300000 \
    --warmup_iterations=10000 \
    --layer=offset_allocator \
    --scenario=mixed \
    --mixed_failure_ratio="${ratio}"
done

taskset -c 0-15 \
  ./build/mooncake-store/benchmarks/offset_allocator_concurrency_bench \
  --threads=16 --iterations=300000 --warmup_iterations=10000 \
  --layer=offset_allocator --scenario=success

taskset -c 0-15 \
  ./build/mooncake-store/benchmarks/offset_allocator_concurrency_bench \
  --threads=16 --iterations=300000 --warmup_iterations=10000 \
  --layer=offset_allocator --scenario=capacity
```

The A/B benchmark used `RelWithDebInfo` builds of the PR base and candidate on the same host, pinned to CPUs 0-15. The execution order was rotated between rounds to reduce order and system-load bias. Throughput and per-operation latency were measured in separate phases, with 4.8 million operations in each phase per round. The successful and 5%-failure results are medians of five rounds; the other results are medians of three rounds.

The high-water workloads use a 1 GiB allocator at 93.75% actual utilization, with a 64 MiB largest free region. Successful operations allocate and immediately release 4 KiB. Expected-failure operations request 128 MiB and therefore cannot fit. For example, a 30% mixed workload contains approximately 30 expected failures and 70 successful allocate/free operations per 100 attempts.

The implementation evolved in three measured steps. Results from the earlier steps are retained below because they motivated the later changes; measurements from different steps were collected in separate runs and should be compared only within each table.

First, the lazy upper-bound policy was compared with the initial eager policy that refreshed the atomic value after every successful allocation. The binaries used the same benchmark and differed only in the hint-update policy.

| Scenario | Eager-refresh QPS | Lazy-hint QPS | QPS change | Eager p99 | Lazy p99 |
|---|---:|---:|---:|---:|---:|
| Successful allocate/free | 838.54 K | 920.17 K | +9.7% | 82,548 ns | 82,908 ns |
| 5% expected failures | 790.06 K | 960.61 K | +21.6% | 81,826 ns | 84,151 ns |
| 30% expected failures | 1.13 M | 1.16 M | +2.7% | 80,053 ns | 78,540 ns |
| 100% expected failures | 1.95 B | 2.33 B | +19.2% | 80 ns | 70 ns |

This established the lazy-hint policy: successful allocations do not update the atomic hint, and the first request that passes the conservative hint but fails under the mutex tightens it for subsequent requests.

Second, the initial lazy-hint implementation was compared with the upstream allocator. This exposed the remaining cost of refreshing the hint through `storageReport()` on every free, especially in success-heavy workloads.

| Scenario | Upstream QPS | Initial lazy-hint QPS | QPS change | Upstream p99 | Initial lazy-hint p99 |
|---|---:|---:|---:|---:|---:|
| Successful allocate/free | 1.03 M | 932.93 K | -9.1% | 82,626 ns | 82,515 ns |
| 5% expected failures | 1.01 M | 880.45 K | -13.1% | 78,939 ns | 85,181 ns |
| 30% expected failures | 1.15 M | 1.18 M | +3.1% | 69,932 ns | 79,429 ns |
| 100% expected failures | 10.73 M | 2.34 B | +217x | 25,238 ns | 71 ns |

The final implementation therefore avoids full-bin scans on the normal free path. Hint maintenance is activated only after a locked failure tightens the hint, and subsequent frees raise it from the newly merged region returned by the allocator. The following final comparison used rotated A/B execution order; the successful and 5%-failure results are medians of five rounds, while the other results are medians of three rounds.

| Scenario | Baseline QPS | Candidate QPS | QPS change | Baseline p99 | Candidate p99 |
|---|---:|---:|---:|---:|---:|
| Successful allocate/free | 902.52 K | 906.39 K | +0.4% | 82,437 ns | 87,667 ns |
| 5% expected failures | 925.96 K | 861.95 K | -6.9% | 81,195 ns | 85,522 ns |
| 30% expected failures | 1.04 M | 1.14 M | +9.2% | 74,381 ns | 82,447 ns |
| 60% expected failures | 1.52 M | 2.06 M | +35.1% | 62,198 ns | 75,563 ns |
| 100% expected failures | 13.34 M | 1.93 B | +145x | 29,927 ns | 80 ns |

The incremental free-side update removes the earlier failure-free throughput regression while preserving the impossible-request fast path. In this local run, the 5%-failure workload still shows a 6.9% throughput cost, while the candidate becomes throughput-positive between 5% and 30% expected failures. Mixed-workload p99 remains higher because its tail is dominated by the successful operations that still enter the mutex; the 100%-failure workload, which directly measures the intended fast path, reduces p99 by 99.7%. Relative QPS improvement is not expected to scale linearly with failure ratio because a locked failed allocation is cheaper than a successful allocate/free pair even in the baseline.

An independent rerun by a reviewer on the final lazy-hint/free-maintenance design showed the same overall trend, with smaller success-path overhead and positive throughput at 5% and 30% expected failures:

| Scenario | Reviewer upstream QPS | Reviewer candidate QPS | QPS change | Reviewer upstream p99 | Reviewer candidate p99 |
|---|---:|---:|---:|---:|---:|
| Successful allocate/free | 850.63 K | 824.05 K | -3.1% | 85,701 ns | 81,844 ns |
| 5% expected failures | 800.10 K | 884.97 K | +10.6% | 83,948 ns | 82,806 ns |
| 30% expected failures | 942.50 K | 1.19 M | +26.7% | 78,397 ns | 80,061 ns |
| 100% expected failures | 13.10 M | 2.31 B | +176x | 29,856 ns | 70 ns |

The 5% result is sensitive to host and run variance, so the PR does not claim a universal crossover point. Both final comparisons show that success-path overhead is small, while the benefit grows substantially as impossible-request frequency increases.

The benchmark also covers the same-segment Put allocation stage and deterministic fragmentation. All benchmark runs completed with zero unexpected results in both the throughput and latency phases.

User-space lock profiling was performed on an earlier fast-fail build using a `pthread_mutex_lock` uprobe and the `syscalls:sys_enter_futex` tracepoint. Across 3,232,000 measured and warmup allocation attempts, `pthread_mutex_lock` calls decreased from 3,232,057 to 57 and futex syscalls decreased from 1,197,395 to 22. The final policy retains the same repeated-request fast path after the first mutex-protected failure tightens the hint. QPS measured while perf probes were active was not used because probe overhead affects the two implementations asymmetrically.

Callgrind was also run on a focused stale-hint allocation-failure test repeated 5,000 times. Gating failure-only metrics behind `VLOG_IS_ON(1)` reduced the instruction count from 339,772,630 to 336,407,164, a 0.99% reduction, while the same test passes with verbose logging both disabled and enabled.

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (focused 16-thread A/B benchmark described above)

The complete `OffsetAllocatorTest` suite passed 51/51 tests, and `buffer_allocator_test` passed 18/18 tests. The tests cover hint tightening after failure, incremental updates after free and neighbor merging, metadata-capacity exhaustion, the verbose failure path, exact segment-selection queries, serialization/deserialization and restored-handle release, SmallFloat bin boundaries, multiplier values 1 through 4, and mutex-free rejection after the hint has been tightened.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all modified files and all applicable hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: N/A; the production implementation is below 500 LOC excluding tests and benchmark code and is not a major architectural change

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Tool: OpenAI Codex

Used for code navigation, implementation, unit tests, benchmark design and automation, and review of implementation details and benchmark results. The submitter reviewed every changed line and is responsible for understanding and defending the changes.
