### PR TITLE
[Bugfix] Clear RDMA context health counter only on successful completions

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -564,7 +564,26 @@ void WorkerPool::performPollCq(int thread_id) {
         }
     }
 
+    // Slices this loop drove to a terminal state, successes and
+    // retry-exhausted failures alike; folded into processed_slice_count_,
+    // which gates worker parking. Every terminal outcome below goes through
+    // finalize_slice() so it is counted exactly once. Slices handed to
+    // redispatch() are not terminal here and are accounted for there.
     int processed_slice_count = 0;
+    // Successful completions only, kept apart because it clears the context
+    // health counter. A completion error is no evidence that this RNIC can
+    // still move data -- including IBV_WC_WR_FLUSH_ERR, which only reports
+    // WRs the hardware discarded after the QP had already entered ERR.
+    int succeeded_slice_count = 0;
+    auto finalize_slice = [&](Transport::Slice *slice, bool success) {
+        if (success) {
+            slice->markSuccess();
+            succeeded_slice_count++;
+        } else {
+            slice->markFailed();
+        }
+        processed_slice_count++;
+    };
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     std::unordered_set<RdmaEndPoint *> local_failed_endpoints;
@@ -610,10 +629,8 @@ void WorkerPool::performPollCq(int thread_id) {
                                 << "), handing off if retry allows";
                         if (shouldRetrySlice(slice))
                             local_failed_slice_list.push_back(slice);
-                        else {
-                            slice->markFailed();
-                            processed_slice_count++;
-                        }
+                        else
+                            finalize_slice(slice, false);
                     } else {
                         if (globalConfig().trace)
                             LOG(INFO) << "Worker: WR flush error (peer_nic: "
@@ -621,10 +638,8 @@ void WorkerPool::performPollCq(int thread_id) {
                                       << "), redispatching if retry allows";
                         if (shouldRetrySlice(slice))
                             failed_slice_list.push_back(slice);
-                        else {
-                            slice->markFailed();
-                            processed_slice_count++;
-                        }
+                        else
+                            finalize_slice(slice, false);
                     }
                     continue;
                 }
@@ -671,12 +686,10 @@ void WorkerPool::performPollCq(int thread_id) {
                 if (shouldRetrySlice(slice)) {
                     retry_list->push_back(slice);
                 } else {
-                    slice->markFailed();
-                    processed_slice_count_++;
+                    finalize_slice(slice, false);
                 }
             } else {
-                slice->markSuccess();
-                processed_slice_count++;
+                finalize_slice(slice, true);
             }
         }
         if (nr_poll)
