### PR TITLE
Non aligned

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1959,11 +1959,11 @@ PYBIND11_MODULE(store, m) {
              [](MooncakeDistributedNoFRegisterPyWrapper &self,
                 const std::string &nqn = "", size_t nsid = 1,
                 const std::string &traddr = "", size_t trsvcid = 4420,
-                uintptr_t base = 0x0, size_t size = 1024,
+                uintptr_t base = 0x0, size_t size = 1024, uint32_t block_size = 512, 
                 const std::string &master_server_addr = "127.0.0.1:50051") {
                  self.register_ = std::make_shared<NoFRegisterClient>();
                  return self.register_->set_register(nqn, nsid, traddr, trsvcid,
-                                                     base, size,
+                                                     base, size, block_size,
                                                      master_server_addr);
              })
         .def("real_unregister_by_endpoint",

--- a/mooncake-store/benchmarks/store_kv_bench.py
+++ b/mooncake-store/benchmarks/store_kv_bench.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 
 import argparse
 import ctypes
-import importlib
-import json
 import logging
 import math
 import os
@@ -17,23 +15,7 @@ import time
 from collections import Counter
 from dataclasses import dataclass, field
 from typing import Callable, Iterable, List, Optional
-
-_store_module = importlib.import_module(
-    os.environ.get("MOONCAKE_STORE_MODULE", "mooncake.store")
-)
-MooncakeDistributedStore = _store_module.MooncakeDistributedStore
-ReplicateConfig = _store_module.ReplicateConfig
-
-try:
-    get_alloc_func_addr = _store_module.get_alloc_func_addr
-    get_free_func_addr = _store_module.get_free_func_addr
-except AttributeError:
-
-    def get_alloc_func_addr():
-        return None
-
-    def get_free_func_addr():
-        return None
+from mooncake.store import MooncakeDistributedStore, ReplicateConfig, get_alloc_func_addr, get_free_func_addr
 
 
 LOG = logging.getLogger("store_kv_bench")
@@ -49,14 +31,11 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         choices=[
             "verify_write",
+            "verify_nof_unaligned",
             "fill",
             "write_perf",
             "read_perf",
             "mixed_rw",
-            "metadata_smoke",
-            "mixed_metadata",
-            "remove_perf",
-            "replay",
         ],
         help="Benchmark scenario to execute.",
     )
@@ -72,15 +51,18 @@ def build_parser() -> argparse.ArgumentParser:
         "--io-api",
         choices=["plain", "zcopy"],
         default="plain",
-        help="plain uses put/get/put_batch/get_batch, zcopy uses put_from/get_into/batch_put_from/batch_get_into",
+        help=(
+            "plain uses put/get/put_batch/get_batch, zcopy uses "
+            "put_from/get_into/batch_put_from/batch_get_into. The NoF "
+            "range-get verification always uses get_into_ranges with an "
+            "internally registered buffer because no plain ranged API exists."
+        ),
     )
 
     parser.add_argument("--numjobs", type=int, default=1)
     parser.add_argument("--iodepth", type=int, default=1)
     parser.add_argument("--batch-size", type=int, default=1)
-    parser.add_argument(
-        "--runtime", type=int, default=0, help="Seconds. 0 means object-count based."
-    )
+    parser.add_argument("--runtime", type=int, default=0, help="Seconds. 0 means object-count based.")
     parser.add_argument("--nr-objects", type=int, default=128)
     parser.add_argument("--write-objects", type=int, default=0)
     parser.add_argument(
@@ -93,28 +75,61 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--key-prefix", default="kvbench")
     parser.add_argument("--key-size", type=int, default=20)
     parser.add_argument("--value-size", type=int, default=4096)
-    parser.add_argument("--rand-seed", type=int, default=1)
-    parser.add_argument("--put-pct", type=int, default=40)
-    parser.add_argument("--get-pct", type=int, default=40)
-    parser.add_argument("--exist-pct", type=int, default=10)
-    parser.add_argument("--remove-pct", type=int, default=10)
-    parser.add_argument("--latency-sample-rate", type=int, default=100)
-    parser.add_argument("--output-dir", default="")
     parser.add_argument(
-        "--journal", choices=["none", "failures", "all"], default="failures"
+        "--unaligned-nof-put",
+        action="store_true",
+        help=(
+            "Enable the NoF unaligned Put test mode. "
+            "Only fill/write_perf with io-api=plain are supported."
+        ),
     )
-    parser.add_argument("--summary-json", default="")
-    parser.add_argument("--replay-file", default="")
-    parser.add_argument("--tenant-id", default="default")
+    parser.add_argument(
+        "--nof-block-size",
+        type=int,
+        default=0,
+        help=(
+            "NoF logical block size used to validate and report padding. "
+            "Required when --unaligned-nof-put is enabled and must match "
+            "the block size used when registering the SSD."
+        ),
+    )
+    parser.add_argument(
+        "--range-src-offset",
+        type=int,
+        default=4,
+        help="Source offset used by the NoF unaligned range-get test.",
+    )
+    parser.add_argument(
+        "--range-size",
+        type=int,
+        default=0,
+        help=(
+            "Range-get length. 0 derives a length containing an unaligned "
+            "head, an aligned middle block, and an unaligned tail."
+        ),
+    )
+    parser.add_argument(
+        "--range-dst-offset",
+        type=int,
+        default=4,
+        help="Destination offset used by the NoF unaligned range-get test.",
+    )
+    parser.add_argument(
+        "--allow-non-dword-sgl",
+        action="store_true",
+        help=(
+            "Allow byte-granular NoF range parameters. Use only when the "
+            "controller reports SGL support without DWORD alignment."
+        ),
+    )
+    parser.add_argument("--rand-seed", type=int, default=1)
 
     parser.add_argument("--memory-replica-num", type=int, default=1)
     parser.add_argument("--nof-replica-num", type=int, default=0)
 
     parser.add_argument("--verify", action="store_true")
     parser.add_argument("--pattern", default="")
-    parser.add_argument(
-        "--prepare-mode", choices=["auto", "none", "write"], default="auto"
-    )
+    parser.add_argument("--prepare-mode", choices=["auto", "none", "write"], default="auto")
     parser.add_argument("--rwmixread", type=int, default=70)
 
     parser.add_argument(
@@ -154,7 +169,6 @@ class PhaseStats:
     start_time: float = 0.0
     end_time: float = 0.0
     dataset_exhausted: bool = False
-    latency_seen: int = 0
 
 
 @dataclass
@@ -167,115 +181,6 @@ class RequestResult:
     misses: int = 0
     verify_failures: int = 0
     error_counts: Counter = field(default_factory=Counter)
-
-
-METADATA_OPERATIONS = ("put", "get", "exist", "remove")
-
-
-def validate_operation_percentages(weights: dict) -> None:
-    if set(weights) != set(METADATA_OPERATIONS):
-        raise ValueError(f"operation percentages require {METADATA_OPERATIONS}")
-    if any(not isinstance(value, int) or value < 0 for value in weights.values()):
-        raise ValueError("operation percentages must be non-negative integers")
-    if sum(weights.values()) != 100:
-        raise ValueError("operation percentages must sum to 100")
-
-
-def choose_metadata_operations(
-    seed: int, lane: int, count: int, weights: dict
-) -> List[str]:
-    validate_operation_percentages(weights)
-    rng = random.Random(seed + lane)
-    boundaries = []
-    total = 0
-    for operation in METADATA_OPERATIONS:
-        total += weights[operation]
-        boundaries.append((total, operation))
-    result = []
-    for _ in range(count):
-        choice = rng.randrange(100)
-        result.append(
-            next(operation for limit, operation in boundaries if choice < limit)
-        )
-    return result
-
-
-class MetadataLaneModel:
-    def __init__(self):
-        self._present = set()
-
-    def is_present(self, object_id: int) -> bool:
-        return object_id in self._present
-
-    def record(self, object_id: int, operation: str, success: bool) -> None:
-        if not success:
-            return
-        if operation == "put":
-            self._present.add(object_id)
-        elif operation == "remove":
-            self._present.discard(object_id)
-
-
-class LatencySampler:
-    def __init__(self, rate: int):
-        if rate <= 0:
-            raise ValueError("latency sample rate must be > 0")
-        self.rate = rate
-        self.seen = 0
-        self.samples = []
-
-    def add(self, value: float) -> None:
-        if self.seen % self.rate == 0:
-            self.samples.append(value)
-        self.seen += 1
-
-
-def write_jsonl(path, records: Iterable[dict]) -> None:
-    os.makedirs(os.path.dirname(os.fspath(path)) or ".", exist_ok=True)
-    with open(path, "w", encoding="utf-8") as output:
-        for record in records:
-            output.write(json.dumps(record, sort_keys=True) + "\n")
-
-
-def read_replay(path) -> List[dict]:
-    required = {
-        "schema_version",
-        "op_id",
-        "lane",
-        "op",
-        "object_id",
-        "key",
-        "invoke_ns",
-        "return_ns",
-        "result",
-    }
-    records = []
-    with open(path, encoding="utf-8") as input_file:
-        for line_number, line in enumerate(input_file, 1):
-            if not line.strip():
-                continue
-            record = json.loads(line)
-            missing = required - set(record)
-            if (
-                missing
-                or record.get("schema_version") != 1
-                or record.get("op") not in METADATA_OPERATIONS
-            ):
-                raise ValueError(
-                    f"invalid replay record at line {line_number}: missing={sorted(missing)}"
-                )
-            records.append(record)
-    return records
-
-
-def write_json_atomic(path, value: dict) -> None:
-    path = os.fspath(path)
-    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-    temporary = path + ".tmp"
-    with open(temporary, "w", encoding="utf-8") as output:
-        json.dump(value, output, sort_keys=True)
-        output.write("\n")
-    os.replace(temporary, path)
 
 
 class PayloadFactory:
@@ -345,6 +250,10 @@ class DatasetState:
         with self.ids_lock:
             return list(self.written_ids)
 
+    def reset_read_cursor(self) -> None:
+        with self.cursor_lock:
+            self.read_cursor = 0
+
     def next_read_ids(
         self,
         count: int,
@@ -355,9 +264,7 @@ class DatasetState:
         source: str = "written",
     ) -> List[int]:
         with self.ids_lock:
-            readable_ids = (
-                self.prepared_ids if source == "prepared" else self.written_ids
-            )
+            readable_ids = self.prepared_ids if source == "prepared" else self.written_ids
         if not readable_ids:
             return []
         if sequential:
@@ -388,12 +295,16 @@ def parse_pattern(pattern_text: str) -> bytes:
 def make_key(prefix: str, key_size: int, object_id: int) -> str:
     suffix = f"{object_id:016d}"
     if key_size < len(suffix):
-        raise ValueError(
-            f"key_size={key_size} is smaller than suffix length {len(suffix)}"
-        )
+        raise ValueError(f"key_size={key_size} is smaller than suffix length {len(suffix)}")
     prefix_space = key_size - len(suffix)
     prefix_part = prefix[:prefix_space].ljust(prefix_space, "_")
     return f"{prefix_part}{suffix}"
+
+
+def align_up(value: int, alignment: int) -> int:
+    if alignment <= 0:
+        return value
+    return ((value + alignment - 1) // alignment) * alignment
 
 
 class StoreSession:
@@ -418,17 +329,12 @@ class StoreSession:
         self._zcopy = None
 
     def put_ids(self, object_ids: List[int]) -> RequestResult:
-        keys = [
-            make_key(self.args.key_prefix, self.args.key_size, object_id)
-            for object_id in object_ids
-        ]
+        keys = [make_key(self.args.key_prefix, self.args.key_size, object_id) for object_id in object_ids]
         ret_codes = self._put_keys(keys, object_ids)
 
         errors: Counter = Counter()
         success_ids: List[int] = []
-        if self.args.io_api == "plain" and not (
-            len(object_ids) == 1 and self.args.batch_size == 1
-        ):
+        if self.args.io_api == "plain" and not (len(object_ids) == 1 and self.args.batch_size == 1):
             ret = ret_codes[0]
             if ret == 0:
                 success_ids.extend(object_ids)
@@ -451,10 +357,7 @@ class StoreSession:
         )
 
     def get_ids(self, object_ids: List[int], verify: bool) -> RequestResult:
-        keys = [
-            make_key(self.args.key_prefix, self.args.key_size, object_id)
-            for object_id in object_ids
-        ]
+        keys = [make_key(self.args.key_prefix, self.args.key_size, object_id) for object_id in object_ids]
         errors: Counter = Counter()
         kv_successes = 0
         misses = 0
@@ -466,9 +369,7 @@ class StoreSession:
                     misses += 1
                     errors["MISS"] += 1
                     continue
-                if verify and not self.payload_factory.verify_payload(
-                    object_id, payload
-                ):
+                if verify and not self.payload_factory.verify_payload(object_id, payload):
                     verify_failures += 1
                     errors["VERIFY_FAIL"] += 1
                     continue
@@ -507,60 +408,66 @@ class StoreSession:
             error_counts=errors,
         )
 
-    def metadata_operation(
-        self, operation: str, object_id: int, expected_present: bool
-    ):
-        key = make_key(self.args.key_prefix, self.args.key_size, object_id)
-        result_code = 0
-        actual_present = expected_present
-        bytes_processed = 0
-        success = False
+    def get_range_ids(self, object_ids: List[int]) -> RequestResult:
+        assert self._zcopy is not None
+
+        keys = [
+            make_key(self.args.key_prefix, self.args.key_size, object_id)
+            for object_id in object_ids
+        ]
+        slot_count = len(object_ids)
+        ptrs = self._zcopy.prepare_read_buffers(slot_count)
+        src_offset = self.args.range_src_offset
+        dst_offset = self.args.range_dst_offset
+        range_size = self.args.range_size
+
+        results = self.store.get_into_ranges(
+            ptrs,
+            [[key] for key in keys],
+            [[[dst_offset]] for _ in keys],
+            [[[src_offset]] for _ in keys],
+            [[[range_size]] for _ in keys],
+        )
+
+        errors: Counter = Counter()
+        kv_successes = 0
         verify_failures = 0
 
-        if operation == "put":
-            payload = self.payload_factory.build(object_id)
-            result_code = self.store.put(key, payload, self.config)
-            actual_present = result_code == 0 or self.store.isExist(key) == 1
-            success = result_code == 0 or (expected_present and actual_present)
-            bytes_processed = len(payload) if success else 0
-        elif operation == "get":
-            payload = self.store.get(key)
-            actual_present = payload not in (None, b"")
-            success = actual_present == expected_present
-            if actual_present and not self.payload_factory.verify_payload(
-                object_id, payload
-            ):
-                success = False
-                verify_failures = 1
-                result_code = "VERIFY_FAIL"
-            elif not success:
-                result_code = "PRESENCE_MISMATCH"
-            bytes_processed = len(payload) if actual_present else 0
-        elif operation == "exist":
-            result_code = self.store.isExist(key)
-            actual_present = result_code == 1
-            success = result_code >= 0 and actual_present == expected_present
-        elif operation == "remove":
-            result_code = self.store.remove(key)
-            actual_present = self.store.isExist(key) == 1
-            success = not actual_present and (result_code == 0 or not expected_present)
-        else:
-            raise ValueError(f"unsupported metadata operation: {operation}")
+        for slot, object_id in enumerate(object_ids):
+            try:
+                result = results[slot][0][0]
+            except (IndexError, TypeError):
+                errors["INVALID_RESULT_SHAPE"] += 1
+                verify_failures += 1
+                continue
 
-        errors = Counter()
-        if not success:
-            errors[result_code] += 1
-        return (
-            RequestResult(
-                request_ok=success,
-                kv_successes=int(success),
-                kv_failures=int(not success),
-                bytes_processed=bytes_processed,
-                verify_failures=verify_failures,
-                error_counts=errors,
-            ),
-            actual_present,
-            result_code,
+            if result < 0:
+                errors[result] += 1
+                continue
+
+            if result != range_size:
+                errors["VERIFY_SIZE_MISMATCH"] += 1
+                verify_failures += 1
+                continue
+
+            actual = self._zcopy.read_bytes_at(slot, dst_offset, range_size)
+            full_payload = self.payload_factory.build(object_id)
+            expected = full_payload[src_offset : src_offset + range_size]
+            if actual != expected:
+                errors["VERIFY_RANGE_MISMATCH"] += 1
+                verify_failures += 1
+                continue
+
+            kv_successes += 1
+
+        kv_failures = len(object_ids) - kv_successes
+        return RequestResult(
+            request_ok=(kv_failures == 0),
+            kv_successes=kv_successes,
+            kv_failures=kv_failures,
+            bytes_processed=kv_successes * range_size,
+            verify_failures=verify_failures,
+            error_counts=errors,
         )
 
     def _put_keys(self, keys: List[str], object_ids: List[int]) -> List[int]:
@@ -592,11 +499,19 @@ class StoreSession:
 
 
 class ZcopyBufferPool:
-    def __init__(self, store_obj, value_size: int, slots: int):
+    def __init__(
+        self,
+        store_obj,
+        value_size: int,
+        slots: int,
+        alignment: int = 1,
+    ):
         self.store = store_obj
         self.value_size = value_size
         self.slots = slots
-        self.total_size = self.value_size * self.slots
+        self.alignment = max(1, alignment)
+        self.slot_stride = align_up(self.value_size, self.alignment)
+        self.total_size = self.slot_stride * self.slots
         self._alloc_fn = None
         self._free_fn = None
         self._registered = False
@@ -605,20 +520,28 @@ class ZcopyBufferPool:
         alloc_addr = get_alloc_func_addr()
         free_addr = get_free_func_addr()
         if alloc_addr is None or free_addr is None:
-            raise RuntimeError(
-                "store module does not expose hugepage alloc/free helpers"
-            )
+            raise RuntimeError("store module does not expose hugepage alloc/free helpers")
 
         self._alloc_fn = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_size_t)(
             get_alloc_func_addr()
         )
-        self._free_fn = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(get_free_func_addr())
+        self._free_fn = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(
+            get_free_func_addr()
+        )
 
         raw_ptr = self._alloc_fn(self.total_size)
         self.base_ptr = ctypes.cast(raw_ptr, ctypes.c_void_p).value or 0
         if self.base_ptr == 0:
             raise RuntimeError(
                 f"direct hugepage alloc failed for zcopy pool: size={self.total_size}"
+            )
+        if self.base_ptr % self.alignment != 0:
+            failed_ptr = self.base_ptr
+            self._free_fn(ctypes.c_void_p(self.base_ptr))
+            self.base_ptr = 0
+            raise RuntimeError(
+                f"zcopy base pointer {failed_ptr:#x} is not "
+                f"{self.alignment}-byte aligned"
             )
         ret = self.store.register_buffer(self.base_ptr, self.total_size)
         if ret != 0:
@@ -638,11 +561,7 @@ class ZcopyBufferPool:
                 try:
                     self.store.unregister_buffer(self.base_ptr)
                 except Exception:
-                    LOG.debug(
-                        "unregister_buffer failed for direct zcopy pool ptr=%s",
-                        self.base_ptr,
-                        exc_info=True,
-                    )
+                    LOG.debug("unregister_buffer failed for direct zcopy pool ptr=%s", self.base_ptr, exc_info=True)
                 self._registered = False
             if self._free_fn is not None:
                 self._free_fn(ctypes.c_void_p(self.base_ptr))
@@ -651,20 +570,82 @@ class ZcopyBufferPool:
     def slot_ptr(self, slot: int) -> int:
         if slot < 0 or slot >= self.slots:
             raise IndexError(f"zcopy slot {slot} is out of range [0, {self.slots})")
-        return self.base_ptr + slot * self.value_size
+        ptr = self.base_ptr + slot * self.slot_stride
+        if ptr % self.alignment != 0:
+            raise RuntimeError(
+                f"zcopy slot pointer {ptr:#x} is not "
+                f"{self.alignment}-byte aligned"
+            )
+        return ptr
+
+
+class RegisteredHostBufferPool:
+    """Registered host buffers used only by plain ranged-read verification."""
+
+    def __init__(
+        self,
+        store_obj,
+        value_size: int,
+        slots: int,
+        alignment: int = 1,
+    ):
+        self.store = store_obj
+        self.value_size = value_size
+        self.slots = slots
+        self.alignment = max(1, alignment)
+        self.slot_stride = align_up(self.value_size, self.alignment)
+        self.total_size = self.slot_stride * self.slots
+        self.allocated_size = self.total_size + self.alignment - 1
+        self._registered = False
+
+        self._buffer = (ctypes.c_ubyte * self.allocated_size)()
+        self.raw_ptr = ctypes.addressof(self._buffer)
+        self.base_ptr = align_up(self.raw_ptr, self.alignment)
+
+        ret = self.store.register_buffer(self.raw_ptr, self.allocated_size)
+        if ret != 0:
+            failed_ptr = self.raw_ptr
+            self._buffer = None
+            self.raw_ptr = 0
+            self.base_ptr = 0
+            raise RuntimeError(
+                "register_buffer failed for host range pool "
+                f"ptr={failed_ptr}: {ret}"
+            )
+        self._registered = True
+
+    def close(self) -> None:
+        if self.raw_ptr and self._registered:
+            try:
+                self.store.unregister_buffer(self.raw_ptr)
+            except Exception:
+                LOG.debug(
+                    "unregister_buffer failed for host range pool ptr=%s",
+                    self.raw_ptr,
+                    exc_info=True,
+                )
+            self._registered = False
+        self._buffer = None
+        self.raw_ptr = 0
+        self.base_ptr = 0
+
+    def slot_ptr(self, slot: int) -> int:
+        if slot < 0 or slot >= self.slots:
+            raise IndexError(
+                f"host range slot {slot} is out of range [0, {self.slots})"
+            )
+        return self.base_ptr + slot * self.slot_stride
 
 
 class ZcopyBufferView:
-    def __init__(self, pool: ZcopyBufferPool, slot_offset: int, slots: int):
+    def __init__(self, pool, slot_offset: int, slots: int):
         self.pool = pool
         self.slot_offset = slot_offset
         self.slots = slots
 
     def _slot_ptr(self, slot: int) -> int:
         if slot < 0 or slot >= self.slots:
-            raise IndexError(
-                f"zcopy view slot {slot} is out of range [0, {self.slots})"
-            )
+            raise IndexError(f"zcopy view slot {slot} is out of range [0, {self.slots})")
         return self.pool.slot_ptr(self.slot_offset + slot)
 
     def fill_write_buffers(self, payloads: List[bytes]) -> List[int]:
@@ -694,9 +675,20 @@ class ZcopyBufferView:
             )
         return ctypes.string_at(self._slot_ptr(slot), size)
 
