### PR TITLE
[Bugfix] Drain RDMA async event queue on each epoll wakeup

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -961,47 +961,57 @@ void WorkerPool::transferWorker(int thread_id) {
 }
 
 int WorkerPool::doProcessContextEvents() {
-    ibv_async_event event;
-    bool event_acked = false;
-    if (ibv_get_async_event(context_.context(), &event) < 0) return ERR_CONTEXT;
-    LOG(WARNING) << "Worker: Received context async event "
-                 << ibv_event_type_str(event.event_type) << " for context "
-                 << context_.deviceName();
-    if (event.event_type == IBV_EVENT_QP_FATAL) {
-        auto endpoint_ptr = (RdmaEndPoint *)event.element.qp->qp_context;
+    // The async fd is edge-triggered (joinNonblockingPollList) and
+    // ibv_get_async_event() returns one record per read, so anything left
+    // queued here waits for an unrelated later event to release it. Bursts
+    // are routine -- IBV_EVENT_COMM_EST fires once per connection -- and a
+    // backlog delays every event behind it, port and device errors included.
+    while (true) {
+        ibv_async_event event;
+        bool event_acked = false;
+        errno = 0;
+        if (ibv_get_async_event(context_.context(), &event) < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;  // drained
+            if (errno == EINTR) continue;
+            return ERR_CONTEXT;
+        }
+        LOG(WARNING) << "Worker: Received context async event "
+                     << ibv_event_type_str(event.event_type) << " for context "
+                     << context_.deviceName();
+        if (event.event_type == IBV_EVENT_QP_FATAL) {
+            auto endpoint_ptr = (RdmaEndPoint *)event.element.qp->qp_context;
 
-        /**
-         * There might be a deadlock if we call endpoint->set_active(false)
-         * before ack the event:
-         *
-         * Thread A:
-         *     Holding endpoint->lock_ and calling ibv_destroy_qp (if using
-         * eRDMA), ibv_destroy_qp will block until the event is acked.
-         *
-         * Thread B (this thread):
-         *     Calling endpoint->set_active(false), which blocks as
-         * endpoint->lock_ is held by Thread A.
-         */
-        ibv_ack_async_event(&event);
-        event_acked = true;
+            /**
+             * There might be a deadlock if we call endpoint->set_active(false)
+             * before ack the event:
+             *
+             * Thread A:
+             *     Holding endpoint->lock_ and calling ibv_destroy_qp (if using
+             * eRDMA), ibv_destroy_qp will block until the event is acked.
+             *
+             * Thread B (this thread):
+             *     Calling endpoint->set_active(false), which blocks as
+             * endpoint->lock_ is held by Thread A.
+             */
+            ibv_ack_async_event(&event);
+            event_acked = true;
 
-        /**
-         * After ack the event, the endpoint might be destroyed if it happened
-         * to be destroying event.element.qp. Therefore, we cannot just
-         * dereference endpoint_ptr. Instead, we need to get the shared_ptr of
-         * the endpoint from context_ and use that shared_ptr to access the
-         * endpoint.
-         */
-        context_.deleteEndpointByPtr(endpoint_ptr);
-    } else if (handleContextEvent(event.event_type, false, &event)) {
-        event_acked = true;
+            /**
+             * After ack the event, the endpoint might be destroyed if it
+             * happened to be destroying event.element.qp. Therefore, we cannot
+             * just dereference endpoint_ptr. Instead, we need to get the
+             * shared_ptr of the endpoint from context_ and use that shared_ptr
+             * to access the endpoint.
+             */
+            context_.deleteEndpointByPtr(endpoint_ptr);
+        } else if (handleContextEvent(event.event_type, false, &event)) {
+            event_acked = true;
+        }
+
+        if (!event_acked) {
+            ibv_ack_async_event(&event);
+        }
     }
-
-    if (!event_acked) {
-        ibv_ack_async_event(&event);
-    }
-
-    return 0;
 }
 
 void WorkerPool::processContextEventForTest(ibv_event_type event_type) {

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -70,6 +70,22 @@ add_test(NAME rdma_endpoint_reestablish_test
          COMMAND rdma_endpoint_reestablish_test)
 set_tests_properties(rdma_endpoint_reestablish_test PROPERTIES LABELS "rdma")
 
+# Regression test for the edge-triggered async event fd: one epoll wakeup must
+# drain the whole queue. Wraps ibv_get_async_event to script the event source,
+# so it needs no RDMA device. -Wl,--wrap is a GNU ld / lld feature that Apple's
+# linker lacks, and the test is meaningless without it, so skip the target there
+# rather than build one that calls the real symbols.
+if(UNIX AND NOT APPLE)
+  add_executable(rdma_async_event_drain_test
+                 ${WORKSPACE}/rdma_async_event_drain_test.cpp)
+  target_link_libraries(rdma_async_event_drain_test PUBLIC transfer_engine
+                                                           gtest gtest_main)
+  target_link_options(
+    rdma_async_event_drain_test PRIVATE "-Wl,--wrap=ibv_get_async_event"
+    "-Wl,--wrap=ibv_ack_async_event")
+  add_test(NAME rdma_async_event_drain_test COMMAND rdma_async_event_drain_test)
+endif()
+
 if(USE_CXL)
   add_executable(cxl_transport_test ${WORKSPACE}/cxl_transport_test.cpp)
   target_link_libraries(cxl_transport_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/rdma_async_event_drain_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_async_event_drain_test.cpp
@@ -1,0 +1,217 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// WorkerPool::doProcessContextEvents() must empty the async event fd on every
+// call: the fd is edge-triggered, so anything left queued is stranded until the
+// next event arrives. These tests replace the event source with a scripted
+// queue via linker wrapping, so no RDMA device is needed.
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cstring>
+#include <deque>
+#include <memory>
+
+#include <glog/logging.h>
+#include <infiniband/verbs.h>
+
+#include "error.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_transport/worker_pool.h"
+
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer)
+#include <sanitizer/lsan_interface.h>
+#define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+#else
+#define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
+#endif
+
+using namespace mooncake;
+
+namespace {
+
+// Stands in for the kernel's async event queue behind async_fd.
+struct AsyncEventScript {
+    std::deque<ibv_event_type> pending;
+    // Reported once `pending` runs dry. EAGAIN mimics a drained non-blocking
+    // fd; anything else mimics a real read failure.
+    int drained_errno = EAGAIN;
+    // Fail this many reads with EINTR before serving the queue.
+    int pending_eintr = 0;
+    int get_calls = 0;
+    int ack_calls = 0;
+};
+
+AsyncEventScript g_script;
+
+}  // namespace
+
+extern "C" int __wrap_ibv_get_async_event(struct ibv_context *context,
+                                          struct ibv_async_event *event) {
+    (void)context;  // Never dereferenced by the code under test.
+    g_script.get_calls++;
+    if (g_script.pending_eintr > 0) {
+        g_script.pending_eintr--;
+        errno = EINTR;
+        return -1;
+    }
+    if (g_script.pending.empty()) {
+        errno = g_script.drained_errno;
+        return -1;
+    }
+    memset(event, 0, sizeof(*event));
+    event->event_type = g_script.pending.front();
+    g_script.pending.pop_front();
+    return 0;
+}
+
+extern "C" void __wrap_ibv_ack_async_event(struct ibv_async_event *event) {
+    (void)event;
+    g_script.ack_calls++;
+}
+
+namespace mooncake {
+
+class WorkerPoolTestPeer {
+   public:
+    static int processContextEvents(WorkerPool &worker_pool) {
+        return worker_pool.doProcessContextEvents();
+    }
+};
+
+}  // namespace mooncake
+
+namespace {
+
+// Only event types whose handlers touch nothing a device-less context lacks.
+// IBV_EVENT_COMM_EST is not claimed by handleContextEvent(), so the caller acks
+// it; IBV_EVENT_PORT_ACTIVE is claimed and only stores a recovery timestamp, so
+// the handler acks it. Together they cover both ack paths.
+constexpr ibv_event_type kUnclaimedEvent = IBV_EVENT_COMM_EST;
+constexpr ibv_event_type kClaimedEvent = IBV_EVENT_PORT_ACTIVE;
+
+class AsyncEventDrainTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // The pool's monitorWorker busy-polls epoll_wait() on an invalid fd
+        // for its whole lifetime because this context was never opened.
+        // Silence it so gtest failures stay readable.
+        previous_min_log_level_ = FLAGS_minloglevel;
+        FLAGS_minloglevel = google::GLOG_FATAL;
+
+        // Intentional leak: ~RdmaTransport dereferences metadata_, which is
+        // null until install(). We only need it as RdmaContext's owner, same
+        // as rdma_endpoint_state_test.
+        transport_ = new RdmaTransport();
+        MC_LSAN_IGNORE_OBJECT(transport_);
+        context_ = std::make_unique<RdmaContext>(*transport_, "unused");
+        // Always fails, on any host, because no device is named "unused" --
+        // which keeps the context from starting a second worker pool that
+        // would race us for the scripted queue. It still creates the endpoint
+        // store first, and monitorWorker's reclaim tick needs that to exist.
+        context_->construct();
+
+        g_script = AsyncEventScript{};
+        worker_pool_ = std::make_unique<WorkerPool>(*context_);
+    }
+
+    void TearDown() override {
+        worker_pool_.reset();
+        context_.reset();
+        FLAGS_minloglevel = previous_min_log_level_;
+    }
+
+    int processContextEvents() {
+        return WorkerPoolTestPeer::processContextEvents(*worker_pool_);
+    }
+
+    int previous_min_log_level_ = 0;
+    RdmaTransport *transport_ = nullptr;
+    std::unique_ptr<RdmaContext> context_;
+    std::unique_ptr<WorkerPool> worker_pool_;
+};
+
+// The regression: a burst arriving between two epoll wakeups must be consumed
+// in full, not one event at a time.
+TEST_F(AsyncEventDrainTest, DrainsEveryQueuedEvent) {
+    constexpr int kBurst = 5;
+    for (int i = 0; i < kBurst; ++i)
+        g_script.pending.push_back(kUnclaimedEvent);
+
+    EXPECT_EQ(processContextEvents(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty())
+        << "one epoll wakeup must drain the whole async event queue; "
+        << g_script.pending.size() << " event(s) were left stranded";
+    // kBurst reads plus the trailing EAGAIN that ends the drain.
+    EXPECT_EQ(g_script.get_calls, kBurst + 1);
+    EXPECT_EQ(g_script.ack_calls, kBurst);
+}
+
+// Both ack paths must drain, and neither may ack twice or not at all.
+TEST_F(AsyncEventDrainTest, DrainsClaimedAndUnclaimedEventsAlike) {
+    g_script.pending.push_back(kUnclaimedEvent);
+    g_script.pending.push_back(kClaimedEvent);
+    g_script.pending.push_back(kUnclaimedEvent);
+
+    EXPECT_EQ(processContextEvents(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty());
+    EXPECT_EQ(g_script.get_calls, 4);
+    EXPECT_EQ(g_script.ack_calls, 3);
+}
+
+// A wakeup with nothing pending is a drained fd, not a failure.
+TEST_F(AsyncEventDrainTest, EmptyQueueIsNotAnError) {
+    EXPECT_EQ(processContextEvents(), 0);
+
+    EXPECT_EQ(g_script.get_calls, 1);
+    EXPECT_EQ(g_script.ack_calls, 0);
+}
+
+// A signal must not end the drain early, or the events behind it are stranded
+// exactly as they were before the fix.
+TEST_F(AsyncEventDrainTest, InterruptedReadIsRetried) {
+    g_script.pending.push_back(kUnclaimedEvent);
+    g_script.pending.push_back(kUnclaimedEvent);
+    g_script.pending_eintr = 1;
+
+    EXPECT_EQ(processContextEvents(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty());
+    // One EINTR, two reads, one trailing EAGAIN.
+    EXPECT_EQ(g_script.get_calls, 4);
+    EXPECT_EQ(g_script.ack_calls, 2);
+}
+
+// A genuine read failure still aborts and propagates, so the loop cannot spin
+// forever on a broken fd.
+TEST_F(AsyncEventDrainTest, RealReadErrorStopsTheDrain) {
+    g_script.pending.push_back(kUnclaimedEvent);
+    g_script.drained_errno = EIO;
+
+    EXPECT_EQ(processContextEvents(), ERR_CONTEXT);
+
+    EXPECT_EQ(g_script.get_calls, 2);
+    EXPECT_EQ(g_script.ack_calls, 1);
+}
+
+}  // namespace


### PR DESCRIPTION
Description
  
  The device async fd is registered edge-triggered (RdmaContext::joinNonblockingPollList), but WorkerPool::doProcessContextEvents() consumed only one event per wakeup — ibv_get_async_event() returns exactly one record per read() (kernel: ib_uverbs_event_read() dequeues a single list entry and returns). Anything still queued therefore got no further EPOLLIN and waited for an unrelated later event to release it, leaving the handler permanently N events behind.

  Bursts are routine, not exceptional: IBV_EVENT_COMM_EST fires once per connection, so batch connection setup alone builds a backlog. Port and device errors queued behind it — including the IBV_EVENT_PORT_ERR that drives               set_active(false) + refreshPublishedLocalTopology() — are delayed by the whole backlog, and stall entirely if no further event arrives.

  Fix: read until the fd reports EAGAIN. EINTR retries instead of aborting the drain (unreachable on this non-blocking fd, but aborting there would reproduce the same stranding). Other errno values still abort and propagate, so the loop cannot spin on a broken fd. A wakeup with nothing pending now returns success instead of ERR_CONTEXT.

  Adds rdma_async_event_drain_test, which drives the real doProcessContextEvents() against a scripted event queue installed by wrapping ibv_get_async_event / ibv_ack_async_event. No RDMA device required, so it runs on ordinary CI runners.

  No existing issue or open PR covers this. #3161 ([TransferEngine] Refactor RDMA worker ownership, WIP) touches the same file but addresses endpoint ownership/UAF.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other
  
  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Built and run in an Ubuntu 22.04 container (no RDMA hardware needed).

  Test commands:
  cmake -S . -B build -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DUSE_ETCD=OFF -DBUILD_UNIT_TESTS=ON
  cmake --build build -j"$(nproc)"
  ctest --test-dir build --output-on-failure
  ./scripts/code_format.sh

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  New test, 5/5 pass:

  [==========] 5 tests from AsyncEventDrainTest ran. (4 ms total)
  [  PASSED  ] 5 tests.

  Reverting only the production hunk and re-running confirms the test catches the regression — 5/5 fail:

  [  FAILED  ] AsyncEventDrainTest.DrainsEveryQueuedEvent
  one epoll wakeup must drain the whole async event queue; 4 event(s) were left stranded
  [  PASSED  ] 0 tests.

  Full ctest: 24/28 pass. The same 4 fail identically with and without this change (default_config_test, tcp_transport_test, transfer_metadata_test, memory_location_test) — container has no NUMA nodes and no metadata server.
  Verified by re-running them against unmodified main.

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [x] I have updated the documentation (if applicable) — N/A, no user-visible behavior changed
  - [x] I have added tests to prove my changes are effective
  - [x] For changes >500 LOC: I have filed an RFC issue — N/A (282 insertions, 39 deletions)

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)