### PR TITLE
[TransferEngine] Share one host KV segment across a TP group

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -44,8 +44,10 @@ message("${PYTHON_SYS_PATH}")
 set(PYTHON_PACKAGE_NAME "mooncake")
 
 if(WITH_TE)
-  pybind11_add_module(engine ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
-                      transfer_engine/transfer_engine_py.cpp)
+  pybind11_add_module(
+    engine ${SOURCES} ${CACHE_ALLOCATOR_SOURCES}
+    transfer_engine/transfer_engine_py.cpp
+    transfer_engine/shared_segment_py.cpp)
   set_target_properties(engine PROPERTIES INSTALL_RPATH "$ORIGIN")
 
   # Propagate EFA compile definition to engine target
@@ -156,6 +158,11 @@ endif()
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/store/async_store.py"
         DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+
+if(WITH_TE)
+  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/shared_segment.py"
+          DESTINATION ${PYTHON_SYS_PATH}/${PYTHON_PACKAGE_NAME})
+endif()
 
 # Install Python scripts from mooncake - wheel / mooncake / directory
 install(

--- a/mooncake-integration/shared_segment.py
+++ b/mooncake-integration/shared_segment.py
@@ -1,0 +1,246 @@
+"""Process-shared host memory for one-writer/many-reader KV offload.
+
+MLA keeps the same KV in every rank of a TP group, so offloading it per rank
+multiplies host memory by the TP size for no benefit. A shared segment allocates
+the pages once, in ``owner_rank``, and maps them into every rank of the group.
+
+Virtual addresses are deliberately not forced to match across ranks: peers agree
+on the byte layout, so the reserved address space equals the segment size rather
+than size x world_size. Layout (which offset holds which tensor) is computed
+here; C++ only shares the raw span.
+
+    from mooncake.shared_segment import create_shared_segment
+
+    seg = create_shared_segment(
+        "vllm_sparse_kv",
+        blocks={
+            "k": dict(count=num_layers, shape=k_shape, dtype=torch.bfloat16),
+            "v": dict(count=num_layers, shape=v_shape, dtype=torch.bfloat16),
+        },
+        world_size=tp_size,
+        rank_id=tp_rank,
+        tp_group=tp_group,
+        mmap=True,
+    )
+    k_caches_cpu = seg.tensors("k")
+"""
+
+from __future__ import annotations
+
+import ctypes
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+import torch
+import torch.distributed as dist
+
+from .engine import SharedSegment as _CppSharedSegment
+
+__all__ = [
+    "SharedSegment",
+    "SharedSegmentError",
+    "create_shared_segment",
+    "shared_segment_supported",
+]
+
+_ALIGN = 4096
+
+
+class SharedSegmentError(RuntimeError):
+    """Raised when a shared segment cannot be created or addressed."""
+
+
+@dataclass(frozen=True)
+class _BlockSpec:
+    count: int
+    shape: Tuple[int, ...]
+    dtype: torch.dtype
+    nbytes: int
+
+
+def shared_segment_supported(mmap: bool = False) -> bool:
+    return _CppSharedSegment.supported(mmap)
+
+
+def _align_up(value: int, alignment: int = _ALIGN) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _parse_block(name: str, spec: Mapping[str, Any]) -> _BlockSpec:
+    try:
+        count = int(spec["count"])
+        shape = tuple(int(dim) for dim in spec["shape"])
+        dtype = spec["dtype"]
+    except (KeyError, TypeError) as exc:
+        raise SharedSegmentError(
+            f"Block {name!r} needs count, shape and dtype"
+        ) from exc
+    if count <= 0:
+        raise SharedSegmentError(f"Block {name!r} needs a positive count")
+    if not shape or any(dim <= 0 for dim in shape):
+        raise SharedSegmentError(f"Block {name!r} needs a positive shape")
+
+    element_size = torch.empty(0, dtype=dtype).element_size()
+    nbytes = element_size
+    for dim in shape:
+        nbytes *= dim
+    return _BlockSpec(count=count, shape=shape, dtype=dtype, nbytes=nbytes)
+
+
+def _build_layout(
+    specs: Dict[str, _BlockSpec], names: Sequence[str]
+) -> Tuple[Dict[str, int], int, int]:
+    """Returns (offsets_by_name, group_stride, total_size)."""
+    stride = 0
+    offsets: Dict[str, int] = {}
+    for name in names:
+        offsets[name] = stride
+        stride += _align_up(specs[name].nbytes)
+    if stride == 0:
+        raise SharedSegmentError("Shared segment needs at least one block")
+    total = stride * max(spec.count for spec in specs.values())
+    return offsets, stride, total
+
+
+def _current_device_index() -> int:
+    """The accelerator this rank runs on, whatever vendor it is."""
+    accelerator = getattr(torch, "accelerator", None)
+    if accelerator is not None:
+        try:
+            return int(accelerator.current_device_index())
+        except (RuntimeError, AttributeError):
+            pass
+    for backend in ("cuda", "npu"):
+        module = getattr(torch, backend, None)
+        if module is not None and module.is_available():
+            return int(module.current_device())
+    return 0
+
+
+def _resolve_cpu_group(tp_group: Any) -> Any:
+    """Accepts a vLLM GroupCoordinator or a plain process group.
+
+    The blobs are exchanged as CPU byte tensors, so a gloo group is required; a
+    coordinator exposes one as ``cpu_group``.
+    """
+    cpu_group = getattr(tp_group, "cpu_group", None)
+    return cpu_group if cpu_group is not None else tp_group
+
+
+def _all_gather_blob(blob: bytes, world_size: int, tp_group: Any) -> List[bytes]:
+    local = torch.frombuffer(bytearray(blob), dtype=torch.uint8)
+    gathered = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local, group=_resolve_cpu_group(tp_group))
+    return [bytes(tensor.numpy()) for tensor in gathered]
+
+
+class SharedSegment:
+    """Handle to one shared host segment. Alive for as long as the mapping is needed."""
+
+    def __init__(
+        self,
+        segment: Any,
+        specs: Dict[str, _BlockSpec],
+        offsets: Dict[str, int],
+        stride: int,
+    ) -> None:
+        self._segment = segment
+        self._specs = specs
+        self._offsets = offsets
+        self._stride = stride
+
+    def tensors(self, block: str) -> List[torch.Tensor]:
+        """Zero-copy host views of every entry of ``block``, in index order.
+
+        With ``mmap=True`` the underlying pages are HostRegister'd for the
+        rank's accelerator, so ``data_ptr()`` can be registered with Transfer
+        Engine as ``location=\"npu\"`` for ROCE D2rH. Views share physical
+        pages across the TP group: what one rank writes is what the others
+        read. Each view holds a reference back to this segment.
+        """
+        spec = self._specs.get(block)
+        if spec is None:
+            raise SharedSegmentError(f"Unknown shared segment block {block!r}")
+        base = self._segment.base_addr()
+        offset = self._offsets[block]
+        views = []
+        for index in range(spec.count):
+            addr = base + offset + index * self._stride
+            buffer = (ctypes.c_int8 * spec.nbytes).from_address(addr)
+            view = torch.frombuffer(buffer, dtype=spec.dtype).view(spec.shape)
+            view._mooncake_segment = self
+            views.append(view)
+        return views
+
+    def base_addr(self) -> int:
+        return self._segment.base_addr()
+
+    def total_size(self) -> int:
+        return self._segment.size()
+
+
+def create_shared_segment(
+    name: str,
+    blocks: Mapping[str, Mapping[str, Any]],
+    world_size: int,
+    rank_id: int,
+    owner_rank: int = 0,
+    device_id: Optional[int] = None,
+    tp_group: Any = None,
+    block_order: Optional[Sequence[str]] = None,
+    mmap: bool = False,
+) -> SharedSegment:
+    """Creates a shared host segment and returns it ready to use.
+
+    Every rank of the group must call this with an identical declaration; a
+    disagreement is reported here rather than silently producing wrong reads.
+    ``tp_group`` may be omitted only when ``world_size`` is 1. ``device_id``
+    defaults to the rank's current accelerator, which is the device the segment
+    is granted access to. Set ``mmap=True`` to share via POSIX shm + HostRegister
+    instead of the platform VMM fabric path.
+    """
+    if not shared_segment_supported(mmap=mmap):
+        raise SharedSegmentError(
+            "This mooncake build has no mmap shared-segment backend"
+            if mmap
+            else "This mooncake build has no VMM backend for shared segments"
+        )
+    # Rank order decides the byte layout, so it must not depend on dict
+    # iteration order differing between ranks.
+    names = list(block_order) if block_order is not None else sorted(blocks)
+    if set(names) != set(blocks):
+        raise SharedSegmentError("block_order must list exactly the declared blocks")
+
+    specs = {
+        block_name: _parse_block(block_name, blocks[block_name]) for block_name in names
+    }
+    offsets, stride, total = _build_layout(specs, names)
+    # Fold the layout into the name so C++'s fingerprint catches peers that
+    # disagree on count/size without exchanging the full declaration.
+    tag = ";".join(f"{n}:{specs[n].count}x{specs[n].nbytes}" for n in names)
+    device = _current_device_index() if device_id is None else device_id
+
+    try:
+        segment, blob = _CppSharedSegment.create(
+            f"{name}|{tag}",
+            total,
+            world_size,
+            rank_id,
+            owner_rank,
+            device,
+            mmap,
+        )
+    except RuntimeError as exc:
+        raise SharedSegmentError(str(exc)) from exc
+
+    try:
+        if world_size == 1:
+            blobs = [blob]
+        elif tp_group is None:
+            raise SharedSegmentError("tp_group is required when world_size > 1")
+        else:
+            blobs = _all_gather_blob(blob, world_size, tp_group)
+        segment.complete(blobs)
+    except RuntimeError as exc:
+        raise SharedSegmentError(str(exc)) from exc
+    return SharedSegment(segment, specs, offsets, stride)

