### PR TITLE
[CI/Build] Add CUDA 13 EFA wheel

### DIFF
--- a/.github/workflows/_build-efa-wheel.yaml
+++ b/.github/workflows/_build-efa-wheel.yaml
@@ -8,7 +8,7 @@ on:
   workflow_call:
     inputs:
       variant:
-        # cuda | non-cuda
+        # cuda | cuda13 | non-cuda
         type: string
         required: true
       use-cuda:
@@ -29,6 +29,9 @@ on:
         # build_wheel.sh package variant, e.g. EFA_BUILD.
         type: string
         required: true
+      cuda-version:
+        type: string
+        default: '12.8.1'
       torch-cuda-arch-list:
         type: string
         default: ''
@@ -51,6 +54,7 @@ jobs:
       EFA_VARIANT: ${{ inputs.variant }}
       USE_CUDA: ${{ inputs.use-cuda }}
       VARIANT_FLAG: ${{ inputs.variant-flag }}
+      CUDA_VERSION: ${{ inputs.cuda-version }}
 
     steps:
       - name: Validate build inputs
@@ -61,7 +65,7 @@ jobs:
           esac
 
           case "$EFA_VARIANT:$USE_CUDA:$VARIANT_FLAG" in
-            cuda:true:EFA_BUILD|non-cuda:false:EFA_NON_CUDA_BUILD) ;;
+            cuda:true:EFA_BUILD|cuda13:true:EFA_CU13_BUILD|non-cuda:false:EFA_NON_CUDA_BUILD) ;;
             *) echo "::error::Inconsistent EFA variant inputs"; exit 1 ;;
           esac
         shell: bash
@@ -88,9 +92,9 @@ jobs:
 
       - name: Install CUDA Toolkit
         if: ${{ inputs.use-cuda }}
-        uses: Jimver/cuda-toolkit@v0.2.24
+        uses: Jimver/cuda-toolkit@v0.2.29
         with:
-          cuda: '12.8.1'
+          cuda: ${{ inputs.cuda-version }}
           method: 'network'
           sub-packages: '["nvcc", "nvrtc-dev"]'
           non-cuda-sub-packages: '["libcusparse-dev", "libcublas-dev", "libcusolver-dev"]'
@@ -194,6 +198,22 @@ jobs:
             exit 1
           fi
           echo "OK: libfabric/libefa correctly excluded (resolve to system EFA at runtime)"
