### PR TITLE
[Store] Decouple business decisions from storage metrics

### DIFF
--- a/docs/source/design/ssd-free-ratio-first-allocation.md
+++ b/docs/source/design/ssd-free-ratio-first-allocation.md
@@ -54,7 +54,7 @@ This document describes `SsdFreeRatioFirstAllocationStrategy`, an allocation str
 
 The flow follows the same high-level structure as the existing `FreeRatioFirstAllocationStrategy`: sample a subset of candidates, compute a ranking metric, sort, and allocate from the top. The key difference is that the ranking metric is SSD free ratio rather than DRAM free ratio.
 
-`MasterService` only passes an `SsdMetricsProvider` when the effective allocation strategy is `SSD_FREE_RATIO_FIRST`. Non-SSD strategies receive `nullptr`, so they avoid unnecessary local-disk segment access.
+`MasterService` only passes an `SsdUsageProvider` when the effective allocation strategy is `SSD_FREE_RATIO_FIRST`. Non-SSD strategies receive `nullptr`, so they avoid unnecessary local-disk segment access.
 
 ---
 
@@ -74,7 +74,7 @@ ssd_free_ratio = (ssd_total_capacity - ssd_used_bytes) / ssd_total_capacity
 
 A segment with 1 TB total SSD capacity and 200 GB used has an SSD free ratio of 0.80. A segment whose SSD is full has a ratio of 0.0.
 
-Before calculating the ratio, `ssd_used_bytes` is clamped to `[0, ssd_total_capacity]`. This keeps transient concurrent accounting drift from producing a negative free ratio or a value greater than 1.0. If no SSD metrics provider is available, or if the reported total capacity is not positive, the strategy treats the segment as fully free.
+Before calculating the ratio, `ssd_used_bytes` is clamped to `[0, ssd_total_capacity]`. This keeps transient concurrent accounting drift from producing a negative free ratio or a value greater than 1.0. If no SSD usage view is available, or if the reported total capacity is not positive, the strategy treats the segment as fully free.
 
 ### Sorting
 
@@ -86,7 +86,7 @@ As with other allocation strategies, segments marked as preferred by the caller 
 
 ### Fallback to random allocation
 
-After allocating from the SSD-ranked candidates, any remaining replicas that could not be satisfied are allocated using the standard random strategy as a fallback. This ensures that allocation succeeds even when SSD metrics are unavailable (for example, on segments without SSD offload configured).
+After allocating from the SSD-ranked candidates, any remaining replicas that could not be satisfied are allocated using the standard random strategy as a fallback. This ensures that allocation succeeds even when SSD usage state is unavailable (for example, on segments without SSD offload configured).
 
 ---
 
@@ -101,16 +101,16 @@ After allocating from the SSD-ranked candidates, any remaining replicas that cou
 
 The counter is atomic to allow concurrent updates from multiple RPC handler threads without requiring a separate lock. The allocation strategy treats it as an eventually consistent placement signal and clamps it before computing the free ratio.
 
-### `SsdMetricsProvider` interface
+### `SsdUsageProvider` interface
 
-`ScopedLocalDiskSegmentAccess` implements the `SsdMetricsProvider` interface, which exposes two methods:
+`ScopedLocalDiskSegmentAccess` implements the `SsdUsageProvider` interface, which exposes two methods:
 
 | Method | Return type | Description |
 |--------|-------------|-------------|
-| `getSsdTotalCapacity` | `int64_t` | Total SSD capacity configured for the segment, in bytes |
-| `getSsdUsedBytes` | `int64_t` | Current SSD usage, read from `ssd_used_bytes` |
+| `GetSsdTotalCapacityBytes` | `int64_t` | Total SSD capacity configured for the segment, in bytes |
+| `GetSsdUsedBytes` | `int64_t` | Current SSD usage, read from `ssd_used_bytes` |
 
-The allocation strategy queries these methods through the `SsdMetricsProvider` interface, keeping the strategy decoupled from the concrete segment implementation.
+The allocation strategy queries these methods through the `SsdUsageProvider` interface, keeping the strategy decoupled from the concrete segment implementation. The former metrics-oriented name was misleading: these values are authoritative domain state and are independent of Prometheus or other telemetry backends.
 
 ---
 
@@ -129,10 +129,10 @@ The parameter is passed as a gflag to the master process at startup.
 | File | Change |
 |------|--------|
 | `mooncake-store/include/types.h` | Add `SSD_FREE_RATIO_FIRST` enum value to the allocation strategy enum |
-| `mooncake-store/include/allocation_strategy.h` | Add `SsdMetricsProvider` interface and `SsdFreeRatioFirstAllocationStrategy` class |
-| `mooncake-store/include/segment.h` | Add `ssd_total_capacity_bytes` and `ssd_used_bytes` fields to `LocalDiskSegment`; inherit `SsdMetricsProvider` |
-| `mooncake-store/src/segment.cpp` | Implement `getSsdTotalCapacity` and `getSsdUsedBytes` |
-| `mooncake-store/src/master_service.cpp` | Pass SSD metrics only to `SSD_FREE_RATIO_FIRST`; update `ssd_used_bytes` after successful `NotifyOffloadSuccess` metadata insertion; release usage when `LOCAL_DISK` replicas are erased |
+| `mooncake-store/include/allocation_strategy.h` | Add `SsdUsageProvider` interface and `SsdFreeRatioFirstAllocationStrategy` class |
+| `mooncake-store/include/segment.h` | Add `ssd_total_capacity_bytes` and `ssd_used_bytes` fields to `LocalDiskSegment`; inherit `SsdUsageProvider` |
+| `mooncake-store/src/segment.cpp` | Implement `GetSsdTotalCapacityBytes` and `GetSsdUsedBytes` |
+| `mooncake-store/src/master_service.cpp` | Pass the SSD usage view only to `SSD_FREE_RATIO_FIRST`; update `ssd_used_bytes` after successful `NotifyOffloadSuccess` metadata insertion; release usage when `LOCAL_DISK` replicas are erased |
 
 ---
 

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -146,12 +146,19 @@ class AllocatorManager {
     friend class SegmentSerializer;  // for fork serialize
 };
 
