### PR TITLE
[TENT] Reject malformed numeric metrics environment overrides

### DIFF
--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -168,7 +168,14 @@ bool ConfigHelper::parseBool(const std::string& str, bool default_value) {
 
 int ConfigHelper::parseInt(const std::string& str, int default_value) {
     try {
-        return std::stoi(str);
+        size_t parsed = 0;
+        int value = std::stoi(str, &parsed);
+        if (parsed != str.size()) {
+            LOG(WARNING) << "Invalid integer value '" << str
+                         << "', using default: " << default_value;
+            return default_value;
+        }
+        return value;
     } catch (const std::exception& e) {
         LOG(WARNING) << "Failed to parse integer '" << str << "': " << e.what()
                      << ", using default: " << default_value;
@@ -179,7 +186,13 @@ int ConfigHelper::parseInt(const std::string& str, int default_value) {
 uint16_t ConfigHelper::parsePort(const std::string& str,
                                  uint16_t default_value) {
     try {
-        int port = std::stoi(str);
+        size_t parsed = 0;
+        int port = std::stoi(str, &parsed);
+        if (parsed != str.size()) {
+            LOG(WARNING) << "Invalid port value '" << str
+                         << "', using default: " << default_value;
+            return default_value;
+        }
         if (port > 0 && port <= 65535) {
             return static_cast<uint16_t>(port);
         } else {

--- a/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
@@ -151,6 +151,18 @@ TEST(MetricsConfigLoaderTest, LoadFromEnvironmentWithPartialVars) {
     EXPECT_EQ(config.http_host, "0.0.0.0");
 }
 
+TEST(MetricsConfigLoaderTest, InvalidNumericEnvironmentValuesUseDefaults) {
+    EnvVarGuard g1(config_keys::ENV_METRICS_HTTP_PORT, "8080junk");
+    EnvVarGuard g2(config_keys::ENV_METRICS_HTTP_SERVER_THREADS, "2x");
+    EnvVarGuard g3(config_keys::ENV_METRICS_REPORT_INTERVAL, "30s");
+
+    MetricsConfig config = MetricsConfigLoader::loadFromEnvironment();
+
+    EXPECT_EQ(config.http_port, 9100);
+    EXPECT_EQ(config.http_server_threads, 2);
+    EXPECT_EQ(config.report_interval_seconds, 30);
+}
+
 //------------------------------------------------------------------------------
 // MetricsConfigLoader::loadWithDefaults Tests
 //------------------------------------------------------------------------------
@@ -301,6 +313,7 @@ TEST(ConfigHelperTest, ParseIntValid) {
 TEST(ConfigHelperTest, ParseIntInvalid) {
     EXPECT_EQ(ConfigHelper::parseInt("not-a-number", 99), 99);
     EXPECT_EQ(ConfigHelper::parseInt("", 50), 50);
+    EXPECT_EQ(ConfigHelper::parseInt("42x", 99), 99);
 }
 
 TEST(ConfigHelperTest, ParsePortValid) {
@@ -312,6 +325,7 @@ TEST(ConfigHelperTest, ParsePortValid) {
 TEST(ConfigHelperTest, ParsePortInvalid) {
     EXPECT_EQ(ConfigHelper::parsePort("not-a-port", 9100), 9100);
     EXPECT_EQ(ConfigHelper::parsePort("", 9100), 9100);
+    EXPECT_EQ(ConfigHelper::parsePort("8080junk", 9100), 9100);
 }
 
 TEST(ConfigHelperTest, ParseDoubleArrayValid) {


### PR DESCRIPTION
## Intro

> Hi team, I couldn’t find a clearly scoped issue that seemed suitable for a first contribution, so I used AI to help inspect the codebase and identify this potential issue. I’m also hoping to use this opportunity to become familiar with the project’s contribution workflow.
> 
> Please let me know if anything here is incorrect or could be improved. If there are other directions you would recommend, I’d be very happy to explore them.

## Description

TENT numeric metrics environment overrides currently accept partial parses such as `8080junk`, `2x`, and `30s` because `std::stoi` is used without checking whether the complete input was consumed. This can silently turn malformed configuration into a valid but unintended value.

This change:
- requires integer and port parsers to consume the complete input;
- preserves the configured default for partially parsed values;
- adds parser-level and environment-loader regression coverage.

No matching open issue or pull request was found.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files mooncake-transfer-engine/tent/src/common/config.cpp mooncake-transfer-engine/tent/tests/metrics_config_loader_test.cpp
```

The production config sources were also compiled on macOS with Apple Clang using `-Wall -Wextra -Werror`, then exercised with partially parsed port, thread-count, and report-interval inputs.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done as described above

The repository TENT unit target requires the Linux dependency stack and was not run locally.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable for this bug fix)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex helped identify the parsing edge cases, implement the focused fix, and add regression tests. The human submitter has reviewed the scope and is responsible for understanding and defending every changed line.