### PR TITLE
[Store] Fix no-operation update of LOCAL_DISK replica endpoint/size o…

### DIFF
--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -422,6 +422,30 @@ class Replica {
         return std::nullopt;
     }
 
+    /**
+     * @brief Update a LOCAL_DISK replica's transport endpoint and object size
+     * in place, keeping the allocated_file_size metric in sync when the size
+     * changes. No-op for non-local_disk replicas.
+     *
+     * Used when the same owning client re-reports an offloaded object (e.g.
+     * re-registration after a restart, where the transport endpoint changes).
+     * Mutates the internal replica data directly: get_descriptor() returns a
+     * by-value copy, so writing through it does not modify the replica.
+     */
+    void update_local_disk_location(std::string transport_endpoint,
+                                    uint64_t object_size) {
+        if (auto* disk_data = std::get_if<LocalDiskReplicaData>(&data_)) {
+            if (disk_data->object_size != object_size) {
+                MasterMetricManager::instance().dec_allocated_file_size(
+                    disk_data->object_size);
+                MasterMetricManager::instance().inc_allocated_file_size(
+                    object_size);
+            }
+            disk_data->transport_endpoint = std::move(transport_endpoint);
+            disk_data->object_size = object_size;
+        }
+    }
+
     [[nodiscard]] size_t get_memory_buffer_size() const {
         if (is_memory_replica()) {
             const auto& mem_data = std::get<MemoryReplicaData>(data_);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3962,15 +3962,10 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
                        client_id;
         },
         [&replica](Replica& rep) {
-            rep.get_descriptor()
-                .get_local_disk_descriptor()
-                .transport_endpoint = replica.get_descriptor()
-                                          .get_local_disk_descriptor()
-                                          .transport_endpoint;
-            rep.get_descriptor().get_local_disk_descriptor().object_size =
-                replica.get_descriptor()
-                    .get_local_disk_descriptor()
-                    .object_size;
+            const auto desc =
+                replica.get_descriptor().get_local_disk_descriptor();
+            rep.update_local_disk_location(desc.transport_endpoint,
+                                           desc.object_size);
         });
     return false;
 }
@@ -6199,18 +6194,11 @@ auto MasterService::NotifyOffloadSuccess(
                                                .client_id == client_id;
                             },
                             [&replica](Replica& rep) {
-                                rep.get_descriptor()
-                                    .get_local_disk_descriptor()
-                                    .transport_endpoint =
+                                const auto desc =
                                     replica.get_descriptor()
-                                        .get_local_disk_descriptor()
-                                        .transport_endpoint;
-                                rep.get_descriptor()
-                                    .get_local_disk_descriptor()
-                                    .object_size =
-                                    replica.get_descriptor()
-                                        .get_local_disk_descriptor()
-                                        .object_size;
+                                        .get_local_disk_descriptor();
+                                rep.update_local_disk_location(
+                                    desc.transport_endpoint, desc.object_size);
                             });
                     }
                     handled_existing_object = true;

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -7721,6 +7721,55 @@ TEST_F(MasterServiceTest, GracefulUnmountSegment_PreventAllocation) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1500));
 }
 
+// Regression test for the LOCAL_DISK replica "update" no-op: when the same
+// owning client re-reports an already-offloaded key with a new transport
+// endpoint, the existing LOCAL_DISK replica's endpoint must be refreshed in
+// place (not written to a discarded get_descriptor() copy).
+TEST_F(MasterServiceTest, NotifyOffloadSuccessRefreshesEndpointForSameClient) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    const UUID client_id = generate_uuid();
+    const std::string key = "local_disk_update_key";
+    constexpr int64_t kSize = 1024;
+
+    auto inject = [&](const std::string& endpoint) {
+        std::vector<OffloadTaskItem> tasks{
+            OffloadTaskItem{.tenant_id = std::string(TenantId::kDefaultValue),
+                            .key = key,
+                            .size = kSize}};
+        StorageObjectMetadata sm;
+        sm.bucket_id = 0;
+        sm.offset = 0;
+        sm.key_size = static_cast<int64_t>(key.size());
+        sm.data_size = kSize;
+        sm.transport_endpoint = endpoint;
+        std::vector<StorageObjectMetadata> metas{sm};
+        return service_->NotifyOffloadSuccess(client_id, tasks, metas)
+            .has_value();
+    };
+
+    // First offload registers the LOCAL_DISK replica.
+    ASSERT_TRUE(inject("endpoint_old"));
+    // Same client re-reports with a new endpoint (e.g. restart re-register)
+    // while the old record still exists -> takes the in-place update branch.
+    ASSERT_TRUE(inject("endpoint_new"));
+
+    auto resp = service_->GetReplicaList(key, TenantId::Default());
+    ASSERT_TRUE(resp.has_value());
+
+    std::vector<std::string> local_disk_endpoints;
+    for (const auto& replica : resp->replicas) {
+        if (replica.is_local_disk_replica()) {
+            local_disk_endpoints.push_back(
+                replica.get_local_disk_descriptor().transport_endpoint);
+        }
+    }
+    // Still exactly one LOCAL_DISK replica, and its endpoint must be the
+    // refreshed value. Before the fix the update was a no-op and this stayed
+    // "endpoint_old".
+    ASSERT_EQ(1u, local_disk_endpoints.size());
+    EXPECT_EQ("endpoint_new", local_disk_endpoints[0]);
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Description

### Problem

