### PR TITLE
[store] feat: support vLLM sha256 hash profile

### DIFF
--- a/mooncake-conductor/example/README.md
+++ b/mooncake-conductor/example/README.md
@@ -112,9 +112,62 @@ CLI mode expresses the same mapping as follows:
   per publisher rank, including multiple ranks for one instance when needed;
 - `--prefiller-registration` may reference only an ID listed by
   `--prefiller-instance-ids`;
-- the hash strategy, algorithm, and projection are fixed to `vllm_v1`,
-  `sha256_cbor`, and `low64_be`; supply the deployment-specific seed with
-  `--python-hash-seed`.
+- the hash strategy and projection are fixed to `vllm_v1` and `low64_be`;
+  select the hash algorithm with `--hash-algorithm sha256` or
+  `--hash-algorithm sha256_cbor` (legacy CLI default: `sha256_cbor`), and
+  supply the deployment-specific seed with `--python-hash-seed`.
+
+### Hash Algorithm Compatibility
+
+Conductor reproduces vLLM v1 prefix-cache block hashes and supports exactly
+two recipes, selected by `hash_profile.algorithm`:
+
+- `sha256`: SHA-256 over CPython Pickle protocol-5 serialization. This is the
+  current vLLM default (`--prefix-caching-hash-algo sha256`).
+- `sha256_cbor`: SHA-256 over canonical CBOR. This remains the proxy's legacy
+  CLI default so existing deployments keep their cache compatibility
+  implicitly.
+
+The registered algorithm must match the `--prefix-caching-hash-algo` of every
+vLLM producer sharing the context, and every producer must run with the same
+explicit fixed seed:
+
+```bash
+export PYTHONHASHSEED=0
+```
+
+An unset producer seed is random per process and cannot be reconstructed by
+Conductor. Never mix algorithms under one active context
+(tenant/model/LoRA/block size): projected keys from the two recipes are
+unrelated, Conductor rejects the conflicting registration, and switching
+requires unregistering the old profile and repopulating cache presence.
+
+Conductor trusts the registered profile as the compatibility contract: KV
+events carry no algorithm or protocol metadata, so a producer whose actual
+`--prefix-caching-hash-algo` disagrees with the registered value publishes
+hashes Conductor cannot match, and queries silently return zero hits. A
+producer-side handshake/canary check is tracked as follow-up work.
+
+The supported input boundary is plain token blocks with an optional LoRA name
+and a first-block cache salt. vLLM multimodal and prompt-embedding extra hash
+keys are not reconstructible by Conductor's query contract; requests whose
+cache identity depends on them are not compatible with this routing example.
+
+For a vLLM deployment using its defaults, register `sha256`:
+
+```jsonc
+"hash_profile": {
+  "strategy": "vllm_v1",
+  "algorithm": "sha256",
+  "python_hash_seed": "0",
+  "index_projection": "low64_be"
+}
+```
+
+and drop `--prefix-caching-hash-algo sha256_cbor` from the vLLM launch flags
+below (or pass `--prefix-caching-hash-algo sha256` explicitly). To keep the
+opt-in CBOR recipe, leave both the vLLM flag and the registered profile at
+`sha256_cbor` as shown in the sample configuration.
 
 The example intentionally does not configure replay. It omits
 `replay_endpoint` from every registration request, and vLLM KV-event