--- a/mooncake-integration/transfer_engine/shared_segment_py.cpp
+++ b/mooncake-integration/transfer_engine/shared_segment_py.cpp
@@ -1,0 +1,87 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "shared_segment_py.h"
+
+#include <pybind11/stl.h>
+
+#include <stdexcept>
+#include <utility>
+
+namespace py = pybind11;
+
+namespace mooncake {
+namespace {
+void ThrowIfError(const Status& status) {
+    if (!status.ok()) {
+        throw std::runtime_error(status.ToString());
+    }
+}
+
+// Returns the unfinished segment plus this rank's blob. The caller all-gathers
+// the blob and passes every rank's copy back to Complete.
+// SharedSegmentOptions is an implementation detail and is not exposed to
+// Python; callers pass the fields directly.
+std::pair<std::shared_ptr<SharedSegment>, py::bytes> SegmentCreate(
+    const std::string& name, uint64_t size, uint32_t world_size,
+    uint32_t rank_id, uint32_t owner_rank, int32_t device_id, bool mmap) {
+    SharedSegmentOptions options;
+    options.world_size = world_size;
+    options.rank_id = rank_id;
+    options.owner_rank = owner_rank;
+    options.device_id = device_id;
+    options.mmap = mmap;
+
+    std::string blob;
+    std::shared_ptr<SharedSegment> segment;
+    Status status = Status::OK();
+    {
+        py::gil_scoped_release release;
+        status = SharedSegment::Create(name, size, options, segment, blob);
+    }
+    ThrowIfError(status);
+    return {std::move(segment), py::bytes(blob)};
+}
+
+void SegmentComplete(const std::shared_ptr<SharedSegment>& segment,
+                     const std::vector<std::string>& blobs) {
+    Status status = Status::OK();
+    {
+        py::gil_scoped_release release;
+        status = segment->Complete(blobs);
+    }
+    ThrowIfError(status);
+}
+}  // namespace
+
+void bind_shared_segment(py::module_& m) {
+    py::class_<SharedSegment, std::shared_ptr<SharedSegment>>(m,
+                                                              "SharedSegment")
+        .def_static("create", &SegmentCreate, py::arg("name"), py::arg("size"),
+                    py::arg("world_size"), py::arg("rank_id"),
+                    py::arg("owner_rank") = 0, py::arg("device_id") = 0,
+                    py::arg("mmap") = false,
+                    "Phase one; returns (segment, blob).")
+        .def_static("supported", &SharedSegment::Supported,
+                    py::arg("mmap") = false,
+                    "Whether this build can share memory across processes.")
+        .def("complete", &SegmentComplete, py::arg("blobs"),
+             "Phase two; blobs are indexed by rank.")
+        .def("ready", &SharedSegment::ready)
+        .def("base_addr", &SharedSegment::base_addr)
+        .def("size", &SharedSegment::size);
+}
+
+}  // namespace mooncake

--- a/mooncake-integration/transfer_engine/shared_segment_py.h
+++ b/mooncake-integration/transfer_engine/shared_segment_py.h
@@ -1,0 +1,27 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHARED_SEGMENT_PY_H
+#define SHARED_SEGMENT_PY_H
+
+#include <pybind11/pybind11.h>
+
+#include "shared_segment/shared_segment.h"
+
+namespace mooncake {
+void bind_shared_segment(pybind11::module_& m);
+}  // namespace mooncake
+
+#endif  // SHARED_SEGMENT_PY_H

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 
 #include <pybind11/stl.h>
+#include "shared_segment_py.h"
 #include "transport/rpc_communicator/rpc_interface.h"
 
 #ifdef USE_TENT
