### PR TITLE
[Store] support CUDA IPC for dummy client buffers

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <limits>
 #include <numeric>
+#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -15,6 +16,7 @@
 #include "memory_alloc.h"
 #include "ssd_register_client.h"
 #include "device/accelerator_registry.h"
+#include "device/cuda_ipc_buffer.h"
 
 #include <cstdlib>  // for atexit
 #include <memory>
@@ -89,61 +91,68 @@ std::optional<ParsedTensorMetadata> parse_tensor_metadata_from_buffer(
 std::pair<int64_t, int64_t> calculate_shard_range(int64_t dim_size, int rank,
                                                   int shard_count);
 
-PyTensorInfo extract_tensor_info(const py::object &tensor,
-                                 const std::string &key_name = "") {
-    PyTensorInfo info = {
-        0,
-        0,
-        {},
-        py::none(),
-    };
-
+PyTensorInfo extract_tensor_info_impl(const py::object &tensor,
+                                      const std::string &key_name,
+                                      bool require_contiguous,
+                                      const char *role) {
+    PyTensorInfo info = {0, 0, {}, py::none()};
     if (!(tensor.attr("__class__")
               .attr("__name__")
               .cast<std::string>()
               .find("Tensor") != std::string::npos)) {
-        LOG(ERROR) << "Input " << (key_name.empty() ? "" : "for " + key_name)
+        LOG(ERROR) << role << " " << (key_name.empty() ? "" : "for " + key_name)
                    << " is not a PyTorch tensor";
         return info;
     }
 
     try {
-        py::object contiguous_tensor = tensor.attr("contiguous")();
-        info.owner = contiguous_tensor;
-        info.data_ptr = contiguous_tensor.attr("data_ptr")().cast<uintptr_t>();
-        size_t numel = contiguous_tensor.attr("numel")().cast<size_t>();
-        size_t element_size =
-            contiguous_tensor.attr("element_size")().cast<size_t>();
+        if (require_contiguous &&
+            !tensor.attr("is_contiguous")().cast<bool>()) {
+            LOG(ERROR) << role << " "
+                       << (key_name.empty() ? "" : "for " + key_name)
+                       << " must be contiguous";
+            return info;
+        }
+
+        py::object inspected =
+            require_contiguous ? tensor : tensor.attr("contiguous")();
+        info.owner = inspected;
+        info.data_ptr = inspected.attr("data_ptr")().cast<uintptr_t>();
+        size_t numel = inspected.attr("numel")().cast<size_t>();
+        size_t element_size = inspected.attr("element_size")().cast<size_t>();
         info.tensor_size = numel * element_size;
 
-        pybind11::object shape_obj = tensor.attr("shape");
-        pybind11::object dtype_obj = tensor.attr("dtype");
-
-        TensorDtype dtype_enum = get_tensor_dtype(dtype_obj);
+        TensorDtype dtype_enum = get_tensor_dtype(inspected.attr("dtype"));
         if (dtype_enum == TensorDtype::UNKNOWN) {
             LOG(ERROR) << "Unsupported tensor dtype"
                        << (key_name.empty() ? "" : " for " + key_name);
             return {0, 0, {}, py::none()};
         }
-
-        pybind11::tuple shape_tuple =
-            pybind11::cast<pybind11::tuple>(shape_obj);
-        int32_t ndim = static_cast<int32_t>(shape_tuple.size());
-
+        int32_t ndim = static_cast<int32_t>(py::len(inspected.attr("shape")));
         if (ndim > static_cast<int32_t>(kMaxTensorDims)) {
             LOG(ERROR) << "Tensor has more than " << kMaxTensorDims
                        << " dimensions: " << ndim;
             return {0, 0, {}, py::none()};
         }
-
         info.metadata =
-            build_full_tensor_metadata(tensor, dtype_enum, info.tensor_size);
+            build_full_tensor_metadata(inspected, dtype_enum, info.tensor_size);
     } catch (const std::exception &e) {
         LOG(ERROR) << "Error extracting tensor info: " << e.what();
         return {0, 0, {}, py::none()};
     }
 
     return info;
+}
+
+PyTensorInfo extract_tensor_info(const py::object &tensor,
+                                 const std::string &key_name = "") {
+    return extract_tensor_info_impl(tensor, key_name, false, "Input");
+}
+
+PyTensorInfo extract_tensor_destination_info(const py::object &tensor,
+                                             const std::string &key_name = "") {
+    return extract_tensor_info_impl(tensor, key_name, true,
+                                    "Destination tensor");
 }
 
 py::tuple tensor_shape_tuple(const TensorMetadata &metadata) {
@@ -313,6 +322,44 @@ py::tuple serialize_tensor_metadata(py::object tensor) {
 }
 
 size_t tensor_metadata_size() { return sizeof(TensorMetadata); }
+
+bool tensor_destination_matches_metadata(const PyTensorInfo &target,
+                                         const ParsedTensorMetadata &stored,
+                                         const std::string &key,
+                                         const std::string &context) {
+    if (target.metadata.header.dtype != stored.metadata.header.dtype ||
+        target.metadata.header.ndim != stored.metadata.header.ndim ||
+        target.tensor_size != stored.data_bytes) {
+        LOG(ERROR) << context << ": destination tensor mismatch for key "
+                   << key;
+        return false;
+    }
+    return TensorShapeToVector(target.metadata.layout.local_shape,
+                               target.metadata.header.ndim) ==
+           TensorShapeToVector(stored.metadata.layout.local_shape,
+                               stored.metadata.header.ndim);
+}
+
+template <typename ResultType>
+bool apply_indexed_results(const char *context,
+                           const std::vector<ResultType> &op_results,
+                           const std::vector<size_t> &original_indices,
+                           std::vector<ResultType> &results) {
+    if (op_results.size() != original_indices.size()) {
+        LOG(ERROR) << context << ": unexpected result count "
+                   << op_results.size() << ", expected "
+                   << original_indices.size();
+        for (size_t index : original_indices) {
+            results[index] =
+                static_cast<ResultType>(toInt(ErrorCode::INTERNAL_ERROR));
+        }
+        return false;
+    }
+    for (size_t i = 0; i < op_results.size(); ++i) {
+        results[original_indices[i]] = op_results[i];
+    }
+    return true;
+}
 
 py::object deserialize_tensor_from_bytes(py::bytes payload) {
     std::string data = payload;
@@ -688,6 +735,140 @@ class MooncakeStorePyWrapper {
         return results_list;
     }
 
+    std::vector<std::optional<ParsedTensorMetadata>>
+    batch_get_tensor_metadata_prefixes(const std::vector<std::string> &keys,
+                                       const std::string &context) {
+        std::vector<std::optional<ParsedTensorMetadata>> metadata(keys.size());
+        if (keys.empty()) return metadata;
+
+        const size_t scratch_size = keys.size() * sizeof(TensorMetadata);
+        auto scratch = store_->allocate_client_buffer(scratch_size);
+        if (!scratch) {
+            LOG(ERROR) << context << ": failed to allocate metadata buffer";
+            return metadata;
+        }
+
+        std::vector<void *> buffers{scratch->ptr()};
+        std::vector<std::vector<std::string>> all_keys{keys};
+        std::vector<std::vector<std::vector<size_t>>> all_dst_offsets(1);
+        std::vector<std::vector<std::vector<size_t>>> all_src_offsets(
+            1, std::vector<std::vector<size_t>>(keys.size(), {0}));
+        std::vector<std::vector<std::vector<size_t>>> all_sizes(
+            1, std::vector<std::vector<size_t>>(keys.size(),
+                                                {sizeof(TensorMetadata)}));
+        all_dst_offsets[0].reserve(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            all_dst_offsets[0].push_back({i * sizeof(TensorMetadata)});
+        }
+
+        std::vector<std::vector<std::vector<int64_t>>> results;
+        {
+            py::gil_scoped_release release_gil;
+            results =
+                store_->get_into_ranges(buffers, all_keys, all_dst_offsets,
+                                        all_src_offsets, all_sizes, nullptr);
+        }
+        if (results.size() != 1 || results[0].size() != keys.size()) {
+            LOG(ERROR) << context << ": metadata read result size mismatch";
+            return metadata;
+        }
+
+        const char *base = static_cast<const char *>(scratch->ptr());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            if (results[0][i].size() != 1 ||
+                results[0][i][0] !=
+                    static_cast<int64_t>(sizeof(TensorMetadata))) {
+                continue;
+            }
+            metadata[i] = parse_tensor_metadata_from_prefix(
+                base + i * sizeof(TensorMetadata), context, keys[i]);
+        }
+        return metadata;
+    }
+
+    int64_t get_tensor_into_cuda(const std::string &key,
+                                 pybind11::object tensor) {
+        py::list tensors;
+        tensors.append(tensor);
+        auto results = batch_get_tensor_into_cuda({key}, tensors);
+        return results.empty() ? to_py_ret(ErrorCode::INVALID_PARAMS)
+                               : results[0];
+    }
+
+    std::vector<int64_t> batch_get_tensor_into_cuda(
+        const std::vector<std::string> &keys, pybind11::list tensors_list) {
+        std::vector<int64_t> results(keys.size(),
+                                     to_py_ret(ErrorCode::INVALID_PARAMS));
+        const std::string context = "batch_get_tensor_into_cuda";
+        if (!is_client_initialized()) {
+            LOG(ERROR) << "Client is not initialized";
+            return results;
+        }
+        if (keys.size() != tensors_list.size()) {
+            LOG(ERROR) << context << ": keys and tensors size mismatch";
+            return results;
+        }
+
+        if (!use_dummy_client_) {
+            LOG(ERROR) << context
+                       << ": CUDA IPC tensor read requires a dummy client";
+            return results;
+        }
+
+        auto metadata = batch_get_tensor_metadata_prefixes(keys, context);
+        std::vector<std::string> valid_keys;
+        std::vector<CudaIpcBufferHandle> dst_buffers;
+        std::vector<size_t> src_offsets;
+        std::vector<size_t> sizes;
+        std::vector<size_t> original_indices;
+        valid_keys.reserve(keys.size());
+        dst_buffers.reserve(keys.size());
+        src_offsets.reserve(keys.size());
+        sizes.reserve(keys.size());
+        original_indices.reserve(keys.size());
+
+        for (size_t i = 0; i < keys.size(); ++i) {
+            PyTensorInfo target = extract_tensor_destination_info(
+                tensors_list[i].cast<py::object>(), keys[i]);
+            if (!target.valid() || !metadata[i].has_value() ||
+                !tensor_destination_matches_metadata(target, *metadata[i],
+                                                     keys[i], context)) {
+                continue;
+            }
+            if (target.tensor_size == 0) {
+                results[i] = 0;
+                continue;
+            }
+            auto dst_buffer = mooncake::device::ExportCudaIpcBuffer(
+                reinterpret_cast<void *>(target.data_ptr), target.tensor_size);
+            if (!dst_buffer) {
+                LOG(ERROR) << context
+                           << ": destination tensor is not CUDA IPC exportable "
+                           << "for key " << keys[i];
+                continue;
+            }
+            valid_keys.push_back(keys[i]);
+            dst_buffers.push_back(*dst_buffer);
+            src_offsets.push_back(metadata[i]->data_offset);
+            sizes.push_back(metadata[i]->data_bytes);
+            original_indices.push_back(i);
+        }
+
+        if (!valid_keys.empty()) {
+            std::vector<int64_t> op_results;
+            {
+                py::gil_scoped_release release_gil;
+                auto dummy_client =
+                    std::static_pointer_cast<DummyClient>(store_);
+                op_results = dummy_client->batch_get_into_cuda_ipc(
+                    valid_keys, dst_buffers, src_offsets, sizes);
+            }
+            apply_indexed_results(context.c_str(), op_results, original_indices,
+                                  results);
+        }
+        return results;
+    }
+
     pybind11::object get_tensor_with_tp_into(const std::string &key,
                                              uintptr_t buffer_ptr, size_t size,
                                              int tp_rank = 0, int tp_size = 1,
@@ -865,6 +1046,10 @@ class MooncakeStorePyWrapper {
         const std::vector<std::string> &keys,
         const std::vector<PyTensorInfo> &infos,
         const ReplicateConfig &config = ReplicateConfig{}) {
+        if (auto cuda_ipc_results =
+                try_dummy_cuda_ipc_batch_put_tensor_impl(keys, infos, config)) {
+            return *cuda_ipc_results;
+        }
         return batch_write_tensor_impl(
             keys, infos, config, "put",
             [this](const std::vector<std::string> &write_keys,
@@ -2310,6 +2495,13 @@ PYBIND11_MODULE(store, m) {
              "Get tensors directly into pre-allocated buffers for "
              "multiple "
              "keys")
+        .def("get_tensor_into_cuda",
+             &MooncakeStorePyWrapper::get_tensor_into_cuda, py::arg("key"),
+             py::arg("tensor"), "Get tensor payload into a CUDA tensor")
+        .def("batch_get_tensor_into_cuda",
+             &MooncakeStorePyWrapper::batch_get_tensor_into_cuda,
+             py::arg("keys"), py::arg("tensors_list"),
+             "Get tensor payloads into pre-allocated CUDA tensors")
         .def(
             "get_tensor_with_tp_into",
             &MooncakeStorePyWrapper::get_tensor_with_tp_into, py::arg("key"),

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -816,15 +816,9 @@ class MooncakeStorePyWrapper {
         }
 
         auto metadata = batch_get_tensor_metadata_prefixes(keys, context);
-        std::vector<std::string> valid_keys;
-        std::vector<CudaIpcBufferHandle> dst_buffers;
-        std::vector<size_t> src_offsets;
-        std::vector<size_t> sizes;
+        std::vector<CudaIpcReadRequest> read_requests;
         std::vector<size_t> original_indices;
-        valid_keys.reserve(keys.size());
-        dst_buffers.reserve(keys.size());
-        src_offsets.reserve(keys.size());
-        sizes.reserve(keys.size());
+        read_requests.reserve(keys.size());
         original_indices.reserve(keys.size());
 
         for (size_t i = 0; i < keys.size(); ++i) {
@@ -847,21 +841,23 @@ class MooncakeStorePyWrapper {
                            << "for key " << keys[i];
                 continue;
             }
-            valid_keys.push_back(keys[i]);
-            dst_buffers.push_back(*dst_buffer);
-            src_offsets.push_back(metadata[i]->data_offset);
-            sizes.push_back(metadata[i]->data_bytes);
+            read_requests.push_back(CudaIpcReadRequest{
+                .key = keys[i],
+                .destination = *dst_buffer,
+                .source_offset = metadata[i]->data_offset,
+                .size = metadata[i]->data_bytes,
+            });
             original_indices.push_back(i);
         }
 
-        if (!valid_keys.empty()) {
+        if (!read_requests.empty()) {
             std::vector<int64_t> op_results;
             {
                 py::gil_scoped_release release_gil;
                 auto dummy_client =
                     std::static_pointer_cast<DummyClient>(store_);
-                op_results = dummy_client->batch_get_into_cuda_ipc(
-                    valid_keys, dst_buffers, src_offsets, sizes);
+                op_results =
+                    dummy_client->batch_get_into_cuda_ipc(read_requests);
             }
             apply_indexed_results(context.c_str(), op_results, original_indices,
                                   results);

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -22,16 +22,10 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
     std::vector<int> results(keys.size(), 0);
     py::gil_scoped_release release_gil;
 
-    std::vector<std::string> valid_keys;
-    std::vector<void *> metadata_buffers;
-    std::vector<size_t> metadata_sizes;
-    std::vector<CudaIpcBufferHandle> payloads;
+    std::vector<CudaIpcWriteRequest> write_requests;
     std::vector<size_t> original_indices;
     std::vector<std::unique_ptr<BufferHandle>> metadata_allocations;
-    valid_keys.reserve(infos.size());
-    metadata_buffers.reserve(infos.size());
-    metadata_sizes.reserve(infos.size());
-    payloads.reserve(infos.size());
+    write_requests.reserve(infos.size());
     original_indices.reserve(infos.size());
     metadata_allocations.reserve(infos.size());
 
@@ -55,22 +49,26 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
         }
 
         std::memcpy(metadata->ptr(), &infos[i].metadata, metadata_size);
-        valid_keys.push_back(keys[i]);
-        metadata_buffers.push_back(metadata->ptr());
-        metadata_sizes.push_back(metadata_size);
-        payloads.push_back(*payload);
+        write_requests.push_back(CudaIpcWriteRequest{
+            .key = keys[i],
+            .metadata =
+                CudaIpcShmBufferRef{
+                    .ptr = reinterpret_cast<uint64_t>(metadata->ptr()),
+                    .size = static_cast<uint64_t>(metadata_size),
+                },
+            .payload = *payload,
+        });
         original_indices.push_back(i);
         metadata_allocations.push_back(
             std::make_unique<BufferHandle>(std::move(*metadata)));
     }
 
-    if (!valid_keys.empty()) {
+    if (!write_requests.empty()) {
         ReplicateConfig write_config =
             MakeIndexedConfig(config, original_indices);
         auto dummy_client = std::static_pointer_cast<DummyClient>(store_);
-        std::vector<int> op_results = dummy_client->batch_put_from_cuda_ipc(
-            valid_keys, metadata_buffers, metadata_sizes, payloads,
-            write_config);
+        std::vector<int> op_results =
+            dummy_client->batch_put_from_cuda_ipc(write_requests, write_config);
         if (!apply_indexed_results("put", op_results, original_indices,
                                    results)) {
             return results;

--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -14,6 +14,71 @@ int write_manifest_impl(const std::string &key,
     return ret;
 }
 
+std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
+    const std::vector<std::string> &keys,
+    const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
+    if (!use_dummy_client_ || keys.size() != infos.size()) return std::nullopt;
+
+    std::vector<int> results(keys.size(), 0);
+    py::gil_scoped_release release_gil;
+
+    std::vector<std::string> valid_keys;
+    std::vector<void *> metadata_buffers;
+    std::vector<size_t> metadata_sizes;
+    std::vector<CudaIpcBufferHandle> payloads;
+    std::vector<size_t> original_indices;
+    std::vector<std::unique_ptr<BufferHandle>> metadata_allocations;
+    valid_keys.reserve(infos.size());
+    metadata_buffers.reserve(infos.size());
+    metadata_sizes.reserve(infos.size());
+    payloads.reserve(infos.size());
+    original_indices.reserve(infos.size());
+    metadata_allocations.reserve(infos.size());
+
+    for (size_t i = 0; i < infos.size(); ++i) {
+        if (!infos[i].valid()) {
+            results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
+            continue;
+        }
+        if (infos[i].tensor_size == 0) return std::nullopt;
+
+        auto payload = mooncake::device::ExportCudaIpcBuffer(
+            reinterpret_cast<const void *>(infos[i].data_ptr),
+            infos[i].tensor_size);
+        if (!payload) return std::nullopt;
+
+        size_t metadata_size = infos[i].metadata.header.data_offset;
+        auto metadata = store_->allocate_client_buffer(metadata_size);
+        if (!metadata) {
+            results[i] = to_py_ret(ErrorCode::NO_AVAILABLE_HANDLE);
+            continue;
+        }
+
+        std::memcpy(metadata->ptr(), &infos[i].metadata, metadata_size);
+        valid_keys.push_back(keys[i]);
+        metadata_buffers.push_back(metadata->ptr());
+        metadata_sizes.push_back(metadata_size);
+        payloads.push_back(*payload);
+        original_indices.push_back(i);
+        metadata_allocations.push_back(
+            std::make_unique<BufferHandle>(std::move(*metadata)));
+    }
+
+    if (!valid_keys.empty()) {
+        ReplicateConfig write_config =
+            MakeIndexedConfig(config, original_indices);
+        auto dummy_client = std::static_pointer_cast<DummyClient>(store_);
+        std::vector<int> op_results = dummy_client->batch_put_from_cuda_ipc(
+            valid_keys, metadata_buffers, metadata_sizes, payloads,
+            write_config);
+        if (!apply_indexed_results("put", op_results, original_indices,
+                                   results)) {
+            return results;
+        }
+    }
+    return results;
+}
+
 template <typename BatchWriteFromFn>
 std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                                          const std::vector<PyTensorInfo> &infos,
@@ -97,18 +162,9 @@ std::vector<int> batch_write_tensor_impl(const std::vector<std::string> &keys,
                 MakeIndexedConfig(config, original_indices);
             std::vector<int> op_results = batch_write_from(
                 valid_keys, buffer_ptrs, buffer_sizes, write_config);
-            if (op_results.size() != original_indices.size()) {
-                LOG(ERROR) << operation_name
-                           << ": unexpected batch write result count "
-                           << op_results.size() << ", expected "
-                           << original_indices.size();
-                for (size_t index : original_indices) {
-                    results[index] = to_py_ret(ErrorCode::INTERNAL_ERROR);
-                }
+            if (!apply_indexed_results(operation_name, op_results,
+                                       original_indices, results)) {
                 return results;
-            }
-            for (size_t i = 0; i < op_results.size(); ++i) {
-                results[original_indices[i]] = op_results[i];
             }
         }
     }

--- a/mooncake-store/include/device/cuda_ipc_buffer.h
+++ b/mooncake-store/include/device/cuda_ipc_buffer.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "device/cuda_ipc_buffer_handle.h"
+
+namespace mooncake {
+namespace device {
+
+tl::expected<CudaIpcBufferHandle, ErrorCode> ExportCudaIpcBuffer(
+    const void *ptr, size_t size);
+
+class CudaIpcBufferMapping {
+   public:
+    CudaIpcBufferMapping() = default;
+    ~CudaIpcBufferMapping();
+
+    CudaIpcBufferMapping(const CudaIpcBufferMapping &) = delete;
+    CudaIpcBufferMapping &operator=(const CudaIpcBufferMapping &) = delete;
+
+    CudaIpcBufferMapping(CudaIpcBufferMapping &&other) noexcept;
+    CudaIpcBufferMapping &operator=(CudaIpcBufferMapping &&other) noexcept;
+
+    static tl::expected<CudaIpcBufferMapping, ErrorCode> Open(
+        const CudaIpcBufferHandle &handle);
+
+    void *ptr() const { return ptr_; }
+
+   private:
+    CudaIpcBufferMapping(void *base, void *ptr, int32_t device_id)
+        : base_(base), ptr_(ptr), device_id_(device_id) {}
+
+    void Close();
+
+    void *base_ = nullptr;
+    void *ptr_ = nullptr;
+    int32_t device_id_ = -1;
+};
+
+}  // namespace device
+}  // namespace mooncake

--- a/mooncake-store/include/device/cuda_ipc_buffer_handle.h
+++ b/mooncake-store/include/device/cuda_ipc_buffer_handle.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include "types.h"
+
+namespace mooncake {
+
+constexpr size_t kCudaIpcHandleSize = 64;
+
+struct CudaIpcBufferHandle {
+    std::array<uint8_t, kCudaIpcHandleSize> handle{};
+    uint64_t offset = 0;
+    uint64_t size = 0;
+    int32_t device_id = -1;
+};
+
+}  // namespace mooncake
+
+YLT_REFL(mooncake::CudaIpcBufferHandle, handle, offset, size, device_id);

--- a/mooncake-store/include/device/cuda_ipc_buffer_handle.h
+++ b/mooncake-store/include/device/cuda_ipc_buffer_handle.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
+#include <string>
 
 #include "types.h"
 
@@ -17,6 +18,27 @@ struct CudaIpcBufferHandle {
     int32_t device_id = -1;
 };
 
+struct CudaIpcShmBufferRef {
+    uint64_t ptr = 0;
+    uint64_t size = 0;
+};
+
+struct CudaIpcWriteRequest {
+    std::string key;
+    CudaIpcShmBufferRef metadata;
+    CudaIpcBufferHandle payload;
+};
+
+struct CudaIpcReadRequest {
+    std::string key;
+    CudaIpcBufferHandle destination;
+    uint64_t source_offset = 0;
+    uint64_t size = 0;
+};
+
 }  // namespace mooncake
 
 YLT_REFL(mooncake::CudaIpcBufferHandle, handle, offset, size, device_id);
+YLT_REFL(mooncake::CudaIpcShmBufferRef, ptr, size);
+YLT_REFL(mooncake::CudaIpcWriteRequest, key, metadata, payload);
+YLT_REFL(mooncake::CudaIpcReadRequest, key, destination, source_offset, size);

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -76,10 +76,7 @@ class DummyClient : public PyClient {
                                         const std::vector<size_t> &sizes);
 
     std::vector<int64_t> batch_get_into_cuda_ipc(
-        const std::vector<std::string> &keys,
-        const std::vector<CudaIpcBufferHandle> &dst_buffers,
-        const std::vector<size_t> &src_offsets,
-        const std::vector<size_t> &sizes);
+        const std::vector<CudaIpcReadRequest> &requests);
 
     std::vector<int> batch_get_into_multi_buffers(
         const std::vector<std::string> &keys,
@@ -107,10 +104,7 @@ class DummyClient : public PyClient {
         const ReplicateConfig &config = ReplicateConfig{});
 
     std::vector<int> batch_put_from_cuda_ipc(
-        const std::vector<std::string> &keys,
-        const std::vector<void *> &metadata_buffers,
-        const std::vector<size_t> &metadata_sizes,
-        const std::vector<CudaIpcBufferHandle> &payloads,
+        const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config = ReplicateConfig{});
 
     std::shared_ptr<BufferHandle> get_buffer(const std::string &key);

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -8,6 +8,7 @@
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
 #include "client_metric.h"
+#include "device/cuda_ipc_buffer_handle.h"
 #include "pyclient.h"
 #include "store_rpc_client_io_context.h"
 #include "shm_helper.h"
@@ -74,6 +75,12 @@ class DummyClient : public PyClient {
                                         const std::vector<void *> &buffers,
                                         const std::vector<size_t> &sizes);
 
+    std::vector<int64_t> batch_get_into_cuda_ipc(
+        const std::vector<std::string> &keys,
+        const std::vector<CudaIpcBufferHandle> &dst_buffers,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes);
+
     std::vector<int> batch_get_into_multi_buffers(
         const std::vector<std::string> &keys,
         const std::vector<std::vector<void *>> &all_buffers,
@@ -97,6 +104,13 @@ class DummyClient : public PyClient {
         const std::vector<std::string> &keys,
         const std::vector<std::vector<void *>> &all_buffers,
         const std::vector<std::vector<size_t>> &all_sizes,
+        const ReplicateConfig &config = ReplicateConfig{});
+
+    std::vector<int> batch_put_from_cuda_ipc(
+        const std::vector<std::string> &keys,
+        const std::vector<void *> &metadata_buffers,
+        const std::vector<size_t> &metadata_sizes,
+        const std::vector<CudaIpcBufferHandle> &payloads,
         const ReplicateConfig &config = ReplicateConfig{});
 
     std::shared_ptr<BufferHandle> get_buffer(const std::string &key);

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -15,6 +15,7 @@
 #include "pyclient.h"
 #include "client_service.h"
 #include "client_buffer.h"
+#include "device/cuda_ipc_buffer_handle.h"
 #include "mutex.h"
 #include "utils.h"
 #include "rpc_types.h"
@@ -447,6 +448,21 @@ class RealClient : public PyClient {
         const std::vector<std::vector<size_t>> &all_sizes,
         const ReplicateConfig &config, int32_t device_id,
         const UUID &client_id);
+
+    std::vector<tl::expected<void, ErrorCode>>
+    batch_put_from_cuda_ipc_dummy_helper(
+        const std::vector<std::string> &keys,
+        const std::vector<uint64_t> &dummy_metadata_buffers,
+        const std::vector<size_t> &metadata_sizes,
+        const std::vector<CudaIpcBufferHandle> &payloads,
+        const ReplicateConfig &config, const UUID &client_id);
+
+    std::vector<tl::expected<int64_t, ErrorCode>>
+    batch_get_into_cuda_ipc_dummy_helper(
+        const std::vector<std::string> &keys,
+        const std::vector<CudaIpcBufferHandle> &dst_buffers,
+        const std::vector<size_t> &src_offsets,
+        const std::vector<size_t> &sizes, const UUID &client_id);
 
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_multi_buffers_dummy_helper(

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -451,18 +451,12 @@ class RealClient : public PyClient {
 
     std::vector<tl::expected<void, ErrorCode>>
     batch_put_from_cuda_ipc_dummy_helper(
-        const std::vector<std::string> &keys,
-        const std::vector<uint64_t> &dummy_metadata_buffers,
-        const std::vector<size_t> &metadata_sizes,
-        const std::vector<CudaIpcBufferHandle> &payloads,
+        const std::vector<CudaIpcWriteRequest> &requests,
         const ReplicateConfig &config, const UUID &client_id);
 
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_cuda_ipc_dummy_helper(
-        const std::vector<std::string> &keys,
-        const std::vector<CudaIpcBufferHandle> &dst_buffers,
-        const std::vector<size_t> &src_offsets,
-        const std::vector<size_t> &sizes, const UUID &client_id);
+        const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id);
 
     std::vector<tl::expected<int64_t, ErrorCode>>
     batch_get_into_multi_buffers_dummy_helper(

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -39,6 +39,7 @@ set(MOONCAKE_STORE_SOURCES
     device/accelerator_registry.cpp
     device/runtime_accelerator.cpp
     device/cuda_like_accelerator_device.cpp
+    device/cuda_ipc_buffer.cpp
     device/hip_accelerator_device.cpp
     device/ascend_accelerator_device.cpp
     device/sunrise_accelerator_device.cpp

--- a/mooncake-store/src/device/cuda_ipc_buffer.cpp
+++ b/mooncake-store/src/device/cuda_ipc_buffer.cpp
@@ -1,0 +1,183 @@
+#include "device/cuda_ipc_buffer.h"
+
+#include <cstring>
+#include <limits>
+#include <utility>
+
+#if defined(USE_CUDA)
+#include "cuda_alike.h"
+#endif
+
+namespace mooncake {
+namespace device {
+namespace {
+
+tl::expected<CudaIpcBufferHandle, ErrorCode> UnsupportedCudaIpc() {
+    return tl::unexpected(ErrorCode::INVALID_PARAMS);
+}
+
+#if defined(USE_CUDA)
+bool AddOverflows(uint64_t a, uint64_t b) {
+    return a > std::numeric_limits<uint64_t>::max() - b;
+}
+
+void ClearCudaError() { cudaGetLastError(); }
+#endif
+
+}  // namespace
+
+tl::expected<CudaIpcBufferHandle, ErrorCode> ExportCudaIpcBuffer(
+    const void *ptr, size_t size) {
+#if defined(USE_CUDA)
+    static_assert(sizeof(cudaIpcMemHandle_t) == kCudaIpcHandleSize,
+                  "Unexpected CUDA IPC handle size");
+
+    if (ptr == nullptr || size == 0) return UnsupportedCudaIpc();
+
+    cudaPointerAttributes attr{};
+    if (cudaPointerGetAttributes(&attr, ptr) != cudaSuccess ||
+        attr.type != cudaMemoryTypeDevice || attr.devicePointer == nullptr) {
+        ClearCudaError();
+        return UnsupportedCudaIpc();
+    }
+
+    // PyTorch may hand out suballocated pointers; CUDA IPC must export the
+    // allocation base and carry the caller pointer offset separately.
+    const auto ptr_addr = reinterpret_cast<uintptr_t>(ptr);
+    CUdeviceptr base_ptr = 0;
+    size_t allocation_size = 0;
+    CUresult cu_ret =
+        cuMemGetAddressRange(&base_ptr, &allocation_size, (CUdeviceptr)ptr);
+    if (cu_ret != CUDA_SUCCESS || base_ptr == 0 || allocation_size == 0) {
+        ClearCudaError();
+        return UnsupportedCudaIpc();
+    }
+
+    const auto base_addr = static_cast<uintptr_t>(base_ptr);
+    if (ptr_addr < base_addr) return UnsupportedCudaIpc();
+
+    const uint64_t offset = static_cast<uint64_t>(ptr_addr - base_addr);
+    const uint64_t payload_size = static_cast<uint64_t>(size);
+    if (AddOverflows(offset, payload_size) ||
+        offset + payload_size > allocation_size) {
+        return UnsupportedCudaIpc();
+    }
+
+    int current_device = -1;
+    cudaGetDevice(&current_device);
+    if (cudaSetDevice(attr.device) != cudaSuccess) {
+        ClearCudaError();
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    cudaIpcMemHandle_t ipc_handle{};
+    cudaError_t ret = cudaIpcGetMemHandle(&ipc_handle, (void *)base_ptr);
+    if (current_device >= 0) cudaSetDevice(current_device);
+    if (ret != cudaSuccess) {
+        ClearCudaError();
+        return UnsupportedCudaIpc();
+    }
+
+    CudaIpcBufferHandle exported;
+    std::memcpy(exported.handle.data(), &ipc_handle, sizeof(ipc_handle));
+    exported.offset = offset;
+    exported.size = payload_size;
+    exported.device_id = attr.device;
+    return exported;
+#else
+    (void)ptr;
+    (void)size;
+    return UnsupportedCudaIpc();
+#endif
+}
+
+CudaIpcBufferMapping::~CudaIpcBufferMapping() { Close(); }
+
+CudaIpcBufferMapping::CudaIpcBufferMapping(
+    CudaIpcBufferMapping &&other) noexcept
+    : base_(std::exchange(other.base_, nullptr)),
+      ptr_(std::exchange(other.ptr_, nullptr)),
+      device_id_(std::exchange(other.device_id_, -1)) {}
+
+CudaIpcBufferMapping &CudaIpcBufferMapping::operator=(
+    CudaIpcBufferMapping &&other) noexcept {
+    if (this != &other) {
+        Close();
+        base_ = std::exchange(other.base_, nullptr);
+        ptr_ = std::exchange(other.ptr_, nullptr);
+        device_id_ = std::exchange(other.device_id_, -1);
+    }
+    return *this;
+}
+
+tl::expected<CudaIpcBufferMapping, ErrorCode> CudaIpcBufferMapping::Open(
+    const CudaIpcBufferHandle &handle) {
+#if defined(USE_CUDA)
+    static_assert(sizeof(cudaIpcMemHandle_t) == kCudaIpcHandleSize,
+                  "Unexpected CUDA IPC handle size");
+
+    if (handle.size == 0 || handle.device_id < 0 ||
+        AddOverflows(handle.offset, handle.size)) {
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    int current_device = -1;
+    cudaGetDevice(&current_device);
+    if (cudaSetDevice(handle.device_id) != cudaSuccess) {
+        ClearCudaError();
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    cudaIpcMemHandle_t ipc_handle{};
+    std::memcpy(&ipc_handle, handle.handle.data(), sizeof(ipc_handle));
+
+    void *base = nullptr;
+    cudaError_t ret =
+        cudaIpcOpenMemHandle(&base, ipc_handle, cudaIpcMemLazyEnablePeerAccess);
+    CUdeviceptr allocation_base = 0;
+    size_t allocation_size = 0;
+    if (ret == cudaSuccess && base != nullptr) {
+        CUresult cu_ret = cuMemGetAddressRange(
+            &allocation_base, &allocation_size, (CUdeviceptr)base);
+        if (cu_ret != CUDA_SUCCESS || allocation_base != (CUdeviceptr)base ||
+            allocation_size == 0 || AddOverflows(handle.offset, handle.size) ||
+            handle.offset + handle.size > allocation_size) {
+            cudaIpcCloseMemHandle(base);
+            base = nullptr;
+            ret = cudaErrorInvalidValue;
+        }
+    }
+    if (current_device >= 0) cudaSetDevice(current_device);
+    if (ret != cudaSuccess || base == nullptr) {
+        ClearCudaError();
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto *ptr = static_cast<char *>(base) + handle.offset;
+    return CudaIpcBufferMapping(base, ptr, handle.device_id);
+#else
+    (void)handle;
+    return tl::unexpected(ErrorCode::INVALID_PARAMS);
+#endif
+}
+
+void CudaIpcBufferMapping::Close() {
+#if defined(USE_CUDA)
+    if (base_ != nullptr) {
+        int current_device = -1;
+        const bool restore_device =
+            cudaGetDevice(&current_device) == cudaSuccess;
+        if (device_id_ >= 0 && cudaSetDevice(device_id_) != cudaSuccess) {
+            ClearCudaError();
+        }
+        cudaIpcCloseMemHandle(base_);
+        if (restore_device) cudaSetDevice(current_device);
+    }
+#endif
+    base_ = nullptr;
+    ptr_ = nullptr;
+    device_id_ = -1;
+}
+
+}  // namespace device
+}  // namespace mooncake

--- a/mooncake-store/src/device/cuda_ipc_buffer.cpp
+++ b/mooncake-store/src/device/cuda_ipc_buffer.cpp
@@ -5,6 +5,8 @@
 #include <utility>
 
 #if defined(USE_CUDA)
+#include <dlfcn.h>
+
 #include "cuda_alike.h"
 #endif
 
@@ -22,6 +24,35 @@ bool AddOverflows(uint64_t a, uint64_t b) {
 }
 
 void ClearCudaError() { cudaGetLastError(); }
+
+using CuMemGetAddressRangeFn = CUresult (*)(CUdeviceptr *, size_t *,
+                                            CUdeviceptr);
+
+CuMemGetAddressRangeFn LoadCuMemGetAddressRange() {
+    static CuMemGetAddressRangeFn fn = [] {
+        void *handle = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_LOCAL);
+        if (handle == nullptr) {
+            handle = dlopen("libcuda.so", RTLD_LAZY | RTLD_LOCAL);
+        }
+        void *symbol = handle != nullptr
+                           ? dlsym(handle, "cuMemGetAddressRange_v2")
+                           : dlsym(RTLD_DEFAULT, "cuMemGetAddressRange_v2");
+        if (symbol == nullptr) {
+            symbol = handle != nullptr
+                         ? dlsym(handle, "cuMemGetAddressRange")
+                         : dlsym(RTLD_DEFAULT, "cuMemGetAddressRange");
+        }
+        return reinterpret_cast<CuMemGetAddressRangeFn>(symbol);
+    }();
+    return fn;
+}
+
+CUresult GetCudaAllocationRange(CUdeviceptr *base, size_t *size,
+                                CUdeviceptr ptr) {
+    auto fn = LoadCuMemGetAddressRange();
+    if (fn == nullptr) return CUDA_ERROR_NOT_FOUND;
+    return fn(base, size, ptr);
+}
 #endif
 
 }  // namespace
@@ -47,7 +78,7 @@ tl::expected<CudaIpcBufferHandle, ErrorCode> ExportCudaIpcBuffer(
     CUdeviceptr base_ptr = 0;
     size_t allocation_size = 0;
     CUresult cu_ret =
-        cuMemGetAddressRange(&base_ptr, &allocation_size, (CUdeviceptr)ptr);
+        GetCudaAllocationRange(&base_ptr, &allocation_size, (CUdeviceptr)ptr);
     if (cu_ret != CUDA_SUCCESS || base_ptr == 0 || allocation_size == 0) {
         ClearCudaError();
         return UnsupportedCudaIpc();
@@ -137,7 +168,7 @@ tl::expected<CudaIpcBufferMapping, ErrorCode> CudaIpcBufferMapping::Open(
     CUdeviceptr allocation_base = 0;
     size_t allocation_size = 0;
     if (ret == cudaSuccess && base != nullptr) {
-        CUresult cu_ret = cuMemGetAddressRange(
+        CUresult cu_ret = GetCudaAllocationRange(
             &allocation_base, &allocation_size, (CUdeviceptr)base);
         if (cu_ret != CUDA_SUCCESS || allocation_base != (CUdeviceptr)base ||
             allocation_size == 0 || AddOverflows(handle.offset, handle.size) ||

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -19,6 +19,7 @@
 #include "types.h"
 #include "default_config.h"
 #include "config.h"
+#include "device/cuda_ipc_buffer.h"
 #ifdef USE_ASCEND_DIRECT
 #include "acl/acl_rt.h"
 #include "ascend_allocator.h"
@@ -64,6 +65,32 @@ size_t sum_successful_nested_sizes(
     return total;
 }
 
+size_t sum_successful_cuda_ipc_sizes(
+    const std::vector<int>& results, const std::vector<size_t>& metadata_sizes,
+    const std::vector<mooncake::CudaIpcBufferHandle>& payloads) {
+    size_t total = sum_successful_sizes(results, metadata_sizes);
+    for (size_t i = 0; i < results.size() && i < payloads.size(); ++i) {
+        if (results[i] == 0) total += payloads[i].size;
+    }
+    return total;
+}
+
+std::optional<std::vector<mooncake::CudaIpcBufferHandle>>
+try_export_cuda_ipc_buffers(const std::vector<void*>& buffers,
+                            const std::vector<size_t>& sizes) {
+    if (buffers.size() != sizes.size() || buffers.empty()) return std::nullopt;
+
+    std::vector<mooncake::CudaIpcBufferHandle> payloads;
+    payloads.reserve(buffers.size());
+    for (size_t i = 0; i < buffers.size(); ++i) {
+        auto payload =
+            mooncake::device::ExportCudaIpcBuffer(buffers[i], sizes[i]);
+        if (!payload) return std::nullopt;
+        payloads.push_back(*payload);
+    }
+    return payloads;
+}
+
 size_t sum_positive_results(const std::vector<int64_t>& results) {
     size_t total = 0;
     for (int64_t result : results) {
@@ -93,6 +120,17 @@ size_t sum_positive_ranges(
         }
     }
     return total;
+}
+
+template <typename Result = int64_t, typename T>
+std::vector<Result> expected_results_to_py(
+    const std::vector<tl::expected<T, mooncake::ErrorCode>>& internal_results) {
+    std::vector<Result> results;
+    results.reserve(internal_results.size());
+    for (const auto& result : internal_results) {
+        results.push_back(static_cast<Result>(mooncake::to_py_ret(result)));
+    }
+    return results;
 }
 
 std::vector<uint64_t> void_ptrs_to_u64(const std::vector<void*>& ptrs) {
@@ -1016,6 +1054,11 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
 
 int64_t DummyClient::get_into(const std::string& key, void* buffer,
                               size_t size) {
+    if (auto dst_buffer = try_export_cuda_ipc_buffers({buffer}, {size})) {
+        auto results = batch_get_into_cuda_ipc({key}, *dst_buffer, {0}, {size});
+        return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
+    }
+
     uint64_t buf_addr = reinterpret_cast<uint64_t>(buffer);
     const auto start_time = std::chrono::steady_clock::now();
     auto result = invoke_rpc<&RealClient::get_into_range_shm_helper,
@@ -1100,6 +1143,12 @@ std::string DummyClient::get_hostname() const {
 std::vector<int> DummyClient::batch_put_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
+    if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes)) {
+        return batch_put_from_cuda_ipc(
+            keys, std::vector<void*>(keys.size(), nullptr),
+            std::vector<size_t>(keys.size(), 0), *payloads, config);
+    }
+
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
@@ -1131,22 +1180,43 @@ int DummyClient::put_from(const std::string& key, void* buffer, size_t size,
 std::vector<int64_t> DummyClient::batch_get_into(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes) {
+    if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes)) {
+        return batch_get_into_cuda_ipc(
+            keys, *dst_buffers, std::vector<size_t>(keys.size(), 0), sizes);
+    }
+
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_batch_rpc<&RealClient::batch_get_into_dummy_helper, int64_t>(
             keys.size(), keys, buffers, sizes, device_id_, client_id_);
-    std::vector<int64_t> results;
-    results.reserve(internal_results.size());
-
-    for (const auto& result : internal_results) {
-        results.push_back(to_py_ret(result));
-    }
+    auto results = expected_results_to_py(internal_results);
 
     const size_t total_bytes = sum_positive_results(results);
     if (total_bytes > 0) {
         ObserveTransferMetric(TransferOperationKind::kRead, "batch_get_into",
                               total_bytes, elapsed_us_since(start_time), true);
+    }
+
+    return results;
+}
+
+std::vector<int64_t> DummyClient::batch_get_into_cuda_ipc(
+    const std::vector<std::string>& keys,
+    const std::vector<mooncake::CudaIpcBufferHandle>& dst_buffers,
+    const std::vector<size_t>& src_offsets, const std::vector<size_t>& sizes) {
+    const auto start_time = std::chrono::steady_clock::now();
+    auto internal_results =
+        invoke_batch_rpc<&RealClient::batch_get_into_cuda_ipc_dummy_helper,
+                         int64_t>(keys.size(), keys, dst_buffers, src_offsets,
+                                  sizes, client_id_);
+    auto results = expected_results_to_py(internal_results);
+
+    const size_t total_bytes = sum_positive_results(results);
+    if (total_bytes > 0) {
+        ObserveTransferMetric(TransferOperationKind::kRead,
+                              "batch_get_into_cuda_ipc", total_bytes,
+                              elapsed_us_since(start_time), true);
     }
 
     return results;
@@ -1173,16 +1243,36 @@ std::vector<int> DummyClient::batch_put_from_multi_buffers(
         invoke_batch_rpc<&RealClient::batch_put_from_multi_buffers_dummy_helper,
                          void>(keys.size(), keys, dummy_nested, all_sizes,
                                config, device_id_, client_id_);
-    std::vector<int> results;
-    results.reserve(internal_results.size());
-    for (const auto& result : internal_results) {
-        results.push_back(to_py_ret(result));
-    }
+    auto results = expected_results_to_py<int>(internal_results);
     const size_t successful_bytes =
         sum_successful_nested_sizes(results, all_sizes);
     if (successful_bytes > 0) {
         ObserveTransferMetric(TransferOperationKind::kWrite,
                               "batch_put_from_multi_buffers", successful_bytes,
+                              elapsed_us_since(start_time), true);
+    }
+    return results;
+}
+
+std::vector<int> DummyClient::batch_put_from_cuda_ipc(
+    const std::vector<std::string>& keys,
+    const std::vector<void*>& metadata_buffers,
+    const std::vector<size_t>& metadata_sizes,
+    const std::vector<mooncake::CudaIpcBufferHandle>& payloads,
+    const ReplicateConfig& config) {
+    std::vector<uint64_t> dummy_metadata_buffers =
+        void_ptrs_to_u64(metadata_buffers);
+    const auto start_time = std::chrono::steady_clock::now();
+    auto internal_results =
+        invoke_batch_rpc<&RealClient::batch_put_from_cuda_ipc_dummy_helper,
+                         void>(keys.size(), keys, dummy_metadata_buffers,
+                               metadata_sizes, payloads, config, client_id_);
+    auto results = expected_results_to_py<int>(internal_results);
+    const size_t successful_bytes =
+        sum_successful_cuda_ipc_sizes(results, metadata_sizes, payloads);
+    if (successful_bytes > 0) {
+        ObserveTransferMetric(TransferOperationKind::kWrite,
+                              "batch_put_from_cuda_ipc", successful_bytes,
                               elapsed_us_since(start_time), true);
     }
     return results;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -66,11 +66,13 @@ size_t sum_successful_nested_sizes(
 }
 
 size_t sum_successful_cuda_ipc_sizes(
-    const std::vector<int>& results, const std::vector<size_t>& metadata_sizes,
-    const std::vector<mooncake::CudaIpcBufferHandle>& payloads) {
-    size_t total = sum_successful_sizes(results, metadata_sizes);
-    for (size_t i = 0; i < results.size() && i < payloads.size(); ++i) {
-        if (results[i] == 0) total += payloads[i].size;
+    const std::vector<int>& results,
+    const std::vector<mooncake::CudaIpcWriteRequest>& requests) {
+    size_t total = 0;
+    for (size_t i = 0; i < results.size() && i < requests.size(); ++i) {
+        if (results[i] == 0) {
+            total += requests[i].metadata.size + requests[i].payload.size;
+        }
     }
     return total;
 }
@@ -1055,7 +1057,15 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
 int64_t DummyClient::get_into(const std::string& key, void* buffer,
                               size_t size) {
     if (auto dst_buffer = try_export_cuda_ipc_buffers({buffer}, {size})) {
-        auto results = batch_get_into_cuda_ipc({key}, *dst_buffer, {0}, {size});
+        std::vector<CudaIpcReadRequest> requests{
+            CudaIpcReadRequest{
+                .key = key,
+                .destination = (*dst_buffer)[0],
+                .source_offset = 0,
+                .size = static_cast<uint64_t>(size),
+            },
+        };
+        auto results = batch_get_into_cuda_ipc(requests);
         return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
     }
 
@@ -1143,10 +1153,18 @@ std::string DummyClient::get_hostname() const {
 std::vector<int> DummyClient::batch_put_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
-    if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes)) {
-        return batch_put_from_cuda_ipc(
-            keys, std::vector<void*>(keys.size(), nullptr),
-            std::vector<size_t>(keys.size(), 0), *payloads, config);
+    if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
+        payloads && keys.size() == payloads->size()) {
+        std::vector<CudaIpcWriteRequest> requests;
+        requests.reserve(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            requests.push_back(CudaIpcWriteRequest{
+                .key = keys[i],
+                .metadata = CudaIpcShmBufferRef{},
+                .payload = (*payloads)[i],
+            });
+        }
+        return batch_put_from_cuda_ipc(requests, config);
     }
 
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
@@ -1180,9 +1198,19 @@ int DummyClient::put_from(const std::string& key, void* buffer, size_t size,
 std::vector<int64_t> DummyClient::batch_get_into(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes) {
-    if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes)) {
-        return batch_get_into_cuda_ipc(
-            keys, *dst_buffers, std::vector<size_t>(keys.size(), 0), sizes);
+    if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
+        dst_buffers && keys.size() == dst_buffers->size()) {
+        std::vector<CudaIpcReadRequest> requests;
+        requests.reserve(keys.size());
+        for (size_t i = 0; i < keys.size(); ++i) {
+            requests.push_back(CudaIpcReadRequest{
+                .key = keys[i],
+                .destination = (*dst_buffers)[i],
+                .source_offset = 0,
+                .size = static_cast<uint64_t>(sizes[i]),
+            });
+        }
+        return batch_get_into_cuda_ipc(requests);
     }
 
     std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
@@ -1202,14 +1230,11 @@ std::vector<int64_t> DummyClient::batch_get_into(
 }
 
 std::vector<int64_t> DummyClient::batch_get_into_cuda_ipc(
-    const std::vector<std::string>& keys,
-    const std::vector<mooncake::CudaIpcBufferHandle>& dst_buffers,
-    const std::vector<size_t>& src_offsets, const std::vector<size_t>& sizes) {
+    const std::vector<mooncake::CudaIpcReadRequest>& requests) {
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_batch_rpc<&RealClient::batch_get_into_cuda_ipc_dummy_helper,
-                         int64_t>(keys.size(), keys, dst_buffers, src_offsets,
-                                  sizes, client_id_);
+                         int64_t>(requests.size(), requests, client_id_);
     auto results = expected_results_to_py(internal_results);
 
     const size_t total_bytes = sum_positive_results(results);
@@ -1255,21 +1280,15 @@ std::vector<int> DummyClient::batch_put_from_multi_buffers(
 }
 
 std::vector<int> DummyClient::batch_put_from_cuda_ipc(
-    const std::vector<std::string>& keys,
-    const std::vector<void*>& metadata_buffers,
-    const std::vector<size_t>& metadata_sizes,
-    const std::vector<mooncake::CudaIpcBufferHandle>& payloads,
+    const std::vector<mooncake::CudaIpcWriteRequest>& requests,
     const ReplicateConfig& config) {
-    std::vector<uint64_t> dummy_metadata_buffers =
-        void_ptrs_to_u64(metadata_buffers);
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_batch_rpc<&RealClient::batch_put_from_cuda_ipc_dummy_helper,
-                         void>(keys.size(), keys, dummy_metadata_buffers,
-                               metadata_sizes, payloads, config, client_id_);
+                         void>(requests.size(), requests, config, client_id_);
     auto results = expected_results_to_py<int>(internal_results);
     const size_t successful_bytes =
-        sum_successful_cuda_ipc_sizes(results, metadata_sizes, payloads);
+        sum_successful_cuda_ipc_sizes(results, requests);
     if (successful_bytes > 0) {
         ObserveTransferMetric(TransferOperationKind::kWrite,
                               "batch_put_from_cuda_ipc", successful_bytes,

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -33,6 +33,7 @@
 #include "device/accelerator_registry.h"
 #include "default_config.h"
 #include "uds_transport.h"
+#include "device/cuda_ipc_buffer.h"
 #include "shm_helper.h"
 #include "memory_location.h"
 #ifdef USE_NOF
@@ -4515,6 +4516,157 @@ RealClient::batch_put_from_multi_buffers_dummy_helper(
 
     return batch_put_from_multi_buffers_internal(
         keys, real_buffers_result.value(), all_sizes, config);
+}
+
+std::vector<tl::expected<void, ErrorCode>>
+RealClient::batch_put_from_cuda_ipc_dummy_helper(
+    const std::vector<std::string> &keys,
+    const std::vector<uint64_t> &dummy_metadata_buffers,
+    const std::vector<size_t> &metadata_sizes,
+    const std::vector<CudaIpcBufferHandle> &payloads,
+    const ReplicateConfig &config, const UUID &client_id) {
+    std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+    auto it = shm_contexts_.find(client_id);
+    if (it == shm_contexts_.end()) {
+        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+
+    const ShmContext &context = it->second;
+    if (keys.size() != dummy_metadata_buffers.size() ||
+        keys.size() != metadata_sizes.size() ||
+        keys.size() != payloads.size()) {
+        LOG(ERROR) << "Invalid cuda ipc tensor write batch sizes";
+        return std::vector<tl::expected<void, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+
+    const bool has_metadata = !metadata_sizes.empty() && metadata_sizes[0] != 0;
+    for (size_t metadata_size : metadata_sizes) {
+        if ((metadata_size != 0) != has_metadata) {
+            LOG(ERROR) << "Mixed cuda ipc metadata batches are not supported";
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
+    }
+
+    std::vector<void *> metadata_buffers;
+    if (has_metadata) {
+        auto metadata_result = map_dummy_addrs_to_real_ptrs(
+            context, dummy_metadata_buffers, metadata_sizes, client_id);
+        if (!metadata_result) {
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(metadata_result.error()));
+        }
+        metadata_buffers = std::move(*metadata_result);
+    }
+
+    std::vector<device::CudaIpcBufferMapping> payload_mappings;
+    std::vector<std::vector<void *>> all_buffers;
+    std::vector<std::vector<size_t>> all_sizes;
+    payload_mappings.reserve(keys.size());
+    all_buffers.reserve(keys.size());
+    all_sizes.reserve(keys.size());
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto mapping = device::CudaIpcBufferMapping::Open(payloads[i]);
+        if (!mapping) {
+            return std::vector<tl::expected<void, ErrorCode>>(
+                keys.size(), tl::unexpected(mapping.error()));
+        }
+        payload_mappings.push_back(std::move(*mapping));
+        void *payload_ptr = payload_mappings.back().ptr();
+        if (has_metadata) {
+            all_buffers.push_back({metadata_buffers[i], payload_ptr});
+            all_sizes.push_back(
+                {metadata_sizes[i], static_cast<size_t>(payloads[i].size)});
+        } else {
+            all_buffers.push_back({payload_ptr});
+            all_sizes.push_back({static_cast<size_t>(payloads[i].size)});
+        }
+    }
+
+    return batch_put_from_multi_buffers_internal(keys, all_buffers, all_sizes,
+                                                 config);
+}
+
+std::vector<tl::expected<int64_t, ErrorCode>>
+RealClient::batch_get_into_cuda_ipc_dummy_helper(
+    const std::vector<std::string> &keys,
+    const std::vector<CudaIpcBufferHandle> &dst_buffers,
+    const std::vector<size_t> &src_offsets, const std::vector<size_t> &sizes,
+    const UUID &client_id) {
+    if (keys.size() != dst_buffers.size() ||
+        keys.size() != src_offsets.size() || keys.size() != sizes.size()) {
+        LOG(ERROR) << "Invalid cuda ipc tensor read batch sizes";
+        return std::vector<tl::expected<int64_t, ErrorCode>>(
+            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
+        if (shm_contexts_.find(client_id) == shm_contexts_.end()) {
+            LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
+            return std::vector<tl::expected<int64_t, ErrorCode>>(
+                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        }
+    }
+
+    std::vector<tl::expected<int64_t, ErrorCode>> results(
+        keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+    std::vector<device::CudaIpcBufferMapping> mappings;
+    std::vector<void *> buffers;
+    std::vector<std::vector<std::string>> all_keys;
+    std::vector<std::vector<std::vector<size_t>>> all_dst_offsets;
+    std::vector<std::vector<std::vector<size_t>>> all_src_offsets;
+    std::vector<std::vector<std::vector<size_t>>> all_sizes;
+    std::vector<size_t> buffer_capacities;
+    std::vector<size_t> original_indices;
+    mappings.reserve(keys.size());
+    buffers.reserve(keys.size());
+    all_keys.reserve(keys.size());
+    all_dst_offsets.reserve(keys.size());
+    all_src_offsets.reserve(keys.size());
+    all_sizes.reserve(keys.size());
+    buffer_capacities.reserve(keys.size());
+    original_indices.reserve(keys.size());
+
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto mapping = device::CudaIpcBufferMapping::Open(dst_buffers[i]);
+        if (!mapping) {
+            results[i] = tl::unexpected(mapping.error());
+            continue;
+        }
+        mappings.push_back(std::move(*mapping));
+        buffers.push_back(mappings.back().ptr());
+        all_keys.push_back({keys[i]});
+        all_dst_offsets.push_back({{0}});
+        all_src_offsets.push_back({{src_offsets[i]}});
+        all_sizes.push_back({{sizes[i]}});
+        buffer_capacities.push_back(sizes[i]);
+        original_indices.push_back(i);
+    }
+
+    if (buffers.empty()) {
+        return results;
+    }
+
+    auto range_results = get_into_ranges_internal(
+        buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,
+        &buffer_capacities, nullptr, nullptr, nullptr);
+    for (size_t i = 0; i < original_indices.size(); ++i) {
+        if (i < range_results.size() && range_results[i].size() == 1 &&
+            range_results[i][0].size() == 1) {
+            results[original_indices[i]] = range_results[i][0][0];
+        } else {
+            LOG(ERROR) << "Invalid cuda ipc tensor read result shape for key "
+                       << keys[original_indices[i]];
+            results[original_indices[i]] =
+                tl::unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+    }
+    return results;
 }
 
 std::vector<tl::expected<int64_t, ErrorCode>>

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4520,70 +4520,66 @@ RealClient::batch_put_from_multi_buffers_dummy_helper(
 
 std::vector<tl::expected<void, ErrorCode>>
 RealClient::batch_put_from_cuda_ipc_dummy_helper(
-    const std::vector<std::string> &keys,
-    const std::vector<uint64_t> &dummy_metadata_buffers,
-    const std::vector<size_t> &metadata_sizes,
-    const std::vector<CudaIpcBufferHandle> &payloads,
+    const std::vector<CudaIpcWriteRequest> &requests,
     const ReplicateConfig &config, const UUID &client_id) {
     std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
         LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
         return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+            requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     }
 
     const ShmContext &context = it->second;
-    if (keys.size() != dummy_metadata_buffers.size() ||
-        keys.size() != metadata_sizes.size() ||
-        keys.size() != payloads.size()) {
-        LOG(ERROR) << "Invalid cuda ipc tensor write batch sizes";
-        return std::vector<tl::expected<void, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
-    const bool has_metadata = !metadata_sizes.empty() && metadata_sizes[0] != 0;
-    for (size_t metadata_size : metadata_sizes) {
-        if ((metadata_size != 0) != has_metadata) {
+    const bool has_metadata =
+        !requests.empty() && requests[0].metadata.size != 0;
+    for (const auto &request : requests) {
+        if ((request.metadata.size != 0) != has_metadata) {
             LOG(ERROR) << "Mixed cuda ipc metadata batches are not supported";
             return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+                requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
         }
-    }
-
-    std::vector<void *> metadata_buffers;
-    if (has_metadata) {
-        auto metadata_result = map_dummy_addrs_to_real_ptrs(
-            context, dummy_metadata_buffers, metadata_sizes, client_id);
-        if (!metadata_result) {
-            return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(metadata_result.error()));
-        }
-        metadata_buffers = std::move(*metadata_result);
     }
 
     std::vector<device::CudaIpcBufferMapping> payload_mappings;
+    std::vector<std::string> keys;
     std::vector<std::vector<void *>> all_buffers;
     std::vector<std::vector<size_t>> all_sizes;
-    payload_mappings.reserve(keys.size());
-    all_buffers.reserve(keys.size());
-    all_sizes.reserve(keys.size());
+    payload_mappings.reserve(requests.size());
+    keys.reserve(requests.size());
+    all_buffers.reserve(requests.size());
+    all_sizes.reserve(requests.size());
 
-    for (size_t i = 0; i < keys.size(); ++i) {
-        auto mapping = device::CudaIpcBufferMapping::Open(payloads[i]);
+    const MappedShm *last_hit_shm = nullptr;
+    for (const auto &request : requests) {
+        auto mapping = device::CudaIpcBufferMapping::Open(request.payload);
         if (!mapping) {
             return std::vector<tl::expected<void, ErrorCode>>(
-                keys.size(), tl::unexpected(mapping.error()));
+                requests.size(), tl::unexpected(mapping.error()));
         }
         payload_mappings.push_back(std::move(*mapping));
         void *payload_ptr = payload_mappings.back().ptr();
+        keys.push_back(request.key);
         if (has_metadata) {
-            all_buffers.push_back({metadata_buffers[i], payload_ptr});
-            all_sizes.push_back(
-                {metadata_sizes[i], static_cast<size_t>(payloads[i].size)});
+            void *metadata_ptr = nullptr;
+            if (!map_dummy_buffer_to_real(
+                    context, request.metadata.ptr,
+                    static_cast<size_t>(request.metadata.size), last_hit_shm,
+                    metadata_ptr)) {
+                LOG(ERROR) << "Dummy metadata buffer at "
+                           << request.metadata.ptr << " (size "
+                           << request.metadata.size
+                           << ") not found in any mapped shared memory, "
+                           << "client_id=" << client_id;
+                return std::vector<tl::expected<void, ErrorCode>>(
+                    requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+            }
+            all_buffers.push_back({metadata_ptr, payload_ptr});
+            all_sizes.push_back({static_cast<size_t>(request.metadata.size),
+                                 static_cast<size_t>(request.payload.size)});
         } else {
             all_buffers.push_back({payload_ptr});
-            all_sizes.push_back({static_cast<size_t>(payloads[i].size)});
+            all_sizes.push_back({static_cast<size_t>(request.payload.size)});
         }
     }
 
@@ -4593,28 +4589,18 @@ RealClient::batch_put_from_cuda_ipc_dummy_helper(
 
 std::vector<tl::expected<int64_t, ErrorCode>>
 RealClient::batch_get_into_cuda_ipc_dummy_helper(
-    const std::vector<std::string> &keys,
-    const std::vector<CudaIpcBufferHandle> &dst_buffers,
-    const std::vector<size_t> &src_offsets, const std::vector<size_t> &sizes,
-    const UUID &client_id) {
-    if (keys.size() != dst_buffers.size() ||
-        keys.size() != src_offsets.size() || keys.size() != sizes.size()) {
-        LOG(ERROR) << "Invalid cuda ipc tensor read batch sizes";
-        return std::vector<tl::expected<int64_t, ErrorCode>>(
-            keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
-    }
-
+    const std::vector<CudaIpcReadRequest> &requests, const UUID &client_id) {
     {
         std::shared_lock<std::shared_mutex> lock(dummy_client_mutex_);
         if (shm_contexts_.find(client_id) == shm_contexts_.end()) {
             LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
             return std::vector<tl::expected<int64_t, ErrorCode>>(
-                keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+                requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
         }
     }
 
     std::vector<tl::expected<int64_t, ErrorCode>> results(
-        keys.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
+        requests.size(), tl::unexpected(ErrorCode::INVALID_PARAMS));
     std::vector<device::CudaIpcBufferMapping> mappings;
     std::vector<void *> buffers;
     std::vector<std::vector<std::string>> all_keys;
@@ -4623,28 +4609,30 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
     std::vector<std::vector<std::vector<size_t>>> all_sizes;
     std::vector<size_t> buffer_capacities;
     std::vector<size_t> original_indices;
-    mappings.reserve(keys.size());
-    buffers.reserve(keys.size());
-    all_keys.reserve(keys.size());
-    all_dst_offsets.reserve(keys.size());
-    all_src_offsets.reserve(keys.size());
-    all_sizes.reserve(keys.size());
-    buffer_capacities.reserve(keys.size());
-    original_indices.reserve(keys.size());
+    mappings.reserve(requests.size());
+    buffers.reserve(requests.size());
+    all_keys.reserve(requests.size());
+    all_dst_offsets.reserve(requests.size());
+    all_src_offsets.reserve(requests.size());
+    all_sizes.reserve(requests.size());
+    buffer_capacities.reserve(requests.size());
+    original_indices.reserve(requests.size());
 
-    for (size_t i = 0; i < keys.size(); ++i) {
-        auto mapping = device::CudaIpcBufferMapping::Open(dst_buffers[i]);
+    for (size_t i = 0; i < requests.size(); ++i) {
+        const auto &request = requests[i];
+        auto mapping = device::CudaIpcBufferMapping::Open(request.destination);
         if (!mapping) {
             results[i] = tl::unexpected(mapping.error());
             continue;
         }
         mappings.push_back(std::move(*mapping));
         buffers.push_back(mappings.back().ptr());
-        all_keys.push_back({keys[i]});
+        all_keys.push_back({request.key});
         all_dst_offsets.push_back({{0}});
-        all_src_offsets.push_back({{src_offsets[i]}});
-        all_sizes.push_back({{sizes[i]}});
-        buffer_capacities.push_back(sizes[i]);
+        all_src_offsets.push_back(
+            {{static_cast<size_t>(request.source_offset)}});
+        all_sizes.push_back({{static_cast<size_t>(request.size)}});
+        buffer_capacities.push_back(static_cast<size_t>(request.size));
         original_indices.push_back(i);
     }
 
@@ -4661,7 +4649,7 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
             results[original_indices[i]] = range_results[i][0][0];
         } else {
             LOG(ERROR) << "Invalid cuda ipc tensor read result shape for key "
-                       << keys[original_indices[i]];
+                       << requests[original_indices[i]].key;
             results[original_indices[i]] =
                 tl::unexpected(ErrorCode::INTERNAL_ERROR);
         }

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -47,6 +47,8 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
         &real_client);
     server.register_handler<
         &RealClient::batch_put_from_multi_buffers_dummy_helper>(&real_client);
+    server.register_handler<&RealClient::batch_put_from_cuda_ipc_dummy_helper>(
+        &real_client);
     server.register_handler<&RealClient::upsert_dummy_helper>(&real_client);
     server.register_handler<&RealClient::upsert_from_dummy_helper>(
         &real_client);
@@ -60,6 +62,8 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
         &real_client);
     server.register_handler<
         &RealClient::batch_get_into_multi_buffers_dummy_helper>(&real_client);
+    server.register_handler<&RealClient::batch_get_into_cuda_ipc_dummy_helper>(
+        &real_client);
     server.register_handler<&RealClient::get_into_range_shm_helper>(
         &real_client);
     server.register_handler<&RealClient::get_into_ranges_shm_helper>(


### PR DESCRIPTION
## Description

This PR adds a same-node CUDA IPC handoff path for dummy-client CUDA buffers.
It is part of the RL training weight offload/restore path discussed in RFC #3229.

When a dummy client receives CUDA-backed tensor or object buffers, it exports a CUDA IPC memory handle to the real client instead of routing the payload through dummy shared-memory staging. The real client opens the handle for the duration of the operation and reuses the existing Store read/write helpers with the mapped CUDA pointer.

Covered paths:
- tensor write: `put_tensor`, `batch_put_tensor`, and tensor parallel write helpers when used by a dummy client
- tensor read into CUDA tensors: `get_tensor_into_cuda`, `batch_get_tensor_into_cuda`
- generic object pointer APIs: `put_from`, `batch_put_from`, `get_into`, `batch_get_into` with CUDA pointers

Current Mooncake capability check:
- Checked `kvcache/main` at `eaa6c79d`.
- Store / integration / wheel do not have CUDA IPC handoff support for dummy-client tensor/object buffers (`CudaIpcBuffer`, `get_tensor_into_cuda`, `batch_get_tensor_into_cuda`, `put_from_cuda_ipc`, and `batch_put_from_cuda_ipc` all have 0 matches on those paths).
- Transfer Engine already has CUDA IPC usage in transport implementations such as NVLink/intranode transports, but that is a transport-layer memory registration/peer-mapping facility. It does not provide the Store dummy-client API path added here, where a dummy process hands a CUDA tensor/object buffer to the real client without SHM staging.

Compatibility notes:
- Existing Python APIs keep their signatures and return conventions.
- Existing `PyClient` base virtual methods are unchanged; CUDA IPC helpers are scoped to `DummyClient` internals.
- Non-CUDA buffers keep the existing dummy SHM paths.
- Existing `put_tensor` behavior for regular and non-contiguous tensors is preserved; the CUDA IPC path is used only when the dummy client can export the payload as a CUDA IPC buffer, otherwise it falls back to the original path.

Safety details:
- CUDA IPC handles carry allocation-base offset and payload size for PyTorch suballocations.
- The real client validates the imported range against the CUDA allocation before using the mapped pointer.
- CUDA IPC mappings are RAII-managed and stay alive until the underlying Store operation returns.
- Non-CUDA buffers keep the existing dummy SHM paths.
- The CUDA Driver API symbol used for allocation-range lookup is resolved at runtime, so regular Store build/link targets do not need a direct `libcuda` link dependency.

Related RFC: https://github.com/kvcache-ai/Mooncake/issues/3229

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
./scripts/code_format.sh
cmake --build build-cuda-ipc-standalone -j32 --target mooncake_client store

# Manual CUDA dummy-client integration test with a fresh master + real client:
# - put_tensor(cuda) + get_tensor_into_cuda
# - put_from(cuda_ptr) + get_into(cuda_ptr)
# - batch_put_from(cuda_ptrs) + batch_get_into(cuda_ptrs)
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Compatibility validation result:
```text
setup_dummy 0
bytes_get 49152 True
tensor_get (128, 8) torch.float32 True
noncontig_get (128, 8) True
cuda_object_get_into 4194304 True
compatibility and cuda ipc verify ok
```

Manual CUDA dummy-client validation result:
```text
setup_dummy 0
tensor_get_into_cuda 4194304 True
put_from_cuda 0 get_size 4194304
get_into_cuda 4194304 True
batch_put_from_cuda [0, 0]
batch_get_into_cuda [1048576, 1048576] [True, True]
cuda ipc pr verify ok
```

Performance validation:
- Environment: same-node dummy client + real client, `MC_STORE_MEMCPY=1`, `MC_STORE_PIN_MEMORY_MAX_BYTES=4294967296`, torch `2.9.1+cu128`.
- Workload: CUDA `float16` tensors, `put_tensor` / `batch_put_tensor`, median of 8 measured iterations after 2 warmups.
- Baseline: current dummy-client path without this CUDA IPC handoff.

| API | Batch size | Size | Baseline GB/s | PR GB/s | Speedup | Baseline median | PR median |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `put_tensor(cuda)` | 1 | 64 MiB | 3.079 | 21.213 | 6.89x | 20.302 ms | 2.946 ms |
| `put_tensor(cuda)` | 1 | 256 MiB | 3.072 | 23.601 | 7.68x | 81.379 ms | 10.593 ms |
| `put_tensor(cuda)` | 1 | 512 MiB | 3.086 | 24.022 | 7.78x | 162.015 ms | 20.815 ms |
| `batch_put_tensor(cuda)` | 2 | 64 MiB | 3.049 | 21.972 | 7.21x | 41.002 ms | 5.689 ms |
| `batch_put_tensor(cuda)` | 2 | 256 MiB | 3.083 | 23.786 | 7.72x | 162.181 ms | 21.021 ms |
| `batch_put_tensor(cuda)` | 2 | 512 MiB | 3.097 | 24.124 | 7.79x | 322.905 ms | 41.452 ms |

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

RFC issue: https://github.com/kvcache-ai/Mooncake/issues/3229

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to help implement, review, and validate the change. The submitter is responsible for the final code and PR.