+    def read_bytes_at(self, slot: int, offset: int, size: int) -> bytes:
+        if offset < 0 or size < 0:
+            raise ValueError("offset and size must be >= 0")
+        if offset + size > self.pool.value_size:
+            raise ValueError(
+                f"Read range [{offset}, {offset + size}) exceeds slot size "
+                f"{self.pool.value_size}"
+            )
+        return ctypes.string_at(self._slot_ptr(slot) + offset, size)
+
 
 class StoreRuntime:
     def __init__(self, args: argparse.Namespace, lane_count: int):
+
         self.lane_count = lane_count
         self.store = MooncakeDistributedStore()
         setup_ret = self.store.setup(
@@ -711,10 +703,28 @@ class StoreRuntime:
         if setup_ret != 0:
             raise RuntimeError(f"setup failed: {setup_ret}")
 
-        self.zcopy_pool: Optional[ZcopyBufferPool] = None
+        self.zcopy_pool = None
+        needs_registered_range_buffers = (
+            args.scenario == "verify_nof_unaligned"
+        )
         if args.io_api == "zcopy":
             slots = max(1, args.batch_size) * lane_count
-            self.zcopy_pool = ZcopyBufferPool(self.store, args.value_size, slots)
+            alignment = args.nof_block_size if args.nof_replica_num > 0 else 1
+            self.zcopy_pool = ZcopyBufferPool(
+                self.store,
+                args.value_size,
+                slots,
+                alignment,
+            )
+        elif needs_registered_range_buffers:
+            slots = max(1, args.batch_size) * lane_count
+            alignment = args.nof_block_size if args.nof_replica_num > 0 else 1
+            self.zcopy_pool = RegisteredHostBufferPool(
+                self.store,
+                args.value_size,
+                slots,
+                alignment,
+            )
 
     def make_session(
         self,
@@ -756,13 +766,10 @@ def merge_stats(name: str, stats_list: List[PhaseStats]) -> PhaseStats:
     merged = PhaseStats(name=name)
     if not stats_list:
         return merged
-    merged.start_time = min(
-        (s.start_time for s in stats_list if s.start_time), default=0.0
-    )
+    merged.start_time = min((s.start_time for s in stats_list if s.start_time), default=0.0)
     merged.end_time = max((s.end_time for s in stats_list if s.end_time), default=0.0)
     for stats in stats_list:
         merged.request_latencies.extend(stats.request_latencies)
-        merged.latency_seen += stats.latency_seen
         merged.requests += stats.requests
         merged.successful_requests += stats.successful_requests
         merged.failed_requests += stats.failed_requests
@@ -806,16 +813,11 @@ def summarize_stats(stats: PhaseStats) -> dict:
         "duration_sec": duration,
         "req_per_sec": (stats.requests / duration) if duration > 0 else 0.0,
         "kv_per_sec": (stats.kvs / duration) if duration > 0 else 0.0,
-        "MiB_per_sec": (stats.bytes_processed / duration / (1024 * 1024))
-        if duration > 0
-        else 0.0,
-        "lat_mean_ms": statistics.mean(stats.request_latencies) * 1000
-        if stats.request_latencies
-        else 0.0,
+        "MiB_per_sec": (stats.bytes_processed / duration / (1024 * 1024)) if duration > 0 else 0.0,
+        "lat_mean_ms": statistics.mean(stats.request_latencies) * 1000 if stats.request_latencies else 0.0,
         "lat_p50_ms": percentile(stats.request_latencies, 0.50) * 1000,
         "lat_p95_ms": percentile(stats.request_latencies, 0.95) * 1000,
         "lat_p99_ms": percentile(stats.request_latencies, 0.99) * 1000,
-        "latency_samples": len(stats.request_latencies),
         "dataset_exhausted": stats.dataset_exhausted,
         "error_counts": dict(stats.error_counts),
     }
@@ -864,7 +866,6 @@ class BenchmarkRunner:
         self.lane_count = args.numjobs * args.iodepth
         self._sessions: Optional[List[StoreSession]] = None
         self._runtime: Optional[StoreRuntime] = None
-        self._journal_records: List[List[dict]] = [[] for _ in range(self.lane_count)]
         self._validate_args()
 
     def _validate_args(self) -> None:
@@ -884,20 +885,6 @@ class BenchmarkRunner:
             raise ValueError("prepare-objects must be >= 0")
         if self.args.rwmixread < 0 or self.args.rwmixread > 100:
             raise ValueError("rwmixread must be within [0, 100]")
-        validate_operation_percentages(
-            {
-                "put": self.args.put_pct,
-                "get": self.args.get_pct,
-                "exist": self.args.exist_pct,
-                "remove": self.args.remove_pct,
-            }
-        )
-        if self.args.latency_sample_rate <= 0:
-            raise ValueError("latency-sample-rate must be > 0")
-        if self.args.tenant_id != "default":
-            raise ValueError("only --tenant-id=default is currently supported")
-        if self.args.scenario == "replay" and not self.args.replay_file:
-            raise ValueError("replay requires --replay-file")
         if self.args.verify and not self.pattern:
             raise ValueError("verify mode currently requires --pattern")
         if self.args.memory_replica_num == 0 and self.args.nof_replica_num == 0:
@@ -908,37 +895,88 @@ class BenchmarkRunner:
             raise ValueError("phase-gap-file must be set when phase-gap-mode=file")
         if self.args.scenario == "mixed_rw" and self.args.runtime <= 0:
             raise ValueError("mixed_rw requires --runtime > 0")
-        if self._scenario_has_write() and self.args.value_size % 512 != 0:
-            raise ValueError(
-                "write-involved scenarios require value-size to be 512B aligned"
-            )
+        if self.args.scenario == "verify_nof_unaligned":
+            if self.args.nof_replica_num <= 0:
+                raise ValueError(
+                    "verify_nof_unaligned requires --nof-replica-num > 0"
+                )
+            if self.args.memory_replica_num != 0:
+                raise ValueError(
+                    "set --memory-replica-num 0 so verification must use NoF"
+                )
+            if self.args.nof_block_size <= 0:
+                raise ValueError("--nof-block-size must be > 0")
+
+            block_size = self.args.nof_block_size
+            if block_size % 4 != 0:
+                raise ValueError("nof-block-size must be DWORD aligned")
+            if self.args.value_size % block_size == 0:
+                raise ValueError(
+                    "value-size must not be aligned to nof-block-size"
+                )
+            if self.args.range_src_offset <= 0:
+                raise ValueError("range-src-offset must be > 0")
+            if self.args.range_src_offset % block_size == 0:
+                raise ValueError("range-src-offset must be block-unaligned")
+            if self.args.range_dst_offset < 0:
+                raise ValueError("range-dst-offset must be >= 0")
+
+            if self.args.range_size == 0:
+                self.args.range_size = 2 * block_size + 36
+            if self.args.range_size <= 0:
+                raise ValueError("range-size must be > 0")
+
+            src_offset = self.args.range_src_offset
+            range_size = self.args.range_size
+            dst_offset = self.args.range_dst_offset
+            if not self.args.allow_non_dword_sgl:
+                dword_fields = {
+                    "value-size": self.args.value_size,
+                    "range-src-offset": src_offset,
+                    "range-dst-offset": dst_offset,
+                    "range-size": range_size,
+                }
+                for name, value in dword_fields.items():
+                    if value % 4 != 0:
+                        raise ValueError(
+                            f"{name} must be DWORD aligned unless "
+                            "--allow-non-dword-sgl is specified"
+                        )
+            if (src_offset + range_size) % block_size == 0:
+                raise ValueError("range end must be block-unaligned")
+
+            head_size = block_size - src_offset % block_size
+            if range_size <= head_size + block_size:
+                raise ValueError(
+                    "range-size must cover an unaligned head, at least one "
+                    "aligned middle block, and an unaligned tail"
+                )
+            if src_offset + range_size > self.args.value_size:
+                raise ValueError("source range exceeds value-size")
+            if dst_offset + range_size > self.args.value_size:
+                raise ValueError("destination range exceeds zcopy slot")
+            if not self.pattern or len(set(self.pattern)) < 2:
+                raise ValueError(
+                    "verify_nof_unaligned requires a non-constant --pattern"
+                )
+        # if self._scenario_has_write() and self.args.value_size % 512 != 0:
+        #     raise ValueError("write-involved scenarios require value-size to be 512B aligned")
         make_key(self.args.key_prefix, self.args.key_size, self.args.object_id_start)
 
     def _scenario_has_write(self) -> bool:
         return self.args.scenario in {
             "verify_write",
+            "verify_nof_unaligned",
             "fill",
             "write_perf",
             "mixed_rw",
-            "metadata_smoke",
-            "mixed_metadata",
-            "remove_perf",
-            "replay",
         }
 
     def _write_budget(self) -> int:
-        return (
-            self.args.write_objects
-            if self.args.write_objects > 0
-            else self.args.nr_objects
-        )
+        return self.args.write_objects if self.args.write_objects > 0 else self.args.nr_objects
 
     def _prepare_budget(self) -> int:
-        return (
-            self.args.prepare_objects
-            if self.args.prepare_objects > 0
-            else self.args.nr_objects
-        )
+        return self.args.prepare_objects if self.args.prepare_objects > 0 else self.args.nr_objects
 
     def _make_sessions(self) -> List[StoreSession]:
         if self._sessions is None:
@@ -968,65 +1006,55 @@ class BenchmarkRunner:
             time.sleep(self.args.phase_gap_sec)
             return
         if mode == "manual":
-            input(
-                f"phase '{label}' is waiting, finish external operations then press Enter to continue..."
-            )
+            input(f"phase '{label}' is waiting, finish external operations then press Enter to continue...")
             return
         deadline = time.time() + self.args.phase_gap_timeout_sec
         while time.time() < deadline:
             if os.path.exists(self.args.phase_gap_file):
-                LOG.info(
-                    "detected phase gap file %s, continuing to %s",
-                    self.args.phase_gap_file,
-                    label,
-                )
+                LOG.info("detected phase gap file %s, continuing to %s", self.args.phase_gap_file, label)
                 return
             time.sleep(1.0)
-        raise TimeoutError(
-            f"timed out waiting for phase gap file {self.args.phase_gap_file}"
-        )
+        raise TimeoutError(f"timed out waiting for phase gap file {self.args.phase_gap_file}")
 
-    def _run_threads(
-        self,
-        phase_name: str,
-        worker_builder: Callable[[StoreSession, int], Callable[[PhaseStats], None]],
-    ) -> PhaseStats:
+    def _run_threads(self, phase_name: str, worker_builder: Callable[[StoreSession, int], Callable[[PhaseStats], None]]) -> PhaseStats:
         sessions = self._make_sessions()
         per_lane_stats: List[Optional[PhaseStats]] = [None] * self.lane_count
+        worker_errors: List[tuple[int, Exception]] = []
+        worker_errors_lock = threading.Lock()
         threads: List[threading.Thread] = []
 
         def runner(index: int, session: StoreSession) -> None:
             stats = PhaseStats(name=f"{phase_name}/lane{index}")
             stats.start_time = time.perf_counter()
-            worker_builder(session, index)(stats)
-            stats.end_time = time.perf_counter()
-            per_lane_stats[index] = stats
+            try:
+                worker_builder(session, index)(stats)
+                per_lane_stats[index] = stats
+            except Exception as exc:
+                with worker_errors_lock:
+                    worker_errors.append((index, exc))
+            finally:
+                stats.end_time = time.perf_counter()
 
         for lane_id, session in enumerate(sessions):
-            thread = threading.Thread(
-                target=runner,
-                args=(lane_id, session),
-                name=f"{phase_name}-lane{lane_id}",
-            )
+            thread = threading.Thread(target=runner, args=(lane_id, session), name=f"{phase_name}-lane{lane_id}")
             threads.append(thread)
             thread.start()
 
         for thread in threads:
             thread.join()
 
+        if worker_errors:
+            lane_id, exc = worker_errors[0]
+            raise RuntimeError(
+                f"{phase_name} worker lane {lane_id} failed: {exc}"
+            ) from exc
+
         merged = merge_stats(phase_name, [s for s in per_lane_stats if s is not None])
         log_phase_stats(merged)
         return merged
 
-    def _record(
-        self, stats: PhaseStats, latency: float, request: RequestResult, kv_count: int
-    ) -> None:
-        if (
-            self.args.runtime <= 0
-            or stats.latency_seen % self.args.latency_sample_rate == 0
-        ):
-            stats.request_latencies.append(latency)
-        stats.latency_seen += 1
+    def _record(self, stats: PhaseStats, latency: float, request: RequestResult, kv_count: int) -> None:
+        stats.request_latencies.append(latency)
         stats.requests += 1
         stats.kvs += kv_count
         if request.request_ok:
@@ -1040,154 +1068,6 @@ class BenchmarkRunner:
         stats.bytes_processed += request.bytes_processed
         stats.error_counts.update(request.error_counts)
 
-    def _run_metadata_operations(
-        self, phase_name: str, operations_by_lane
-    ) -> PhaseStats:
-        def worker(session: StoreSession, lane_id: int) -> Callable[[PhaseStats], None]:
-            def run(stats: PhaseStats) -> None:
-                model = MetadataLaneModel()
-                for op_id, (operation, object_id) in enumerate(
-                    operations_by_lane(lane_id)
-                ):
-                    expected_present = model.is_present(object_id)
-                    invoke_ns = time.time_ns()
-                    start = time.perf_counter()
-                    result, actual_present, result_code = session.metadata_operation(
-                        operation, object_id, expected_present
-                    )
-                    return_ns = time.time_ns()
-                    self._record(
-                        stats,
-                        time.perf_counter() - start,
-                        result,
-                        1,
-                    )
-                    model.record(object_id, operation, result.request_ok)
-                    if self.args.journal == "all" or (
-                        self.args.journal == "failures" and not result.request_ok
-                    ):
-                        self._journal_records[lane_id].append(
-                            {
-                                "schema_version": 1,
-                                "op_id": op_id,
-                                "lane": lane_id,
-                                "op": operation,
-                                "object_id": object_id,
-                                "key": make_key(
-                                    self.args.key_prefix,
-                                    self.args.key_size,
-                                    object_id,
-                                ),
-                                "invoke_ns": invoke_ns,
-                                "return_ns": return_ns,
-                                "result": result_code,
-                                "ok": result.request_ok,
-                                "expected_present": expected_present,
-                                "actual_present": actual_present,
-                            }
-                        )
-
-            return run
-
-        return self._run_threads(phase_name, worker)
-
-    def _metadata_smoke(self) -> PhaseStats:
-        sequence = ("put", "exist", "get", "remove", "exist")
-
-        def operations(lane_id: int):
-            object_id = self.args.object_id_start + lane_id
-            if object_id >= self.args.object_id_start + self.args.nr_objects:
-                return []
-            return [(operation, object_id) for operation in sequence]
-
-        stats = self._run_metadata_operations("metadata_smoke", operations)
-        if stats.failed_kvs:
-            raise RuntimeError(f"metadata_smoke failed operations={stats.failed_kvs}")
-        return stats
-
-    def _mixed_metadata(self) -> PhaseStats:
-        weights = {
-            "put": self.args.put_pct,
-            "get": self.args.get_pct,
-            "exist": self.args.exist_pct,
-            "remove": self.args.remove_pct,
-        }
-
-        def operations(lane_id: int):
-            object_ids = list(
-                range(
-                    self.args.object_id_start + lane_id,
-                    self.args.object_id_start + self.args.nr_objects,
-                    self.lane_count,
-                )
-            )
-            if not object_ids:
-                return []
-            count = len(object_ids)
-            choices = choose_metadata_operations(
-                self.args.rand_seed, lane_id, count, weights
-            )
-            return [
-                (operation, object_ids[index % len(object_ids)])
-                for index, operation in enumerate(choices)
-            ]
-
-        return self._run_metadata_operations("mixed_metadata", operations)
-
-    def _remove_prepared(self) -> PhaseStats:
-        object_ids = self.dataset.snapshot_written_ids()
-
-        def operations(lane_id: int):
-            return [
-                ("remove", object_id)
-                for index, object_id in enumerate(object_ids)
-                if index % self.lane_count == lane_id
-            ]
-
-        return self._run_metadata_operations("remove_perf", operations)
-
-    def _replay(self) -> PhaseStats:
-        records = read_replay(self.args.replay_file)
-
-        def operations(lane_id: int):
-            return [
-                (record["op"], int(record["object_id"]))
-                for record in records
-                if int(record["lane"]) == lane_id
-            ]
-
-        return self._run_metadata_operations("replay", operations)
-
-    def write_outputs(self, phases: List[PhaseStats]) -> None:
-        records = sorted(
-            (record for lane in self._journal_records for record in lane),
-            key=lambda record: (
-                record["invoke_ns"],
-                record["lane"],
-                record["op_id"],
-            ),
-        )
-        if self.args.output_dir:
-            os.makedirs(self.args.output_dir, exist_ok=True)
-        if self.args.journal != "none" and self.args.output_dir:
-            write_jsonl(os.path.join(self.args.output_dir, "journal.jsonl"), records)
-        summary_path = self.args.summary_json
-        if not summary_path and self.args.output_dir:
-            summary_path = os.path.join(self.args.output_dir, "summary.json")
-        if summary_path:
-            overall = merge_stats("overall", phases)
-            write_json_atomic(
-                summary_path,
-                {
-                    "schema_version": 1,
-                    "scenario": self.args.scenario,
-                    "ok": overall.failed_kvs == 0 and overall.verify_failures == 0,
-                    "phases": {phase.name: summarize_stats(phase) for phase in phases},
-                    "overall": summarize_stats(overall),
-                    "journal_records": len(records),
-                },
-            )
-
     def _run_fixed_write(
         self,
         phase_name: str,
@@ -1198,14 +1078,10 @@ class BenchmarkRunner:
     ) -> PhaseStats:
         write_upper = self.dataset.next_write_id + total_objects
 
-        def worker(
-            session: StoreSession, _lane_id: int
-        ) -> Callable[[PhaseStats], None]:
+        def worker(session: StoreSession, _lane_id: int) -> Callable[[PhaseStats], None]:
             def run(stats: PhaseStats) -> None:
                 while True:
-                    object_ids = self.dataset.reserve_write_ids(
-                        self.args.batch_size, write_upper
-                    )
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
                     if not object_ids:
                         break
                     start = time.perf_counter()
@@ -1216,10 +1092,7 @@ class BenchmarkRunner:
                         if write_scope == "prepared":
                             self.dataset.mark_prepared(result.successful_object_ids)
                         else:
-                            self.dataset.mark_runtime_written(
-                                result.successful_object_ids
-                            )
-
+                            self.dataset.mark_runtime_written(result.successful_object_ids)
             return run
 
         stats = self._run_threads(phase_name, worker)
@@ -1238,14 +1111,10 @@ class BenchmarkRunner:
         write_upper = self.dataset.next_write_id + total_objects
         stop_event = threading.Event()
 
-        def worker(
-            session: StoreSession, _lane_id: int
-        ) -> Callable[[PhaseStats], None]:
+        def worker(session: StoreSession, _lane_id: int) -> Callable[[PhaseStats], None]:
             def run(stats: PhaseStats) -> None:
                 while time.time() < deadline and not stop_event.is_set():
-                    object_ids = self.dataset.reserve_write_ids(
-                        self.args.batch_size, write_upper
-                    )
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
                     if not object_ids:
                         stats.dataset_exhausted = True
                         stop_event.set()
@@ -1256,7 +1125,6 @@ class BenchmarkRunner:
                     self._record(stats, latency, result, len(object_ids))
                     if result.successful_object_ids:
                         self.dataset.mark_runtime_written(result.successful_object_ids)
-
             return run
 
         return self._run_threads(phase_name, worker)
@@ -1274,9 +1142,7 @@ class BenchmarkRunner:
         if runtime_sec > 0:
             deadline = time.time() + runtime_sec
 
-            def worker(
-                session: StoreSession, lane_id: int
-            ) -> Callable[[PhaseStats], None]:
+            def worker(session: StoreSession, lane_id: int) -> Callable[[PhaseStats], None]:
                 rng = random.Random(seed_base + lane_id)
 
                 def run(stats: PhaseStats) -> None:
@@ -1323,6 +1189,51 @@ class BenchmarkRunner:
 
         return self._run_threads(phase_name, worker)
 
+    def _run_nof_range_verify(self, phase_name: str) -> PhaseStats:
+        self.dataset.reset_read_cursor()
+        seed_base = self.args.rand_seed
+
+        def worker(
+            session: StoreSession,
+            lane_id: int,
+        ) -> Callable[[PhaseStats], None]:
+            rng = random.Random(seed_base + lane_id)
+
+            def run(stats: PhaseStats) -> None:
+                while True:
+                    object_ids = self.dataset.next_read_ids(
+                        self.args.batch_size,
+                        loop=False,
+                        sequential=True,
+                        rng=rng,
+                        source="prepared",
+                    )
+                    if not object_ids:
+                        break
+
+                    start = time.perf_counter()
+                    result = session.get_range_ids(object_ids)
+                    latency = time.perf_counter() - start
+                    self._record(stats, latency, result, len(object_ids))
+
+            return run
+
+        stats = self._run_threads(phase_name, worker)
+        expected = self._write_budget()
+        if (
+            stats.failed_kvs > 0
+            or stats.verify_failures > 0
+            or stats.successful_kvs != expected
+        ):
+            raise RuntimeError(
+                f"{phase_name} failed: expected={expected}, "
+                f"success={stats.successful_kvs}, "
+                f"failed={stats.failed_kvs}, "
+                f"verify_failures={stats.verify_failures}, "
+                f"errors={dict(stats.error_counts)}"
+            )
+        return stats
+
     def _run_mixed_phase(self, phase_name: str, extra_write_budget: int) -> PhaseStats:
         deadline = time.time() + self.args.runtime
         write_upper = self.dataset.next_write_id + extra_write_budget
@@ -1351,9 +1262,7 @@ class BenchmarkRunner:
                         self._record(stats, latency, result, len(object_ids))
                         continue
 
-                    object_ids = self.dataset.reserve_write_ids(
-                        self.args.batch_size, write_upper
-                    )
+                    object_ids = self.dataset.reserve_write_ids(self.args.batch_size, write_upper)
                     if not object_ids:
                         stats.dataset_exhausted = True
                         stop_event.set()
@@ -1372,10 +1281,7 @@ class BenchmarkRunner:
     def _maybe_prepare_dataset(self) -> Optional[PhaseStats]:
         if self.args.prepare_mode == "none":
             return None
-        if self.args.prepare_mode == "write" or self.args.scenario in {
-            "read_perf",
-            "mixed_rw",
-        }:
+        if self.args.prepare_mode == "write" or self.args.scenario in {"read_perf", "mixed_rw"}:
             stats = self._run_fixed_write(
                 "prepare_write",
                 self._prepare_budget(),
@@ -1405,6 +1311,41 @@ class BenchmarkRunner:
         )
 
         phases: List[PhaseStats] = []
+        if self.args.scenario == "verify_nof_unaligned":
+            phases.append(
+                self._run_fixed_write(
+                    "nof_unaligned_put",
+                    self._write_budget(),
+                    strict=True,
+                    write_scope="prepared",
+                )
+            )
+            self.dataset.reset_read_cursor()
+            full_get_stats = self._run_read_phase(
+                "nof_unaligned_full_get",
+                verify=True,
+                sequential=True,
+                loop=False,
+            )
+            if (
+                full_get_stats.failed_kvs > 0
+                or full_get_stats.verify_failures > 0
+                or full_get_stats.successful_kvs != self._write_budget()
+            ):
+                raise RuntimeError(
+                    "nof_unaligned_full_get failed: "
+                    f"expected={self._write_budget()}, "
+                    f"success={full_get_stats.successful_kvs}, "
+                    f"failed={full_get_stats.failed_kvs}, "
+                    f"verify_failures={full_get_stats.verify_failures}, "
+                    f"errors={dict(full_get_stats.error_counts)}"
+                )
+            phases.append(full_get_stats)
+            phases.append(
+                self._run_nof_range_verify("nof_unaligned_range_get")
+            )
+            return phases
+
         if self.args.scenario == "verify_write":
             phases.append(
                 self._run_fixed_write(
@@ -1415,17 +1356,11 @@ class BenchmarkRunner:
                 )
             )
             self._phase_gap("verify_read")
-            phases.append(
-                self._run_read_phase(
-                    "verify_read", verify=True, sequential=True, loop=False
-                )
-            )
+            phases.append(self._run_read_phase("verify_read", verify=True, sequential=True, loop=False))
             return phases
 
         if self.args.scenario == "fill":
-            phases.append(
-                self._run_fixed_write("fill_write", self._write_budget(), strict=False)
-            )
+            phases.append(self._run_fixed_write("fill_write", self._write_budget(), strict=False))
             return phases
 
         if self.args.scenario == "write_perf":
@@ -1433,33 +1368,7 @@ class BenchmarkRunner:
             if self.args.runtime > 0:
                 phases.append(self._run_time_based_write("write_perf", total_objects))
             else:
-                phases.append(
-                    self._run_fixed_write("write_perf", total_objects, strict=False)
-                )
-            return phases
-
-        if self.args.scenario == "metadata_smoke":
-            phases.append(self._metadata_smoke())
-            return phases
-
-        if self.args.scenario == "mixed_metadata":
-            phases.append(self._mixed_metadata())
-            return phases
-
-        if self.args.scenario == "remove_perf":
-            phases.append(
-                self._run_fixed_write(
-                    "prepare_write",
-                    self._prepare_budget(),
-                    strict=True,
-                    write_scope="prepared",
-                )
-            )
-            phases.append(self._remove_prepared())
-            return phases
-
-        if self.args.scenario == "replay":
-            phases.append(self._replay())
+                phases.append(self._run_fixed_write("write_perf", total_objects, strict=False))
             return phases
 
         if self.args.scenario == "read_perf":
@@ -1499,20 +1408,10 @@ def main() -> int:
         runner = BenchmarkRunner(args)
         phases = runner.run()
         log_overall_summary(phases)
-        runner.write_outputs(phases)
         if any(phase.verify_failures > 0 for phase in phases):
             return 20
-        if args.verify and any(
-            phase.misses > 0 for phase in phases if "read" in phase.name
-        ):
+        if args.verify and any(phase.misses > 0 for phase in phases if "read" in phase.name):
             return 21
-        if args.scenario in {
-            "metadata_smoke",
-            "mixed_metadata",
-            "remove_perf",
-            "replay",
-        } and any(phase.failed_kvs > 0 for phase in phases):
-            return 22
         return 0
     except KeyboardInterrupt:
         LOG.warning("benchmark interrupted")

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -457,6 +457,17 @@ class Replica {
         }
     }
 