**In one line:** the code that updates an existing LOCAL_DISK replica's `endpoint`/`object_size` writes through `rep.get_descriptor()`, which returns a **by-value copy**, so the write lands on a throwaway temporary and the real record is never changed — the update is a no-operation. Two sites are affected (`master_service.cpp`): the `AddReplica` update branch and the `NotifyOffloadSuccess` update branch.

```cpp
[&replica](Replica& rep) {
    rep.get_descriptor()                       // get_descriptor() returns a temporary COPY by value
        .get_local_disk_descriptor()
        .transport_endpoint = ...;             // written into the copy -> discarded at end of statement
    rep.get_descriptor().get_local_disk_descriptor().object_size = ...;   // same, no effect
});
```

`get_descriptor()` (`replica.h`) builds a fresh `Descriptor` copy each call; the replica's real data lives in the private `data_` member, which is never touched.

**Is the update always ineffective?** Yes — whenever this "update" branch runs, nothing is written. But it only becomes a *visible* failure under a specific condition:

| Condition | Does the lost update matter? | Outcome |
|---|---|---|
| Re-report carries the **same** endpoint (common case) | No — stored value was already correct | No observable difference (why the bug hid so long) |
| Re-report carries a **different** endpoint (node restart, new RPC address) | **Yes** — record keeps the stale value | Stale endpoint → reads dial a dead address → **read failure** |

**HA note:** in HA mode the oplog-persistence branch persists the **new** endpoint/size while the in-memory metadata keeps the **old** value — the two diverge, and behavior can drift if state is later restored from oplog/snapshot.

### Solution

1. **Add a real mutator** `Replica::update_local_disk_location(transport_endpoint, object_size)` (`replica.h`) that mutates the internal `LocalDiskReplicaData` directly via `std::get_if<LocalDiskReplicaData>(&data_)` (does nothing for non-local_disk replicas). It also keeps the `allocated_file_size` metric in sync: when `object_size` changes it does `dec_allocated_file_size(old) + inc_allocated_file_size(new)`, mirroring the accounting already done in the replica constructor/destructor.
2. **Replace both no-operation update sites** with a call to this mutator:
   - `AddReplica` update branch (`master_service.cpp`);
   - `NotifyOffloadSuccess` update branch (`master_service.cpp`).

### Key mechanism: `Replica::update_local_disk_location`

The real data lives in the private `data_` member, unreachable from the call sites; the fix provides an in-class entry point that mutates it directly:

```cpp
// replica.h
void update_local_disk_location(std::string transport_endpoint,
                                uint64_t object_size) {
    if (auto* disk_data = std::get_if<LocalDiskReplicaData>(&data_)) {
        if (disk_data->object_size != object_size) {
            MasterMetricManager::instance().dec_allocated_file_size(
                disk_data->object_size);
            MasterMetricManager::instance().inc_allocated_file_size(object_size);
        }
        disk_data->transport_endpoint = std::move(transport_endpoint);
        disk_data->object_size = object_size;
    }
}
```

Call sites now do:

```cpp
const auto& desc = replica.get_descriptor().get_local_disk_descriptor();
rep.update_local_disk_location(desc.transport_endpoint, desc.object_size);
```

### Testing summary

WSL Ubuntu Debug build (gcc, -O0): full `master_service_test` **147/147 passed**, including the new regression test below; zero regressions.

---

## Test Scenarios

### Scenario: `NotifyOffloadSuccessRefreshesEndpointForSameClient`

- **Purpose**: the same owning client re-reports an already-offloaded key with a new transport endpoint; the existing LOCAL_DISK replica's endpoint must be refreshed in place (this exercises the previously no-operation update branch).
- **Setup**: one `MasterService`; via `NotifyOffloadSuccess`, the same `client_id` reports key `K` first with `endpoint_old`, then again with `endpoint_new` (the old record still exists, so the second call takes the update branch); read back with `GetReplicaList`.
- **Result**: exactly **1** LOCAL_DISK replica remains, with endpoint **`endpoint_new`**.

**Before / after, reproduced on the build tree by reverting the fix:**

Before the fix (old `get_descriptor()`-copy write) — the test FAILS, the endpoint read back is still `endpoint_old`:

```
[ RUN      ] MasterServiceTest.NotifyOffloadSuccessRefreshesEndpointForSameClient
master_service_test.cpp:7720: Failure
Expected equality of these values:
  "endpoint_new"
    Which is: "endpoint_old"
[  FAILED  ] MasterServiceTest.NotifyOffloadSuccessRefreshesEndpointForSameClient
```

After the fix (`update_local_disk_location`) — the test PASSES:

```
[ RUN      ] MasterServiceTest.NotifyOffloadSuccessRefreshesEndpointForSameClient
[       OK ] MasterServiceTest.NotifyOffloadSuccessRefreshesEndpointForSameClient (1021 ms)
[  PASSED  ] 1 test.
```

The test fails on the unpatched code and passes after the fix, so it genuinely guards the defect rather than being a tautological green.

---

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_UNIT_TESTS=ON
ninja -C build master_service_test
./build/mooncake-store/tests/master_service_test
```

**Test results:**
- [x] Unit tests pass (master_service_test **147/147 PASSED**, incl. 1 new regression test)
- [ ] Integration tests pass (if applicable) (end-to-end integration tests not run; change is master-side metadata only)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (this PR is ~82 LOC, below the RFC threshold)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI coding assistants were used to help implement the feature, write the tests, diagnose test behavior, and review the change. The human submitter has reviewed the changes and is responsible for defending them end-to-end.