### PR TITLE
[CI] Fix a flaky test-wheel-ubuntu CI failure caused by a port 8080 race condition in run_tests.sh

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -131,6 +131,19 @@ python test_cli.py
 killall mooncake_http_metadata_server || true
 killall mooncake_master || true
 killall mooncake_client || true
+# killall only sends SIGTERM and returns immediately; the next master enables
+# the embedded HTTP metadata server and must bind 8080, which the Python
+# mooncake_http_metadata_server may still hold while it shuts down. Poll until
+# nothing listens on 8080 anymore instead of racing it (bounded to ~10s).
+for i in $(seq 1 100); do
+    ss -tlnp 2>/dev/null | grep -q ':8080 ' || break
+    sleep 0.1
+done
+if ss -tlnp 2>/dev/null | grep -q ':8080 '; then
+    echo "ERROR: port 8080 is still in use after 10s, cannot start master with embedded HTTP metadata server"
+    ss -tlnp | grep ':8080 ' || true
+    exit 1
+fi
 mooncake_master --default_kv_lease_ttl=500 --enable_http_metadata_server=true &
 MASTER_PID=$!
 sleep 1


### PR DESCRIPTION
## Description

Fix a flaky `test-wheel-ubuntu` CI failure caused by a port 8080 race condition in `run_tests.sh`.

Related PR  (#3118): https://github.com/kvcache-ai/Mooncake/actions/runs/30271804475/job/90502655247?pr=3118

## Root Cause

In `run_tests.sh`, the last test block does:

```bash
killall mooncake_http_metadata_server || true
killall mooncake_master || true
mooncake_master --default_kv_lease_ttl=500 --enable_http_metadata_server=true &
```

`killall` sends SIGTERM and returns immediately, but the Python metadata server may still be shutting down and holding port 8080. When the new master starts with `--enable_http_metadata_server=true`, it races to bind 8080. If it loses the race, the master FATAL-crashes, and `test_distributed_object_store.py` fails with:

```
Failed to start HTTP metadata server on 0.0.0.0:8080
Failed to start HTTP metadata server
*** Check failure stack trace: ***
```

This is probabilistic — it triggers more easily on slower CI runners, hence the flaky pattern across different Ubuntu versions.

## Fix

Replace the implicit race with an explicit poll: after `killall`, wait until nothing listens on 8080 before starting the master (bounded to 10s):

```bash
for i in $(seq 1 100); do
    ss -tlnp 2>/dev/null | grep -q ':8080 ' || break
    sleep 0.1
done
```