### PR TITLE
[Store] Add minimal MasterService scenario DSL

### DIFF
--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -69,6 +69,8 @@ add_store_test(master_service_test master_service_test.cpp)
 add_store_test(batch_evict_test batch_evict_test.cpp)
 add_store_test(master_scenario_test master_scenario.cpp
                master_scenario_test.cpp)
+add_store_test(master_service_scenario_test master_scenario.cpp
+               master_service_scenario_test.cpp)
 add_store_test(master_service_config_test master_service_config_test.cpp)
 add_store_test(master_service_processing_key_double_erase_test
                master_service_processing_key_double_erase_test.cpp)

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -67,6 +67,8 @@ if(ENABLE_KV_EVENTS)
 endif()
 add_store_test(master_service_test master_service_test.cpp)
 add_store_test(batch_evict_test batch_evict_test.cpp)
+add_store_test(master_scenario_test master_scenario.cpp
+               master_scenario_test.cpp)
 add_store_test(master_service_config_test master_service_config_test.cpp)
 add_store_test(master_service_processing_key_double_erase_test
                master_service_processing_key_double_erase_test.cpp)

--- a/mooncake-store/tests/master_scenario.cpp
+++ b/mooncake-store/tests/master_scenario.cpp
@@ -1,0 +1,184 @@
+#include "master_scenario.h"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <utility>
+
+#include "types.h"
+
+namespace mooncake::test {
+namespace {
+
+constexpr uint64_t kFnvOffset = 14695981039346656037ULL;
+constexpr uint64_t kFnvPrime = 1099511628211ULL;
+
+uint64_t StableHash(std::string_view kind, std::string_view name,
+                    uint64_t seed) {
+    uint64_t hash = seed;
+    for (const char value : kind) {
+        hash = (hash ^ static_cast<unsigned char>(value)) * kFnvPrime;
+    }
+    for (const char value : name) {
+        hash = (hash ^ static_cast<unsigned char>(value)) * kFnvPrime;
+    }
+    return hash;
+}
+
+UUID StableUuid(std::string_view kind, std::string_view name) {
+    return {StableHash(kind, name, kFnvOffset),
+            StableHash(kind, name, kFnvOffset ^ 0x9e3779b97f4a7c15ULL)};
+}
+
+}  // namespace
+
+MemoryNodeSpec MemoryNode(std::string name) {
+    return {.name = std::move(name)};
+}
+
+PutStartAction PutStart(std::string key, uint64_t size) {
+    return {.key = std::move(key), .size = size};
+}
+
+PutEndAction PutEnd(std::string key) { return {.key = std::move(key)}; }
+
+ObjectSpec Object(std::string key) { return {.key = std::move(key)}; }
+
+MasterScenario::MasterScenario(std::string name) : name_(std::move(name)) {}
+
+MasterScenario::~MasterScenario() = default;
+
+MasterScenario& MasterScenario::Given(MemoryNodeSpec node) {
+    if (declarations_frozen_) {
+        Fail("MemoryNode declarations must precede actions and assertions");
+        return *this;
+    }
+    if (node.name.empty()) {
+        Fail("MemoryNode requires a name");
+        return *this;
+    }
+    if (node.capacity == 0) {
+        Fail("MemoryNode " + node.name + " requires non-zero capacity");
+        return *this;
+    }
+    const auto duplicate = std::find_if(
+        nodes_.begin(), nodes_.end(),
+        [&](const auto& existing) { return existing.name == node.name; });
+    if (duplicate != nodes_.end()) {
+        Fail("duplicate MemoryNode " + node.name);
+        return *this;
+    }
+    nodes_.push_back(std::move(node));
+    return *this;
+}
+
+MasterScenario& MasterScenario::When(PutStartAction action) {
+    if (!EnsureService()) {
+        return *this;
+    }
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const auto result =
+        service_->PutStart(ActorId(action.actor), action.key,
+                           TenantId::Default(), action.size, config);
+    ValidateActionResult("PutStart(" + action.key + ")", action.expected_error,
+                         result.has_value(),
+                         result ? ErrorCode::OK : result.error());
+    return *this;
+}
+
+MasterScenario& MasterScenario::When(PutEndAction action) {
+    if (!EnsureService()) {
+        return *this;
+    }
+
+    const auto result =
+        service_->PutEnd(ActorId(action.actor), action.key, TenantId::Default(),
+                         ReplicaType::MEMORY);
+    ValidateActionResult("PutEnd(" + action.key + ")", action.expected_error,
+                         result.has_value(),
+                         result ? ErrorCode::OK : result.error());
+    return *this;
+}
+
+MasterScenario& MasterScenario::Then(ObjectSpec object) {
+    if (!EnsureService()) {
+        return *this;
+    }
+    if (!object.expected_readable) {
+        Fail("Object(" + object.key + ") has no assertion");
+        return *this;
+    }
+
+    const auto result =
+        service_->GetReplicaList(object.key, TenantId::Default());
+    if (!result) {
+        Fail("Object(" + object.key +
+             ") is not readable: " + toString(result.error()));
+    } else if (result->replicas.empty()) {
+        Fail("Object(" + object.key + ") has no readable replicas");
+    }
+    return *this;
+}
+
+bool MasterScenario::EnsureService() {
+    if (service_) {
+        return true;
+    }
+    declarations_frozen_ = true;
+    if (nodes_.empty()) {
+        Fail("scenario requires at least one MemoryNode");
+        return false;
+    }
+
+    service_ = std::make_unique<MasterService>();
+    for (const auto& node : nodes_) {
+        Segment segment;
+        segment.id = StableUuid("segment", node.name);
+        segment.name = node.name;
+        segment.base = next_segment_base_;
+        segment.size = node.capacity;
+        segment.te_endpoint = node.name;
+        next_segment_base_ += node.capacity + 4096;
+
+        const auto result = service_->MountSegment(segment, ActorId(node.name));
+        if (!result) {
+            Fail("failed to mount MemoryNode " + node.name + ": " +
+                 toString(result.error()));
+            service_.reset();
+            return false;
+        }
+    }
+    return true;
+}
+
+UUID MasterScenario::ActorId(std::string_view actor) {
+    const std::string name(actor);
+    const auto result = actor_ids_.emplace(name, StableUuid("actor", name));
+    return result.first->second;
+}
+
+void MasterScenario::ValidateActionResult(
+    std::string_view action, const std::optional<ErrorCode>& expected_error,
+    bool succeeded, ErrorCode error) {
+    if (!expected_error.has_value()) {
+        if (!succeeded) {
+            Fail(std::string(action) + " failed: " + toString(error));
+        }
+        return;
+    }
+    if (succeeded) {
+        Fail(std::string(action) + " succeeded; expected " +
+             toString(*expected_error));
+    } else if (error != *expected_error) {
+        Fail(std::string(action) + " failed with " + toString(error) +
+             "; expected " + toString(*expected_error));
+    }
+}
+
+void MasterScenario::Fail(std::string message) const {
+    ADD_FAILURE() << "MasterScenario[" << name_ << "]: " << message;
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_scenario.cpp
+++ b/mooncake-store/tests/master_scenario.cpp
@@ -42,6 +42,10 @@ PutStartAction PutStart(std::string key, uint64_t size) {
 
 PutEndAction PutEnd(std::string key) { return {.key = std::move(key)}; }
 
+PutRevokeAction PutRevoke(std::string key) { return {.key = std::move(key)}; }
+
+RemoveAction Remove(std::string key) { return {.key = std::move(key)}; }
+
 ObjectSpec Object(std::string key) { return {.key = std::move(key)}; }
 
 MasterScenario::MasterScenario(std::string name) : name_(std::move(name)) {}
@@ -85,6 +89,21 @@ MasterScenario& MasterScenario::When(PutStartAction action) {
     ValidateActionResult("PutStart(" + action.key + ")", action.expected_error,
                          result.has_value(),
                          result ? ErrorCode::OK : result.error());
+    if (!result) {
+        return *this;
+    }
+    if (action.expected_replica_count.has_value() &&
+        result->size() != *action.expected_replica_count) {
+        Fail("PutStart(" + action.key + ") returned " +
+             std::to_string(result->size()) + " replicas; expected " +
+             std::to_string(*action.expected_replica_count));
+    }
+    if (action.expected_replica_status.has_value() &&
+        std::any_of(result->begin(), result->end(), [&](const auto& replica) {
+            return replica.status != *action.expected_replica_status;
+        })) {
+        Fail("PutStart(" + action.key + ") replica status mismatch");
+    }
     return *this;
 }
 
@@ -102,22 +121,77 @@ MasterScenario& MasterScenario::When(PutEndAction action) {
     return *this;
 }
 
+MasterScenario& MasterScenario::When(PutRevokeAction action) {
+    if (!EnsureService()) {
+        return *this;
+    }
+
+    const auto result =
+        service_->PutRevoke(ActorId(action.actor), action.key,
+                            TenantId::Default(), ReplicaType::MEMORY);
+    ValidateActionResult("PutRevoke(" + action.key + ")", action.expected_error,
+                         result.has_value(),
+                         result ? ErrorCode::OK : result.error());
+    return *this;
+}
+
+MasterScenario& MasterScenario::When(RemoveAction action) {
+    if (!EnsureService()) {
+        return *this;
+    }
+
+    const auto result = service_->Remove(action.key, TenantId::Default());
+    ValidateActionResult("Remove(" + action.key + ")", action.expected_error,
+                         result.has_value(),
+                         result ? ErrorCode::OK : result.error());
+    return *this;
+}
+
 MasterScenario& MasterScenario::Then(ObjectSpec object) {
     if (!EnsureService()) {
         return *this;
     }
-    if (!object.expected_readable) {
+    if (object.readability == ObjectSpec::Readability::UNSPECIFIED &&
+        !object.expected_replica_count.has_value() &&
+        !object.expected_complete_replica_count.has_value()) {
         Fail("Object(" + object.key + ") has no assertion");
         return *this;
     }
 
     const auto result =
         service_->GetReplicaList(object.key, TenantId::Default());
+    if (object.readability == ObjectSpec::Readability::NOT_READY) {
+        if (result || result.error() != ErrorCode::REPLICA_IS_NOT_READY) {
+            Fail("Object(" + object.key + ") was expected to be not ready");
+        }
+        return *this;
+    }
     if (!result) {
         Fail("Object(" + object.key +
              ") is not readable: " + toString(result.error()));
-    } else if (result->replicas.empty()) {
+        return *this;
+    }
+    if (object.readability == ObjectSpec::Readability::READABLE &&
+        result->replicas.empty()) {
         Fail("Object(" + object.key + ") has no readable replicas");
+    }
+    if (object.expected_replica_count.has_value() &&
+        result->replicas.size() != *object.expected_replica_count) {
+        Fail("Object(" + object.key + ") has " +
+             std::to_string(result->replicas.size()) + " replicas; expected " +
+             std::to_string(*object.expected_replica_count));
+    }
+    if (object.expected_complete_replica_count.has_value()) {
+        const size_t complete =
+            std::count_if(result->replicas.begin(), result->replicas.end(),
+                          [](const auto& replica) {
+                              return replica.status == ReplicaStatus::COMPLETE;
+                          });
+        if (complete != *object.expected_complete_replica_count) {
+            Fail("Object(" + object.key + ") has " + std::to_string(complete) +
+                 " complete replicas; expected " +
+                 std::to_string(*object.expected_complete_replica_count));
+        }
     }
     return *this;
 }

--- a/mooncake-store/tests/master_scenario.cpp
+++ b/mooncake-store/tests/master_scenario.cpp
@@ -36,8 +36,8 @@ MemoryNodeSpec MemoryNode(std::string name) {
     return {.name = std::move(name)};
 }
 
-PutStartAction PutStart(std::string key, uint64_t size) {
-    return {.key = std::move(key), .size = size};
+PutStartAction<> PutStart(std::string key, uint64_t size) {
+    return PutStartAction<>(std::move(key), size);
 }
 
 PutEndAction PutEnd(std::string key) { return {.key = std::move(key)}; }
@@ -46,7 +46,7 @@ PutRevokeAction PutRevoke(std::string key) { return {.key = std::move(key)}; }
 
 RemoveAction Remove(std::string key) { return {.key = std::move(key)}; }
 
-ObjectSpec Object(std::string key) { return {.key = std::move(key)}; }
+ObjectSpec<> Object(std::string key) { return ObjectSpec<>(std::move(key)); }
 
 MasterScenario::MasterScenario(std::string name) : name_(std::move(name)) {}
 
@@ -76,7 +76,7 @@ MasterScenario& MasterScenario::Given(MemoryNodeSpec node) {
     return *this;
 }
 
-MasterScenario& MasterScenario::When(PutStartAction action) {
+MasterScenario& MasterScenario::WhenPutStart(PutStartActionData action) {
     if (!EnsureService()) {
         return *this;
     }
@@ -147,20 +147,15 @@ MasterScenario& MasterScenario::When(RemoveAction action) {
     return *this;
 }
 
-MasterScenario& MasterScenario::Then(ObjectSpec object) {
+MasterScenario& MasterScenario::ThenObject(ObjectSpecData object,
+                                           ObjectExpectation expectation) {
     if (!EnsureService()) {
-        return *this;
-    }
-    if (object.readability == ObjectSpec::Readability::UNSPECIFIED &&
-        !object.expected_replica_count.has_value() &&
-        !object.expected_complete_replica_count.has_value()) {
-        Fail("Object(" + object.key + ") has no assertion");
         return *this;
     }
 
     const auto result =
         service_->GetReplicaList(object.key, TenantId::Default());
-    if (object.readability == ObjectSpec::Readability::NOT_READY) {
+    if (expectation == ObjectExpectation::NOT_READY) {
         if (result || result.error() != ErrorCode::REPLICA_IS_NOT_READY) {
             Fail("Object(" + object.key + ") was expected to be not ready");
         }
@@ -171,8 +166,7 @@ MasterScenario& MasterScenario::Then(ObjectSpec object) {
              ") is not readable: " + toString(result.error()));
         return *this;
     }
-    if (object.readability == ObjectSpec::Readability::READABLE &&
-        result->replicas.empty()) {
+    if (result->replicas.empty()) {
         Fail("Object(" + object.key + ") has no readable replicas");
     }
     if (object.expected_replica_count.has_value() &&

--- a/mooncake-store/tests/master_scenario.h
+++ b/mooncake-store/tests/master_scenario.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "master_service.h"
+
+namespace mooncake::test {
+
+constexpr uint64_t operator""_KB(unsigned long long value) {
+    return value * 1024;
+}
+
+struct MemoryNodeSpec {
+    std::string name;
+    uint64_t capacity{16 * 1024 * 1024};
+
+    MemoryNodeSpec& Capacity(uint64_t value) {
+        capacity = value;
+        return *this;
+    }
+};
+
+MemoryNodeSpec MemoryNode(std::string name);
+
+struct PutStartAction {
+    std::string key;
+    uint64_t size;
+    std::string actor{"default"};
+    std::optional<ErrorCode> expected_error{};
+
+    PutStartAction& By(std::string value) {
+        actor = std::move(value);
+        return *this;
+    }
+
+    PutStartAction& ExpectError(ErrorCode value) {
+        expected_error = value;
+        return *this;
+    }
+};
+
+PutStartAction PutStart(std::string key, uint64_t size);
+
+struct PutEndAction {
+    std::string key;
+    std::string actor{"default"};
+    std::optional<ErrorCode> expected_error{};
+
+    PutEndAction& By(std::string value) {
+        actor = std::move(value);
+        return *this;
+    }
+
+    PutEndAction& ExpectError(ErrorCode value) {
+        expected_error = value;
+        return *this;
+    }
+};
+
+PutEndAction PutEnd(std::string key);
+
+struct ObjectSpec {
+    std::string key;
+    bool expected_readable{false};
+
+    ObjectSpec& IsReadable() {
+        expected_readable = true;
+        return *this;
+    }
+};
+
+ObjectSpec Object(std::string key);
+
+class MasterScenario {
+   public:
+    explicit MasterScenario(std::string name);
+    ~MasterScenario();
+
+    MasterScenario(const MasterScenario&) = delete;
+    MasterScenario& operator=(const MasterScenario&) = delete;
+
+    MasterScenario& Given(MemoryNodeSpec node);
+    MasterScenario& When(PutStartAction action);
+    MasterScenario& When(PutEndAction action);
+    MasterScenario& Then(ObjectSpec object);
+
+   private:
+    bool EnsureService();
+    UUID ActorId(std::string_view actor);
+    void ValidateActionResult(std::string_view action,
+                              const std::optional<ErrorCode>& expected_error,
+                              bool succeeded, ErrorCode error);
+    void Fail(std::string message) const;
+
+    std::string name_;
+    bool declarations_frozen_{false};
+    uintptr_t next_segment_base_{0x300000000};
+    std::vector<MemoryNodeSpec> nodes_;
+    std::unique_ptr<MasterService> service_;
+    std::unordered_map<std::string, UUID> actor_ids_;
+};
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_scenario.h
+++ b/mooncake-store/tests/master_scenario.h
@@ -30,36 +30,66 @@ struct MemoryNodeSpec {
 
 MemoryNodeSpec MemoryNode(std::string name);
 
-struct PutStartAction {
+enum class PutStartExpectation {
+    UNSPECIFIED,
+    SUCCESS,
+    ERROR,
+};
+
+struct PutStartActionData {
     std::string key;
     uint64_t size;
     std::string actor{"default"};
     std::optional<ErrorCode> expected_error{};
     std::optional<size_t> expected_replica_count{};
     std::optional<ReplicaStatus> expected_replica_status{};
+};
+
+template <PutStartExpectation expectation = PutStartExpectation::UNSPECIFIED>
+struct PutStartAction : PutStartActionData {
+    PutStartAction(std::string key, uint64_t size)
+        requires(expectation == PutStartExpectation::UNSPECIFIED)
+        : PutStartActionData{.key = std::move(key), .size = size} {}
 
     PutStartAction& By(std::string value) {
         actor = std::move(value);
         return *this;
     }
 
-    PutStartAction& ExpectError(ErrorCode value) {
-        expected_error = value;
-        return *this;
+    auto ExpectError(ErrorCode value) const
+        requires(expectation == PutStartExpectation::UNSPECIFIED)
+    {
+        PutStartAction<PutStartExpectation::ERROR> action(*this);
+        action.expected_error = value;
+        return action;
     }
 
-    PutStartAction& ExpectReplicas(size_t value) {
-        expected_replica_count = value;
-        return *this;
+    auto ExpectReplicas(size_t value) const
+        requires(expectation != PutStartExpectation::ERROR)
+    {
+        PutStartAction<PutStartExpectation::SUCCESS> action(*this);
+        action.expected_replica_count = value;
+        return action;
     }
 
-    PutStartAction& ExpectStatus(ReplicaStatus value) {
-        expected_replica_status = value;
-        return *this;
+    auto ExpectStatus(ReplicaStatus value) const
+        requires(expectation != PutStartExpectation::ERROR)
+    {
+        PutStartAction<PutStartExpectation::SUCCESS> action(*this);
+        action.expected_replica_status = value;
+        return action;
     }
+
+   private:
+    template <PutStartExpectation other>
+    friend struct PutStartAction;
+
+    template <PutStartExpectation other>
+    PutStartAction(const PutStartAction<other>& action)
+        : PutStartActionData(action) {}
 };
 
-PutStartAction PutStart(std::string key, uint64_t size);
+PutStartAction<> PutStart(std::string key, uint64_t size);
 
 struct PutEndAction {
     std::string key;
@@ -109,40 +139,61 @@ struct RemoveAction {
 
 RemoveAction Remove(std::string key);
 
-struct ObjectSpec {
-    enum class Readability {
-        UNSPECIFIED,
-        READABLE,
-        NOT_READY,
-    };
-
-    std::string key;
-    Readability readability{Readability::UNSPECIFIED};
-    std::optional<size_t> expected_replica_count{};
-    std::optional<size_t> expected_complete_replica_count{};
-
-    ObjectSpec& IsReadable() {
-        readability = Readability::READABLE;
-        return *this;
-    }
-
-    ObjectSpec& IsNotReady() {
-        readability = Readability::NOT_READY;
-        return *this;
-    }
-
-    ObjectSpec& HasReplicas(size_t value) {
-        expected_replica_count = value;
-        return *this;
-    }
-
-    ObjectSpec& HasCompleteReplicas(size_t value) {
-        expected_complete_replica_count = value;
-        return *this;
-    }
+enum class ObjectExpectation {
+    UNSPECIFIED,
+    READABLE,
+    NOT_READY,
 };
 
-ObjectSpec Object(std::string key);
+struct ObjectSpecData {
+    std::string key;
+    std::optional<size_t> expected_replica_count{};
+    std::optional<size_t> expected_complete_replica_count{};
+};
+
+template <ObjectExpectation expectation = ObjectExpectation::UNSPECIFIED>
+struct ObjectSpec : ObjectSpecData {
+    explicit ObjectSpec(std::string key)
+        requires(expectation == ObjectExpectation::UNSPECIFIED)
+        : ObjectSpecData{.key = std::move(key)} {}
+
+    auto IsReadable() const
+        requires(expectation != ObjectExpectation::NOT_READY)
+    {
+        return ObjectSpec<ObjectExpectation::READABLE>(*this);
+    }
+
+    auto IsNotReady() const
+        requires(expectation == ObjectExpectation::UNSPECIFIED)
+    {
+        return ObjectSpec<ObjectExpectation::NOT_READY>(*this);
+    }
+
+    auto HasReplicas(size_t value) const
+        requires(expectation != ObjectExpectation::NOT_READY)
+    {
+        ObjectSpec<ObjectExpectation::READABLE> object(*this);
+        object.expected_replica_count = value;
+        return object;
+    }
+
+    auto HasCompleteReplicas(size_t value) const
+        requires(expectation != ObjectExpectation::NOT_READY)
+    {
+        ObjectSpec<ObjectExpectation::READABLE> object(*this);
+        object.expected_complete_replica_count = value;
+        return object;
+    }
+
+   private:
+    template <ObjectExpectation other>
+    friend struct ObjectSpec;
+
+    template <ObjectExpectation other>
+    ObjectSpec(const ObjectSpec<other>& object) : ObjectSpecData(object) {}
+};
+
+ObjectSpec<> Object(std::string key);
 
 class MasterScenario {
    public:
@@ -153,13 +204,25 @@ class MasterScenario {
     MasterScenario& operator=(const MasterScenario&) = delete;
 
     MasterScenario& Given(MemoryNodeSpec node);
-    MasterScenario& When(PutStartAction action);
+    template <PutStartExpectation expectation>
+    MasterScenario& When(PutStartAction<expectation> action) {
+        return WhenPutStart(std::move(action));
+    }
+
     MasterScenario& When(PutEndAction action);
     MasterScenario& When(PutRevokeAction action);
     MasterScenario& When(RemoveAction action);
-    MasterScenario& Then(ObjectSpec object);
+
+    template <ObjectExpectation expectation>
+        requires(expectation != ObjectExpectation::UNSPECIFIED)
+    MasterScenario& Then(ObjectSpec<expectation> object) {
+        return ThenObject(std::move(object), expectation);
+    }
 
    private:
+    MasterScenario& WhenPutStart(PutStartActionData action);
+    MasterScenario& ThenObject(ObjectSpecData object,
+                               ObjectExpectation expectation);
     bool EnsureService();
     UUID ActorId(std::string_view actor);
     void ValidateActionResult(std::string_view action,

--- a/mooncake-store/tests/master_scenario.h
+++ b/mooncake-store/tests/master_scenario.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -34,6 +35,8 @@ struct PutStartAction {
     uint64_t size;
     std::string actor{"default"};
     std::optional<ErrorCode> expected_error{};
+    std::optional<size_t> expected_replica_count{};
+    std::optional<ReplicaStatus> expected_replica_status{};
 
     PutStartAction& By(std::string value) {
         actor = std::move(value);
@@ -42,6 +45,16 @@ struct PutStartAction {
 
     PutStartAction& ExpectError(ErrorCode value) {
         expected_error = value;
+        return *this;
+    }
+
+    PutStartAction& ExpectReplicas(size_t value) {
+        expected_replica_count = value;
+        return *this;
+    }
+
+    PutStartAction& ExpectStatus(ReplicaStatus value) {
+        expected_replica_status = value;
         return *this;
     }
 };
@@ -66,12 +79,65 @@ struct PutEndAction {
 
 PutEndAction PutEnd(std::string key);
 
-struct ObjectSpec {
+struct PutRevokeAction {
     std::string key;
-    bool expected_readable{false};
+    std::string actor{"default"};
+    std::optional<ErrorCode> expected_error{};
+
+    PutRevokeAction& By(std::string value) {
+        actor = std::move(value);
+        return *this;
+    }
+
+    PutRevokeAction& ExpectError(ErrorCode value) {
+        expected_error = value;
+        return *this;
+    }
+};
+
+PutRevokeAction PutRevoke(std::string key);
+
+struct RemoveAction {
+    std::string key;
+    std::optional<ErrorCode> expected_error{};
+
+    RemoveAction& ExpectError(ErrorCode value) {
+        expected_error = value;
+        return *this;
+    }
+};
+
+RemoveAction Remove(std::string key);
+
+struct ObjectSpec {
+    enum class Readability {
+        UNSPECIFIED,
+        READABLE,
+        NOT_READY,
+    };
+
+    std::string key;
+    Readability readability{Readability::UNSPECIFIED};
+    std::optional<size_t> expected_replica_count{};
+    std::optional<size_t> expected_complete_replica_count{};
 
     ObjectSpec& IsReadable() {
-        expected_readable = true;
+        readability = Readability::READABLE;
+        return *this;
+    }
+
+    ObjectSpec& IsNotReady() {
+        readability = Readability::NOT_READY;
+        return *this;
+    }
+
+    ObjectSpec& HasReplicas(size_t value) {
+        expected_replica_count = value;
+        return *this;
+    }
+
+    ObjectSpec& HasCompleteReplicas(size_t value) {
+        expected_complete_replica_count = value;
         return *this;
     }
 };
@@ -89,6 +155,8 @@ class MasterScenario {
     MasterScenario& Given(MemoryNodeSpec node);
     MasterScenario& When(PutStartAction action);
     MasterScenario& When(PutEndAction action);
+    MasterScenario& When(PutRevokeAction action);
+    MasterScenario& When(RemoveAction action);
     MasterScenario& Then(ObjectSpec object);
 
    private:

--- a/mooncake-store/tests/master_scenario_test.cpp
+++ b/mooncake-store/tests/master_scenario_test.cpp
@@ -1,0 +1,18 @@
+#include "master_scenario.h"
+
+#include <gtest/gtest.h>
+
+namespace mooncake::test {
+
+TEST(MasterServiceTest, PutStartEndFlow) {
+    MasterScenario("put start/end flow")
+        .Given(MemoryNode("memory"))
+        .When(PutStart("test_key", 1_KB).By("writer"))
+        .When(PutEnd("test_key")
+                  .By("other-writer")
+                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
+        .When(PutEnd("test_key").By("writer"))
+        .Then(Object("test_key").IsReadable());
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_scenario_test.cpp
+++ b/mooncake-store/tests/master_scenario_test.cpp
@@ -1,8 +1,55 @@
 #include "master_scenario.h"
 
+#include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 namespace mooncake::test {
+namespace {
+
+template <typename T>
+concept SupportsExpectError =
+    requires(T value) { value.ExpectError(ErrorCode::INTERNAL_ERROR); };
+
+template <typename T>
+concept SupportsExpectReplicas = requires(T value) { value.ExpectReplicas(1); };
+
+template <typename T>
+concept SupportsExpectStatus =
+    requires(T value) { value.ExpectStatus(ReplicaStatus::COMPLETE); };
+
+template <typename T>
+concept SupportsIsReadable = requires(T value) { value.IsReadable(); };
+
+template <typename T>
+concept SupportsIsNotReady = requires(T value) { value.IsNotReady(); };
+
+template <typename T>
+concept SupportsHasReplicas = requires(T value) { value.HasReplicas(1); };
+
+template <typename T>
+concept SupportsThen =
+    requires(MasterScenario& scenario, T value) { scenario.Then(value); };
+
+using ErrorExpectedPutStart =
+    decltype(PutStart("compile-time", 1_KB)
+                 .ExpectError(ErrorCode::INTERNAL_ERROR));
+using SuccessExpectedPutStart =
+    decltype(PutStart("compile-time", 1_KB).ExpectReplicas(1));
+using UnspecifiedObject = decltype(Object("compile-time"));
+using NotReadyObject = decltype(Object("compile-time").IsNotReady());
+using ReadableObject = decltype(Object("compile-time").HasReplicas(1));
+
+static_assert(!SupportsExpectReplicas<ErrorExpectedPutStart>);
+static_assert(!SupportsExpectStatus<ErrorExpectedPutStart>);
+static_assert(!SupportsExpectError<SuccessExpectedPutStart>);
+static_assert(!SupportsIsReadable<NotReadyObject>);
+static_assert(!SupportsHasReplicas<NotReadyObject>);
+static_assert(!SupportsIsNotReady<ReadableObject>);
+static_assert(!SupportsThen<UnspecifiedObject>);
+static_assert(SupportsThen<NotReadyObject>);
+static_assert(SupportsThen<ReadableObject>);
+
+}  // namespace
 
 TEST(MasterServiceTest, PutStartEndFlow) {
     MasterScenario("put start/end flow")
@@ -24,6 +71,72 @@ TEST(MasterServiceTest, PutStartEndFlow) {
                   .IsReadable()
                   .HasReplicas(1)
                   .HasCompleteReplicas(1));
+}
+
+TEST(MasterScenarioContractTest, ReportsUnexpectedActionError) {
+    EXPECT_NONFATAL_FAILURE(MasterScenario("unexpected action error")
+                                .Given(MemoryNode("memory"))
+                                .When(PutEnd("missing")),
+                            "PutEnd(missing) failed: OBJECT_NOT_FOUND");
+}
+
+TEST(MasterScenarioContractTest, ReportsUnexpectedActionSuccess) {
+    EXPECT_NONFATAL_FAILURE(
+        MasterScenario("unexpected action success")
+            .Given(MemoryNode("memory"))
+            .When(PutStart("key", 1_KB)
+                      .ExpectError(ErrorCode::OBJECT_ALREADY_EXISTS)),
+        "PutStart(key) succeeded; expected OBJECT_ALREADY_EXISTS");
+}
+
+TEST(MasterScenarioContractTest, ReportsWrongErrorCode) {
+    EXPECT_NONFATAL_FAILURE(
+        MasterScenario("wrong error code")
+            .Given(MemoryNode("memory"))
+            .When(PutEnd("missing").ExpectError(ErrorCode::ILLEGAL_CLIENT)),
+        "PutEnd(missing) failed with OBJECT_NOT_FOUND; expected "
+        "ILLEGAL_CLIENT");
+}
+
+TEST(MasterScenarioContractTest, ReportsPutStartReplicaCountMismatch) {
+    EXPECT_NONFATAL_FAILURE(MasterScenario("put start replica count mismatch")
+                                .Given(MemoryNode("memory"))
+                                .When(PutStart("key", 1_KB).ExpectReplicas(2)),
+                            "PutStart(key) returned 1 replicas; expected 2");
+}
+
+TEST(MasterScenarioContractTest, ReportsPutStartReplicaStatusMismatch) {
+    EXPECT_NONFATAL_FAILURE(
+        MasterScenario("put start replica status mismatch")
+            .Given(MemoryNode("memory"))
+            .When(PutStart("key", 1_KB).ExpectStatus(ReplicaStatus::COMPLETE)),
+        "PutStart(key) replica status mismatch");
+}
+
+TEST(MasterScenarioContractTest, ReportsUnreadableObject) {
+    EXPECT_NONFATAL_FAILURE(
+        MasterScenario("unreadable object")
+            .Given(MemoryNode("memory"))
+            .Then(Object("missing").IsReadable()),
+        "Object(missing) is not readable: OBJECT_NOT_FOUND");
+}
+
+TEST(MasterScenarioContractTest, ReportsObjectReplicaCountMismatch) {
+    EXPECT_NONFATAL_FAILURE(MasterScenario("object replica count mismatch")
+                                .Given(MemoryNode("memory"))
+                                .When(PutStart("key", 1_KB))
+                                .When(PutEnd("key"))
+                                .Then(Object("key").HasReplicas(2)),
+                            "Object(key) has 1 replicas; expected 2");
+}
+
+TEST(MasterScenarioContractTest, ReportsCompleteReplicaCountMismatch) {
+    EXPECT_NONFATAL_FAILURE(MasterScenario("complete replica count mismatch")
+                                .Given(MemoryNode("memory"))
+                                .When(PutStart("key", 1_KB))
+                                .When(PutEnd("key"))
+                                .Then(Object("key").HasCompleteReplicas(0)),
+                            "Object(key) has 1 complete replicas; expected 0");
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_scenario_test.cpp
+++ b/mooncake-store/tests/master_scenario_test.cpp
@@ -51,28 +51,6 @@ static_assert(SupportsThen<ReadableObject>);
 
 }  // namespace
 
-TEST(MasterServiceTest, PutStartEndFlow) {
-    MasterScenario("put start/end flow")
-        .Given(MemoryNode("memory"))
-        .When(PutStart("test_key", 1_KB)
-                  .By("writer")
-                  .ExpectReplicas(1)
-                  .ExpectStatus(ReplicaStatus::PROCESSING))
-        .Then(Object("test_key").IsNotReady())
-        .When(Remove("test_key").ExpectError(ErrorCode::REPLICA_IS_NOT_READY))
-        .When(PutEnd("test_key")
-                  .By("other-writer")
-                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
-        .When(PutRevoke("test_key")
-                  .By("other-writer")
-                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
-        .When(PutEnd("test_key").By("writer"))
-        .Then(Object("test_key")
-                  .IsReadable()
-                  .HasReplicas(1)
-                  .HasCompleteReplicas(1));
-}
-
 TEST(MasterScenarioContractTest, ReportsUnexpectedActionError) {
     EXPECT_NONFATAL_FAILURE(MasterScenario("unexpected action error")
                                 .Given(MemoryNode("memory"))

--- a/mooncake-store/tests/master_scenario_test.cpp
+++ b/mooncake-store/tests/master_scenario_test.cpp
@@ -7,12 +7,23 @@ namespace mooncake::test {
 TEST(MasterServiceTest, PutStartEndFlow) {
     MasterScenario("put start/end flow")
         .Given(MemoryNode("memory"))
-        .When(PutStart("test_key", 1_KB).By("writer"))
+        .When(PutStart("test_key", 1_KB)
+                  .By("writer")
+                  .ExpectReplicas(1)
+                  .ExpectStatus(ReplicaStatus::PROCESSING))
+        .Then(Object("test_key").IsNotReady())
+        .When(Remove("test_key").ExpectError(ErrorCode::REPLICA_IS_NOT_READY))
         .When(PutEnd("test_key")
                   .By("other-writer")
                   .ExpectError(ErrorCode::ILLEGAL_CLIENT))
+        .When(PutRevoke("test_key")
+                  .By("other-writer")
+                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
         .When(PutEnd("test_key").By("writer"))
-        .Then(Object("test_key").IsReadable());
+        .Then(Object("test_key")
+                  .IsReadable()
+                  .HasReplicas(1)
+                  .HasCompleteReplicas(1));
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_scenario_test.cpp
+++ b/mooncake-store/tests/master_service_scenario_test.cpp
@@ -1,0 +1,29 @@
+#include "master_scenario.h"
+
+#include <gtest/gtest.h>
+
+namespace mooncake::test {
+
+TEST(MasterServiceTest, PutStartEndFlow) {
+    MasterScenario("put start/end flow")
+        .Given(MemoryNode("memory"))
+        .When(PutStart("test_key", 1_KB)
+                  .By("writer")
+                  .ExpectReplicas(1)
+                  .ExpectStatus(ReplicaStatus::PROCESSING))
+        .Then(Object("test_key").IsNotReady())
+        .When(Remove("test_key").ExpectError(ErrorCode::REPLICA_IS_NOT_READY))
+        .When(PutEnd("test_key")
+                  .By("other-writer")
+                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
+        .When(PutRevoke("test_key")
+                  .By("other-writer")
+                  .ExpectError(ErrorCode::ILLEGAL_CLIENT))
+        .When(PutEnd("test_key").By("writer"))
+        .Then(Object("test_key")
+                  .IsReadable()
+                  .HasReplicas(1)
+                  .HasCompleteReplicas(1));
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1686,60 +1686,6 @@ TEST_F(MasterServiceTest, WrappedBatchPutStartMixedGroupIdsPreservesOrder) {
     }
 }
 
-TEST_F(MasterServiceTest, PutStartEndFlow) {
-    std::unique_ptr<MasterService> service_(new MasterService());
-    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
-    const UUID client_id = generate_uuid();
-    const UUID invalid_client_id = generate_uuid();
-    ASSERT_NE(client_id, invalid_client_id);
-
-    // Test PutStart
-    std::string key = "test_key";
-    uint64_t value_length = 1024;
-    ReplicateConfig config;
-    config.replica_num = 1;
-
-    auto put_start_result = service_->PutStart(
-        client_id, key, TenantId::Default(), value_length, config);
-    EXPECT_TRUE(put_start_result.has_value());
-    replica_list = put_start_result.value();
-    EXPECT_FALSE(replica_list.empty());
-    EXPECT_EQ(ReplicaStatus::PROCESSING, replica_list[0].status);
-
-    // During put, Get/Remove should fail
-    auto get_replica_result =
-        service_->GetReplicaList(key, TenantId::Default());
-    EXPECT_FALSE(get_replica_result.has_value());
-    EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, get_replica_result.error());
-    auto remove_result = service_->Remove(key, TenantId::Default());
-    EXPECT_FALSE(remove_result.has_value());
-    EXPECT_EQ(ErrorCode::REPLICA_IS_NOT_READY, remove_result.error());
-
-    // PutEnd should fail if the client_id does not match.
-    auto put_end_fail_result = service_->PutEnd(
-        invalid_client_id, key, TenantId::Default(), ReplicaType::MEMORY);
-    EXPECT_FALSE(put_end_fail_result.has_value());
-    EXPECT_EQ(put_end_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
-
-    // PutRevoke should fail if the client_id does not match.
-    auto put_revoke_fail_result = service_->PutRevoke(
-        invalid_client_id, key, TenantId::Default(), ReplicaType::MEMORY);
-    EXPECT_FALSE(put_revoke_fail_result.has_value());
-    EXPECT_EQ(put_revoke_fail_result.error(), ErrorCode::ILLEGAL_CLIENT);
-
-    // Test PutEnd
-    auto put_end_result = service_->PutEnd(client_id, key, TenantId::Default(),
-                                           ReplicaType::MEMORY);
-    EXPECT_TRUE(put_end_result.has_value());
-
-    // Verify replica list after PutEnd
-    auto final_get_result = service_->GetReplicaList(key, TenantId::Default());
-    EXPECT_TRUE(final_get_result.has_value());
-    replica_list = final_get_result.value().replicas;
-    EXPECT_EQ(1, replica_list.size());
-    EXPECT_EQ(ReplicaStatus::COMPLETE, replica_list[0].status);
-}
-
 TEST_F(MasterServiceTest, TenantPutGetRemoveIsolatesSameUserKey) {
     const std::string key = "shared_user_key";
     const TenantId tenant_a("tenant_a");


### PR DESCRIPTION
## Description

Add the smallest useful typed C++ embedded scenario DSL for `MasterService` tests and prove it end to end by migrating `MasterServiceTest.PutStartEndFlow`.

The test-only foundation provides:

- declarative `MemoryNode` setup with lazy `MasterService` construction;
- typed `PutStart` and `PutEnd` actions with named actors;
- deterministic name-derived client UUIDs;
- success-by-default validation and explicit `ExpectError(ErrorCode)`;
- `Object(...).IsReadable()` verification;
- RAII ownership of service and scenario resources.

The old direct-fixture body is removed, so the behavior is covered once through the DSL. Public production APIs are unchanged.

Related RFC: #3098

This is the first small split from experimental draft #3100, not a duplicate of its broad implementation. It deliberately excludes concurrency checkpoints, scheduling, replay artifacts, tenants/quotas, additional operations, RPC, snapshots, and broad test migration.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -G Ninja -DBUILD_UNIT_TESTS=ON -DWITH_STORE_RUST=OFF
cmake --build build --target master_scenario_test master_service_test --parallel 128
GLOG_minloglevel=3 ./build/mooncake-store/tests/master_scenario_test --gtest_color=no
GLOG_minloglevel=3 ./build/mooncake-store/tests/master_service_test --gtest_color=no
pre-commit run --files mooncake-store/tests/CMakeLists.txt mooncake-store/tests/master_service_test.cpp mooncake-store/tests/master_scenario.cpp mooncake-store/tests/master_scenario.h mooncake-store/tests/master_scenario_test.cpp
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done (focused scenario and full relevant legacy suite)
- `master_scenario_test`: 1/1 passed.
- `master_service_test`: 146/146 passed.
- All touched-file pre-commit hooks passed.

A separate production/non-unit build is unaffected because all implementation and build wiring is under `mooncake-store/tests`, which is included only when `BUILD_UNIT_TESTS` is enabled.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable: test-only behavior; RFC #3098 documents the experiment)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable to this 368-line diff; related RFC #3098 exists)

Touched-file pre-commit validation was used per repository guidance; `--all-files` was not run to avoid unrelated rewrites.

This PR is intentionally a draft. The human submitter must review every changed line and be able to defend the implementation before marking it ready.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex helped reduce RFC #3098 and draft #3100 to this focused typed DSL slice, implement the test-only code, migrate the single scenario, and run validation. The human submitter remains responsible for reviewing and defending every changed line.