### PR TITLE
[Store] Fix processing_keys double-erase UAF in MetadataAccessorRW

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -82,6 +82,10 @@ class MasterServiceTenantQuotaTest;
 // relying on segment pressure plus the background eviction thread.
 class BatchEvictTest;
 class MasterServiceHATest;
+// Friended so the processing_keys double-erase reproduction test can
+// invalidate a segment allocator via PrepareUnmountSegment WITHOUT the
+// ClearInvalidHandles sweep that MasterService::UnmountSegment performs.
+class MasterServiceProcessingKeyDoubleEraseTest;
 }  // namespace test
 namespace benchmarks {
 class BatchEvictBench;
@@ -112,6 +116,8 @@ class MasterService {
     friend class benchmarks::BatchEvictBench;
     friend class test::MasterServiceTenantQuotaTest;
     friend class test::BatchEvictTest;
+    // double-erase processing_keys UAF repro (2026-08-03 prod segfault)
+    friend class test::MasterServiceProcessingKeyDoubleEraseTest;
     friend class MasterSnapshotManager;    // Allow access to internal state for
                                            // snapshot
     friend class ha::MasterSnapshotCodec;  // Allow codec to access private
@@ -1739,12 +1745,12 @@ class MasterService {
                 }
                 // If no valid replicas remain, delete the whole object.
                 if (!it_->second.IsValid()) {
-                    const bool had_processing =
-                        processing_it_ != tenant_state_->processing_keys.end();
+                    // NOTE: Erase() -> EraseMetadata() already removes the key
+                    // from processing_keys (by key), so calling
+                    // EraseFromProcessing() here would re-erase the same node
+                    // via the now-dangling processing_it_ iterator
+                    // (use-after-free, prod segfault 2026-08-03).
                     this->Erase();
-                    if (tenant_state_ != nullptr && had_processing) {
-                        this->EraseFromProcessing();
-                    }
                     if (tenant_state_ != nullptr) {
                         service_->ErasePromotionTaskIfPresent(
                             *tenant_state_, object_id_.user_key,

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -68,6 +68,8 @@ endif()
 add_store_test(master_service_test master_service_test.cpp)
 add_store_test(batch_evict_test batch_evict_test.cpp)
 add_store_test(master_service_config_test master_service_config_test.cpp)
+add_store_test(master_service_processing_key_double_erase_test
+               master_service_processing_key_double_erase_test.cpp)
 add_store_test(master_service_tenant_quota_test
                master_service_tenant_quota_test.cpp)
 add_store_test(batch_remove_test batch_remove_test.cpp)

--- a/mooncake-store/tests/master_service_processing_key_double_erase_test.cpp
+++ b/mooncake-store/tests/master_service_processing_key_double_erase_test.cpp
@@ -1,0 +1,202 @@
+// Reproduction/regression test for the MetadataAccessorRW double-erase
+// use-after-free (prod incident 2026-08-03: mooncake_master segfaulted every
+// ~5 minutes after a snapshot restore, always at the same instruction inside
+// std::unordered_set<std::string>::erase(const_iterator) — the bucket-chain
+// walk dereferencing the chain-end nullptr).
+//
+// The bug — MasterService::MetadataAccessorRW constructor
+// (mooncake-store/include/master_service.h):
+//
+//     if (!it_->second.IsValid()) {
+//         const bool had_processing =
+//             processing_it_ != tenant_state_->processing_keys.end();
+//         this->Erase();  // -> EraseMetadata(), which already does
+//                         //    processing_keys.erase(key)
+//                         //    (master_service.cpp), freeing the
+//                         //    node processing_it_ points to
+//         if (tenant_state_ != nullptr && had_processing) {
+//             this->EraseFromProcessing();  // -> processing_keys.erase(
+//         }                                 //    processing_it_)
+//     }                                     //    STALE ITERATOR!
+//
+// Erase() already removes the key from processing_keys (by key); the follow-up
+// EraseFromProcessing() erases the SAME node again via the now-dangling
+// iterator. libstdc++ re-reads the cached hash from the freed node, walks the
+// bucket chain looking for it by address, runs off the end of the chain and
+// dereferences nullptr -> SIGSEGV (fault address 0x0, exactly as observed in
+// the prod kernel logs).
+//
+// Production trigger chain reproduced here (public API + one friend hook):
+//   1. MountSegment                     (a "ghost" client mounts a segment)
+//   2. PutStart without PutEnd          (key stays in processing_keys with an
+//                                        incomplete replica on that segment)
+//   3. PrepareUnmountSegment            (ghost client expires; the replica's
+//                                        allocator weak_ptr expires, so
+//                                        has_invalid_mem_handle() == true)
+//   4. PutEnd (or any op constructing   (ctor cleanup: erases invalid replicas
+//      MetadataAccessorRW for the key)   -> !IsValid() -> Erase() +
+//                                        EraseFromProcessing() double-erase)
+//
+// Two scenario details matter for a deterministic repro:
+//   * Step 3 must NOT use MasterService::UnmountSegment: it internally runs
+//     ClearInvalidHandles(), which would erase the crafted object through the
+//     SAFE path (EraseMetadata) before step 4 can hit the buggy accessor path.
+//     Production had the same window: the expiry thread unmounts the ghost
+//     segment and only THEN slowly sweeps 23M keys in ClearInvalidHandles —
+//     any RPC landing in that window hits the buggy accessor cleanup first.
+//   * A second live key ON THE SAME METADATA SHARD must keep the TenantState
+//     non-empty. Otherwise MaybeEraseEmptyTenant() erases the tenant and
+//     nulls tenant_state_, masking the bug (the buggy branch is guarded by
+//     tenant_state_ != nullptr). Production tenants hold millions of keys,
+//     so the buggy branch always executed.
+//
+// On the buggy code step 4 segfaults; the forked-child assertion below turns
+// that into a clean test failure. After the fix the child exits 0 (PutEnd
+// simply reports OBJECT_NOT_FOUND) and the test passes.
+
+#include "master_service.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace mooncake::test {
+
+class MasterServiceProcessingKeyDoubleEraseTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("MasterServiceProcessingKeyDoubleEraseTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    static constexpr size_t kSegmentBase = 0x300000000;
+    static constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+
+    // Exit codes used by the child to report how far it got.
+    static constexpr int kExitOk = 0;              // reached past the trigger
+    static constexpr int kExitMountFailed = 2;     // scenario setup broken
+    static constexpr int kExitPutStartFailed = 3;  // scenario setup broken
+    static constexpr int kExitUnmountFailed = 4;   // scenario setup broken
+
+    // Friend access: find a key that routes to the SAME metadata shard as
+    // `key` (getMetadataShardIndex hashes tenant+key, so a naive second key
+    // lands in a different shard's TenantState and cannot keep THIS shard's
+    // tenant non-empty).
+    std::string FindKeyOnSameShard(MasterService& service,
+                                   const std::string& key) {
+        const size_t target =
+            service.getMetadataShardIndex(TenantId::Default(), key);
+        for (int i = 0; i < 100000; ++i) {
+            std::string candidate = key + "_keepalive_" + std::to_string(i);
+            if (service.getMetadataShardIndex(TenantId::Default(), candidate) ==
+                target) {
+                return candidate;
+            }
+        }
+        return key + "_keepalive_fallback";
+    }
+
+    // Builds the incident state and fires the trigger. Only returns on
+    // fixed code; on buggy code it dies with SIGSEGV inside the
+    // MetadataAccessorRW constructor invoked by PutEnd.
+    void RunIncidentScenario() {
+        MasterService service(MasterServiceConfig::builder().build());
+
+        // 1. Ghost client mounts a segment.
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = "ghost_segment";
+        segment.base = kSegmentBase;
+        segment.size = kSegmentSize;
+        segment.te_endpoint = segment.name;
+        const UUID client_id = generate_uuid();
+        if (!service.MountSegment(segment, client_id).has_value()) {
+            ::_exit(kExitMountFailed);
+        }
+
+        // 2. PutStart a key onto the segment and never complete it — the key
+        //    stays in TenantState::processing_keys (client "died" mid-put).
+        ReplicateConfig config;
+        config.replica_num = 1;
+        config.preferred_segment = segment.name;
+        const std::string key = "orphan_processing_key";
+        if (!service.PutStart(client_id, key, TenantId::Default(), 1024, config)
+                 .has_value()) {
+            ::_exit(kExitPutStartFailed);
+        }
+
+        // 2b. A second, completed key on the SAME shard keeps the TenantState
+        //     non-empty in step 4 (see file header for why this is required).
+        const std::string keepalive_key = FindKeyOnSameShard(service, key);
+        if (!service
+                 .PutStart(client_id, keepalive_key, TenantId::Default(), 1024,
+                           config)
+                 .has_value() ||
+            !service
+                 .PutEnd(client_id, keepalive_key, TenantId::Default(),
+                         ReplicaType::MEMORY)
+                 .has_value()) {
+            ::_exit(kExitPutStartFailed);
+        }
+
+        // 3. Ghost client expires: the segment allocator is destroyed,
+        //    invalidating the replica's memory handle (weak_ptr expires).
+        //    No ClearInvalidHandles sweep here (see file header).
+        size_t metrics_dec_capacity = 0;
+        {
+            auto segment_access = service.segment_manager_.getSegmentAccess();
+            if (segment_access.PrepareUnmountSegment(
+                    segment.id, metrics_dec_capacity) != ErrorCode::OK) {
+                ::_exit(kExitUnmountFailed);
+            }
+        }
+
+        // 4. Trigger: PutEnd constructs MetadataAccessorRW(service, key).
+        //    The ctor erases the invalid replica, finds !IsValid(), calls
+        //    Erase() (frees the processing_keys node) and then
+        //    EraseFromProcessing() with the stale processing_it_ iterator.
+        (void)service.PutEnd(client_id, key, TenantId::Default(),
+                             ReplicaType::MEMORY);
+        ::_exit(kExitOk);  // only reachable on fixed code
+    }
+};
+
+// Regression assertion: the incident scenario must complete without crashing.
+// On the current buggy code the forked child dies with SIGSEGV (this is the
+// reproduction); after the fix it exits kExitOk and the test passes.
+TEST_F(MasterServiceProcessingKeyDoubleEraseTest,
+       AccessorCleanupAfterSegmentUnmountDoesNotCrash) {
+    ::fflush(nullptr);
+    pid_t pid = ::fork();
+    ASSERT_NE(pid, -1) << "fork failed: " << strerror(errno);
+    if (pid == 0) {
+        RunIncidentScenario();
+        ::_exit(kExitOk);  // unreachable (RunIncidentScenario exits itself)
+    }
+
+    int status = 0;
+    ASSERT_EQ(::waitpid(pid, &status, 0), pid);
+
+    if (WIFSIGNALED(status)) {
+        FAIL() << "MetadataAccessorRW double-erase reproduced: child died "
+                  "with signal "
+               << WTERMSIG(status)
+               << (WTERMSIG(status) == SIGSEGV ? " (SIGSEGV)" : "")
+               << ". Erase() -> EraseMetadata() already erases the key from "
+                  "processing_keys; the subsequent EraseFromProcessing() "
+                  "re-erases it via the stale processing_it_ iterator.";
+    }
+    ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally";
+    EXPECT_EQ(WEXITSTATUS(status), kExitOk)
+        << "scenario setup failed (exit " << WEXITSTATUS(status)
+        << ": 2=MountSegment, 3=PutStart, 4=UnmountSegment)";
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

Fix a use-after-free (double erase) in the `MasterService::MetadataAccessorRW`
constructor's invalid-handle cleanup that segfaults `mooncake_master`
deterministically (fault address `0x0`, inside
`std::unordered_set<std::string>::erase(const_iterator)`).

**Root cause.** When an object loses all valid replicas, the constructor's
cleanup does:

```cpp
const bool had_processing =
    processing_it_ != tenant_state_->processing_keys.end();
this->Erase();  // -> EraseMetadata() already does processing_keys.erase(key)
if (tenant_state_ != nullptr && had_processing) {
    this->EraseFromProcessing();  // erases the SAME node via a dangling iterator
}
```

`Erase()` -> `EraseMetadata()` already removes the key from `processing_keys`
by key (freeing the node). The subsequent `EraseFromProcessing()` then erases
the *same* node again through the now-dangling `processing_it_` iterator.
libstdc++ re-reads the cached hash from the freed node, walks the bucket chain
looking for it by address, runs off the chain end and dereferences nullptr
-> SIGSEGV.

**Trigger observed in production.** A snapshot restore resurrected dead
("ghost") clients and their mounted segments. When the restore grace period
expired, `ClientMonitorFunc` expired the ghosts and `PrepareUnmountSegment`
destroyed their segment allocators, invalidating every replica handle on those
segments. Any RPC hitting a key whose replicas all lived on ghost segments and
which was still in `processing_keys` (an interrupted put) executed the buggy
cleanup before `ClearInvalidHandles` could sweep the key via the safe path.
The crash repeats every restart while such state persists in snapshots.

Note this cleanup path only runs when `!(enable_ha_ && enable_oplog_)`; the HA
+ oplog configuration takes a different path, but the default configuration
hits it.

**Fix.** Drop the redundant `EraseFromProcessing()` call; `EraseMetadata()`
already handles `processing_keys` (and `replication_tasks` / promotion tasks)
unconditionally. The three remaining `EraseFromProcessing()` call sites are
safe: they are either mutually exclusive with `Erase()` (`else if` after an
`Exists()`/validity check) or order the iterator erase before `Erase()`, in
which case the by-key erase inside `EraseMetadata()` is a no-op.

**Test.** Adds `master_service_processing_key_double_erase_test`, a
forked-child reproduction that drives the real production path through public
APIs plus one friend hook:

1. `MountSegment` (a "ghost" client mounts a segment);
2. `PutStart` without `PutEnd` (key stays in `processing_keys` with an
   incomplete replica on that segment), plus a second completed key on the
   same metadata shard to keep the tenant non-empty;
3. `PrepareUnmountSegment` directly (`UnmountSegment` would run
   `ClearInvalidHandles` and erase the crafted object via the safe path
   first), destroying the allocator so the replica handle becomes invalid;
4. `PutEnd` -> `MetadataAccessorRW` constructor cleanup.

On buggy code the forked child dies with SIGSEGV and the test FAILs; after the
fix the child exits cleanly (`PutEnd` reports `OBJECT_NOT_FOUND`) and the test
passes. So the test fails before this change and passes after it.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The new regression test forks a child that runs the incident scenario; on the
unfixed code the child SIGSEGVs inside `processing_keys.erase()` exactly as in
production, and the test fails. With the fix, the child exits 0 and the test
passes.

**Test commands:**
```bash
cd build && cmake .. && make master_service_processing_key_double_erase_test -j
./build/mooncake-store/tests/master_service_processing_key_double_erase_test
# regression guard on the surrounding areas:
make master_service_test master_service_ssd_test -j
./build/mooncake-store/tests/master_service_test
./build/mooncake-store/tests/master_service_ssd_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Reproduced the original crash in production (periodic SIGSEGV at the same
instruction after snapshot restore), confirmed the root cause with the repro
test, and verified the fixed master passes the store unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
      (pre-commit is not installable in my environment; ran the applicable
      hooks manually instead: code_format.sh, trailing-whitespace,
      end-of-file-fixer, no merge-conflict markers)
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code assisted with the crash triage, root-cause analysis, the fix and
the regression test. The submitter has reviewed every changed line and can
defend the change end-to-end.