### PR TITLE
[Doc] Update RBG integration example to workloads.x-k8s.io/v1alpha2

### DIFF
--- a/docs/source/deployment/kubernetes-deployment-guide/rbg-integration.md
+++ b/docs/source/deployment/kubernetes-deployment-guide/rbg-integration.md
@@ -14,13 +14,7 @@ For background on the integration, see the RBG [Mooncake integration KEP](https:
 
 ## Production Mooncake Cluster Example
 
-A production Mooncake cluster on RBG (`workloads.x-k8s.io/v1alpha1`): a Mooncake **Store** (one `master` plus NUMA-split `store` pods) and SGLang **prefill/decode** engines, all over RDMA. The two RBGs below are the Mooncake-side backend; a router/gateway (out of scope for this page) fronts the prefill/decode endpoints to make the P/D deployment servable — see the [overview](index) and the [Prefill/Decode Disaggregation quick start](../integrations/sglang/hicache-quick-start.md).
-
-```{note}
-The inline manifests below target `workloads.x-k8s.io/v1alpha1`. For the latest
-API version `v1alpha2`, please refer to the upstream examples linked under
-[RBG example](#rbg-example) above.
-```
+A production Mooncake cluster on RBG (`workloads.x-k8s.io/v1alpha2`): a Mooncake **Store** (one `master` plus NUMA-split `store` pods) and SGLang **prefill/decode** engines, all over RDMA. The two RBGs below are the Mooncake-side backend; a router/gateway (out of scope for this page) fronts the prefill/decode endpoints to make the P/D deployment servable — see the [overview](index) and the [Prefill/Decode Disaggregation quick start](../integrations/sglang/hicache-quick-start.md).
 
 | Group | Roles | Purpose |
 |---|---|---|
@@ -36,7 +30,7 @@ These manifests are sanitized **excerpts** that show the structure and the Moonc
 The Store `RoleBasedGroup` has a `master` (the Store coordinator) and a `store-<size>` role whose pods each run two NUMA-pinned store processes. The RBG operator creates a Service `s-qwen3-0-master` for the master role, so clients reach it at `s-qwen3-0-master:50051` — no Service object of your own. Node scheduling uses custom `kvcache.ai/master` and `kvcache.ai/store` labels so a node belongs to exactly one role/size.
 
 ```yaml
-apiVersion: workloads.x-k8s.io/v1alpha1
+apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
 metadata:
   name: qwen3-0
@@ -46,115 +40,115 @@ spec:
   roles:
   - name: master
     replicas: 1
-    template:
-      metadata:
-        labels: { role: master, app.kubernetes.io/instance: qwen3-0 }
-      spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - { key: kvcache.ai/master, operator: In, values: [qwen3_0_master] }
-        containers:
-        - name: master
-          image: <image>
-          command:
-          - sh
-          - -c
-          - |
-            ulimit -n 1048576
-            ulimit -l unlimited
-            mooncake_master \
-              --rpc_address=$(POD_IP) \
-              --rpc_port=50051 \
-              --eviction_high_watermark_ratio=0.9 \
-              --default_kv_lease_ttl=10000
-          env:
-          - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-          - { name: NVIDIA_VISIBLE_DEVICES, value: "void" }   # master needs no GPU
-          securityContext:
-            # master is an RPC coordinator with no RDMA data path — it does not need
-            # `privileged`. IPC_LOCK/SYS_RESOURCE cover the `ulimit -l unlimited` / mlock above.
-            privileged: false
-            capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
-          livenessProbe:
-            exec: { command: ["/bin/sh", "-c", "pgrep -x mooncake_master >/dev/null"] }
-            initialDelaySeconds: 20
-            periodSeconds: 15
-          ports:
-          - { containerPort: 50051, name: http }
-          - { containerPort: 9003, name: metrics }
-    workload: { apiVersion: apps/v1, kind: StatefulSet }
+    standalonePattern:
+      template:
+        metadata:
+          labels: { role: master, app.kubernetes.io/instance: qwen3-0 }
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - { key: kvcache.ai/master, operator: In, values: [qwen3_0_master] }
+          containers:
+          - name: master
+            image: <image>
+            command:
+            - sh
+            - -c
+            - |
+              ulimit -n 1048576
+              ulimit -l unlimited
+              mooncake_master \
+                --rpc_address=$(POD_IP) \
+                --rpc_port=50051 \
+                --eviction_high_watermark_ratio=0.9 \
+                --default_kv_lease_ttl=10000
+            env:
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: NVIDIA_VISIBLE_DEVICES, value: "void" }   # master needs no GPU
+            securityContext:
+              # master is an RPC coordinator with no RDMA data path — it does not need
+              # `privileged`. IPC_LOCK/SYS_RESOURCE cover the `ulimit -l unlimited` / mlock above.
+              privileged: false
+              capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
+            livenessProbe:
+              exec: { command: ["/bin/sh", "-c", "pgrep -x mooncake_master >/dev/null"] }
+              initialDelaySeconds: 20
+              periodSeconds: 15
+            ports:
+            - { containerPort: 50051, name: http }
+            - { containerPort: 9003, name: metrics }
 
   - name: store-1000gb
     replicas: 3
-    template:
-      metadata:
-        labels:
-          role: store-1000gb
-          app.kubernetes.io/instance: qwen3-0
-          app.kubernetes.io/part-of: mooncake
-      spec:
-        affinity:
-          nodeAffinity:
-            requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-              - matchExpressions:
-                - { key: kvcache.ai/store, operator: In, values: [qwen3_0_store-1000gb] }
-          podAntiAffinity:                    # at most one store pod per node across sizes
-            requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                - { key: app.kubernetes.io/part-of, operator: In, values: [mooncake] }
-                - { key: app.kubernetes.io/instance, operator: In, values: [qwen3-0] }
-              topologyKey: kubernetes.io/hostname
-        hostNetwork: true                     # RDMA
-        dnsPolicy: ClusterFirstWithHostNet
-        containers:
-        - name: store-numa0
-          image: <image>
-          command:
-          - sh
-          - -c
-          - |
-            ulimit -n 1048576
-            ulimit -l unlimited
-            exec numactl --cpunodebind=0 --membind=0 python3 -m mooncake.mooncake_store_service --port=8099
-          env:
-          - { name: MOONCAKE_LOCAL_HOSTNAME, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-          - { name: MOONCAKE_MASTER, value: "s-qwen3-0-master:50051" }
-          - { name: MOONCAKE_TE_META_DATA_SERVER, value: "P2PHANDSHAKE" }
-          - { name: MOONCAKE_GLOBAL_SEGMENT_SIZE, value: "1000gb" }   # DRAM this store contributes
-          - { name: MOONCAKE_LOCAL_BUFFER_SIZE, value: "67108864" }
-          - { name: MOONCAKE_PROTOCOL, value: "rdma" }
-          - { name: MOONCAKE_DEVICE, value: "<rdma-devices>" }
-          - { name: MC_ENABLE_DEST_DEVICE_AFFINITY, value: "1" }
-          # pin the client metrics HTTP server per container (numa0=9300 / numa1=9301);
-          # under hostNetwork two processes cannot share 9300.
-          - { name: MOONCAKE_ENABLE_CLIENT_HTTP_SERVER, value: "true" }
-          - { name: MOONCAKE_CLIENT_HTTP_PORT, value: "9300" }
-          ports: [{ containerPort: 8099 }]
-          startupProbe:
-            exec: { command: ["sh", "-c", "nc -z 127.0.0.1 8099"] }
-            periodSeconds: 10
-            failureThreshold: 90
-          livenessProbe:
-            exec: { command: ["sh", "-c", "nc -z 127.0.0.1 8099"] }
-            initialDelaySeconds: 10
-            periodSeconds: 10
-          securityContext:
-            # least-privilege RDMA: no `privileged` needed — IPC_LOCK/SYS_RESOURCE plus
-            # the /dev/infiniband device mount below are enough for the Transfer Engine NICs.
-            privileged: false
-            capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
-          volumeMounts:
-          - { mountPath: /dev/infiniband, name: ib }
-        # store-numa1: identical, but `numactl --cpunodebind=1 --membind=1`, --port=8100,
-        # containerPort 8100, and MOONCAKE_CLIENT_HTTP_PORT=9301.
-        volumes:
-        - { name: ib, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
-    workload: { apiVersion: apps/v1, kind: StatefulSet }
+    standalonePattern:
+      template:
+        metadata:
+          labels:
+            role: store-1000gb
+            app.kubernetes.io/instance: qwen3-0
+            app.kubernetes.io/part-of: mooncake
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - { key: kvcache.ai/store, operator: In, values: [qwen3_0_store-1000gb] }
+            podAntiAffinity:                  # at most one store pod per node across sizes
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - { key: app.kubernetes.io/part-of, operator: In, values: [mooncake] }
+                  - { key: app.kubernetes.io/instance, operator: In, values: [qwen3-0] }
+                topologyKey: kubernetes.io/hostname
+          hostNetwork: true                   # RDMA
+          dnsPolicy: ClusterFirstWithHostNet
+          containers:
+          - name: store-numa0
+            image: <image>
+            command:
+            - sh
+            - -c
+            - |
+              ulimit -n 1048576
+              ulimit -l unlimited
+              exec numactl --cpunodebind=0 --membind=0 python3 -m mooncake.mooncake_store_service --port=8099
+            env:
+            - { name: MOONCAKE_LOCAL_HOSTNAME, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: MOONCAKE_MASTER, value: "s-qwen3-0-master:50051" }
+            - { name: MOONCAKE_TE_META_DATA_SERVER, value: "P2PHANDSHAKE" }
+            - { name: MOONCAKE_GLOBAL_SEGMENT_SIZE, value: "1000gb" }   # DRAM this store contributes
+            - { name: MOONCAKE_LOCAL_BUFFER_SIZE, value: "67108864" }
+            - { name: MOONCAKE_PROTOCOL, value: "rdma" }
+            - { name: MOONCAKE_DEVICE, value: "<rdma-devices>" }
+            - { name: MC_ENABLE_DEST_DEVICE_AFFINITY, value: "1" }
+            # pin the client metrics HTTP server per container (numa0=9300 / numa1=9301);
+            # under hostNetwork two processes cannot share 9300.
+            - { name: MOONCAKE_ENABLE_CLIENT_HTTP_SERVER, value: "true" }
+            - { name: MOONCAKE_CLIENT_HTTP_PORT, value: "9300" }
+            ports: [{ containerPort: 8099 }]
+            startupProbe:
+              exec: { command: ["sh", "-c", "nc -z 127.0.0.1 8099"] }
+              periodSeconds: 10
+              failureThreshold: 90
+            livenessProbe:
+              exec: { command: ["sh", "-c", "nc -z 127.0.0.1 8099"] }
+              initialDelaySeconds: 10
+              periodSeconds: 10
+            securityContext:
+              # least-privilege RDMA: no `privileged` needed — IPC_LOCK/SYS_RESOURCE plus
+              # the /dev/infiniband device mount below are enough for the Transfer Engine NICs.
+              privileged: false
+              capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
+            volumeMounts:
+            - { mountPath: /dev/infiniband, name: ib }
+          # store-numa1: identical, but `numactl --cpunodebind=1 --membind=1`, --port=8100,
+          # containerPort 8100, and MOONCAKE_CLIENT_HTTP_PORT=9301.
+          volumes:
+          - { name: ib, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
 ```
 
 ### 2. Inference workers — prefill + decode
@@ -165,7 +159,7 @@ spec:
 - **`decode`** only participates in the P/D Transfer Engine — `--disaggregation-mode decode --disaggregation-ib-device`. It is **not** a Store/HiCache client: it sets no `MOONCAKE_MASTER` and enables no hierarchical cache.
 
 ```yaml
-apiVersion: workloads.x-k8s.io/v1alpha1
+apiVersion: workloads.x-k8s.io/v1alpha2
 kind: RoleBasedGroup
 metadata:
   name: sglang-workers-0
@@ -174,77 +168,77 @@ spec:
   roles:
   - name: prefill
     replicas: 4
-    template:
-      metadata:
-        labels:
-          app: sglang-worker
-          rolebasedgroup.workloads.x-k8s.io/name: sglang-workers-0
-          rolebasedgroup.workloads.x-k8s.io/role: prefill
-      spec:
-        hostNetwork: true                     # RDMA
-        dnsPolicy: ClusterFirstWithHostNet
-        nodeSelector: { deployment: sglang_0_prefill }
-        containers:
-        - name: sglang-prefill
-          image: <image>
-          command:
-          - bash
-          - -c
-          - |
-            set -e
-            ulimit -n 1048576; ulimit -l unlimited
-            python -m sglang.launch_server \
-              --model ${MODEL_PATH} --served-model-name Qwen3-0.6B \
-              --host 0.0.0.0 --port 8000 \
-              --disaggregation-mode prefill \
-              --disaggregation-ib-device $IB_DEVICE_LIST \
-              --enable-hierarchical-cache --hicache-storage-backend mooncake \
-              --tp 8 --page-size 64 --trust-remote-code \
-              --enable-metrics --enable-cache-report
-              # … model/hardware tuning flags omitted (context length, mem fraction,
-              #    NSA backends, EAGLE speculative decoding, KV-cache dtype, etc.)
-          env:
-          # --- pod identity ---
-          - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
-          - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-          - { name: MOONCAKE_LOCAL_HOSTNAME, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-          - { name: SGLANG_HOST_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
-          # --- model + fabric ---
-          - { name: MODEL_PATH, value: /models/Qwen3-0.6B }
-          - { name: IB_DEVICE_LIST, value: "<rdma-devices>" }
-          # --- Mooncake wiring ---
-          - { name: MOONCAKE_TE_META_DATA_SERVER, value: P2PHANDSHAKE }
-          - { name: MOONCAKE_MASTER, value: "s-qwen3-0-master:50051" }   # the Store group's master
-          - { name: MOONCAKE_PROTOCOL, value: rdma }
-          - { name: MOONCAKE_DEVICE, value: "<rdma-devices>" }
-          - { name: MOONCAKE_GLOBAL_SEGMENT_SIZE, value: "0" }   # pure client, contributes no DRAM
-          - { name: MC_TE_METRIC, value: "true" }
-          # … SGLANG_* / MC_* performance tuning omitted (heartbeat, timeouts,
-          #   spec-decoding v2, auto-empty-cache, NCCL, JIT, CPU affinity, PRC port range) …
-          ports:
-          - { containerPort: 8000, name: http }
-          - { containerPort: 8998, name: bootstrap }
-          readinessProbe:
-            tcpSocket: { port: 8000 }
-            initialDelaySeconds: 30
-            periodSeconds: 10
-          resources:
-            limits: { nvidia.com/gpu: "8" }
-            requests: { nvidia.com/gpu: "8" }
-          securityContext:
-            # least-privilege RDMA: no `privileged` needed — IPC_LOCK/SYS_RESOURCE plus
-            # the /dev/infiniband device mount below are enough for the NICs.
-            privileged: false
-            capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
-          volumeMounts:
-          - { mountPath: /models, name: model }
-          - { mountPath: /dev/shm, name: dshm }
-          - { mountPath: /dev/infiniband, name: ib }
-        volumes:
-        - { name: model, hostPath: { path: <model-host-path>, type: DirectoryOrCreate } }
-        - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1300Gi } }
-        - { name: ib, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
-    workload: { apiVersion: apps/v1, kind: StatefulSet }
+    standalonePattern:
+      template:
+        metadata:
+          labels:
+            app: sglang-worker
+            rbg.workloads.x-k8s.io/group-name: sglang-workers-0
+            rbg.workloads.x-k8s.io/role-name: prefill
+        spec:
+          hostNetwork: true                   # RDMA
+          dnsPolicy: ClusterFirstWithHostNet
+          nodeSelector: { deployment: sglang_0_prefill }
+          containers:
+          - name: sglang-prefill
+            image: <image>
+            command:
+            - bash
+            - -c
+            - |
+              set -e
+              ulimit -n 1048576; ulimit -l unlimited
+              python -m sglang.launch_server \
+                --model ${MODEL_PATH} --served-model-name Qwen3-0.6B \
+                --host 0.0.0.0 --port 8000 \
+                --disaggregation-mode prefill \
+                --disaggregation-ib-device $IB_DEVICE_LIST \
+                --enable-hierarchical-cache --hicache-storage-backend mooncake \
+                --tp 8 --page-size 64 --trust-remote-code \
+                --enable-metrics --enable-cache-report
+                # … model/hardware tuning flags omitted (context length, mem fraction,
+                #    NSA backends, EAGLE speculative decoding, KV-cache dtype, etc.)
+            env:
+            # --- pod identity ---
+            - { name: POD_NAME, valueFrom: { fieldRef: { fieldPath: metadata.name } } }
+            - { name: POD_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: MOONCAKE_LOCAL_HOSTNAME, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            - { name: SGLANG_HOST_IP, valueFrom: { fieldRef: { fieldPath: status.podIP } } }
+            # --- model + fabric ---
+            - { name: MODEL_PATH, value: /models/Qwen3-0.6B }
+            - { name: IB_DEVICE_LIST, value: "<rdma-devices>" }
+            # --- Mooncake wiring ---
+            - { name: MOONCAKE_TE_META_DATA_SERVER, value: P2PHANDSHAKE }
+            - { name: MOONCAKE_MASTER, value: "s-qwen3-0-master:50051" }   # the Store group's master
+            - { name: MOONCAKE_PROTOCOL, value: rdma }
+            - { name: MOONCAKE_DEVICE, value: "<rdma-devices>" }
+            - { name: MOONCAKE_GLOBAL_SEGMENT_SIZE, value: "0" }   # pure client, contributes no DRAM
+            - { name: MC_TE_METRIC, value: "true" }
+            # … SGLANG_* / MC_* performance tuning omitted (heartbeat, timeouts,
+            #   spec-decoding v2, auto-empty-cache, NCCL, JIT, CPU affinity, PRC port range) …
+            ports:
+            - { containerPort: 8000, name: http }
+            - { containerPort: 8998, name: bootstrap }
+            readinessProbe:
+              tcpSocket: { port: 8000 }
+              initialDelaySeconds: 30
+              periodSeconds: 10
+            resources:
+              limits: { nvidia.com/gpu: "8" }
+              requests: { nvidia.com/gpu: "8" }
+            securityContext:
+              # least-privilege RDMA: no `privileged` needed — IPC_LOCK/SYS_RESOURCE plus
+              # the /dev/infiniband device mount below are enough for the NICs.
+              privileged: false
+              capabilities: { add: ["IPC_LOCK", "SYS_RESOURCE"] }
+            volumeMounts:
+            - { mountPath: /models, name: model }
+            - { mountPath: /dev/shm, name: dshm }
+            - { mountPath: /dev/infiniband, name: ib }
+          volumes:
+          - { name: model, hostPath: { path: <model-host-path>, type: DirectoryOrCreate } }
+          - { name: dshm, emptyDir: { medium: Memory, sizeLimit: 1300Gi } }
+          - { name: ib, hostPath: { path: /dev/infiniband, type: DirectoryOrCreate } }
 
   - name: decode
     replicas: 1
@@ -255,8 +249,8 @@ spec:
     #   env:     NO MOONCAKE_MASTER / MOONCAKE_GLOBAL_SEGMENT_SIZE / hierarchical cache;
     #            keeps POD_NAME / POD_IP / MODEL_PATH / IB_DEVICE_LIST (P/D transfer only)
     #   sched:   nodeSelector deployment: sglang_0_decode ; dshm sizeLimit 15Gi
-    template: { }   # fill in a real PodSpec to deploy
-    workload: { apiVersion: apps/v1, kind: StatefulSet }
+    standalonePattern:
+      template: { }   # fill in a real PodSpec to deploy
 ```
 
 ### Mooncake integration points (recap)


### PR DESCRIPTION
## Description

Follow-up to the review on #2771 (https://github.com/kvcache-ai/Mooncake/pull/2771#discussion_r3557295605).

The inline manifests on the RBG integration page target `workloads.x-k8s.io/v1alpha1`, while the three upstream RBG examples this same page links to are all on `v1alpha2`. RBG serves `v1alpha2` as the storage version from v0.7.0 onward, and the `workload` field the page uses no longer exists there. This ports both manifests to `v1alpha2` and removes the note that pointed readers elsewhere for a current example.

Changes:

- Bump `apiVersion` on both `RoleBasedGroup`s.
- Move each role's PodSpec under `standalonePattern.template`.
- Drop the per-role `workload` field. Per the upstream ["Remove Workload Field from v1alpha2 API" KEP](https://github.com/sgl-project/rbg/blob/main/keps/workload-compatibility-mode/README.md), new v1alpha2 groups should use the default `RoleInstanceSet`; the `rbg.workloads.x-k8s.io/role-workload-type` annotation is documented there as "for conversion compatibility only" / "Internal Use Only". All three upstream Mooncake examples omit it.
- Update the prefill pod labels to the `rbg.workloads.x-k8s.io/` prefix v0.7.0 uses (`group-name` / `role-name`).
- Remove the `{note}` block that told readers this page was v1alpha1 — now redundant.

The pod templates are otherwise untouched. Three of the four roles are byte-identical to before; only `prefill` differs, by the two renamed labels. The Mooncake wiring needs no edit either: the operator still exposes a role as the headless Service `s-<rbg>-<role>`, so `MOONCAKE_MASTER=s-qwen3-0-master:50051` still resolves.

One correction to the review thread, since it shaped the original ask: the reported `no matches for kind "RoleBasedGroup" in version "workloads.x-k8s.io/v1alpha1"` does not reproduce on a current RBG install. `v0.7.0`, `v0.8.0-alpha.3` and `main` all still have `v1alpha1: served=true`, and the pre-change page passes `kubectl apply --dry-run=server` unmodified. The reason to move is that `v1alpha2` is the storage version and the shape the upstream examples use — not a hard apply failure.

## Module

- [x] Docs

## Type of Change

- [x] Documentation update

## How Has This Been Tested?

Verified against a real RBG v0.7.0 install (4-node cluster), not just rendered.

**Test commands:**
```bash
# 1. docs build
cd docs && make html

# 2. both manifests extracted verbatim from the page, validated against the live v1alpha2 API
#    (this exercises the CEL x-kubernetes-validations rules and the conversion webhook)
kubectl apply --dry-run=server -f doc-manifests.yaml

# 3. end-to-end: the page's manifests deployed with mock containers
#    (busybox listeners in place of the real binaries; GPU/RDMA/model paths substituted)
kubectl apply -f mock.yaml
kubectl exec qwen3-0-store-1000gb-0 -c store-numa0 -- nc -z -w3 s-qwen3-0-master 50051
```

**Test results:**
- [x] Manual testing done (described below)

- `make html`: build succeeded, no warnings; the rendered page has no remaining `v1alpha1` or old label prefix.
- `--dry-run=server` on both manifests as written on the page: accepted.
- Deployed with mocked containers against RBG v0.7.0. Retained from the page verbatim: `hostNetwork`, both NUMA store containers, `nodeAffinity` + `podAntiAffinity`, `IPC_LOCK`/`SYS_RESOURCE` with `privileged: false`, all three probe kinds, all `MOONCAKE_*` env, all three volumes. Substituted only what the test cluster cannot provide (image, commands, `nvidia.com/gpu`, `dshm` size, node label values, host paths).
  - Both groups reconcile; roles come up as `RoleInstanceSet` with pod names `qwen3-0-master-0`, `qwen3-0-store-1000gb-0..2`, `sglang-workers-0-prefill-0..3`, `sglang-workers-0-decode-0`.
  - `s-qwen3-0-master` is created headless; store pods and prefill both reach `s-qwen3-0-master:50051`.
  - Ran the same spec both ways — default `RoleInstanceSet` vs. the annotation forcing `apps/v1/StatefulSet` — and compared. Pod names, Service shape, RBG status and connectivity are identical; the only difference is that `RoleInstanceSet` adds the `InPlaceUpdateReady` / `InstancePodReady` readiness gates. Nothing on this page depends on the distinction.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` — n/a, docs only
- [x] I have run `pre-commit run --all-files` and all hooks pass — run on the changed file; passed with no rewrites
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective — n/a, docs only
- [x] For changes >500 LOC: I have filed an RFC issue — n/a, 182 insertions / 188 deletions in one file

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code was used to port the manifests, to cross-check the v1alpha2 schema and Service behaviour against the RBG v0.7.0 sources, and to run the cluster verification described above. The submitter has reviewed every changed line.