### PR TITLE
[Bugfix] Use GPU_PREFIX for HCA peer affinity under USE_HIP

### DIFF
--- a/mooncake-transfer-engine/src/topology.cpp
+++ b/mooncake-transfer-engine/src/topology.cpp
@@ -316,7 +316,9 @@ static void precomputeResolvedHcaPeerAffinity(
     }
 
     for (const auto &entry : matrix) {
-        if (entry.first.rfind("cuda:", 0) != 0) continue;
+        // Match the vendor-specific GPU location prefix (cuda:/hip:/...).
+        // Hardcoding "cuda:" silently disables HCA peer affinity under USE_HIP.
+        if (entry.first.rfind(GPU_PREFIX, 0) != 0) continue;
 
         std::unordered_set<std::string> preferred_set(
             entry.second.preferred_hca.begin(),

--- a/mooncake-transfer-engine/tests/hip_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/hip_transport_test.cpp
@@ -71,10 +71,10 @@ TEST(HipTransportTest, RestoresActiveDeviceAfterTransfer) {
     void* src = allocOnDevice(kLen, kSourceDevice);
     void* dst = allocOnDevice(kLen, kSourceDevice);
     ASSERT_EQ(engine->registerLocalMemory(
-                  src, kLen, "cuda:" + std::to_string(kSourceDevice)),
+                  src, kLen, GPU_PREFIX + std::to_string(kSourceDevice)),
               0);
     ASSERT_EQ(engine->registerLocalMemory(
-                  dst, kLen, "cuda:" + std::to_string(kSourceDevice)),
+                  dst, kLen, GPU_PREFIX + std::to_string(kSourceDevice)),
               0);
 
     auto segment_id = engine->openSegment(server_name);

--- a/mooncake-transfer-engine/tests/topology_test.cpp
+++ b/mooncake-transfer-engine/tests/topology_test.cpp
@@ -3,7 +3,11 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <cstdlib>
+#include <string>
+#include <unordered_map>
 
+#include "config.h"
+#include "cuda_alike.h"
 #include "transfer_metadata.h"
 #include "memory_location.h"
 
@@ -153,6 +157,38 @@ TEST(ToplogyTest, TestDisableDeviceRemovesLocalHcaAffinityCandidate) {
     ASSERT_EQ(topology.disableDevice("mlx5_2"), 0);
     ASSERT_NE(topology.selectDeviceByLocalHca("cpu:0", "mlx5_2", 0),
               disabled_index);
+}
+
+// HCA peer affinity must key off GPU_PREFIX (cuda:/hip:/...), not a
+// hardcoded "cuda:" string — otherwise USE_HIP builds never resolve affinity
+// for discovered hip:N topology entries.
+TEST(ToplogyTest, HcaPeerAffinityAppliesToGpuPrefixEntries) {
+    auto &cfg = mooncake::globalConfig();
+    const bool old_enable = cfg.enable_hca_peer_affinity;
+    const auto old_map = cfg.nic_peer_affinity;
+    cfg.enable_hca_peer_affinity = true;
+    cfg.nic_peer_affinity = {{"L", {"P0"}}};
+
+    const std::string gpu_loc = GPU_PREFIX + "0";
+    const std::string json_str = "{\"" + gpu_loc + "\" : [[\"P0\",\"P1\"],[]]}";
+
+    mooncake::Topology topology;
+    ASSERT_EQ(topology.parse(json_str), 0);
+    ASSERT_EQ(topology.getHcaList().size(), static_cast<size_t>(2));
+    ASSERT_EQ(topology.getHcaList()[0], "P0");
+
+    std::unordered_map<int, int> hist;
+    for (int i = 0; i < 64; ++i) {
+        int id = topology.selectDeviceByLocalHca(gpu_loc, "L", 0);
+        hist[id]++;
+    }
+
+    cfg.enable_hca_peer_affinity = old_enable;
+    cfg.nic_peer_affinity = old_map;
+
+    ASSERT_EQ(hist.size(), static_cast<size_t>(1));
+    EXPECT_EQ(hist[0], 64) << "peer affinity should pin " << gpu_loc
+                           << " to P0 for local HCA L";
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
## Description

`Topology::precomputeResolvedHcaPeerAffinity` previously filtered topology entries with a hardcoded `"cuda:"` prefix. Under `USE_HIP`, discovered GPU locations are `hip:N`, so HCA peer affinity (`MC_ENABLE_HCA_PEER_AFFINITY` / `MC_NIC_PEER_AFFINITY`) never resolved for GPU buffers and RDMA fell back to unrestricted preferred-HCA selection.

This change matches entries with `GPU_PREFIX` (works for both `cuda:` and `hip:`), updates `hip_transport_test` to register with `GPU_PREFIX`, and adds a unit test that asserts affinity pins the vendor GPU location.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Unit test (USE_HIP build)
./topology_test --gtest_filter='*HcaPeerAffinity*'
./topology_test   # full suite: 13/13 passed

# Manual affinity probe (before/after)
env MC_ENABLE_HCA_PEER_AFFINITY=1 MC_NIC_PEER_AFFINITY='L=P0' \
  <affinity_probe>
# After fix: selectDeviceByLocalHca(hip:0, L) always returns P0
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

On ROCm host: with the fix, `hip:0` selections under `MC_NIC_PEER_AFFINITY=L=P0` are 200/200 on `P0` (pre-fix: ~50/50 `P0`/`P1`).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Agent assisted with locating the hardcoded `"cuda:"` filter, drafting the `GPU_PREFIX` fix/tests, and local reproduction under `USE_HIP`. Human submitter reviewed all changed lines.

Made with [Cursor](https://cursor.com)