### PR TITLE
[Bugfix] Detect AMD amdgpu for TENT GPUDirect RDMA capability

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -245,10 +245,16 @@ static bool isGpuDirectRdmaSupported(std::shared_ptr<Config> conf) {
     if (disable_gpu_direct) {
         return false;
     }
+    // Detect vendor GPUDirect/peer-memory drivers from /proc/modules.
+    // NVIDIA: nvidia_peermem. AMD: peermem is built into amdgpu (linked with
+    // ib_core), so the amdgpu module itself is the presence signal.
     std::ifstream modules("/proc/modules");
     std::string line;
     while (std::getline(modules, line)) {
-        if (line.find("nvidia_peermem") != std::string::npos) {
+        const auto name_end = line.find(' ');
+        const auto name =
+            name_end == std::string::npos ? line : line.substr(0, name_end);
+        if (name == "nvidia_peermem" || name == "amdgpu") {
             return true;
         }
     }


### PR DESCRIPTION
## Description

TENT's `isGpuDirectRdmaSupported()` previously only checked `/proc/modules` for `nvidia_peermem`. On AMD ROCm hosts, GPU peer memory is integrated into `amdgpu` and `nvidia_peermem` is never loaded, so the RDMA transport never enabled `gpu_to_gpu` / `gpu_to_dram` / `dram_to_gpu`. As a result, VRAM↔VRAM (and other GPU-involved) RDMA requests failed at transport selection with `UNSPEC`.

This change also recognizes the `amdgpu` module and matches by the first field of `/proc/modules` (exact module name) to avoid false matches in the dependency list.

Note: classic TE does not have this gate; it registers GPU memory via HIP dmabuf / `ibv_reg_mr` at MR registration time. This bug is TENT-specific.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake .. -DCMAKE_BUILD_TYPE=Release \
  -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON -DUSE_HIP=ON \
  -DUSE_CUDA=OFF -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF
cmake --build . --target tebench -j64

# Target: all GPUs, default discovery (no MC_TENT_CONF / MC_TE_FILTERS)
./tebench --backend=tent --seg_type=VRAM --xport_type=rdma \
  --metadata_type=p2p --local_gpu_id=-1 --total_buffer_size=$((512<<20))

# Initiator: all GPUs -> target
./tebench --backend=tent --target_seg_name=<SEG> --seg_type=VRAM \
  --xport_type=rdma --op_type=read --local_gpu_id=-1 --duration=5 \
  --start_block_size=1048576 --max_block_size=1048576 \
  --start_num_threads=1 --max_num_threads=8 \
  --total_buffer_size=$((512<<20))
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual validation on 8× MI308X + ROCm 7.2 + 8× Broadcom RoCE NICs (`bnxt_re_bond0`–`7`), without `MC_TENT_CONF` / `MC_TE_FILTERS`, `--local_gpu_id=-1` (8 VRAM buffers × 512 MiB per side):
- Before: VRAM RDMA failed with `Unable to find registered buffer` / transport `UNSPEC`
- After: VRAM RDMA read succeeded; engine used default policy and all 8 RDMA devices

| Threads | BW (GB/s) | Avg Lat (us) | P99 Tx (us) |
| ---: | ---: | ---: | ---: |
| 1 | 20.8 | 50.3 | 55 |
| 2 | 35.3 | 59.4 | 75 |
| 4 | 52.2 | 80.3 | 113 |
| 8 | 59.6 | 140.7 | 252 |

TENT metrics reported ~981 GB read with 0 failures during the run.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Agent helped identify the root cause, draft the patch, and reproduce/validate with tebench on a local ROCm host. The human submitter reviewed every changed line.

Made with [Cursor](https://cursor.com)