### PR TITLE
[Bugfix][TE] Fix dma-buf offsets for chunked GPU MRs

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -394,6 +394,11 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     for (size_t ci = 0; ci < chunks.size(); ++ci) {
         void *chunk_addr = chunks[ci].first;
         size_t chunk_len = chunks[ci].second;
+        const uint64_t chunk_offset = reinterpret_cast<uintptr_t>(chunk_addr) -
+                                      reinterpret_cast<uintptr_t>(addr);
+        DmabufExport chunk_dmabuf_exp = dmabuf_exp;
+        if (chunk_dmabuf_exp.method == DmabufExport::Method::kDmabufReg)
+            chunk_dmabuf_exp.offset += chunk_offset;
 
         if (do_pre_touch) {
             // Parallel pre-touch the memory to speed up registration.
@@ -429,10 +434,10 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
             const int ar = access_rights;  // Local copy for lambda capture
 
             for (size_t i = 0; i < context_list_.size(); ++i) {
-                reg_threads.emplace_back([this, &ret_codes, &dmabuf_exp, i,
+                reg_threads.emplace_back([this, &ret_codes, chunk_dmabuf_exp, i,
                                           chunk_addr, chunk_len, ar]() {
                     ret_codes[i] = context_list_[i]->registerMemoryRegion(
-                        chunk_addr, chunk_len, ar, dmabuf_exp);
+                        chunk_addr, chunk_len, ar, chunk_dmabuf_exp);
                 });
             }
 
@@ -453,7 +458,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
         } else {
             for (size_t i = 0; i < context_list_.size(); ++i) {
                 int ret = context_list_[i]->registerMemoryRegion(
-                    chunk_addr, chunk_len, access_rights, dmabuf_exp);
+                    chunk_addr, chunk_len, access_rights, chunk_dmabuf_exp);
                 if (ret) {
                     LOG(ERROR) << "Failed to register memory region (chunk "
                                << ci << ") with context " << i;

--- a/mooncake-transfer-engine/tests/rdma_async_event_drain_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_async_event_drain_test.cpp
@@ -37,9 +37,17 @@
 #else
 #define MC_HAS_FEATURE(x) 0
 #endif
-#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer)
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer) || \
+    MC_HAS_FEATURE(leak_sanitizer)
 #include <sanitizer/lsan_interface.h>
 #define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+
+// Suppress false positives from libnuma.so's process-wide static cache
+// allocated in numa_node_to_cpus() which is intentionally retained until exit.
+extern "C" __attribute__((weak, visibility("default"))) const char *
+__lsan_default_suppressions() {
+    return "leak:libnuma.so\n";
+}
 #else
 #define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
 #endif

--- a/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
@@ -44,6 +44,7 @@
 
 #if defined(USE_CUDA) || defined(USE_HIP)
 #include "cuda_alike.h"
+#include "environ.h"
 #endif
 #include "config.h"
 #include "transfer_engine.h"
@@ -214,6 +215,86 @@ TEST_F(RDMALargeMrTest, WriteWithSourceStraddlingChunkBoundary) {
     ASSERT_EQ(0, memcmp((char *)addr + kSourceOffset,
                         (char *)addr + kTargetOffset, kDataLength));
 }
+
+#if defined(USE_CUDA) || defined(USE_HIP)
+class RDMAGpuDmabufChunkTest : public ::testing::Test {
+   protected:
+    std::unique_ptr<TransferEngine> engine;
+    void *gpu_addr = nullptr;
+
+    void SetUp() override {
+        int device_count = 0;
+        ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+        if (device_count == 0) GTEST_SKIP() << "No GPU available";
+        ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+#if defined(USE_CUDA)
+        ASSERT_FALSE(Environ::Get().GetWithNvidiaPeermem())
+            << "Launch with WITH_NVIDIA_PEERMEM=0 so this test exercises "
+               "ibv_reg_dmabuf_mr instead of the nvidia-peermem fallback";
+#endif
+
+        engine = std::make_unique<TransferEngine>(true);
+        const char *env_meta = std::getenv("MC_METADATA_SERVER");
+        std::string metadata_server = env_meta ? env_meta : "P2PHANDSHAKE";
+        ASSERT_EQ(engine->init(metadata_server, "test_node_gpu_dmabuf_chunk"),
+                  0);
+        ASSERT_EQ(globalConfig().max_mr_size, kMaxMrSize)
+            << "Launch this test process with MC_MAX_MR_SIZE=" << kMaxMrSize;
+
+        ASSERT_EQ(cudaMalloc(&gpu_addr, kBufferSize), cudaSuccess);
+        ASSERT_EQ(engine->registerLocalMemory(gpu_addr, kBufferSize,
+                                              GPU_PREFIX + "0"),
+                  0);
+    }
+
+    void TearDown() override {
+        if (engine && gpu_addr) engine->unregisterLocalMemory(gpu_addr);
+        if (gpu_addr) cudaFree(gpu_addr);
+    }
+};
+
+// The allocation is split into four MRs. Before the fix, every chunk is
+// registered with the dma-buf offset of chunk 0. A loopback WRITE targeting
+// chunk 3 therefore maps the wrong GPU pages, fails registration/transfer, or
+// completes without updating the requested destination bytes.
+TEST_F(RDMAGpuDmabufChunkTest, LaterChunkUsesItsOwnDmabufOffset) {
+    const size_t kDataLength = 1ull << 20;
+    const size_t kTargetOffset = kBufferSize - kDataLength;
+    std::vector<char> source(kDataLength);
+    std::vector<char> result(kDataLength, 0);
+    for (size_t i = 0; i < source.size(); ++i)
+        source[i] = (char)('a' + (lrand48() % 26));
+
+    ASSERT_EQ(cudaMemcpy(gpu_addr, source.data(), kDataLength,
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+    ASSERT_EQ(cudaMemset((char *)gpu_addr + kTargetOffset, 0, kDataLength),
+              cudaSuccess);
+
+    auto batch_id = engine->allocateBatchID(1);
+    TransferRequest entry;
+    entry.opcode = TransferRequest::WRITE;
+    entry.length = kDataLength;
+    entry.source = gpu_addr;
+    entry.target_id = LOCAL_SEGMENT_ID;
+    entry.target_offset = (uint64_t)gpu_addr + kTargetOffset;
+    ASSERT_TRUE(engine->submitTransfer(batch_id, {entry}).ok());
+
+    TransferStatus status;
+    while (true) {
+        ASSERT_EQ(engine->getTransferStatus(batch_id, 0, status), Status::OK());
+        if (status.s != TransferStatusEnum::WAITING) break;
+    }
+    ASSERT_EQ(engine->freeBatchID(batch_id), Status::OK());
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    ASSERT_EQ(cudaMemcpy(result.data(), (char *)gpu_addr + kTargetOffset,
+                         kDataLength, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(result, source);
+}
+#endif
 
 }  // namespace mooncake
 


### PR DESCRIPTION
## Description

Large GPU buffers are split into multiple memory regions (MRs) when exceeding `max_mr_size`. Previously, every chunk reused the dma-buf offset exported for the base buffer address. As a result, later chunks registered or mapped the wrong GPU pages.

This change fixes the issue by adding each chunk's relative displacement (`chunk_addr - addr`) to its `chunk_dmabuf_exp.offset` in both serial and parallel registration paths inside `RdmaTransport::registerLocalMemoryInternal`. It also adds a GPU loopback regression test (`RDMAGpuDmabufChunkTest.LaterChunkUsesItsOwnDmabufOffset`) that transfers data targeting a later chunk.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
MC_MAX_MR_SIZE=67108864 \
WITH_NVIDIA_PEERMEM=0 \
./build/mooncake-transfer-engine/tests/rdma_large_mr_test \
  --gtest_filter=RDMAGpuDmabufChunkTest.LaterChunkUsesItsOwnDmabufOffset