+    void set_nof_metadata(uint64_t object_size, uint32_t block_size) {
+        if (!is_nof_replica()) {
+        LOG(ERROR) << "Cannot set NoF metadata on non-NoF replica";
+        return;
+        }
+
+        auto& nof_data = std::get<NoFReplicaData>(data_);
+        nof_data.object_size = object_size;
+        nof_data.block_size = block_size;
+    }
+
     void mark_removed() {
         if (status_ == ReplicaStatus::COMPLETE ||
             status_ == ReplicaStatus::PROCESSING) {

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -627,10 +627,14 @@ inline Replica::Descriptor Replica::get_descriptor() const {
         NoFDescriptor nof_desc;
         if (nof_data.buffer) {
             nof_desc.buffer_descriptor = nof_data.buffer->get_descriptor();
+            nof_desc.object_size = nof_data.object_size;
+            nof_desc.block_size = nof_data.block_size;
         } else {
             nof_desc.buffer_descriptor.size_ = 0;
             nof_desc.buffer_descriptor.buffer_address_ = 0;
             nof_desc.buffer_descriptor.transport_endpoint_ = "";
+            nof_desc.object_size = 0;
+            nof_desc.block_size = 0;
             LOG(ERROR) << "Trying to get invalid nof replica descriptor";
         }
         desc.descriptor_variant = std::move(nof_desc);

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -192,7 +192,9 @@ struct MemoryDescriptor {
 
 struct NoFDescriptor {
     AllocatedBuffer::Descriptor buffer_descriptor;
-    YLT_REFL(NoFDescriptor, buffer_descriptor);
+    uint64_t object_size{0};
+    uint32_t block_size{0};
+    YLT_REFL(NoFDescriptor, buffer_descriptor, object_size, block_size);
 };
 
 struct DiskDescriptor {

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -170,6 +170,8 @@ struct MemoryReplicaData {
 
 struct NoFReplicaData {
     std::unique_ptr<AllocatedBuffer> buffer;
+    uint64_t object_size{0};
+    uint32_t block_size{0};
 };
 
 struct DiskReplicaData {

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -82,6 +82,7 @@ inline std::ostream& operator<<(
        << ", segment.name=" << snapshot.segment.name
        << ", segment.base=" << snapshot.segment.base
        << ", segment.size=" << snapshot.segment.size
+       << ", segment.block_size=" << snapshot.segment.block_size
        << ", segment.te_endpoint=" << snapshot.segment.te_endpoint
        << ", status=" << snapshot.status << "}";
     return os;
@@ -560,7 +561,10 @@ class NoFSegmentManager {
         std::shared_lock<std::shared_mutex> lock(segment_mutex_);
         return mounted_segments_.size();
     }
-
+    uint32_t getBlockSize() const {
+        std::shared_lock<std::shared_mutex> lock(segment_mutex_);
+        return block_size_;
+    }
     void GetMountedSegmentsSnapshot(
         std::vector<MountedNoFSegmentSnapshot>& segments) const;
 
@@ -593,7 +597,7 @@ class NoFSegmentManager {
 
     std::unordered_map<std::string, UUID>
         client_by_name_;  // segment name -> client_id
-
+    uint32_t block_size_{0};
     friend class ScopedNoFSegmentAccess;
     friend class SegmentTest;
 };

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -344,8 +344,8 @@ class ScopedNoFSegmentAccess {
 class ScopedAllocatorAccess {
    public:
     explicit ScopedAllocatorAccess(const AllocatorManager& allocator_manager,
-                                   std::shared_mutex& mutex)
-        : allocator_manager_(allocator_manager), lock_(mutex) {}
+                                   std::shared_mutex& mutex, const uint32_t& block_size)
+        : allocator_manager_(allocator_manager), lock_(mutex), block_size_(block_size) {}
 
     explicit ScopedAllocatorAccess(const AllocatorManager& allocator_manager,
                                    const HostSegmentIndex& segments_by_host,
@@ -358,11 +358,13 @@ class ScopedAllocatorAccess {
 
     std::vector<std::string> GetHostOrderedSegments(
         const std::string& writer_host_id, const std::string& key) const;
-
+    
+    uint32_t getBlockSize() const {return block_size_;}
    private:
     const AllocatorManager& allocator_manager_;
     const HostSegmentIndex* segments_by_host_{nullptr};
     std::shared_lock<std::shared_mutex> lock_;
+    uint32_t block_size_{0};
 };
 
 /**
@@ -550,7 +552,7 @@ class NoFSegmentManager {
      * @return ScopedAllocatorAccess object that holds the lock
      */
     ScopedAllocatorAccess getAllocatorAccess() {
-        return ScopedAllocatorAccess(allocator_manager_, segment_mutex_);
+        return ScopedAllocatorAccess(allocator_manager_, segment_mutex_, block_size_);
     }
 
     /**
@@ -562,11 +564,6 @@ class NoFSegmentManager {
         return mounted_segments_.size();
     }
 
-    uint32_t getBlockSize() const {
-        std::shared_lock<std::shared_mutex> lock(segment_mutex_);
-        return block_size_;
-    }
-    
     void GetMountedSegmentsSnapshot(
         std::vector<MountedNoFSegmentSnapshot>& segments) const;
 

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -561,10 +561,12 @@ class NoFSegmentManager {
         std::shared_lock<std::shared_mutex> lock(segment_mutex_);
         return mounted_segments_.size();
     }
+
     uint32_t getBlockSize() const {
         std::shared_lock<std::shared_mutex> lock(segment_mutex_);
         return block_size_;
     }
+    
     void GetMountedSegmentsSnapshot(
         std::vector<MountedNoFSegmentSnapshot>& segments) const;
 

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -19,6 +19,11 @@ constexpr int kSpdkNofOpRead = 0;
 constexpr int kSpdkNofOpWrite = 1;
 constexpr int kSpdkNofOpNum = 2;
 
+struct SpdkSglCapabilities {
+    bool supported{false};
+    bool requires_dword_alignment{false};
+};
+
 struct nof_seg_handle;
 struct tr_info;
 struct ctrlr_info;
@@ -46,9 +51,18 @@ class SpdkWrapper {
 
     uint32_t GetBlockSize(const nof_seg_handle *seg_handle);
 
+    bool GetSglCapabilities(const nof_seg_handle *seg_handle,
+                            SpdkSglCapabilities *capabilities);
+
     int SubmitRequest(const nof_seg_handle *seg_handle, void *ptr, uint64_t lba,
                       uint32_t lba_count, int op, spdk_nvme_cmd_cb cb_fn,
                       void *cb_ctx);
+                      
+    int SubmitSglRequest(
+        const nof_seg_handle *seg_handle, uint64_t lba, uint32_t lba_count,
+        int op, spdk_nvme_cmd_cb cb_fn, void *cb_ctx,
+        spdk_nvme_req_reset_sgl_cb reset_sgl_fn,
+        spdk_nvme_req_next_sge_cb next_sge_fn);
 
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);

--- a/mooncake-store/include/ssd_register_client.h
+++ b/mooncake-store/include/ssd_register_client.h
@@ -16,7 +16,7 @@ class NoFRegisterClient {
 
     int set_register(const std::string &nqn, size_t nsid,
                      const std::string &traddr, size_t trsvcid, uintptr_t base,
-                     size_t size, const std::string &master_server_addr);
+                     size_t size, uint32_t block_size, const std::string &master_server_addr);
 
     /**
      * @brief Unregister a NoF SSD segment by its te_endpoint

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -157,33 +157,19 @@ class MemcpyOperationState : public OperationState {
  */
 class SpdkNofOperationState : public OperationState {
    public:
-    explicit SpdkNofOperationState(size_t pending_tasks = 1)
-        : pending_tasks_(pending_tasks) {
-        assert(pending_tasks_ > 0);
-    }
 
     bool is_completed() override {
         std::lock_guard<std::mutex> lock(mutex_);
         return result_.has_value();
     }
     void set_completed(ErrorCode error_code) {
-        bool notify = false;
 
         {
             std::lock_guard<std::mutex> lock(mutex_);
             assert(!result_.has_value());
-            assert(pending_tasks_ > 0);
-            if (error_code != ErrorCode::OK && first_error_ == ErrorCode::OK) {
-                first_error_ = error_code;
-            }
-            --pending_tasks_;
-            if (pending_tasks_ == 0) {
-                result_.emplace(first_error_);
-                notify = true;
-            }
+            result_.emplace(first_error_);
         }
-        if (notify) {
-            cv_.notify_all();
+        cv_.notify_all();
         }
     }
 
@@ -196,9 +182,6 @@ class SpdkNofOperationState : public OperationState {
         return TransferStrategy::SPDK_NVMF;
     }
 
-   private:
-    size_t pending_tasks_;
-    ErrorCode first_error_{ErrorCode::OK};
 };
 
 class FilereadOperationState : public OperationState {

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -347,21 +348,33 @@ class MemcpyWorkerPool {
 };
 
 #ifdef USE_NOF
-// struct SpdkNofSubTask;
+
 struct SpdkNofQos;
 
+struct SpdkNofSge {
+    void* address{nullptr};
+    uint64_t length{0};
+
+    static SpdkNofSge Data(void* address, uint64_t length) {
+        SpdkNofSge result;
+        result.address = address;
+        result.length = length;
+        return result;
+    }
+};
 /**
  * @brief Spdk nvmf operation descriptor
  */
 struct SpdkNofTask {
     nof_seg_handle* seg_handle;
-    void* ptr;
+    std::vector<SpdkNofSge> sgl;
+    std::vector<std::shared_ptr<void>> buffer_owners;
     uint64_t lba;
     uint32_t lba_count;
-    int remaining_lba;
+    uint64_t sgl_size;
+    uint32_t remaining_lba;
     int outstanding_sub_io;
     int op;   // kSpdkNofOpRead or kSpdkNofOpWrite
-    int idx;  // subop idx
     bool failed;
     bool on_chain;
     std::shared_ptr<SpdkNofOperationState> state;
@@ -369,28 +382,47 @@ struct SpdkNofTask {
     SpdkNofQos* nof_qos;
     SpdkNofTask* nxt;
 
-    SpdkNofTask(nof_seg_handle* handle, void* buf, uint64_t off, uint32_t len,
-                int op_code, std::shared_ptr<SpdkNofOperationState> s)
+    SpdkNofTask(
+        nof_seg_handle* handle, std::vector<SpdkNofSge> entries,
+        uint64_t off, uint32_t len, int op_code,
+        std::shared_ptr<SpdkNofOperationState> operation_state,
+        std::vector<std::shared_ptr<void>> owners = {})
         : seg_handle(handle),
-          ptr(buf),
+          sgl(std::move(entries)),
+          buffer_owners(std::move(owners)),
           lba(off),
           lba_count(len),
+          sgl_size(0),
           remaining_lba(lba_count),
           outstanding_sub_io(0),
           op(op_code),
-          idx(0),
           failed(false),
           on_chain(false),
-          state(std::move(s)),
+          state(std::move(operation_state)),
           io_count(nullptr),
           nof_qos(nullptr),
-          nxt(nullptr) {}
+          nxt(nullptr) {
+        for (const auto& entry : sgl) {
+            if (entry.length >
+                std::numeric_limits<uint64_t>::max() - sgl_size) {
+                sgl_size = 0;
+                break;
+            }
+            sgl_size += entry.length;
+        }
+    }
 };
 
 struct SpdkNofSubTask {
-    SpdkNofTask* task;
-    int submit_lba_count;
-    std::stack<SpdkNofSubTask*>* sub_task_pool;
+    SpdkNofTask* task{nullptr};
+    uint32_t submit_lba_count{0};
+    uint64_t payload_offset{0};
+    uint64_t payload_size{0};
+    size_t cursor_sge_index{0};
+    uint64_t cursor_sge_offset{0};
+    uint64_t cursor_remaining{0};
+    bool cursor_valid{false};
+    std::stack<SpdkNofSubTask*>* sub_task_pool{nullptr};
 };
 
 constexpr int kDefaultSpdkNofSubmitChunkBytes = (1 << 17);    // 128k
@@ -423,6 +455,9 @@ struct SpdkNofQos {
     void PopTask(int op) {
         if (head[op]) {
             head[op] = head[op]->nxt;
+            if (head[op] == nullptr) {
+                tail[op] = nullptr;
+            }
         }
     }
 };
@@ -631,6 +666,9 @@ class TransferSubmitter {
     std::optional<TransferFuture> submitSpdkNofOperation(
         const AllocatedBuffer::Descriptor& handle, void* ptr, size_t size,
         const TransferRequest::OpCode op_code);
+    std::optional<TransferFuture> submitSpdkNofRangeReadOperation(
+        const NoFDescriptor& descriptor, void* ptr, size_t size,
+        uint64_t src_offset);
 #endif
 
     /**

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -167,11 +167,11 @@ class SpdkNofOperationState : public OperationState {
         {
             std::lock_guard<std::mutex> lock(mutex_);
             assert(!result_.has_value());
-            result_.emplace(first_error_);
+            result_.emplace(error_code);
         }
         cv_.notify_all();
-        }
     }
+    
 
     void wait_for_completion() override {
         std::unique_lock<std::mutex> lock(mutex_);

--- a/mooncake-store/include/transfer_task.h
+++ b/mooncake-store/include/transfer_task.h
@@ -157,18 +157,34 @@ class MemcpyOperationState : public OperationState {
  */
 class SpdkNofOperationState : public OperationState {
    public:
+    explicit SpdkNofOperationState(size_t pending_tasks = 1)
+        : pending_tasks_(pending_tasks) {
+        assert(pending_tasks_ > 0);
+    }
+
     bool is_completed() override {
         std::lock_guard<std::mutex> lock(mutex_);
         return result_.has_value();
     }
-
     void set_completed(ErrorCode error_code) {
+        bool notify = false;
+
         {
             std::lock_guard<std::mutex> lock(mutex_);
             assert(!result_.has_value());
-            result_.emplace(error_code);
+            assert(pending_tasks_ > 0);
+            if (error_code != ErrorCode::OK && first_error_ == ErrorCode::OK) {
+                first_error_ = error_code;
+            }
+            --pending_tasks_;
+            if (pending_tasks_ == 0) {
+                result_.emplace(first_error_);
+                notify = true;
+            }
         }
-        cv_.notify_all();
+        if (notify) {
+            cv_.notify_all();
+        }
     }
 
     void wait_for_completion() override {
@@ -179,6 +195,10 @@ class SpdkNofOperationState : public OperationState {
     TransferStrategy get_strategy() const override {
         return TransferStrategy::SPDK_NVMF;
     }
+
+   private:
+    size_t pending_tasks_;
+    ErrorCode first_error_{ErrorCode::OK};
 };
 
 class FilereadOperationState : public OperationState {

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -472,7 +472,7 @@ struct NoFSegment {
     std::string te_endpoint{};
     NoFSegment() = default;
 };
-YLT_REFL(NoFSegment, id, name, base, size, te_endpoint);
+YLT_REFL(NoFSegment, id, name, base, size, block_size, te_endpoint);
 
 /**
  * @brief Client status from the master's perspective

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -467,6 +467,7 @@ struct NoFSegment {
     std::string name{};  // Logical segment name used for preferred allocation
     uintptr_t base{0};
     size_t size{0};
+    uint32_t block_size{0};
     // TE p2p endpoint (ip:port) for transport-only addressing
     std::string te_endpoint{};
     NoFSegment() = default;

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -150,7 +150,7 @@ uint64_t calculate_total_size(const Replica::Descriptor& replica) {
     } else if (replica.is_local_disk_replica()) {
         total_length = replica.get_local_disk_descriptor().object_size;
     } else if (replica.is_nof_replica()) {
-        total_length = replica.get_nof_descriptor().buffer_descriptor.size_;
+        total_length = replica.get_nof_descriptor().object_size;
     } else {
         total_length = replica.get_memory_descriptor().buffer_descriptor.size_;
     }

--- a/mooncake-store/src/client_buffer.cpp
+++ b/mooncake-store/src/client_buffer.cpp
@@ -173,9 +173,8 @@ int allocateSlices(std::vector<Slice>& slices,
         slices.emplace_back(
             Slice{buffer_ptr, replica.get_local_disk_descriptor().object_size});
     } else if (replica.is_nof_replica()) {
-        auto& handle = replica.get_nof_descriptor().buffer_descriptor;
-        void* chunk_ptr = buffer_ptr;
-        slices.emplace_back(Slice{chunk_ptr, handle.size_});
+        const auto& nof_desc = replica.get_nof_descriptor();
+        slices.emplace_back(Slice{buffer_ptr, nof_desc.object_size});
     } else {
         // For memory-based replica, split into slices based on buffer
         // descriptors

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1310,8 +1310,9 @@ tl::expected<void, ErrorCode> Client::Get(const std::string& object_key,
         }
         return tl::unexpected(err);
     }
-    if (!replica.is_memory_replica()) {
-        LOG(ERROR) << "Range read only supported for memory replicas, key="
+    if (!replica.is_memory_replica() && !replica.is_nof_replica()) {
+        LOG(ERROR)
+            << "Range read only supported for memory and NoF replicas, key="
                    << object_key;
         return tl::unexpected(ErrorCode::INVALID_REPLICA);
     }
@@ -3772,7 +3773,7 @@ ErrorCode Client::TransferRead(const Replica::Descriptor& replica_descriptor,
         total_size = mem_desc.buffer_descriptor.size_;
     } else if (replica_descriptor.is_nof_replica()) {
         auto& nof_desc = replica_descriptor.get_nof_descriptor();
-        total_size = nof_desc.buffer_descriptor.size_;
+        total_size = nof_desc.object_size;
     } else if (replica_descriptor.is_disk_replica()) {
         auto& disk_desc = replica_descriptor.get_disk_descriptor();
         total_size = disk_desc.object_size;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2604,10 +2604,13 @@ void MasterService::RestoreFromStandbySnapshot(
                         alloc = std::make_shared<DummyBufferAllocator>(
                             endpoint, endpoint);
                     }
-                    replicas.emplace_back(
-                        std::make_unique<AllocatedBuffer>(
-                            alloc, nof_desc.buffer_descriptor),
-                        desc.status, ReplicaType::NOF_SSD);
+                    const uint64_t object_size = nof_desc.object_size;
+                    const uint32_t block_size = nof_desc.block_size;
+                    Replica replica(
+                        std::make_unique<AllocatedBuffer>(alloc, nof_desc.buffer_descriptor),
+                        desc.status,ReplicaType::NOF_SSD);
+                    replica.set_nof_metadata(object_size, block_size)
+                    replicas.emplace_back(std::move(replica));
                 } else if (desc.is_disk_replica()) {
                     const auto& disk_desc = desc.get_disk_descriptor();
                     replicas.emplace_back(disk_desc.file_path,
@@ -3445,7 +3448,7 @@ auto MasterService::AllocateAndInsertMetadata(
             nof_segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
 
-        const uint32_t nof_block_size = nof_segment_manager_.getBlockSize(); 
+        const uint32_t nof_block_size = allocator_access.getBlockSize(); 
         if (value_length > std::numeric_limits<uint64_t>::max() -(nof_block_size - 1)) {
             abort_reserved_quota();
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2609,7 +2609,7 @@ void MasterService::RestoreFromStandbySnapshot(
                     Replica replica(
                         std::make_unique<AllocatedBuffer>(alloc, nof_desc.buffer_descriptor),
                         desc.status,ReplicaType::NOF_SSD);
-                    replica.set_nof_metadata(object_size, block_size)
+                    replica.set_nof_metadata(object_size, block_size);
                     replicas.emplace_back(std::move(replica));
                 } else if (desc.is_disk_replica()) {
                     const auto& disk_desc = desc.get_disk_descriptor();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3445,11 +3445,19 @@ auto MasterService::AllocateAndInsertMetadata(
             nof_segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
 
+        const uint32_t nof_block_size = nof_segment_manager_.getBlockSize(); 
+        if (value_length > std::numeric_limits<uint64_t>::max() -(nof_block_size - 1)) {
+            abort_reserved_quota();
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        const uint64_t nof_allocation_length = ((value_length + nof_block_size - 1) / nof_block_size) * nof_block_size;
+        
+
         std::vector<std::string> preferred_segments =
             config.preferred_nof_segments;
 
         auto allocation_result = allocation_strategy_->Allocate(
-            allocator_manager, value_length, config.nof_replica_num,
+            allocator_manager, nof_allocation_length, config.nof_replica_num,
             preferred_segments, std::set<std::string>(), ReplicaType::NOF_SSD);
 
         if (!allocation_result.has_value()) {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3476,6 +3476,7 @@ auto MasterService::AllocateAndInsertMetadata(
         } else {
             allocated_nof_replicas = allocation_result->size();
             for (auto& replica : allocation_result.value()) {
+                replica.set_nof_metadata(value_length, nof_block_size);
                 replicas.push_back(std::move(replica));
             }
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3413,7 +3413,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         auto runtime_accelerator =
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
-        if (runtime_accelerator.FindDeviceForPointer(dst)) {
+        if (!replica.is_nof_replica() && runtime_accelerator.FindDeviceForPointer(dst)) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -3527,9 +3527,18 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
             total_size);
     }
 
-    if (!replica.is_memory_replica()) {
-        LOG(ERROR) << "ranged reads only support memory/disk replicas";
-        return tl::unexpected(ErrorCode::INVALID_REPLICA);
+    if (replica.is_nof_replica()) {
+        void* dst = static_cast<char*>(buffer) + dst_offset;
+        std::vector<Slice> slices{Slice{dst, size}};
+        auto filtered_qr = FilterQueryResult(query_result, replica);
+        auto get_result =
+            client_->Get(key, filtered_qr, slices, src_offset);
+        if (!get_result) {
+            LOG(ERROR) << "NoF ranged Get failed for key: " << key
+                       << ", error=" << toString(get_result.error());
+            return tl::unexpected(get_result.error());
+        }
+        return static_cast<int64_t>(size);
     }
 
     auto runtime_accelerator =

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3528,16 +3528,36 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
     }
 
     if (replica.is_nof_replica()) {
-        void* dst = static_cast<char*>(buffer) + dst_offset;
-        std::vector<Slice> slices{Slice{dst, size}};
+        if (!client_buffer_allocator_) {
+            LOG(ERROR) << "Client buffer allocator is not provided";
+            return tl::unexpected(ErrorCode::INVALID_PARAMS);
+        }
+
+        auto alloc_result = client_buffer_allocator_->allocate(size);
+        if (!alloc_result) {
+            LOG(ERROR) << "Failed to allocate temporary DMA buffer for NoF "
+                        "ranged read"
+                        << ", key=" << key << ", size=" << size;
+            return tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+        }
+
+        BufferHandle tmp_handle(std::move(*alloc_result));
+        std::vector<Slice> tmp_slices{Slice{tmp_handle.ptr(), size},};
+
         auto filtered_qr = FilterQueryResult(query_result, replica);
-        auto get_result =
-            client_->Get(key, filtered_qr, slices, src_offset);
+        auto get_result = client_->Get(key, filtered_qr, tmp_slices, src_offset);
         if (!get_result) {
             LOG(ERROR) << "NoF ranged Get failed for key: " << key
-                       << ", error=" << toString(get_result.error());
+                   << ", error=" << toString(get_result.error());
             return tl::unexpected(get_result.error());
         }
+
+        void* dst = static_cast<char*>(buffer) + dst_offset;
+        auto copy_result = scatter_host_to_maybe_device(dst, tmp_handle.ptr(), size, "NoF ranged read, key: " + key);
+        if (!copy_result) {
+            return tl::unexpected(copy_result.error());
+        }
+
         return static_cast<int64_t>(size);
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3413,7 +3413,7 @@ tl::expected<int64_t, ErrorCode> RealClient::execute_ranged_read(
         auto runtime_accelerator =
             device::GetAcceleratorRegistry().RuntimeAccelerators();
         void *dst = static_cast<char *>(buffer) + dst_offset;
-        if (!replica.is_nof_replica() && runtime_accelerator.FindDeviceForPointer(dst)) {
+        if (runtime_accelerator.FindDeviceForPointer(dst)) {
             if (!client_buffer_allocator_) {
                 LOG(ERROR) << "Client buffer allocator is not provided";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1305,9 +1305,9 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
     }
 
     if (nof_segment_manager_->block_size_ != 0 &&
-        nof_segment_manager_->block_size_ != block_size) {
+        nof_segment_manager_->block_size_ != segment.block_size) {
         LOG(ERROR) << "NoF segment block size differs from pool"
-                   << ", segment=" << block_size
+                   << ", segment=" << segment.block_size
                    << ", pool=" << nof_segment_manager_->block_size_;
         return ErrorCode::INVALID_PARAMS;
     }
@@ -1390,7 +1390,7 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
         segment, client_id, SegmentStatus::OK, std::move(allocator)};
     nof_segment_manager_->client_by_name_[segment.name] = client_id;
     if (nof_segment_manager_->block_size_ == 0) {
-        nof_segment_manager_->block_size_ = block_size;
+        nof_segment_manager_->block_size_ = segment.block_size;
     }
     MasterMetricManager::instance().inc_total_nof_capacity(segment.name, size);
 

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1304,6 +1304,14 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
         return ErrorCode::INVALID_PARAMS;
     }
 
+    if (nof_segment_manager_->block_size_ != 0 &&
+        nof_segment_manager_->block_size_ != block_size) {
+        LOG(ERROR) << "NoF segment block size differs from pool"
+                   << ", segment=" << block_size
+                   << ", pool=" << nof_segment_manager_->block_size_;
+        return ErrorCode::INVALID_PARAMS;
+    }
+
     if (nof_segment_manager_->memory_allocator_ ==
             BufferAllocatorType::CACHELIB &&
         (buffer % facebook::cachelib::Slab::kSize ||
@@ -1381,6 +1389,9 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
     nof_segment_manager_->mounted_segments_[segment.id] = {
         segment, client_id, SegmentStatus::OK, std::move(allocator)};
     nof_segment_manager_->client_by_name_[segment.name] = client_id;
+    if (nof_segment_manager_->block_size_ == 0) {
+        nof_segment_manager_->block_size_ = block_size;
+    }
     MasterMetricManager::instance().inc_total_nof_capacity(segment.name, size);
 
     return ErrorCode::OK;
@@ -1472,6 +1483,9 @@ ErrorCode ScopedNoFSegmentAccess::CommitUnmountSegment(
     }
 
     nof_segment_manager_->mounted_segments_.erase(segment_id);
+    if (nof_segment_manager_->mounted_segments_.empty()) {
+        nof_segment_manager_->block_size_ = 0;
+    }
     MasterMetricManager::instance().dec_total_nof_capacity(
         segment_name, metrics_dec_capacity);
 

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -428,13 +428,7 @@ int SpdkWrapper::SubmitSglRequest(
         return -EINVAL;
     }
 
-    SpdkSglCapabilities capabilities;
-    if (!GetSglCapabilities(seg_handle, &capabilities)) {
-        return -EINVAL;
-    }
-    if (!capabilities.supported) {
-        return -ENOTSUP;
-    }
+    
 
     if (op == kSpdkNofOpRead) {
         return spdk_nvme_ns_cmd_readv(

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -370,6 +370,32 @@ uint32_t SpdkWrapper::GetBlockSize(const nof_seg_handle *seg_handle) {
     return spdk_nvme_ns_get_sector_size(seg_handle->ns);
 }
 
+bool SpdkWrapper::GetSglCapabilities(
+    const nof_seg_handle *seg_handle, SpdkSglCapabilities *capabilities) {
+    if (capabilities == nullptr) {
+        return false;
+    }
+
+    *capabilities = SpdkSglCapabilities{};
+    if (seg_handle == nullptr || seg_handle->ns == nullptr) {
+        return false;
+    }
+
+    struct spdk_nvme_ctrlr *ctrlr =
+        spdk_nvme_ns_get_ctrlr(seg_handle->ns);
+    if (ctrlr == nullptr) {
+        return false;
+    }
+
+    const uint64_t flags = spdk_nvme_ctrlr_get_flags(ctrlr);
+    capabilities->supported =
+        (flags & SPDK_NVME_CTRLR_SGL_SUPPORTED) != 0;
+    capabilities->requires_dword_alignment =
+        capabilities->supported &&
+        ((flags & SPDK_NVME_CTRLR_SGL_REQUIRES_DWORD_ALIGNMENT) != 0);
+    return true;
+}
+
 int SpdkWrapper::SubmitRequest(const nof_seg_handle *seg_handle, void *ptr,
                                uint64_t lba, uint32_t lba_count, int op,
                                spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
@@ -388,6 +414,40 @@ int SpdkWrapper::SubmitRequest(const nof_seg_handle *seg_handle, void *ptr,
                                       cb_ctx, 0);
     }
     return -1;
+}
+
+int SpdkWrapper::SubmitSglRequest(
+    const nof_seg_handle *seg_handle, uint64_t lba, uint32_t lba_count,
+    int op, spdk_nvme_cmd_cb cb_fn, void *cb_ctx,
+    spdk_nvme_req_reset_sgl_cb reset_sgl_fn,
+    spdk_nvme_req_next_sge_cb next_sge_fn) {
+    if (seg_handle == nullptr || seg_handle->qpair == nullptr ||
+        seg_handle->ns == nullptr || lba_count == 0 || cb_fn == nullptr ||
+        cb_ctx == nullptr || reset_sgl_fn == nullptr ||
+        next_sge_fn == nullptr) {
+        return -EINVAL;
+    }
+
+    SpdkSglCapabilities capabilities;
+    if (!GetSglCapabilities(seg_handle, &capabilities)) {
+        return -EINVAL;
+    }
+    if (!capabilities.supported) {
+        return -ENOTSUP;
+    }
+
+    if (op == kSpdkNofOpRead) {
+        return spdk_nvme_ns_cmd_readv(
+            seg_handle->ns, seg_handle->qpair, lba, lba_count, cb_fn, cb_ctx, 0,
+            reset_sgl_fn, next_sge_fn);
+    }
+    if (op == kSpdkNofOpWrite) {
+        return spdk_nvme_ns_cmd_writev(
+            seg_handle->ns, seg_handle->qpair, lba, lba_count, cb_fn, cb_ctx, 0,
+            reset_sgl_fn, next_sge_fn);
+    }
+
+    return -EINVAL;
 }
 
 SpdkWrapper::ProbeBuffer *SpdkWrapper::GetOrCreateProbeBuffer(

--- a/mooncake-store/src/ssd_register_client.cpp
+++ b/mooncake-store/src/ssd_register_client.cpp
@@ -12,13 +12,20 @@ NoFRegisterClient::~NoFRegisterClient() = default;
 
 int NoFRegisterClient::set_register(const std::string &nqn, size_t nsid,
                                     const std::string &traddr, size_t trsvcid,
-                                    uintptr_t base, size_t size,
+                                    uintptr_t base, size_t size, uint32_t block_size,
                                     const std::string &master_server_addr) {
     LOG(INFO) << "Registering SSD: nqn=" << nqn << ",nsid=" << nsid
               << ",traddr=" << traddr << ",trsvcid=" << trsvcid
               << ",master=" << master_server_addr << ",base=" << base
-              << ",size=" << size;
-
+              << ",size=" << size << ",block_size=" << block_size;
+    
+    if (block_size == 0 || (block_size & (block_size - 1)) != 0 ||
+        size == 0 || base % block_size != 0 || size % block_size != 0) {
+        LOG(ERROR) << "Invalid SSD registration"
+                   << ", block_size=" << block_size << ", base=" << base
+                   << ", size=" << size;
+        return OPERATION_FAILED;
+    }
     auto err = master_client_.Connect(master_server_addr);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "Failed to connect to master";
@@ -47,6 +54,7 @@ int NoFRegisterClient::set_register(const std::string &nqn, size_t nsid,
     segment.id = generate_uuid();
     segment.name = te_endpoint;
     segment.te_endpoint = te_endpoint;
+    segment.block_size = block_size;
     auto mount_result = master_client_.MountNoFSegment(segment);
     if (!mount_result) {
         LOG(ERROR) << "mount_segment_to_master_failed ";

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1708,8 +1708,7 @@ TransferSubmitter::submitSpdkNofRangeReadOperation(
     }
     std::shared_ptr<void> discard_owner;
     if (discard_size != 0) {
-        discard_owner = AllocateDmaOwner(
-            static_cast<size_t>(discard_size), block_size, &discard_buffer);
+        discard_owner = AllocateDmaOwner(static_cast<size_t>(discard_size), block_size, &discard_buffer);
         if (!discard_owner) {
             LOG(ERROR) << "Failed to allocate NoF discard DMA buffer";
             return std::nullopt;
@@ -1733,8 +1732,7 @@ TransferSubmitter::submitSpdkNofRangeReadOperation(
         }
         const uintptr_t tail_address =
             discard_address + static_cast<uintptr_t>(head_discard);
-        if (!AppendDmaSges(reinterpret_cast<void*>(tail_address),
-                           tail_discard, &sgl)) {
+        if (!AppendDmaSges(reinterpret_cast<void*>(tail_address), tail_discard, &sgl)) {
             return std::nullopt;
         }
     }
@@ -1744,19 +1742,14 @@ TransferSubmitter::submitSpdkNofRangeReadOperation(
 
     if (!ValidateSgl(sgl, physical_size, capabilities)) {
         LOG(ERROR) << "NoF range-read SGL violates Controller requirements"
-                   << ", dword_required="
-                   << capabilities.requires_dword_alignment
-                   << ", src_offset=" << src_offset
-                   << ", destination=" << ptr
-                   << ", size=" << size
-                   << ", head_discard=" << head_discard
+                   << ", dword_required=" << capabilities.requires_dword_alignment
+                   << ", src_offset=" << src_offset << ", destination=" << ptr
+                   << ", size=" << size << ", head_discard=" << head_discard
                    << ", tail_discard=" << tail_discard;
         return std::nullopt;
     }
 
-    const uint64_t start_lba =
-        handle.buffer_address_ / block_size +
-        physical_relative_start / block_size;
+    const uint64_t start_lba = handle.buffer_address_ / block_size + physical_relative_start / block_size;
     auto state = std::make_shared<SpdkNofOperationState>();
     SpdkNofTask task(seg_handle, std::move(sgl), start_lba, lba_count,
                      TransferRequest::READ, state, std::move(owners));

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -8,6 +8,7 @@
 #include <cerrno>
 #include <cstring>
 #include <cstdlib>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -102,6 +103,86 @@ static int CountSpdkNofQueuedTasks(const mooncake::SpdkNofTask* head) {
     return count;
 }
 
+static void nvmf_reset_sgl(void* ctx, uint32_t offset) {
+    auto* sub_task = reinterpret_cast<mooncake::SpdkNofSubTask*>(ctx);
+    if (sub_task == nullptr) {
+        return;
+    }
+
+    sub_task->cursor_valid = false;
+    sub_task->cursor_sge_index = 0;
+    sub_task->cursor_sge_offset = 0;
+    sub_task->cursor_remaining = 0;
+
+    if (sub_task->task == nullptr ||
+        static_cast<uint64_t>(offset) > sub_task->payload_size ||
+        sub_task->payload_offset > std::numeric_limits<uint64_t>::max() - static_cast<uint64_t>(offset)) {
+        return;
+    }
+
+    uint64_t skip = sub_task->payload_offset + static_cast<uint64_t>(offset);
+    const auto& sgl = sub_task->task->sgl;
+    size_t index = 0;
+
+    while (index < sgl.size()) {
+        const auto& entry = sgl[index];
+        if (skip < entry.length) {
+            sub_task->cursor_sge_index = index;
+            sub_task->cursor_sge_offset = skip;
+            sub_task->cursor_remaining = sub_task->payload_size - static_cast<uint64_t>(offset);
+            sub_task->cursor_valid = true;
+            return;
+        }
+        skip -= entry.length;
+        ++index;
+    }
+
+    if (skip == 0 &&
+        static_cast<uint64_t>(offset) == sub_task->payload_size) {
+        sub_task->cursor_sge_index = sgl.size();
+        sub_task->cursor_sge_offset = 0;
+        sub_task->cursor_remaining = 0;
+        sub_task->cursor_valid = true;
+    }
+}
+
+static int nvmf_next_sge(void* ctx, void** address, uint32_t* length) {
+    auto* sub_task = reinterpret_cast<mooncake::SpdkNofSubTask*>(ctx);
+    if (sub_task == nullptr || sub_task->task == nullptr ||
+        address == nullptr || length == nullptr ||
+        !sub_task->cursor_valid || sub_task->cursor_remaining == 0) {
+        return -EINVAL;
+    }
+
+    const auto& sgl = sub_task->task->sgl;
+    while (sub_task->cursor_sge_index < sgl.size()) {
+        const auto& entry = sgl[sub_task->cursor_sge_index];
+
+        uint64_t available = entry.length - sub_task->cursor_sge_offset;
+        available = std::min(available, sub_task->cursor_remaining);
+        constexpr uint64_t kMaxSgeLength = static_cast<uint64_t>(UINT32_MAX) & ~3ULL;
+        available = std::min(available, kMaxSgeLength);
+        if (available == 0) {
+            return -EINVAL;
+        }
+
+        const uintptr_t base = reinterpret_cast<uintptr_t>(entry.address);
+        
+        *address = reinterpret_cast<void*>(base + sub_task->cursor_sge_offset);
+        *length = static_cast<uint32_t>(available);
+
+        sub_task->cursor_sge_offset += available;
+        sub_task->cursor_remaining -= available;
+        if (sub_task->cursor_sge_offset == entry.length) {
+            ++sub_task->cursor_sge_index;
+            sub_task->cursor_sge_offset = 0;
+        }
+        return 0;
+    }
+
+    return -EINVAL;
+}
+
 static inline void SpdkNofTaskCompletion(mooncake::SpdkNofTask* task) {
     if (task->remaining_lba == 0 && task->outstanding_sub_io == 0) {
         task->state->set_completed(task->failed
@@ -144,9 +225,10 @@ static void nvmf_io_complete(void* ctx, const struct spdk_nvme_cpl* cpl) {
         task->failed = true;
     }
 
+    auto* sub_task_pool = sub_task->sub_task_pool;
+    sub_task->task = nullptr;
+    sub_task_pool->push(sub_task);
     SpdkNofTaskCompletion(task);
-
-    sub_task->sub_task_pool->push(sub_task);
 }
 #endif
 namespace mooncake {
@@ -435,19 +517,24 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                 if (task == nullptr) {
                     LOG(ERROR)
                         << "alloc SpdkNofTask failed, worker " << work_idx;
+                    task_queue.front().state->set_completed(ErrorCode::TRANSFER_FAIL);
+                    task_queue.pop();
                     continue;
                 }
 
                 SpdkNofQos* nof_qos = nullptr;
                 auto it = seg_to_qos.find(task->seg_handle);
                 if (it == seg_to_qos.end()) {
-                    auto qos = std::make_unique<SpdkNofQos>(
-                        SpdkWrapper::GetInstance().GetBlockSize(
-                            task->seg_handle));
+                    std::unique_ptr<SpdkNofQos> qos(
+                        new (std::nothrow) SpdkNofQos(
+                            SpdkWrapper::GetInstance().GetBlockSize(
+                                task->seg_handle)));
                     if (qos == nullptr) {
                         LOG(ERROR)
                             << "alloc SpdkNofQos failed, worker " << work_idx;
+                        task->state->set_completed(ErrorCode::TRANSFER_FAIL);
                         delete task;
+                        task_queue.pop();
                         continue;
                     }
                     nof_qos = qos.get();
@@ -481,16 +568,29 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                                    nof_qos->inflight_blocks[i];
                 while (nof_qos->head[i] && avail_blocks > 0) {
                     SpdkNofTask* task = nof_qos->head[i];
-                    SpdkNofSubTask* sub_task;
+
                     while (task->remaining_lba > 0 && avail_blocks > 0) {
-                        uint32_t submit_lba_count = std::min(
-                            avail_blocks, std::min(task->remaining_lba,
-                                                   nof_qos->blocks_per_chunk));
-                        int lba_off = task->lba_count - task->remaining_lba;
-                        uint64_t submit_lba = task->lba + lba_off;
-                        void* submit_ptr = reinterpret_cast<void*>(
-                            reinterpret_cast<char*>(task->ptr) +
-                            lba_off * block_size);
+                        const uint32_t submit_budget = static_cast<uint32_t>(std::min(
+                                avail_blocks, nof_qos->blocks_per_chunk));
+                        const uint32_t submit_lba_count =
+                            std::min(task->remaining_lba, submit_budget);
+                        const uint64_t lba_offset =
+                            static_cast<uint64_t>(task->lba_count - task->remaining_lba);
+                        const uint64_t submit_lba = task->lba + lba_offset;
+                        const uint64_t payload_offset = lba_offset * block_size;
+                        const uint64_t payload_size = static_cast<uint64_t>(submit_lba_count) * block_size;
+
+                        if (payload_offset > task->sgl_size ||
+                            payload_size > task->sgl_size - payload_offset) {
+                            LOG(ERROR)
+                                << "Invalid NoF SGL window"
+                                << ", payload_offset=" << payload_offset
+                                << ", payload_size=" << payload_size
+                                << ", sgl_size=" << task->sgl_size;
+                            task->failed = true;
+                            task->remaining_lba = 0;
+                            break;
+                        }
 
                         if (!CheckSubTaskPool(sub_task_pool, sub_task_chunks,
                                               work_idx)) {
@@ -498,22 +598,39 @@ void SpdkNofWorkerPool::workerThread(int work_idx) {
                             task->remaining_lba = 0;
                             break;
                         }
-                        sub_task = sub_task_pool.top();
+                        SpdkNofSubTask* sub_task = sub_task_pool.top();
                         sub_task_pool.pop();
                         sub_task->task = task;
                         sub_task->submit_lba_count = submit_lba_count;
+                        sub_task->payload_offset = payload_offset;
+                        sub_task->payload_size = payload_size;
 
-                        int ret = SpdkWrapper::GetInstance().SubmitRequest(
-                            task->seg_handle, submit_ptr, submit_lba,
-                            submit_lba_count, task->op, nvmf_io_complete,
-                            sub_task);
+                        nvmf_reset_sgl(sub_task, 0);
+                        if (!sub_task->cursor_valid) {
+                            LOG(ERROR)
+                                << "Failed to initialize NoF SGL cursor";
+                            sub_task->task = nullptr;
+                            sub_task_pool.push(sub_task);
+                            task->failed = true;
+                            task->remaining_lba = 0;
+                            break;
+                        }
+
+                        const int ret = SpdkWrapper::GetInstance().SubmitSglRequest(
+                                task->seg_handle, submit_lba,
+                                submit_lba_count, task->op, nvmf_io_complete,
+                                sub_task, nvmf_reset_sgl, nvmf_next_sge);
                         if (ret != 0) {
-                            LOG(ERROR) << "work " << work_idx << ", seg "
-                                       << task->seg_handle << " submit io fail";
+                            LOG(ERROR)
+                                << "worker " << work_idx << ", seg "
+                                << task->seg_handle
+                                << " submit SGL I/O failed, ret=" << ret;
+                            sub_task->task = nullptr;
+                            sub_task_pool.push(sub_task);
                             task->failed = true;
                             task->remaining_lba = 0;
                         } else {
-                            task->idx++;
+                            
                             task->remaining_lba -= submit_lba_count;
                             nof_qos->inflight_blocks[i] += submit_lba_count;
                             avail_blocks -= submit_lba_count;
@@ -1273,8 +1390,33 @@ std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
 
         future = submitMemoryReadOperation(handle, slices, src_offset);
     } else if (replica.is_nof_replica()) {
-        LOG(ERROR) << "Range read not supported for NoF replicas";
+#ifdef USE_NOF
+        void* range_ptr = slices.front().ptr;
+        if (range_ptr == nullptr) {
+            return std::nullopt;
+        }
+
+        uintptr_t expected = reinterpret_cast<uintptr_t>(range_ptr);
+        size_t range_size = 0;
+        for (const auto& slice : slices) {
+            if (slice.ptr == nullptr ||
+                reinterpret_cast<uintptr_t>(slice.ptr) != expected ||
+                slice.size > std::numeric_limits<size_t>::max() - range_size ||
+                slice.size > std::numeric_limits<uintptr_t>::max() - expected) {
+                LOG(ERROR)
+                    << "NoF range read requires contiguous slices";
+                return std::nullopt;
+            }
+            range_size += slice.size;
+            expected += slice.size;
+        }
+        future = submitSpdkNofRangeReadOperation(
+            replica.get_nof_descriptor(), range_ptr, range_size, src_offset);
+#else
+        LOG(ERROR)
+            << "NoF range read requested while USE_NOF is disabled";
         return std::nullopt;
+#endif
     } else if (replica.is_disk_replica() || replica.is_local_disk_replica()) {
         LOG(ERROR)
             << "Range read not supported for disk replicas (use full read)";
@@ -1287,43 +1429,338 @@ std::optional<TransferFuture> TransferSubmitter::submitRangeRead(
 
     return future;
 }
-
 #ifdef USE_NOF
+namespace {
+bool AppendDmaSges(void* ptr, uint64_t size,
+                   std::vector<SpdkNofSge>* sgl) {
+    if (ptr == nullptr || size == 0 || sgl == nullptr) {
+        return false;
+    }
+
+    uintptr_t cursor = reinterpret_cast<uintptr_t>(ptr);
+    uint64_t remaining = size;
+    while (remaining != 0) {
+        uint64_t contiguous = remaining;
+        void* current = reinterpret_cast<void*>(cursor);
+        const uint64_t physical_address =
+            spdk_vtophys(current, &contiguous);
+        if (physical_address == SPDK_VTOPHYS_ERROR || contiguous == 0) {
+            LOG(ERROR) << "NoF buffer is not registered for SPDK DMA"
+                       << ", address=" << current
+                       << ", remaining=" << remaining;
+            return false;
+        }
+
+        contiguous = std::min(contiguous, remaining);
+        sgl->push_back(SpdkNofSge::Data(current, contiguous));
+        if (contiguous >
+            std::numeric_limits<uintptr_t>::max() - cursor) {
+            return false;
+        }
+        cursor += contiguous;
+        remaining -= contiguous;
+    }
+    return true;
+}
+
+bool ValidateSgl(const std::vector<SpdkNofSge>& sgl,
+                 uint64_t expected_size,
+                 const SpdkSglCapabilities& capabilities) {
+    if (!capabilities.supported || sgl.empty()) {
+        return false;
+    }
+
+    uint64_t total_size = 0;
+    for (const auto& entry : sgl) {
+        if (entry.address == nullptr || entry.length == 0 ||
+            total_size >
+                std::numeric_limits<uint64_t>::max() - entry.length) {
+            return false;
+        }
+        if (capabilities.requires_dword_alignment &&
+            ((reinterpret_cast<uintptr_t>(entry.address) & 3ULL) != 0 ||
+             (entry.length & 3ULL) != 0)) {
+            return false;
+        }
+        total_size += entry.length;
+    }
+    return total_size == expected_size;
+}
+
+bool SizeToLbaCount(uint64_t physical_size, uint32_t block_size,
+                    uint32_t* lba_count) {
+    if (lba_count == nullptr || block_size == 0 || physical_size == 0 ||
+        physical_size % block_size != 0) {
+        return false;
+    }
+
+    const uint64_t count = physical_size / block_size;
+    if (count == 0 || count > std::numeric_limits<uint32_t>::max()) {
+        return false;
+    }
+    *lba_count = static_cast<uint32_t>(count);
+    return true;
+}
+
+std::shared_ptr<void> AllocateDmaOwner(size_t size, size_t alignment,
+                                       void** buffer) {
+    if (buffer == nullptr || size == 0) {
+        return {};
+    }
+
+    *buffer = SpdkWrapper::GetInstance().Alloc(size, alignment, -1);
+    if (*buffer == nullptr) {
+        return {};
+    }
+
+    return std::shared_ptr<void>(
+        *buffer, [](void* ptr) { SpdkWrapper::GetInstance().Free(ptr); });
+}
+
+} 
+
 std::optional<TransferFuture> TransferSubmitter::submitSpdkNofOperation(
     const AllocatedBuffer::Descriptor& handle, void* ptr, size_t size,
     const TransferRequest::OpCode op_code) {
-    if (handle.transport_endpoint_.empty() || handle.size_ < size) {
+    if (handle.transport_endpoint_.empty()) {
         LOG(ERROR) << "Invalid NoF request endpoint="
-                   << handle.transport_endpoint_
-                   << ", buffer_size=" << handle.size_
-                   << ", request_size=" << size;
+                   << handle.transport_endpoint_;
         return std::nullopt;
     }
 
     nof_seg_handle* seg_handle =
         SpdkWrapper::GetInstance().OpenNofSegment(handle.transport_endpoint_);
-    if (!seg_handle) {
+    if (seg_handle == nullptr) {
         LOG(ERROR) << "Failed to open NoF segment endpoint="
                    << handle.transport_endpoint_;
         return std::nullopt;
     }
 
-    uint32_t block_size = SpdkWrapper::GetInstance().GetBlockSize(seg_handle);
-    if (block_size == INVALID_BLOCK_SIZE ||
-        handle.buffer_address_ % block_size != 0 || size % block_size != 0 ||
-        reinterpret_cast<std::uintptr_t>(ptr) % block_size != 0) {
-        LOG(ERROR) << "NoF request offset=" << handle.buffer_address_
-                   << ", ptr=" << ptr << ", size=" << size
-                   << " is not aligned to block size " << block_size;
+    const uint32_t block_size =
+        SpdkWrapper::GetInstance().GetBlockSize(seg_handle);
+    if (block_size == INVALID_BLOCK_SIZE || block_size == 0 ||
+        handle.buffer_address_ % block_size != 0 ||
+        handle.size_ % block_size != 0) {
+        LOG(ERROR) << "Invalid NoF block alignment"
+                   << ", remote_address=" << handle.buffer_address_
+                   << ", allocated_size=" << handle.size_
+                   << ", block_size=" << block_size;
         return std::nullopt;
     }
 
-    auto state = std::make_shared<SpdkNofOperationState>();
-    SpdkNofTask task(seg_handle, ptr, handle.buffer_address_ / block_size,
-                     size / block_size, op_code, state);
-    spdk_nvmf_pool_->submitTask(std::move(task));
+    if (static_cast<uint64_t>(size) >
+        std::numeric_limits<uint64_t>::max() - (block_size - 1ULL)) {
+        LOG(ERROR) << "NoF physical size overflow";
+        return std::nullopt;
+    }
 
-    VLOG(1) << "SPDK NoF transfer submitted to " << handle.transport_endpoint_;
+    const uint64_t physical_size =
+        ((static_cast<uint64_t>(size) + block_size - 1ULL) / block_size) *
+        block_size;
+    if (physical_size > handle.size_) {
+        LOG(ERROR) << "NoF allocation is smaller than request"
+                   << ", logical_size=" << size
+                   << ", physical_size=" << physical_size
+                   << ", allocated_size=" << handle.size_;
+        return std::nullopt;
+    }
+
+    uint32_t lba_count = 0;
+    if (!SizeToLbaCount(physical_size, block_size, &lba_count)) {
+        return std::nullopt;
+    }
+
+    SpdkSglCapabilities capabilities;
+    if (!SpdkWrapper::GetInstance().GetSglCapabilities(
+            seg_handle, &capabilities) ||
+        !capabilities.supported) {
+        LOG(ERROR) << "NVMe Controller does not support SGL";
+        return std::nullopt;
+    }
+
+    std::vector<SpdkNofSge> sgl;
+    std::vector<std::shared_ptr<void>> owners;
+    if (!AppendDmaSges(ptr, static_cast<uint64_t>(size), &sgl)) {
+        return std::nullopt;
+    }
+
+    const uint64_t padding_size =
+        physical_size - static_cast<uint64_t>(size);
+    if (padding_size != 0) {
+        void* padding_buffer = nullptr;
+        auto padding_owner =
+            AllocateDmaOwner(block_size, block_size, &padding_buffer);
+        if (!padding_owner) {
+            LOG(ERROR) << "Failed to allocate NoF padding DMA buffer";
+            return std::nullopt;
+        }
+        if (!AppendDmaSges(padding_buffer, padding_size, &sgl)) {
+            return std::nullopt;
+        }
+        owners.push_back(std::move(padding_owner));
+    }
+
+    if (!ValidateSgl(sgl, physical_size, capabilities)) {
+        LOG(ERROR) << "NoF SGL does not satisfy Controller requirements"
+                   << ", dword_required="
+                   << capabilities.requires_dword_alignment
+                   << ", logical_size=" << size
+                   << ", physical_size=" << physical_size
+                   << ", ptr=" << ptr;
+        return std::nullopt;
+    }
+
+    auto state = std::make_shared<SpdkNofOperationState>(1);
+    SpdkNofTask task(seg_handle, std::move(sgl),
+                     handle.buffer_address_ / block_size, lba_count, op_code,
+                     state, std::move(owners));
+    spdk_nvmf_pool_->submitTask(std::move(task));
+    return TransferFuture(state);
+}
+
+std::optional<TransferFuture>
+TransferSubmitter::submitSpdkNofRangeReadOperation(
+    const NoFDescriptor& descriptor, void* ptr, size_t size,
+    uint64_t src_offset) {
+    const auto& handle = descriptor.buffer_descriptor;
+    if (handle.transport_endpoint_.empty() || ptr == nullptr || size == 0) {
+        LOG(ERROR) << "Invalid NoF range-read request";
+        return std::nullopt;
+    }
+
+    if (src_offset > descriptor.object_size ||
+        static_cast<uint64_t>(size) >
+            descriptor.object_size - src_offset) {
+        LOG(ERROR) << "NoF logical range-read overflow"
+                   << ", src_offset=" << src_offset
+                   << ", size=" << size
+                   << ", object_size=" << descriptor.object_size;
+        return std::nullopt;
+    }
+
+    nof_seg_handle* seg_handle =
+        SpdkWrapper::GetInstance().OpenNofSegment(handle.transport_endpoint_);
+    if (seg_handle == nullptr) {
+        LOG(ERROR) << "Failed to open NoF segment endpoint="
+                   << handle.transport_endpoint_;
+        return std::nullopt;
+    }
+
+    const uint32_t block_size =
+        SpdkWrapper::GetInstance().GetBlockSize(seg_handle);
+    if (block_size == INVALID_BLOCK_SIZE || block_size == 0 ||
+        descriptor.block_size == 0 || descriptor.block_size != block_size ||
+        handle.buffer_address_ % block_size != 0 ||
+        handle.size_ % block_size != 0) {
+        LOG(ERROR) << "Invalid NoF range-read metadata/alignment"
+                   << ", descriptor_block_size=" << descriptor.block_size
+                   << ", namespace_block_size=" << block_size
+                   << ", remote_address=" << handle.buffer_address_
+                   << ", allocated_size=" << handle.size_;
+        return std::nullopt;
+    }
+
+    const uint64_t physical_relative_start =
+        (src_offset / block_size) * block_size;
+    const uint64_t head_discard =
+        src_offset - physical_relative_start;
+    if (static_cast<uint64_t>(size) >
+        std::numeric_limits<uint64_t>::max() - head_discard) {
+        return std::nullopt;
+    }
+
+    const uint64_t covered_size =
+        head_discard + static_cast<uint64_t>(size);
+    if (covered_size >
+        std::numeric_limits<uint64_t>::max() - (block_size - 1ULL)) {
+        return std::nullopt;
+    }
+
+    const uint64_t physical_size =
+        ((covered_size + block_size - 1ULL) / block_size) * block_size;
+    if (physical_relative_start > handle.size_ ||
+        physical_size > handle.size_ - physical_relative_start) {
+        LOG(ERROR) << "NoF physical range-read overflow";
+        return std::nullopt;
+    }
+    const uint64_t tail_discard = physical_size - covered_size;
+
+    uint32_t lba_count = 0;
+    if (!SizeToLbaCount(physical_size, block_size, &lba_count)) {
+        return std::nullopt;
+    }
+
+    SpdkSglCapabilities capabilities;
+    if (!SpdkWrapper::GetInstance().GetSglCapabilities(
+            seg_handle, &capabilities) ||
+        !capabilities.supported) {
+        LOG(ERROR) << "NVMe Controller does not support SGL";
+        return std::nullopt;
+    }
+
+    std::vector<SpdkNofSge> sgl;
+    std::vector<std::shared_ptr<void>> owners;
+    void* discard_buffer = nullptr;
+    const uint64_t discard_size = head_discard + tail_discard;
+    if (discard_size > std::numeric_limits<size_t>::max()) {
+        LOG(ERROR) << "NoF discard DMA buffer size overflows size_t";
+        return std::nullopt;
+    }
+    std::shared_ptr<void> discard_owner;
+    if (discard_size != 0) {
+        discard_owner = AllocateDmaOwner(
+            static_cast<size_t>(discard_size), block_size, &discard_buffer);
+        if (!discard_owner) {
+            LOG(ERROR) << "Failed to allocate NoF discard DMA buffer";
+            return std::nullopt;
+        }
+    }
+
+    if (head_discard != 0 &&
+        !AppendDmaSges(discard_buffer, head_discard, &sgl)) {
+        return std::nullopt;
+    }
+    if (!AppendDmaSges(ptr, static_cast<uint64_t>(size), &sgl)) {
+        return std::nullopt;
+    }
+    if (tail_discard != 0) {
+        const uintptr_t discard_address =
+            reinterpret_cast<uintptr_t>(discard_buffer);
+        if (head_discard >
+            std::numeric_limits<uintptr_t>::max() - discard_address) {
+            LOG(ERROR) << "NoF discard DMA buffer address overflows";
+            return std::nullopt;
+        }
+        const uintptr_t tail_address =
+            discard_address + static_cast<uintptr_t>(head_discard);
+        if (!AppendDmaSges(reinterpret_cast<void*>(tail_address),
+                           tail_discard, &sgl)) {
+            return std::nullopt;
+        }
+    }
+    if (discard_owner) {
+        owners.push_back(std::move(discard_owner));
+    }
+
+    if (!ValidateSgl(sgl, physical_size, capabilities)) {
+        LOG(ERROR) << "NoF range-read SGL violates Controller requirements"
+                   << ", dword_required="
+                   << capabilities.requires_dword_alignment
+                   << ", src_offset=" << src_offset
+                   << ", destination=" << ptr
+                   << ", size=" << size
+                   << ", head_discard=" << head_discard
+                   << ", tail_discard=" << tail_discard;
+        return std::nullopt;
+    }
+
+    const uint64_t start_lba =
+        handle.buffer_address_ / block_size +
+        physical_relative_start / block_size;
+    auto state = std::make_shared<SpdkNofOperationState>(1);
+    SpdkNofTask task(seg_handle, std::move(sgl), start_lba, lba_count,
+                     TransferRequest::READ, state, std::move(owners));
+    spdk_nvmf_pool_->submitTask(std::move(task));
     return TransferFuture(state);
 }
 #endif
@@ -1431,7 +1868,7 @@ bool TransferSubmitter::validateTransferParams(
     for (auto slice : slices) {
         all_slice_len += slice.size;
     }
-    if (handle.size_ != all_slice_len) {
+    if (handle.size_ < all_slice_len) {
         LOG(ERROR) << "handles len:" << handle.size_
                    << ", all_slice_len:" << all_slice_len;
         return false;

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -1610,7 +1610,7 @@ std::optional<TransferFuture> TransferSubmitter::submitSpdkNofOperation(
         return std::nullopt;
     }
 
-    auto state = std::make_shared<SpdkNofOperationState>(1);
+    auto state = std::make_shared<SpdkNofOperationState>();
     SpdkNofTask task(seg_handle, std::move(sgl),
                      handle.buffer_address_ / block_size, lba_count, op_code,
                      state, std::move(owners));
@@ -1757,7 +1757,7 @@ TransferSubmitter::submitSpdkNofRangeReadOperation(
     const uint64_t start_lba =
         handle.buffer_address_ / block_size +
         physical_relative_start / block_size;
-    auto state = std::make_shared<SpdkNofOperationState>(1);
+    auto state = std::make_shared<SpdkNofOperationState>();
     SpdkNofTask task(seg_handle, std::move(sgl), start_lba, lba_count,
                      TransferRequest::READ, state, std::move(owners));
     spdk_nvmf_pool_->submitTask(std::move(task));

--- a/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
+++ b/mooncake-store/tests/e2e/run_nof_heartbeat_tcp_e2e.sh
@@ -111,6 +111,7 @@ ret = store.MooncakeDistributedNoFRegister().real_register(
     int("$TARGET_PORT"),
     0,
     int("$NOF_SIZE"),
+    4096,
     "$MASTER_RPC",
 )
 print(f"register_ret {ret}", flush=True)

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -153,6 +153,7 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         segment.id = generate_uuid();
         segment.name = std::move(name);
         segment.base = kSegmentBase + next_segment_offset_;
+        segment.block_size = 512;
         segment.size = size;
         segment.te_endpoint = segment.name;
         next_segment_offset_ += size + 4096;

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -157,6 +157,7 @@ class MasterServiceTest : public ::testing::Test {
         segment.name = std::move(name);
         segment.base = base;
         segment.size = size;
+        segment.block_size = 512;
         segment.te_endpoint = std::move(endpoint);
         return segment;
     }

--- a/mooncake-store/tests/nof_heartbeat_test.cpp
+++ b/mooncake-store/tests/nof_heartbeat_test.cpp
@@ -23,6 +23,7 @@ NoFSegment MakeNoFSegment(std::string name, std::string endpoint,
     segment.name = std::move(name);
     segment.base = base;
     segment.size = size;
+    segment.block_size = 512;
     segment.te_endpoint = std::move(endpoint);
     return segment;
 }

--- a/mooncake-wheel/mooncake/mooncake_ssd_register.py
+++ b/mooncake-wheel/mooncake/mooncake_ssd_register.py
@@ -205,6 +205,7 @@ class MooncakeNoFRegister:
                             'trsvcid': int(trsvcid),  # Ensure trsvcid is integer
                             'base': 0,
                             'size': size,
+                            'block_size': block_size,
                             'master_server_address': master_server_address,
                             'metadata_server': ''
                         }
@@ -246,6 +247,7 @@ class MooncakeNoFRegister:
                     cfg["trsvcid"],
                     cfg["base"],
                     cfg["size"],
+                    cfg["block_size"],
                     cfg["master_server_address"]
                 )
 


### PR DESCRIPTION
## Description

Add block-unaligned I/O support for Mooncake Store NVMe-oF replicas.

Previously, NoF operations required the logical object size, transfer size, and range offsets to be aligned to the NVMe namespace block size. This change separates the logical object size from the block-aligned physical allocation and I/O size.

Key changes:

- Round NoF allocations and physical I/O ranges up to the NVMe block size while preserving the original logical object size in replica metadata.
- Add SPDK SGL-based I/O using `spdk_nvme_ns_cmd_readv()` and `spdk_nvme_ns_cmd_writev()`.
- Split registered buffers into DMA-accessible, physically contiguous SGL entries.
- Support block-unaligned writes by appending a zero-initialized DMA padding buffer without reading beyond the user buffer.
- Support block-unaligned NoF range reads by:
  - aligning the physical read range to LBA boundaries;
  - directing leading and trailing unwanted bytes into temporary discard buffers;
  - transferring the requested bytes directly into the destination buffer.
- Validate controller SGL support, DWORD alignment requirements, SGL lengths, address arithmetic, and LBA count conversions.
- Keep temporary padding and discard DMA buffers alive until asynchronous I/O completion.
- Propagate the NVMe block size through NoF registration, segment metadata, and replica descriptors.
- Reject NoF segments with inconsistent block sizes in the same segment pool.
- Add NoF ranged-read support to the Store client path.
- Add the `verify_nof_unaligned` benchmark scenario for validating unaligned Put/Get behavior.

NoF controllers used by this path must report SGL support. Controllers requiring DWORD-aligned SGL entries only accept addresses and lengths aligned to four bytes.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The change introduces the `verify_nof_unaligned` benchmark scenario to verify:

- writing an object whose logical size is not block-aligned;
- reading the complete logical object without exposing padding bytes;
- reading a range with an unaligned source offset;
- reading a range with unaligned head and tail boundaries;
- copying the requested range into a destination buffer with a non-zero offset;
- validating returned data against the original pattern.

The manual test requires an NVMe-oF controller that supports SGL.

**Test commands:**

```bash
./scripts/code_format.sh
pre-commit run --all-files

python3 mooncake-store/benchmarks/store_kv_bench.py \
  --scenario verify_nof_unaligned \
  --memory-replica-num 0 \
  --nof-replica-num 1 \
  --nof-block-size 4096 \
  --value-size 12300 \
  --range-src-offset 4 \
  --range-size 8228 \
  --range-dst-offset 4 \
  <NoF environment-specific arguments>