### PR TITLE
[Store] Harden Put/Upsert completion against promotion lifecycle

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1352,7 +1352,8 @@ class MasterService {
         ObjectMetadata& metadata);
     size_t EraseReplicasWithCacheTotalAccounting(
         ObjectMetadata& metadata,
-        const std::function<bool(const Replica&)>& pred_fn);
+        const std::function<bool(const Replica&)>& pred_fn,
+        std::vector<ReplicaID>* erased_replica_ids = nullptr);
 
     std::unordered_map<std::string, std::string> object_group_ids_
         GUARDED_BY(group_routing_mutex_);
@@ -1549,7 +1550,7 @@ class MasterService {
     // Helper to clean up stale handles pointing to unmounted segments
     // or local_disk replicas whose owner client is no longer alive.
     bool CleanupStaleHandles(
-        ObjectMetadata& metadata,
+        TenantState& tenant_state, ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
         MetadataShardAccessorRW* shard = nullptr);
 
@@ -1650,6 +1651,10 @@ class MasterService {
             MasterMetricManager::instance().inc_promotion_cancelled();
         }
     }
+    void CancelPromotionTaskForRemovedReplicas(
+        TenantState& tenant_state, ObjectMetadata& metadata,
+        const std::vector<ReplicaID>& removed_replica_ids)
+        NO_THREAD_SAFETY_ANALYSIS;
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
@@ -1722,10 +1727,15 @@ class MasterService {
                 // replicas.
                 const uint64_t before_charge =
                     service_->CompletedMemoryQuotaCharge(it_->second);
+                std::vector<ReplicaID> removed_replica_ids;
                 service_->EraseReplicasWithCacheTotalAccounting(
-                    it_->second, [](const Replica& replica) {
+                    it_->second,
+                    [](const Replica& replica) {
                         return replica.has_invalid_mem_handle();
-                    });
+                    },
+                    &removed_replica_ids);
+                service_->CancelPromotionTaskForRemovedReplicas(
+                    *tenant_state_, it_->second, removed_replica_ids);
                 const uint64_t after_charge =
                     service_->CompletedMemoryQuotaCharge(it_->second);
                 if (before_charge > after_charge) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3787,34 +3787,51 @@ auto MasterService::PutEnd(const UUID& client_id, const ObjectMeta& object_meta,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    // Promotion stages PROCESSING replicas without registering a primary
-    // Put/Upsert operation. End is valid only after a successful primary
-    // Start installed the processing marker for this key.
+    auto is_target_replica = [replica_type](const Replica& replica) {
+        if (replica_type == ReplicaType::ALL) {
+            return (replica.is_memory_replica() &&
+                    !replica.has_invalid_mem_handle()) ||
+                   (replica.is_nof_replica() &&
+                    !replica.has_invalid_nof_handle());
+        }
+        if (replica_type == ReplicaType::MEMORY) {
+            return replica.is_memory_replica() &&
+                   !replica.has_invalid_mem_handle();
+        }
+        if (replica_type == ReplicaType::NOF_SSD) {
+            return replica.is_nof_replica() &&
+                   !replica.has_invalid_nof_handle();
+        }
+        return replica.type() == replica_type;
+    };
+
+    // A successful End removes the processing marker. Treat a retry as a
+    // no-op only when every replica targeted by that End is already COMPLETE.
+    // In particular, a promotion-owned PROCESSING replica keeps this check
+    // from accepting a MEMORY/ALL End and is never modified here.
     if (!accessor.InProcessing()) {
+        bool has_target_replica = false;
+        bool all_target_replicas_complete = true;
+        for (const auto& replica : metadata.GetAllReplicas()) {
+            if (!is_target_replica(replica)) {
+                continue;
+            }
+            has_target_replica = true;
+            if (!replica.is_completed()) {
+                all_target_replicas_complete = false;
+                break;
+            }
+        }
+        if (has_target_replica && all_target_replicas_complete) {
+            return {};
+        }
         LOG(ERROR) << "key=" << key << ", error=no_primary_write_in_progress";
         return tl::make_unexpected(ErrorCode::INVALID_WRITE);
     }
 
     metadata.VisitReplicas(
-        [replica_type](const Replica& replica) {
-            if (!replica.is_processing()) {
-                return false;
-            }
-            if (replica_type == ReplicaType::ALL) {
-                return (replica.is_memory_replica() &&
-                        !replica.has_invalid_mem_handle()) ||
-                       (replica.is_nof_replica() &&
-                        !replica.has_invalid_nof_handle());
-            }
-            if (replica_type == ReplicaType::MEMORY) {
-                return replica.is_memory_replica() &&
-                       !replica.has_invalid_mem_handle();
-            }
-            if (replica_type == ReplicaType::NOF_SSD) {
-                return replica.is_nof_replica() &&
-                       !replica.has_invalid_nof_handle();
-            }
-            return replica.type() == replica_type;
+        [&is_target_replica](const Replica& replica) {
+            return replica.is_processing() && is_target_replica(replica);
         },
         [](Replica& replica) { replica.mark_complete(); });
 

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1649,9 +1649,17 @@ std::vector<Replica> MasterService::PopReplicasWithCacheTotalAccounting(
 
 size_t MasterService::EraseReplicasWithCacheTotalAccounting(
     ObjectMetadata& metadata,
-    const std::function<bool(const Replica&)>& pred_fn) {
+    const std::function<bool(const Replica&)>& pred_fn,
+    std::vector<ReplicaID>* erased_replica_ids) {
     auto erased_replicas =
         PopReplicasWithCacheTotalAccounting(metadata, pred_fn);
+    if (erased_replica_ids != nullptr) {
+        erased_replica_ids->reserve(erased_replica_ids->size() +
+                                    erased_replicas.size());
+        for (const auto& replica : erased_replicas) {
+            erased_replica_ids->push_back(replica.id());
+        }
+    }
     // Release SSD/local-disk usage for any local-disk replicas being removed.
     // No-op for memory/noF replicas, so it is safe to call unconditionally.
     ReleaseLocalDiskUsage(erased_replicas);
@@ -1690,6 +1698,11 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     if (erased_replicas.empty()) {
         return;
     }
+    std::vector<ReplicaID> erased_replica_ids;
+    erased_replica_ids.reserve(erased_replicas.size());
+    for (const auto& replica : erased_replicas) {
+        erased_replica_ids.push_back(replica.id());
+    }
     const uint64_t erased_memory_replicas = static_cast<uint64_t>(std::count_if(
         erased_replicas.begin(), erased_replicas.end(),
         [](const Replica& replica) { return replica.is_memory_replica(); }));
@@ -1705,6 +1718,8 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     if (erased_local_disk) {
         shard.OnDiskReplicaRemoved(erased_local_disk, metadata);
     }
+    CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
+                                          erased_replica_ids);
     if (!metadata.IsValid()) {
         EraseMetadata(tenant_state, metadata_it, tenant_id, quota_mode, &shard);
         if (tenant_state.Empty()) {
@@ -2082,8 +2097,8 @@ void MasterService::ClearInvalidHandles(
                             continue;
                         }
                     }
-                    if (CleanupStaleHandles(it->second, alive_clients,
-                                            &shard)) {
+                    if (CleanupStaleHandles(tenant_state, it->second,
+                                            alive_clients, &shard)) {
                         it = EraseMetadata(tenant_state, it, tenant_it->first,
                                            QuotaEraseMode::kFull, &shard);
                     } else {
@@ -3660,8 +3675,8 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     if (enable_oplog_) {
                         return tl::make_unexpected(
                             ErrorCode::OBJECT_ALREADY_EXISTS);
-                    } else if (CleanupStaleHandles(it->second, alive_clients,
-                                                   &shard)) {
+                    } else if (CleanupStaleHandles(tenant_state, it->second,
+                                                   alive_clients, &shard)) {
                         EraseMetadata(tenant_state, it, object_id.tenant_id,
                                       QuotaEraseMode::kFull, &shard);
                         it = tenant_state.metadata.end();
@@ -3772,8 +3787,19 @@ auto MasterService::PutEnd(const UUID& client_id, const ObjectMeta& object_meta,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
+    // Promotion stages PROCESSING replicas without registering a primary
+    // Put/Upsert operation. End is valid only after a successful primary
+    // Start installed the processing marker for this key.
+    if (!accessor.InProcessing()) {
+        LOG(ERROR) << "key=" << key << ", error=no_primary_write_in_progress";
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+    }
+
     metadata.VisitReplicas(
         [replica_type](const Replica& replica) {
+            if (!replica.is_processing()) {
+                return false;
+            }
             if (replica_type == ReplicaType::ALL) {
                 return (replica.is_memory_replica() &&
                         !replica.has_invalid_mem_handle()) ||
@@ -3994,6 +4020,11 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
+    if (!accessor.InProcessing()) {
+        LOG(ERROR) << "key=" << key << ", error=no_primary_write_in_progress";
+        return tl::make_unexpected(ErrorCode::INVALID_WRITE);
+    }
+
     auto processing_rep = metadata.GetFirstReplica([replica_type](
                                                        const Replica& replica) {
         if (replica_type == ReplicaType::ALL) {
@@ -4009,6 +4040,9 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
     }
 
     auto target_pred = [replica_type](const Replica& r) {
+        if (!r.is_processing()) {
+            return false;
+        }
         if (replica_type == ReplicaType::ALL) {
             return r.is_memory_replica() || r.is_nof_replica();
         }
@@ -4231,8 +4265,8 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     if (enable_oplog_) {
                         return tl::make_unexpected(
                             ErrorCode::OBJECT_ALREADY_EXISTS);
-                    } else if (CleanupStaleHandles(it->second, alive_clients,
-                                                   &shard)) {
+                    } else if (CleanupStaleHandles(tenant_state, it->second,
+                                                   alive_clients, &shard)) {
                         // EraseMetadata handles processing_keys,
                         // replication_tasks, offloading_tasks (with
                         // dec_refcnt), and promotion task cleanup.
@@ -4261,6 +4295,13 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 if (tenant_state.replication_tasks.count(key) > 0) {
                     LOG(INFO) << "key=" << key
                               << ", error=object_has_replication_task";
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+                }
+
+                if (tenant_state.promotion_tasks.count(key) > 0) {
+                    LOG(INFO)
+                        << "key=" << key << ", error=object_has_promotion_task";
                     return tl::make_unexpected(
                         ErrorCode::OBJECT_HAS_REPLICATION_TASK);
                 }
@@ -5773,8 +5814,8 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                             ? ErrorCode::OBJECT_NOT_FOUND
                             : ErrorCode::OBJECT_ALREADY_EXISTS);
                     continue;
-                } else if (CleanupStaleHandles(it->second, alive_clients,
-                                               &shard)) {
+                } else if (CleanupStaleHandles(tenant_state, it->second,
+                                               alive_clients, &shard)) {
                     EraseMetadata(tenant_state, it, normalized_tenant,
                                   QuotaEraseMode::kFull, &shard);
                     if (tenant_state.Empty()) {
@@ -5862,8 +5903,44 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
     return results;
 }
 
+void MasterService::CancelPromotionTaskForRemovedReplicas(
+    TenantState& tenant_state, ObjectMetadata& metadata,
+    const std::vector<ReplicaID>& removed_replica_ids) {
+    if (removed_replica_ids.empty()) {
+        return;
+    }
+
+    auto task_it = tenant_state.promotion_tasks.find(metadata.user_key);
+    if (task_it == tenant_state.promotion_tasks.end() ||
+        task_it->second.alloc_id == 0 ||
+        std::find(removed_replica_ids.begin(), removed_replica_ids.end(),
+                  task_it->second.alloc_id) == removed_replica_ids.end()) {
+        return;
+    }
+
+    if (auto* source = metadata.GetReplicaByID(task_it->second.source_id);
+        source != nullptr) {
+        source->dec_refcnt();
+    }
+    const UUID holder_id = task_it->second.holder_id;
+    ErasePromotionTaskIfPresent(tenant_state, metadata.user_key,
+                                metadata.tenant_id);
+
+    // Best-effort cleanup of a task that may still be queued on the holder.
+    ScopedLocalDiskSegmentAccess local_disk_segment_access =
+        segment_manager_.getLocalDiskSegmentAccess();
+    auto& client_local_disk_segment =
+        local_disk_segment_access.getClientLocalDiskSegment();
+    auto segment_it = client_local_disk_segment.find(holder_id);
+    if (segment_it != client_local_disk_segment.end()) {
+        MutexLocker locker(&segment_it->second->offloading_mutex_);
+        segment_it->second->promotion_objects.erase(
+            metadata.tenant_id.MakeScopedKey(metadata.user_key));
+    }
+}
+
 bool MasterService::CleanupStaleHandles(
-    ObjectMetadata& metadata,
+    TenantState& tenant_state, ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
     MetadataShardAccessorRW* shard) {
     bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
@@ -5872,13 +5949,18 @@ bool MasterService::CleanupStaleHandles(
     // Remove those with invalid allocators (memory replicas on unmounted
     // segments) and local_disk replicas whose owner client is no longer alive.
     const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
+    std::vector<ReplicaID> removed_replica_ids;
     EraseReplicasWithCacheTotalAccounting(
-        metadata, [&alive_clients](const Replica& replica) {
+        metadata,
+        [&alive_clients](const Replica& replica) {
             return (replica.has_invalid_mem_handle() ||
                     replica.has_invalid_nof_handle() ||
                     replica.has_stale_local_disk_client(alive_clients)) &&
                    replica.is_completed();
-        });
+        },
+        &removed_replica_ids);
+    CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
+                                          removed_replica_ids);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
     if (before_charge > after_charge) {
         ReleaseCommittedQuotaCharge(metadata, before_charge - after_charge);
@@ -6592,6 +6674,7 @@ size_t MasterService::RunPromotionCandidateRetry(size_t max_shards_to_scan) {
                     auto meta_it = tenant_state.metadata.find(key);
                     if (meta_it == tenant_state.metadata.end() ||
                         !meta_it->second.IsValid() ||
+                        tenant_state.processing_keys.count(key) > 0 ||
                         tenant_state.promotion_tasks.count(key) > 0 ||
                         meta_it->second.HasReplica(
                             &Replica::fn_is_memory_replica) ||
@@ -6685,6 +6768,13 @@ MasterService::PromotionQueueResult MasterService::TryPushPromotionQueue(
     }
     auto& metadata = accessor.Get();
     auto& tenant_state = accessor.GetTenantState();
+
+    // A primary Put/Upsert owns all PROCESSING replicas while the key is in
+    // processing_keys. Promotion must not establish a second owner.
+    if (accessor.InProcessing()) {
+        EraseCandidate(tenant_state, key);
+        return PromotionQueueResult::kAlreadyInFlight;
+    }
 
     // Dedup: don't queue twice if a promotion is already in flight or if a
     // MEMORY replica has appeared since GetReplicaList observed only-disk.
@@ -6819,6 +6909,10 @@ auto MasterService::PromotionAllocStart(
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
     auto& metadata = accessor.Get();
+
+    if (accessor.InProcessing()) {
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_NOT_READY);
+    }
 
     // Verify the in-flight task still exists before allocating. The
     // reaper can sweep it between the holder's heartbeat and this

--- a/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_ssd_test_for_snapshot.cpp
@@ -483,10 +483,11 @@ TEST_F(MasterServiceSSDSnapshotTest, PutStartExpires) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
-        // Try PutEnd the discarded replica.
+        // PutEnd must reject a replica discarded after the write expired.
         put_end_result =
             service_->PutEnd(client_id, key, TenantId::Default(), discard_type);
-        EXPECT_TRUE(put_end_result.has_value());
+        ASSERT_FALSE(put_end_result.has_value());
+        EXPECT_EQ(put_end_result.error(), ErrorCode::INVALID_WRITE);
 
         // Check that the key has only one replica.
         auto get_result = service_->GetReplicaList(key, TenantId::Default());

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -522,10 +522,11 @@ TEST_F(MasterServiceSSDTest, PutStartExpires) {
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
-        // Try PutEnd the discarded replica.
+        // PutEnd must reject a replica discarded after the write expired.
         put_end_result =
             service_->PutEnd(client_id, key, TenantId::Default(), discard_type);
-        EXPECT_TRUE(put_end_result.has_value());
+        ASSERT_FALSE(put_end_result.has_value());
+        EXPECT_EQ(put_end_result.error(), ErrorCode::INVALID_WRITE);
 
         // Check that the key has only one replica.
         auto get_result = service_->GetReplicaList(key, TenantId::Default());

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -13,10 +13,8 @@
 #include <fstream>
 #include <map>
 #include <memory>
-#include <optional>
 #include <string>
 #include <thread>
-#include <tuple>
 #include <vector>
 
 #include <unistd.h>
@@ -35,22 +33,6 @@ size_t CountPromotionTask(const std::vector<PromotionTaskItem>& tasks,
 
 class PromotionOnHitTest : public ::testing::Test {
    protected:
-    struct EndStateForTesting {
-        bool in_processing{false};
-        std::optional<uint64_t> object_checksum;
-        std::chrono::system_clock::time_point lease_timeout;
-        std::optional<std::chrono::system_clock::time_point> soft_pin_timeout;
-        uint64_t reserved_quota_charge_bytes{0};
-        uint64_t committed_quota_charge_bytes{0};
-        uint64_t pending_replaced_quota_charge_bytes{0};
-        std::vector<std::tuple<ReplicaID, ReplicaStatus, uint32_t>> replicas;
-        std::optional<std::tuple<ReplicaID, ReplicaID, uint64_t>>
-            promotion_task;
-        uint64_t promotion_in_flight{0};
-
-        bool operator==(const EndStateForTesting&) const = default;
-    };
-
     void SetUp() override {
         google::InitGoogleLogging("PromotionOnHitTest");
         FLAGS_logtostderr = true;
@@ -124,49 +106,6 @@ class PromotionOnHitTest : public ::testing::Test {
         auto* replica = accessor.Get().GetReplicaByID(replica_id);
         ASSERT_NE(replica, nullptr);
         replica->mark_complete();
-    }
-
-    static EndStateForTesting CaptureEndStateForTesting(
-        MasterService* service, const TenantId& tenant_id,
-        const std::string& key) {
-        MasterService::MetadataAccessorRW accessor(
-            service, MasterService::ObjectIdentity{.tenant_id = tenant_id,
-                                                   .user_key = key});
-        EXPECT_TRUE(accessor.Exists());
-
-        EndStateForTesting state;
-        if (!accessor.Exists()) {
-            return state;
-        }
-        auto& metadata = accessor.Get();
-        state.in_processing = accessor.InProcessing();
-        state.object_checksum = metadata.object_checksum;
-        {
-            SpinLocker locker(&metadata.lock);
-            state.lease_timeout = metadata.lease_timeout;
-            state.soft_pin_timeout = metadata.soft_pin_timeout;
-        }
-        state.reserved_quota_charge_bytes =
-            metadata.reserved_quota_charge_bytes;
-        state.committed_quota_charge_bytes =
-            metadata.committed_quota_charge_bytes;
-        state.pending_replaced_quota_charge_bytes =
-            metadata.pending_replaced_quota_charge_bytes;
-        for (const auto& replica : metadata.GetAllReplicas()) {
-            state.replicas.emplace_back(replica.id(), replica.status(),
-                                        replica.get_refcnt());
-        }
-
-        auto& tenant_state = accessor.GetTenantState();
-        auto task_it = tenant_state.promotion_tasks.find(key);
-        if (task_it != tenant_state.promotion_tasks.end()) {
-            state.promotion_task.emplace(
-                task_it->second.source_id, task_it->second.alloc_id,
-                task_it->second.reserved_quota_charge_bytes);
-        }
-        state.promotion_in_flight =
-            service->promotion_in_flight_.load(std::memory_order_relaxed);
-        return state;
     }
 
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
@@ -511,100 +450,6 @@ TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
 
-TEST_F(PromotionOnHitTest, PrimaryEndRetryIsIdempotent) {
-    MasterServiceConfig config;
-    config.enable_offload = true;
-    config.promotion_on_hit = true;
-    config.promotion_admission_threshold = 1;
-    auto service = std::make_unique<MasterService>(config);
-
-    constexpr size_t seg_size = 1024 * 1024 * 16;
-    Segment holder_segment =
-        MakeSegment("end_retry", kDefaultSegmentBase, seg_size);
-    const UUID holder_id = generate_uuid();
-    ASSERT_TRUE(service->MountSegment(holder_segment, holder_id).has_value());
-    ASSERT_TRUE(service->MountLocalDiskSegment(holder_id, true).has_value());
-    ASSERT_TRUE(
-        service->ReMountSegment({holder_segment}, holder_id).has_value());
-    const MountedSegmentContext holder{.segment_id = holder_segment.id,
-                                       .client_id = holder_id,
-                                       .segment_name = holder_segment.name};
-
-    // A completed PutEnd retry must be a pure no-op.
-    ReplicateConfig put_config;
-    put_config.replica_num = 1;
-    auto put_start = service->PutStart(holder.client_id, "k_memory",
-                                       TenantId::Default(), 1024, put_config);
-    ASSERT_TRUE(put_start.has_value());
-    ObjectMeta put_meta{"k_memory", 42};
-    ASSERT_TRUE(service
-                    ->PutEnd(holder.client_id, put_meta, TenantId::Default(),
-                             ReplicaType::MEMORY)
-                    .has_value());
-    const auto put_state_before = CaptureEndStateForTesting(
-        service.get(), TenantId::Default(), "k_memory");
-    std::this_thread::sleep_for(std::chrono::milliseconds(2));
-    ASSERT_TRUE(service
-                    ->PutEnd(holder.client_id, put_meta, TenantId::Default(),
-                             ReplicaType::MEMORY)
-                    .has_value());
-    EXPECT_EQ(CaptureEndStateForTesting(service.get(), TenantId::Default(),
-                                        "k_memory"),
-              put_state_before);
-
-    // Establish a completed LOCAL_DISK Upsert lifecycle, then start a
-    // promotion. Retrying that same UpsertEnd must succeed without touching
-    // the promotion-owned PROCESSING MEMORY replica or its accounting.
-    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
-                                       1024, holder.segment_name));
-    auto upsert_start = service->UpsertStart(
-        holder.client_id, "k_cold", TenantId::Default(), 1024, put_config);
-    ASSERT_TRUE(upsert_start.has_value());
-    ASSERT_EQ(upsert_start->size(), 1u);
-    EXPECT_TRUE(upsert_start->front().is_local_disk_replica());
-    ASSERT_TRUE(service
-                    ->UpsertEnd(holder.client_id, "k_cold", TenantId::Default(),
-                                ReplicaType::LOCAL_DISK)
-                    .has_value());
-
-    const auto completed_disk_state =
-        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold");
-    ASSERT_EQ(completed_disk_state.replicas.size(), 1u);
-    EXPECT_FALSE(completed_disk_state.in_processing);
-    EXPECT_EQ(std::get<1>(completed_disk_state.replicas.front()),
-              ReplicaStatus::COMPLETE);
-
-    auto read = service->GetReplicaList("k_cold", TenantId::Default());
-    ASSERT_TRUE(read.has_value());
-    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
-                                              TenantId::Default(), 1024, {});
-    ASSERT_TRUE(alloc.has_value());
-
-    const auto promotion_state_before =
-        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold");
-    const auto promoted_replica_it = std::find_if(
-        promotion_state_before.replicas.begin(),
-        promotion_state_before.replicas.end(), [&alloc](const auto& replica) {
-            return std::get<0>(replica) == alloc->memory_descriptor.id;
-        });
-    ASSERT_NE(promoted_replica_it, promotion_state_before.replicas.end());
-    EXPECT_EQ(std::get<1>(*promoted_replica_it), ReplicaStatus::PROCESSING);
-
-    ASSERT_TRUE(service
-                    ->UpsertEnd(holder.client_id, "k_cold", TenantId::Default(),
-                                ReplicaType::LOCAL_DISK)
-                    .has_value());
-    EXPECT_EQ(
-        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold"),
-        promotion_state_before);
-
-    ASSERT_TRUE(service
-                    ->NotifyPromotionSuccess(holder.client_id, "k_cold",
-                                             TenantId::Default())
-                    .has_value());
-    service->RemoveAll();
-}
-
 TEST_F(PromotionOnHitTest, InvalidPrimaryEndCannotCompletePromotionReplica) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -613,39 +458,60 @@ TEST_F(PromotionOnHitTest, InvalidPrimaryEndCannotCompletePromotionReplica) {
     auto service = std::make_unique<MasterService>(config);
 
     constexpr size_t seg_size = 1024 * 1024 * 16;
-    auto holder = PrepareSegment(*service, "issue_3203_end",
-                                 kDefaultSegmentBase, seg_size);
-    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
-                                       1024, holder.segment_name));
+    Segment holder_segment =
+        MakeSegment("issue_3203_end", kDefaultSegmentBase, seg_size);
+    const UUID holder_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(holder_segment, holder_id).has_value());
+    ASSERT_TRUE(service->MountLocalDiskSegment(holder_id, true).has_value());
+    ASSERT_TRUE(
+        service->ReMountSegment({holder_segment}, holder_id).has_value());
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder_id, "k_cold", 1024,
+                                       holder_segment.name));
+
+    ReplicateConfig upsert_config;
+    upsert_config.replica_num = 1;
+    ASSERT_TRUE(service
+                    ->UpsertStart(holder_id, "k_cold", TenantId::Default(),
+                                  1024, upsert_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    ->UpsertEnd(holder_id, "k_cold", TenantId::Default(),
+                                ReplicaType::LOCAL_DISK)
+                    .has_value());
 
     auto read = service->GetReplicaList("k_cold", TenantId::Default());
     ASSERT_TRUE(read.has_value());
-    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+    auto alloc = service->PromotionAllocStart(holder_id, "k_cold",
                                               TenantId::Default(), 1024, {});
     ASSERT_TRUE(alloc.has_value());
+
+    // Retrying the completed End is a no-op: it succeeds, and the promotion
+    // still owns its PROCESSING MEMORY replica and task.
+    ASSERT_TRUE(service
+                    ->UpsertEnd(holder_id, "k_cold", TenantId::Default(),
+                                ReplicaType::LOCAL_DISK)
+                    .has_value());
 
     // There was no primary PutStart. PutEnd must not complete the staged
     // promotion replica even though the metadata client_id matches.
     auto invalid_put_end = service->PutEnd(
-        holder.client_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
+        holder_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
     ASSERT_FALSE(invalid_put_end.has_value());
     EXPECT_EQ(invalid_put_end.error(), ErrorCode::INVALID_WRITE);
 
-    ReplicateConfig upsert_config;
-    upsert_config.replica_num = 1;
     auto rejected_upsert = service->UpsertStart(
-        holder.client_id, "k_cold", TenantId::Default(), 1024, upsert_config);
+        holder_id, "k_cold", TenantId::Default(), 1024, upsert_config);
     ASSERT_FALSE(rejected_upsert.has_value());
     EXPECT_EQ(rejected_upsert.error(), ErrorCode::OBJECT_HAS_REPLICATION_TASK);
 
     // A caller must not be able to finalize after the rejected UpsertStart.
     auto invalid_upsert_end = service->UpsertEnd(
-        holder.client_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
+        holder_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
     ASSERT_FALSE(invalid_upsert_end.has_value());
     EXPECT_EQ(invalid_upsert_end.error(), ErrorCode::INVALID_WRITE);
 
     // Only the promotion completion path owns the staged replica.
-    auto notify = service->NotifyPromotionSuccess(holder.client_id, "k_cold",
+    auto notify = service->NotifyPromotionSuccess(holder_id, "k_cold",
                                                   TenantId::Default());
     ASSERT_TRUE(notify.has_value());
 

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -86,6 +86,28 @@ class PromotionOnHitTest : public ::testing::Test {
         return service->promotion_in_flight_.load(std::memory_order_relaxed);
     }
 
+    static bool PromotionAdmissionBlockedByPrimaryWriteForTesting(
+        MasterService* service, const TenantId& tenant_id,
+        const std::string& key) {
+        const auto result =
+            service->TryPushPromotionQueue(MasterService::ObjectIdentity{
+                .tenant_id = tenant_id, .user_key = key});
+        return result == MasterService::PromotionQueueResult::kAlreadyInFlight;
+    }
+
+    static void MarkReplicaCompleteForTesting(MasterService* service,
+                                              const TenantId& tenant_id,
+                                              const std::string& key,
+                                              ReplicaID replica_id) {
+        MasterService::MetadataAccessorRW accessor(
+            service, MasterService::ObjectIdentity{.tenant_id = tenant_id,
+                                                   .user_key = key});
+        ASSERT_TRUE(accessor.Exists());
+        auto* replica = accessor.Get().GetReplicaByID(replica_id);
+        ASSERT_NE(replica, nullptr);
+        replica->mark_complete();
+    }
+
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
 
     std::string WriteTenantQuotaPolicyFile(
@@ -426,6 +448,147 @@ TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
                                              TenantId::Default(), 1024, {});
     ASSERT_FALSE(resp.has_value());
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(PromotionOnHitTest, InvalidPrimaryEndCannotCompletePromotionReplica) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder = PrepareSegment(*service, "issue_3203_end",
+                                 kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    auto read = service->GetReplicaList("k_cold", TenantId::Default());
+    ASSERT_TRUE(read.has_value());
+    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+                                              TenantId::Default(), 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // There was no primary PutStart. PutEnd must not complete the staged
+    // promotion replica even though the metadata client_id matches.
+    auto invalid_put_end = service->PutEnd(
+        holder.client_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
+    ASSERT_FALSE(invalid_put_end.has_value());
+    EXPECT_EQ(invalid_put_end.error(), ErrorCode::INVALID_WRITE);
+
+    ReplicateConfig upsert_config;
+    upsert_config.replica_num = 1;
+    auto rejected_upsert = service->UpsertStart(
+        holder.client_id, "k_cold", TenantId::Default(), 1024, upsert_config);
+    ASSERT_FALSE(rejected_upsert.has_value());
+    EXPECT_EQ(rejected_upsert.error(), ErrorCode::OBJECT_HAS_REPLICATION_TASK);
+
+    // A caller must not be able to finalize after the rejected UpsertStart.
+    auto invalid_upsert_end = service->UpsertEnd(
+        holder.client_id, "k_cold", TenantId::Default(), ReplicaType::MEMORY);
+    ASSERT_FALSE(invalid_upsert_end.has_value());
+    EXPECT_EQ(invalid_upsert_end.error(), ErrorCode::INVALID_WRITE);
+
+    // Only the promotion completion path owns the staged replica.
+    auto notify = service->NotifyPromotionSuccess(holder.client_id, "k_cold",
+                                                  TenantId::Default());
+    ASSERT_TRUE(notify.has_value());
+
+    service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, PrimaryWriteBlocksPromotionAdmission) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto holder = PrepareSegment(*service, "issue_3203_primary",
+                                 kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+
+    ReplicateConfig upsert_config;
+    upsert_config.replica_num = 1;
+    auto upsert = service->UpsertStart(
+        holder.client_id, "k_cold", TenantId::Default(), 1024, upsert_config);
+    ASSERT_TRUE(upsert.has_value());
+
+    EXPECT_TRUE(PromotionAdmissionBlockedByPrimaryWriteForTesting(
+        service.get(), TenantId::Default(), "k_cold"));
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 0u);
+
+    auto end = service->UpsertEnd(holder.client_id, "k_cold",
+                                  TenantId::Default(), ReplicaType::LOCAL_DISK);
+    ASSERT_TRUE(end.has_value());
+
+    service->RemoveAll();
+}
+
+TEST_F(PromotionOnHitTest, StalePromotionReplicaCleanupErasesTask) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    Segment holder_segment =
+        MakeSegment("issue_3203_holder", kDefaultSegmentBase, seg_size);
+    const UUID holder_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(holder_segment, holder_id).has_value());
+    ASSERT_TRUE(service->MountLocalDiskSegment(holder_id, true).has_value());
+    ASSERT_TRUE(
+        service->ReMountSegment({holder_segment}, holder_id).has_value());
+
+    Segment target_segment = MakeSegment(
+        "issue_3203_target", kDefaultSegmentBase + seg_size, seg_size);
+    const UUID target_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(target_segment, target_id).has_value());
+
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder_id, "k_cold", 1024,
+                                       holder_segment.name));
+    auto read = service->GetReplicaList("k_cold", TenantId::Default());
+    ASSERT_TRUE(read.has_value());
+    auto alloc = service->PromotionAllocStart(
+        holder_id, "k_cold", TenantId::Default(), 1024, {target_segment.name});
+    ASSERT_TRUE(alloc.has_value());
+    ASSERT_EQ(alloc->memory_descriptor.get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              target_segment.name);
+
+    // Recreate the legacy bad state: an invalid primary End used to mark the
+    // promotion-owned replica COMPLETE before stale-handle cleanup removed it.
+    MarkReplicaCompleteForTesting(service.get(), TenantId::Default(), "k_cold",
+                                  alloc->memory_descriptor.id);
+
+    auto& metrics = MasterMetricManager::instance();
+    const int64_t cancelled_before = metrics.get_promotion_cancelled();
+    ASSERT_EQ(GetPromotionInFlightForTesting(service.get()), 1u);
+
+    ASSERT_TRUE(
+        service->UnmountSegment(target_segment.id, target_id).has_value());
+
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 0u);
+    EXPECT_EQ(metrics.get_promotion_cancelled() - cancelled_before, 1);
+    auto pending = service->PromotionObjectHeartbeat(holder_id);
+    ASSERT_TRUE(pending.has_value());
+    EXPECT_TRUE(pending->empty());
+
+    auto notify = service->NotifyPromotionSuccess(holder_id, "k_cold",
+                                                  TenantId::Default());
+    ASSERT_FALSE(notify.has_value());
+    EXPECT_EQ(notify.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    auto remaining =
+        service->GetReplicaListForAdmin("k_cold", TenantId::Default());
+    ASSERT_TRUE(remaining.has_value());
+    ASSERT_EQ(remaining->replicas.size(), 1u);
+    EXPECT_TRUE(remaining->replicas[0].is_local_disk_replica());
+
+    service->RemoveAll();
 }
 
 // NotifyPromotionSuccess on a non-existent key returns OBJECT_NOT_FOUND.

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -13,8 +13,10 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <vector>
 
 #include <unistd.h>
@@ -33,6 +35,22 @@ size_t CountPromotionTask(const std::vector<PromotionTaskItem>& tasks,
 
 class PromotionOnHitTest : public ::testing::Test {
    protected:
+    struct EndStateForTesting {
+        bool in_processing{false};
+        std::optional<uint64_t> object_checksum;
+        std::chrono::system_clock::time_point lease_timeout;
+        std::optional<std::chrono::system_clock::time_point> soft_pin_timeout;
+        uint64_t reserved_quota_charge_bytes{0};
+        uint64_t committed_quota_charge_bytes{0};
+        uint64_t pending_replaced_quota_charge_bytes{0};
+        std::vector<std::tuple<ReplicaID, ReplicaStatus, uint32_t>> replicas;
+        std::optional<std::tuple<ReplicaID, ReplicaID, uint64_t>>
+            promotion_task;
+        uint64_t promotion_in_flight{0};
+
+        bool operator==(const EndStateForTesting&) const = default;
+    };
+
     void SetUp() override {
         google::InitGoogleLogging("PromotionOnHitTest");
         FLAGS_logtostderr = true;
@@ -106,6 +124,49 @@ class PromotionOnHitTest : public ::testing::Test {
         auto* replica = accessor.Get().GetReplicaByID(replica_id);
         ASSERT_NE(replica, nullptr);
         replica->mark_complete();
+    }
+
+    static EndStateForTesting CaptureEndStateForTesting(
+        MasterService* service, const TenantId& tenant_id,
+        const std::string& key) {
+        MasterService::MetadataAccessorRW accessor(
+            service, MasterService::ObjectIdentity{.tenant_id = tenant_id,
+                                                   .user_key = key});
+        EXPECT_TRUE(accessor.Exists());
+
+        EndStateForTesting state;
+        if (!accessor.Exists()) {
+            return state;
+        }
+        auto& metadata = accessor.Get();
+        state.in_processing = accessor.InProcessing();
+        state.object_checksum = metadata.object_checksum;
+        {
+            SpinLocker locker(&metadata.lock);
+            state.lease_timeout = metadata.lease_timeout;
+            state.soft_pin_timeout = metadata.soft_pin_timeout;
+        }
+        state.reserved_quota_charge_bytes =
+            metadata.reserved_quota_charge_bytes;
+        state.committed_quota_charge_bytes =
+            metadata.committed_quota_charge_bytes;
+        state.pending_replaced_quota_charge_bytes =
+            metadata.pending_replaced_quota_charge_bytes;
+        for (const auto& replica : metadata.GetAllReplicas()) {
+            state.replicas.emplace_back(replica.id(), replica.status(),
+                                        replica.get_refcnt());
+        }
+
+        auto& tenant_state = accessor.GetTenantState();
+        auto task_it = tenant_state.promotion_tasks.find(key);
+        if (task_it != tenant_state.promotion_tasks.end()) {
+            state.promotion_task.emplace(
+                task_it->second.source_id, task_it->second.alloc_id,
+                task_it->second.reserved_quota_charge_bytes);
+        }
+        state.promotion_in_flight =
+            service->promotion_in_flight_.load(std::memory_order_relaxed);
+        return state;
     }
 
     static constexpr size_t kDefaultSegmentBase = 0x300000000;
@@ -448,6 +509,100 @@ TEST_F(PromotionOnHitTest, AllocStartUnknownKey) {
                                              TenantId::Default(), 1024, {});
     ASSERT_FALSE(resp.has_value());
     EXPECT_EQ(resp.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
+TEST_F(PromotionOnHitTest, PrimaryEndRetryIsIdempotent) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    Segment holder_segment =
+        MakeSegment("end_retry", kDefaultSegmentBase, seg_size);
+    const UUID holder_id = generate_uuid();
+    ASSERT_TRUE(service->MountSegment(holder_segment, holder_id).has_value());
+    ASSERT_TRUE(service->MountLocalDiskSegment(holder_id, true).has_value());
+    ASSERT_TRUE(
+        service->ReMountSegment({holder_segment}, holder_id).has_value());
+    const MountedSegmentContext holder{.segment_id = holder_segment.id,
+                                       .client_id = holder_id,
+                                       .segment_name = holder_segment.name};
+
+    // A completed PutEnd retry must be a pure no-op.
+    ReplicateConfig put_config;
+    put_config.replica_num = 1;
+    auto put_start = service->PutStart(holder.client_id, "k_memory",
+                                       TenantId::Default(), 1024, put_config);
+    ASSERT_TRUE(put_start.has_value());
+    ObjectMeta put_meta{"k_memory", 42};
+    ASSERT_TRUE(service
+                    ->PutEnd(holder.client_id, put_meta, TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    const auto put_state_before = CaptureEndStateForTesting(
+        service.get(), TenantId::Default(), "k_memory");
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    ASSERT_TRUE(service
+                    ->PutEnd(holder.client_id, put_meta, TenantId::Default(),
+                             ReplicaType::MEMORY)
+                    .has_value());
+    EXPECT_EQ(CaptureEndStateForTesting(service.get(), TenantId::Default(),
+                                        "k_memory"),
+              put_state_before);
+
+    // Establish a completed LOCAL_DISK Upsert lifecycle, then start a
+    // promotion. Retrying that same UpsertEnd must succeed without touching
+    // the promotion-owned PROCESSING MEMORY replica or its accounting.
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, holder.client_id, "k_cold",
+                                       1024, holder.segment_name));
+    auto upsert_start = service->UpsertStart(
+        holder.client_id, "k_cold", TenantId::Default(), 1024, put_config);
+    ASSERT_TRUE(upsert_start.has_value());
+    ASSERT_EQ(upsert_start->size(), 1u);
+    EXPECT_TRUE(upsert_start->front().is_local_disk_replica());
+    ASSERT_TRUE(service
+                    ->UpsertEnd(holder.client_id, "k_cold", TenantId::Default(),
+                                ReplicaType::LOCAL_DISK)
+                    .has_value());
+
+    const auto completed_disk_state =
+        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold");
+    ASSERT_EQ(completed_disk_state.replicas.size(), 1u);
+    EXPECT_FALSE(completed_disk_state.in_processing);
+    EXPECT_EQ(std::get<1>(completed_disk_state.replicas.front()),
+              ReplicaStatus::COMPLETE);
+
+    auto read = service->GetReplicaList("k_cold", TenantId::Default());
+    ASSERT_TRUE(read.has_value());
+    auto alloc = service->PromotionAllocStart(holder.client_id, "k_cold",
+                                              TenantId::Default(), 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    const auto promotion_state_before =
+        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold");
+    const auto promoted_replica_it = std::find_if(
+        promotion_state_before.replicas.begin(),
+        promotion_state_before.replicas.end(), [&alloc](const auto& replica) {
+            return std::get<0>(replica) == alloc->memory_descriptor.id;
+        });
+    ASSERT_NE(promoted_replica_it, promotion_state_before.replicas.end());
+    EXPECT_EQ(std::get<1>(*promoted_replica_it), ReplicaStatus::PROCESSING);
+
+    ASSERT_TRUE(service
+                    ->UpsertEnd(holder.client_id, "k_cold", TenantId::Default(),
+                                ReplicaType::LOCAL_DISK)
+                    .has_value());
+    EXPECT_EQ(
+        CaptureEndStateForTesting(service.get(), TenantId::Default(), "k_cold"),
+        promotion_state_before);
+
+    ASSERT_TRUE(service
+                    ->NotifyPromotionSuccess(holder.client_id, "k_cold",
+                                             TenantId::Default())
+                    .has_value());
+    service->RemoveAll();
 }
 
 TEST_F(PromotionOnHitTest, InvalidPrimaryEndCannotCompletePromotionReplica) {


### PR DESCRIPTION
## Description

Fixes #3203.

`PutEnd` / `UpsertEnd` previously trusted only `metadata.client_id` and could complete any matching staged replica. Promotion also stages a `PROCESSING` replica under the object's metadata, but does not register a primary write in `processing_keys`. An invalid or out-of-order primary End could therefore complete a promotion-owned replica. If that replica later became stale, cleanup could remove it while leaving the associated `PromotionTask`, quota reservation, source refcount, in-flight count, and queued client work behind.

This change:

- requires an active primary Start marker before `PutEnd`, `UpsertEnd`, or `PutRevoke`, and only finalizes/revokes matching `PROCESSING` replicas;
- makes primary writes and promotion mutually exclusive at Upsert admission, promotion admission/retry, and promotion allocation;
- cancels promotion state when stale-handle cleanup removes the task's allocated replica, including the durable HA finalization path;
- captures removed replica IDs during the existing cleanup pass, avoiding an additional replica scan.

The validation reuses existing transient `processing_keys` and `promotion_tasks` state. It adds no persistent object metadata, RPC fields, snapshot fields, or oplog fields.

PR #3162 includes only the `UpsertStart` promotion-task gate as part of broader quota work. This standalone follow-up is based on current `main` and completes the End ownership and stale-cleanup fixes without including the quota changes.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build /tmp/mooncake-issue-3203-build --target promotion_on_hit_test master_service_test -j 16
/tmp/mooncake-issue-3203-build/mooncake-store/tests/promotion_on_hit_test
/tmp/mooncake-issue-3203-build/mooncake-store/tests/master_service_test --gtest_brief=1
pre-commit run --files mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/tests/promotion_on_hit_test.cpp
```

**Test results:**
- [x] Unit tests pass
  - issue #3203 regression tests: 3/3
  - `promotion_on_hit_test`: 50/50
  - `master_service_test`: 147/147
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done: reproduced the historical invalid-End/stale-replica state in a focused regression test and verified full task cleanup

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
  - Relevant hooks pass for all three touched files.
- [x] I have updated the documentation (not applicable; no user-facing API or configuration change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; this change is under 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

OpenAI Codex assisted with root-cause analysis, implementation, performance review, and regression-test construction. I reviewed and edited the generated code before submission.