+        shell: bash
+
+      - name: Verify CUDA runtime dependency
+        if: ${{ inputs.use-cuda }}
+        run: |
+          WHL=$(ls mooncake-wheel/dist-py${{ steps.python-tag.outputs.python_version_tag }}/*.whl | head -1)
+          inspect_dir=$(mktemp -d)
+          unzip -q "$WHL" mooncake/engine.so -d "$inspect_dir"
+          cuda_major=${CUDA_VERSION%%.*}
+          if ! readelf -d "$inspect_dir/mooncake/engine.so" | \
+              grep -Fq "Shared library: [libcudart.so.${cuda_major}]"; then
+            echo "::error::EFA wheel does not depend on libcudart.so.${cuda_major}"
+            readelf -d "$inspect_dir/mooncake/engine.so" | grep NEEDED
+            exit 1
+          fi
+          echo "OK: EFA wheel depends on libcudart.so.${cuda_major}"
         shell: bash
 
       - name: Upload Python wheel artifact

--- a/.github/workflows/ci_efa.yml
+++ b/.github/workflows/ci_efa.yml
@@ -13,10 +13,17 @@ jobs:
           - variant: cuda
             use_cuda: "ON"
             build_env: "EFA_BUILD"
+            cuda-version: "12.8.1"
+            python-version: "3.12"
+          - variant: cuda13
+            use_cuda: "ON"
+            build_env: "EFA_CU13_BUILD"
+            cuda-version: "13.0.2"
             python-version: "3.12"
           - variant: non-cuda
             use_cuda: "OFF"
             build_env: "EFA_NON_CUDA_BUILD"
+            cuda-version: "12.8.1"
             python-version: "3.10"
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
@@ -29,5 +36,6 @@ jobs:
         -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=ON -DBUILD_BENCHMARK=ON
         -DENABLE_DEBUG_SYMBOLS=OFF
       variant-flag: ${{ matrix.build_env }}
+      cuda-version: ${{ matrix.cuda-version }}
       torch-cuda-arch-list: '8.0;9.0'
       artifact-prefix: mooncake-wheel-efa-${{ matrix.variant }}-ubuntu

--- a/.github/workflows/release-efa-cuda13.yaml
+++ b/.github/workflows/release-efa-cuda13.yaml
@@ -1,26 +1,26 @@
-name: Release EFA
+name: Release EFA CUDA 13
 
 on:
   push:
     tags:
       - 'v*'
 
-# Publishes mooncake-transfer-engine-efa, the CUDA 12-aware AWS EFA wheel.
+# Publishes mooncake-transfer-engine-efa-cuda13, the CUDA 13-aware AWS EFA wheel.
 jobs:
   build:
     permissions:
       contents: write
     uses: ./.github/workflows/_build-efa-wheel.yaml
     with:
-      variant: cuda
+      variant: cuda13
       use-cuda: true
-      cuda-version: '12.8.1'
+      cuda-version: '13.0.2'
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       build-profile: release
       cmake-args: >-
         -DUSE_HTTP=ON -DUSE_ETCD=ON -DWITH_EP=OFF -DSTORE_USE_ETCD=ON
-      variant-flag: EFA_BUILD
-      artifact-prefix: mooncake-wheel-efa
+      variant-flag: EFA_CU13_BUILD
+      artifact-prefix: mooncake-wheel-efa-cuda13
 
   publish-release:
     if: ${{ !contains(github.ref_name, '-') }}
@@ -30,6 +30,6 @@ jobs:
       id-token: write
     uses: ./.github/workflows/_publish-wheel.yaml
     with:
-      artifact-pattern: 'mooncake-wheel-efa-py*'
+      artifact-pattern: 'mooncake-wheel-efa-cuda13-py*'
     secrets:
       pypi-token: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
   [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
   [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
   [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=F97316)](https://pypi.org/project/mooncake-transfer-engine-musa/)
-  [![PyPI EFA CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20%2B%20CUDA&color=F59E0B)](https://pypi.org/project/mooncake-transfer-engine-efa/)
+  [![PyPI EFA CUDA 12](https://img.shields.io/static/v1?label=pypi&message=EFA%20%2B%20CUDA%2012&color=F59E0B)](https://pypi.org/project/mooncake-transfer-engine-efa/)
+  [![PyPI EFA CUDA 13](https://img.shields.io/static/v1?label=pypi&message=EFA%20%2B%20CUDA%2013&color=F59E0B)](https://pypi.org/project/mooncake-transfer-engine-efa-cuda13/)
   [![PyPI EFA Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=EFA%20non-CUDA&color=F59E0B)](https://pypi.org/project/mooncake-transfer-engine-efa-non-cuda/)
 </div>
 <br/>

--- a/docs/source/design/transfer-engine/efa_transport.md
+++ b/docs/source/design/transfer-engine/efa_transport.md
@@ -37,15 +37,20 @@ This installs all system packages, git submodules (including pybind11 and yalant
 
 ## Installing from PyPI (recommended)
 
-Pre-built EFA wheels are published to PyPI by the official release pipeline, so most users do not need to build from source. The EFA transport's memory path is CUDA-aware, so two variants are published:
+Pre-built EFA wheels are published to PyPI by the official release pipeline, so most users do not need to build from source. The EFA transport's memory path is CUDA-aware, so separate CUDA 12, CUDA 13, and non-CUDA variants are published:
 
 ```bash
-# GPU memory transfers (e.g., KV cache in vLLM) — built with USE_CUDA=ON
+# GPU memory transfers with CUDA 12 — built with USE_CUDA=ON
 pip install mooncake-transfer-engine-efa
+
+# GPU memory transfers with CUDA 13 — built with USE_CUDA=ON
+pip install mooncake-transfer-engine-efa-cuda13
 
 # CPU/DRAM-only transfers — built with USE_CUDA=OFF
 pip install mooncake-transfer-engine-efa-non-cuda
 ```
+
+The CUDA 13 wheel requires an NVIDIA 580-series or newer driver, following the [CUDA compatibility requirements](https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html).
 
 > **Note:** These wheels deliberately do **not** bundle `libfabric`/`libefa` (see the runtime note in [Building a Distributable Wheel](#efa-distributable-wheel)). They resolve to the system AWS EFA installation at runtime, so the EFA driver and libfabric from the [Prerequisites](#efa-prerequisites-driver) must still be present on the instance. Make sure `/opt/amazon/efa/lib` is on `LD_LIBRARY_PATH`.
 
@@ -108,17 +113,20 @@ PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
 pip install dist/mooncake_transfer_engine-*.whl
 ```
 
-To produce a wheel whose package name matches the published variants (`mooncake-transfer-engine-efa` / `-efa-non-cuda`), set the corresponding build-variant environment variable — this is exactly what the release pipeline does:
+To produce a wheel whose package name matches one of the published variants, set the corresponding build-variant environment variable — this is exactly what the release pipeline does:
 
 ```bash
 # GPU build (cmake was configured with USE_CUDA=ON):
 EFA_BUILD=1 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
 
+# CUDA 13 GPU build (cmake was configured with CUDA 13 and USE_CUDA=ON):
+EFA_CU13_BUILD=1 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
+
 # CPU build (cmake was configured with USE_CUDA=OFF):
 EFA_NON_CUDA_BUILD=1 PYTHON_VERSION=3.13 BUILD_DIR=build bash scripts/build_wheel.sh 3.13 dist
 ```
 
-> **CI/CD:** EFA wheels are built and published automatically — see `.github/workflows/ci_efa.yml` (per-PR build validation) and `.github/workflows/release-efa.yaml` (tagged release to GitHub Release + PyPI). No EFA hardware is required to *build* the wheel: only the libfabric headers/library are needed to compile and link, which the CI runner obtains from the distro `libfabric-dev` package.
+> **CI/CD:** EFA wheels are built and published automatically — see `.github/workflows/ci_efa.yml` (per-PR build validation), `.github/workflows/release-efa.yaml` (CUDA 12 release), `.github/workflows/release-efa-cuda13.yaml` (CUDA 13 release), and `.github/workflows/release-efa-non-cuda.yaml` (non-CUDA release). No EFA hardware is required to *build* the wheel: only the libfabric headers/library are needed to compile and link, which the CI runner obtains from the distro `libfabric-dev` package.
 
 > **Important (EFA builds):** `auditwheel repair` excludes `libfabric` and `libefa` from the wheel so they resolve to the system EFA installation (`/opt/amazon/efa/lib`) at runtime. This is required because the in-process `aws-ofi-nccl` plugin (loaded by NCCL) links the **same** system `libfabric`. If the wheel bundled its own copy, the process would load two independent libfabric instances — Mooncake's bundled one and NCCL's system one — and whichever initializes first claims the EFA device, leaving the other with an empty provider list (`fi_getinfo: provider efa output empty list`). NCCL then silently falls back to the TCP provider and cross-node collectives such as `all_gather_object` hang. Excluding libfabric/libefa (see `scripts/build_wheel.sh`) keeps a single shared libfabric in the process. If you are on an older Mooncake build whose wheel still bundles libfabric, force the system copy with `export LD_PRELOAD=/opt/amazon/efa/lib/libfabric.so.1` as a workaround.
 

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -6,7 +6,8 @@
 #
 # NOTE: the `keywords` and `classifiers` arrays below MUST stay on a
 # single line. They are sed-substituted by scripts/build_wheel.sh for
-# each build variant (non-cuda, cuda13, npu, efa, efa-non-cuda, musa);
+# each build variant (non-cuda, cuda13, npu, efa, efa-cuda13, efa-non-cuda,
+# musa);
 # reordering or wrapping will silently break the variant build matrix.
 #
 # `readme = "README.md"` points at a per-build copy of the repo-root

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -173,7 +173,7 @@ cleanup_wheel_metadata_state() {
 }
 trap cleanup_wheel_metadata_state EXIT
 
-BUILD_VARIANTS="NON_CUDA_BUILD CU13_BUILD NPU_BUILD EFA_BUILD EFA_NON_CUDA_BUILD MUSA_BUILD HIP_BUILD"
+BUILD_VARIANTS="NON_CUDA_BUILD CU13_BUILD NPU_BUILD EFA_BUILD EFA_CU13_BUILD EFA_NON_CUDA_BUILD MUSA_BUILD HIP_BUILD"
 BUILD_VARIANT_COUNT=0
 for build_variant in $BUILD_VARIANTS; do
     if [ "${!build_variant}" = "1" ]; then
@@ -235,6 +235,15 @@ elif [ "$EFA_BUILD" = "1" ]; then
     sed -i 's/^description = "\(.*\)"$/description = "\1 (AWS EFA, CUDA version)"/' pyproject.toml
     sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "aws", "efa", "libfabric", "cuda"]/' pyproject.toml
     echo "Package name modified to: mooncake-transfer-engine-efa"
+elif [ "$EFA_CU13_BUILD" = "1" ]; then
+    echo "Modifying package name for AWS EFA build (CUDA 13)"
+    # Backup original pyproject.toml
+    cp pyproject.toml pyproject.toml.backup
+    # Replace package name and description
+    sed -i 's/name = "mooncake-transfer-engine"/name = "mooncake-transfer-engine-efa-cuda13"/' pyproject.toml
+    sed -i 's/^description = "\(.*\)"$/description = "\1 (AWS EFA, CUDA 13 version)"/' pyproject.toml
+    sed -i 's/^keywords = \[\(.*\)\]$/keywords = [\1, "aws", "efa", "libfabric", "cuda13"]/' pyproject.toml
+    echo "Package name modified to: mooncake-transfer-engine-efa-cuda13"
 elif [ "$EFA_NON_CUDA_BUILD" = "1" ]; then
     echo "Modifying package name for AWS EFA build (non-CUDA)"
     # Backup original pyproject.toml


### PR DESCRIPTION
## Description

Add an official CUDA 13 build of the AWS EFA wheel as the separate
`mooncake-transfer-engine-efa-cuda13` distribution. Keeping a separate package
preserves the existing CUDA 12 wheel and lets each wheel depend on the correct
`libcudart` SONAME.

This change:

- parameterizes the reusable EFA wheel builder by CUDA toolkit version;
- adds CUDA 13.0.2 to PR CI and the tagged release pipeline;
- adds the `EFA_CU13_BUILD` package variant;
- verifies every CUDA-enabled EFA wheel links the requested `libcudart` major;
- documents the CUDA 12, CUDA 13, and non-CUDA EFA packages.

The EFA wheel continues to exclude `libfabric` and `libefa`, so deployments use
the system AWS EFA installation. No open issue or PR was found covering EFA
CUDA 13 wheel support.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
actionlint \
  .github/workflows/_build-efa-wheel.yaml \
  .github/workflows/ci_efa.yml \
  .github/workflows/release-efa.yaml \
  .github/workflows/release-efa-cuda13.yaml

pre-commit run
bash -n scripts/build_wheel.sh
git diff --cached --check

cd docs
make html
```

The new package metadata substitutions were also applied to an isolated copy of
`pyproject.toml` and checked for the expected distribution name, description,
and `cuda13` keyword.

**Test results:**

- [x] Unit tests pass (workflow, shell, and package metadata static checks)
- [ ] Integration tests pass (requires the GitHub CUDA 13 builder and EFA hardware)
- [x] Manual testing done (rendered EFA documentation inspected)

`actionlint`, all applicable pre-commit hooks, shell/YAML checks, and the Sphinx
HTML build pass. The documentation build emitted only external intersphinx
inventory network warnings. This machine has CUDA 11.5 and no EFA hardware, so
the CUDA 13 wheel build and runtime EFA transfer are left to PR CI and hardware
validation.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (no C/C++ files changed)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (all applicable hooks pass on the changed files)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective (CI builds and validates the new wheel)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 107-line diff)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex inspected the existing CUDA and EFA release paths, implemented the new
wheel variant and CI/release coverage, updated documentation, and ran the local
static validation. The PR is intentionally a draft for human review of every
changed line and CUDA 13 CI results.