### PR TITLE
[Store] fix: Honor OpLog poll interval command-line override

### DIFF
--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1004,6 +1004,11 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.enable_oplog = FLAGS_enable_oplog;
     }
+    if ((google::GetCommandLineFlagInfo("oplog_poll_interval_ms", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.oplog_poll_interval_ms = FLAGS_oplog_poll_interval_ms;
+    }
     if ((google::GetCommandLineFlagInfo("oplog_batch_max_entries", &info) &&
          !info.is_default) ||
         !conf_set) {


### PR DESCRIPTION
## Description

`--oplog_poll_interval_ms` is defined as a command-line flag and loaded from
the master config file, but it was omitted from `LoadConfigFromCmdline()`.
As a result, an explicit command-line value did not override the configured
value like the adjacent OpLog flags do.

Add the missing explicit-flag check and propagate the command-line value into
`MasterConfig`. This is a focused follow-up to #2826.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files mooncake-store/src/master.cpp
cmake --build build --target mooncake_master -j2
```

Manual Debug-build inspection immediately after `LoadConfigFromCmdline()`
confirmed that `--oplog_poll_interval_ms=50` overrides the `1000` value in
`mooncake-store/conf/master.yaml`.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done as described above

No new automated test is included because this change only restores the same
flag-merging path already used by the adjacent OpLog settings; a process-level
test would require additional test registration and observability changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using the repository pre-commit hook
- [x] I have run pre-commit on all files changed by this PR
- [x] Documentation is not applicable to this internal configuration merge fix
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex helped inspect the configuration flow, prepare the focused
five-line fix, run formatting/build/manual verification, and draft this PR.