@@ -687,10 +700,12 @@ void WorkerPool::performPollCq(int thread_id) {
     for (auto &entry : qp_depth_set)
         entry.first->fetch_sub(entry.second, std::memory_order_acq_rel);
 
-    if (processed_slice_count) {
+    if (processed_slice_count)
         processed_slice_count_.fetch_add(processed_slice_count);
-        markContextSuccess();
-    }
+    // Clear the consecutive-failure counter only on proven data movement, so
+    // that repeated local completion failures can still reach the threshold
+    // and retire this RNIC (see handleLocalFailure()).
+    if (succeeded_slice_count) markContextSuccess();
 
     if (!local_failed_slice_list.empty()) {
         redispatch(local_failed_slice_list, thread_id, true);


### PR DESCRIPTION
Description

  WorkerPool::performPollCq() cleared the per-context consecutive-failure counter whenever the poll loop retired any slice, including slices that failed. Because processed_slice_count mixes successful completions with retry-exhausted failures, a single failed slice was enough to call markContextSuccess() and reset context_failure_count_ to 0.

  Root cause. The counter and its clear condition disagreed on what counts as evidence of a healthy RNIC:

  if (processed_slice_count) {                       // successes AND failures
      processed_slice_count_.fetch_add(processed_slice_count);
      markContextSuccess();                          // resets context_failure_count_
  }

  Why it matters. context_failure_count_ is the only mechanism that retires a catastrophically failing local RNIC (markContextFailure() → set_active(false) + refreshPublishedLocalTopology() at kContextFailureThreshold = 32). Increment and reset happen inside the same performPollCq() call, so they cancel out:

  1. A CQE returns IBV_WC_LOC_PROT_ERR → handleLocalFailure() → counter goes to 1, and deleteEndpointByPtr() moves the QP to ERR.
  2. The remaining WRs on that QP are flushed as IBV_WC_WR_FLUSH_ERR. Those that exhaust retries call markFailed() and bump processed_slice_count.
  3. End of the function: markContextSuccess() resets the counter to 0.

  recorded_local_context_failure already limits the counter to at most +1 per poll round, so 32 independent rounds are needed — and any terminal failure in between wiped the progress. In practice the counter never reached the threshold and a dead RNIC was never retired. The failure mode is self-reinforcing: the worse the hardware, the more slices exhaust retries, and the more often the counter is cleared.

  A second consumer was affected too. worker_pool.cpp:411 uses handoff_to_local_worker = !context_.active() || !contextHealthy() to re-route slices already queued against a now-suspect NIC. With the counter pinned at 0, contextHealthy() was always true, so queued slices kept being redispatched on the sick local RNIC instead of being handed off.

  Fix. Split the accumulator in two and route them to their respective consumers:

  - processed_slice_count — every terminal slice (success + retry-exhausted failure), folded into processed_slice_count_. Failures must stay here: transferWorker() gates worker parking on processed == submitted, so dropping them would leave workers spinning forever.
  - succeeded_slice_count — IBV_WC_SUCCESS only; gates markContextSuccess().

  A finalize_slice(slice, success) lambda funnels all four terminal branches (flush error on inactive context, flush error on active context, non-flush error with retries exhausted, success) so every terminal slice is accounted for exactly once and success/failure cannot be miscategorized. Slices handed to redispatch() are not terminal here and are accounted for there.

  This also removes a pre-existing inconsistency: the non-flush retry-exhausted branch incremented the member atomic processed_slice_count_ directly instead of the local accumulator, so that path never contributed to the if (processed_slice_count) guard.

  Regression origin. markContextSuccess() was added to this call site in #2155 (5e5052fe, 2026-06-09). The dedicated IBV_WC_WR_FLUSH_ERR branch that feeds processed_slice_count predates it (#1903, ea8fa5da), so the call site has been ineffective since it was introduced.

  Overlap check. Searched open PRs and issues; nothing covers this. #3161 ([TransferEngine] Refactor RDMA worker ownership to avoid endpoint UAF, WIP) touches the same file but addresses endpoint ownership/UAF, not the health-counter reset condition.

  Known coverage gap
  
  No automated test is included, and there is currently no existing coverage for context health tracking (context_failure_count_ / kContextFailureThreshold / markContextSuccess). Two concrete blockers, both verified:

  - The regression lives in a local variable inside performPollCq(), and WorkerPool's constructor unconditionally spawns worker threads that epoll_wait(context_.eventFd()), so it cannot be instantiated against a context that was never construct()ed. Reaching it in a test requires either a live RDMA device or extracting the poll-round accounting out of the function body.
  - CI runs ctest -j on GitHub-hosted runners with no RDMA hardware, so a device-gated test would self-skip and provide no protection on PRs.

  Deliberately left out of this PR to keep the fix minimal and to avoid structural conflicts with #3161, which is refactoring the same file. Happy to follow up with the extraction plus a hardware-free unit test if reviewers prefer it here.

  Module
  
  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change
  
  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other
  
  How Has This Been Tested?

  Static checks only so far; see the coverage-gap note above for why no automated test accompanies the change.

  Test commands:
  # Formatting (run locally, passes clean)
  ./scripts/code_format.sh
  
  # Full suite, to be run in a Linux container / on CI
  cmake -B build -DUSE_ETCD=OFF -DBUILD_UNIT_TESTS=ON
  cmake --build build -j"$(nproc)"
  ctest --test-dir build --output-on-failure

  Test results:
  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable) — N/A, no user-visible behavior changed
  - [ ] I have added tests to prove my changes are effective — see "Known coverage gap"
  - [x] For changes >500 LOC: I have filed an RFC issue — N/A (30 insertions, 15 deletions in 1 file)

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)