@@ -159,7 +212,9 @@ at or after commit `5b3807e862fe70f51139ac518a5dd361e57de2e5` (PR #42892,
 events can register successfully but are rejected during event decoding, so
 queries remain at zero hits.
 
-For the first sample prefill, the relevant flags are:
+For the first sample prefill, the relevant flags are (CBOR recipe shown; for
+a vLLM-default `sha256` deployment, drop `--prefix-caching-hash-algo` or pass
+`sha256` and register the matching algorithm as described above):
 
 ```bash
 export PYTHONHASHSEED=0

--- a/mooncake-conductor/example/cache_aware_disagg_proxy.py
+++ b/mooncake-conductor/example/cache_aware_disagg_proxy.py
@@ -16,7 +16,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal, cast
 from urllib.parse import urlsplit, urlunsplit
 
 import httpx
@@ -25,9 +25,16 @@ from fastapi.responses import StreamingResponse
 
 logger = logging.getLogger(__name__)
 
+HashAlgorithm = Literal["sha256", "sha256_cbor"]
+
+# Keep the profile shape stable while allowing the recipe to be selected by
+# registration.  The CBOR recipe remains the default for the legacy CLI mode;
+# JSON configurations must state the algorithm explicitly in their profile.
+SUPPORTED_HASH_ALGORITHMS: frozenset[str] = frozenset({"sha256", "sha256_cbor"})
+DEFAULT_HASH_ALGORITHM: HashAlgorithm = "sha256_cbor"
 SUPPORTED_HASH_PROFILE = {
     "strategy": "vllm_v1",
-    "algorithm": "sha256_cbor",
+    "algorithm": DEFAULT_HASH_ALGORITHM,
     "index_projection": "low64_be",
 }
 MAX_DP_RANK = (1 << 31) - 1
@@ -50,6 +57,7 @@ CLI_CONFIG_OPTIONS = (
     ("block_size", "--block-size"),
     ("tenant_id", "--tenant-id"),
     ("lora_name", "--lora-name"),
+    ("hash_algorithm", "--hash-algorithm"),
     ("python_hash_seed", "--python-hash-seed"),
     ("query_timeout_seconds", "--query-timeout-seconds"),
     ("registration_timeout_seconds", "--registration-timeout-seconds"),
@@ -67,7 +75,7 @@ class ConductorProtocolError(RuntimeError):
 @dataclass(frozen=True)
 class HashProfileConfig:
     strategy: str
-    algorithm: str
+    algorithm: HashAlgorithm
     python_hash_seed: str
     index_projection: str
 
@@ -211,10 +219,23 @@ def _parse_hash_profile(raw: Any, path: str) -> HashProfileConfig:
         "index_projection",
     }
     _reject_unknown_fields(value, allowed, path)
-    for field, expected in SUPPORTED_HASH_PROFILE.items():
-        actual = _require_nonempty_string(value, field, path)
-        if actual != expected:
-            raise ConfigError(f"{path}.{field} must be {expected!r}")
+    strategy = _require_nonempty_string(value, "strategy", path)
+    if strategy != SUPPORTED_HASH_PROFILE["strategy"]:
+        raise ConfigError(
+            f"{path}.strategy must be {SUPPORTED_HASH_PROFILE['strategy']!r}"
+        )
+
+    algorithm = _require_nonempty_string(value, "algorithm", path)
+    if algorithm not in SUPPORTED_HASH_ALGORITHMS:
+        supported = ", ".join(sorted(SUPPORTED_HASH_ALGORITHMS))
+        raise ConfigError(f"{path}.algorithm must be one of: {supported}")
+
+    index_projection = _require_nonempty_string(value, "index_projection", path)
+    if index_projection != SUPPORTED_HASH_PROFILE["index_projection"]:
+        raise ConfigError(
+            f"{path}.index_projection must be "
+            f"{SUPPORTED_HASH_PROFILE['index_projection']!r}"
+        )
 
     seed = _require_nonempty_string(value, "python_hash_seed", path)
     if seed != "random":
@@ -226,10 +247,10 @@ def _parse_hash_profile(raw: Any, path: str) -> HashProfileConfig:
             raise ConfigError(f"{path}.python_hash_seed must be in the uint32 range")
 
     return HashProfileConfig(
-        strategy=value["strategy"],
-        algorithm=value["algorithm"],
+        strategy=strategy,
+        algorithm=cast(HashAlgorithm, algorithm),
         python_hash_seed=seed,
-        index_projection=value["index_projection"],
+        index_projection=index_projection,
     )
 
 
@@ -485,6 +506,11 @@ def _cli_config_dict(args: argparse.Namespace) -> dict[str, Any]:
     python_hash_seed = _required_cli_value(
         args, "python_hash_seed", "--python-hash-seed"
     )
+    hash_algorithm = (
+        args.hash_algorithm
+        if args.hash_algorithm is not None
+        else DEFAULT_HASH_ALGORITHM
+    )
 
     return {
         "conductor": {
@@ -510,7 +536,7 @@ def _cli_config_dict(args: argparse.Namespace) -> dict[str, Any]:
                 "lora_name": args.lora_name if args.lora_name is not None else "",
                 "hash_profile": {
                     "strategy": SUPPORTED_HASH_PROFILE["strategy"],
-                    "algorithm": SUPPORTED_HASH_PROFILE["algorithm"],
+                    "algorithm": hash_algorithm,
                     "python_hash_seed": python_hash_seed,
                     "index_projection": SUPPORTED_HASH_PROFILE["index_projection"],
                 },
@@ -1048,6 +1074,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--block-size", type=int)
     parser.add_argument("--tenant-id")
     parser.add_argument("--lora-name")
+    parser.add_argument(
+        "--hash-algorithm",
+        "--hash-algo",
+        "--prefix-caching-hash-algo",
+        dest="hash_algorithm",
+        help=(
+            "vLLM prefix-cache hash recipe (sha256 or sha256_cbor); "
+            "legacy CLI default: sha256_cbor"
+        ),
+    )
     parser.add_argument("--python-hash-seed")
     parser.add_argument("--query-timeout-seconds", type=float)
     parser.add_argument("--registration-timeout-seconds", type=float)

--- a/mooncake-conductor/src/kvevent/config.cpp
+++ b/mooncake-conductor/src/kvevent/config.cpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <limits>
 #include <set>
+#include <string_view>
 
 #include "conductor/common/utils.h"
 #include "conductor/prefixindex/hash_strategy.h"
@@ -44,6 +45,15 @@ bool JsonInt64(const Json::Value& value, int64_t* out) {
         return true;
     }
     return false;
+}
+
+// Keep the configuration boundary deliberately narrower than the internal
+// hash-strategy implementation.  The registration contract currently
+// exposes exactly the two recipes that vLLM supports for v1 prefix caching;
+// rejecting anything else here also guarantees that an invalid algorithm
+// cannot cause root derivation or any later subscription side effects.
+bool IsSupportedHashAlgorithm(std::string_view algorithm) {
+    return algorithm == "sha256" || algorithm == "sha256_cbor";
 }
 
 bool ParseHashProfile(const Json::Value& raw,
@@ -88,6 +98,14 @@ bool ParseHashProfile(const Json::Value& raw,
         return false;
     }
 
+    if (!IsSupportedHashAlgorithm(source.algorithm)) {
+        *error = "unsupported hash algorithm: " + source.algorithm;
+        return false;
+    }
+
+    // Resolve (and therefore derive) the recipe-specific root while parsing
+    // the immutable static configuration.  No service is returned until this
+    // succeeds, so callers cannot subscribe with an unresolved/forged root.
     *error = prefixindex::ResolveHashProfile(source, profile);
     return error->empty();
 }

--- a/mooncake-conductor/src/kvevent/event_manager.cpp
+++ b/mooncake-conductor/src/kvevent/event_manager.cpp
@@ -64,6 +64,14 @@ bool JsonInt64(const Json::Value& value, int64_t* out) {
     return false;
 }
 
+// The HTTP registration contract intentionally exposes only the two vLLM v1
+// recipes.  Validate this at the request boundary before invoking root
+// derivation so an unsupported selector cannot trigger any hash work or state
+// mutation, and so the error is attributed to the algorithm field.
+bool IsSupportedHashAlgorithm(std::string_view algorithm) {
+    return algorithm == "sha256" || algorithm == "sha256_cbor";
+}
+
 // Writes an error response: text/plain body with trailing \n.
 void HttpError(coro_http_response& resp, status_type status,
                const std::string& message) {
@@ -219,12 +227,22 @@ bool ParseHashProfileConfig(const Json::Value& body, coro_http_response& resp,
         return false;
     }
 
+    if (!IsSupportedHashAlgorithm(source.algorithm)) {
+        HttpJsonError(resp, "invalid_value",
+                      "unsupported hash algorithm: " + source.algorithm,
+                      "algorithm");
+        return false;
+    }
+
+    // Resolve the selected recipe before ParseServiceConfigRequest returns.
+    // SubscribeToService (and thus prefix-index/ZMQ state mutation) is only
+    // reached after this derived profile has been validated.
     if (std::string error = prefixindex::ResolveHashProfile(source, profile);
         !error.empty()) {
         const char* field = "python_hash_seed";
         if (source.strategy != "vllm_v1") {
             field = "strategy";
-        } else if (source.algorithm != "sha256_cbor") {
+        } else if (!IsSupportedHashAlgorithm(source.algorithm)) {
             field = "algorithm";
         } else if (source.index_projection != "low64_be") {
             field = "index_projection";
@@ -504,6 +522,20 @@ Json::Value CacheHitResultToJson(const prefixindex::CacheHitResult& result) {
     return out;
 }
 
+Json::Value HashProfileToJson(const common::ResolvedHashProfile& profile) {
+    Json::Value out(Json::objectValue);
+    // Keep the resolved profile fields in one place so /services and
+    // /global_view cannot drift when a new recipe is added.  root_digest is
+    // intentionally emitted here only as a derived diagnostic; it is not
+    // accepted by ParseHashProfileConfig as registration input.
+    out["strategy"] = profile.strategy;
+    out["algorithm"] = profile.algorithm;
+    out["python_hash_seed"] = profile.python_hash_seed;
+    out["root_digest"] = profile.root_digest;
+    out["index_projection"] = profile.index_projection;
+    return out;
+}
+
 Json::Value ServiceConfigToJson(const common::ServiceConfig& svc) {
     // Field names are the exported struct-field names of
     // common.ServiceConfig (fixed JSON wire contract).
@@ -522,13 +554,7 @@ Json::Value ServiceConfigToJson(const common::ServiceConfig& svc) {
     } else {
         out["CacheGroup"] = Json::Value(Json::nullValue);
     }
-    Json::Value profile(Json::objectValue);
-    profile["strategy"] = svc.hash_profile.strategy;
-    profile["algorithm"] = svc.hash_profile.algorithm;
-    profile["python_hash_seed"] = svc.hash_profile.python_hash_seed;
-    profile["root_digest"] = svc.hash_profile.root_digest;
-    profile["index_projection"] = svc.hash_profile.index_projection;
-    out["HashProfile"] = profile;
+    out["HashProfile"] = HashProfileToJson(svc.hash_profile);
     return out;
 }
 

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -16,6 +16,44 @@ namespace {
 constexpr size_t kSha256DigestSize = 32;
 constexpr uint64_t kMaxPythonHashSeed = std::numeric_limits<uint32_t>::max();
 
+// ---------------------------------------------------------------------------
+// Recipe boundary
+//
+// The vLLM v1 chain (complete-block selection, full-32-byte parent
+// advancement, SHA-256 digesting, and the low64_be projection) is shared by
+// every supported algorithm.  Each algorithm name selects exactly one value
+// codec that owns serialization of the seed root and of each
+// (parent, token tuple, extra keys) block value.  The codec receives the
+// already-computed extra-key ordering (non-empty LoRA on every block,
+// non-empty cache salt after LoRA only on the first block) and never sees
+// value shapes outside the Conductor query contract.
+//
+// Multimodal and prompt-embedding vLLM extra keys are deliberately NOT
+// representable here: the Conductor query API cannot express them, so the
+// codecs reject that shape by construction instead of approximating it.
+// ---------------------------------------------------------------------------
+
+struct VllmBlockValues {
+    std::span<const uint8_t> parent_digest;  // full 32-byte parent digest
+    std::span<const int32_t> token_ids;      // exactly one complete block
+    const std::string* lora_name;            // nullptr when no LoRA extra key
+    const std::string* cache_salt;           // nullptr when no salt extra key
+};
+
+class VllmValueCodec {
+   public:
+    virtual ~VllmValueCodec() = default;
+
+    virtual void EncodeSeed(std::string_view seed,
+                            std::vector<uint8_t>* out) const = 0;
+    virtual void EncodeBlock(const VllmBlockValues& values,
+                             std::vector<uint8_t>* out) const = 0;
+};
+
+// ---------------------------------------------------------------------------
+// Canonical-CBOR codec (sha256_cbor)
+// ---------------------------------------------------------------------------
+
 void AppendTypeAndLength(uint8_t major_type, uint64_t value,
                          std::vector<uint8_t>* out) {
     const uint8_t initial = static_cast<uint8_t>(major_type << 5);
@@ -70,6 +108,332 @@ void AppendSignedInteger(int32_t value, std::vector<uint8_t>* out) {
     }
     const int64_t signed_value = value;
     AppendTypeAndLength(1, static_cast<uint64_t>(-1 - signed_value), out);
+}
+
+class CborVllmCodec final : public VllmValueCodec {
+   public:
+    void EncodeSeed(std::string_view seed,
+                    std::vector<uint8_t>* out) const override {
+        out->clear();
+        AppendText(seed, out);
+    }
+
+    void EncodeBlock(const VllmBlockValues& values,
+                     std::vector<uint8_t>* out) const override {
+        out->clear();
+        AppendArrayHeader(3, out);
+        AppendBytes(values.parent_digest, out);
+
+        AppendArrayHeader(values.token_ids.size(), out);
+        for (const int32_t token : values.token_ids) {
+            AppendSignedInteger(token, out);
+        }
+
+        const bool has_lora = values.lora_name != nullptr;
+        const bool has_salt = values.cache_salt != nullptr;
+        if (!has_lora && !has_salt) {
+            out->push_back(0xf6U);
+        } else {
+            AppendArrayHeader(
+                static_cast<size_t>(has_lora) + static_cast<size_t>(has_salt),
+                out);
+            if (has_lora) {
+                AppendText(*values.lora_name, out);
+            }
+            if (has_salt) {
+                AppendText(*values.cache_salt, out);
+            }
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// CPython Pickle protocol-5 codec (sha256)
+//
+// Restricted encoder for the value types the Conductor query contract can
+// express: UTF-8 seed strings, full parent bytes, signed int32 token IDs,
+// None, tuple containers, and LoRA/cache-salt strings.  It reproduces the
+// CPython pickler byte-for-byte for those shapes:
+//   * \x80\x05 protocol header and protocol-4+ framing (frames committed at
+//     the start of every object save once the pending frame reaches 64 KiB,
+//     and one final forced frame before/around STOP);
+//   * SHORT_BINUNICODE/BINUNICODE/BINUNICODE8 and SHORT_BINBYTES/BINBYTES/
+//     BINBYTES8 length thresholds;
+//   * BININT1/BININT2/BININT integer thresholds;
+//   * EMPTY_TUPLE/TUPLE1/TUPLE2/TUPLE3/MARK+TUPLE arity opcodes;
+//   * MEMOIZE markers after every non-empty bytes/str/tuple object;
+//   * the \x2e STOP terminator inside the final frame.
+//
+// Values are always emitted fresh (no BINGET back-references).  That matches
+// CPython whenever the memoized objects are distinct, which is the only case
+// the Conductor contract can produce; Python object-identity aliasing between
+// equal strings is an explicitly unsupported shape, as are multimodal and
+// prompt-embedding extra-key object graphs.
+// ---------------------------------------------------------------------------
+
+constexpr uint8_t kPickleMark = 0x28;             // MARK
+constexpr uint8_t kPickleStop = 0x2e;             // STOP
+constexpr uint8_t kPickleEmptyTuple = 0x29;       // EMPTY_TUPLE
+constexpr uint8_t kPickleBinbytes = 0x42;         // BINBYTES
+constexpr uint8_t kPickleShortBinbytes = 0x43;    // SHORT_BINBYTES
+constexpr uint8_t kPickleBinint = 0x4a;           // BININT
+constexpr uint8_t kPickleBinint1 = 0x4b;          // BININT1
+constexpr uint8_t kPickleBinint2 = 0x4d;          // BININT2
+constexpr uint8_t kPickleNone = 0x4e;             // NONE
+constexpr uint8_t kPickleBinunicode = 0x58;       // BINUNICODE
+constexpr uint8_t kPickleTuple = 0x74;            // TUPLE
+constexpr uint8_t kPickleProto = 0x80;            // PROTO
+constexpr uint8_t kPickleTuple1 = 0x85;           // TUPLE1
+constexpr uint8_t kPickleTuple2 = 0x86;           // TUPLE2
+constexpr uint8_t kPickleTuple3 = 0x87;           // TUPLE3
+constexpr uint8_t kPickleShortBinunicode = 0x8c;  // SHORT_BINUNICODE
+constexpr uint8_t kPickleBinunicode8 = 0x8d;      // BINUNICODE8
+constexpr uint8_t kPickleBinbytes8 = 0x8e;        // BINBYTES8
+constexpr uint8_t kPickleMemoize = 0x94;          // MEMOIZE
+constexpr uint8_t kPickleFrame = 0x95;            // FRAME
+constexpr uint8_t kPickleProtocol5 = 0x05;
+
+// CPython _Framer._FRAME_SIZE_TARGET: a pending frame is committed before the
+// next object save once it reaches this size.
+constexpr size_t kPickleFrameTarget = 64 * 1024;
+
+// Emulates CPython's protocol-4+ _Framer: object bytes accumulate in
+// frame_bytes_; Checkpoint() flushes a full frame at the start of each object
+// save, and Finish() emits the final forced frame.
+class PickleStream {
+   public:
+    // Bytes written before framing starts (the protocol header).
+    void WriteRaw(uint8_t value) { out_.push_back(value); }
+
+    void Write(uint8_t value) { frame_.push_back(value); }
+
+    void Write(std::span<const uint8_t> bytes) {
+        frame_.insert(frame_.end(), bytes.begin(), bytes.end());
+    }
+
+    // Mirrors _Framer.commit_frame() at the start of Pickler.save().
+    void Checkpoint() {
+        if (frame_.size() >= kPickleFrameTarget) {
+            FlushFrame();
+        }
+    }
+
+    // Mirrors _Framer.write_large_bytes: the current frame is force-committed
+    // and the large payload is written with its length header but without a
+    // frame opcode.  `header` is the already-packed little-endian length.
+    void WriteLargePayload(uint8_t opcode, std::span<const uint8_t> header,
+                           std::span<const uint8_t> payload) {
+        FlushFrame();
+        out_.push_back(opcode);
+        out_.insert(out_.end(), header.begin(), header.end());
+        out_.insert(out_.end(), payload.begin(), payload.end());
+    }
+
+    // Mirrors _Framer.end_framing(): force-commit whatever remains.
+    void Finish() { FlushFrame(); }
+
+    const std::vector<uint8_t>& bytes() const { return out_; }
+
+   private:
+    void FlushFrame() {
+        if (frame_.empty()) {
+            return;
+        }
+        out_.push_back(kPickleFrame);
+        AppendLittleEndian(static_cast<uint64_t>(frame_.size()), &out_);
+        out_.insert(out_.end(), frame_.begin(), frame_.end());
+        frame_.clear();
+    }
+
+    static void AppendLittleEndian(uint64_t value, std::vector<uint8_t>* out) {
+        for (int shift = 0; shift < 64; shift += 8) {
+            out->push_back(static_cast<uint8_t>(value >> shift));
+        }
+    }
+
+    std::vector<uint8_t> out_;
+    std::vector<uint8_t> frame_;
+};
+
+void PickleAppendLittleEndian(uint64_t value, size_t byte_count,
+                              std::vector<uint8_t>* out) {
+    for (size_t index = 0; index < byte_count; ++index) {
+        out->push_back(static_cast<uint8_t>(value >> (index * 8)));
+    }
+}
+
+void PickleEncodeBytes(std::span<const uint8_t> value, PickleStream* stream) {
+    const uint64_t length = value.size();
+    if (length <= 0xffU) {
+        stream->Write(kPickleShortBinbytes);
+        stream->Write(static_cast<uint8_t>(length));
+        stream->Write(value);
+    } else if (length > std::numeric_limits<uint32_t>::max()) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 8, &header);
+        stream->WriteLargePayload(kPickleBinbytes8, header, value);
+    } else if (length >= kPickleFrameTarget) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 4, &header);
+        stream->WriteLargePayload(kPickleBinbytes, header, value);
+    } else {
+        stream->Write(kPickleBinbytes);
+        for (int shift = 0; shift < 32; shift += 8) {
+            stream->Write(static_cast<uint8_t>(length >> shift));
+        }
+        stream->Write(value);
+    }
+    stream->Write(kPickleMemoize);
+}
+
+void PickleEncodeString(std::string_view value, PickleStream* stream) {
+    const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+    const std::span<const uint8_t> encoded(bytes, value.size());
+    const uint64_t length = encoded.size();
+    if (length <= 0xffU) {
+        stream->Write(kPickleShortBinunicode);
+        stream->Write(static_cast<uint8_t>(length));
+        stream->Write(encoded);
+    } else if (length > std::numeric_limits<uint32_t>::max()) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 8, &header);
+        stream->WriteLargePayload(kPickleBinunicode8, header, encoded);
+    } else if (length >= kPickleFrameTarget) {
+        std::vector<uint8_t> header;
+        PickleAppendLittleEndian(length, 4, &header);
+        stream->WriteLargePayload(kPickleBinunicode, header, encoded);
+    } else {
+        stream->Write(kPickleBinunicode);
+        for (int shift = 0; shift < 32; shift += 8) {
+            stream->Write(static_cast<uint8_t>(length >> shift));
+        }
+        stream->Write(encoded);
+    }
+    stream->Write(kPickleMemoize);
+}
+
+void PickleEncodeInt(int32_t value, PickleStream* stream) {
+    if (value >= 0 && value <= 0xff) {
+        stream->Write(kPickleBinint1);
+        stream->Write(static_cast<uint8_t>(value));
+        return;
+    }
+    if (value >= 0 && value <= 0xffff) {
+        stream->Write(kPickleBinint2);
+        const uint16_t narrow = static_cast<uint16_t>(value);
+        stream->Write(static_cast<uint8_t>(narrow));
+        stream->Write(static_cast<uint8_t>(narrow >> 8));
+        return;
+    }
+    stream->Write(kPickleBinint);
+    const uint32_t bits = static_cast<uint32_t>(value);
+    for (int shift = 0; shift < 32; shift += 8) {
+        stream->Write(static_cast<uint8_t>(bits >> shift));
+    }
+}
+
+// Encodes the token tuple: per-element save checkpoints, the CPython tuple
+// arity opcodes, and the trailing MEMOIZE marker for non-empty tuples.
+void PickleEncodeTokenTuple(std::span<const int32_t> tokens,
+                            PickleStream* stream) {
+    if (tokens.empty()) {
+        stream->Write(kPickleEmptyTuple);
+        return;
+    }
+    if (tokens.size() > 3) {
+        stream->Write(kPickleMark);
+    }
+    for (const int32_t token : tokens) {
+        stream->Checkpoint();
+        PickleEncodeInt(token, stream);
+    }
+    switch (tokens.size()) {
+        case 1:
+            stream->Write(kPickleTuple1);
+            break;
+        case 2:
+            stream->Write(kPickleTuple2);
+            break;
+        case 3:
+            stream->Write(kPickleTuple3);
+            break;
+        default:
+            stream->Write(kPickleTuple);
+            break;
+    }
+    stream->Write(kPickleMemoize);
+}
+
+// Encodes the extras slot: Python None when there are no extra keys,
+// otherwise the (LoRA, salt) string tuple in vLLM's ordering.  The caller
+// must have executed the save-entry checkpoint for this value already.
+void PickleEncodeExtras(const VllmBlockValues& values, PickleStream* stream) {
+    const bool has_lora = values.lora_name != nullptr;
+    const bool has_salt = values.cache_salt != nullptr;
+    if (!has_lora && !has_salt) {
+        stream->Write(kPickleNone);
+        return;
+    }
+    if (has_lora) {
+        stream->Checkpoint();
+        PickleEncodeString(*values.lora_name, stream);
+    }
+    if (has_salt) {
+        stream->Checkpoint();
+        PickleEncodeString(*values.cache_salt, stream);
+    }
+    stream->Write(has_lora && has_salt ? kPickleTuple2 : kPickleTuple1);
+    stream->Write(kPickleMemoize);
+}
+
+class PickleVllmCodec final : public VllmValueCodec {
+   public:
+    void EncodeSeed(std::string_view seed,
+                    std::vector<uint8_t>* out) const override {
+        PickleStream stream;
+        stream.WriteRaw(kPickleProto);
+        stream.WriteRaw(kPickleProtocol5);
+        stream.Checkpoint();
+        PickleEncodeString(seed, &stream);
+        stream.Write(kPickleStop);
+        stream.Finish();
+        *out = stream.bytes();
+    }
+
+    void EncodeBlock(const VllmBlockValues& values,
+                     std::vector<uint8_t>* out) const override {
+        PickleStream stream;
+        stream.WriteRaw(kPickleProto);
+        stream.WriteRaw(kPickleProtocol5);
+
+        // Outer (parent, tokens, extras) tuple: TUPLE3.  Each Checkpoint()
+        // mirrors Pickler.save() entry for the corresponding value.
+        stream.Checkpoint();  // save((parent, tokens, extras))
+        stream.Checkpoint();  // save(parent bytes)
+        PickleEncodeBytes(values.parent_digest, &stream);
+        stream.Checkpoint();  // save(token tuple)
+        PickleEncodeTokenTuple(values.token_ids, &stream);
+        stream.Checkpoint();  // save(extras)
+        PickleEncodeExtras(values, &stream);
+        stream.Write(kPickleTuple3);
+        stream.Write(kPickleMemoize);
+
+        stream.Write(kPickleStop);
+        stream.Finish();
+        *out = stream.bytes();
+    }
+};
+
+const VllmValueCodec* CodecForAlgorithm(std::string_view algorithm) {
+    static const CborVllmCodec kCborCodec;
+    static const PickleVllmCodec kPickleCodec;
+    if (algorithm == "sha256_cbor") {
+        return &kCborCodec;
+    }
+    if (algorithm == "sha256") {
+        return &kPickleCodec;
+    }
+    return nullptr;
 }
 
 bool IsContinuationByte(uint8_t value) { return (value & 0xc0U) == 0x80U; }
@@ -161,7 +525,7 @@ std::string ValidateProfileSelectors(std::string_view strategy,
     if (strategy != "vllm_v1") {
         return "unsupported hash strategy: " + std::string(strategy);
     }
-    if (algorithm != "sha256_cbor") {
+    if (algorithm != "sha256" && algorithm != "sha256_cbor") {
         return "unsupported hash algorithm: " + std::string(algorithm);
     }
     if (index_projection != "low64_be") {
@@ -246,9 +610,9 @@ ProjectedPrefix ProjectDigest(
 
 class VllmV1HashStrategy final : public HashStrategy {
    public:
-    explicit VllmV1HashStrategy(
-        std::array<uint8_t, kSha256DigestSize> root_digest)
-        : root_digest_(std::move(root_digest)) {}
+    VllmV1HashStrategy(const VllmValueCodec* codec,
+                       std::array<uint8_t, kSha256DigestSize> root_digest)
+        : codec_(codec), root_digest_(std::move(root_digest)) {}
 
     std::string Compute(const ContextKey& context,
                         std::span<const int32_t> token_ids,
@@ -278,34 +642,19 @@ class VllmV1HashStrategy final : public HashStrategy {
 
         std::array<uint8_t, kSha256DigestSize> parent = root_digest_;
         for (size_t block_index = 0; block_index < block_count; ++block_index) {
-            std::vector<uint8_t> encoded;
-            AppendArrayHeader(3, &encoded);
-            AppendBytes(parent, &encoded);
-
-            AppendArrayHeader(block_size, &encoded);
-            const size_t token_offset = block_index * block_size;
-            for (size_t token_index = 0; token_index < block_size;
-                 ++token_index) {
-                AppendSignedInteger(token_ids[token_offset + token_index],
-                                    &encoded);
-            }
-
             const bool has_lora = !context.lora_name.empty();
             const bool has_salt = block_index == 0 && cache_salt.has_value() &&
                                   !cache_salt->empty();
-            if (!has_lora && !has_salt) {
-                encoded.push_back(0xf6U);
-            } else {
-                AppendArrayHeader(static_cast<size_t>(has_lora) +
-                                      static_cast<size_t>(has_salt),
-                                  &encoded);
-                if (has_lora) {
-                    AppendText(context.lora_name, &encoded);
-                }
-                if (has_salt) {
-                    AppendText(*cache_salt, &encoded);
-                }
-            }
+            const VllmBlockValues values{
+                .parent_digest = parent,
+                .token_ids =
+                    token_ids.subspan(block_index * block_size, block_size),
+                .lora_name = has_lora ? &context.lora_name : nullptr,
+                .cache_salt = has_salt ? &*cache_salt : nullptr,
+            };
+
+            std::vector<uint8_t> encoded;
+            codec_->EncodeBlock(values, &encoded);
 
             HashBlock block;
             if (std::string error = Sha256(encoded, &block.digest);
@@ -322,6 +671,7 @@ class VllmV1HashStrategy final : public HashStrategy {
     }
 
    private:
+    const VllmValueCodec* codec_;
     std::array<uint8_t, kSha256DigestSize> root_digest_;
 };
 
@@ -344,8 +694,13 @@ std::string ResolveHashProfile(const common::HashProfileConfig& config,
         return error;
     }
 
+    const VllmValueCodec* codec = CodecForAlgorithm(config.algorithm);
+    if (codec == nullptr) {
+        return "unsupported hash algorithm: " + config.algorithm;
+    }
+
     std::vector<uint8_t> encoded_seed;
-    AppendText(config.python_hash_seed, &encoded_seed);
+    codec->EncodeSeed(config.python_hash_seed, &encoded_seed);
     std::array<uint8_t, kSha256DigestSize> root_digest{};
     if (auto error = Sha256(encoded_seed, &root_digest); !error.empty()) {
         return error;
@@ -391,8 +746,15 @@ std::unique_ptr<HashStrategy> CreateHashStrategy(const HashProfile& profile,
     if (!validation_error.empty()) {
         return nullptr;
     }
+    const VllmValueCodec* codec = CodecForAlgorithm(profile.algorithm);
+    if (codec == nullptr) {
+        if (error != nullptr) {
+            *error = "unsupported hash algorithm: " + profile.algorithm;
+        }
+        return nullptr;
+    }
     return std::make_unique<VllmV1HashStrategy>(
-        DecodeRootDigest(profile.root_digest));
+        codec, DecodeRootDigest(profile.root_digest));
 }
 
 std::string DigestToHex(const std::array<uint8_t, 32>& digest) {

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
@@ -51,6 +51,28 @@ class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
             self.assertNotIn("replay_endpoint", payload)
             self.assertNotIn("cache_salt", payload)
 
+    async def test_registration_payloads_preserve_selected_hash_algorithm(self) -> None:
+        for algorithm in ("sha256", "sha256_cbor"):
+            with self.subTest(algorithm=algorithm):
+                raw = __import__("_support").cloned_config_dict()
+                raw["prefill"]["config"]["hash_profile"]["algorithm"] = algorithm
+                config = proxy.parse_config(raw)
+                factory = RecordingClientFactory(registration_success_handler)
+                client = factory(
+                    config.conductor.address, config.conductor.query_timeout_seconds
+                )
+                conductor = proxy.ConductorClient(
+                    config.conductor, config.prefill.config, client
+                )
+                self.addAsyncCleanup(client.aclose)
+
+                payloads = conductor.registration_payloads(config.prefill.instances)
+
+                self.assertEqual(
+                    {algorithm},
+                    {payload["hash_profile"]["algorithm"] for payload in payloads},
+                )
+
     async def test_runtime_registers_all_ranks_and_does_not_unregister(self) -> None:
         config = valid_config()
         factory = RecordingClientFactory(registration_success_handler)

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_config.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_config.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from _support import EXAMPLE_DIR, cloned_config_dict, proxy, valid_config_dict
 
 
-def valid_cli_args() -> list[str]:
-    return [
+def valid_cli_args(hash_algorithm: str | None = None) -> list[str]:
+    args = [
         "--prefiller-hosts",
         "prefill-a.test",
         "prefill-b.test",
@@ -56,6 +56,9 @@ def valid_cli_args() -> list[str]:
         "--registration-timeout-seconds",
         "2.0",
     ]
+    if hash_algorithm is not None:
+        args.extend(["--hash-algorithm", hash_algorithm])
+    return args
 
 
 class ConfigTest(unittest.TestCase):
@@ -96,6 +99,16 @@ class ConfigTest(unittest.TestCase):
             config.prefill.instances[0].http_endpoint,
         )
 
+    def test_json_accepts_each_supported_hash_algorithm(self) -> None:
+        for algorithm in ("sha256", "sha256_cbor"):
+            with self.subTest(algorithm=algorithm):
+                raw = cloned_config_dict()
+                raw["prefill"]["config"]["hash_profile"]["algorithm"] = algorithm
+                config = proxy.parse_config(raw)
+                self.assertEqual(
+                    algorithm, config.prefill.config.hash_profile.algorithm
+                )
+
     def test_json_and_cli_configuration_are_equivalent(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             config_path = Path(directory) / "proxy.json"
@@ -119,6 +132,18 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual("0.0.0.0", json_args.host)
         self.assertEqual(9000, json_args.port)
         self.assertEqual("DEBUG", json_args.log_level)
+
+    def test_json_and_cli_sha256_selection_are_equivalent(self) -> None:
+        raw = cloned_config_dict()
+        raw["prefill"]["config"]["hash_profile"]["algorithm"] = "sha256"
+        with tempfile.TemporaryDirectory() as directory:
+            config_path = Path(directory) / "proxy.json"
+            config_path.write_text(json.dumps(raw), encoding="utf-8")
+            json_config = proxy.parse_args(["--config", str(config_path)]).proxy_config
+
+        cli_config = proxy.parse_args(valid_cli_args("sha256")).proxy_config
+        self.assertEqual(json_config, cli_config)
+        self.assertEqual("sha256", cli_config.prefill.config.hash_profile.algorithm)
 
     def test_cli_mode_preserves_proxy_defaults_and_aliases(self) -> None:
         config = proxy.parse_args(
@@ -146,6 +171,7 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(
             "http://localhost:8200", config.decode.instances[0].http_endpoint
         )
+        self.assertEqual("sha256_cbor", config.prefill.config.hash_profile.algorithm)
 
         alias_args = [
             {
@@ -366,6 +392,9 @@ class ConfigTest(unittest.TestCase):
         for index, raw in enumerate(cases):
             with self.subTest(index=index), self.assertRaises(proxy.ConfigError):
                 proxy.parse_config(raw)
+
+    def test_cli_rejects_unsupported_hash_algorithm(self) -> None:
+        self.assert_cli_error(valid_cli_args("xxh64"), "hash_profile.algorithm")
 
     def test_load_config_reports_invalid_json(self) -> None:
         invalid = Path(__file__).with_name("invalid-config.json")

--- a/mooncake-conductor/tests/compute_hash_test.cpp
+++ b/mooncake-conductor/tests/compute_hash_test.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <openssl/evp.h>
+
 #include <array>
 #include <cstdint>
 #include <optional>
@@ -27,6 +29,8 @@ constexpr char kSeedZeroRoot[] =
     "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e";
 constexpr char kPaddedSeedZeroRoot[] =
     "8d912e4e62b3cc377b1d1c7a14ef61dffbdaa0990237035c05401c29414c4172";
+constexpr char kPickleSeedZeroRoot[] =
+    "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c";
 
 HashProfile ProfileFrom(const Json::Value& value) {
     HashProfile profile;
@@ -38,9 +42,10 @@ HashProfile ProfileFrom(const Json::Value& value) {
     return profile;
 }
 
-HashProfileConfig SourceProfile(std::string python_hash_seed = "0") {
+HashProfileConfig SourceProfile(std::string python_hash_seed = "0",
+                                std::string algorithm = "sha256_cbor") {
     return {.strategy = "vllm_v1",
-            .algorithm = "sha256_cbor",
+            .algorithm = std::move(algorithm),
             .python_hash_seed = std::move(python_hash_seed),
             .index_projection = "low64_be"};
 }
@@ -55,10 +60,22 @@ HashProfile ValidProfile() {
     };
 }
 
-HashProfile ResolvedProfile(std::string python_hash_seed) {
+HashProfile ValidPickleProfile() {
+    return HashProfile{
+        .strategy = "vllm_v1",
+        .algorithm = "sha256",
+        .python_hash_seed = "0",
+        .root_digest = kPickleSeedZeroRoot,
+        .index_projection = "low64_be",
+    };
+}
+
+HashProfile ResolvedProfile(std::string python_hash_seed,
+                            std::string algorithm = "sha256_cbor") {
     HashProfile profile;
     const std::string error = ResolveHashProfile(
-        SourceProfile(std::move(python_hash_seed)), &profile);
+        SourceProfile(std::move(python_hash_seed), std::move(algorithm)),
+        &profile);
     EXPECT_TRUE(error.empty()) << error;
     return profile;
 }
@@ -72,11 +89,68 @@ std::vector<int32_t> TokensFrom(const Json::Value& values) {
     return tokens;
 }
 
+// Expands the compact repeat encoding used by large fixture cases.
+std::vector<int32_t> CaseTokens(const Json::Value& test_case) {
+    if (test_case.isMember("token_ids_repeat")) {
+        const Json::Value& repeat = test_case["token_ids_repeat"];
+        return std::vector<int32_t>(
+            static_cast<size_t>(repeat["count"].asUInt64()),
+            static_cast<int32_t>(repeat["value"].asInt64()));
+    }
+    return TokensFrom(test_case["token_ids"]);
+}
+
+std::string CaseLora(const Json::Value& test_case) {
+    if (test_case.isMember("lora_name_repeat")) {
+        const Json::Value& repeat = test_case["lora_name_repeat"];
+        return std::string(static_cast<size_t>(repeat["count"].asUInt64()),
+                           repeat["value"].asString().front());
+    }
+    return test_case["lora_name"].asString();
+}
+
 std::optional<std::string> SaltFrom(const Json::Value& value) {
     if (value.isNull()) {
         return std::nullopt;
     }
     return value.asString();
+}
+
+std::vector<uint8_t> HexToBytes(const std::string& hex) {
+    std::vector<uint8_t> bytes;
+    bytes.reserve(hex.size() / 2);
+    auto nibble = [](char value) -> int {
+        if (value >= '0' && value <= '9') {
+            return value - '0';
+        }
+        if (value >= 'a' && value <= 'f') {
+            return value - 'a' + 10;
+        }
+        return -1;
+    };
+    for (size_t index = 0; index + 1 < hex.size(); index += 2) {
+        const int high = nibble(hex[index]);
+        const int low = nibble(hex[index + 1]);
+        EXPECT_GE(high, 0);
+        EXPECT_GE(low, 0);
+        bytes.push_back(static_cast<uint8_t>((high << 4) | low));
+    }
+    return bytes;
+}
+
+// Recomputes SHA-256 over the fixture's pinned serialized bytes so the test
+// compares serialized bytes as well as digests.
+std::string Sha256Hex(const std::vector<uint8_t>& input) {
+    std::array<uint8_t, 32> digest{};
+    unsigned int digest_size = 0;
+    EVP_MD_CTX* context = EVP_MD_CTX_new();
+    EXPECT_NE(context, nullptr);
+    EXPECT_EQ(EVP_DigestInit_ex(context, EVP_sha256(), nullptr), 1);
+    EXPECT_EQ(EVP_DigestUpdate(context, input.data(), input.size()), 1);
+    EXPECT_EQ(EVP_DigestFinal_ex(context, digest.data(), &digest_size), 1);
+    EVP_MD_CTX_free(context);
+    EXPECT_EQ(digest_size, digest.size());
+    return DigestToHex(digest);
 }
 
 TEST(HashProfileResolver, MatchesSeedRootGoldenVectors) {
@@ -94,6 +168,30 @@ TEST(HashProfileResolver, MatchesSeedRootGoldenVectors) {
         ASSERT_TRUE(error.empty()) << error;
         EXPECT_EQ(resolved.python_hash_seed, seed);
         EXPECT_EQ(resolved.root_digest, vector["root_digest"].asString());
+    }
+}
+
+TEST(HashProfileResolver, MatchesPickleSeedRootGoldenVectors) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const Json::Value& vectors = fixture["seed_root_vectors"];
+    ASSERT_TRUE(vectors.isArray());
+    ASSERT_GE(vectors.size(), 4u);
+
+    for (const auto& vector : vectors) {
+        const std::string seed = vector["python_hash_seed"].asString();
+        SCOPED_TRACE(seed);
+        HashProfile resolved;
+        const std::string error =
+            ResolveHashProfile(SourceProfile(seed, "sha256"), &resolved);
+        ASSERT_TRUE(error.empty()) << error;
+        EXPECT_EQ(resolved.algorithm, "sha256");
+        EXPECT_EQ(resolved.python_hash_seed, seed);
+        EXPECT_EQ(resolved.root_digest, vector["root_digest"].asString());
+        // The serialized seed bytes pinned by the fixture must be exactly
+        // what the digest was computed over.
+        EXPECT_EQ(Sha256Hex(HexToBytes(vector["pickle_hex"].asString())),
+                  vector["root_digest"].asString());
     }
 }
 
@@ -125,6 +223,22 @@ TEST(HashProfileResolver, AcceptsSupportedSeedsAndPreservesExactText) {
     EXPECT_NE(ResolvedProfile("0"), ResolvedProfile("00"));
 }
 
+TEST(HashProfileResolver, AcceptsPickleSeedsAndPreservesExactText) {
+    const HashProfile resolved = ResolvedProfile("0", "sha256");
+    EXPECT_EQ(resolved.strategy, "vllm_v1");
+    EXPECT_EQ(resolved.algorithm, "sha256");
+    EXPECT_EQ(resolved.python_hash_seed, "0");
+    EXPECT_EQ(resolved.root_digest, kPickleSeedZeroRoot);
+    EXPECT_EQ(resolved.index_projection, "low64_be");
+    EXPECT_TRUE(ValidateHashProfile(resolved).empty());
+
+    // Seed text is never normalized, under either supported algorithm.
+    EXPECT_NE(ResolvedProfile("0", "sha256"), ResolvedProfile("00", "sha256"));
+    // Identical seed text under different algorithms yields different roots.
+    EXPECT_NE(ResolvedProfile("0", "sha256").root_digest,
+              ResolvedProfile("0", "sha256_cbor").root_digest);
+}
+
 TEST(HashProfileResolver, RejectsMalformedSeedTextAndClearsOutput) {
     const std::vector<std::string> invalid = {
         "",    "+1",     "-1",      " 0",         "0 ",         "0\n",
@@ -133,10 +247,13 @@ TEST(HashProfileResolver, RejectsMalformedSeedTextAndClearsOutput) {
 
     for (const std::string& seed : invalid) {
         SCOPED_TRACE(seed);
-        HashProfile resolved = ValidProfile();
-        EXPECT_FALSE(
-            ResolveHashProfile(SourceProfile(seed), &resolved).empty());
-        EXPECT_EQ(resolved, HashProfile{});
+        for (const std::string& algorithm : {"sha256_cbor", "sha256"}) {
+            HashProfile resolved = ValidProfile();
+            EXPECT_FALSE(
+                ResolveHashProfile(SourceProfile(seed, algorithm), &resolved)
+                    .empty());
+            EXPECT_EQ(resolved, HashProfile{});
+        }
     }
 
     EXPECT_FALSE(ResolveHashProfile(SourceProfile(), nullptr).empty());
@@ -156,7 +273,19 @@ TEST(HashProfileResolver, RejectsInvalidUtf8AndUnsupportedSelectors) {
     source.strategy = "vllm_v2";
     unsupported.push_back(source);
     source = SourceProfile();
-    source.algorithm = "sha256";
+    source.algorithm = "md5";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "sha512";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "xxhash";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "SHA256";
+    unsupported.push_back(source);
+    source = SourceProfile();
+    source.algorithm = "";
     unsupported.push_back(source);
     source = SourceProfile();
     source.index_projection = "high64_be";
@@ -170,14 +299,16 @@ TEST(HashProfileResolver, RejectsInvalidUtf8AndUnsupportedSelectors) {
 }
 
 TEST(HashProfile, AcceptsOnlyTheSupportedResolvedProfile) {
-    HashProfile profile = ValidProfile();
-    EXPECT_TRUE(ValidateHashProfile(profile).empty());
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        EXPECT_TRUE(ValidateHashProfile(profile).empty());
 
-    std::string error = "stale error";
-    auto strategy = CreateHashStrategy(profile, &error);
-    EXPECT_NE(strategy, nullptr);
-    EXPECT_TRUE(error.empty());
-    EXPECT_NE(CreateHashStrategy(profile, nullptr), nullptr);
+        std::string error = "stale error";
+        auto strategy = CreateHashStrategy(profile, &error);
+        EXPECT_NE(strategy, nullptr);
+        EXPECT_TRUE(error.empty());
+        EXPECT_NE(CreateHashStrategy(profile, nullptr), nullptr);
+    }
 }
 
 TEST(HashProfile, RejectsUnsupportedAndMalformedResolvedShapes) {
@@ -188,7 +319,7 @@ TEST(HashProfile, RejectsUnsupportedAndMalformedResolvedShapes) {
     cases.emplace_back("strategy", profile);
 
     profile = ValidProfile();
-    profile.algorithm = "sha256";
+    profile.algorithm = "md5";
     cases.emplace_back("algorithm", profile);
 
     profile = ValidProfile();
@@ -238,6 +369,20 @@ TEST(HashProfile, SemanticValidationRejectsForgedSeedRootPair) {
     EXPECT_TRUE(factory_error.empty());
 }
 
+TEST(HashProfile, SemanticValidationUsesTheSelectedRecipe) {
+    // A root derived with one recipe must not validate under the other
+    // algorithm even when every other field is well formed.
+    HashProfile mismatched = ValidPickleProfile();
+    mismatched.algorithm = "sha256_cbor";
+    EXPECT_NE(ValidateHashProfile(mismatched).find("does not match"),
+              std::string::npos);
+
+    mismatched = ValidProfile();
+    mismatched.algorithm = "sha256";
+    EXPECT_NE(ValidateHashProfile(mismatched).find("does not match"),
+              std::string::npos);
+}
+
 TEST(HashStrategyGolden, MatchesVllmAndCbor2Vectors) {
     const Json::Value fixture = LoadJsonFixture("hash_golden_vectors.json");
     const HashProfile profile = ProfileFrom(fixture["profile"]);
@@ -280,6 +425,134 @@ TEST(HashStrategyGolden, MatchesVllmAndCbor2Vectors) {
     }
 }
 
+TEST(HashStrategyGolden, MatchesVllmPickleVectors) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const HashProfile profile = ProfileFrom(fixture["profile"]);
+    ASSERT_EQ(profile.algorithm, "sha256");
+    ASSERT_TRUE(ValidateHashProfile(profile).empty());
+
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(profile, &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    const Json::Value& cases = fixture["cases"];
+    ASSERT_GT(cases.size(), 0u);
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case["name"].asString());
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "golden-model",
+            .lora_name = CaseLora(test_case),
+            .block_size = test_case["block_size"].asInt64(),
+        };
+        const std::vector<int32_t> tokens = CaseTokens(test_case);
+
+        std::vector<HashBlock> blocks;
+        const std::string error = strategy->Compute(
+            context, tokens, SaltFrom(test_case["cache_salt"]), &blocks);
+        ASSERT_TRUE(error.empty()) << error;
+
+        const Json::Value& expected = test_case["expected"];
+        ASSERT_EQ(blocks.size(), expected.size());
+        for (Json::ArrayIndex index = 0; index < expected.size(); ++index) {
+            const std::string digest = DigestToHex(blocks[index].digest);
+            EXPECT_EQ(digest, expected[index]["digest"].asString())
+                << "block=" << index;
+            EXPECT_EQ(digest.substr(48),
+                      expected[index]["projected_hex"].asString())
+                << "block=" << index;
+            EXPECT_EQ(blocks[index].projected.value,
+                      ParseU64(expected[index]["projected_decimal"]))
+                << "block=" << index;
+            if (expected[index].isMember("pickle_hex")) {
+                // The fixture pins the exact serialized Pickle bytes; their
+                // SHA-256 must reproduce the pinned digest.
+                EXPECT_EQ(Sha256Hex(HexToBytes(
+                              expected[index]["pickle_hex"].asString())),
+                          expected[index]["digest"].asString())
+                    << "block=" << index;
+            }
+        }
+    }
+}
+
+TEST(HashStrategyGolden, PickleMultiBlockChainDoesNotReuseLow64AsParent) {
+    const Json::Value fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+    const Json::Value& test_case = fixture["cases"][0];
+    ASSERT_EQ(test_case["name"].asString(), "spec_unsalted");
+
+    std::string factory_error;
+    auto strategy =
+        CreateHashStrategy(ProfileFrom(fixture["profile"]), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "golden-model",
+        .lora_name = "",
+        .block_size = test_case["block_size"].asInt64(),
+    };
+    const std::vector<int32_t> tokens = CaseTokens(test_case);
+    std::vector<HashBlock> blocks;
+    ASSERT_TRUE(
+        strategy->Compute(context, tokens, std::nullopt, &blocks).empty());
+    ASSERT_EQ(blocks.size(), 2u);
+
+    const std::string second_digest = DigestToHex(blocks[1].digest);
+    EXPECT_EQ(second_digest, test_case["expected"][1]["digest"].asString());
+    EXPECT_NE(second_digest,
+              test_case["incorrect_low64_parent_digest"].asString());
+}
+
+TEST(HashStrategyGolden, AlgorithmsProduceDistinctDigestsForIdenticalTokens) {
+    const Json::Value cbor_fixture =
+        LoadJsonFixture("hash_golden_vectors.json");
+    const Json::Value pickle_fixture =
+        LoadJsonFixture("hash_golden_vectors_sha256.json");
+
+    std::string factory_error;
+    auto cbor_strategy = CreateHashStrategy(
+        ProfileFrom(cbor_fixture["profile"]), &factory_error);
+    ASSERT_NE(cbor_strategy, nullptr) << factory_error;
+    auto pickle_strategy = CreateHashStrategy(
+        ProfileFrom(pickle_fixture["profile"]), &factory_error);
+    ASSERT_NE(pickle_strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "golden-model",
+        .lora_name = "",
+        .block_size = 4,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8};
+    std::vector<HashBlock> cbor_blocks;
+    std::vector<HashBlock> pickle_blocks;
+    ASSERT_TRUE(
+        cbor_strategy->Compute(context, tokens, std::nullopt, &cbor_blocks)
+            .empty());
+    ASSERT_TRUE(
+        pickle_strategy->Compute(context, tokens, std::nullopt, &pickle_blocks)
+            .empty());
+    ASSERT_EQ(cbor_blocks.size(), pickle_blocks.size());
+
+    // Identical tokens under the two recipes must produce distinct digests
+    // while each recipe matches its own vLLM reference vectors.
+    for (size_t index = 0; index < cbor_blocks.size(); ++index) {
+        EXPECT_NE(cbor_blocks[index], pickle_blocks[index])
+            << "block=" << index;
+        EXPECT_EQ(DigestToHex(cbor_blocks[index].digest),
+                  cbor_fixture["cases"][0]["expected"]
+                              [static_cast<Json::ArrayIndex>(index)]["digest"]
+                                  .asString());
+        EXPECT_EQ(DigestToHex(pickle_blocks[index].digest),
+                  pickle_fixture["cases"][0]["expected"]
+                                [static_cast<Json::ArrayIndex>(index)]["digest"]
+                                    .asString());
+    }
+}
+
 TEST(HashStrategyGolden, MultiBlockChainDoesNotReuseLow64AsParent) {
     const Json::Value fixture = LoadJsonFixture("hash_golden_vectors.json");
     const Json::Value& test_case = fixture["cases"][0];
@@ -309,24 +582,29 @@ TEST(HashStrategyGolden, MultiBlockChainDoesNotReuseLow64AsParent) {
 }
 
 TEST(HashStrategy, EmptySaltHasNoExtraKey) {
-    std::string factory_error;
-    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
-    ASSERT_NE(strategy, nullptr) << factory_error;
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        std::string factory_error;
+        auto strategy = CreateHashStrategy(profile, &factory_error);
+        ASSERT_NE(strategy, nullptr) << factory_error;
 
-    ContextKey context{
-        .tenant_id = "default",
-        .model_name = "model",
-        .lora_name = "",
-        .block_size = 4,
-    };
-    const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8};
-    std::vector<HashBlock> omitted_salt;
-    std::vector<HashBlock> empty_salt;
-    ASSERT_TRUE(strategy->Compute(context, tokens, std::nullopt, &omitted_salt)
-                    .empty());
-    ASSERT_TRUE(
-        strategy->Compute(context, tokens, std::string{}, &empty_salt).empty());
-    EXPECT_EQ(empty_salt, omitted_salt);
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "model",
+            .lora_name = "",
+            .block_size = 4,
+        };
+        const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8};
+        std::vector<HashBlock> omitted_salt;
+        std::vector<HashBlock> empty_salt;
+        ASSERT_TRUE(
+            strategy->Compute(context, tokens, std::nullopt, &omitted_salt)
+                .empty());
+        ASSERT_TRUE(
+            strategy->Compute(context, tokens, std::string{}, &empty_salt)
+                .empty());
+        EXPECT_EQ(empty_salt, omitted_salt);
+    }
 }
 
 TEST(HashStrategy, RejectsInvalidComputeInputsWithoutPartialOutput) {

--- a/mooncake-conductor/tests/concurrency_test.cpp
+++ b/mooncake-conductor/tests/concurrency_test.cpp
@@ -73,6 +73,18 @@ HashProfile RaceProfile() {
     return profile;
 }
 
+HashProfile RacePickleProfile() {
+    const conductor::common::HashProfileConfig source{
+        .strategy = "vllm_v1",
+        .algorithm = "sha256",
+        .python_hash_seed = "0",
+        .index_projection = "low64_be",
+    };
+    HashProfile profile;
+    EXPECT_EQ(ResolveHashProfile(source, &profile), "");
+    return profile;
+}
+
 ServiceConfig RaceService(const std::string& instance_id, int endpoint_slot,
                           int dp_rank = 0) {
     ServiceConfig svc;
@@ -233,6 +245,57 @@ TEST(Concurrency, ConcurrentRegisterUnregister) {
               0u);
     EXPECT_EQ(conductor::kvevent::EventManagerTestPeer::ActiveConfigCount(mgr),
               0u);
+    mgr.Stop();
+}
+
+TEST(Concurrency, ConcurrentMixedAlgorithmRegistrationKeepsSingleProfile) {
+    // Threads race to bind the same ContextKey under both supported
+    // algorithms.  Exactly one resolved profile must win; every registration
+    // naming the other algorithm must fail without mutating state.
+    EventManager mgr({}, 0);
+
+    constexpr int kThreads = 8;
+    std::atomic<int> subscribed{0};
+    std::atomic<int> conflicts{0};
+    std::atomic<int> unexpected{0};
+    std::barrier start(kThreads);
+    std::vector<std::thread> workers;
+    for (int w = 0; w < kThreads; ++w) {
+        workers.emplace_back([&mgr, &start, &subscribed, &conflicts,
+                              &unexpected, w] {
+            ServiceConfig svc =
+                RaceService("instance-" + std::to_string(w), 200 + w);
+            svc.hash_profile =
+                (w % 2 == 0) ? RaceProfile() : RacePickleProfile();
+            start.arrive_and_wait();
+            const auto result =
+                conductor::kvevent::EventManagerTestPeer::Subscribe(mgr, svc);
+            if (result.first) {
+                subscribed.fetch_add(1);
+                return;
+            }
+            if (result.second.find("conflict") != std::string::npos) {
+                conflicts.fetch_add(1);
+                return;
+            }
+            unexpected.fetch_add(1);
+        });
+    }
+    for (auto& t : workers) t.join();
+
+    EXPECT_EQ(unexpected.load(), 0);
+    EXPECT_EQ(subscribed.load() + conflicts.load(), kThreads);
+    EXPECT_GE(subscribed.load(), 1);
+
+    const auto view = mgr.GetIndexer()->GetGlobalView();
+    ASSERT_EQ(view.context_count, 1);
+    ASSERT_EQ(view.contexts.size(), 1u);
+    const HashProfile winner = view.contexts[0].profile;
+    EXPECT_TRUE(winner == RaceProfile() || winner == RacePickleProfile());
+    EXPECT_EQ(static_cast<int>(view.contexts[0].instance_ranks.size()),
+              subscribed.load());
+    EXPECT_EQ(conductor::kvevent::EventManagerTestPeer::SubscriberCount(mgr),
+              static_cast<size_t>(subscribed.load()));
     mgr.Stop();
 }
 

--- a/mooncake-conductor/tests/event_manager_test.cpp
+++ b/mooncake-conductor/tests/event_manager_test.cpp
@@ -76,13 +76,16 @@ using conductor::zmq::VllmStoredEvent;
 
 constexpr std::string_view kRootDigest =
     "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e";
+constexpr std::string_view kPickleRootDigest =
+    "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c";
 constexpr std::string_view kOtherRootDigest =
     "0000000000000000000000000000000000000000000000000000000000000000";
 
-HashProfile TestProfile(std::string python_hash_seed = "0") {
+HashProfile TestProfile(std::string python_hash_seed = "0",
+                        std::string algorithm = "sha256_cbor") {
     const conductor::common::HashProfileConfig source{
         .strategy = "vllm_v1",
-        .algorithm = "sha256_cbor",
+        .algorithm = std::move(algorithm),
         .python_hash_seed = std::move(python_hash_seed),
         .index_projection = "low64_be",
     };
@@ -551,6 +554,45 @@ TEST_F(QueryHttpTest, ReturnsExactSharedCacheResponse) {
     ASSERT_NO_FATAL_FAILURE(ExpectRankMapsAligned(body["instances"]["2"]));
 }
 
+TEST_F(QueryHttpTest, PickleProfileResolvesQueryHashes) {
+    auto service = VllmService("pickle", "default", 0, 16);
+    service.model_name = "pickle-model";
+    service.hash_profile = TestProfile("0", "sha256");
+    ASSERT_TRUE(manager_->GetIndexer()
+                    ->Register(RegistrationFor(service))
+                    .error.empty());
+
+    const ContextKey context = ContextFor(service);
+    const auto prefixes =
+        ProjectedFor(context, TestProfile("0", "sha256"), tokens_);
+    ASSERT_EQ(prefixes.size(), 3u);
+    ASSERT_TRUE(manager_->GetIndexer()
+                    ->StoreGpu({.context = context,
+                                .prefixes = {prefixes[0], prefixes[1]},
+                                .owner = {.source_stream = "engine-pickle",
+                                          .instance_id = "pickle",
+                                          .dp_rank = 0},
+                                .effective_block_size = 16})
+                    .empty());
+
+    Json::Value body;
+    ASSERT_NO_FATAL_FAILURE(
+        ExpectJsonStatus(Post(QueryJson(context, tokens_)), 200, &body));
+    ASSERT_TRUE(body["instances"].isMember("pickle"));
+    const Json::Value& instance = body["instances"]["pickle"];
+    EXPECT_EQ(instance["longest_matched"].asInt64(), 32);
+    EXPECT_EQ(instance["gpu"].asInt64(), 32);
+    EXPECT_EQ(instance["dp"]["0"].asInt64(), 32);
+    ASSERT_NO_FATAL_FAILURE(ExpectRankMapsAligned(instance));
+
+    // The CBOR-bound context is unaffected: its instances still resolve with
+    // their own registered profile.
+    Json::Value cbor_body;
+    ASSERT_NO_FATAL_FAILURE(
+        ExpectJsonStatus(Post(ValidQuery()), 200, &cbor_body));
+    EXPECT_EQ(cbor_body["instances"]["1"]["gpu"].asInt64(), 32);
+}
+
 TEST_F(QueryHttpTest, ReturnsOrderedFourBlockTierBoundaries) {
     auto service = VllmService("ordered", "default", 0, 16);
     service.model_name = "ordered-model";
@@ -865,6 +907,77 @@ TEST_F(RegistrationHttpTest, ResolvesReportsAndRetriesSeedProfile) {
     const Json::Value& context_profile = view["contexts"][0]["hash_profile"];
     EXPECT_EQ(context_profile["python_hash_seed"].asString(), "0");
     EXPECT_EQ(context_profile["root_digest"].asString(), kRootDigest);
+}
+
+TEST_F(RegistrationHttpTest, ResolvesAndReportsPickleProfile) {
+    auto service = VllmService();
+    service.hash_profile = TestProfile("0", "sha256");
+    ASSERT_EQ(Register(service).status, 200);
+    ASSERT_EQ(Register(service).status, 200);
+    EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 1u);
+
+    const HttpResponse services_response = HttpGet(port_, "/services");
+    ASSERT_EQ(services_response.status, 200);
+    const Json::Value services = ParseJsonResponse(services_response);
+    ASSERT_EQ(services["count"].asInt(), 1);
+    ASSERT_EQ(services["services"].size(), 1u);
+    const Json::Value& service_profile = services["services"][0]["HashProfile"];
+    EXPECT_EQ(service_profile["strategy"].asString(), "vllm_v1");
+    EXPECT_EQ(service_profile["algorithm"].asString(), "sha256");
+    EXPECT_EQ(service_profile["python_hash_seed"].asString(), "0");
+    EXPECT_EQ(service_profile["root_digest"].asString(), kPickleRootDigest);
+    EXPECT_EQ(service_profile["index_projection"].asString(), "low64_be");
+
+    const HttpResponse view_response = HttpGet(port_, "/global_view");
+    ASSERT_EQ(view_response.status, 200);
+    const Json::Value view = ParseJsonResponse(view_response);
+    ASSERT_EQ(view["context_count"].asInt(), 1);
+    ASSERT_EQ(view["contexts"].size(), 1u);
+    const Json::Value& context_profile = view["contexts"][0]["hash_profile"];
+    EXPECT_EQ(context_profile["algorithm"].asString(), "sha256");
+    EXPECT_EQ(context_profile["python_hash_seed"].asString(), "0");
+    EXPECT_EQ(context_profile["root_digest"].asString(), kPickleRootDigest);
+
+    // The registered ContextKey resolves the query profile: an empty query
+    // for the registered context succeeds.
+    const Json::Value query = QueryEmpty(service);
+    EXPECT_TRUE(query.isMember("instances"));
+}
+
+TEST_F(RegistrationHttpTest, RejectsUnsupportedAlgorithmWithoutMutation) {
+    for (const std::string algorithm : {"md5", "sha512", "xxhash", "SHA256"}) {
+        SCOPED_TRACE(algorithm);
+        Json::Value body = ServiceJson(VllmService());
+        body["hash_profile"]["algorithm"] = algorithm;
+        const HttpResponse response =
+            HttpPostJson(port_, "/register", JsonDocument(body));
+        EXPECT_EQ(response.status, 400);
+        const Json::Value error = ParseJsonResponse(response);
+        EXPECT_EQ(error["reason"].asString(), "invalid_value");
+        EXPECT_EQ(error["field"].asString(), "algorithm");
+        EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 0u);
+        EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, 0);
+    }
+}
+
+TEST_F(RegistrationHttpTest, MixedAlgorithmConflictIsAtomic) {
+    const auto original = VllmService("instance-1");
+    ASSERT_EQ(Register(original).status, 200);
+
+    auto conflicting = VllmService("instance-2");
+    conflicting.hash_profile = TestProfile("0", "sha256");
+    const HttpResponse response = Register(conflicting);
+    ASSERT_EQ(response.status, 400);
+    EXPECT_EQ(ParseJsonResponse(response)["reason"].asString(),
+              "invalid_registration");
+
+    EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 1u);
+    const auto view = manager_->GetIndexer()->GetGlobalView();
+    ASSERT_EQ(view.contexts.size(), 1u);
+    EXPECT_EQ(view.contexts[0].profile, TestProfile());
+    EXPECT_EQ(view.contexts[0].instance_ranks.size(), 1u);
+    EXPECT_TRUE(view.contexts[0].instance_ranks.contains("instance-1"));
+    EXPECT_FALSE(view.contexts[0].instance_ranks.contains("instance-2"));
 }
 
 TEST_F(RegistrationHttpTest, RejectsInvalidSeedProfilesWithoutMutation) {
@@ -2065,6 +2178,48 @@ TEST(ParseConfig, RejectsLegacyMissingMalformedAndUnknownProfiles) {
     EXPECT_EQ(services[0].instance_id, "valid");
     EXPECT_EQ(services[0].hash_profile, TestProfile("00"));
     EXPECT_NE(services[0].hash_profile.root_digest, kRootDigest);
+    std::remove(path.c_str());
+}
+
+TEST(ParseConfig, AcceptsPickleAlgorithmAndRejectsUnsupportedAlgorithms) {
+    ConfigEnvGuard guard;
+    const std::string path =
+        ::testing::TempDir() + "conductor_cfg_pickle_profile.json";
+    {
+        std::ofstream out(path);
+        out << R"({
+          "kvevent_instance": {
+            "pickle": {
+              "endpoint": "tcp://127.0.0.1:5561", "type": "vLLM",
+              "modelname": "m1", "block_size": 16, "dp_rank": 0,
+              "hash_profile": {
+                "strategy": "vllm_v1", "algorithm": "sha256",
+                "python_hash_seed": "0", "index_projection": "low64_be"}},
+            "bad-md5": {
+              "endpoint": "tcp://127.0.0.1:5562", "type": "vLLM",
+              "modelname": "m1", "block_size": 16, "dp_rank": 0,
+              "hash_profile": {
+                "strategy": "vllm_v1", "algorithm": "md5",
+                "python_hash_seed": "0", "index_projection": "low64_be"}},
+            "bad-xxhash": {
+              "endpoint": "tcp://127.0.0.1:5563", "type": "vLLM",
+              "modelname": "m1", "block_size": 16, "dp_rank": 0,
+              "hash_profile": {
+                "strategy": "vllm_v1", "algorithm": "xxhash",
+                "python_hash_seed": "0", "index_projection": "low64_be"}}
+          }
+        })";
+    }
+    guard.SetPath(path);
+
+    int port = 13333;
+    const auto services = conductor::kvevent::ParseConfig(&port);
+    ASSERT_EQ(services.size(), 1u);
+    EXPECT_EQ(services[0].instance_id, "pickle");
+    // Static configuration and HTTP registration must resolve identical
+    // profiles from identical fields.
+    EXPECT_EQ(services[0].hash_profile, TestProfile("0", "sha256"));
+    EXPECT_EQ(services[0].hash_profile.root_digest, kPickleRootDigest);
     std::remove(path.c_str());
 }
 

--- a/mooncake-conductor/tests/fixtures/generate_hash_golden_vectors.py
+++ b/mooncake-conductor/tests/fixtures/generate_hash_golden_vectors.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+"""Generates hash_golden_vectors_sha256.json from the vLLM `sha256` recipe.
+
+The `sha256` vLLM prefix-cache hash is SHA-256 over
+``pickle.dumps(value, protocol=pickle.HIGHEST_PROTOCOL)``; for the supported
+Python range (3.10-3.14) HIGHEST_PROTOCOL is protocol 5.  This script uses the
+real CPython pickler as the normative oracle and replicates
+vLLM's ``hash_block_tokens`` value shapes:
+
+    root  = sha256(pickle(seed_string))
+    block = sha256(pickle((parent_digest_bytes, tuple(block_token_ids),
+                           extra_keys)))
+
+with ``extra_keys`` equal to None, or the tuple ``(lora_name,)`` /
+``(lora_name, cache_salt)`` (salt only on the first block), matching
+vLLM's ``lora + mm + cache_salt + prompt_embeds`` ordering for the subset the
+Conductor query contract can express.
+
+The checked-in fixture pins the generator environment below.  Regenerate with:
+
+    python3 generate_hash_golden_vectors.py
+
+from this directory and diff the result; only regenerate intentionally.
+"""
+
+import hashlib
+import json
+import pickle
+import platform
+import sys
+from pathlib import Path
+
+PROTOCOL = pickle.HIGHEST_PROTOCOL
+assert PROTOCOL == 5, f"expected Pickle protocol 5, got {PROTOCOL}"
+
+# Pinned reference: vLLM v1 kv_cache_utils.hash_block_tokens +
+# utils/hashing.py sha256, verified against checkout
+# v0.22.1rc0-459-g462ef83d5 (commit 462ef83d58e6fadeb6e216dc583554a6980a0af9).
+VLLM_REFERENCE = (
+    "vLLM v0.22.1rc0-459-g462ef83d5 hash_block_tokens value shapes with "
+    "utils/hashing.py sha256 = SHA256(pickle.dumps(value, protocol=5))"
+)
+
+# Serialized block bytes are recorded in full for every case small enough to
+# keep the fixture reviewable.  Cases that must cross CPython's 64 KiB frame
+# target (frame boundary and large-payload paths) record pickle_len instead;
+# their digest is still the SHA-256 of the exact serialized bytes, so a digest
+# match certifies byte equality.
+PICKLE_HEX_SIZE_LIMIT = 8192
+
+SEEDS = ["0", "00", "random", "4294967295"]
+
+
+def sha256_pickle(value) -> bytes:
+    return hashlib.sha256(pickle.dumps(value, protocol=PROTOCOL)).digest()
+
+
+def extras_for(lora_name: str, cache_salt, block_index: int):
+    keys = []
+    if lora_name:
+        keys.append(lora_name)
+    if block_index == 0 and cache_salt:
+        keys.append(cache_salt)
+    return tuple(keys) if keys else None
+
+
+def block_entry(pickle_bytes: bytes) -> dict:
+    digest = hashlib.sha256(pickle_bytes).digest()
+    entry = {
+        "digest": digest.hex(),
+        "projected_hex": digest[-8:].hex(),
+        "projected_decimal": str(int.from_bytes(digest[-8:], "big")),
+    }
+    if len(pickle_bytes) <= PICKLE_HEX_SIZE_LIMIT:
+        entry["pickle_hex"] = pickle_bytes.hex()
+    else:
+        entry["pickle_len"] = len(pickle_bytes)
+    return entry
+
+
+def expand_tokens(case: dict):
+    if "token_ids_repeat" in case:
+        spec = case["token_ids_repeat"]
+        return [spec["value"]] * spec["count"]
+    return list(case["token_ids"])
+
+
+CASES = [
+    {
+        "name": "spec_unsalted",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "single_token_tuple",
+        "block_size": 1,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7],
+    },
+    {
+        "name": "two_token_tuple",
+        "block_size": 2,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7, 8],
+    },
+    {
+        "name": "three_token_tuple",
+        "block_size": 3,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [7, 8, 9],
+    },
+    {
+        "name": "empty_extras_encode_as_none",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [10, 20, 30, 40],
+    },
+    {
+        "name": "signed_integer_boundaries",
+        "block_size": 8,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [-2147483648, -1, 0, 255, 256, 65535, 65536, 2147483647],
+    },
+    {
+        "name": "utf8_multibyte",
+        "block_size": 4,
+        "lora_name": "模型-适配器",
+        "cache_salt": "盐值-🚀",
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_length_255",
+        "block_size": 4,
+        "lora_name": "a" * 255,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_length_256",
+        "block_size": 4,
+        "lora_name": "a" * 256,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "salt_length_255",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "s" * 255,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "salt_length_256",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "s" * 256,
+        "token_ids": [1, 2, 3, 4],
+    },
+    {
+        "name": "lora_every_block",
+        "block_size": 4,
+        "lora_name": "adapter-A",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "salt_first_block_only",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": "tenant-salt",
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "lora_then_salt",
+        "block_size": 4,
+        "lora_name": "adapter-A",
+        "cache_salt": "tenant-salt",
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+    },
+    {
+        "name": "multi_block_chain",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": list(range(1, 17)),
+    },
+    {
+        "name": "incomplete_tail",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4, 5, 6],
+    },
+    {
+        "name": "no_complete_block",
+        "block_size": 4,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids": [1, 2, 3],
+    },
+    {
+        # 22000 BININT2 tokens serialize to ~66 KiB inside the token tuple,
+        # forcing CPython's _Framer to commit a frame mid-value.
+        "name": "frame_boundary_token_stream",
+        "block_size": 22000,
+        "lora_name": "",
+        "cache_salt": None,
+        "token_ids_repeat": {"value": 256, "count": 22000},
+    },
+    {
+        # A >= 64 KiB extra-key string takes CPython's write_large_bytes path:
+        # the pending frame is force-committed and the string is written
+        # without a frame opcode.
+        "name": "large_lora_large_payload",
+        "block_size": 4,
+        "lora_name": "a" * 70000,
+        "cache_salt": None,
+        "token_ids": [1, 2, 3, 4],
+    },
+]
+
+
+def main() -> None:
+    seed_root_vectors = []
+    for seed in SEEDS:
+        serialized = pickle.dumps(seed, protocol=PROTOCOL)
+        seed_root_vectors.append(
+            {
+                "python_hash_seed": seed,
+                "pickle_hex": serialized.hex(),
+                "root_digest": hashlib.sha256(serialized).hexdigest(),
+            }
+        )
+
+    root_digest = sha256_pickle("0")
+    cases = []
+    for case in CASES:
+        tokens = expand_tokens(case)
+        block_size = case["block_size"]
+        lora_name = case["lora_name"]
+        cache_salt = case["cache_salt"]
+
+        expected = []
+        parent = root_digest
+        for block_index in range(len(tokens) // block_size):
+            block_tokens = tokens[
+                block_index * block_size : (block_index + 1) * block_size
+            ]
+            value = (
+                parent,
+                tuple(block_tokens),
+                extras_for(lora_name, cache_salt, block_index),
+            )
+            serialized = pickle.dumps(value, protocol=PROTOCOL)
+            expected.append(block_entry(serialized))
+            parent = hashlib.sha256(serialized).digest()
+
+        entry = {
+            "name": case["name"],
+            "block_size": block_size,
+            "lora_name": lora_name if len(lora_name) <= 512 else "",
+            "cache_salt": cache_salt,
+            "expected": expected,
+        }
+        if len(lora_name) > 512:
+            entry["lora_name_repeat"] = {"value": "a", "count": len(lora_name)}
+        if "token_ids_repeat" in case:
+            entry["token_ids_repeat"] = case["token_ids_repeat"]
+        else:
+            entry["token_ids"] = tokens
+
+        if case["name"] == "spec_unsalted":
+            # Digest of the second block when the low-64 projection is
+            # incorrectly reused as the parent instead of the full digest.
+            first_digest = bytes.fromhex(expected[0]["digest"])
+            wrong_value = (
+                first_digest[-8:],
+                tuple(tokens[4:8]),
+                None,
+            )
+            entry["incorrect_low64_parent_digest"] = hashlib.sha256(
+                pickle.dumps(wrong_value, protocol=PROTOCOL)
+            ).hexdigest()
+
+        cases.append(entry)
+
+    fixture = {
+        "description": (
+            "Golden vectors for the supported vLLM v1 sha256 (CPython Pickle "
+            "protocol 5) seed-derived root and block-hash profile.  pickle_hex "
+            "records the exact serialized bytes hashed for small values; large "
+            "frame-boundary values record pickle_len and are certified by "
+            "their digest."
+        ),
+        "generator": VLLM_REFERENCE,
+        "generator_metadata": {
+            "python_version": platform.python_version(),
+            "pickle_protocol": PROTOCOL,
+            "pickle_highest_protocol": pickle.HIGHEST_PROTOCOL,
+        },
+        "profile": {
+            "strategy": "vllm_v1",
+            "algorithm": "sha256",
+            "python_hash_seed": "0",
+            "root_digest": root_digest.hex(),
+            "index_projection": "low64_be",
+        },
+        "seed_root_vectors": seed_root_vectors,
+        "cases": cases,
+    }
+
+    out = Path(__file__).with_name("hash_golden_vectors_sha256.json")
+    out.write_text(json.dumps(fixture, indent=2, ensure_ascii=False) + "\n")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-conductor/tests/fixtures/hash_golden_vectors_sha256.json
+++ b/mooncake-conductor/tests/fixtures/hash_golden_vectors_sha256.json
@@ -1,0 +1,485 @@
+{
+  "description": "Golden vectors for the supported vLLM v1 sha256 (CPython Pickle protocol 5) seed-derived root and block-hash profile.  pickle_hex records the exact serialized bytes hashed for small values; large frame-boundary values record pickle_len and are certified by their digest.",
+  "generator": "vLLM v0.22.1rc0-459-g462ef83d5 hash_block_tokens value shapes with utils/hashing.py sha256 = SHA256(pickle.dumps(value, protocol=5))",
+  "generator_metadata": {
+    "python_version": "3.12.13",
+    "pickle_protocol": 5,
+    "pickle_highest_protocol": 5
+  },
+  "profile": {
+    "strategy": "vllm_v1",
+    "algorithm": "sha256",
+    "python_hash_seed": "0",
+    "root_digest": "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c",
+    "index_projection": "low64_be"
+  },
+  "seed_root_vectors": [
+    {
+      "python_hash_seed": "0",
+      "pickle_hex": "80059505000000000000008c0130942e",
+      "root_digest": "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c"
+    },
+    {
+      "python_hash_seed": "00",
+      "pickle_hex": "80059506000000000000008c023030942e",
+      "root_digest": "67c61e0f70ad5d3fc0eacb59744008ac6f2a8bd2edad43540a743eaf0fb4993c"
+    },
+    {
+      "python_hash_seed": "random",
+      "pickle_hex": "8005950a000000000000008c0672616e646f6d942e",
+      "root_digest": "fa1326fc0ad784c54e10f808051a77f999f7b675b12fba49cbef92b3e1a09cb7"
+    },
+    {
+      "python_hash_seed": "4294967295",
+      "pickle_hex": "8005950e000000000000008c0a34323934393637323935942e",
+      "root_digest": "670c2eca46f5f7e11b9dce5c3bd2ff0e9e19567fd45b50c2db5cc0c9aae470d9"
+    }
+  ],
+  "cases": [
+    {
+      "name": "spec_unsalted",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        },
+        {
+          "digest": "9e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b",
+          "projected_hex": "ad1746592a2b036b",
+          "projected_decimal": "12472515041799373675",
+          "pickle_hex": "80059532000000000000004320762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d94284b054b064b074b0874944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ],
+      "incorrect_low64_parent_digest": "22f70d17411c10aa544ecdac1d2df0fc1d7c7ac2d21efe1aebe32028620638c6"
+    },
+    {
+      "name": "single_token_tuple",
+      "block_size": 1,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "4e7493abc7315520e17ce180ee400439b7dc83e7406fb239462766705eb058c8",
+          "projected_hex": "462766705eb058c8",
+          "projected_decimal": "5055121739557656776",
+          "pickle_hex": "8005952b0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b0785944e87942e"
+        }
+      ],
+      "token_ids": [
+        7
+      ]
+    },
+    {
+      "name": "two_token_tuple",
+      "block_size": 2,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "aa9e79304bb6921235ea2e187b25f9bb43d9044ec232e3d1c07d7e21e51e64ee",
+          "projected_hex": "c07d7e21e51e64ee",
+          "projected_decimal": "13870381111413990638",
+          "pickle_hex": "8005952d0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b074b0886944e87942e"
+        }
+      ],
+      "token_ids": [
+        7,
+        8
+      ]
+    },
+    {
+      "name": "three_token_tuple",
+      "block_size": 3,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "6368e68a46c970c8ec2ebab3eb9d2fe7ddc2730165bb64d698aaed2907396794",
+          "projected_hex": "98aaed2907396794",
+          "projected_decimal": "11000865800276502420",
+          "pickle_hex": "8005952f0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c944b074b084b0987944e87942e"
+        }
+      ],
+      "token_ids": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "name": "empty_extras_encode_as_none",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "569de0636f6064532b63312eab095a4577e72dc55286dbfb43821ec866309e47",
+          "projected_hex": "43821ec866309e47",
+          "projected_decimal": "4864484393570311751",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b0a4b144b1e4b2874944e87942e"
+        }
+      ],
+      "token_ids": [
+        10,
+        20,
+        30,
+        40
+      ]
+    },
+    {
+      "name": "signed_integer_boundaries",
+      "block_size": 8,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "6c9e5f944f0a93319b3ba9478115a9447de2f6d4ef1cd1c0b19a7ebd607353e8",
+          "projected_hex": "b19a7ebd607353e8",
+          "projected_decimal": "12797680642958775272",
+          "pickle_hex": "800595480000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284a000000804affffffff4b004bff4d00014dffff4a000001004affffff7f74944e87942e"
+        }
+      ],
+      "token_ids": [
+        -2147483648,
+        -1,
+        0,
+        255,
+        256,
+        65535,
+        65536,
+        2147483647
+      ]
+    },
+    {
+      "name": "utf8_multibyte",
+      "block_size": 4,
+      "lora_name": "模型-适配器",
+      "cache_salt": "盐值-🚀",
+      "expected": [
+        {
+          "digest": "cc1a2ab147f91a34070bb430e35dbc6ca6261a93b490a2307d0b4b31696a247a",
+          "projected_hex": "7d0b4b31696a247a",
+          "projected_decimal": "9010378155078853754",
+          "pickle_hex": "800595540000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c10e6a8a1e59e8b2de98082e9858de599a8948c0be79b90e580bc2df09f9a8094869487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_length_255",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "866b277c9d76457e35bd6a5dd3ec0d5b598faa9e36d108608f6e925149b1524b",
+          "projected_hex": "8f6e925149b1524b",
+          "projected_decimal": "10335359072688230987",
+          "pickle_hex": "800595350100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948cff61616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_length_256",
+      "block_size": 4,
+      "lora_name": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "0c934ab8aa543128da871a91a46387ed907ed3ca8b39e5c137da510f80a106df",
+          "projected_hex": "37da510f80a106df",
+          "projected_decimal": "4024618344033355487",
+          "pickle_hex": "800595390100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b04749458000100006161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616161616194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "salt_length_255",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "expected": [
+        {
+          "digest": "167d69abb219f81883e1fc5e554564bab043051f849914feb058487c8bffc398",
+          "projected_hex": "b058487c8bffc398",
+          "projected_decimal": "12706986048387793816",
+          "pickle_hex": "800595350100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948cff73737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737394859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "salt_length_256",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss",
+      "expected": [
+        {
+          "digest": "0875d6e8c04ec7bb02928dc8f4b9e336aecb8adfae9078a9b6b54fe557b6857d",
+          "projected_hex": "b6b54fe557b6857d",
+          "projected_decimal": "13165516932125197693",
+          "pickle_hex": "800595390100000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b04749458000100007373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737373737394859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    },
+    {
+      "name": "lora_every_block",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "5c5d9e04e03de9f2f4a9f38766c4d0fb0e207ccf5d2fb3b272c50117f336ae0c",
+          "projected_hex": "72c50117f336ae0c",
+          "projected_decimal": "8270017493112106508",
+          "pickle_hex": "8005953f0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c09616461707465722d4194859487942e"
+        },
+        {
+          "digest": "bde66cc24757972cc88e0fe62079d85934868c2733874ffa1c54ff679604f61a",
+          "projected_hex": "1c54ff679604f61a",
+          "projected_decimal": "2041537351469299226",
+          "pickle_hex": "8005953f0000000000000043205c5d9e04e03de9f2f4a9f38766c4d0fb0e207ccf5d2fb3b272c50117f336ae0c94284b054b064b074b0874948c09616461707465722d4194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "salt_first_block_only",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": "tenant-salt",
+      "expected": [
+        {
+          "digest": "373c09c29ab08b91b13bf1a67e0a461990572d476016c064b6ba6b75c163ceb1",
+          "projected_hex": "b6ba6b75c163ceb1",
+          "projected_decimal": "13166954614070955697",
+          "pickle_hex": "800595410000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c0b74656e616e742d73616c7494859487942e"
+        },
+        {
+          "digest": "141900dd6fe59d22764357a125ecf4d670923bb12ad705a520de0e98c7338d5d",
+          "projected_hex": "20de0e98c7338d5d",
+          "projected_decimal": "2368346503383321949",
+          "pickle_hex": "80059532000000000000004320373c09c29ab08b91b13bf1a67e0a461990572d476016c064b6ba6b75c163ceb194284b054b064b074b0874944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "lora_then_salt",
+      "block_size": 4,
+      "lora_name": "adapter-A",
+      "cache_salt": "tenant-salt",
+      "expected": [
+        {
+          "digest": "dacd8a5addba8cf4b89589bedab04999b3676299a455ba3e085cc7777be6b328",
+          "projected_hex": "085cc7777be6b328",
+          "projected_decimal": "602575766154556200",
+          "pickle_hex": "8005954d0000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474948c09616461707465722d41948c0b74656e616e742d73616c7494869487942e"
+        },
+        {
+          "digest": "55575bd9b63ced6a3dc36c355afbb5f551599533795c26d27d8b5fc836681618",
+          "projected_hex": "7d8b5fc836681618",
+          "projected_decimal": "9046429590014662168",
+          "pickle_hex": "8005953f000000000000004320dacd8a5addba8cf4b89589bedab04999b3676299a455ba3e085cc7777be6b32894284b054b064b074b0874948c09616461707465722d4194859487942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8
+      ]
+    },
+    {
+      "name": "multi_block_chain",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        },
+        {
+          "digest": "9e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b",
+          "projected_hex": "ad1746592a2b036b",
+          "projected_decimal": "12472515041799373675",
+          "pickle_hex": "80059532000000000000004320762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d94284b054b064b074b0874944e87942e"
+        },
+        {
+          "digest": "fd503875de30430b3c7e35f7ecca2fe995f2d55487bfef31707e09b175f917a0",
+          "projected_hex": "707e09b175f917a0",
+          "projected_decimal": "8105927037106591648",
+          "pickle_hex": "800595320000000000000043209e62b5a7ec298f33cb4c7d9e00b659874bb2432d23ad6879ad1746592a2b036b94284b094b0a4b0b4b0c74944e87942e"
+        },
+        {
+          "digest": "ac30858a66380467632841b758acc6cbe95ff9cfd7b9d226aa33de029248adff",
+          "projected_hex": "aa33de029248adff",
+          "projected_decimal": "12264390312885530111",
+          "pickle_hex": "80059532000000000000004320fd503875de30430b3c7e35f7ecca2fe995f2d55487bfef31707e09b175f917a094284b0d4b0e4b0f4b1074944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16
+      ]
+    },
+    {
+      "name": "incomplete_tail",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "762b2e7e1520febd3a0aedb7358e8602facf3924440e18538fce057e23bae91d",
+          "projected_hex": "8fce057e23bae91d",
+          "projected_decimal": "10362225831949560093",
+          "pickle_hex": "800595320000000000000043201973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c94284b014b024b034b0474944e87942e"
+        }
+      ],
+      "token_ids": [
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ]
+    },
+    {
+      "name": "no_complete_block",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [],
+      "token_ids": [
+        1,
+        2,
+        3
+      ]
+    },
+    {
+      "name": "frame_boundary_token_stream",
+      "block_size": 22000,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "7f245129165bb9ba11747856a9a908740bf7b29c0033da4958281d87b252f469",
+          "projected_hex": "58281d87b252f469",
+          "projected_decimal": "6352359743055656041",
+          "pickle_len": 66062
+        }
+      ],
+      "token_ids_repeat": {
+        "value": 256,
+        "count": 22000
+      }
+    },
+    {
+      "name": "large_lora_large_payload",
+      "block_size": 4,
+      "lora_name": "",
+      "cache_salt": null,
+      "expected": [
+        {
+          "digest": "f30f906062e861807059e2099b689baf2c9484128a0c2fd40a5fdd1e1032f47f",
+          "projected_hex": "0a5fdd1e1032f47f",
+          "projected_decimal": "747559184357323903",
+          "pickle_len": 70077
+        }
+      ],
+      "lora_name_repeat": {
+        "value": "a",
+        "count": 70000
+      },
+      "token_ids": [
+        1,
+        2,
+        3,
+        4
+      ]
+    }
+  ]
+}

--- a/mooncake-conductor/tests/fixtures/verify_fixture_against_vllm.py
+++ b/mooncake-conductor/tests/fixtures/verify_fixture_against_vllm.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Verifies hash_golden_vectors_sha256.json against the checked-out vLLM.
+
+Loads ``vllm/utils/hashing.py`` directly from a vLLM source checkout (without
+importing the heavy ``vllm`` package) and uses its ``sha256`` function as the
+normative oracle: SHA-256 over ``pickle.dumps(value, protocol=5)``.  The block
+value shapes mirror ``vllm/v1/core/kv_cache_utils.py::hash_block_tokens``.
+
+Usage:
+
+    python3 verify_fixture_against_vllm.py [path-to-vllm-checkout]
+
+The default checkout path is /home/lolopop/vllm/vllm.  Prints the pinned
+Python/vLLM/protocol metadata and exits non-zero on any mismatch.
+"""
+
+import importlib.util
+import json
+import pickle
+import platform
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+FIXTURE = Path(__file__).with_name("hash_golden_vectors_sha256.json")
+DEFAULT_VLLM = Path("/home/lolopop/vllm/vllm")
+
+
+def load_vllm_hashing(checkout: Path):
+    hashing_py = checkout / "vllm" / "utils" / "hashing.py"
+    if not hashing_py.is_file():
+        raise SystemExit(f"vLLM hashing.py not found at {hashing_py}")
+    # hashing.py imports cbor2 at module scope; the sha256 recipe under test
+    # never touches it, so a stub is sufficient when cbor2 is absent.
+    if "cbor2" not in sys.modules:
+        try:
+            import cbor2  # noqa: F401
+        except ImportError:
+            sys.modules["cbor2"] = types.ModuleType("cbor2")
+    spec = importlib.util.spec_from_file_location("vllm_hashing", hashing_py)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.sha256
+
+
+def vllm_revision(checkout: Path) -> str:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(checkout), "describe", "--tags", "--always"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def expand_tokens(case: dict):
+    if "token_ids_repeat" in case:
+        spec = case["token_ids_repeat"]
+        return [spec["value"]] * spec["count"]
+    return list(case["token_ids"])
+
+
+def expand_lora(case: dict) -> str:
+    if "lora_name_repeat" in case:
+        spec = case["lora_name_repeat"]
+        return spec["value"] * spec["count"]
+    return case["lora_name"]
+
+
+def extras_for(lora_name: str, cache_salt, block_index: int):
+    keys = []
+    if lora_name:
+        keys.append(lora_name)
+    if block_index == 0 and cache_salt:
+        keys.append(cache_salt)
+    return tuple(keys) if keys else None
+
+
+def main() -> int:
+    checkout = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_VLLM
+    vllm_sha256 = load_vllm_hashing(checkout)
+    fixture = json.loads(FIXTURE.read_text())
+
+    print(f"python: {platform.python_version()}")
+    print(f"pickle protocol: {pickle.HIGHEST_PROTOCOL}")
+    print(f"vLLM checkout: {checkout} ({vllm_revision(checkout)})")
+
+    failures = 0
+
+    def check(label: str, actual: str, expected: str) -> None:
+        nonlocal failures
+        if actual != expected:
+            failures += 1
+            print(f"MISMATCH {label}:\n  actual   {actual}\n  expected {expected}")
+
+    for vector in fixture["seed_root_vectors"]:
+        seed = vector["python_hash_seed"]
+        check(f"seed root {seed!r}", vllm_sha256(seed).hex(), vector["root_digest"])
+        check(
+            f"seed pickle bytes {seed!r}",
+            pickle.dumps(seed, protocol=5).hex(),
+            vector["pickle_hex"],
+        )
+
+    root = bytes.fromhex(fixture["profile"]["root_digest"])
+    for case in fixture["cases"]:
+        tokens = expand_tokens(case)
+        block_size = case["block_size"]
+        lora_name = expand_lora(case)
+        cache_salt = case["cache_salt"]
+        parent = root
+        for index, entry in enumerate(case["expected"]):
+            block_tokens = tuple(tokens[index * block_size : (index + 1) * block_size])
+            value = (
+                parent,
+                block_tokens,
+                extras_for(lora_name, cache_salt, index),
+            )
+            serialized = pickle.dumps(value, protocol=5)
+            digest = vllm_sha256(value).hex()
+            check(f"{case['name']} block {index}", digest, entry["digest"])
+            if "pickle_hex" in entry:
+                check(
+                    f"{case['name']} block {index} pickle bytes",
+                    serialized.hex(),
+                    entry["pickle_hex"],
+                )
+            else:
+                check(
+                    f"{case['name']} block {index} pickle length",
+                    str(len(serialized)),
+                    str(entry["pickle_len"]),
+                )
+            parent = bytes.fromhex(digest)
+
+    if failures:
+        print(f"{failures} mismatch(es)")
+        return 1
+    print("all seed roots, block digests, and serialized bytes match vLLM")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mooncake-conductor/tests/prefix_indexer_test.cpp
+++ b/mooncake-conductor/tests/prefix_indexer_test.cpp
@@ -38,6 +38,8 @@ constexpr char kRootDigest[] =
     "4e1195df020de59e0d65a33a4279f1183e7ae4e5d980e309f8b55adff2e61c3e";
 constexpr char kPaddedSeedRootDigest[] =
     "8d912e4e62b3cc377b1d1c7a14ef61dffbdaa0990237035c05401c29414c4172";
+constexpr char kPickleRootDigest[] =
+    "1973e23848344dc43a988a9b478663803cfffe1243480253f9a3cf004b14aa7c";
 
 ContextKey TestContext(int64_t block_size = 16) {
     return {.tenant_id = "tenant-a",
@@ -59,6 +61,14 @@ HashProfile PaddedSeedProfile() {
             .algorithm = "sha256_cbor",
             .python_hash_seed = "00",
             .root_digest = kPaddedSeedRootDigest,
+            .index_projection = "low64_be"};
+}
+
+HashProfile PickleProfile() {
+    return {.strategy = "vllm_v1",
+            .algorithm = "sha256",
+            .python_hash_seed = "0",
+            .root_digest = kPickleRootDigest,
             .index_projection = "low64_be"};
 }
 
@@ -312,6 +322,43 @@ TEST(Registration, ProfileBindingValidationIsExactAndLookupOnly) {
     const HashProfile conflict = PaddedSeedProfile();
     EXPECT_FALSE(table.ValidateProfileBinding(TestContext(), conflict).empty());
     EXPECT_EQ(PrefixCacheTableTestPeer::Snapshot(table), registered);
+}
+
+TEST(Registration, MixedAlgorithmsUnderOneContextAreRejected) {
+    // The resolved profile is immutable per ContextKey: the same seed under
+    // the other supported algorithm is still a conflict, in both orders.
+    {
+        PrefixCacheTable table;
+        RegisterOrFail(table, Registration());
+        const auto before = PrefixCacheTableTestPeer::Snapshot(table);
+
+        auto conflicting = Registration("instance-b", 1);
+        conflicting.profile = PickleProfile();
+        const auto result = table.Register(conflicting);
+        EXPECT_FALSE(result.error.empty());
+        EXPECT_FALSE(result.inserted);
+        EXPECT_EQ(PrefixCacheTableTestPeer::Snapshot(table), before);
+
+        EXPECT_FALSE(
+            table.ValidateProfileBinding(TestContext(), PickleProfile())
+                .empty());
+        EXPECT_EQ(PrefixCacheTableTestPeer::Snapshot(table), before);
+    }
+    {
+        PrefixCacheTable table;
+        auto pickle_registration = Registration();
+        pickle_registration.profile = PickleProfile();
+        RegisterOrFail(table, pickle_registration);
+        const auto before = PrefixCacheTableTestPeer::Snapshot(table);
+        EXPECT_EQ(table.ValidateProfileBinding(TestContext(), PickleProfile()),
+                  "");
+
+        auto conflicting = Registration("instance-b", 1);
+        const auto result = table.Register(conflicting);
+        EXPECT_FALSE(result.error.empty());
+        EXPECT_FALSE(result.inserted);
+        EXPECT_EQ(PrefixCacheTableTestPeer::Snapshot(table), before);
+    }
 }
 
 TEST(Mutations, StoreRequiresKnownContextAndRegisteredGpuRank) {


### PR DESCRIPTION
## Description

Conductor previously reconstructed only vLLM's sha256_cbor prefix-hash recipe, while current vLLM releases default to sha256 (SHA-256 over CPython Pickle protocol-5 serialization). A producer using the default published hashes Conductor could not reproduce for /query, causing silent cache misses.

- Refactor hash_strategy.cpp behind a value-codec boundary: the shared vLLM v1 chain (complete-block selection, full 32-byte parent advancement, SHA-256, low64_be projection) delegates value encoding to algorithm-specific codecs without changing CBOR behavior.
- Implement a restricted CPython Pickle protocol-5 encoder covering the protocol header, 64 KiB framing and large-payload writes, string/bytes/integer length thresholds, tuple arity opcodes, memoize markers, and the LoRA/cache-salt extra-key ordering. Multimodal and prompt-embedding extra-key shapes remain explicitly unsupported.
- Accept exactly sha256 and sha256_cbor in profile selector validation, static configuration, and POST /register; derive and validate roots with the selected recipe before any subscription or index mutation.
- Expose the explicit algorithm choice in the cache-aware proxy (--hash-algorithm / JSON hash_profile.algorithm), preserving sha256_cbor as the legacy CLI default and propagating the selection in every registration payload.
- Add vLLM-oracle golden vectors (serialized bytes, full digests, low64 projections) with a Pickle fixture generator and a verifier that loads the checked-out vLLM hashing.py directly; extend hash, prefix-index, event-manager, HTTP, concurrency, and proxy tests for both algorithms including mixed-algorithm ContextKey rejection.
- Document algorithm selection, the mandatory fixed PYTHONHASHSEED, and the no-handshake trust limitation in the example README.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [x] No AI tools were used
- [ ] AI tools were used (specify below)