@@ -1272,6 +1273,8 @@ PYBIND11_MODULE(engine, m) {
 
     py::class_<TransferEngine, std::shared_ptr<TransferEngine>>(
         m, "InnerTransferEngine");
+
+    mooncake::bind_shared_segment(m);
 
     // Bind RpcInterface (this also registers ReceivedData, ReceivedTensor, and
     // factory functions)

--- a/mooncake-transfer-engine/include/shared_segment/shared_segment.h
+++ b/mooncake-transfer-engine/include/shared_segment/shared_segment.h
@@ -1,0 +1,110 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHARED_SEGMENT_H
+#define SHARED_SEGMENT_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/base/status.h"
+
+namespace mooncake {
+
+// A shared segment is one contiguous span of host memory whose physical pages
+// exist exactly once, in the process of `owner_rank`, while every rank of the
+// group maps them at a rank-local address. It targets the write-once/read-many
+// KV offload pattern: sizes are known before the first allocation, nothing is
+// ever freed, and addresses must stay fixed so they can be captured in a graph.
+//
+// Virtual addresses are deliberately *not* required to match across ranks.
+// Peers agree on the byte layout instead, so a rank locates data as
+// `local_base + offset`. That keeps the reserved address space equal to the
+// segment size rather than size x world_size. Layout (which offset holds which
+// tensor) is the caller's responsibility; this class only shares the raw span.
+//
+// Creation is two-phase because the only communicator in reach belongs to the
+// framework (a torch process group in practice), and driving it from C++ would
+// mean calling back into Python:
+//
+//   1. Create  — reserve the local address window; the owner also allocates and
+//                exports the physical pages. Returns a fixed-length blob.
+//   2. Complete — after the caller all-gathers the blobs, verify every rank
+//                asked for the same thing and, on non-owners, map the owner's
+//                pages into the reserved window.
+//
+// Peers are trusted: the checks catch a group that was configured
+// inconsistently, not a peer that lies. The owner's segment must outlive every
+// other rank's, because freeing its pages invalidates their mappings.
+
+struct SharedSegmentOptions {
+    uint32_t world_size = 1;
+    uint32_t rank_id = 0;
+    uint32_t owner_rank = 0;
+    // Accelerator that is granted access to the host pages (D2H/H2D).
+    int32_t device_id = 0;
+    // true: POSIX shm_open + mmap on the same host, then HostRegister for
+    // device_id. false: platform VMM with a fabric shareable handle (default).
+    bool mmap = false;
+};
+
+class SharedSegmentBackend;
+
+class SharedSegment {
+   public:
+    ~SharedSegment();
+
+    SharedSegment(const SharedSegment&) = delete;
+    SharedSegment& operator=(const SharedSegment&) = delete;
+
+    // Phase one. On success `segment` owns the reservation (and, on the owner,
+    // the allocation) and `out_blob` is ready for the caller's all-gather.
+    static Status Create(const std::string& name, uint64_t size,
+                         const SharedSegmentOptions& options,
+                         std::shared_ptr<SharedSegment>& segment,
+                         std::string& out_blob);
+
+    // Whether this build can share memory across processes. When `mmap` is
+    // true, POSIX shm plus a HostRegister runtime (CUDA or Ascend) is required;
+    // otherwise a platform VMM backend is required.
+    static bool Supported(bool mmap = false);
+
+    // Phase two. `blobs` is indexed by rank. After success, `ready()` is true
+    // and `base_addr()` is valid.
+    Status Complete(const std::vector<std::string>& blobs);
+
+    bool ready() const { return ready_; }
+    uintptr_t base_addr() const { return base_addr_; }
+    uint64_t size() const { return size_; }
+
+   private:
+    SharedSegment(std::string name, uint64_t size,
+                  SharedSegmentOptions options);
+
+    std::string name_;
+    uint64_t size_ = 0;
+    SharedSegmentOptions options_;
+    uint64_t fingerprint_ = 0;
+    uint64_t alloc_size_ = 0;
+    uintptr_t base_addr_ = 0;
+    bool ready_ = false;
+    std::unique_ptr<SharedSegmentBackend> backend_;
+};
+
+}  // namespace mooncake
+
+#endif  // SHARED_SEGMENT_H

--- a/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/adxl_compat.h
+++ b/mooncake-transfer-engine/include/transport/ascend_transport/ascend_direct_transport/adxl_compat.h
@@ -73,6 +73,13 @@ struct TransferArgs {
 enum FeatureType : int32_t {
     AUTO_CONNECT = 0,
     CLIENT_SERVER_COMM = 1,
+    MALLOC_MEM_EXPORTED_HANDLE = 2,
+};
+
+// Fabric share handle of memory allocated by MallocMem. Layout is identical to
+// aclrtMemFabricHandle.
+struct MemFabricHandle {
+    uint8_t data[128] = {};
 };
 
 class ASCEND_FUNC_VISIBILITY AdxlEngine {
@@ -183,6 +190,16 @@ class ASCEND_FUNC_VISIBILITY AdxlEngine {
      */
     __attribute__((weak)) static Status MallocMem(MemType type, size_t size,
                                                   void** ptr);
+
+    /**
+     * @brief 获取MallocMem申请内存导出的fabric share handle
+     * @param [in] addr MallocMem返回的虚拟内存ptr
+     * @param [out] handle 导出的fabric share handle
+     * @return 成功:SUCCESS, 地址非MallocMem申请或已释放:PARAM_INVALID,
+     * 失败:其它.
+     */
+    __attribute__((weak)) static Status GetExportedHandle(
+        void* addr, MemFabricHandle& handle);
 
     /**
      * @brief 释放MallocMem申请的内存内存

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB ENGINE_SOURCES "*.cpp")
+file(GLOB ENGINE_SOURCES "*.cpp" "shared_segment/*.cpp")
 add_subdirectory(common)
 add_subdirectory(transport)
 
@@ -11,6 +11,9 @@ if(USE_HIP)
 endif()
 
 add_library(transfer_engine ${ENGINE_SOURCES} $<TARGET_OBJECTS:transport>)
+# Platform backends under shared_segment/ include their own headers by bare name.
+target_include_directories(transfer_engine
+                           PRIVATE ${CMAKE_CURRENT_LIST_DIR}/shared_segment)
 if(BUILD_SHARED_LIBS)
   install(TARGETS transfer_engine DESTINATION lib)
 endif()

--- a/mooncake-transfer-engine/src/shared_segment/ascend_shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/ascend_shared_segment.cpp
@@ -1,0 +1,243 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_ASCEND_DIRECT
+
+#include <acl/acl.h>
+#include <glog/logging.h>
+
+#include <cstring>
+
+#include "shared_segment_internal.h"
+#include "transport/ascend_transport/ascend_direct_transport/adxl_compat.h"
+
+namespace mooncake {
+namespace {
+constexpr uint16_t kAscendBackendId = 1;
+// Used when the runtime cannot report a granularity; matches the smallest huge
+// page ACL falls back to for host allocations.
+constexpr uint64_t kFallbackGranularity = 2ULL * 1024 * 1024;
+constexpr size_t kMemAccessDescCount = 1;
+// The owner's pages are huge pages, so a peer's reservation has to be huge-page
+// backed too.
+constexpr uint64_t kReserveHugePageFlag = 1;
+
+static_assert(sizeof(adxl::MemFabricHandle) == sizeof(aclrtMemFabricHandle),
+              "adxl::MemFabricHandle must match aclrtMemFabricHandle");
+static_assert(alignof(adxl::MemFabricHandle) == alignof(aclrtMemFabricHandle),
+              "adxl::MemFabricHandle must match aclrtMemFabricHandle");
+static_assert(sizeof(aclrtMemFabricHandle) <= kMaxHandleBytes,
+              "Fabric handle must fit into a shared segment blob");
+
+// The symbols are weak, so an older adxl shared object resolves them to null
+// instead of failing to load; the capability flag then tells us whether
+// MallocMem of that runtime really exports.
+bool IsAdxlExportedHandleAvailable() {
+    if (&adxl::AdxlEngine::MallocMem == nullptr ||
+        &adxl::AdxlEngine::FreeMem == nullptr ||
+        &adxl::AdxlEngine::GetExportedHandle == nullptr) {
+        return false;
+    }
+    return adxl::IsAdxlFeatureSupported(adxl::MALLOC_MEM_EXPORTED_HANDLE);
+}
+
+aclrtPhysicalMemProp BuildHostMemProp() {
+    aclrtPhysicalMemProp prop = {};
+    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
+    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
+    prop.reserve = 0;
+    prop.memAttr = ACL_MEM_P2P_HUGE;
+    prop.location.type = ACL_MEM_LOCATION_TYPE_HOST;
+    prop.location.id = 0;
+    return prop;
+}
+
+// Host pages are only bound to the host by Map; the NPU needs an explicit grant
+// before kernels can touch them. AdxlEngine::MallocMem already does this for
+// the owner.
+Status GrantDeviceAccess(void* addr, uint64_t size, int32_t device_id) {
+    aclrtMemAccessDesc desc{};
+    desc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
+    desc.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
+    desc.location.id = static_cast<uint32_t>(device_id);
+    auto ret = aclrtMemSetAccess(addr, size, &desc, kMemAccessDescCount);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtMemSetAccess failed for the imported shared segment, ret " +
+            std::to_string(ret));
+    }
+    return Status::OK();
+}
+
+class AscendSharedSegmentBackend : public SharedSegmentBackend {
+   public:
+    ~AscendSharedSegmentBackend() override { Release(); }
+
+    uint64_t Granularity(const SharedSegmentOptions& options) const override;
+
+    Status CreateOwner(uint64_t size, const SharedSegmentOptions& options,
+                       uintptr_t& base_addr,
+                       std::vector<uint8_t>& handle) override;
+
+    Status ReserveLocal(uint64_t size, const SharedSegmentOptions& options,
+                        uintptr_t& base_addr) override;
+
+    Status ImportAndMap(uint64_t size, const SharedSegmentOptions& options,
+                        const std::vector<uint8_t>& handle) override;
+
+    uint16_t BackendId() const override { return kAscendBackendId; }
+
+   private:
+    void Release();
+
+    void* owner_addr_ = nullptr;
+    void* reserved_addr_ = nullptr;
+    aclrtDrvMemHandle imported_handle_ = nullptr;
+    bool mapped_ = false;
+};
+
+uint64_t AscendSharedSegmentBackend::Granularity(
+    const SharedSegmentOptions&) const {
+    // adxl may still fall back to smaller pages than the property asks for;
+    // that only wastes a little address space, whereas an allocation size below
+    // the granularity is rejected outright.
+    auto prop = BuildHostMemProp();
+    size_t granularity = 0;
+    auto ret = aclrtMemGetAllocationGranularity(
+        &prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
+    if (ret != ACL_ERROR_NONE || granularity == 0) {
+        return kFallbackGranularity;
+    }
+    return granularity;
+}
+
+Status AscendSharedSegmentBackend::CreateOwner(
+    uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr,
+    std::vector<uint8_t>& handle) {
+    // MallocMem takes the device from the calling thread rather than an
+    // argument, so a mismatch would hand peers memory pinned to the wrong NUMA
+    // node and granted to the wrong device.
+    int32_t current_device = -1;
+    auto ret = aclrtGetDevice(&current_device);
+    if (ret != ACL_ERROR_NONE || current_device != options.device_id) {
+        return Status::InvalidArgument(
+            "Shared segment owner must run on device " +
+            std::to_string(options.device_id) + ", but the current device is " +
+            std::to_string(current_device));
+    }
+    void* addr = nullptr;
+    auto status = adxl::AdxlEngine::MallocMem(adxl::MEM_HOST, size, &addr);
+    if (status != adxl::SUCCESS) {
+        return Status::Memory(
+            "AdxlEngine::MallocMem failed for a shared segment of " +
+            std::to_string(size) + " bytes, status " + std::to_string(status));
+    }
+    adxl::MemFabricHandle exported{};
+    status = adxl::AdxlEngine::GetExportedHandle(addr, exported);
+    if (status != adxl::SUCCESS) {
+        (void)adxl::AdxlEngine::FreeMem(addr);
+        return Status::Memory(
+            "AdxlEngine::GetExportedHandle failed for the shared segment, "
+            "status " +
+            std::to_string(status));
+    }
+
+    owner_addr_ = addr;
+    base_addr = reinterpret_cast<uintptr_t>(addr);
+    handle.assign(exported.data, exported.data + sizeof(exported.data));
+    return Status::OK();
+}
+
+Status AscendSharedSegmentBackend::ReserveLocal(
+    uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr) {
+    void* addr = nullptr;
+    auto ret = aclrtReserveMemAddress(&addr, size, Granularity(options),
+                                      nullptr, kReserveHugePageFlag);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory("aclrtReserveMemAddress failed for " +
+                              std::to_string(size) + " bytes, ret " +
+                              std::to_string(ret));
+    }
+    reserved_addr_ = addr;
+    base_addr = reinterpret_cast<uintptr_t>(addr);
+    return Status::OK();
+}
+
+Status AscendSharedSegmentBackend::ImportAndMap(
+    uint64_t size, const SharedSegmentOptions& options,
+    const std::vector<uint8_t>& handle) {
+    if (reserved_addr_ == nullptr) {
+        return Status::InvalidArgument(
+            "Shared segment import needs a reserved address window");
+    }
+    if (handle.size() != sizeof(aclrtMemFabricHandle)) {
+        return Status::InvalidArgument(
+            "Shared segment owner handle has an unexpected length");
+    }
+    aclrtMemFabricHandle share_handle{};
+    memcpy(share_handle.data, handle.data(), handle.size());
+    auto ret = aclrtMemImportFromShareableHandleV2(
+        &share_handle, ACL_MEM_SHARE_HANDLE_TYPE_FABRIC, 0, &imported_handle_);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtMemImportFromShareableHandleV2 failed for the shared "
+            "segment, ret " +
+            std::to_string(ret));
+    }
+    auto* addr = reserved_addr_;
+    ret = aclrtMapMem(addr, size, 0, imported_handle_, 0);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtMapMem failed for the shared segment, ret " +
+            std::to_string(ret));
+    }
+    mapped_ = true;
+    return GrantDeviceAccess(addr, size, options.device_id);
+}
+
+void AscendSharedSegmentBackend::Release() {
+    if (owner_addr_ != nullptr) {
+        (void)adxl::AdxlEngine::FreeMem(owner_addr_);
+        owner_addr_ = nullptr;
+    }
+    if (mapped_) {
+        (void)aclrtUnmapMem(reserved_addr_);
+        mapped_ = false;
+    }
+    if (imported_handle_ != nullptr) {
+        (void)aclrtFreePhysical(imported_handle_);
+        imported_handle_ = nullptr;
+    }
+    if (reserved_addr_ != nullptr) {
+        (void)aclrtReleaseMemAddress(reserved_addr_);
+        reserved_addr_ = nullptr;
+    }
+}
+}  // namespace
+
+std::unique_ptr<SharedSegmentBackend> CreateAscendSharedSegmentBackend() {
+    if (!IsAdxlExportedHandleAvailable()) {
+        // Callers probe support before every attempt, so say this only once.
+        LOG_FIRST_N(WARNING, 1)
+            << "Shared segments need an adxl runtime that exports fabric "
+               "handles from MallocMem";
+        return nullptr;
+    }
+    return std::make_unique<AscendSharedSegmentBackend>();
+}
+
+}  // namespace mooncake
+
+#endif  // USE_ASCEND_DIRECT

--- a/mooncake-transfer-engine/src/shared_segment/cuda_shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/cuda_shared_segment.cpp
@@ -1,0 +1,254 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef USE_CUDA
+
+#include <glog/logging.h>
+
+#include <array>
+#include <cstring>
+
+#include "cuda_alike.h"
+#include "shared_segment_internal.h"
+
+namespace mooncake {
+namespace {
+constexpr uint16_t kCudaBackendId = 2;
+constexpr uint64_t kFallbackGranularity = 2ULL * 1024 * 1024;
+
+static_assert(sizeof(CUmemFabricHandle) <= kMaxHandleBytes,
+              "Fabric handle must fit into a shared segment blob");
+
+std::string DriverError(const char* api, CUresult result) {
+    const char* text = nullptr;
+    cuGetErrorString(result, &text);
+    return std::string(api) +
+           " failed: " + (text != nullptr ? text : "unknown error");
+}
+
+int32_t QueryDeviceAttribute(CUdevice_attribute attribute, int32_t device_id,
+                             const char* what) {
+    CUdevice device{};
+    auto result = cuDeviceGet(&device, device_id);
+    if (result != CUDA_SUCCESS) {
+        LOG(WARNING) << "Shared segment cannot read " << what << ": "
+                     << DriverError("cuDeviceGet", result);
+        return -1;
+    }
+    int32_t value = 0;
+    result = cuDeviceGetAttribute(&value, attribute, device);
+    if (result != CUDA_SUCCESS) {
+        LOG(WARNING) << "Shared segment cannot read " << what << ": "
+                     << DriverError("cuDeviceGetAttribute", result);
+        return -1;
+    }
+    return value;
+}
+
+// Host allocations are pinned to the NUMA node the GPU hangs off, so a D2H
+// write and the later reads stay on the near memory controller.
+int32_t HostNumaNodeOf(int32_t device_id) {
+    const auto numa_id = QueryDeviceAttribute(CU_DEVICE_ATTRIBUTE_HOST_NUMA_ID,
+                                              device_id, "the host NUMA node");
+    return numa_id < 0 ? 0 : numa_id;
+}
+
+// Fabric handles are the only handle type that survives a plain byte exchange:
+// a POSIX file descriptor would additionally need an out-of-band SCM_RIGHTS
+// channel between the ranks.
+CUmemAllocationProp BuildHostAllocationProp(
+    const SharedSegmentOptions& options) {
+    CUmemAllocationProp prop = {};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_FABRIC;
+    prop.location.type = CU_MEM_LOCATION_TYPE_HOST_NUMA;
+    prop.location.id = HostNumaNodeOf(options.device_id);
+    return prop;
+}
+
+// Host memory has to be granted to the CPU and to the local GPU separately.
+Status GrantAccess(CUdeviceptr ptr, uint64_t size,
+                   const SharedSegmentOptions& options) {
+    std::array<CUmemAccessDesc, 2> descs{};
+    descs[0].location.type = CU_MEM_LOCATION_TYPE_HOST;
+    descs[0].location.id = 0;
+    descs[0].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    descs[1].location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    descs[1].location.id = options.device_id;
+    descs[1].flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+
+    auto result = cuMemSetAccess(ptr, size, descs.data(), descs.size());
+    if (result != CUDA_SUCCESS) {
+        return Status::Memory(DriverError("cuMemSetAccess", result));
+    }
+    return Status::OK();
+}
+
+class CudaSharedSegmentBackend : public SharedSegmentBackend {
+   public:
+    ~CudaSharedSegmentBackend() override { Release(); }
+
+    uint64_t Granularity(const SharedSegmentOptions& options) const override;
+
+    Status CreateOwner(uint64_t size, const SharedSegmentOptions& options,
+                       uintptr_t& base_addr,
+                       std::vector<uint8_t>& handle) override;
+
+    Status ReserveLocal(uint64_t size, const SharedSegmentOptions& options,
+                        uintptr_t& base_addr) override;
+
+    Status ImportAndMap(uint64_t size, const SharedSegmentOptions& options,
+                        const std::vector<uint8_t>& handle) override;
+
+    uint16_t BackendId() const override { return kCudaBackendId; }
+
+   private:
+    Status MapAndGrant(CUdeviceptr ptr, uint64_t size,
+                       const SharedSegmentOptions& options);
+    void Release();
+
+    CUdeviceptr reserved_ptr_ = 0;
+    uint64_t reserved_size_ = 0;
+    CUmemGenericAllocationHandle allocation_ = 0;
+    bool mapped_ = false;
+};
+
+uint64_t CudaSharedSegmentBackend::Granularity(
+    const SharedSegmentOptions& options) const {
+    // cuMemCreate rejects a size that is not a multiple of this, so it has to
+    // be queried for the very property the allocation will use.
+    auto prop = BuildHostAllocationProp(options);
+    size_t granularity = 0;
+    auto result = cuMemGetAllocationGranularity(
+        &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
+    if (result != CUDA_SUCCESS || granularity == 0) {
+        return kFallbackGranularity;
+    }
+    return granularity;
+}
+
+Status CudaSharedSegmentBackend::MapAndGrant(
+    CUdeviceptr ptr, uint64_t size, const SharedSegmentOptions& options) {
+    auto result = cuMemMap(ptr, size, 0, allocation_, 0);
+    if (result != CUDA_SUCCESS) {
+        return Status::Memory(DriverError("cuMemMap", result));
+    }
+    mapped_ = true;
+    return GrantAccess(ptr, size, options);
+}
+
+Status CudaSharedSegmentBackend::CreateOwner(
+    uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr,
+    std::vector<uint8_t>& handle) {
+    auto prop = BuildHostAllocationProp(options);
+    auto result = cuMemCreate(&allocation_, size, &prop, 0);
+    if (result != CUDA_SUCCESS) {
+        allocation_ = 0;
+        return Status::Memory(DriverError("cuMemCreate", result));
+    }
+    auto status = ReserveLocal(size, options, base_addr);
+    if (!status.ok()) {
+        return status;
+    }
+    status = MapAndGrant(reserved_ptr_, size, options);
+    if (!status.ok()) {
+        return status;
+    }
+
+    CUmemFabricHandle exported{};
+    result = cuMemExportToShareableHandle(&exported, allocation_,
+                                          CU_MEM_HANDLE_TYPE_FABRIC, 0);
+    if (result != CUDA_SUCCESS) {
+        return Status::Memory(
+            DriverError("cuMemExportToShareableHandle", result) +
+            "; sharing a segment across processes needs fabric handles, which "
+            "require an IMEX channel");
+    }
+    const auto* bytes = reinterpret_cast<const uint8_t*>(&exported);
+    handle.assign(bytes, bytes + sizeof(exported));
+    return Status::OK();
+}
+
+Status CudaSharedSegmentBackend::ReserveLocal(
+    uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr) {
+    auto result =
+        cuMemAddressReserve(&reserved_ptr_, size, Granularity(options), 0, 0);
+    if (result != CUDA_SUCCESS) {
+        reserved_ptr_ = 0;
+        return Status::Memory(DriverError("cuMemAddressReserve", result));
+    }
+    reserved_size_ = size;
+    base_addr = static_cast<uintptr_t>(reserved_ptr_);
+    return Status::OK();
+}
+
+Status CudaSharedSegmentBackend::ImportAndMap(
+    uint64_t size, const SharedSegmentOptions& options,
+    const std::vector<uint8_t>& handle) {
+    if (reserved_ptr_ == 0) {
+        return Status::InvalidArgument(
+            "Shared segment import needs a reserved address window");
+    }
+    if (handle.size() != sizeof(CUmemFabricHandle)) {
+        return Status::InvalidArgument(
+            "Shared segment owner handle has an unexpected length");
+    }
+    CUmemFabricHandle imported{};
+    memcpy(&imported, handle.data(), handle.size());
+    auto result = cuMemImportFromShareableHandle(&allocation_, &imported,
+                                                 CU_MEM_HANDLE_TYPE_FABRIC);
+    if (result != CUDA_SUCCESS) {
+        allocation_ = 0;
+        return Status::Memory(
+            DriverError("cuMemImportFromShareableHandle", result));
+    }
+    return MapAndGrant(reserved_ptr_, size, options);
+}
+
+void CudaSharedSegmentBackend::Release() {
+    if (mapped_) {
+        (void)cuMemUnmap(reserved_ptr_, reserved_size_);
+        mapped_ = false;
+    }
+    if (allocation_ != 0) {
+        (void)cuMemRelease(allocation_);
+        allocation_ = 0;
+    }
+    if (reserved_ptr_ != 0) {
+        (void)cuMemAddressFree(reserved_ptr_, reserved_size_);
+        reserved_ptr_ = 0;
+    }
+    reserved_size_ = 0;
+}
+}  // namespace
+
+std::unique_ptr<SharedSegmentBackend> CreateCudaSharedSegmentBackend() {
+    // Without fabric handle support there is no way to hand a peer process a
+    // handle it can import, so report the segment as unsupported instead of
+    // failing later inside cuMemCreate.
+    if (QueryDeviceAttribute(CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED,
+                             0, "fabric handle support") <= 0) {
+        // Callers probe support before every attempt, so say this only once.
+        LOG_FIRST_N(WARNING, 1)
+            << "Shared segments need fabric handle support, which requires an "
+               "IMEX channel on this system";
+        return nullptr;
+    }
+    return std::make_unique<CudaSharedSegmentBackend>();
+}
+
+}  // namespace mooncake
+
+#endif  // USE_CUDA

--- a/mooncake-transfer-engine/src/shared_segment/mmap_shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/mmap_shared_segment.cpp
@@ -1,0 +1,433 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <random>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "shared_segment_internal.h"
+
+#if defined(USE_CUDA)
+#include <cuda_runtime_api.h>
+#endif
+
+#if defined(USE_ASCEND_DIRECT)
+#include <acl/acl.h>
+#endif
+
+namespace mooncake {
+namespace {
+constexpr uint16_t kMmapBackendId = 3;
+constexpr uint64_t kFallbackPageSize = 4096;
+// Matches the common PMD THP size when sysfs is unavailable.
+constexpr uint64_t kFallbackHugePageSize = 2ULL * 1024 * 1024;
+constexpr int kShmCreateRetries = 64;
+constexpr const char* kThpPmdSizePath =
+    "/sys/kernel/mm/transparent_hugepage/hpage_pmd_size";
+constexpr const char* kShmemThpEnabledPath =
+    "/sys/kernel/mm/transparent_hugepage/shmem_enabled";
+
+#if !defined(USE_CUDA) && !defined(USE_ASCEND_DIRECT)
+constexpr bool kHostRegisterRuntimeAvailable = false;
+#else
+constexpr bool kHostRegisterRuntimeAvailable = true;
+#endif
+
+uint64_t BasePageSize() {
+    long page = sysconf(_SC_PAGESIZE);
+    if (page <= 0) {
+        return kFallbackPageSize;
+    }
+    return static_cast<uint64_t>(page);
+}
+
+// mmap uses shm_open (tmpfs/shmem), so only shmem THP matters. Sysfs looks like
+// "always within_size [advise] never deny force"; the active mode is bracketed.
+bool ShmemThpEnabled() {
+    static const bool kEnabled = []() -> bool {
+        FILE* fp = std::fopen(kShmemThpEnabledPath, "r");
+        if (fp == nullptr) {
+            return false;
+        }
+        char buf[256];
+        const char* line = std::fgets(buf, sizeof(buf), fp);
+        std::fclose(fp);
+        if (line == nullptr) {
+            return false;
+        }
+        const char* open = std::strchr(buf, '[');
+        if (open == nullptr) {
+            return false;
+        }
+        const char* close = std::strchr(open + 1, ']');
+        if (close == nullptr || close <= open + 1) {
+            return false;
+        }
+        const std::string mode(open + 1, close);
+        if (mode == "never" || mode == "deny") {
+            return false;
+        }
+        return mode == "always" || mode == "within_size" || mode == "advise" ||
+               mode == "force";
+    }();
+    return kEnabled;
+}
+
+uint64_t HugePageSize() {
+    static const uint64_t kSize = []() -> uint64_t {
+        FILE* fp = std::fopen(kThpPmdSizePath, "r");
+        if (fp != nullptr) {
+            unsigned long long value = 0;
+            const int matched = std::fscanf(fp, "%llu", &value);
+            std::fclose(fp);
+            if (matched == 1 && value > 0 && (value & (value - 1)) == 0) {
+                return static_cast<uint64_t>(value);
+            }
+        }
+        return kFallbackHugePageSize;
+    }();
+    return kSize;
+}
+
+// Hint only when shmem THP is on; failure must not abort the segment.
+void AdviseTransparentHugePages(void* addr, uint64_t size) {
+    if (!ShmemThpEnabled()) {
+        return;
+    }
+#ifdef MADV_HUGEPAGE
+    if (addr == nullptr || size == 0) {
+        return;
+    }
+    if (madvise(addr, size, MADV_HUGEPAGE) != 0) {
+        VLOG(1) << "madvise(MADV_HUGEPAGE) failed for shared segment mmap: "
+                << std::strerror(errno);
+    }
+#else
+    (void)addr;
+    (void)size;
+#endif
+}
+
+Status HostRegister(void* addr, uint64_t size, int32_t device_id,
+                    void** ascend_dev_ptr) {
+#if defined(USE_ASCEND_DIRECT)
+    uint32_t device_count = 0;
+    auto ret = aclrtGetDeviceCount(&device_count);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtGetDeviceCount failed for shared segment mmap, ret " +
+            std::to_string(ret));
+    }
+    if (device_count == 0 || device_id < 0 ||
+        static_cast<uint32_t>(device_id) >= device_count) {
+        return Status::Memory(
+            "Shared segment mmap HostRegister needs a valid Ascend device");
+    }
+    ret = aclrtSetDevice(device_id);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory("aclrtSetDevice failed for shared segment mmap, "
+                              "ret " +
+                              std::to_string(ret));
+    }
+    void* dev_ptr = nullptr;
+    ret = aclrtHostRegister(addr, size, ACL_HOST_REGISTER_MAPPED, &dev_ptr);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtHostRegister failed for shared segment mmap, ret " +
+            std::to_string(ret));
+    }
+    if (ascend_dev_ptr != nullptr) {
+        *ascend_dev_ptr = dev_ptr;
+    }
+    return Status::OK();
+#elif defined(USE_CUDA)
+    (void)ascend_dev_ptr;
+    int device_count = 0;
+    auto err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess) {
+        return Status::Memory(
+            std::string("cudaGetDeviceCount failed for shared segment mmap: ") +
+            cudaGetErrorString(err));
+    }
+    if (device_count == 0 || device_id < 0 || device_id >= device_count) {
+        return Status::Memory(
+            "Shared segment mmap HostRegister needs a valid CUDA device");
+    }
+    err = cudaSetDevice(device_id);
+    if (err != cudaSuccess) {
+        return Status::Memory(
+            std::string("cudaSetDevice failed for shared segment mmap: ") +
+            cudaGetErrorString(err));
+    }
+    err = cudaHostRegister(addr, size, cudaHostRegisterPortable);
+    if (err != cudaSuccess) {
+        return Status::Memory(
+            std::string("cudaHostRegister failed for shared segment mmap: ") +
+            cudaGetErrorString(err));
+    }
+    return Status::OK();
+#else
+    (void)addr;
+    (void)size;
+    (void)device_id;
+    (void)ascend_dev_ptr;
+    return Status::NotImplemented(
+        "Shared segment mmap needs CUDA or Ascend for HostRegister");
+#endif
+}
+
+void HostUnregister(void* addr, void* /*ascend_dev_ptr*/) {
+#if defined(USE_ASCEND_DIRECT)
+    if (addr != nullptr) {
+        (void)aclrtHostUnregister(addr);
+    }
+#elif defined(USE_CUDA)
+    if (addr != nullptr) {
+        (void)cudaHostUnregister(addr);
+    }
+#else
+    (void)addr;
+#endif
+}
+
+std::string MakeShmName() {
+    static thread_local std::mt19937_64 rng{std::random_device{}()};
+    // POSIX shm names are typically limited to NAME_MAX and must start with /.
+    char name[32];
+    std::snprintf(name, sizeof(name), "/mcss_%016llx",
+                  static_cast<unsigned long long>(rng()));
+    return name;
+}
+
+class MmapSharedSegmentBackend : public SharedSegmentBackend {
+   public:
+    ~MmapSharedSegmentBackend() override { Release(); }
+
+    uint64_t Granularity(const SharedSegmentOptions& /*options*/) const override {
+        if (ShmemThpEnabled()) {
+            return HugePageSize();
+        }
+        return BasePageSize();
+    }
+
+    Status CreateOwner(uint64_t size, const SharedSegmentOptions& options,
+                       uintptr_t& base_addr,
+                       std::vector<uint8_t>& handle) override;
+
+    Status ReserveLocal(uint64_t size, const SharedSegmentOptions& options,
+                        uintptr_t& base_addr) override;
+
+    Status ImportAndMap(uint64_t size, const SharedSegmentOptions& options,
+                        const std::vector<uint8_t>& handle) override;
+
+    uint16_t BackendId() const override { return kMmapBackendId; }
+
+   private:
+    Status MapShared(const std::string& shm_name, uint64_t size, bool create,
+                     void*& addr);
+    Status RegisterMapped(const SharedSegmentOptions& options);
+    void Release();
+
+    void* addr_ = nullptr;
+    uint64_t size_ = 0;
+    bool registered_ = false;
+    bool unlink_on_release_ = false;
+    std::string shm_name_;
+    void* ascend_dev_ptr_ = nullptr;
+};
+
+Status MmapSharedSegmentBackend::RegisterMapped(
+    const SharedSegmentOptions& options) {
+    auto status =
+        HostRegister(addr_, size_, options.device_id, &ascend_dev_ptr_);
+    if (!status.ok()) {
+        return status;
+    }
+    registered_ = true;
+    return Status::OK();
+}
+
+Status MmapSharedSegmentBackend::MapShared(const std::string& shm_name,
+                                           uint64_t size, bool create,
+                                           void*& addr) {
+    int flags = create ? (O_CREAT | O_EXCL | O_RDWR) : O_RDWR;
+    int fd = shm_open(shm_name.c_str(), flags, 0600);
+    if (fd < 0) {
+        return Status::Memory(std::string("shm_open failed: ") +
+                              std::strerror(errno));
+    }
+    if (create && ftruncate(fd, static_cast<off_t>(size)) != 0) {
+        const int err = errno;
+        close(fd);
+        shm_unlink(shm_name.c_str());
+        return Status::Memory(std::string("ftruncate failed: ") +
+                              std::strerror(err));
+    }
+
+    int map_flags = MAP_SHARED;
+    void* hint = addr;
+    if (hint != nullptr) {
+        map_flags |= MAP_FIXED;
+    }
+    void* mapped =
+        mmap(hint, size, PROT_READ | PROT_WRITE, map_flags, fd, 0);
+    const int map_err = errno;
+    close(fd);
+    if (mapped == MAP_FAILED) {
+        if (create) {
+            shm_unlink(shm_name.c_str());
+        }
+        return Status::Memory(std::string("mmap failed: ") +
+                              std::strerror(map_err));
+    }
+    AdviseTransparentHugePages(mapped, size);
+    addr = mapped;
+    return Status::OK();
+}
+
+Status MmapSharedSegmentBackend::CreateOwner(
+    uint64_t size, const SharedSegmentOptions& options, uintptr_t& base_addr,
+    std::vector<uint8_t>& handle) {
+    for (int attempt = 0; attempt < kShmCreateRetries; ++attempt) {
+        const std::string name = MakeShmName();
+        int fd = shm_open(name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+        if (fd < 0) {
+            if (errno == EEXIST) {
+                continue;
+            }
+            return Status::Memory(std::string("shm_open failed: ") +
+                                  std::strerror(errno));
+        }
+        if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
+            const int err = errno;
+            close(fd);
+            shm_unlink(name.c_str());
+            return Status::Memory(std::string("ftruncate failed: ") +
+                                  std::strerror(err));
+        }
+        void* mapped =
+            mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        const int map_err = errno;
+        close(fd);
+        if (mapped == MAP_FAILED) {
+            shm_unlink(name.c_str());
+            return Status::Memory(std::string("mmap failed: ") +
+                                  std::strerror(map_err));
+        }
+        AdviseTransparentHugePages(mapped, size);
+
+        addr_ = mapped;
+        size_ = size;
+        unlink_on_release_ = true;
+        shm_name_ = name;
+        auto status = RegisterMapped(options);
+        if (!status.ok()) {
+            Release();
+            return status;
+        }
+        base_addr = reinterpret_cast<uintptr_t>(addr_);
+        handle.assign(name.begin(), name.end());
+        return Status::OK();
+    }
+    return Status::Memory("Failed to allocate a unique POSIX shm name");
+}
+
+Status MmapSharedSegmentBackend::ReserveLocal(
+    uint64_t size, const SharedSegmentOptions& /*options*/,
+    uintptr_t& base_addr) {
+    void* reserved =
+        mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (reserved == MAP_FAILED) {
+        return Status::Memory(std::string("mmap reserve failed: ") +
+                              std::strerror(errno));
+    }
+    addr_ = reserved;
+    size_ = size;
+    base_addr = reinterpret_cast<uintptr_t>(addr_);
+    return Status::OK();
+}
+
+Status MmapSharedSegmentBackend::ImportAndMap(
+    uint64_t size, const SharedSegmentOptions& options,
+    const std::vector<uint8_t>& handle) {
+    if (addr_ == nullptr || size_ == 0) {
+        return Status::InvalidArgument(
+            "Shared segment import needs a reserved address window");
+    }
+    if (size != size_) {
+        return Status::InvalidArgument(
+            "Shared segment import size does not match the reservation");
+    }
+    if (handle.empty() || handle.size() > kMaxHandleBytes) {
+        return Status::InvalidArgument(
+            "Shared segment owner handle has an unexpected length");
+    }
+    const std::string name(handle.begin(), handle.end());
+    if (name.empty() || name[0] != '/') {
+        return Status::InvalidArgument(
+            "Shared segment owner handle is not a POSIX shm name");
+    }
+
+    void* mapped = addr_;
+    auto status = MapShared(name, size, /*create=*/false, mapped);
+    if (!status.ok()) {
+        return status;
+    }
+    addr_ = mapped;
+    shm_name_ = name;
+    status = RegisterMapped(options);
+    if (!status.ok()) {
+        return status;
+    }
+    return Status::OK();
+}
+
+void MmapSharedSegmentBackend::Release() {
+    if (registered_) {
+        HostUnregister(addr_, ascend_dev_ptr_);
+        registered_ = false;
+        ascend_dev_ptr_ = nullptr;
+    }
+    if (addr_ != nullptr) {
+        (void)munmap(addr_, size_);
+        addr_ = nullptr;
+    }
+    if (unlink_on_release_ && !shm_name_.empty()) {
+        (void)shm_unlink(shm_name_.c_str());
+        unlink_on_release_ = false;
+    }
+    shm_name_.clear();
+    size_ = 0;
+}
+}  // namespace
+
+std::unique_ptr<SharedSegmentBackend> CreateMmapSharedSegmentBackend() {
+    if (!kHostRegisterRuntimeAvailable) {
+        LOG_FIRST_N(WARNING, 1)
+            << "Shared segment mmap needs CUDA or Ascend for HostRegister";
+        return nullptr;
+    }
+    return std::make_unique<MmapSharedSegmentBackend>();
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/shared_segment/shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/shared_segment.cpp
@@ -1,0 +1,286 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "shared_segment/shared_segment.h"
+
+#include <cstring>
+#include <glog/logging.h>
+
+#include "shared_segment_internal.h"
+
+namespace mooncake {
+namespace {
+constexpr uint32_t kSegmentBlobMagic = 0x4D435353;  // "MCSS"
+constexpr uint16_t kSegmentBlobVersion = 1;
+constexpr uint64_t kFnvOffsetBasis = 1469598103934665603ULL;
+constexpr uint64_t kFnvPrime = 1099511628211ULL;
+// A segment that does not fit in the virtual address space several times over
+// is a declaration bug.
+constexpr uint64_t kMaxSegmentBytes = 1ULL << 46;
+
+uint64_t HashBytes(uint64_t seed, const void* data, size_t length) {
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    uint64_t hash = seed;
+    for (size_t i = 0; i < length; ++i) {
+        hash = (hash ^ bytes[i]) * kFnvPrime;
+    }
+    return hash;
+}
+
+uint64_t HashValue(uint64_t seed, uint64_t value) {
+    return HashBytes(seed, &value, sizeof(value));
+}
+
+Status ValidateOptions(const SharedSegmentOptions& options) {
+    if (options.world_size == 0) {
+        return Status::InvalidArgument(
+            "Shared segment world_size must not be zero");
+    }
+    if (options.rank_id >= options.world_size ||
+        options.owner_rank >= options.world_size) {
+        return Status::InvalidArgument(
+            "Shared segment rank_id and owner_rank must be below world_size");
+    }
+    return Status::OK();
+}
+
+Status CheckPeerBlob(uint32_t rank, uint16_t backend_id, uint64_t fingerprint,
+                     uint64_t alloc_size, const std::string& blob,
+                     SegmentBlobHeader& header, std::vector<uint8_t>& handle) {
+    auto status = DecodeSegmentBlob(blob, header, handle);
+    if (!status.ok()) {
+        return status;
+    }
+    if (header.rank_id != rank) {
+        return Status::InvalidArgument("Shared segment blob of rank " +
+                                       std::to_string(rank) +
+                                       " carries a different rank id");
+    }
+    if (header.backend_id != backend_id) {
+        return Status::InvalidArgument("Shared segment backend of rank " +
+                                       std::to_string(rank) + " differs");
+    }
+    if (header.fingerprint != fingerprint) {
+        return Status::InvalidArgument("Shared segment declaration of rank " +
+                                       std::to_string(rank) +
+                                       " differs from the local one");
+    }
+    if (header.alloc_size != alloc_size) {
+        return Status::InvalidArgument(
+            "Shared segment allocation size of rank " + std::to_string(rank) +
+            " differs from the local one");
+    }
+    return Status::OK();
+}
+
+Status ExtractOwnerHandle(const SharedSegmentOptions& options,
+                          uint16_t backend_id, uint64_t fingerprint,
+                          uint64_t alloc_size,
+                          const std::vector<std::string>& blobs,
+                          std::vector<uint8_t>& owner_handle) {
+    if (blobs.size() != options.world_size) {
+        return Status::InvalidArgument(
+            "Shared segment expects one blob per rank, got " +
+            std::to_string(blobs.size()));
+    }
+    for (uint32_t rank = 0; rank < blobs.size(); ++rank) {
+        SegmentBlobHeader header{};
+        std::vector<uint8_t> handle;
+        auto status = CheckPeerBlob(rank, backend_id, fingerprint, alloc_size,
+                                    blobs[rank], header, handle);
+        if (!status.ok()) {
+            return status;
+        }
+        if (rank == options.owner_rank) {
+            owner_handle = std::move(handle);
+        }
+    }
+    if (owner_handle.empty()) {
+        return Status::InvalidArgument(
+            "Shared segment owner rank did not export a handle");
+    }
+    return Status::OK();
+}
+}  // namespace
+
+uint64_t AlignUp(uint64_t value, uint64_t alignment) {
+    return (value + alignment - 1) / alignment * alignment;
+}
+
+uint64_t ComputeSegmentFingerprint(const std::string& name, uint64_t size,
+                                   const SharedSegmentOptions& options) {
+    uint64_t hash = HashBytes(kFnvOffsetBasis, name.data(), name.size());
+    hash = HashValue(hash, size);
+    hash = HashValue(hash, options.world_size);
+    hash = HashValue(hash, options.owner_rank);
+    return hash;
+}
+
+Status EncodeSegmentBlob(const SegmentBlobHeader& header,
+                         const std::vector<uint8_t>& handle,
+                         std::string& blob) {
+    if (handle.size() > kMaxHandleBytes) {
+        return Status::InvalidArgument("Shared segment handle of " +
+                                       std::to_string(handle.size()) +
+                                       " bytes does not fit in a blob");
+    }
+    blob.assign(kSegmentBlobBytes, '\0');
+    SegmentBlobHeader stamped = header;
+    stamped.magic = kSegmentBlobMagic;
+    stamped.version = kSegmentBlobVersion;
+    stamped.handle_bytes = static_cast<uint32_t>(handle.size());
+    memcpy(blob.data(), &stamped, sizeof(stamped));
+    if (!handle.empty()) {
+        memcpy(blob.data() + sizeof(stamped), handle.data(), handle.size());
+    }
+    return Status::OK();
+}
+
+Status DecodeSegmentBlob(const std::string& blob, SegmentBlobHeader& header,
+                         std::vector<uint8_t>& handle) {
+    if (blob.size() != kSegmentBlobBytes) {
+        return Status::InvalidArgument(
+            "Shared segment blob has an unexpected length");
+    }
+    memcpy(&header, blob.data(), sizeof(header));
+    if (header.magic != kSegmentBlobMagic) {
+        return Status::InvalidArgument("Shared segment blob magic mismatch");
+    }
+    if (header.version != kSegmentBlobVersion) {
+        return Status::InvalidArgument(
+            "Shared segment blob version mismatch, peers run different builds");
+    }
+    if (header.handle_bytes > kMaxHandleBytes) {
+        return Status::InvalidArgument(
+            "Shared segment blob declares an oversized handle");
+    }
+    const auto* payload =
+        reinterpret_cast<const uint8_t*>(blob.data()) + sizeof(header);
+    handle.assign(payload, payload + header.handle_bytes);
+    return Status::OK();
+}
+
+std::unique_ptr<SharedSegmentBackend> CreateSharedSegmentBackend(
+    const SharedSegmentOptions& options) {
+    if (options.mmap) {
+        return CreateMmapSharedSegmentBackend();
+    }
+#if defined(USE_ASCEND_DIRECT)
+    return CreateAscendSharedSegmentBackend();
+#elif defined(USE_CUDA)
+    return CreateCudaSharedSegmentBackend();
+#else
+    return nullptr;
+#endif
+}
+
+SharedSegment::SharedSegment(std::string name, uint64_t size,
+                             SharedSegmentOptions options)
+    : name_(std::move(name)), size_(size), options_(options) {}
+
+SharedSegment::~SharedSegment() = default;
+
+bool SharedSegment::Supported(bool mmap) {
+    SharedSegmentOptions options;
+    options.mmap = mmap;
+    return CreateSharedSegmentBackend(options) != nullptr;
+}
+
+Status SharedSegment::Create(const std::string& name, uint64_t size,
+                             const SharedSegmentOptions& options,
+                             std::shared_ptr<SharedSegment>& segment,
+                             std::string& out_blob) {
+    auto status = ValidateOptions(options);
+    if (!status.ok()) {
+        return status;
+    }
+    if (size == 0 || size > kMaxSegmentBytes) {
+        return Status::InvalidArgument("Shared segment size must be in (0, " +
+                                       std::to_string(kMaxSegmentBytes) + "]");
+    }
+
+    auto candidate =
+        std::shared_ptr<SharedSegment>(new SharedSegment(name, size, options));
+    candidate->backend_ = CreateSharedSegmentBackend(options);
+    if (candidate->backend_ == nullptr) {
+        return Status::NotImplemented(
+            options.mmap
+                ? "This build has no mmap shared-segment backend (needs CUDA "
+                  "or Ascend for HostRegister)"
+                : "This build has no VMM backend for shared segments");
+    }
+
+    candidate->fingerprint_ = ComputeSegmentFingerprint(name, size, options);
+    const uint64_t granularity = candidate->backend_->Granularity(options);
+    candidate->alloc_size_ = AlignUp(size, granularity);
+
+    SegmentBlobHeader header{};
+    header.backend_id = candidate->backend_->BackendId();
+    header.rank_id = options.rank_id;
+    header.fingerprint = candidate->fingerprint_;
+    header.alloc_size = candidate->alloc_size_;
+
+    std::vector<uint8_t> handle;
+    if (options.rank_id == options.owner_rank) {
+        status = candidate->backend_->CreateOwner(
+            candidate->alloc_size_, options, candidate->base_addr_, handle);
+    } else {
+        status = candidate->backend_->ReserveLocal(
+            candidate->alloc_size_, options, candidate->base_addr_);
+    }
+    if (!status.ok()) {
+        return status;
+    }
+
+    status = EncodeSegmentBlob(header, handle, out_blob);
+    if (!status.ok()) {
+        return status;
+    }
+    LOG(INFO) << "Shared segment " << name << " create: rank "
+              << options.rank_id << " of " << options.world_size << ", base 0x"
+              << std::hex << candidate->base_addr_ << std::dec << ", "
+              << candidate->alloc_size_ << " bytes";
+    segment = std::move(candidate);
+    return Status::OK();
+}
+
+Status SharedSegment::Complete(const std::vector<std::string>& blobs) {
+    if (ready_) {
+        return Status::InvalidArgument(
+            "SharedSegment::Complete has already been called");
+    }
+    if (backend_ == nullptr) {
+        return Status::InvalidArgument(
+            "SharedSegment::Complete needs a segment returned by Create");
+    }
+    std::vector<uint8_t> owner_handle;
+    auto status =
+        ExtractOwnerHandle(options_, backend_->BackendId(), fingerprint_,
+                           alloc_size_, blobs, owner_handle);
+    if (!status.ok()) {
+        return status;
+    }
+
+    if (options_.rank_id != options_.owner_rank) {
+        status = backend_->ImportAndMap(alloc_size_, options_, owner_handle);
+        if (!status.ok()) {
+            return status;
+        }
+    }
+    ready_ = true;
+    return Status::OK();
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/shared_segment/shared_segment_internal.h
+++ b/mooncake-transfer-engine/src/shared_segment/shared_segment_internal.h
@@ -1,0 +1,123 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef SHARED_SEGMENT_INTERNAL_H
+#define SHARED_SEGMENT_INTERNAL_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "shared_segment/shared_segment.h"
+
+namespace mooncake {
+
+// Platform VMM operations behind a shared segment. One instance owns the
+// resources of exactly one segment in one process and releases them on
+// destruction.
+class SharedSegmentBackend {
+   public:
+    virtual ~SharedSegmentBackend() = default;
+
+    // Allocation size must be a multiple of this, and the reserved base address
+    // is aligned to it. It depends on the options because the host NUMA node is
+    // derived from device_id.
+    virtual uint64_t Granularity(const SharedSegmentOptions& options) const = 0;
+
+    // Owner path: allocate physical memory, map it at a fresh local address,
+    // and export a handle that peers can import. The handle is opaque bytes and
+    // must fit in kMaxHandleBytes.
+    virtual Status CreateOwner(uint64_t size,
+                               const SharedSegmentOptions& options,
+                               uintptr_t& base_addr,
+                               std::vector<uint8_t>& handle) = 0;
+
+    // Non-owner path, phase one: reserve an address window. Done before the
+    // handle exchange so the segment base is known as early as on the owner.
+    virtual Status ReserveLocal(uint64_t size,
+                                const SharedSegmentOptions& options,
+                                uintptr_t& base_addr) = 0;
+
+    // Non-owner path, phase two: map the owner's physical pages into the window
+    // this instance reserved.
+    virtual Status ImportAndMap(uint64_t size,
+                                const SharedSegmentOptions& options,
+                                const std::vector<uint8_t>& handle) = 0;
+
+    // Identifies the backend in the exchanged blob, so a mismatched peer build
+    // is rejected instead of importing garbage.
+    virtual uint16_t BackendId() const = 0;
+};
+
+// Returns nullptr when the requested backend is unavailable on this build or
+// the running system cannot share memory.
+std::unique_ptr<SharedSegmentBackend> CreateSharedSegmentBackend(
+    const SharedSegmentOptions& options);
+
+// Always compiled; returns nullptr when neither CUDA nor Ascend is available
+// for HostRegister.
+std::unique_ptr<SharedSegmentBackend> CreateMmapSharedSegmentBackend();
+
+#ifdef USE_ASCEND_DIRECT
+std::unique_ptr<SharedSegmentBackend> CreateAscendSharedSegmentBackend();
+#endif
+
+#ifdef USE_CUDA
+std::unique_ptr<SharedSegmentBackend> CreateCudaSharedSegmentBackend();
+#endif
+
+// Largest platform handle carried in a blob: aclrtMemFabricHandle is 128 bytes,
+// CUmemFabricHandle is 64.
+constexpr size_t kMaxHandleBytes = 128;
+
+// Every rank contributes a blob of the same length, so the exchange is a plain
+// fixed-size all-gather with no serialization framework involved. Only the
+// owner fills in a handle.
+struct SegmentBlobHeader {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t backend_id;
+    uint32_t rank_id;
+    uint32_t handle_bytes;
+    uint64_t fingerprint;
+    uint64_t alloc_size;
+};
+
+// The header is memcpy'd raw into the blob, so its layout is part of the wire
+// format.
+static_assert(sizeof(SegmentBlobHeader) == 32,
+              "SegmentBlobHeader layout is part of the exchanged blob");
+
+constexpr size_t kSegmentBlobBytes =
+    sizeof(SegmentBlobHeader) + kMaxHandleBytes;
+
+Status EncodeSegmentBlob(const SegmentBlobHeader& header,
+                         const std::vector<uint8_t>& handle, std::string& blob);
+
+Status DecodeSegmentBlob(const std::string& blob, SegmentBlobHeader& header,
+                         std::vector<uint8_t>& handle);
+
+uint64_t AlignUp(uint64_t value, uint64_t alignment);
+
+// Digest of everything the ranks must agree on. Ranks compare digests instead
+// of exchanging the full spec, which keeps the blob fixed-length. Callers that
+// care about a richer layout should fold that declaration into `name`.
+uint64_t ComputeSegmentFingerprint(const std::string& name, uint64_t size,
+                                   const SharedSegmentOptions& options);
+
+}  // namespace mooncake
+
+#endif  // SHARED_SEGMENT_INTERNAL_H

--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/ascend_direct_transport.cpp
@@ -311,6 +311,69 @@ Status AscendDirectTransport::getTransferStatus(BatchID batch_id,
     return Status::OK();
 }
 
+namespace {
+// HostRegister(MAPPED) pages are registered with TE via the caller's host VA
+// (e.g. SharedSegment.tensors().data_ptr()) and location=npu. ADXL ROCE D2rH
+// needs the mapped device VA; resolve it when present, otherwise keep addr.
+void *ResolveAscendRegisterAddr(void *addr, const std::string &location,
+                                adxl::MemType &mem_type) {
+    if (location.starts_with("cpu")) {
+        mem_type = adxl::MEM_HOST;
+        return addr;
+    }
+    if (location.starts_with("npu")) {
+        mem_type = adxl::MEM_DEVICE;
+        void *device_ptr = nullptr;
+        if (aclrtHostGetDevicePointer(addr, &device_ptr, 0) == ACL_ERROR_NONE &&
+            device_ptr != nullptr) {
+            LOG(INFO) << "HostRegister-mapped host " << addr
+                      << " resolved to device " << device_ptr
+                      << " for location=" << location;
+            return device_ptr;
+        }
+        return addr;
+    }
+    if (location == kWildcardLocation) {
+        aclrtPtrAttributes attributes;
+        if (aclrtPointerGetAttributes(addr, &attributes) != ACL_ERROR_NONE) {
+            LOG(ERROR) << "aclrtPointerGetAttributes failed for addr " << addr
+                       << ", errmsg: " << aclGetRecentErrMsg();
+            return nullptr;
+        }
+        if (attributes.location.type == ACL_MEM_LOCATION_TYPE_HOST) {
+            mem_type = adxl::MEM_HOST;
+            void *device_ptr = nullptr;
+            if (aclrtHostGetDevicePointer(addr, &device_ptr, 0) ==
+                    ACL_ERROR_NONE &&
+                device_ptr != nullptr) {
+                // Prefer device mapping when the host pages were HostRegister'd.
+                mem_type = adxl::MEM_DEVICE;
+                return device_ptr;
+            }
+            return addr;
+        }
+        if (attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
+            mem_type = adxl::MEM_DEVICE;
+            return addr;
+        }
+        LOG(INFO) << "mem addr:" << addr
+                  << " can not be recognized, try set to host mem.";
+        mem_type = adxl::MEM_HOST;
+        return addr;
+    }
+    return nullptr;
+}
+
+void *ResolveAscendUnregisterAddr(void *addr) {
+    void *device_ptr = nullptr;
+    if (aclrtHostGetDevicePointer(addr, &device_ptr, 0) == ACL_ERROR_NONE &&
+        device_ptr != nullptr) {
+        return device_ptr;
+    }
+    return addr;
+}
+}  // namespace
+
 int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
                                                const std::string &location,
                                                bool remote_accessible,
@@ -325,32 +388,17 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
     MAKE_GUARD(ctx_restore,
                [saved_ctx]() { (void)aclrtSetCurrentContext(saved_ctx); });
 
-    BufferDesc buffer_desc;
-    buffer_desc.name = location;
-    buffer_desc.addr = (uint64_t)addr;
-    buffer_desc.length = (uint64_t)length;
-
     adxl::MemType mem_type;
-    if (location.starts_with("cpu")) {
-        mem_type = adxl::MEM_HOST;
-    } else if (location.starts_with("npu")) {
-        mem_type = adxl::MEM_DEVICE;
-    } else if (location == kWildcardLocation) {
-        aclrtPtrAttributes attributes;
-        CHECK_ACL(aclrtPointerGetAttributes(addr, &attributes));
-        if (attributes.location.type == ACL_MEM_LOCATION_TYPE_HOST) {
-            mem_type = adxl::MEM_HOST;
-        } else if (attributes.location.type == ACL_MEM_LOCATION_TYPE_DEVICE) {
-            mem_type = adxl::MEM_DEVICE;
-        } else {
-            LOG(INFO) << "mem addr:" << addr
-                      << " can not be recognized, try set to host mem.";
-            mem_type = adxl::MEM_HOST;
-        }
-    } else {
+    void *reg_addr = ResolveAscendRegisterAddr(addr, location, mem_type);
+    if (reg_addr == nullptr) {
         LOG(ERROR) << "location:" << location << " is not supported.";
         return ERR_INVALID_ARGUMENT;
     }
+
+    BufferDesc buffer_desc;
+    buffer_desc.name = location;
+    buffer_desc.addr = (uint64_t)reg_addr;
+    buffer_desc.length = (uint64_t)length;
 
     int ret = metadata_->addLocalMemoryBuffer(buffer_desc, update_metadata);
     if (ret) {
@@ -359,14 +407,14 @@ int AscendDirectTransport::registerLocalMemory(void *addr, size_t length,
     }
 
     const int register_ret = transfer_executor_->registerMem(
-        addr, length, mem_type, transfer_executor_->getUseBufferPool(),
+        reg_addr, length, mem_type, transfer_executor_->getUseBufferPool(),
         roce_mode_, agent_mode_);
     if (register_ret == 0) {
         return 0;
     }
 
     const int rollback_ret =
-        metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+        metadata_->removeLocalMemoryBuffer(reg_addr, update_metadata);
     if (rollback_ret != 0) {
         LOG(ERROR) << "removeLocalMemoryBuffer rollback failed, ret: "
                    << rollback_ret;
@@ -385,11 +433,12 @@ int AscendDirectTransport::unregisterLocalMemory(void *addr,
     MAKE_GUARD(ctx_restore,
                [saved_ctx]() { (void)aclrtSetCurrentContext(saved_ctx); });
 
-    int ret = transfer_executor_->deregisterMem(addr);
+    void *reg_addr = ResolveAscendUnregisterAddr(addr);
+    int ret = transfer_executor_->deregisterMem(reg_addr);
     if (ret != 0) {
         return ret;
     }
-    (void)metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    (void)metadata_->removeLocalMemoryBuffer(reg_addr, update_metadata);
     return 0;
 }
 

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -24,6 +24,15 @@ target_link_libraries(endpoint_store_test PUBLIC transfer_engine gtest
                                                  gtest_main)
 add_test(NAME endpoint_store_test COMMAND endpoint_store_test)
 
+# Fingerprint, blob and option checks run without a VMM backend.
+add_executable(shared_segment_test ${WORKSPACE}/shared_segment_test.cpp)
+target_include_directories(
+  shared_segment_test
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/shared_segment)
+target_link_libraries(shared_segment_test PUBLIC transfer_engine gtest
+                                                 gtest_main)
+add_test(NAME shared_segment_test COMMAND shared_segment_test)
+
 add_executable(rdma_endpoint_state_test
                ${WORKSPACE}/rdma_endpoint_state_test.cpp)
 target_link_libraries(rdma_endpoint_state_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/shared_segment_test.cpp
+++ b/mooncake-transfer-engine/tests/shared_segment_test.cpp
@@ -1,0 +1,262 @@
+// Copyright 2026 Huawei Technologies Co., Ltd
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstring>
+
+#include "shared_segment/shared_segment.h"
+#include "shared_segment_internal.h"
+
+namespace mooncake {
+namespace {
+constexpr uint64_t kSegmentSize = 61 * (4096 + 8192);
+
+SharedSegmentOptions KvOptions(uint32_t rank_id = 0, uint32_t world_size = 2) {
+    SharedSegmentOptions options;
+    options.world_size = world_size;
+    options.rank_id = rank_id;
+    options.owner_rank = 0;
+    return options;
+}
+}  // namespace
+
+TEST(SharedSegmentFingerprintTest, ChangesWithEveryDeclaredField) {
+    SharedSegmentOptions options = KvOptions();
+    const auto base = ComputeSegmentFingerprint("kv", kSegmentSize, options);
+
+    EXPECT_NE(ComputeSegmentFingerprint("other", kSegmentSize, options), base);
+    EXPECT_NE(ComputeSegmentFingerprint("kv", kSegmentSize + 1, options), base);
+
+    auto different_world = options;
+    different_world.world_size = 8;
+    EXPECT_NE(ComputeSegmentFingerprint("kv", kSegmentSize, different_world),
+              base);
+
+    auto different_owner = options;
+    different_owner.owner_rank = 1;
+    EXPECT_NE(ComputeSegmentFingerprint("kv", kSegmentSize, different_owner),
+              base);
+
+    // rank_id and device_id are local and must not affect the digest.
+    auto different_rank = options;
+    different_rank.rank_id = 7;
+    different_rank.device_id = 3;
+    EXPECT_EQ(ComputeSegmentFingerprint("kv", kSegmentSize, different_rank),
+              base);
+}
+
+TEST(SharedSegmentBlobTest, RoundTripsHeaderAndHandle) {
+    SegmentBlobHeader header{};
+    header.backend_id = 1;
+    header.rank_id = 5;
+    header.fingerprint = 0xDEADBEEFCAFEULL;
+    header.alloc_size = 1ULL << 30;
+    const std::vector<uint8_t> handle(kMaxHandleBytes, 0xA5);
+
+    std::string blob;
+    ASSERT_TRUE(EncodeSegmentBlob(header, handle, blob).ok());
+    EXPECT_EQ(blob.size(), kSegmentBlobBytes);
+
+    SegmentBlobHeader decoded{};
+    std::vector<uint8_t> decoded_handle;
+    ASSERT_TRUE(DecodeSegmentBlob(blob, decoded, decoded_handle).ok());
+    EXPECT_EQ(decoded.backend_id, header.backend_id);
+    EXPECT_EQ(decoded.rank_id, header.rank_id);
+    EXPECT_EQ(decoded.fingerprint, header.fingerprint);
+    EXPECT_EQ(decoded.alloc_size, header.alloc_size);
+    EXPECT_EQ(decoded_handle, handle);
+}
+
+TEST(SharedSegmentBlobTest, NonOwnerBlobHasTheSameLengthButNoHandle) {
+    SegmentBlobHeader header{};
+    header.rank_id = 2;
+    std::string blob;
+    ASSERT_TRUE(EncodeSegmentBlob(header, {}, blob).ok());
+    EXPECT_EQ(blob.size(), kSegmentBlobBytes);
+
+    SegmentBlobHeader decoded{};
+    std::vector<uint8_t> decoded_handle;
+    ASSERT_TRUE(DecodeSegmentBlob(blob, decoded, decoded_handle).ok());
+    EXPECT_TRUE(decoded_handle.empty());
+}
+
+TEST(SharedSegmentBlobTest, RejectsHandlesThatDoNotFit) {
+    std::string blob;
+    EXPECT_TRUE(
+        EncodeSegmentBlob({}, std::vector<uint8_t>(kMaxHandleBytes + 1), blob)
+            .IsInvalidArgument());
+}
+
+TEST(SharedSegmentBlobTest, RejectsCorruptedBlobs) {
+    std::vector<uint8_t> decoded_handle;
+    SegmentBlobHeader decoded{};
+
+    EXPECT_TRUE(DecodeSegmentBlob("short", decoded, decoded_handle)
+                    .IsInvalidArgument());
+
+    std::string blob;
+    ASSERT_TRUE(EncodeSegmentBlob({}, {}, blob).ok());
+    auto corrupted = blob;
+    corrupted[0] = static_cast<char>(corrupted[0] + 1);
+    EXPECT_TRUE(DecodeSegmentBlob(corrupted, decoded, decoded_handle)
+                    .IsInvalidArgument());
+
+    auto wrong_version = blob;
+    wrong_version[offsetof(SegmentBlobHeader, version)] += 1;
+    EXPECT_TRUE(DecodeSegmentBlob(wrong_version, decoded, decoded_handle)
+                    .IsInvalidArgument());
+
+    auto oversized_handle = blob;
+    const uint32_t too_many = kMaxHandleBytes + 1;
+    memcpy(oversized_handle.data() + offsetof(SegmentBlobHeader, handle_bytes),
+           &too_many, sizeof(too_many));
+    EXPECT_TRUE(DecodeSegmentBlob(oversized_handle, decoded, decoded_handle)
+                    .IsInvalidArgument());
+}
+
+TEST(SharedSegmentTest, RejectsInvalidOptions) {
+    std::string blob;
+    std::shared_ptr<SharedSegment> segment;
+    SharedSegmentOptions options;
+    options.world_size = 0;
+    EXPECT_TRUE(
+        SharedSegment::Create("kv", kSegmentSize, options, segment, blob)
+            .IsInvalidArgument());
+
+    options.world_size = 2;
+    options.rank_id = 2;
+    EXPECT_TRUE(
+        SharedSegment::Create("kv", kSegmentSize, options, segment, blob)
+            .IsInvalidArgument());
+
+    options.rank_id = 0;
+    options.owner_rank = 5;
+    EXPECT_TRUE(
+        SharedSegment::Create("kv", kSegmentSize, options, segment, blob)
+            .IsInvalidArgument());
+
+    options.owner_rank = 0;
+    EXPECT_TRUE(SharedSegment::Create("kv", 0, options, segment, blob)
+                    .IsInvalidArgument());
+}
+
+TEST(SharedSegmentTest, ReportsWhenNoBackendIsCompiledIn) {
+    if (SharedSegment::Supported()) {
+        GTEST_SKIP() << "This build has a working VMM backend";
+    }
+    std::string blob;
+    std::shared_ptr<SharedSegment> segment;
+    EXPECT_TRUE(SharedSegment::Create("kv", kSegmentSize, KvOptions(0, 1),
+                                      segment, blob)
+                    .IsNotImplemented());
+}
+
+TEST(SharedSegmentMmapTest, SupportedWhenHostRegisterRuntimeIsPresent) {
+#if defined(USE_CUDA) || defined(USE_ASCEND_DIRECT)
+    EXPECT_TRUE(SharedSegment::Supported(/*mmap=*/true));
+#else
+    EXPECT_FALSE(SharedSegment::Supported(/*mmap=*/true));
+#endif
+}
+
+TEST(SharedSegmentMmapTest, SingleRankRoundTrip) {
+    if (!SharedSegment::Supported(/*mmap=*/true)) {
+        GTEST_SKIP() << "mmap shared segment needs CUDA or Ascend";
+    }
+    SharedSegmentOptions options = KvOptions(0, 1);
+    options.mmap = true;
+
+    std::string blob;
+    std::shared_ptr<SharedSegment> segment;
+    auto status =
+        SharedSegment::Create("mmap-kv", kSegmentSize, options, segment, blob);
+    if (!status.ok()) {
+        GTEST_SKIP() << "HostRegister unavailable: " << status.ToString();
+    }
+    ASSERT_TRUE(segment->Complete({blob}).ok());
+    ASSERT_TRUE(segment->ready());
+    ASSERT_NE(segment->base_addr(), 0u);
+
+    auto* bytes = reinterpret_cast<uint8_t*>(segment->base_addr());
+    bytes[0] = 0x3C;
+    bytes[kSegmentSize - 1] = 0xC3;
+    EXPECT_EQ(bytes[0], 0x3C);
+    EXPECT_EQ(bytes[kSegmentSize - 1], 0xC3);
+}
+
+TEST(SharedSegmentMmapTest, TwoRanksSharePagesInOneProcess) {
+    if (!SharedSegment::Supported(/*mmap=*/true)) {
+        GTEST_SKIP() << "mmap shared segment needs CUDA or Ascend";
+    }
+    SharedSegmentOptions owner_opts = KvOptions(0, 2);
+    owner_opts.mmap = true;
+    SharedSegmentOptions peer_opts = KvOptions(1, 2);
+    peer_opts.mmap = true;
+
+    std::string owner_blob;
+    std::string peer_blob;
+    std::shared_ptr<SharedSegment> owner;
+    std::shared_ptr<SharedSegment> peer;
+    auto status = SharedSegment::Create("mmap-tp", kSegmentSize, owner_opts,
+                                        owner, owner_blob);
+    if (!status.ok()) {
+        GTEST_SKIP() << "HostRegister unavailable: " << status.ToString();
+    }
+    ASSERT_TRUE(SharedSegment::Create("mmap-tp", kSegmentSize, peer_opts, peer,
+                                      peer_blob)
+                    .ok());
+
+    const std::vector<std::string> blobs = {owner_blob, peer_blob};
+    ASSERT_TRUE(owner->Complete(blobs).ok());
+    ASSERT_TRUE(peer->Complete(blobs).ok());
+
+    auto* owner_bytes = reinterpret_cast<uint8_t*>(owner->base_addr());
+    auto* peer_bytes = reinterpret_cast<uint8_t*>(peer->base_addr());
+    owner_bytes[0] = 0xAB;
+    owner_bytes[4095] = 0xCD;
+    EXPECT_EQ(peer_bytes[0], 0xAB);
+    EXPECT_EQ(peer_bytes[4095], 0xCD);
+    // Rank-local VAs need not match.
+    EXPECT_NE(owner->base_addr(), peer->base_addr());
+}
+
+TEST(SharedSegmentMmapTest, RejectsMixedBackendBlobs) {
+    if (!SharedSegment::Supported(/*mmap=*/true)) {
+        GTEST_SKIP() << "mmap shared segment needs CUDA or Ascend";
+    }
+    SharedSegmentOptions mmap_opts = KvOptions(0, 1);
+    mmap_opts.mmap = true;
+
+    std::string mmap_blob;
+    std::shared_ptr<SharedSegment> mmap_segment;
+    auto status = SharedSegment::Create("mmap-mix", kSegmentSize, mmap_opts,
+                                        mmap_segment, mmap_blob);
+    if (!status.ok()) {
+        GTEST_SKIP() << "HostRegister unavailable: " << status.ToString();
+    }
+
+    // Forge a peer blob that claims a different backend id.
+    SegmentBlobHeader header{};
+    std::vector<uint8_t> handle;
+    ASSERT_TRUE(DecodeSegmentBlob(mmap_blob, header, handle).ok());
+    header.backend_id = 1;  // Ascend VMM id
+    std::string forged;
+    ASSERT_TRUE(EncodeSegmentBlob(header, handle, forged).ok());
+    EXPECT_TRUE(mmap_segment->Complete({forged}).IsInvalidArgument());
+}
+
+}  // namespace mooncake

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -32,6 +32,9 @@ cp mooncake-integration/fabric_allocator_utils.py mooncake-wheel/mooncake/fabric
 # Copy engine.so to mooncake directory (will be imported by transfer module)
 cp ${BUILD_DIR}/mooncake-integration/engine.*.so mooncake-wheel/mooncake/engine.so
 
+# Copy the shared segment wrapper, which builds on engine.so
+cp mooncake-integration/shared_segment.py mooncake-wheel/mooncake/shared_segment.py
+
 # Copy libasio.so to mooncake directory (runtime dependency of engine.so)
 cp ${BUILD_DIR}/mooncake-common/libasio.so mooncake-wheel/mooncake/libasio.so
 


### PR DESCRIPTION
## Motivation

MLA keeps the same KV cache in every rank of a tensor-parallel group. When those ranks offload KV to host memory during decode, each one allocates its own copy, so host usage grows with the TP size while every copy holds identical bytes.

This PR adds a *shared segment*: the owner rank allocates the pages once through the platform's virtual memory manager, and every other rank maps the very same physical memory. Host usage for offloaded MLA KV drops to 1/TP.

## Design

C++ shares one contiguous host span. Tensor layout (which offset holds which layer's K/V) is computed in Python and folded into the segment name so peers that disagree still fail the fingerprint check.

**Two-phase creation.** The handle exchange belongs to the caller's process group:

1. `SharedSegment::Create` reserves address space (owner also allocates and exports) and returns a fixed-size blob.
2. The caller `all_gather`s the blob over its own group.
3. `segment->Complete(blobs)` maps the owner's pages and verifies that every rank declared the same thing.

Doing it this way avoids calling back into Python collectives from C++ under the GIL. Non-owner blobs are the same length as the owner's, so a plain fixed-size all-gather carries them.

**Addresses are not forced to match.** Ranks agree on the byte layout, not on virtual addresses, so each rank reserves `size` rather than `size * world_size`.

**Backends.** Compiled in per platform and both optional:

| Platform | Mechanism | Handle |
| --- | --- | --- |
| Ascend | ACL VMM via `adxl::AdxlEngine` | `aclrtMemFabricHandle` |
| NVIDIA | CUDA VMM (`cuMemCreate`/`cuMemMap`) | `CUmemFabricHandle`, CUDA 12.4+ |

`SharedSegment::Supported()` reports whether the running system can actually share memory. Builds without either backend return `kNotImplemented` rather than failing to link.

## Python API

```python
from mooncake.shared_segment import create_shared_segment

seg = create_shared_segment(
    "vllm_sparse_kv",
    blocks={
        "k": dict(count=num_layers, shape=k_shape, dtype=torch.bfloat16),
        "v": dict(count=num_layers, shape=v_shape, dtype=torch.bfloat16),
    },
    world_size=tp_size,
    rank_id=tp_rank,
    tp_group=tp_group,
)
k_caches_cpu = seg.tensors("k")  # zero-copy views onto the shared pages
```

## Test plan

- [x] `shared_segment_test`: fingerprint, blob encode/decode, and the full two-phase protocol against a fake backend.
- [x] Ascend build and pybind smoke test on a CANN toolchain.
- [x] CUDA backend compiles clean under `-Wall -Wextra` against the CUDA driver headers.
- [ ] Multi-rank run on real Ascend hardware, paired with HiXL https://gitcode.com/cann/hixl/merge_requests/851