### PR TITLE
[PG] Inherit control host from injected TransferEngine

### DIFF
--- a/docs/source/design/mooncake-backend-pg.md
+++ b/docs/source/design/mooncake-backend-pg.md
@@ -82,7 +82,11 @@ By default, Mooncake Backend initializes its own Transfer Engine. Advanced
 integrations may call `pg.set_transfer_engine(engine)` before
 `init_process_group()` to inject an external Transfer Engine. In that mode, the
 caller owns the engine and must keep it alive until all Mooncake process groups
-using it are destroyed.
+using it are destroyed. The injected, initialized engine's local endpoint also
+supplies the default control-plane host identity, so integrations do not need
+to configure `pg.set_host_ip()` separately. `set_host_ip()` remains an explicit
+override for PG-owned engines and specialized deployments when called after
+the engine is injected.
 
 ## Initialization lifecycle
 

--- a/mooncake-pg/src/pg_py.cpp
+++ b/mooncake-pg/src/pg_py.cpp
@@ -1,4 +1,5 @@
 #include <mooncake_backend.h>
+#include <common.h>
 #include <pybind11/gil.h>
 #include <pybind11/stl.h>
 #include <torch/csrc/utils/pybind.h>
@@ -241,6 +242,12 @@ void setTransferEnginePy(pybind11::object engine_obj) {
     g_ctx.external_engine = reinterpret_cast<TransferEngine*>(ptr);
     g_ctx.engine = g_ctx.external_engine;
     g_ctx.engine_initialized = true;
+    const auto endpoint = g_ctx.engine->getLocalIpAndPort();
+    const auto host_ip = getHostNameWithoutPort(endpoint);
+    TORCH_CHECK(!host_ip.empty(),
+                "set_transfer_engine requires an initialized TransferEngine "
+                "with a local endpoint");
+    g_ctx.host_ip = host_ip;
 }
 
 void shutdownProcessContext() {
@@ -283,7 +290,9 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("set_transfer_engine", &setTransferEnginePy, py::arg("engine"),
           "Set an external TransferEngine to be used by MooncakeBackend. "
           "Must be called before init_process_group(). The engine must already "
-          "be initialized. Pass None to reset to default behavior. "
+          "be initialized. Its local endpoint supplies the default PG "
+          "control-plane host; set_host_ip() called afterward overrides it. "
+          "Pass None to reset to default engine behavior. "
           "The caller must ensure the TransferEngine object outlives all "
           "MooncakeBackend instances.");
     m.def("get_preferred_hca", &getPreferredHca);


### PR DESCRIPTION
## Description

When `pg.set_transfer_engine(engine)` adopts an initialized external TransferEngine, derive the process-group control-plane host from `engine.getLocalIpAndPort()`. This keeps Agent/Coordinator RPC advertisement aligned with the injected engine endpoint and removes the need for integrations such as SGLang to call `pg.set_host_ip()` separately.

`set_host_ip()` remains an explicit override when called after engine injection.

## Module

- [x] Mooncake PG (`mooncake-pg`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] Documentation update

## How Has This Been Tested?

**Test commands:**
```bash
# Four ranks across two RDMA hosts; each rank initializes an external TransferEngine,
# calls mooncake.pg.set_transfer_engine(engine), intentionally omits set_host_ip(),
# then initializes Mooncake PG and runs GPU all-reduce.
MOONCAKE_PGTEST_SHARED_TE=1 python3 scripts/mooncake_pg_cross_node_smoke.py
```

**Test results:**
- [x] Manual testing done: all four ranks completed GPU all-reduce with value `10`; node 1 registered against the injected engine host rather than `127.0.0.1`.
- [x] Static checks: `clang-format --dry-run --Werror mooncake-pg/src/pg_py.cpp` and `git diff --check`.
- [ ] Unit tests pass: not run; this path requires an initialized external TransferEngine and cross-node RDMA.
- [ ] Integration tests pass (if applicable)

The existing shared-TransferEngine teardown SIGSEGV in `LinkManager::tearDownPeerLink` remains separate from this bootstrap fix: it occurs after a successful collective and predates this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (checked the changed C++ file with `clang-format --dry-run --Werror`)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (the local environment does not have `pre-commit` installed)
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective (covered by the cross-node shared-TE smoke above)
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (Codex assisted with code organization, documentation, and validation planning; the author reviewed the implementation and test results.)