-class SsdMetricsProvider {
+/**
+ * Read-only domain view of client-local SSD capacity and occupancy.
+ *
+ * Values come from LocalDiskSegment state. Implementations must return zero
+ * for unknown segments; callers clamp transient occupancy drift to the
+ * reported capacity before making placement decisions.
+ */
+class SsdUsageProvider {
    public:
-    virtual ~SsdMetricsProvider() = default;
-    virtual int64_t getSsdTotalCapacity(
+    virtual ~SsdUsageProvider() = default;
+    virtual int64_t GetSsdTotalCapacityBytes(
         const std::string& segment_name) const = 0;
-    virtual int64_t getSsdUsedBytes(const std::string& segment_name) const = 0;
+    virtual int64_t GetSsdUsedBytes(const std::string& segment_name) const = 0;
 };
 
 /**
@@ -206,9 +213,8 @@ class AllocationStrategy {
         const size_t replica_num,
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
-        const ReplicaType replica_type,
-        const SsdMetricsProvider* ssd_provider) {
-        (void)ssd_provider;
+        const ReplicaType replica_type, const SsdUsageProvider* ssd_usage) {
+        (void)ssd_usage;
         return Allocate(allocator_manager, slice_length, replica_num,
                         preferred_segments, excluded_segments, replica_type);
     }
@@ -582,7 +588,7 @@ class SsdFreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
         const ReplicaType replica_type,
-        const SsdMetricsProvider* ssd_provider) override {
+        const SsdUsageProvider* ssd_usage) override {
         if (slice_length == 0 || replica_num == 0) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -639,7 +645,7 @@ class SsdFreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
                 continue;
             }
 
-            double ssd_free_ratio = getSegmentSsdFreeRatio(name, ssd_provider);
+            double ssd_free_ratio = getSegmentSsdFreeRatio(name, ssd_usage);
             candidates.push_back({idx, ssd_free_ratio});
         }
 
@@ -703,12 +709,12 @@ class SsdFreeRatioFirstAllocationStrategy : public RandomAllocationStrategy {
     static constexpr size_t kMaxRetryLimit = 100;
     static constexpr size_t kCandidateMultiplier = 6;
 
-    double getSegmentSsdFreeRatio(
-        const std::string& name, const SsdMetricsProvider* ssd_provider) const {
-        if (!ssd_provider) return 1.0;
-        int64_t total = ssd_provider->getSsdTotalCapacity(name);
+    double getSegmentSsdFreeRatio(const std::string& name,
+                                  const SsdUsageProvider* ssd_usage) const {
+        if (!ssd_usage) return 1.0;
+        int64_t total = ssd_usage->GetSsdTotalCapacityBytes(name);
         if (total <= 0) return 1.0;
-        int64_t used = ssd_provider->getSsdUsedBytes(name);
+        int64_t used = ssd_usage->GetSsdUsedBytes(name);
         used = std::clamp<int64_t>(used, 0, total);
         int64_t free_bytes = total - used;
         return static_cast<double>(free_bytes) / static_cast<double>(total);

--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -105,6 +105,7 @@ class MasterAdminServer {
                          coro_http::coro_http_response& resp);
 
     void RegisterHandler();
+    void RefreshStorageMetrics() const;
 
     uint16_t http_port_;
     bool enable_metric_reporting_ = false;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <chrono>
 #include <mutex>
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -11,6 +12,8 @@
 #include "ylt/metric/histogram.hpp"
 
 namespace mooncake {
+
+struct TieredStorageUsageSnapshot;
 
 class MasterMetricManager {
    public:
@@ -29,7 +32,6 @@ class MasterMetricManager {
     void inc_total_mem_capacity(const std::string& segment, int64_t val = 1);
     void dec_total_mem_capacity(const std::string& segment, int64_t val = 1);
     void reset_total_mem_capacity();
-    double get_global_mem_used_ratio(void);
 
     void inc_mem_cache_hit_nums(int64_t val = 1);
     void inc_file_cache_hit_nums(int64_t val = 1);
@@ -55,7 +57,14 @@ class MasterMetricManager {
     void inc_total_nof_capacity(const std::string& segment, int64_t val = 1);
     void dec_total_nof_capacity(const std::string& segment, int64_t val = 1);
     void reset_total_nof_capacity();
-    double get_global_nof_used_ratio(void);
+
+    /**
+     * @brief Refresh storage gauges from authoritative allocator snapshots.
+     *
+     * This is an observability projection. Business code must use the domain
+     * snapshots directly and must not read the resulting gauges.
+     */
+    void project_storage_usage(const TieredStorageUsageSnapshot& snapshot);
 
     enum class CacheHitStat {
         MEMORY_HITS,
@@ -81,26 +90,16 @@ class MasterMetricManager {
     CacheHitStatDict calculate_cache_stats();
 
     // Memory Storage Metrics
-    void inc_allocated_mem_size(int64_t val = 1);
-    void dec_allocated_mem_size(int64_t val = 1);
-    void inc_total_mem_capacity(int64_t val = 1);
-    void dec_total_mem_capacity(int64_t val = 1);
     int64_t get_allocated_mem_size();
     int64_t get_total_mem_capacity();
-    double get_segment_mem_used_ratio(const std::string& segment);
     void reset_segment_allocated_mem_size(const std::string& segment);
     void reset_segment_total_mem_capacity(const std::string& segment);
     int64_t get_segment_allocated_mem_size(const std::string& segment);
     int64_t get_segment_total_mem_capacity(const std::string& segment);
 
     // NoF segment Metrics
-    void inc_allocated_nof_size(int64_t val = 1);
-    void dec_allocated_nof_size(int64_t val = 1);
-    void inc_total_nof_capacity(int64_t val = 1);
-    void dec_total_nof_capacity(int64_t val = 1);
     int64_t get_allocated_nof_size();
     int64_t get_total_nof_capacity();
-    double get_segment_nof_used_ratio(const std::string& segment);
     int64_t get_segment_allocated_nof_size(const std::string& segment);
     int64_t get_segment_total_nof_capacity(const std::string& segment);
 
@@ -529,6 +528,10 @@ class MasterMetricManager {
     // --- Metric Members ---
     std::mutex summary_snapshot_mutex_;
     SummarySnapshot summary_snapshot_;
+
+    std::mutex storage_projection_mutex_;
+    std::set<std::string> projected_mem_segments_;
+    std::set<std::string> projected_nof_segments_;
 
     // Memory Storage Metrics
     ylt::metric::gauge_t

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -129,6 +129,7 @@ class MasterService {
     bool IsNoFSegmentMountedForTesting(const UUID& segment_id);
     std::optional<uint32_t> GetNoFHeartbeatFailureCountForTesting(
         const UUID& segment_id);
+    [[nodiscard]] TieredStorageUsageSnapshot GetStorageUsageSnapshot() const;
     bool IsTenantQuotaEnabled() const;
     std::vector<TenantQuotaSnapshot> ListTenantQuotaSnapshots() const;
     std::optional<TenantQuotaSnapshot> GetTenantQuotaSnapshot(

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -187,6 +187,8 @@ class WrappedMasterService {
 
     tl::expected<std::string, ErrorCode> ServiceReady();
 
+    [[nodiscard]] TieredStorageUsageSnapshot GetStorageUsageSnapshot() const;
+
     tl::expected<std::vector<TenantQuotaSnapshot>, ErrorCode>
     ListTenantQuotaSnapshots();
     tl::expected<TenantQuotaSnapshot, ErrorCode> GetTenantQuotaSnapshot(

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -368,7 +368,7 @@ class ScopedAllocatorAccess {
  * @brief RAII-style access to LocalDiskOffloadingQueues for thread-safe
  * LocalDiskOffloadingQueue usage
  */
-class ScopedLocalDiskSegmentAccess : public SsdMetricsProvider {
+class ScopedLocalDiskSegmentAccess : public SsdUsageProvider {
    public:
     explicit ScopedLocalDiskSegmentAccess(
         std::unordered_map<std::string, UUID>& client_by_name,
@@ -389,8 +389,9 @@ class ScopedLocalDiskSegmentAccess : public SsdMetricsProvider {
         return client_local_disk_segment_;
     }
 
-    int64_t getSsdTotalCapacity(const std::string& segment_name) const override;
-    int64_t getSsdUsedBytes(const std::string& segment_name) const override;
+    int64_t GetSsdTotalCapacityBytes(
+        const std::string& segment_name) const override;
+    int64_t GetSsdUsedBytes(const std::string& segment_name) const override;
 
    private:
     const std::unordered_map<std::string, UUID>&

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -440,6 +440,19 @@ class SegmentSerializer {
     SegmentManager* segment_manager_;
 };
 
+struct MemoryUsageSnapshot {
+    size_t used_bytes{0};
+    size_t capacity_bytes{0};
+
+    [[nodiscard]] double used_ratio() const noexcept {
+        if (capacity_bytes == 0) {
+            return 0.0;
+        }
+        return static_cast<double>(used_bytes) /
+               static_cast<double>(capacity_bytes);
+    }
+};
+
 class SegmentManager {
    public:
     /**
@@ -486,6 +499,14 @@ class SegmentManager {
     }
 
     SegmentView getView() const { return SegmentView(this); }
+
+    /**
+     * @brief Return current DRAM usage derived from mounted allocators.
+     *
+     * Shared allocators (for example the global CXL allocator) are counted
+     * once even when they are referenced by multiple mounted segments.
+     */
+    [[nodiscard]] MemoryUsageSnapshot GetMemoryUsageSnapshot() const;
 
     void initializeCxlAllocator(const std::string& cxl_path,
                                 const size_t cxl_size);

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -440,7 +440,7 @@ class SegmentSerializer {
     SegmentManager* segment_manager_;
 };
 
-struct MemoryUsageSnapshot {
+struct StorageUsage {
     size_t used_bytes{0};
     size_t capacity_bytes{0};
 
@@ -451,6 +451,15 @@ struct MemoryUsageSnapshot {
         return static_cast<double>(used_bytes) /
                static_cast<double>(capacity_bytes);
     }
+};
+
+struct StorageUsageSnapshot : StorageUsage {
+    std::map<std::string, StorageUsage> segments;
+};
+
+struct TieredStorageUsageSnapshot {
+    StorageUsageSnapshot memory;
+    StorageUsageSnapshot nof;
 };
 
 class SegmentManager {
@@ -506,7 +515,7 @@ class SegmentManager {
      * Shared allocators (for example the global CXL allocator) are counted
      * once even when they are referenced by multiple mounted segments.
      */
-    [[nodiscard]] MemoryUsageSnapshot GetMemoryUsageSnapshot() const;
+    [[nodiscard]] StorageUsageSnapshot GetMemoryUsageSnapshot() const;
 
     void initializeCxlAllocator(const std::string& cxl_path,
                                 const size_t cxl_size);
@@ -584,6 +593,11 @@ class NoFSegmentManager {
 
     void GetMountedSegmentsSnapshot(
         std::vector<MountedNoFSegmentSnapshot>& segments) const;
+
+    /**
+     * @brief Return current NoF usage derived from mounted allocators.
+     */
+    [[nodiscard]] StorageUsageSnapshot GetUsageSnapshot() const;
 
     tl::expected<std::vector<NoFSegmentOwnerInfo>, ErrorCode> GetSegmentsByName(
         const std::string& segment_name) const {

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -278,6 +278,7 @@ bool MasterAdminServer::Start() {
         metric_report_running_.store(true);
         metric_report_thread_ = std::thread([this]() {
             while (metric_report_running_.load()) {
+                RefreshStorageMetrics();
                 const auto snapshot = SnapshotState();
                 std::ostringstream log_stream;
                 log_stream << "Master Admin Metrics: role="
@@ -359,6 +360,7 @@ MasterAdminServer::RuntimeSnapshot MasterAdminServer::SnapshotState() const {
 }
 
 std::string MasterAdminServer::BuildMetricsText() const {
+    RefreshStorageMetrics();
     std::string metrics = AppendMetricSections(
         MasterMetricManager::instance().serialize_metrics(),
         HAMetricManager::instance().serialize_metrics());
@@ -454,6 +456,7 @@ std::string MasterAdminServer::BuildTenantQuotaMetricsText() const {
 }
 
 std::string MasterAdminServer::BuildMetricsSummaryText() const {
+    RefreshStorageMetrics();
     const auto snapshot = SnapshotState();
     std::ostringstream oss;
     oss << "role=" << ha::MasterRuntimeRoleToString(snapshot.state)
@@ -520,6 +523,14 @@ std::shared_ptr<WrappedMasterService> MasterAdminServer::GetActiveService()
         return nullptr;
     }
     return snapshot.service;
+}
+
+void MasterAdminServer::RefreshStorageMetrics() const {
+    const auto runtime = SnapshotState();
+    const auto storage = runtime.service
+                             ? runtime.service->GetStorageUsageSnapshot()
+                             : TieredStorageUsageSnapshot{};
+    MasterMetricManager::instance().project_storage_usage(storage);
 }
 
 template <typename Handler>

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -7,6 +7,7 @@
 #include <vector>   // Required by histogram serialization
 #include <cmath>
 
+#include "segment.h"
 #include "utils.h"
 
 namespace mooncake {
@@ -676,15 +677,6 @@ int64_t MasterMetricManager::get_total_mem_capacity() {
     return mem_total_capacity_.value();
 }
 
-double MasterMetricManager::get_global_mem_used_ratio(void) {
-    double allocated = mem_allocated_size_.value();
-    double capacity = mem_total_capacity_.value();
-    if (capacity == 0) {
-        return 0.0;
-    }
-    return allocated / capacity;
-}
-
 int64_t MasterMetricManager::get_segment_allocated_mem_size(
     const std::string& segment) {
     return mem_allocated_size_per_segment_.value({segment});
@@ -703,16 +695,6 @@ void MasterMetricManager::reset_segment_total_mem_capacity(
 int64_t MasterMetricManager::get_segment_total_mem_capacity(
     const std::string& segment) {
     return mem_total_capacity_per_segment_.value({segment});
-}
-
-double MasterMetricManager::get_segment_mem_used_ratio(
-    const std::string& segment) {
-    double allocated = get_segment_allocated_mem_size(segment);
-    double capacity = get_segment_total_mem_capacity(segment);
-    if (capacity == 0) {
-        return 0.0;
-    }
-    return allocated / capacity;
 }
 
 // NoF segment Metrics
@@ -756,13 +738,42 @@ int64_t MasterMetricManager::get_total_nof_capacity() {
     return nof_total_capacity_.value();
 }
 
-double MasterMetricManager::get_global_nof_used_ratio(void) {
-    double allocated = nof_allocated_size_.value();
-    double capacity = nof_total_capacity_.value();
-    if (capacity == 0) {
-        return 0.0;
-    }
-    return allocated / capacity;
+void MasterMetricManager::project_storage_usage(
+    const TieredStorageUsageSnapshot& snapshot) {
+    std::lock_guard<std::mutex> lock(storage_projection_mutex_);
+
+    auto project_tier = [](const StorageUsageSnapshot& tier,
+                           ylt::metric::gauge_t& allocated,
+                           ylt::metric::gauge_t& capacity,
+                           ylt::metric::dynamic_gauge_1t& allocated_by_segment,
+                           ylt::metric::dynamic_gauge_1t& capacity_by_segment,
+                           std::set<std::string>& projected_segments) {
+        allocated.update(static_cast<int64_t>(tier.used_bytes));
+        capacity.update(static_cast<int64_t>(tier.capacity_bytes));
+
+        std::set<std::string> current_segments;
+        for (const auto& [segment_name, usage] : tier.segments) {
+            current_segments.insert(segment_name);
+            allocated_by_segment.update({segment_name},
+                                        static_cast<int64_t>(usage.used_bytes));
+            capacity_by_segment.update(
+                {segment_name}, static_cast<int64_t>(usage.capacity_bytes));
+        }
+        for (const auto& segment_name : projected_segments) {
+            if (!current_segments.contains(segment_name)) {
+                allocated_by_segment.update({segment_name}, 0);
+                capacity_by_segment.update({segment_name}, 0);
+            }
+        }
+        projected_segments = std::move(current_segments);
+    };
+
+    project_tier(snapshot.memory, mem_allocated_size_, mem_total_capacity_,
+                 mem_allocated_size_per_segment_,
+                 mem_total_capacity_per_segment_, projected_mem_segments_);
+    project_tier(snapshot.nof, nof_allocated_size_, nof_total_capacity_,
+                 nof_allocated_size_per_segment_,
+                 nof_total_capacity_per_segment_, projected_nof_segments_);
 }
 
 int64_t MasterMetricManager::get_segment_allocated_nof_size(
@@ -773,16 +784,6 @@ int64_t MasterMetricManager::get_segment_allocated_nof_size(
 int64_t MasterMetricManager::get_segment_total_nof_capacity(
     const std::string& segment) {
     return nof_total_capacity_per_segment_.value({segment});
-}
-
-double MasterMetricManager::get_segment_nof_used_ratio(
-    const std::string& segment) {
-    double allocated = get_segment_allocated_nof_size(segment);
-    double capacity = get_segment_total_nof_capacity(segment);
-    if (capacity == 0) {
-        return 0.0;
-    }
-    return allocated / capacity;
 }
 
 // File Storage Metrics

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -671,6 +671,13 @@ std::optional<uint32_t> MasterService::GetNoFHeartbeatFailureCountForTesting(
     return it->second.consecutive_failures;
 }
 
+TieredStorageUsageSnapshot MasterService::GetStorageUsageSnapshot() const {
+    return {
+        .memory = segment_manager_.GetMemoryUsageSnapshot(),
+        .nof = nof_segment_manager_.GetUsageSnapshot(),
+    };
+}
+
 bool MasterService::IsTenantQuotaEnabled() const {
     return enable_multi_tenants_;
 }
@@ -7164,7 +7171,7 @@ void MasterService::EvictionThreadFunc() {
 
 #ifdef USE_NOF
         double nof_used_ratio =
-            MasterMetricManager::instance().get_global_nof_used_ratio();
+            nof_segment_manager_.GetUsageSnapshot().used_ratio();
         if (nof_used_ratio > nof_eviction_high_watermark_ratio_ ||
             (need_nof_eviction_ && nof_eviction_ratio_ > 0.0)) {
             double nof_evict_ratio_target =
@@ -7687,7 +7694,7 @@ tl::expected<void, SerializationError> MasterService::ApplySnapshotState(
         }
 
         LOG(INFO) << "[Restore] Total allocated size after restore: "
-                  << MasterMetricManager::instance().get_allocated_mem_size();
+                  << segment_manager_.GetMemoryUsageSnapshot().used_bytes;
     }
 
     // Rebuild total capacity metrics

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3413,18 +3413,18 @@ auto MasterService::AllocateAndInsertMetadata(
             }
         }
 
-        const SsdMetricsProvider* ssd_provider = nullptr;
+        const SsdUsageProvider* ssd_usage = nullptr;
         std::optional<ScopedLocalDiskSegmentAccess> ssd_access;
         if (allocation_strategy_type_ ==
             AllocationStrategyType::SSD_FREE_RATIO_FIRST) {
             ssd_access.emplace(segment_manager_.getLocalDiskSegmentAccess());
-            ssd_provider = &*ssd_access;
+            ssd_usage = &*ssd_access;
         }
 
         auto allocation_result = allocation_strategy_->Allocate(
             allocator_manager, value_length, config.replica_num,
             preferred_segments, std::set<std::string>(), ReplicaType::MEMORY,
-            ssd_provider);
+            ssd_usage);
 
         if (!allocation_result.has_value()) {
             VLOG(1) << "Failed to allocate replicas for key=" << key

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6662,7 +6662,7 @@ MasterService::PromotionQueueResult MasterService::TryPushPromotionQueue(
     // pressure. The check is best-effort (state can change between this
     // sample and the actual allocation in PromotionAllocStart).
     const double used_ratio =
-        MasterMetricManager::instance().get_global_mem_used_ratio();
+        segment_manager_.GetMemoryUsageSnapshot().used_ratio();
     if (used_ratio >= eviction_high_watermark_ratio_) {
         MasterMetricManager::instance().inc_promotion_rejected_watermark();
         if (record_candidate) {
@@ -7131,7 +7131,7 @@ void MasterService::EvictionThreadFunc() {
     while (eviction_running_) {
         const auto now = std::chrono::system_clock::now();
         double used_ratio =
-            MasterMetricManager::instance().get_global_mem_used_ratio();
+            segment_manager_.GetMemoryUsageSnapshot().used_ratio();
         if (used_ratio > eviction_high_watermark_ratio_ ||
             (need_mem_eviction_ && eviction_ratio_ > 0.0)) {
             LOG(INFO) << "[EVICT-TRIGGER] memory_ratio=" << used_ratio

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1383,6 +1383,11 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
     return GetMooncakeStoreVersion();
 }
 
+TieredStorageUsageSnapshot WrappedMasterService::GetStorageUsageSnapshot()
+    const {
+    return master_service_.GetStorageUsageSnapshot();
+}
+
 tl::expected<std::vector<TenantQuotaSnapshot>, ErrorCode>
 WrappedMasterService::ListTenantQuotaSnapshots() {
     if (!master_service_.IsTenantQuotaEnabled()) {

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -109,6 +109,29 @@ std::vector<std::string> ScopedAllocatorAccess::GetHostOrderedSegments(
     return BuildHostOrderedSegments(*segments_by_host_, writer_host_id, key);
 }
 
+MemoryUsageSnapshot SegmentManager::GetMemoryUsageSnapshot() const {
+    std::shared_lock<std::shared_mutex> lock(segment_mutex_);
+    MemoryUsageSnapshot snapshot;
+    bool counted_cxl_allocator = false;
+
+    for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
+        (void)segment_id;
+        const auto& allocator = mounted_segment.buf_allocator;
+        if (!allocator) {
+            continue;
+        }
+        if (allocator == cxl_global_allocator_) {
+            if (counted_cxl_allocator) {
+                continue;
+            }
+            counted_cxl_allocator = true;
+        }
+        snapshot.used_bytes += allocator->size();
+        snapshot.capacity_bytes += allocator->capacity();
+    }
+    return snapshot;
+}
+
 ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
                                             const UUID& client_id) {
     const uintptr_t buffer = segment.base;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -4,6 +4,7 @@
 #include "utils/zstd_util.h"
 
 #include <functional>
+#include <unordered_set>
 
 namespace mooncake {
 namespace {
@@ -99,6 +100,27 @@ std::vector<std::string> BuildHostOrderedSegments(
     return ordered_segments;
 }
 
+void AddAllocatorUsage(
+    StorageUsageSnapshot& snapshot,
+    const std::shared_ptr<BufferAllocatorBase>& allocator,
+    std::unordered_set<const BufferAllocatorBase*>& counted_allocators) {
+    if (!allocator || !counted_allocators.insert(allocator.get()).second) {
+        return;
+    }
+
+    const size_t used_bytes = allocator->size();
+    const size_t capacity_bytes = allocator->capacity();
+    snapshot.used_bytes += used_bytes;
+    snapshot.capacity_bytes += capacity_bytes;
+
+    const std::string segment_name = allocator->getSegmentName();
+    if (!segment_name.empty()) {
+        auto& segment = snapshot.segments[segment_name];
+        segment.used_bytes += used_bytes;
+        segment.capacity_bytes += capacity_bytes;
+    }
+}
+
 }  // namespace
 
 std::vector<std::string> ScopedAllocatorAccess::GetHostOrderedSegments(
@@ -109,25 +131,19 @@ std::vector<std::string> ScopedAllocatorAccess::GetHostOrderedSegments(
     return BuildHostOrderedSegments(*segments_by_host_, writer_host_id, key);
 }
 
-MemoryUsageSnapshot SegmentManager::GetMemoryUsageSnapshot() const {
+StorageUsageSnapshot SegmentManager::GetMemoryUsageSnapshot() const {
     std::shared_lock<std::shared_mutex> lock(segment_mutex_);
-    MemoryUsageSnapshot snapshot;
-    bool counted_cxl_allocator = false;
+    StorageUsageSnapshot snapshot;
+    std::unordered_set<const BufferAllocatorBase*> counted_allocators;
+
+    // The CXL allocator is owned by SegmentManager independently of client
+    // mounts and may be shared by multiple mounted segment records.
+    AddAllocatorUsage(snapshot, cxl_global_allocator_, counted_allocators);
 
     for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
         (void)segment_id;
-        const auto& allocator = mounted_segment.buf_allocator;
-        if (!allocator) {
-            continue;
-        }
-        if (allocator == cxl_global_allocator_) {
-            if (counted_cxl_allocator) {
-                continue;
-            }
-            counted_cxl_allocator = true;
-        }
-        snapshot.used_bytes += allocator->size();
-        snapshot.capacity_bytes += allocator->capacity();
+        AddAllocatorUsage(snapshot, mounted_segment.buf_allocator,
+                          counted_allocators);
     }
     return snapshot;
 }
@@ -1578,6 +1594,18 @@ void NoFSegmentManager::GetMountedSegmentsSnapshot(
             segment_id, mounted_segment.client_id, mounted_segment.segment,
             mounted_segment.status});
     }
+}
+
+StorageUsageSnapshot NoFSegmentManager::GetUsageSnapshot() const {
+    std::shared_lock<std::shared_mutex> lock(segment_mutex_);
+    StorageUsageSnapshot snapshot;
+    std::unordered_set<const BufferAllocatorBase*> counted_allocators;
+    for (const auto& [segment_id, mounted_segment] : mounted_segments_) {
+        (void)segment_id;
+        AddAllocatorUsage(snapshot, mounted_segment.buf_allocator,
+                          counted_allocators);
+    }
+    return snapshot;
 }
 
 void SegmentManager::releaseCapacityMetrics() {

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1640,7 +1640,7 @@ void SegmentManager::initializeCxlAllocator(const std::string& cxl_path,
     MasterMetricManager::instance().inc_total_mem_capacity(cxl_path, cxl_size);
 }
 
-int64_t ScopedLocalDiskSegmentAccess::getSsdTotalCapacity(
+int64_t ScopedLocalDiskSegmentAccess::GetSsdTotalCapacityBytes(
     const std::string& segment_name) const {
     auto client_it = client_by_name_.find(segment_name);
     if (client_it == client_by_name_.end()) {
@@ -1653,7 +1653,7 @@ int64_t ScopedLocalDiskSegmentAccess::getSsdTotalCapacity(
     return disk_it->second->ssd_total_capacity_bytes;
 }
 
-int64_t ScopedLocalDiskSegmentAccess::getSsdUsedBytes(
+int64_t ScopedLocalDiskSegmentAccess::GetSsdUsedBytes(
     const std::string& segment_name) const {
     auto client_it = client_by_name_.find(segment_name);
     if (client_it == client_by_name_.end()) {

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -755,18 +755,18 @@ TEST_F(AllocationStrategyTest, PerformanceTest) {
 // public API. The functionality is now encapsulated within the Allocate()
 // method.
 
-// Mock SsdMetricsProvider for testing SSD-aware allocation
-class MockSsdMetricsProvider : public SsdMetricsProvider {
+// Mock SsdUsageProvider for testing SSD-aware allocation
+class MockSsdUsageProvider : public SsdUsageProvider {
    public:
     std::unordered_map<std::string, int64_t> total_capacity;
     std::unordered_map<std::string, int64_t> used_bytes;
 
-    int64_t getSsdTotalCapacity(const std::string& name) const override {
+    int64_t GetSsdTotalCapacityBytes(const std::string& name) const override {
         auto it = total_capacity.find(name);
         return it != total_capacity.end() ? it->second : 0;
     }
 
-    int64_t getSsdUsedBytes(const std::string& name) const override {
+    int64_t GetSsdUsedBytes(const std::string& name) const override {
         auto it = used_bytes.find(name);
         return it != used_bytes.end() ? it->second : 0;
     }
@@ -788,18 +788,17 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstChoosesHighestFreeRatio) {
     }
 
     // SSD free ratios: segment 0 = 20%, segment 1 = 60%, segment 2 = 90%
-    MockSsdMetricsProvider ssd_provider;
+    MockSsdUsageProvider ssd_usage;
     for (int i = 0; i < kNumSegments; i++) {
         const auto name = std::to_string(i) + "-segment";
-        ssd_provider.total_capacity[name] = 1000 * MiB;
+        ssd_usage.total_capacity[name] = 1000 * MiB;
     }
-    ssd_provider.used_bytes["0-segment"] = 800 * MiB;  // 20% free
-    ssd_provider.used_bytes["1-segment"] = 400 * MiB;  // 60% free
-    ssd_provider.used_bytes["2-segment"] = 100 * MiB;  // 90% free
+    ssd_usage.used_bytes["0-segment"] = 800 * MiB;  // 20% free
+    ssd_usage.used_bytes["1-segment"] = 400 * MiB;  // 60% free
+    ssd_usage.used_bytes["2-segment"] = 100 * MiB;  // 90% free
 
-    auto result =
-        ssd_strategy->Allocate(allocator_manager, 64 * 1024, 1, {}, {},
-                               ReplicaType::MEMORY, &ssd_provider);
+    auto result = ssd_strategy->Allocate(allocator_manager, 64 * 1024, 1, {},
+                                         {}, ReplicaType::MEMORY, &ssd_usage);
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1u);
 
@@ -811,9 +810,8 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstChoosesHighestFreeRatio) {
 }
 
 // Test that SsdFreeRatioFirstAllocationStrategy works without an
-// SsdMetricsProvider (delegates to base class random allocation).
-TEST_F(AllocationStrategyTest,
-       SsdFreeRatioFirstWithoutMetricsProviderAllocates) {
+// SsdUsageProvider (delegates to base class random allocation).
+TEST_F(AllocationStrategyTest, SsdFreeRatioFirstWithoutUsageProviderAllocates) {
     auto ssd_strategy = std::make_unique<SsdFreeRatioFirstAllocationStrategy>();
 
     auto allocator = std::make_shared<OffsetBufferAllocator>(
@@ -844,21 +842,21 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstExcludedSegmentsSkipped) {
     }
 
     // SSD free ratios: 0-segment=95%, 1-segment=50%, 2-segment=30%
-    MockSsdMetricsProvider ssd_provider;
+    MockSsdUsageProvider ssd_usage;
     for (int i = 0; i < kNumSegments; i++) {
         const auto name = std::to_string(i) + "-segment";
-        ssd_provider.total_capacity[name] = 1000 * MiB;
+        ssd_usage.total_capacity[name] = 1000 * MiB;
     }
-    ssd_provider.used_bytes["0-segment"] = 50 * MiB;   // 95% free (highest)
-    ssd_provider.used_bytes["1-segment"] = 500 * MiB;  // 50% free
-    ssd_provider.used_bytes["2-segment"] = 700 * MiB;  // 30% free
+    ssd_usage.used_bytes["0-segment"] = 50 * MiB;   // 95% free (highest)
+    ssd_usage.used_bytes["1-segment"] = 500 * MiB;  // 50% free
+    ssd_usage.used_bytes["2-segment"] = 700 * MiB;  // 30% free
 
     // Exclude 0-segment which has the highest SSD free ratio
     std::set<std::string> excluded = {"0-segment"};
 
     auto result =
         ssd_strategy->Allocate(allocator_manager, 64 * 1024, 1, {}, excluded,
-                               ReplicaType::MEMORY, &ssd_provider);
+                               ReplicaType::MEMORY, &ssd_usage);
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1u);
 
@@ -889,15 +887,14 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstUsedExceedsTotalIsClamped) {
 
     // 0-segment: used exceeds total (concurrent drift) → clamped to 0% free
     // 1-segment: used=100, total=1000 → 90% free
-    MockSsdMetricsProvider ssd_provider;
-    ssd_provider.total_capacity["0-segment"] = 1000 * MiB;
-    ssd_provider.total_capacity["1-segment"] = 1000 * MiB;
-    ssd_provider.used_bytes["0-segment"] = 1500 * MiB;  // exceeds total
-    ssd_provider.used_bytes["1-segment"] = 100 * MiB;   // 90% free
+    MockSsdUsageProvider ssd_usage;
+    ssd_usage.total_capacity["0-segment"] = 1000 * MiB;
+    ssd_usage.total_capacity["1-segment"] = 1000 * MiB;
+    ssd_usage.used_bytes["0-segment"] = 1500 * MiB;  // exceeds total
+    ssd_usage.used_bytes["1-segment"] = 100 * MiB;   // 90% free
 
-    auto result =
-        ssd_strategy->Allocate(allocator_manager, 64 * 1024, 1, {}, {},
-                               ReplicaType::MEMORY, &ssd_provider);
+    auto result = ssd_strategy->Allocate(allocator_manager, 64 * 1024, 1, {},
+                                         {}, ReplicaType::MEMORY, &ssd_usage);
     ASSERT_TRUE(result.has_value());
     ASSERT_EQ(result.value().size(), 1u);
 
@@ -911,7 +908,7 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstUsedExceedsTotalIsClamped) {
 
 // Strategy-level performance comparison: Random vs SsdFreeRatioFirst.
 // Uses OffsetBufferAllocator (real physical memory via aligned_alloc) and
-// MockSsdMetricsProvider. Measures pure strategy overhead without MasterService
+// MockSsdUsageProvider. Measures pure strategy overhead without MasterService
 // locking, reflecting only the allocation algorithm cost.
 TEST_F(AllocationStrategyTest, SsdFreeRatioFirstVsRandomStrategyPerformance) {
     constexpr size_t kNumSegments = 64;
@@ -931,12 +928,12 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstVsRandomStrategyPerformance) {
     }
 
     // SSD free ratios vary uniformly from ~10% to ~90% across segments
-    MockSsdMetricsProvider ssd_provider;
+    MockSsdUsageProvider ssd_usage;
     for (size_t i = 0; i < kNumSegments; i++) {
         const auto name = "perf_seg_" + std::to_string(i);
-        ssd_provider.total_capacity[name] = 1000 * MiB;
+        ssd_usage.total_capacity[name] = 1000 * MiB;
         // used: 100 MiB (10% used) to 900 MiB (90% used)
-        ssd_provider.used_bytes[name] =
+        ssd_usage.used_bytes[name] =
             static_cast<int64_t>((100 + i * 800 / kNumSegments)) * MiB;
     }
 
@@ -967,8 +964,7 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstVsRandomStrategyPerformance) {
         // Warmup
         for (int i = 0; i < kWarmupRounds; i++) {
             (void)ssd_strategy->Allocate(allocator_manager, kAllocSize, 1, {},
-                                         {}, ReplicaType::MEMORY,
-                                         &ssd_provider);
+                                         {}, ReplicaType::MEMORY, &ssd_usage);
         }
     }
     std::vector<std::vector<Replica>> ssd_replicas;
@@ -977,7 +973,7 @@ TEST_F(AllocationStrategyTest, SsdFreeRatioFirstVsRandomStrategyPerformance) {
     auto t_ssd_start = std::chrono::steady_clock::now();
     for (int i = 0; i < kBenchmarkRounds; i++) {
         auto r = ssd_strategy->Allocate(allocator_manager, kAllocSize, 1, {},
-                                        {}, ReplicaType::MEMORY, &ssd_provider);
+                                        {}, ReplicaType::MEMORY, &ssd_usage);
         ASSERT_TRUE(r.has_value());
         ssd_replicas.emplace_back(std::move(r.value()));
     }

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -591,7 +591,7 @@ class MasterServiceHATest : public ::testing::Test {
     static int64_t GetLocalDiskUsedBytesForTesting(
         MasterService& service, const std::string& segment_name) {
         auto access = service.segment_manager_.getLocalDiskSegmentAccess();
-        return access.getSsdUsedBytes(segment_name);
+        return access.GetSsdUsedBytes(segment_name);
     }
 
     std::vector<std::string> policy_files_;

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -51,7 +51,6 @@ TEST_F(MasterMetricsTest, InitialStatusTest) {
     // Mem Storage Metrics
     ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
     ASSERT_EQ(metrics.get_total_mem_capacity(), 0);
-    ASSERT_DOUBLE_EQ(metrics.get_global_mem_used_ratio(), 0.0);
 
     // File Storage Metrics
     ASSERT_EQ(metrics.get_allocated_file_size(), 0);
@@ -166,11 +165,9 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_TRUE(mount_result.has_value());
     ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
     ASSERT_EQ(metrics.get_total_mem_capacity(), kSegmentSize);
-    ASSERT_DOUBLE_EQ(metrics.get_global_mem_used_ratio(), 0.0);
     ASSERT_EQ(metrics.get_segment_allocated_mem_size(segment.name), 0);
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
               kSegmentSize);
-    ASSERT_DOUBLE_EQ(metrics.get_segment_mem_used_ratio(segment.name), 0.0);
     ASSERT_EQ(metrics.get_mount_segment_requests(), 1);
     ASSERT_EQ(metrics.get_mount_segment_failures(), 0);
 
@@ -265,14 +262,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ASSERT_EQ(metrics.get_key_count(), 0);
     ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
     ASSERT_EQ(metrics.get_total_mem_capacity(), 0);
-    ASSERT_DOUBLE_EQ(metrics.get_global_mem_used_ratio(), 0.0);
     ASSERT_EQ(metrics.get_segment_allocated_mem_size(segment.name), 0);
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name), 0);
-    ASSERT_DOUBLE_EQ(metrics.get_segment_mem_used_ratio(segment.name), 0.0);
-
-    // check segment mem used ratio for non-existent segment
-    ASSERT_DOUBLE_EQ(metrics.get_segment_mem_used_ratio(""), 0.0);
-    ASSERT_DOUBLE_EQ(metrics.get_segment_mem_used_ratio("xxxxxx_segment"), 0.0);
 }
 
 TEST_F(MasterMetricsTest, ServiceTeardownReleasesSegmentCapacity) {
@@ -323,6 +314,16 @@ TEST_F(MasterMetricsTest, SnapshotReaderTeardownKeepsCapacityIntact) {
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
               static_cast<int64_t>(segment.size));
 
+    constexpr size_t kAllocationSize = 4 * 1024 * 1024;
+    std::shared_ptr<BufferAllocatorBase> source_allocator;
+    {
+        auto access = source_manager.getSegmentAccess();
+        source_allocator = access.GetAllocator(segment.id);
+    }
+    ASSERT_NE(source_allocator, nullptr);
+    auto source_buffer = source_allocator->allocate(kAllocationSize);
+    ASSERT_NE(source_buffer, nullptr);
+
     auto snapshot = SegmentSerializer(&source_manager).Serialize();
     ASSERT_TRUE(snapshot.has_value());
 
@@ -335,12 +336,20 @@ TEST_F(MasterMetricsTest, SnapshotReaderTeardownKeepsCapacityIntact) {
         SegmentSerializer reader_serializer(&reader);
         ASSERT_TRUE(
             reader_serializer.Deserialize(snapshot.value()).has_value());
+        const auto restored_usage = reader.GetMemoryUsageSnapshot();
+        EXPECT_EQ(restored_usage.used_bytes, kAllocationSize);
+        EXPECT_EQ(restored_usage.capacity_bytes, segment.size);
+        EXPECT_DOUBLE_EQ(restored_usage.used_ratio(), 0.25);
+        ASSERT_EQ(restored_usage.segments.size(), 1u);
+        EXPECT_EQ(restored_usage.segments.at(segment.name).used_bytes,
+                  kAllocationSize);
     }
     ASSERT_EQ(metrics.get_total_mem_capacity(), capacity_after_mount);
     ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
               static_cast<int64_t>(segment.size));
 
     // Unmount to restore the gauges for the other tests.
+    source_buffer.reset();
     {
         auto access = source_manager.getSegmentAccess();
         size_t dec_capacity = 0;
@@ -487,6 +496,14 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
 }
 
 TEST_F(MasterMetricsTest, AdminServerExposesStandbyStateWithoutService) {
+    TieredStorageUsageSnapshot stale_storage;
+    stale_storage.memory.used_bytes = 4096;
+    stale_storage.memory.capacity_bytes = 8192;
+    stale_storage.memory.segments["stale_leader_segment"] = {4096, 8192};
+    auto& metrics = MasterMetricManager::instance();
+    metrics.project_storage_usage(stale_storage);
+    ASSERT_EQ(metrics.get_allocated_mem_size(), 4096);
+
     const int http_port = getFreeTcpPort();
     MasterAdminServer admin_server(static_cast<uint16_t>(http_port),
                                    /*enable_metric_reporting=*/false);
@@ -504,6 +521,15 @@ TEST_F(MasterMetricsTest, AdminServerExposesStandbyStateWithoutService) {
     auto status_resp = FetchUrl(http_port, "/ha_status");
     EXPECT_EQ(status_resp.http_status, 200);
     EXPECT_EQ(status_resp.body, "standby");
+
+    auto metrics_resp = FetchUrl(http_port, "/metrics");
+    EXPECT_EQ(metrics_resp.http_status, 200);
+    EXPECT_EQ(metrics.get_allocated_mem_size(), 0);
+    EXPECT_EQ(metrics.get_total_mem_capacity(), 0);
+    EXPECT_EQ(metrics.get_segment_allocated_mem_size("stale_leader_segment"),
+              0);
+    EXPECT_EQ(metrics.get_segment_total_mem_capacity("stale_leader_segment"),
+              0);
 
     auto leader_resp = FetchUrl(http_port, "/leader");
     EXPECT_EQ(leader_resp.http_status, 200);
@@ -537,6 +563,13 @@ TEST_F(MasterMetricsTest, AdminServerRoutesServiceEndpointsWhenAvailable) {
     segment.size = 8 * 1024 * 1024;
     UUID client_id = generate_uuid();
     ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ReplicateConfig config;
+    config.replica_num = 1;
+    constexpr size_t kAllocationSize = 4096;
+    ASSERT_TRUE(service
+                    ->PutStart(client_id, "admin_metrics_projection_key",
+                               kAllocationSize, config)
+                    .has_value());
 
     const int http_port = getFreeTcpPort();
     MasterAdminServer admin_server(static_cast<uint16_t>(http_port),
@@ -545,6 +578,27 @@ TEST_F(MasterMetricsTest, AdminServerRoutesServiceEndpointsWhenAvailable) {
     admin_server.SetRuntimeState(ha::MasterRuntimeState::kServing);
     admin_server.SetServiceDelegate(service);
     admin_server.SetServiceAvailable(true);
+
+    auto& metrics = MasterMetricManager::instance();
+    metrics.reset_allocated_mem_size();
+    metrics.reset_total_mem_capacity();
+    metrics.reset_segment_allocated_mem_size(segment.name);
+    metrics.reset_segment_total_mem_capacity(segment.name);
+    ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
+    ASSERT_EQ(metrics.get_total_mem_capacity(), 0);
+
+    auto metrics_resp = FetchUrl(http_port, "/metrics");
+    EXPECT_EQ(metrics_resp.http_status, 200);
+    EXPECT_NE(metrics_resp.body.find("master_allocated_bytes 4096"),
+              std::string::npos);
+    EXPECT_NE(metrics_resp.body.find("master_total_capacity_bytes 8388608"),
+              std::string::npos);
+    EXPECT_EQ(metrics.get_allocated_mem_size(), kAllocationSize);
+    EXPECT_EQ(metrics.get_total_mem_capacity(), segment.size);
+    EXPECT_EQ(metrics.get_segment_allocated_mem_size(segment.name),
+              kAllocationSize);
+    EXPECT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
+              segment.size);
 
     auto segments_resp = FetchUrl(http_port, "/get_all_segments");
     EXPECT_EQ(segments_resp.http_status, 200);
@@ -565,6 +619,12 @@ TEST_F(MasterMetricsTest, AdminServerRoutesServiceEndpointsWhenAvailable) {
               std::string::npos);
     EXPECT_NE(detail_resp.body.find("\"allocator_capacity_bytes\""),
               std::string::npos);
+
+    ASSERT_TRUE(service
+                    ->PutRevoke(client_id, "admin_metrics_projection_key",
+                                ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service->UnmountSegment(segment.id, client_id).has_value());
 
     admin_server.Stop();
 }

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -822,7 +822,7 @@ TEST_F(MasterServiceSSDTest, EvictDiskReplicaDecrementsFileCacheNums) {
 // three configurations:
 //   (A) RANDOM, no offload        — baseline, original behavior
 //   (B) RANDOM, with offload      — isolates disk-replica creation overhead
-//   (C) SSD_FREE_RATIO_FIRST, with offload — adds SSD metrics lock + sorting
+//   (C) SSD_FREE_RATIO_FIRST, with offload — adds SSD usage lock + sorting
 //
 // Comparing A→B separates the cost of mounting LocalDisk segments.
 // Comparing B→C isolates the pure SSD-ranking strategy overhead.

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -84,8 +84,8 @@ class BlockingAllocationStrategy final : public AllocationStrategy {
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
         const ReplicaType replica_type,
-        const SsdMetricsProvider* ssd_provider) override {
-        (void)ssd_provider;
+        const SsdUsageProvider* ssd_usage) override {
+        (void)ssd_usage;
         return Allocate(allocator_manager, slice_length, replica_num,
                         preferred_segments, excluded_segments, replica_type);
     }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -2223,12 +2223,12 @@ TEST_F(PromotionOnHitTest, WatermarkUsesAllocatorStateAfterMetricsReset) {
     metrics.reset_total_mem_capacity();
     metrics.reset_segment_allocated_mem_size(segment_name);
     metrics.reset_segment_total_mem_capacity(segment_name);
-    EXPECT_DOUBLE_EQ(metrics.get_global_mem_used_ratio(), 0.0);
+    EXPECT_EQ(metrics.get_allocated_mem_size(), 0);
+    EXPECT_EQ(metrics.get_total_mem_capacity(), 0);
 
-    const int64_t rejected_before =
-        metrics.get_promotion_rejected_watermark();
-    auto get_result = service->GetReplicaList("allocator_watermark_key",
-                                              TenantId::Default());
+    const int64_t rejected_before = metrics.get_promotion_rejected_watermark();
+    auto get_result =
+        service->GetReplicaList("allocator_watermark_key", TenantId::Default());
     EXPECT_TRUE(get_result.has_value());
     EXPECT_EQ(metrics.get_promotion_rejected_watermark() - rejected_before, 1);
 

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -86,6 +86,19 @@ class PromotionOnHitTest : public ::testing::Test {
         return service->promotion_in_flight_.load(std::memory_order_relaxed);
     }
 
+    static std::unique_ptr<AllocatedBuffer> AllocateOnSegmentForTesting(
+        MasterService* service, const UUID& segment_id, size_t size) {
+        std::shared_ptr<BufferAllocatorBase> allocator;
+        {
+            auto segment_access = service->segment_manager_.getSegmentAccess();
+            allocator = segment_access.GetAllocator(segment_id);
+        }
+        if (!allocator) {
+            return nullptr;
+        }
+        return allocator->allocate(size);
+    }
+
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
 
     std::string WriteTenantQuotaPolicyFile(
@@ -2182,6 +2195,50 @@ TEST_F(PromotionOnHitTest, MetricsRejectionCountersIncrementOnGateMiss) {
     EXPECT_EQ(mm.get_promotion_rejected_watermark() - wm_pre, 1);
 
     wm_service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, WatermarkUsesAllocatorStateAfterMetricsReset) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.eviction_high_watermark_ratio = 0.5;
+    config.default_kv_lease_ttl = 2000;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+    constexpr size_t kAllocationSize = 12 * 1024 * 1024;
+    const std::string segment_name = "allocator_watermark_segment";
+    auto segment = PrepareSegment(*service, segment_name, kDefaultSegmentBase,
+                                  kSegmentSize);
+    auto allocated = AllocateOnSegmentForTesting(
+        service.get(), segment.segment_id, kAllocationSize);
+    ASSERT_NE(allocated, nullptr);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, segment.client_id,
+                                       "allocator_watermark_key", 1024,
+                                       segment.segment_name));
+
+    auto& metrics = MasterMetricManager::instance();
+    metrics.reset_allocated_mem_size();
+    metrics.reset_total_mem_capacity();
+    metrics.reset_segment_allocated_mem_size(segment_name);
+    metrics.reset_segment_total_mem_capacity(segment_name);
+    EXPECT_DOUBLE_EQ(metrics.get_global_mem_used_ratio(), 0.0);
+
+    const int64_t rejected_before =
+        metrics.get_promotion_rejected_watermark();
+    auto get_result = service->GetReplicaList("allocator_watermark_key",
+                                              TenantId::Default());
+    EXPECT_TRUE(get_result.has_value());
+    EXPECT_EQ(metrics.get_promotion_rejected_watermark() - rejected_before, 1);
+
+    // Restore the observable gauges before normal teardown. The business
+    // assertion above intentionally reset them, but allocator and service
+    // destructors still emit their matching decrements.
+    metrics.inc_allocated_mem_size(segment_name, kAllocationSize);
+    metrics.inc_total_mem_capacity(segment_name, kSegmentSize);
+    allocated.reset();
+    service->RemoveAll();
 }
 
 TEST_F(PromotionOnHitTest, AdmissionFrequencyIsTenantScoped) {

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -163,6 +163,63 @@ TEST_F(SegmentTest, MountSegmentSuccess) {
     ValidateMountedSegment(segment_manager, segment, client_id);
 }
 
+TEST_F(SegmentTest, MemoryUsageSnapshotTracksMountedAllocatorState) {
+    SegmentManager segment_manager(BufferAllocatorType::OFFSET);
+    constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+    constexpr size_t kAllocationSize = 4 * 1024 * 1024;
+
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "usage_snapshot_segment";
+    segment.size = kSegmentSize;
+    segment.base = 0x100000000;
+    UUID client_id = generate_uuid();
+
+    std::shared_ptr<BufferAllocatorBase> allocator;
+    {
+        auto segment_access = segment_manager.getSegmentAccess();
+        ASSERT_EQ(segment_access.MountSegment(segment, client_id),
+                  ErrorCode::OK);
+        allocator = segment_access.GetAllocator(segment.id);
+    }
+    ASSERT_NE(allocator, nullptr);
+
+    auto buffer = allocator->allocate(kAllocationSize);
+    ASSERT_NE(buffer, nullptr);
+
+    auto snapshot = segment_manager.GetMemoryUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+    EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.25);
+
+    {
+        auto segment_access = segment_manager.getSegmentAccess();
+        ASSERT_EQ(segment_access.SetSegmentStatusByName(
+                      segment.name, SegmentStatus::DRAINING),
+                  ErrorCode::OK);
+    }
+    snapshot = segment_manager.GetMemoryUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+
+    buffer.reset();
+    {
+        auto segment_access = segment_manager.getSegmentAccess();
+        size_t metrics_dec_capacity = 0;
+        ASSERT_EQ(segment_access.PrepareUnmountSegment(
+                      segment.id, metrics_dec_capacity),
+                  ErrorCode::OK);
+        ASSERT_EQ(segment_access.CommitUnmountSegment(
+                      segment.id, client_id, metrics_dec_capacity),
+                  ErrorCode::OK);
+    }
+
+    snapshot = segment_manager.GetMemoryUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, 0u);
+    EXPECT_EQ(snapshot.capacity_bytes, 0u);
+    EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.0);
+}
+
 // MountSegmentDuplicate Tests:
 // 1. MountSegment with the same segment id. The second mount operation return
 // SEGMENT_ALREADY_EXISTS.

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -1,5 +1,7 @@
 #include "segment.h"
 
+#include "master_metric_manager.h"
+
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
@@ -141,6 +143,25 @@ class SegmentTest : public ::testing::Test {
         client_ids.push_back(client_id);
         ValidateMountedLocalDiskSegments(segment_manager, segments, client_ids);
     }
+
+    void InstallSharedCxlAllocatorForTesting(
+        SegmentManager& segment_manager,
+        const std::shared_ptr<BufferAllocatorBase>& allocator,
+        const std::vector<Segment>& segments) {
+        segment_manager.cxl_global_allocator_ = allocator;
+        for (const auto& segment : segments) {
+            segment_manager.mounted_segments_[segment.id] = {
+                segment, SegmentStatus::OK, allocator};
+        }
+    }
+
+    std::shared_ptr<BufferAllocatorBase> GetNoFAllocatorForTesting(
+        NoFSegmentManager& segment_manager, const UUID& segment_id) {
+        auto it = segment_manager.mounted_segments_.find(segment_id);
+        return it == segment_manager.mounted_segments_.end()
+                   ? nullptr
+                   : it->second.buf_allocator;
+    }
 };
 
 // Mount Segment Operations Tests:
@@ -191,6 +212,9 @@ TEST_F(SegmentTest, MemoryUsageSnapshotTracksMountedAllocatorState) {
     EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
     EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
     EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.25);
+    ASSERT_EQ(snapshot.segments.size(), 1u);
+    EXPECT_EQ(snapshot.segments.at(segment.name).used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.segments.at(segment.name).capacity_bytes, kSegmentSize);
 
     {
         auto segment_access = segment_manager.getSegmentAccess();
@@ -206,11 +230,11 @@ TEST_F(SegmentTest, MemoryUsageSnapshotTracksMountedAllocatorState) {
     {
         auto segment_access = segment_manager.getSegmentAccess();
         size_t metrics_dec_capacity = 0;
-        ASSERT_EQ(segment_access.PrepareUnmountSegment(
-                      segment.id, metrics_dec_capacity),
+        ASSERT_EQ(segment_access.PrepareUnmountSegment(segment.id,
+                                                       metrics_dec_capacity),
                   ErrorCode::OK);
-        ASSERT_EQ(segment_access.CommitUnmountSegment(
-                      segment.id, client_id, metrics_dec_capacity),
+        ASSERT_EQ(segment_access.CommitUnmountSegment(segment.id, client_id,
+                                                      metrics_dec_capacity),
                   ErrorCode::OK);
     }
 
@@ -218,6 +242,97 @@ TEST_F(SegmentTest, MemoryUsageSnapshotTracksMountedAllocatorState) {
     EXPECT_EQ(snapshot.used_bytes, 0u);
     EXPECT_EQ(snapshot.capacity_bytes, 0u);
     EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.0);
+}
+
+TEST_F(SegmentTest, MemoryUsageSnapshotCountsSharedCxlAllocatorOnce) {
+    SegmentManager segment_manager(BufferAllocatorType::OFFSET,
+                                   /*enable_cxl=*/true);
+    constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+    constexpr size_t kAllocationSize = 4 * 1024 * 1024;
+    auto allocator = std::make_shared<OffsetBufferAllocator>(
+        "cxl_pool", 0x200000000, kSegmentSize, "cxl_pool");
+    InstallSharedCxlAllocatorForTesting(segment_manager, allocator, {});
+
+    auto buffer = allocator->allocate(kAllocationSize);
+    ASSERT_NE(buffer, nullptr);
+
+    auto snapshot = segment_manager.GetMemoryUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+
+    Segment first;
+    first.id = generate_uuid();
+    first.name = "cxl_client_a";
+    first.protocol = "cxl";
+    Segment second;
+    second.id = generate_uuid();
+    second.name = "cxl_client_b";
+    second.protocol = "cxl";
+    InstallSharedCxlAllocatorForTesting(segment_manager, allocator,
+                                        {first, second});
+
+    snapshot = segment_manager.GetMemoryUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+    ASSERT_EQ(snapshot.segments.size(), 1u);
+    EXPECT_EQ(snapshot.segments.at("cxl_pool").used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.segments.at("cxl_pool").capacity_bytes, kSegmentSize);
+}
+
+TEST_F(SegmentTest, NoFUsageSnapshotSurvivesMetricsReset) {
+    NoFSegmentManager segment_manager(BufferAllocatorType::OFFSET);
+    constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+    constexpr size_t kAllocationSize = 4 * 1024 * 1024;
+
+    NoFSegment segment;
+    segment.id = generate_uuid();
+    segment.name = "nof_usage_snapshot_segment";
+    segment.size = kSegmentSize;
+    segment.base = 0x300000000;
+    segment.te_endpoint = "nof_usage_snapshot_endpoint";
+    UUID client_id = generate_uuid();
+
+    {
+        auto segment_access = segment_manager.getNoFSegmentAccess();
+        ASSERT_EQ(segment_access.MountSegment(segment, client_id),
+                  ErrorCode::OK);
+    }
+    auto allocator = GetNoFAllocatorForTesting(segment_manager, segment.id);
+    ASSERT_NE(allocator, nullptr);
+    auto buffer = allocator->allocate(kAllocationSize);
+    ASSERT_NE(buffer, nullptr);
+
+    auto snapshot = segment_manager.GetUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+    EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.25);
+
+    auto& metrics = MasterMetricManager::instance();
+    metrics.reset_allocated_nof_size();
+    metrics.reset_total_nof_capacity();
+    EXPECT_EQ(metrics.get_allocated_nof_size(), 0);
+    EXPECT_EQ(metrics.get_total_nof_capacity(), 0);
+
+    snapshot = segment_manager.GetUsageSnapshot();
+    EXPECT_EQ(snapshot.used_bytes, kAllocationSize);
+    EXPECT_EQ(snapshot.capacity_bytes, kSegmentSize);
+    EXPECT_DOUBLE_EQ(snapshot.used_ratio(), 0.25);
+
+    // Restore global gauges before teardown because allocator and segment
+    // cleanup still emit their matching decrements.
+    metrics.inc_allocated_nof_size("", kAllocationSize);
+    metrics.inc_total_nof_capacity("", kSegmentSize);
+    buffer.reset();
+    {
+        auto segment_access = segment_manager.getNoFSegmentAccess();
+        size_t metrics_dec_capacity = 0;
+        ASSERT_EQ(segment_access.PrepareUnmountSegment(segment.id,
+                                                       metrics_dec_capacity),
+                  ErrorCode::OK);
+        ASSERT_EQ(segment_access.CommitUnmountSegment(segment.id, client_id,
+                                                      metrics_dec_capacity),
+                  ErrorCode::OK);
+    }
 }
 
 // MountSegmentDuplicate Tests:


### PR DESCRIPTION
## Description

This umbrella refactor makes storage metrics a projection of authoritative Store state instead of an input to business decisions:

- add coherent DRAM and NoF usage snapshots derived from mounted allocators, including shared CXL allocator deduplication;
- use domain snapshots for DRAM eviction, promotion admission, NoF eviction, and restore logging;
- refresh Prometheus DRAM/NoF gauges from tiered snapshots on admin metric reads and periodic reports, clearing stale HA leader projections on standby;
- rename `SsdMetricsProvider` to `SsdUsageProvider` and document its domain-state invariants;
- remove the business-oriented DRAM/NoF ratio APIs from `MasterMetricManager`;
- cover metric reset, snapshot restore, standby/HA transition, shared CXL, NoF, and Prometheus projection behavior.

The change is organized as three reviewable commits:

1. decouple DRAM eviction and promotion decisions;
2. add NoF/domain projection, API cleanup, and resilience tests;
3. clarify the SSD usage domain boundary and update documentation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
./scripts/code_format.sh -b origin/main
pre-commit run --files <all touched files>
make -C docs html
cmake -S . -B /private/tmp/mooncake-3158-build -G Ninja \
  -DBUILD_UNIT_TESTS=ON -DBUILD_BENCHMARK=OFF \
  -DWITH_STORE_RUST=OFF -DWITH_STORE_GO=OFF \
  -DWITH_P2P_STORE=OFF -DWITH_EP=OFF \
  -DUSE_CUDA=OFF -DUSE_NOF=OFF
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

- clang-format 20 and all pre-commit hooks passed on every touched file.
- Sphinx HTML build succeeded. It emitted seven warnings only because external intersphinx inventories were unreachable in the sandbox.
- The local CMake configure reached dependency discovery but could not complete on macOS because the required `yaml-cpp` system development package is unavailable. Linux PR CI is the authoritative compile/unit-test validation.

## Checklist

- [ ] I have performed a human self-review of every changed line
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (scoped run on all touched files passed)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3158)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with the architecture audit, implementation, test additions, documentation updates, formatting, and PR preparation. The human submitter must review every changed line and be able to defend the change end-to-end before marking this draft ready for review.