### PR TITLE
[store] conductor: unify HTTP API on native msgpack and speed up long-context /query

### DIFF
--- a/docs/source/design/conductor/indexer-api-design.md
+++ b/docs/source/design/conductor/indexer-api-design.md
@@ -20,12 +20,13 @@ current parser and serializer.
 
 ## Common request and response rules
 
-All `POST` bodies are JSON objects. Unknown fields are rejected. Successful
-responses use `application/json`; JSON object key order is not part of the
-contract.
+Every endpoint speaks **msgpack only**. `POST` bodies are msgpack maps sent
+with `Content-Type: application/msgpack`; success responses and error bodies
+are msgpack maps with `Content-Type: application/msgpack`. `GET` endpoints
+(`/services`, `/global_view`) also return msgpack. Unknown fields are rejected
+on every endpoint. Map key order is not part of the contract.
 
-Most validation failures return status `400` with an
-`application/json` object:
+Most validation failures return status `400` with a msgpack map:
 
 ```json
 {
@@ -35,9 +36,9 @@ Most validation failures return status `400` with an
 }
 ```
 
-`field` is present when one field caused the error. `index` is also present
-when one array element caused it. The [error formats](#understand-errors)
-section lists the cases that return plain text instead.
+(`json` is used here only for readability; on the wire this is a msgpack map
+with the same keys.) `field` is present when one field caused the error.
+`index` is also present when one array element caused it.
 
 ## `POST /register`
 
@@ -95,26 +96,35 @@ HTTP endpoint.
 
 ### Minimal request
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "endpoint": "tcp://127.0.0.1:5557",
-    "type": "vLLM",
-    "modelname": "test-model",
-    "instance_id": "engine-a",
-    "block_size": 16,
-    "dp_rank": 0,
-    "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+```python
+import msgpack
+import httpx
+
+body = msgpack.packb(
+    {
+        "endpoint": "tcp://127.0.0.1:5557",
+        "type": "vLLM",
+        "modelname": "test-model",
+        "instance_id": "engine-a",
+        "block_size": 16,
+        "dp_rank": 0,
+        "hash_profile": {
+            "strategy": "vllm_v1",
+            "algorithm": "sha256_cbor",
+            "python_hash_seed": "0",
+            "index_projection": "low64_be",
+        },
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/register",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
-Status `200` returns:
+Status `200` returns a msgpack map equivalent to:
 
 ```json
 {
@@ -125,8 +135,9 @@ Status `200` returns:
 
 Submitting the exact same active registration again returns the same success
 without starting another subscriber. A conflicting service key, endpoint, or
-hash profile returns a JSON `400` with `reason` `invalid_registration`.
-Failure to start the local subscription client returns plain-text `500`.
+hash profile returns a msgpack `400` with `reason` `invalid_registration`.
+Failure to start the local subscription client returns a msgpack `500` error
+map.
 
 ## `POST /unregister`
 
@@ -145,13 +156,19 @@ No other fields are accepted.
 
 ### Minimal request
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","dp_rank":0}'
+```python
+import msgpack
+import httpx
+
+body = msgpack.packb({"instance_id": "engine-a", "dp_rank": 0}, use_bin_type=True)
+response = httpx.post(
+    "http://127.0.0.1:13333/unregister",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
-Status `200` returns the exact service key that was removed:
+Status `200` returns a msgpack map with the exact service key that was removed:
 
 ```json
 {
@@ -162,10 +179,10 @@ Status `200` returns the exact service key that was removed:
 }
 ```
 
-An unknown service key returns plain-text status `404`. A cleanup failure after
-the subscriber stops returns plain-text status `500`. Conductor keeps that
-service key and endpoint reserved, so neither can be registered again. Retry
-the same `/unregister` request until cleanup succeeds.
+An unknown service key returns a msgpack error map with status `404`. A
+cleanup failure after the subscriber stops returns status `500`. Conductor
+keeps that service key and endpoint reserved, so neither can be registered
+again. Retry the same `/unregister` request until cleanup succeeds.
 
 ## `POST /query`
 
@@ -174,16 +191,23 @@ for the requested tenant, model, LoRA name, and block size. The request cannot
 override the strategy, algorithm, `python_hash_seed`, derived root digest, or
 final-eight-byte lookup rule.
 
+**The request body is msgpack, like every other endpoint.** Send a msgpack
+map with `Content-Type: application/msgpack`; any other content type is
+rejected with `unsupported_content_type`. `token_ids` may be a msgpack `bin`
+of little-endian signed 32-bit integers (preferred: 4 bytes per token, no
+per-element parsing) or a msgpack array of integers. The response is a
+msgpack map as well.
+
 ### Request fields
 
 | Field | Required | Accepted value and when it matters |
 |---|---|---|
-| `model` | Yes | Non-empty model name. It must match registration `modelname`. |
+| `model` | Yes | Non-empty model name string. It must match registration `modelname`. |
 | `block_size` | Yes | Positive integer. Only complete groups of this many tokens are hashed. |
-| `token_ids` | Yes | JSON array of signed 32-bit integers. An empty array is valid and reports zero hits for compatible registered ranks. |
+| `token_ids` | Yes | msgpack `bin` of little-endian int32, or an array of signed 32-bit integers. An empty value is valid and reports zero hits for compatible registered ranks. |
 | `tenant_id` | No | String. Omitted or `""` becomes `"default"`. |
 | `lora_name` | No | String. Defaults to `""` for the base model. |
-| `cache_salt` | No | String, `null`, or omitted. `null`, `""`, and omission all select the no-salt hash path; a non-empty value must match the producer. |
+| `cache_salt` | No | String, `nil`, or omitted. `nil`, `""`, and omission all select the no-salt hash path; a non-empty value must match the producer. |
 | `instance_id` | No | String filter. A matching registered instance is returned alone; an unknown value returns an empty `instances` object. |
 
 No hash-profile override fields are accepted. A missing cache-sharing group
@@ -192,14 +216,25 @@ state.
 
 ### Minimal request
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/query \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "test-model",
-    "block_size": 16,
-    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-  }'
+```python
+import msgpack
+import struct
+import httpx
+
+token_ids = list(range(16))
+body = msgpack.packb(
+    {
+        "model": "test-model",
+        "block_size": 16,
+        "token_ids": struct.pack(f"<{len(token_ids)}i", *token_ids),
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/query",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 If `engine-a` rank `0` is registered and no matching cache event has arrived,
@@ -341,12 +376,17 @@ It takes no request body.
 
 ### Minimal request
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+import msgpack
+import httpx
+
+view = msgpack.unpackb(
+    httpx.get("http://127.0.0.1:13333/global_view").content, raw=False
+)
 ```
 
 After registering `engine-a` ranks `0` and `1`, before cache events arrive, a
-one-context response has this shape:
+one-context response (msgpack map, rendered as JSON here) has this shape:
 
 ```json
 {
@@ -391,11 +431,16 @@ the register request.
 
 ### Minimal request
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+import msgpack
+import httpx
+
+services = msgpack.unpackb(
+    httpx.get("http://127.0.0.1:13333/services").content, raw=False
+)
 ```
 
-After the minimal register example, status `200` returns:
+After the minimal register example, status `200` returns a msgpack map:
 
 ```json
 {
@@ -433,30 +478,28 @@ cache-producing traffic.
 
 ## Understand errors
 
-Conductor deliberately uses both JSON validation errors and plain-text
-operational errors:
+All error responses are msgpack maps; the JSON rendering below is for
+readability only. Validation failures carry a stable `reason`, operational
+failures carry only `error`:
 
-| Situation | Status | Content type and body |
+| Situation | Status | Body |
 |---|---|---|
-| Field validation for any `POST` endpoint | `400` | `application/json` with `error`, `reason`, and applicable `field` or `index`. |
-| Malformed `/query` JSON or a non-object body | `400` | `application/json` with `{"error":"Invalid JSON object","reason":"invalid_json"}`. |
-| Malformed `/register` or `/unregister` JSON, or a non-object body | `400` | `text/plain; charset=utf-8` with `Invalid JSON\n`. |
-| `/unregister` service key not found | `404` | `text/plain; charset=utf-8`, for example `service not found: engine-a\|default\|0\n`. |
-| `GET` on `/register`, `/unregister`, or `/query`; `POST` on `/global_view` or `/services` | `405` | `text/plain; charset=utf-8` with `Method not allowed\n`. |
-| `/register` cannot start the local subscription client | `500` | `text/plain; charset=utf-8` beginning `Failed to subscribe: failed to start ZMQ client:`. |
-| `/unregister` stops the subscriber but cache cleanup fails | `500` | `text/plain; charset=utf-8` beginning `Failed to unregister prefix context:`. |
+| Field validation for any `POST` endpoint | `400` | `error`, `reason`, and applicable `field` or `index`. |
+| Any `POST` endpoint with a non-msgpack `Content-Type` | `400` | `{"error":"Content-Type must be application/msgpack","reason":"unsupported_content_type"}`. |
+| Malformed msgpack body or a non-map body on any `POST` endpoint | `400` | `{"error":"Invalid msgpack object","reason":"invalid_msgpack"}`. |
+| `/unregister` service key not found | `404` | `{"error":"service not found: engine-a\|default\|0"}`. |
+| `GET` on `/register`, `/unregister`, or `/query`; `POST` on `/global_view` or `/services` | `405` | `{"error":"Method not allowed"}`. |
+| `/register` cannot start the local subscription client | `500` | `error` beginning `Failed to subscribe: failed to start ZMQ client:`. |
+| `/unregister` stops the subscriber but cache cleanup fails | `500` | `error` beginning `Failed to unregister prefix context:`. |
 
-For example, a string in `token_ids` produces an element-specific JSON error:
+For example, a string element in a `token_ids` array produces an
+element-specific error:
 
 ```json
 {
-  "error": "token_ids element must be a JSON integer",
+  "error": "token_ids element must be an integer",
   "reason": "invalid_type",
   "field": "token_ids",
   "index": 0
 }
 ```
-
-Conductor-generated JSON responses end with a newline except `/services`,
-whose compact JSON body has no trailing newline. Plain-text errors shown with
-`\n` above include that trailing newline.

--- a/docs/source/design/conductor/usage.md
+++ b/docs/source/design/conductor/usage.md
@@ -178,13 +178,34 @@ subscriptions:
 }
 ```
 
+All examples call this small msgpack helper, since every Conductor
+endpoint speaks msgpack only:
+
+```python
+import msgpack
+import httpx
+
+BASE = "http://127.0.0.1:13333"
+
+def conductor(path, payload=None):
+    if payload is None:
+        r = httpx.get(BASE + path, timeout=5)
+    else:
+        r = httpx.post(
+            BASE + path,
+            content=msgpack.packb(payload, use_bin_type=True),
+            headers={"Content-Type": "application/msgpack"},
+            timeout=5,
+        )
+    r.raise_for_status()
+    return msgpack.unpackb(r.content, raw=False)
+```
+
 After starting the binary, register every vLLM rank. This first request
 registers rank `0`:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:5557",
     "replay_endpoint": "tcp://127.0.0.1:5558",
     "type": "vLLM",
@@ -196,21 +217,19 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 0,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 Register rank `1` with its own event endpoint and the same engine and hash
 settings:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:5567",
     "replay_endpoint": "tcp://127.0.0.1:5568",
     "type": "vLLM",
@@ -222,19 +241,19 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 1,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 Each successful request returns `registered successfully`. Confirm the engine
 context before allowing cache-producing traffic:
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+conductor("/global_view")
 ```
 
 The matching context must show `tenant_id` `default`, `model_name`
@@ -251,10 +270,8 @@ start the Mooncake Master publisher as described in the
 [Mooncake publisher guide](../kv-event/publisher-design.md), then register its
 live endpoint:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:6557",
     "replay_endpoint": "",
     "type": "Mooncake",
@@ -266,12 +283,12 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 0,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 Configure the Mooncake publisher so each event carries the same tenant, model,
@@ -288,8 +305,8 @@ event checks.
 Confirm that `/services` contains both vLLM ranks and the Mooncake subscription
 before releasing traffic:
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+conductor("/services")
 ```
 
 For static configuration, use the other safe choice: keep cache-producing
@@ -309,8 +326,8 @@ not resend that earlier state.
 
 Inspect the active subscriptions:
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+conductor("/services")
 ```
 
 For the dynamic example, success means `count` is `3`, the two `vLLM` entries
@@ -320,8 +337,8 @@ match, including `python_hash_seed` `"0"` and its derived `root_digest`.
 
 Inspect the cache-sharing groups and registered inference ranks:
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+conductor("/global_view")
 ```
 
 Success means one matching context shows `"engine-a":[0,1]`. Mooncake does not
@@ -331,19 +348,33 @@ each block.
 
 ## Query
 
-Send token IDs produced by the tokenizer for the registered model. This
-example contains one complete 16-token block:
+`/query` is msgpack-only: send a msgpack map with
+`Content-Type: application/msgpack`. Carry `token_ids` as a msgpack `bin` of
+little-endian int32 (or an integer array). Use token IDs produced by the
+tokenizer for the registered model. This example contains one complete
+16-token block:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/query \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "test-model",
-    "lora_name": "",
-    "tenant_id": "default",
-    "block_size": 16,
-    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-  }'
+```python
+import msgpack
+import struct
+import httpx
+
+token_ids = list(range(16))
+body = msgpack.packb(
+    {
+        "model": "test-model",
+        "lora_name": "",
+        "tenant_id": "default",
+        "block_size": 16,
+        "token_ids": struct.pack(f"<{len(token_ids)}i", *token_ids),
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/query",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 A successful response has an `instances.engine-a` object with DP rank keys
@@ -363,22 +394,15 @@ formed from `instance_id`, normalized `tenant_id`, and `dp_rank`.
 
 Remove the Mooncake subscription:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"shared-pool","tenant_id":"default","dp_rank":0}'
+```python
+conductor("/unregister", {"instance_id": "shared-pool", "tenant_id": "default", "dp_rank": 0})
 ```
 
 Remove each vLLM rank separately:
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","tenant_id":"default","dp_rank":1}'
-
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","tenant_id":"default","dp_rank":0}'
+```python
+conductor("/unregister", {"instance_id": "engine-a", "tenant_id": "default", "dp_rank": 1})
+conductor("/unregister", {"instance_id": "engine-a", "tenant_id": "default", "dp_rank": 0})
 ```
 
 Each successful response contains `unregistered successfully` and the exact

--- a/docs/source/zh/design/conductor/indexer-api-design.md
+++ b/docs/source/zh/design/conductor/indexer-api-design.md
@@ -19,10 +19,12 @@
 
 ## 通用请求和响应规则
 
-所有 `POST` 请求体都必须是 JSON 对象。Conductor 会拒绝未知字段。成功响应使用
-`application/json`；JSON 对象中各字段的顺序不属于接口约定。
+所有端点**仅使用 msgpack**。`POST` 请求体是以 `Content-Type: application/msgpack`
+发送的 msgpack map；成功响应和错误响应也是以 `Content-Type: application/msgpack`
+返回的 msgpack map。`GET` 端点（`/services`、`/global_view`）同样返回 msgpack。
+所有接口都会拒绝未知字段。map 中各字段的顺序不属于接口约定。
 
-大多数参数检查错误返回状态码 `400` 和一个 `application/json` 对象：
+大多数参数检查错误返回状态码 `400` 和一个 msgpack map（此处以 JSON 形式展示）：
 
 ```json
 {
@@ -33,7 +35,7 @@
 ```
 
 如果错误由某个字段引起，响应会包含 `field`。如果错误来自数组中的某个元素，
-响应还会包含 `index`。[错误格式](#理解错误)一节列出了改为返回纯文本的情况。
+响应还会包含 `index`。
 
 ## `POST /register`
 
@@ -87,23 +89,32 @@ HTTP 接口不接受该字段。
 
 ### 最小请求
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "endpoint": "tcp://127.0.0.1:5557",
-    "type": "vLLM",
-    "modelname": "test-model",
-    "instance_id": "engine-a",
-    "block_size": 16,
-    "dp_rank": 0,
-    "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+```python
+import msgpack
+import httpx
+
+body = msgpack.packb(
+    {
+        "endpoint": "tcp://127.0.0.1:5557",
+        "type": "vLLM",
+        "modelname": "test-model",
+        "instance_id": "engine-a",
+        "block_size": 16,
+        "dp_rank": 0,
+        "hash_profile": {
+            "strategy": "vllm_v1",
+            "algorithm": "sha256_cbor",
+            "python_hash_seed": "0",
+            "index_projection": "low64_be",
+        },
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/register",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 状态码 `200` 返回：
@@ -137,10 +148,16 @@ curl -sS -X POST http://127.0.0.1:13333/register \
 
 ### 最小请求
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","dp_rank":0}'
+```python
+import msgpack
+import httpx
+
+body = msgpack.packb({"instance_id": "engine-a", "dp_rank": 0}, use_bin_type=True)
+response = httpx.post(
+    "http://127.0.0.1:13333/unregister",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 状态码 `200` 返回实际删除的服务键：
@@ -154,7 +171,7 @@ curl -sS -X POST http://127.0.0.1:13333/unregister \
 }
 ```
 
-服务键不存在时返回纯文本 `404`。如果订阅客户端停止后清理失败，则返回纯文本
+服务键不存在时返回 msgpack 错误 map 和状态码 `404`。如果订阅客户端停止后清理失败，则返回状态码
 `500`。此时 Conductor 会继续占用该服务键和 endpoint，二者都不能重新注册。
 请重复发送相同的 `/unregister` 请求，直到清理成功。
 
@@ -164,16 +181,21 @@ curl -sS -X POST http://127.0.0.1:13333/unregister \
 租户、模型、LoRA 名称和块大小必须能找到对应的注册信息。请求不能覆盖算法、
 策略、`python_hash_seed`、派生根摘要或最后八字节的查询规则。
 
+**请求体使用 msgpack 而不是 JSON。** 以 `Content-Type: application/msgpack`
+发送一个 msgpack map；其他内容类型会被 `unsupported_content_type` 拒绝。
+`token_ids` 可以是小端 int32 组成的 msgpack `bin`（推荐：每个 token 4 字节，
+服务端无需逐元素解析），也可以是整数数组。响应同样是 msgpack map。
+
 ### 请求字段
 
 | 字段 | 必填 | 可接受的值和用途 |
 |---|---|---|
 | `model` | 是 | 非空的模型名，必须与注册信息中的 `modelname` 一致。 |
 | `block_size` | 是 | 正整数。只有包含足够 token 的完整块会参与哈希计算。 |
-| `token_ids` | 是 | 由有符号 32 位整数组成的 JSON 数组。空数组有效，并会为匹配的已注册 rank 返回零命中。 |
+| `token_ids` | 是 | 小端 int32 组成的 msgpack `bin`，或由有符号 32 位整数组成的数组。空值有效，并会为匹配的已注册 rank 返回零命中。 |
 | `tenant_id` | 否 | 字符串。省略或传入 `""` 都会变成 `"default"`。 |
 | `lora_name` | 否 | 字符串。默认值是 `""`，表示基础模型。 |
-| `cache_salt` | 否 | 字符串、`null` 或省略。`null`、`""` 和省略都表示不加 salt；非空值必须与生产方一致。 |
+| `cache_salt` | 否 | 字符串、`nil` 或省略。`nil`、`""` 和省略都表示不加 salt；非空值必须与生产方一致。 |
 | `instance_id` | 否 | 字符串过滤条件。匹配时只返回指定实例；未知值返回空的 `instances` 对象。 |
 
 请求不能包含覆盖哈希配置的字段。如果找不到对应的缓存共享范围，也会返回状态码
@@ -181,14 +203,25 @@ curl -sS -X POST http://127.0.0.1:13333/unregister \
 
 ### 最小请求
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/query \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "test-model",
-    "block_size": 16,
-    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-  }'
+```python
+import msgpack
+import struct
+import httpx
+
+token_ids = list(range(16))
+body = msgpack.packb(
+    {
+        "model": "test-model",
+        "block_size": 16,
+        "token_ids": struct.pack(f"<{len(token_ids)}i", *token_ids),
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/query",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 如果已经注册 `engine-a` 的 rank `0`，但还没有收到匹配的缓存事件，响应如下：
@@ -323,8 +356,13 @@ longest_matched == disk
 
 ### 最小请求
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+import msgpack
+import httpx
+
+view = msgpack.unpackb(
+    httpx.get("http://127.0.0.1:13333/global_view").content, raw=False
+)
 ```
 
 注册 `engine-a` 的 rank `0` 和 `1` 后，在收到缓存事件前，单个缓存范围的响应
@@ -371,8 +409,13 @@ CPU 或 Disk 记录的不同查询值；这里的查询值是完整摘要的最�
 
 ### 最小请求
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+import msgpack
+import httpx
+
+services = msgpack.unpackb(
+    httpx.get("http://127.0.0.1:13333/services").content, raw=False
+)
 ```
 
 发送上面的最小注册请求后，状态码 `200` 返回：
@@ -412,28 +455,27 @@ curl -sS http://127.0.0.1:13333/services
 
 ## 理解错误
 
-Conductor 会根据错误类型返回 JSON 参数错误或纯文本运行错误：
+所有错误响应都是 msgpack map（此处以 JSON 形式展示以便阅读）。参数错误带有稳定的
+`reason`，运行错误只带 `error`：
 
 | 情况 | 状态码 | Content type 和响应体 |
 |---|---|---|
-| 任意 `POST` 接口的字段检查失败 | `400` | `application/json`，包含 `error`、`reason`，以及适用时的 `field` 或 `index`。 |
-| `/query` 的 JSON 格式错误，或请求体不是对象 | `400` | `application/json`，内容为 `{"error":"Invalid JSON object","reason":"invalid_json"}`。 |
-| `/register` 或 `/unregister` 的 JSON 格式错误，或请求体不是对象 | `400` | `text/plain; charset=utf-8`，内容为 `Invalid JSON\n`。 |
-| `/unregister` 找不到服务键 | `404` | `text/plain; charset=utf-8`，例如 `service not found: engine-a\|default\|0\n`。 |
-| 使用 `GET` 请求 `/register`、`/unregister` 或 `/query`；使用 `POST` 请求 `/global_view` 或 `/services` | `405` | `text/plain; charset=utf-8`，内容为 `Method not allowed\n`。 |
-| `/register` 无法启动本地订阅客户端 | `500` | `text/plain; charset=utf-8`，开头是 `Failed to subscribe: failed to start ZMQ client:`。 |
-| `/unregister` 已停止订阅客户端，但缓存清理失败 | `500` | `text/plain; charset=utf-8`，开头是 `Failed to unregister prefix context:`。 |
+| 任意 `POST` 接口的字段检查失败 | `400` | 包含 `error`、`reason`，以及适用时的 `field` 或 `index`。 |
+| 任意 `POST` 接口的 `Content-Type` 不是 msgpack | `400` | `{"error":"Content-Type must be application/msgpack","reason":"unsupported_content_type"}`。 |
+| 任意 `POST` 接口的 msgpack 格式错误，或请求体不是 map | `400` | `{"error":"Invalid msgpack object","reason":"invalid_msgpack"}`。 |
+| `/unregister` 找不到服务键 | `404` | msgpack map，例如 `service not found: engine-a\|default\|0`。 |
+| 使用 `GET` 请求 `/register`、`/unregister` 或 `/query`；使用 `POST` 请求 `/global_view` 或 `/services` | `405` | msgpack map，内容为 `Method not allowed`。 |
+| `/register` 无法启动本地订阅客户端 | `500` | msgpack map，开头是 `Failed to subscribe: failed to start ZMQ client:`。 |
+| `/unregister` 已停止订阅客户端，但缓存清理失败 | `500` | msgpack map，开头是 `Failed to unregister prefix context:`。 |
 
-例如，`token_ids` 中出现字符串时，会返回精确到数组元素的 JSON 错误：
+例如，`token_ids` 数组中出现字符串元素时，会返回精确到元素的错误（此处以
+JSON 形式展示）：
 
 ```json
 {
-  "error": "token_ids element must be a JSON integer",
+  "error": "token_ids element must be an integer",
   "reason": "invalid_type",
   "field": "token_ids",
   "index": 0
 }
 ```
-
-除 `/services` 外，Conductor 生成的 JSON 响应都以换行符结尾；该紧凑 JSON
-响应没有结尾换行。上表中用 `\n` 表示的纯文本错误会带有该结尾换行。

--- a/docs/source/zh/design/conductor/router-integration-design.md
+++ b/docs/source/zh/design/conductor/router-integration-design.md
@@ -132,7 +132,9 @@ endpoint 映射都以 Router 自己的状态为准；Conductor 不执行这些�
 
 ## 如何理解查询结果
 
-Router 使用真实执行所需的 token IDs 调用 `POST /query`：
+Router 使用真实执行所需的 token IDs 调用 `POST /query`。请求体为 msgpack map
+（`Content-Type: application/msgpack`），`token_ids` 以小端 int32 的 `bin`
+（或整数数组）承载，字段含义与下表一致：
 
 ```json
 {

--- a/docs/source/zh/design/conductor/usage.md
+++ b/docs/source/zh/design/conductor/usage.md
@@ -142,12 +142,33 @@ export CONDUCTOR_LOG_LEVEL=INFO
 }
 ```
 
+以下示例统一调用这个 msgpack 小工具函数，因为 Conductor 的所有端点都只接受
+msgpack：
+
+```python
+import msgpack
+import httpx
+
+BASE = "http://127.0.0.1:13333"
+
+def conductor(path, payload=None):
+    if payload is None:
+        r = httpx.get(BASE + path, timeout=5)
+    else:
+        r = httpx.post(
+            BASE + path,
+            content=msgpack.packb(payload, use_bin_type=True),
+            headers={"Content-Type": "application/msgpack"},
+            timeout=5,
+        )
+    r.raise_for_status()
+    return msgpack.unpackb(r.content, raw=False)
+```
+
 启动可执行文件后，注册每个 vLLM rank。第一个请求注册 rank `0`：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:5557",
     "replay_endpoint": "tcp://127.0.0.1:5558",
     "type": "vLLM",
@@ -159,20 +180,18 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 0,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 用该 rank 自己的事件 endpoint 注册 rank `1`，引擎和哈希设置保持不变：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:5567",
     "replay_endpoint": "tcp://127.0.0.1:5568",
     "type": "vLLM",
@@ -184,18 +203,18 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 1,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 每个成功请求都会返回 `registered successfully`。放开会产生缓存的业务流量前，先确认引擎信息：
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+conductor("/global_view")
 ```
 
 对应结果必须显示 `tenant_id` 为 `default`、`model_name` 为 `test-model`、`lora_name` 为空、`block_size` 为 `16`、`python_hash_seed` 为 `"0"`、根摘要为上文的派生值，并且 `"engine-a":[0,1]` 位于 `instances` 下。还要检查 `/services`：其中应包含两个 vLLM 订阅，并显示相同的种子和派生根摘要。如果部署中只有 vLLM，现在可以开始产生缓存的业务流量。
@@ -204,10 +223,8 @@ curl -sS http://127.0.0.1:13333/global_view
 
 添加共享缓存池时，先不要放开会产生缓存的业务流量。按照 [Mooncake 发布端指南](../kv-event/publisher-design.md)启用并启动 Mooncake Master 发布端，然后注册它的实时事件地址：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/register \
-  -H 'Content-Type: application/json' \
-  -d '{
+```python
+conductor("/register", {
     "endpoint": "tcp://127.0.0.1:6557",
     "replay_endpoint": "",
     "type": "Mooncake",
@@ -219,20 +236,20 @@ curl -sS -X POST http://127.0.0.1:13333/register \
     "dp_rank": 0,
     "cache_group": 0,
     "hash_profile": {
-      "strategy": "vllm_v1",
-      "algorithm": "sha256_cbor",
-      "python_hash_seed": "0",
-      "index_projection": "low64_be"
-    }
-  }'
+        "strategy": "vllm_v1",
+        "algorithm": "sha256_cbor",
+        "python_hash_seed": "0",
+        "index_projection": "low64_be",
+    },
+})
 ```
 
 配置 Mooncake 发布端，使每个事件携带的租户、模型、LoRA 名称和块大小与 vLLM 的缓存信息一致。`hash_profile` 来自 Mooncake 注册项，并且必须与该事件对应的缓存信息已经绑定的哈希配置相同。注册时也使用同样的缓存信息，这样更容易对照 `/services` 和发布端。Mooncake 的 `instance_id` 和 `dp_rank` 只用于在 `/services` 中标识订阅，以及通过 `/unregister` 注销；它们不会创建查询实例，也不会覆盖事件中的缓存信息。`stored` 事件还必须带有对象 key 和可用的完整连接器哈希；事件检查规则请参阅[订阅兼容指南](../kv-event/subscriber-guide.md)。
 
 放开业务流量前，确认 `/services` 同时包含两个 vLLM rank 和 Mooncake 订阅：
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+conductor("/services")
 ```
 
 如果使用静态配置，则采用另一种稳妥做法：在 `/global_view` 显示预期的 vLLM 缓存信息、引擎、rank、配置种子和派生根摘要，并且 `/services` 显示所有预期订阅和同一份已解析 hash profile 前，保持会产生缓存的业务流量暂停。静态订阅会同时启动，与 JSON 中的排列顺序无关。
@@ -243,34 +260,47 @@ curl -sS http://127.0.0.1:13333/services
 
 查看当前订阅：
 
-```bash
-curl -sS http://127.0.0.1:13333/services
+```python
+conductor("/services")
 ```
 
 对于上面的动态注册示例，`count` 为 `3` 才表示成功。两个 `vLLM` 项的 `InstanceID` 都应为 `engine-a`，`DPRank` 分别为 `0` 和 `1`；`Mooncake` 项的 `InstanceID` 应为 `shared-pool`。三个 `HashProfile` 必须相同，包括 `python_hash_seed` `"0"` 及其派生的 `root_digest`。
 
 查看缓存共享组合和已注册的推理 rank：
 
-```bash
-curl -sS http://127.0.0.1:13333/global_view
+```python
+conductor("/global_view")
 ```
 
 对应结果中出现 `"engine-a":[0,1]`，说明检查成功。Mooncake 不会作为另一个推理实例出现。收到实时事件后，`prefix_count` 可能增加，但仅凭这个计数无法判断每个块来自哪个缓存位置。
 
 ## 查询
 
-发送已注册模型的分词器（tokenizer）生成的 token IDs。下面的示例包含一个完整的 16-token 块：
+`/query` 仅接受 msgpack：以 `Content-Type: application/msgpack` 发送一个 msgpack
+map，`token_ids` 使用小端 int32 的 msgpack `bin`（或整数数组）承载。发送已注册
+模型的分词器（tokenizer）生成的 token IDs。下面的示例包含一个完整的 16-token 块：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/query \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "test-model",
-    "lora_name": "",
-    "tenant_id": "default",
-    "block_size": 16,
-    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-  }'
+```python
+import msgpack
+import struct
+import httpx
+
+token_ids = list(range(16))
+body = msgpack.packb(
+    {
+        "model": "test-model",
+        "lora_name": "",
+        "tenant_id": "default",
+        "block_size": 16,
+        "token_ids": struct.pack(f"<{len(token_ids)}i", *token_ids),
+    },
+    use_bin_type=True,
+)
+response = httpx.post(
+    "http://127.0.0.1:13333/query",
+    content=body,
+    headers={"Content-Type": "application/msgpack"},
+)
 ```
 
 成功响应中会有 `instances.engine-a` 对象，其中 DP rank key 为 `"0"` 和 `"1"`。在收到匹配的实时事件前，命中值可能为零。查询只计算完整块。如果事件生产端使用缓存盐值（cache salt）计算请求哈希，请在这次查询中添加取值相同的 `cache_salt` 字符串，不要把它加入注册项。
@@ -283,22 +313,15 @@ curl -sS -X POST http://127.0.0.1:13333/query \
 
 删除 Mooncake 订阅：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"shared-pool","tenant_id":"default","dp_rank":0}'
+```python
+conductor("/unregister", {"instance_id": "shared-pool", "tenant_id": "default", "dp_rank": 0})
 ```
 
 分别删除每个 vLLM rank：
 
-```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","tenant_id":"default","dp_rank":1}'
-
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"engine-a","tenant_id":"default","dp_rank":0}'
+```python
+conductor("/unregister", {"instance_id": "engine-a", "tenant_id": "default", "dp_rank": 1})
+conductor("/unregister", {"instance_id": "engine-a", "tenant_id": "default", "dp_rank": 0})
 ```
 
 每个成功响应都包含 `unregistered successfully` 和准确的已删除 service key，例如 `engine-a|default|0`。检查 `/services`，确认对应订阅已经消失。注销一个 vLLM rank 只删除该 rank 的 GPU 信息；注销 Mooncake 只删除由该 Mooncake endpoint 报告的对象。

--- a/mooncake-conductor/example/README.md
+++ b/mooncake-conductor/example/README.md
@@ -26,7 +26,7 @@ Build Conductor as described in the main
 the proxy's Python dependencies:
 
 ```bash
-python3 -m pip install fastapi httpx uvicorn
+python3 -m pip install fastapi httpx uvicorn msgpack
 ```
 
 The proxy does not load a tokenizer model. It uses the root-level `/tokenize`
@@ -288,7 +288,7 @@ is accepted by Conductor's idempotent API.
 List the active event subscriptions:
 
 ```bash
-curl -sS http://127.0.0.1:13333/services
+python3 -c "import msgpack, httpx; print(msgpack.unpackb(httpx.get('http://127.0.0.1:13333/services').content, raw=False))"
 ```
 
 The response must contain every configured `InstanceID`, `DPRank`, `Endpoint`,
@@ -299,7 +299,7 @@ arrived.
 Inspect the instance/rank grouping:
 
 ```bash
-curl -sS http://127.0.0.1:13333/global_view
+python3 -c "import msgpack, httpx; print(msgpack.unpackb(httpx.get('http://127.0.0.1:13333/global_view').content, raw=False))"
 ```
 
 The expected context must show `prefill-a` and `prefill-b` with their configured
@@ -333,18 +333,34 @@ request_id=... cache_aware_fallback reason=all_cache_hits_zero selected_instance
 ## Diagnose Empty Or Zero Hits
 
 Tokenize a representative prompt through one prefill, then send those token IDs
-to Conductor directly:
+to Conductor directly. `/query` is msgpack-only; carry the token IDs as a bin
+of little-endian int32:
 
 ```bash
-curl -sS -X POST http://127.0.0.1:13333/query \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "model": "Qwen/Qwen2.5-7B-Instruct",
-    "block_size": 16,
-    "tenant_id": "default",
-    "lora_name": "",
-    "token_ids": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]
-  }'
+python3 - <<'EOF'
+import msgpack
+import struct
+import httpx
+
+token_ids = list(range(16))
+body = msgpack.packb(
+    {
+        "model": "Qwen/Qwen2.5-7B-Instruct",
+        "block_size": 16,
+        "tenant_id": "default",
+        "lora_name": "",
+        "token_ids": struct.pack(f"<{len(token_ids)}i", *token_ids),
+    },
+    use_bin_type=True,
+)
+print(
+    httpx.post(
+        "http://127.0.0.1:13333/query",
+        content=body,
+        headers={"Content-Type": "application/msgpack"},
+    ).json()
+)
+EOF
 ```
 
 If `instances` is empty or every `longest_matched` is zero, compare the request
@@ -367,9 +383,25 @@ first created an idempotent registration.
 Unregister a rank only when its publisher is removed or replaced:
 
 ```bash
-curl -sS -X POST http://127.0.0.1:13333/unregister \
-  -H 'Content-Type: application/json' \
-  -d '{"instance_id":"prefill-a","tenant_id":"default","dp_rank":0}'
+python3 - <<'EOF'
+import msgpack
+import httpx
+
+body = msgpack.packb(
+    {"instance_id": "prefill-a", "tenant_id": "default", "dp_rank": 0},
+    use_bin_type=True,
+)
+print(
+    msgpack.unpackb(
+        httpx.post(
+            "http://127.0.0.1:13333/unregister",
+            content=body,
+            headers={"Content-Type": "application/msgpack"},
+        ).content,
+        raw=False,
+    )
+)
+EOF
 ```
 
 Repeat the command for every rank being removed. Before registering a new

--- a/mooncake-conductor/example/cache_aware_disagg_proxy.py
+++ b/mooncake-conductor/example/cache_aware_disagg_proxy.py
@@ -10,6 +10,7 @@ import json
 import logging
 import math
 import os
+import struct
 import uuid
 from collections.abc import AsyncIterator, Callable, Mapping
 from contextlib import asynccontextmanager
@@ -638,12 +639,13 @@ class ConductorClient:
         for payload in self.registration_payloads(prefills):
             response = await self.client.post(
                 "/register",
-                json=payload,
+                content=_msgpack_encode(payload),
+                headers={"Content-Type": "application/msgpack"},
                 timeout=self.conductor_config.registration_timeout_seconds,
             )
             try:
                 response.raise_for_status()
-                body = _response_object(response, "Conductor register")
+                body = _response_msgpack(response, "Conductor register")
                 if (
                     body.get("status") != "registered successfully"
                     or body.get("instance_id") != payload["instance_id"]
@@ -669,10 +671,12 @@ class ConductorClient:
         model = request_data.get("model")
         if not isinstance(model, str) or not model:
             raise ConductorProtocolError("request model is missing or invalid")
+        # /query is msgpack-only: token_ids travel as a bin of little-endian
+        # int32 (4 bytes/token, no per-element JSON parsing on the server).
         payload: dict[str, Any] = {
             "model": model,
             "block_size": self.prefill_config.block_size,
-            "token_ids": token_ids,
+            "token_ids": _pack_token_ids(token_ids),
             "tenant_id": self.prefill_config.tenant_id,
             "lora_name": self.prefill_config.lora_name,
         }
@@ -681,25 +685,41 @@ class ConductorClient:
 
         response = await self.client.post(
             "/query",
-            json=payload,
-            headers={"X-Request-Id": request_id},
+            content=_msgpack_encode(payload),
+            headers={
+                "Content-Type": "application/msgpack",
+                "X-Request-Id": request_id,
+            },
             timeout=self.conductor_config.query_timeout_seconds,
         )
         try:
             response.raise_for_status()
-            return _response_object(response, "Conductor query")
+            return _response_msgpack(response, "Conductor query")
         finally:
             await response.aclose()
 
 
-def _response_object(response: httpx.Response, operation: str) -> dict[str, Any]:
+def _response_msgpack(response: httpx.Response, operation: str) -> dict[str, Any]:
+    import msgpack
+
     try:
-        body = response.json()
+        body = msgpack.unpackb(response.content, raw=False)
     except ValueError as exc:
-        raise ConductorProtocolError(f"{operation} returned invalid JSON") from exc
+        raise ConductorProtocolError(f"{operation} returned invalid msgpack") from exc
     if not isinstance(body, dict):
-        raise ConductorProtocolError(f"{operation} response must be a JSON object")
+        raise ConductorProtocolError(f"{operation} response must be a msgpack map")
     return body
+
+
+def _pack_token_ids(token_ids: list[int]) -> bytes:
+    """Packs token ids as little-endian int32 for the msgpack bin channel."""
+    return struct.pack(f"<{len(token_ids)}i", *token_ids)
+
+
+def _msgpack_encode(payload: Mapping[str, Any]) -> bytes:
+    import msgpack
+
+    return msgpack.packb(payload, use_bin_type=True)
 
 
 class ProxyRuntime:

--- a/mooncake-conductor/src/kvevent/event_manager.cpp
+++ b/mooncake-conductor/src/kvevent/event_manager.cpp
@@ -1,7 +1,7 @@
 #include "conductor/kvevent/event_manager.h"
 
 #include <glog/logging.h>
-#include <json/json.h>
+#include <msgpack.hpp>
 #include <csignal>
 #include <ylt/coro_http/coro_http_server.hpp>
 
@@ -24,8 +24,11 @@ using coro_http::coro_http_request;
 using coro_http::coro_http_response;
 using coro_http::status_type;
 
-constexpr const char* kTextPlain = "text/plain; charset=utf-8";
-constexpr const char* kApplicationJson = "application/json";
+// Every endpoint speaks msgpack only: request bodies, success responses, and
+// error envelopes are all msgpack maps. There is no JSON wire path.
+constexpr const char* kApplicationMsgpack = "application/msgpack";
+
+using MsgpackPacker = msgpack::packer<msgpack::sbuffer>;
 
 prefixindex::ContextKey ContextFromService(
     const common::ServiceConfig& service) {
@@ -50,15 +53,17 @@ prefixindex::EngineRegistration RegistrationFromService(
             .cache_group = service.cache_group};
 }
 
-bool JsonInt64(const Json::Value& value, int64_t* out) {
-    if (value.type() == Json::intValue) {
-        *out = value.asInt64();
+bool MsgpackInt64(const msgpack::object& value, int64_t* out) {
+    if (value.type == msgpack::type::POSITIVE_INTEGER) {
+        if (value.via.u64 >
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+            return false;
+        }
+        *out = static_cast<int64_t>(value.via.u64);
         return true;
     }
-    if (value.type() == Json::uintValue &&
-        value.asUInt64() <=
-            static_cast<Json::UInt64>(std::numeric_limits<int64_t>::max())) {
-        *out = static_cast<int64_t>(value.asUInt64());
+    if (value.type == msgpack::type::NEGATIVE_INTEGER) {
+        *out = value.via.i64;
         return true;
     }
     return false;
@@ -72,165 +77,249 @@ bool IsSupportedHashAlgorithm(std::string_view algorithm) {
     return algorithm == "sha256" || algorithm == "sha256_cbor";
 }
 
-// Writes an error response: text/plain body with trailing \n.
+// ---------------------------------------------------------------------------
+// Response writers
+// ---------------------------------------------------------------------------
+
+void HttpMsgpack(coro_http_response& resp, status_type status,
+                 const msgpack::sbuffer& body) {
+    resp.add_header("Content-Type", kApplicationMsgpack);
+    resp.set_status_and_content(status, std::string(body.data(), body.size()));
+}
+
+// Writes an error response: msgpack map {"error": message}.
 void HttpError(coro_http_response& resp, status_type status,
                const std::string& message) {
-    resp.add_header("Content-Type", kTextPlain);
-    resp.set_status_and_content(status, message + "\n");
+    msgpack::sbuffer body;
+    MsgpackPacker packer(&body);
+    packer.pack_map(1);
+    packer.pack("error");
+    packer.pack(message);
+    HttpMsgpack(resp, status, body);
 }
 
-void HttpJson(coro_http_response& resp, status_type status,
-              const Json::Value& value) {
-    Json::StreamWriterBuilder wb;
-    wb["indentation"] = "";
-    // JSON-encoded output terminates with a trailing '\n' (wire contract).
-    resp.add_header("Content-Type", kApplicationJson);
-    resp.set_status_and_content(status, Json::writeString(wb, value) + "\n");
-}
-
-void HttpJson(coro_http_response& resp, const Json::Value& value) {
-    HttpJson(resp, status_type::ok, value);
-}
-
-void HttpJsonError(coro_http_response& resp, const char* reason,
-                   const std::string& message, const char* field = nullptr,
-                   std::optional<size_t> index = std::nullopt) {
-    Json::Value error(Json::objectValue);
-    error["error"] = message;
-    error["reason"] = reason;
+void HttpValidationError(coro_http_response& resp, const char* reason,
+                         const std::string& message,
+                         const char* field = nullptr,
+                         std::optional<size_t> index = std::nullopt) {
+    msgpack::sbuffer body;
+    MsgpackPacker packer(&body);
+    uint32_t size = 2;
     if (field != nullptr) {
-        error["field"] = field;
+        ++size;
     }
     if (index.has_value()) {
-        error["index"] = Json::Value::UInt64(*index);
+        ++size;
     }
-    HttpJson(resp, status_type::bad_request, error);
+    packer.pack_map(size);
+    packer.pack("error");
+    packer.pack(message);
+    packer.pack("reason");
+    packer.pack(reason);
+    if (field != nullptr) {
+        packer.pack("field");
+        packer.pack(field);
+    }
+    if (index.has_value()) {
+        packer.pack("index");
+        packer.pack(static_cast<uint64_t>(*index));
+    }
+    HttpMsgpack(resp, status_type::bad_request, body);
 }
 
-bool RejectUnknownFields(const Json::Value& body,
+// ---------------------------------------------------------------------------
+// Request helpers (msgpack-native)
+// ---------------------------------------------------------------------------
+
+std::string_view ObjectStr(const msgpack::object& object) {
+    return std::string_view(object.via.str.ptr, object.via.str.size);
+}
+
+// Finds a string-keyed member in a msgpack map; nullptr when absent.
+const msgpack::object* MapFind(const msgpack::object_map& map,
+                               std::string_view key) {
+    for (uint32_t i = 0; i < map.size; ++i) {
+        const msgpack::object& k = map.ptr[i].key;
+        if (k.type == msgpack::type::STR && ObjectStr(k) == key) {
+            return &map.ptr[i].val;
+        }
+    }
+    return nullptr;
+}
+
+// Parses the request body as a msgpack map. Returns false (and writes the
+// error response) on a wrong content type, malformed payload, or non-map root.
+// The returned object_map points into the handle's zone; keep handle alive.
+bool ParseMsgpackBody(coro_http_request& req, coro_http_response& resp,
+                      const char* what, msgpack::object_handle* handle,
+                      msgpack::object_map* out) {
+    const std::string_view content_type = req.get_header_value("content-type");
+    if (content_type.find(kApplicationMsgpack) == std::string_view::npos) {
+        HttpValidationError(resp, "unsupported_content_type",
+                            "Content-Type must be application/msgpack");
+        return false;
+    }
+    const auto body = req.get_body();
+    try {
+        *handle = msgpack::unpack(body.data(), body.size());
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to decode " << what
+                   << " msgpack err=" << e.what();
+        HttpValidationError(resp, "invalid_msgpack", "Invalid msgpack object");
+        return false;
+    }
+    const msgpack::object root = handle->get();
+    if (root.type != msgpack::type::MAP) {
+        HttpValidationError(resp, "invalid_msgpack",
+                            "request body must be a msgpack map");
+        return false;
+    }
+    *out = root.via.map;
+    return true;
+}
+
+bool RejectUnknownFields(const msgpack::object_map& body,
                          const std::set<std::string>& allowed,
                          coro_http_response& resp) {
-    for (const std::string& name : body.getMemberNames()) {
+    for (uint32_t i = 0; i < body.size; ++i) {
+        const msgpack::object& key = body.ptr[i].key;
+        if (key.type != msgpack::type::STR) {
+            HttpValidationError(resp, "invalid_msgpack",
+                                "map keys must be strings");
+            return false;
+        }
+        const std::string name(ObjectStr(key));
         if (!allowed.contains(name)) {
-            HttpJsonError(resp, "unknown_field",
-                          "unsupported request field: " + name, name.c_str());
+            HttpValidationError(resp, "unknown_field",
+                                "unsupported request field: " + name,
+                                name.c_str());
             return false;
         }
     }
     return true;
 }
 
-bool RequiredString(const Json::Value& body, const char* field,
+bool RequiredString(const msgpack::object_map& body, const char* field,
                     coro_http_response& resp, std::string* out) {
-    if (!body.isMember(field)) {
-        HttpJsonError(resp, "missing", std::string(field) + " is required",
-                      field);
+    const msgpack::object* value = MapFind(body, field);
+    if (value == nullptr) {
+        HttpValidationError(resp, "missing",
+                            std::string(field) + " is required", field);
         return false;
     }
-    if (!body[field].isString()) {
-        HttpJsonError(resp, "invalid_type",
-                      std::string(field) + " must be a string", field);
+    if (value->type != msgpack::type::STR) {
+        HttpValidationError(resp, "invalid_type",
+                            std::string(field) + " must be a string", field);
         return false;
     }
-    *out = body[field].asString();
+    *out = std::string(ObjectStr(*value));
     if (out->empty()) {
-        HttpJsonError(resp, "invalid_value",
-                      std::string(field) + " must not be empty", field);
+        HttpValidationError(resp, "invalid_value",
+                            std::string(field) + " must not be empty", field);
         return false;
     }
     return true;
 }
 
-bool OptionalStringStrict(const Json::Value& body, const char* field,
+bool OptionalStringStrict(const msgpack::object_map& body, const char* field,
                           const std::string& fallback, coro_http_response& resp,
                           std::string* out) {
-    if (!body.isMember(field)) {
+    const msgpack::object* value = MapFind(body, field);
+    if (value == nullptr) {
         *out = fallback;
         return true;
     }
-    if (!body[field].isString()) {
-        HttpJsonError(resp, "invalid_type",
-                      std::string(field) + " must be a string", field);
+    if (value->type != msgpack::type::STR) {
+        HttpValidationError(resp, "invalid_type",
+                            std::string(field) + " must be a string", field);
         return false;
     }
-    *out = body[field].asString();
+    *out = std::string(ObjectStr(*value));
     return true;
 }
 
-bool RequiredPositiveInt64(const Json::Value& body, const char* field,
+bool RequiredPositiveInt64(const msgpack::object_map& body, const char* field,
                            coro_http_response& resp, int64_t* out) {
-    if (!body.isMember(field)) {
-        HttpJsonError(resp, "missing", std::string(field) + " is required",
-                      field);
+    const msgpack::object* value = MapFind(body, field);
+    if (value == nullptr) {
+        HttpValidationError(resp, "missing",
+                            std::string(field) + " is required", field);
         return false;
     }
-    if (!JsonInt64(body[field], out)) {
-        HttpJsonError(resp, "invalid_type",
-                      std::string(field) + " must be an integer", field);
+    if (!MsgpackInt64(*value, out)) {
+        HttpValidationError(resp, "invalid_type",
+                            std::string(field) + " must be an integer", field);
         return false;
     }
     if (*out <= 0) {
-        HttpJsonError(resp, "out_of_range",
-                      std::string(field) + " must be greater than zero", field);
+        HttpValidationError(resp, "out_of_range",
+                            std::string(field) + " must be greater than zero",
+                            field);
         return false;
     }
     return true;
 }
 
-bool ParseOptionalCacheGroup(const Json::Value& body, coro_http_response& resp,
+bool ParseOptionalCacheGroup(const msgpack::object_map& body,
+                             coro_http_response& resp,
                              std::optional<int64_t>* cache_group) {
-    if (!body.isMember("cache_group") || body["cache_group"].isNull()) {
+    const msgpack::object* value = MapFind(body, "cache_group");
+    if (value == nullptr || value->type == msgpack::type::NIL) {
         cache_group->reset();
         return true;
     }
-    int64_t value = 0;
-    if (!JsonInt64(body["cache_group"], &value)) {
-        HttpJsonError(resp, "invalid_type",
-                      "cache_group must be an integer or null", "cache_group");
+    int64_t parsed = 0;
+    if (!MsgpackInt64(*value, &parsed)) {
+        HttpValidationError(resp, "invalid_type",
+                            "cache_group must be an integer or null",
+                            "cache_group");
         return false;
     }
-    if (value != 0) {
-        HttpJsonError(resp, "unsupported", "only cache group zero is supported",
-                      "cache_group");
+    if (parsed != 0) {
+        HttpValidationError(resp, "unsupported",
+                            "only cache group zero is supported",
+                            "cache_group");
         return false;
     }
-    *cache_group = value;
+    *cache_group = parsed;
     return true;
 }
 
-bool ParseHashProfileConfig(const Json::Value& body, coro_http_response& resp,
+bool ParseHashProfileConfig(const msgpack::object_map& body,
+                            coro_http_response& resp,
                             common::ResolvedHashProfile* profile) {
-    if (!body.isMember("hash_profile")) {
-        HttpJsonError(resp, "missing", "hash_profile is required",
-                      "hash_profile");
+    const msgpack::object* value = MapFind(body, "hash_profile");
+    if (value == nullptr) {
+        HttpValidationError(resp, "missing", "hash_profile is required",
+                            "hash_profile");
         return false;
     }
-    const Json::Value& value = body["hash_profile"];
-    if (!value.isObject()) {
-        HttpJsonError(resp, "invalid_type", "hash_profile must be an object",
-                      "hash_profile");
+    if (value->type != msgpack::type::MAP) {
+        HttpValidationError(resp, "invalid_type", "hash_profile must be a map",
+                            "hash_profile");
         return false;
     }
+    const msgpack::object_map& profile_map = value->via.map;
     static const std::set<std::string> kAllowedProfileFields = {
         "algorithm", "index_projection", "python_hash_seed", "strategy"};
-    if (!RejectUnknownFields(value, kAllowedProfileFields, resp)) {
+    if (!RejectUnknownFields(profile_map, kAllowedProfileFields, resp)) {
         return false;
     }
 
     common::HashProfileConfig source;
-    if (!RequiredString(value, "strategy", resp, &source.strategy) ||
-        !RequiredString(value, "algorithm", resp, &source.algorithm) ||
-        !RequiredString(value, "python_hash_seed", resp,
+    if (!RequiredString(profile_map, "strategy", resp, &source.strategy) ||
+        !RequiredString(profile_map, "algorithm", resp, &source.algorithm) ||
+        !RequiredString(profile_map, "python_hash_seed", resp,
                         &source.python_hash_seed) ||
-        !RequiredString(value, "index_projection", resp,
+        !RequiredString(profile_map, "index_projection", resp,
                         &source.index_projection)) {
         return false;
     }
 
     if (!IsSupportedHashAlgorithm(source.algorithm)) {
-        HttpJsonError(resp, "invalid_value",
-                      "unsupported hash algorithm: " + source.algorithm,
-                      "algorithm");
+        HttpValidationError(resp, "invalid_value",
+                            "unsupported hash algorithm: " + source.algorithm,
+                            "algorithm");
         return false;
     }
 
@@ -247,7 +336,7 @@ bool ParseHashProfileConfig(const Json::Value& body, coro_http_response& resp,
         } else if (source.index_projection != "low64_be") {
             field = "index_projection";
         }
-        HttpJsonError(resp, "invalid_value", error, field);
+        HttpValidationError(resp, "invalid_value", error, field);
         return false;
     }
     return true;
@@ -286,100 +375,6 @@ std::string ValidateServiceConfig(const common::ServiceConfig& service) {
     return "unsupported publisher kind";
 }
 
-bool ParseJsonObject(coro_http_request& req, Json::Value* out,
-                     std::string* errors, bool strict = false) {
-    Json::CharReaderBuilder rb;
-    if (strict) {
-        rb["allowComments"] = false;
-        rb["allowTrailingCommas"] = false;
-        rb["failIfExtra"] = true;
-    }
-    const auto body = req.get_body();
-    std::unique_ptr<Json::CharReader> reader(rb.newCharReader());
-    if (!reader->parse(body.data(), body.data() + body.size(), out, errors)) {
-        return false;
-    }
-    if (!out->isObject()) {
-        *errors = "request body must be a JSON object";
-        return false;
-    }
-    return true;
-}
-
-// Parses a request body as a JSON object. Returns false (and writes the
-// 400 response) on malformed JSON.
-bool ParseJsonBody(coro_http_request& req, coro_http_response& resp,
-                   const char* what, Json::Value* out) {
-    std::string errs;
-    if (!ParseJsonObject(req, out, &errs)) {
-        LOG(ERROR) << "Failed to decode " << what << " JSON err=" << errs;
-        HttpError(resp, status_type::bad_request, "Invalid JSON");
-        return false;
-    }
-    return true;
-}
-
-bool ParseQueryJsonBody(coro_http_request& req, coro_http_response& resp,
-                        Json::Value* out) {
-    std::string errs;
-    if (!ParseJsonObject(req, out, &errs, true)) {
-        LOG(ERROR) << "Failed to decode query JSON err=" << errs;
-        HttpJsonError(resp, "invalid_json", "Invalid JSON object");
-        return false;
-    }
-    return true;
-}
-
-bool ParseQueryTokenIds(const Json::Value& body, coro_http_response& resp,
-                        std::vector<int32_t>* token_ids) {
-    if (!body.isMember("token_ids")) {
-        HttpJsonError(resp, "missing", "token_ids is required", "token_ids");
-        return false;
-    }
-
-    const Json::Value& values = body["token_ids"];
-    if (!values.isArray()) {
-        HttpJsonError(resp, "not_array", "token_ids must be an array",
-                      "token_ids");
-        return false;
-    }
-
-    token_ids->clear();
-    token_ids->reserve(values.size());
-    for (Json::ArrayIndex index = 0; index < values.size(); ++index) {
-        const Json::Value& value = values[index];
-        int32_t token_id = 0;
-        if (value.type() == Json::intValue) {
-            const Json::Int64 signed_value = value.asInt64();
-            if (signed_value < std::numeric_limits<int32_t>::min() ||
-                signed_value > std::numeric_limits<int32_t>::max()) {
-                HttpJsonError(resp, "out_of_range",
-                              "token_ids element is outside the int32 range",
-                              "token_ids", index);
-                return false;
-            }
-            token_id = static_cast<int32_t>(signed_value);
-        } else if (value.type() == Json::uintValue) {
-            const Json::UInt64 unsigned_value = value.asUInt64();
-            if (unsigned_value > static_cast<Json::UInt64>(
-                                     std::numeric_limits<int32_t>::max())) {
-                HttpJsonError(resp, "out_of_range",
-                              "token_ids element is outside the int32 range",
-                              "token_ids", index);
-                return false;
-            }
-            token_id = static_cast<int32_t>(unsigned_value);
-        } else {
-            HttpJsonError(resp, "invalid_type",
-                          "token_ids element must be a JSON integer",
-                          "token_ids", index);
-            return false;
-        }
-        token_ids->push_back(token_id);
-    }
-    return true;
-}
-
 struct QueryRequest {
     prefixindex::ContextKey context;
     std::vector<int32_t> token_ids;
@@ -387,55 +382,225 @@ struct QueryRequest {
     std::optional<std::string> instance_filter;
 };
 
-bool ParseQueryRequest(const Json::Value& body, coro_http_response& resp,
-                       QueryRequest* request) {
-    static const std::set<std::string> kAllowedFields = {
-        "block_size", "cache_salt", "instance_id", "lora_name",
-        "model",      "tenant_id",  "token_ids"};
-    if (!RejectUnknownFields(body, kAllowedFields, resp)) {
+// Decodes one little-endian int32 from a msgpack bin token_ids element.
+int32_t DecodeLeInt32(const char* p) {
+    const uint32_t v =
+        static_cast<uint32_t>(static_cast<unsigned char>(p[0])) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(p[1])) << 8) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(p[2])) << 16) |
+        (static_cast<uint32_t>(static_cast<unsigned char>(p[3])) << 24);
+    return static_cast<int32_t>(v);
+}
+
+// Parses a /query request body encoded as msgpack (Content-Type:
+// application/msgpack). Same schema and validation semantics as
+// ParseQueryRequest; token_ids may be a msgpack bin of little-endian int32
+// (preferred: 4 bytes/token, no per-element parsing) or an array of integers.
+// Errors are reported as JSON regardless of request encoding.
+bool ParseQueryMsgpackRequest(coro_http_request& req, coro_http_response& resp,
+                              QueryRequest* request) {
+    const auto body = req.get_body();
+    msgpack::object_handle handle;
+    try {
+        handle = msgpack::unpack(body.data(), body.size());
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Failed to decode query msgpack err=" << e.what();
+        HttpValidationError(resp, "invalid_msgpack", "Invalid msgpack object");
+        return false;
+    }
+    const msgpack::object root = handle.get();
+    if (root.type != msgpack::type::MAP) {
+        HttpValidationError(resp, "invalid_msgpack",
+                            "request body must be a msgpack map");
         return false;
     }
 
-    if (!RequiredString(body, "model", resp, &request->context.model_name) ||
-        !RequiredPositiveInt64(body, "block_size", resp,
-                               &request->context.block_size) ||
-        !ParseQueryTokenIds(body, resp, &request->token_ids) ||
-        !OptionalStringStrict(body, "tenant_id", "default", resp,
-                              &request->context.tenant_id) ||
-        !OptionalStringStrict(body, "lora_name", "", resp,
-                              &request->context.lora_name)) {
+    bool have_model = false;
+    bool have_block_size = false;
+    bool have_token_ids = false;
+    request->cache_salt.reset();
+    request->instance_filter.reset();
+
+    const msgpack::object_map& map = root.via.map;
+    for (uint32_t i = 0; i < map.size; ++i) {
+        const msgpack::object_kv& kv = map.ptr[i];
+        if (kv.key.type != msgpack::type::STR) {
+            HttpValidationError(resp, "invalid_msgpack",
+                                "map keys must be strings");
+            return false;
+        }
+        const std::string_view key(kv.key.via.str.ptr, kv.key.via.str.size);
+        const msgpack::object& value = kv.val;
+
+        if (key == "model") {
+            if (value.type != msgpack::type::STR) {
+                HttpValidationError(resp, "invalid_type",
+                                    "model must be a string", "model");
+                return false;
+            }
+            request->context.model_name.assign(value.via.str.ptr,
+                                               value.via.str.size);
+            if (request->context.model_name.empty()) {
+                HttpValidationError(resp, "invalid_value",
+                                    "model must not be empty", "model");
+                return false;
+            }
+            have_model = true;
+        } else if (key == "block_size") {
+            if (value.type == msgpack::type::POSITIVE_INTEGER) {
+                if (value.via.u64 == 0 ||
+                    value.via.u64 > static_cast<uint64_t>(
+                                        std::numeric_limits<int64_t>::max())) {
+                    HttpValidationError(resp, "out_of_range",
+                                        "block_size must be a positive integer",
+                                        "block_size");
+                    return false;
+                }
+                request->context.block_size =
+                    static_cast<int64_t>(value.via.u64);
+                have_block_size = true;
+            } else if (value.type == msgpack::type::NEGATIVE_INTEGER) {
+                HttpValidationError(resp, "out_of_range",
+                                    "block_size must be a positive integer",
+                                    "block_size");
+                return false;
+            } else {
+                HttpValidationError(resp, "invalid_type",
+                                    "block_size must be an integer",
+                                    "block_size");
+                return false;
+            }
+        } else if (key == "token_ids") {
+            request->token_ids.clear();
+            if (value.type == msgpack::type::BIN) {
+                const msgpack::object_bin& bin = value.via.bin;
+                if (bin.size % sizeof(int32_t) != 0) {
+                    HttpValidationError(
+                        resp, "invalid_value",
+                        "token_ids bin size must be a multiple of 4",
+                        "token_ids");
+                    return false;
+                }
+                const size_t count = bin.size / sizeof(int32_t);
+                request->token_ids.reserve(count);
+                for (size_t t = 0; t < count; ++t) {
+                    request->token_ids.push_back(
+                        DecodeLeInt32(bin.ptr + t * sizeof(int32_t)));
+                }
+            } else if (value.type == msgpack::type::ARRAY) {
+                const msgpack::object_array& array = value.via.array;
+                request->token_ids.reserve(array.size);
+                for (uint32_t t = 0; t < array.size; ++t) {
+                    const msgpack::object& element = array.ptr[t];
+                    int64_t token_id = 0;
+                    if (element.type == msgpack::type::POSITIVE_INTEGER) {
+                        if (element.via.u64 >
+                            static_cast<uint64_t>(
+                                std::numeric_limits<int32_t>::max())) {
+                            HttpValidationError(
+                                resp, "out_of_range",
+                                "token_ids element is outside the int32 range",
+                                "token_ids", t);
+                            return false;
+                        }
+                        token_id = static_cast<int64_t>(element.via.u64);
+                    } else if (element.type ==
+                               msgpack::type::NEGATIVE_INTEGER) {
+                        if (element.via.i64 <
+                            std::numeric_limits<int32_t>::min()) {
+                            HttpValidationError(
+                                resp, "out_of_range",
+                                "token_ids element is outside the int32 range",
+                                "token_ids", t);
+                            return false;
+                        }
+                        token_id = element.via.i64;
+                    } else {
+                        HttpValidationError(
+                            resp, "invalid_type",
+                            "token_ids element must be an integer", "token_ids",
+                            t);
+                        return false;
+                    }
+                    request->token_ids.push_back(
+                        static_cast<int32_t>(token_id));
+                }
+            } else {
+                HttpValidationError(resp, "invalid_type",
+                                    "token_ids must be a bin or an array",
+                                    "token_ids");
+                return false;
+            }
+            have_token_ids = true;
+        } else if (key == "tenant_id") {
+            if (value.type != msgpack::type::STR) {
+                HttpValidationError(resp, "invalid_type",
+                                    "tenant_id must be a string", "tenant_id");
+                return false;
+            }
+            request->context.tenant_id.assign(value.via.str.ptr,
+                                              value.via.str.size);
+        } else if (key == "lora_name") {
+            if (value.type != msgpack::type::STR) {
+                HttpValidationError(resp, "invalid_type",
+                                    "lora_name must be a string", "lora_name");
+                return false;
+            }
+            request->context.lora_name.assign(value.via.str.ptr,
+                                              value.via.str.size);
+        } else if (key == "cache_salt") {
+            if (value.type == msgpack::type::NIL) {
+                // no salt
+            } else if (value.type == msgpack::type::STR) {
+                const std::string salt(value.via.str.ptr, value.via.str.size);
+                if (!salt.empty()) {
+                    request->cache_salt = salt;
+                }
+            } else {
+                HttpValidationError(resp, "invalid_type",
+                                    "cache_salt must be a string or null",
+                                    "cache_salt");
+                return false;
+            }
+        } else if (key == "instance_id") {
+            if (value.type != msgpack::type::STR) {
+                HttpValidationError(resp, "invalid_type",
+                                    "instance_id must be a string",
+                                    "instance_id");
+                return false;
+            }
+            request->instance_filter =
+                std::string(value.via.str.ptr, value.via.str.size);
+        } else {
+            const std::string field(key);
+            HttpValidationError(resp, "unknown_field",
+                                "unsupported request field: " + field,
+                                field.c_str());
+            return false;
+        }
+    }
+
+    if (!have_model) {
+        HttpValidationError(resp, "missing", "model is required", "model");
+        return false;
+    }
+    if (!have_block_size) {
+        HttpValidationError(resp, "missing", "block_size is required",
+                            "block_size");
+        return false;
+    }
+    if (!have_token_ids) {
+        HttpValidationError(resp, "missing", "token_ids is required",
+                            "token_ids");
         return false;
     }
     if (request->context.tenant_id.empty()) {
         request->context.tenant_id = "default";
     }
-
-    request->cache_salt.reset();
-    if (body.isMember("cache_salt") && !body["cache_salt"].isNull()) {
-        if (!body["cache_salt"].isString()) {
-            HttpJsonError(resp, "invalid_type",
-                          "cache_salt must be a string or null", "cache_salt");
-            return false;
-        }
-        const std::string value = body["cache_salt"].asString();
-        if (!value.empty()) {
-            request->cache_salt = value;
-        }
-    }
-
-    request->instance_filter.reset();
-    if (body.isMember("instance_id")) {
-        if (!body["instance_id"].isString()) {
-            HttpJsonError(resp, "invalid_type", "instance_id must be a string",
-                          "instance_id");
-            return false;
-        }
-        request->instance_filter = body["instance_id"].asString();
-    }
     return true;
 }
 
-bool ParseServiceConfigRequest(const Json::Value& body,
+bool ParseServiceConfigRequest(const msgpack::object_map& body,
                                coro_http_response& resp,
                                common::ServiceConfig* service) {
     static const std::set<std::string> kAllowedFields = {
@@ -462,8 +627,8 @@ bool ParseServiceConfigRequest(const Json::Value& body,
     }
     const auto publisher_kind = common::ParsePublisherKind(publisher_type);
     if (!publisher_kind.has_value()) {
-        HttpJsonError(resp, "invalid_value", "type must be vLLM or Mooncake",
-                      "type");
+        HttpValidationError(resp, "invalid_value",
+                            "type must be vLLM or Mooncake", "type");
         return false;
     }
     service->publisher_kind = *publisher_kind;
@@ -471,91 +636,116 @@ bool ParseServiceConfigRequest(const Json::Value& body,
         service->tenant_id = "default";
     }
 
-    if (!body.isMember("dp_rank")) {
-        HttpJsonError(resp, "missing", "dp_rank is required", "dp_rank");
+    const msgpack::object* dp_rank_value = MapFind(body, "dp_rank");
+    if (dp_rank_value == nullptr) {
+        HttpValidationError(resp, "missing", "dp_rank is required", "dp_rank");
         return false;
     }
     int64_t dp_rank = 0;
-    if (!JsonInt64(body["dp_rank"], &dp_rank)) {
-        HttpJsonError(resp, "invalid_type", "dp_rank must be an integer",
-                      "dp_rank");
+    if (!MsgpackInt64(*dp_rank_value, &dp_rank)) {
+        HttpValidationError(resp, "invalid_type", "dp_rank must be an integer",
+                            "dp_rank");
         return false;
     }
     if (dp_rank < 0 ||
         dp_rank > static_cast<int64_t>(std::numeric_limits<int>::max())) {
-        HttpJsonError(resp, "out_of_range",
-                      "dp_rank must be a non-negative int", "dp_rank");
+        HttpValidationError(resp, "out_of_range",
+                            "dp_rank must be a non-negative int", "dp_rank");
         return false;
     }
     service->dp_rank = static_cast<int>(dp_rank);
 
     if (const std::string error = ValidateServiceConfig(*service);
         !error.empty()) {
-        HttpJsonError(resp, "invalid_registration", error);
+        HttpValidationError(resp, "invalid_registration", error);
         return false;
     }
     return true;
 }
 
-Json::Value CacheHitResultToJson(const prefixindex::CacheHitResult& result) {
-    Json::Value out(Json::objectValue);
-    out["longest_matched"] = Json::Value::Int64(result.longest_match_tokens);
-    Json::Value dp(Json::objectValue);
+void PackCacheHitResult(MsgpackPacker& packer,
+                        const prefixindex::CacheHitResult& result) {
+    packer.pack_map(6);
+    packer.pack("longest_matched");
+    packer.pack(result.longest_match_tokens);
+    packer.pack("dp");
+    packer.pack_map(static_cast<uint32_t>(result.dp.size()));
     for (const auto& [rank, tokens] : result.dp) {
-        // map<int64,int64> is serialised with decimal-string keys (JSON wire
-        // contract).
-        dp[std::to_string(rank)] = Json::Value::Int64(tokens);
+        // Rank keys keep their decimal-string form from the previous wire
+        // contract.
+        packer.pack(std::to_string(rank));
+        packer.pack(tokens);
     }
-    out["dp"] = dp;
-    Json::Value rank_matches(Json::objectValue);
+    packer.pack("rank_matches");
+    packer.pack_map(static_cast<uint32_t>(result.rank_matches.size()));
     for (const auto& [rank, match] : result.rank_matches) {
-        Json::Value rank_match(Json::objectValue);
-        rank_match["gpu"] = Json::Value::Int64(match.gpu);
-        rank_match["cpu"] = Json::Value::Int64(match.cpu);
-        rank_match["disk"] = Json::Value::Int64(match.disk);
-        rank_matches[std::to_string(rank)] = rank_match;
+        packer.pack(std::to_string(rank));
+        packer.pack_map(3);
+        packer.pack("gpu");
+        packer.pack(match.gpu);
+        packer.pack("cpu");
+        packer.pack(match.cpu);
+        packer.pack("disk");
+        packer.pack(match.disk);
     }
-    out["rank_matches"] = rank_matches;
-    out["gpu"] = Json::Value::Int64(result.gpu);
-    out["cpu"] = Json::Value::Int64(result.cpu);
-    out["disk"] = Json::Value::Int64(result.disk);
-    return out;
+    packer.pack("gpu");
+    packer.pack(result.gpu);
+    packer.pack("cpu");
+    packer.pack(result.cpu);
+    packer.pack("disk");
+    packer.pack(result.disk);
 }
 
-Json::Value HashProfileToJson(const common::ResolvedHashProfile& profile) {
-    Json::Value out(Json::objectValue);
+void PackHashProfile(MsgpackPacker& packer,
+                     const common::ResolvedHashProfile& profile) {
     // Keep the resolved profile fields in one place so /services and
     // /global_view cannot drift when a new recipe is added.  root_digest is
     // intentionally emitted here only as a derived diagnostic; it is not
     // accepted by ParseHashProfileConfig as registration input.
-    out["strategy"] = profile.strategy;
-    out["algorithm"] = profile.algorithm;
-    out["python_hash_seed"] = profile.python_hash_seed;
-    out["root_digest"] = profile.root_digest;
-    out["index_projection"] = profile.index_projection;
-    return out;
+    packer.pack_map(5);
+    packer.pack("strategy");
+    packer.pack(profile.strategy);
+    packer.pack("algorithm");
+    packer.pack(profile.algorithm);
+    packer.pack("python_hash_seed");
+    packer.pack(profile.python_hash_seed);
+    packer.pack("root_digest");
+    packer.pack(profile.root_digest);
+    packer.pack("index_projection");
+    packer.pack(profile.index_projection);
 }
 
-Json::Value ServiceConfigToJson(const common::ServiceConfig& svc) {
+void PackServiceConfig(MsgpackPacker& packer,
+                       const common::ServiceConfig& svc) {
     // Field names are the exported struct-field names of
-    // common.ServiceConfig (fixed JSON wire contract).
-    Json::Value out(Json::objectValue);
-    out["Endpoint"] = svc.endpoint;
-    out["ReplayEndpoint"] = svc.replay_endpoint;
-    out["Type"] = std::string(common::PublisherKindName(svc.publisher_kind));
-    out["ModelName"] = svc.model_name;
-    out["LoraName"] = svc.lora_name;
-    out["TenantID"] = svc.tenant_id;
-    out["InstanceID"] = svc.instance_id;
-    out["BlockSize"] = Json::Value::Int64(svc.block_size);
-    out["DPRank"] = svc.dp_rank;
+    // common.ServiceConfig (fixed wire contract).
+    packer.pack_map(11);
+    packer.pack("Endpoint");
+    packer.pack(svc.endpoint);
+    packer.pack("ReplayEndpoint");
+    packer.pack(svc.replay_endpoint);
+    packer.pack("Type");
+    packer.pack(std::string(common::PublisherKindName(svc.publisher_kind)));
+    packer.pack("ModelName");
+    packer.pack(svc.model_name);
+    packer.pack("LoraName");
+    packer.pack(svc.lora_name);
+    packer.pack("TenantID");
+    packer.pack(svc.tenant_id);
+    packer.pack("InstanceID");
+    packer.pack(svc.instance_id);
+    packer.pack("BlockSize");
+    packer.pack(svc.block_size);
+    packer.pack("DPRank");
+    packer.pack(svc.dp_rank);
+    packer.pack("CacheGroup");
     if (svc.cache_group.has_value()) {
-        out["CacheGroup"] = Json::Value::Int64(*svc.cache_group);
+        packer.pack(*svc.cache_group);
     } else {
-        out["CacheGroup"] = Json::Value(Json::nullValue);
+        packer.pack_nil();
     }
-    out["HashProfile"] = HashProfileToJson(svc.hash_profile);
-    return out;
+    packer.pack("HashProfile");
+    PackHashProfile(packer, svc.hash_profile);
 }
 
 }  // namespace
@@ -862,31 +1052,41 @@ void EventManager::RegisterHttpHandlers() {
     auto* server = http_server_.get();
 
     // ---- /query ---------------------------------------------------------
+    // msgpack-only protocol (JSON support was dropped during development:
+    // JsonCpp DOM parsing dominates cost at long context). token_ids may be
+    // a bin of little-endian int32 or an integer array. Responses and error
+    // bodies remain JSON.
     server->set_http_handler<POST>(
         "/query", [this](coro_http_request& req, coro_http_response& resp) {
             VLOG(1) << "receive req method=POST path=/query";
 
-            Json::Value body;
-            if (!ParseQueryJsonBody(req, resp, &body)) {
+            const std::string_view content_type =
+                req.get_header_value("content-type");
+            if (content_type.find("application/msgpack") ==
+                std::string_view::npos) {
+                HttpValidationError(resp, "unsupported_content_type",
+                                    "Content-Type must be application/msgpack");
                 return;
             }
 
             QueryRequest query;
-            if (!ParseQueryRequest(body, resp, &query)) {
+            if (!ParseQueryMsgpackRequest(req, resp, &query)) {
                 return;
             }
 
             const auto results =
                 indexer_.Query(query.context, query.token_ids, query.cache_salt,
                                query.instance_filter);
-            Json::Value instances(Json::objectValue);
+            msgpack::sbuffer body;
+            MsgpackPacker packer(&body);
+            packer.pack_map(1);
+            packer.pack("instances");
+            packer.pack_map(static_cast<uint32_t>(results.size()));
             for (const auto& [instance_id, result] : results) {
-                instances[instance_id] = CacheHitResultToJson(result);
+                packer.pack(instance_id);
+                PackCacheHitResult(packer, result);
             }
-
-            Json::Value response_result(Json::objectValue);
-            response_result["instances"] = instances;
-            HttpJson(resp, response_result);
+            HttpMsgpack(resp, status_type::ok, body);
         });
     server->set_http_handler<GET>("/query", [](coro_http_request&,
                                                coro_http_response& resp) {
@@ -896,8 +1096,9 @@ void EventManager::RegisterHttpHandlers() {
     // ---- /register ------------------------------------------------------
     server->set_http_handler<POST>(
         "/register", [this](coro_http_request& req, coro_http_response& resp) {
-            Json::Value body;
-            if (!ParseJsonBody(req, resp, "register", &body)) {
+            msgpack::object_handle handle;
+            msgpack::object_map body{};
+            if (!ParseMsgpackBody(req, resp, "register", &handle, &body)) {
                 return;
             }
 
@@ -917,7 +1118,7 @@ void EventManager::RegisterHttpHandlers() {
                         HttpError(resp, status_type::internal_server_error,
                                   "Failed to subscribe: " + err);
                     } else {
-                        HttpJsonError(resp, "invalid_registration", err);
+                        HttpValidationError(resp, "invalid_registration", err);
                     }
                     return;
                 }
@@ -926,10 +1127,14 @@ void EventManager::RegisterHttpHandlers() {
                 }
             }
 
-            Json::Value out(Json::objectValue);
-            out["status"] = "registered successfully";
-            out["instance_id"] = svc.instance_id;
-            HttpJson(resp, out);
+            msgpack::sbuffer response_body;
+            MsgpackPacker packer(&response_body);
+            packer.pack_map(2);
+            packer.pack("status");
+            packer.pack("registered successfully");
+            packer.pack("instance_id");
+            packer.pack(svc.instance_id);
+            HttpMsgpack(resp, status_type::ok, response_body);
         });
     server->set_http_handler<GET>("/register", [](coro_http_request&,
                                                   coro_http_response& resp) {
@@ -940,8 +1145,9 @@ void EventManager::RegisterHttpHandlers() {
     server->set_http_handler<POST>(
         "/unregister",
         [this](coro_http_request& req, coro_http_response& resp) {
-            Json::Value body;
-            if (!ParseJsonBody(req, resp, "unregister", &body)) {
+            msgpack::object_handle handle;
+            msgpack::object_map body{};
+            if (!ParseMsgpackBody(req, resp, "unregister", &handle, &body)) {
                 return;
             }
 
@@ -960,17 +1166,20 @@ void EventManager::RegisterHttpHandlers() {
             if (target_tenant.empty()) {
                 target_tenant = "default";
             }
-            if (!body.isMember("dp_rank")) {
-                HttpJsonError(resp, "missing", "dp_rank is required",
-                              "dp_rank");
+            const msgpack::object* dp_rank_value = MapFind(body, "dp_rank");
+            if (dp_rank_value == nullptr) {
+                HttpValidationError(resp, "missing", "dp_rank is required",
+                                    "dp_rank");
                 return;
             }
             int64_t parsed_rank = 0;
-            if (!JsonInt64(body["dp_rank"], &parsed_rank) || parsed_rank < 0 ||
+            if (!MsgpackInt64(*dp_rank_value, &parsed_rank) ||
+                parsed_rank < 0 ||
                 parsed_rank >
                     static_cast<int64_t>(std::numeric_limits<int>::max())) {
-                HttpJsonError(resp, "invalid_value",
-                              "dp_rank must be a non-negative int", "dp_rank");
+                HttpValidationError(resp, "invalid_value",
+                                    "dp_rank must be a non-negative int",
+                                    "dp_rank");
                 return;
             }
             const int dp_rank = static_cast<int>(parsed_rank);
@@ -991,12 +1200,15 @@ void EventManager::RegisterHttpHandlers() {
                 return;
             }
 
-            Json::Value out(Json::objectValue);
-            out["status"] = "unregistered successfully";
-            Json::Value removed(Json::arrayValue);
-            removed.append(target_key);
-            out["removed_instances"] = removed;
-            HttpJson(resp, out);
+            msgpack::sbuffer response_body;
+            MsgpackPacker packer(&response_body);
+            packer.pack_map(2);
+            packer.pack("status");
+            packer.pack("unregistered successfully");
+            packer.pack("removed_instances");
+            packer.pack_array(1);
+            packer.pack(target_key);
+            HttpMsgpack(resp, status_type::ok, response_body);
         });
     server->set_http_handler<GET>("/unregister", [](coro_http_request&,
                                                     coro_http_response& resp) {
@@ -1008,38 +1220,40 @@ void EventManager::RegisterHttpHandlers() {
         "/global_view", [this](coro_http_request&, coro_http_response& resp) {
             const auto global_view = indexer_.GetGlobalView();
 
-            Json::Value out(Json::objectValue);
-            out["context_count"] = global_view.context_count;
-            Json::Value contexts(Json::arrayValue);
+            msgpack::sbuffer body;
+            MsgpackPacker packer(&body);
+            packer.pack_map(2);
+            packer.pack("context_count");
+            packer.pack(static_cast<uint64_t>(global_view.context_count));
+            packer.pack("contexts");
+            packer.pack_array(
+                static_cast<uint32_t>(global_view.contexts.size()));
             for (const auto& view : global_view.contexts) {
-                Json::Value c(Json::objectValue);
-                c["model_name"] = view.context.model_name;
-                c["lora_name"] = view.context.lora_name;
-                c["block_size"] = Json::Value::Int64(view.context.block_size);
-                c["tenant_id"] = view.context.tenant_id;
-                c["prefix_count"] = Json::Value::UInt64(view.prefix_count);
-
-                Json::Value profile(Json::objectValue);
-                profile["strategy"] = view.profile.strategy;
-                profile["algorithm"] = view.profile.algorithm;
-                profile["python_hash_seed"] = view.profile.python_hash_seed;
-                profile["root_digest"] = view.profile.root_digest;
-                profile["index_projection"] = view.profile.index_projection;
-                c["hash_profile"] = profile;
-
-                Json::Value instances(Json::objectValue);
+                packer.pack_map(7);
+                packer.pack("model_name");
+                packer.pack(view.context.model_name);
+                packer.pack("lora_name");
+                packer.pack(view.context.lora_name);
+                packer.pack("block_size");
+                packer.pack(view.context.block_size);
+                packer.pack("tenant_id");
+                packer.pack(view.context.tenant_id);
+                packer.pack("prefix_count");
+                packer.pack(static_cast<uint64_t>(view.prefix_count));
+                packer.pack("hash_profile");
+                PackHashProfile(packer, view.profile);
+                packer.pack("instances");
+                packer.pack_map(
+                    static_cast<uint32_t>(view.instance_ranks.size()));
                 for (const auto& [instance_id, ranks] : view.instance_ranks) {
-                    Json::Value rank_values(Json::arrayValue);
+                    packer.pack(instance_id);
+                    packer.pack_array(static_cast<uint32_t>(ranks.size()));
                     for (const int64_t rank : ranks) {
-                        rank_values.append(Json::Value::Int64(rank));
+                        packer.pack(rank);
                     }
-                    instances[instance_id] = rank_values;
                 }
-                c["instances"] = instances;
-                contexts.append(c);
             }
-            out["contexts"] = contexts;
-            HttpJson(resp, out);
+            HttpMsgpack(resp, status_type::ok, body);
         });
     server->set_http_handler<POST>(
         "/global_view", [](coro_http_request&, coro_http_response& resp) {
@@ -1052,26 +1266,21 @@ void EventManager::RegisterHttpHandlers() {
         "/services", [this](coro_http_request&, coro_http_response& resp) {
             VLOG(1) << "receive req method=GET path=/services";
 
-            Json::Value services(Json::arrayValue);
-            int count = 0;
+            msgpack::sbuffer body;
+            MsgpackPacker packer(&body);
+            packer.pack_map(2);
+            packer.pack("count");
             {
                 std::shared_lock lock(mu_);
+                packer.pack(static_cast<uint64_t>(active_configs_.size()));
+                packer.pack("services");
+                packer.pack_array(
+                    static_cast<uint32_t>(active_configs_.size()));
                 for (const auto& [key, svc] : active_configs_) {
-                    services.append(ServiceConfigToJson(svc));
-                    ++count;
+                    PackServiceConfig(packer, svc);
                 }
             }
-
-            Json::Value out(Json::objectValue);
-            out["count"] = count;
-            out["services"] = services;
-            // This endpoint writes the JSON body with no trailing newline,
-            // unlike the other endpoints (fixed wire contract).
-            Json::StreamWriterBuilder wb;
-            wb["indentation"] = "";
-            resp.add_header("Content-Type", kApplicationJson);
-            resp.set_status_and_content(status_type::ok,
-                                        Json::writeString(wb, out));
+            HttpMsgpack(resp, status_type::ok, body);
         });
     server->set_http_handler<POST>("/services", [](coro_http_request&,
                                                    coro_http_response& resp) {

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -509,6 +509,24 @@ std::string Sha256(std::span<const uint8_t> input,
     return "";
 }
 
+// Same as Sha256 but reuses a caller-owned context across invocations,
+// avoiding an EVP_MD_CTX allocation per hashed block in long hash chains.
+std::string Sha256Reuse(EVP_MD_CTX* context, std::span<const uint8_t> input,
+                        std::array<uint8_t, kSha256DigestSize>* digest) {
+    if (EVP_MD_CTX_reset(context) != 1 ||
+        EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(context, input.data(), input.size()) != 1) {
+        return "OpenSSL EVP SHA-256 initialization failed";
+    }
+
+    unsigned int digest_size = 0;
+    if (EVP_DigestFinal_ex(context, digest->data(), &digest_size) != 1 ||
+        digest_size != digest->size()) {
+        return "OpenSSL EVP SHA-256 finalization failed";
+    }
+    return "";
+}
+
 int LowerHexValue(char value) {
     if (value >= '0' && value <= '9') {
         return value - '0';
@@ -640,6 +658,20 @@ class VllmV1HashStrategy final : public HashStrategy {
         std::vector<HashBlock> computed;
         computed.reserve(block_count);
 
+        // Reused across blocks: every codec clears the buffer at the start of
+        // EncodeBlock, so a single allocation with worst-case capacity avoids
+        // a malloc/free per block (dominant cost at large block counts).
+        std::vector<uint8_t> encoded;
+        encoded.reserve(64 + block_size * 9);
+
+        // One EVP context for the whole chain, reset per block.
+        using EvpContext =
+            std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+        EvpContext evp(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+        if (!evp) {
+            return "OpenSSL EVP MD context allocation failed";
+        }
+
         std::array<uint8_t, kSha256DigestSize> parent = root_digest_;
         for (size_t block_index = 0; block_index < block_count; ++block_index) {
             const bool has_lora = !context.lora_name.empty();
@@ -653,11 +685,11 @@ class VllmV1HashStrategy final : public HashStrategy {
                 .cache_salt = has_salt ? &*cache_salt : nullptr,
             };
 
-            std::vector<uint8_t> encoded;
             codec_->EncodeBlock(values, &encoded);
 
             HashBlock block;
-            if (std::string error = Sha256(encoded, &block.digest);
+            if (std::string error =
+                    Sha256Reuse(evp.get(), encoded, &block.digest);
                 !error.empty()) {
                 return error;
             }

--- a/mooncake-conductor/tests/cache_aware_proxy/_support.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/_support.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import json
+import struct
 import sys
 from collections.abc import Awaitable, Callable
 from pathlib import Path
@@ -77,6 +78,23 @@ def request_json(request: httpx.Request) -> dict[str, Any]:
     return body
 
 
+def request_msgpack(request: httpx.Request) -> dict[str, Any]:
+    """Decodes a msgpack /query request body.
+
+    token_ids travel as a bin of little-endian int32; they are converted back
+    to a list[int] so assertions read like the old JSON payloads.
+    """
+    import msgpack
+
+    body = msgpack.unpackb(request.content, raw=False)
+    assert isinstance(body, dict)
+    token_ids = body.get("token_ids")
+    if isinstance(token_ids, bytes):
+        count = len(token_ids) // 4
+        body["token_ids"] = list(struct.unpack(f"<{count}i", token_ids))
+    return body
+
+
 Handler = Callable[[httpx.Request], Awaitable[httpx.Response]]
 
 
@@ -103,13 +121,24 @@ class RecordingClientFactory:
         return client
 
 
+def msgpack_response(status: int, payload: dict[str, Any]) -> httpx.Response:
+    """Builds an httpx response with a msgpack body (conductor wire format)."""
+    import msgpack
+
+    return httpx.Response(
+        status,
+        content=msgpack.packb(payload, use_bin_type=True),
+        headers={"Content-Type": "application/msgpack"},
+    )
+
+
 async def registration_success_handler(request: httpx.Request) -> httpx.Response:
     if request.url.path != "/register":
         raise AssertionError(f"unexpected request: {request.method} {request.url}")
-    payload = request_json(request)
-    return httpx.Response(
+    payload = request_msgpack(request)
+    return msgpack_response(
         200,
-        json={
+        {
             "status": "registered successfully",
             "instance_id": payload["instance_id"],
         },

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_conductor.py
@@ -8,7 +8,8 @@ from _support import (
     RecordingClientFactory,
     proxy,
     registration_success_handler,
-    request_json,
+    msgpack_response,
+    request_msgpack,
     valid_config,
 )
 
@@ -98,7 +99,7 @@ class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
             nonlocal calls
             calls += 1
             if calls == 2:
-                return httpx.Response(400, json={"reason": "invalid_registration"})
+                return msgpack_response(400, {"reason": "invalid_registration"})
             return await registration_success_handler(request)
 
         factory = RecordingClientFactory(handler)
@@ -134,10 +135,9 @@ class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_registration_rejects_unexpected_success_body(self) -> None:
         async def handler(request: httpx.Request) -> httpx.Response:
-            payload = request_json(request)
-            return httpx.Response(
-                200,
-                json={"status": "ok", "instance_id": payload["instance_id"]},
+            payload = request_msgpack(request)
+            return msgpack_response(
+                200, {"status": "ok", "instance_id": payload["instance_id"]}
             )
 
         factory = RecordingClientFactory(handler)
@@ -149,7 +149,7 @@ class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_query_payload_forwards_optional_cache_salt_and_timeout(self) -> None:
         async def handler(request: httpx.Request) -> httpx.Response:
-            return httpx.Response(200, json={"instances": {}})
+            return msgpack_response(200, {"instances": {}})
 
         config = valid_config()
         factory = RecordingClientFactory(handler)
@@ -172,8 +172,8 @@ class ConductorClientTest(unittest.IsolatedAsyncioTestCase):
             "request-2",
         )
 
-        salted = request_json(factory.requests[0])
-        unsalted = request_json(factory.requests[1])
+        salted = request_msgpack(factory.requests[0])
+        unsalted = request_msgpack(factory.requests[1])
         self.assertEqual(
             {
                 "model": "test-model",

--- a/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_endpoints.py
+++ b/mooncake-conductor/tests/cache_aware_proxy/test_cache_aware_proxy_endpoints.py
@@ -6,7 +6,14 @@ from unittest.mock import patch
 
 import httpx
 
-from _support import RecordingClientFactory, proxy, request_json, valid_config
+from _support import (
+    RecordingClientFactory,
+    msgpack_response,
+    proxy,
+    request_json,
+    request_msgpack,
+    valid_config,
+)
 
 
 class EndpointTest(unittest.IsolatedAsyncioTestCase):
@@ -20,18 +27,18 @@ class EndpointTest(unittest.IsolatedAsyncioTestCase):
             outbound.append(request)
             path = request.url.path
             if request.url.host == "conductor.test" and path == "/register":
-                payload = request_json(request)
-                return httpx.Response(
+                payload = request_msgpack(request)
+                return msgpack_response(
                     200,
-                    json={
+                    {
                         "status": "registered successfully",
                         "instance_id": payload["instance_id"],
                     },
                 )
             if request.url.host == "conductor.test" and path == "/query":
-                return httpx.Response(
+                return msgpack_response(
                     200,
-                    json={
+                    {
                         "instances": {
                             "prefill-a": {
                                 "longest_matched": 16,
@@ -125,7 +132,7 @@ class EndpointTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, tokenize_body["max_tokens"])
         self.assertNotIn("stream_options", tokenize_body)
 
-        self.assertEqual("salt-a", request_json(query)["cache_salt"])
+        self.assertEqual("salt-a", request_msgpack(query)["cache_salt"])
 
         prefill_body = request_json(prefill)
         self.assertFalse(prefill_body["stream"])
@@ -156,18 +163,18 @@ class EndpointTest(unittest.IsolatedAsyncioTestCase):
             outbound.append(request)
             path = request.url.path
             if request.url.host == "conductor.test" and path == "/register":
-                payload = request_json(request)
-                return httpx.Response(
+                payload = request_msgpack(request)
+                return msgpack_response(
                     200,
-                    json={
+                    {
                         "status": "registered successfully",
                         "instance_id": payload["instance_id"],
                     },
                 )
             if request.url.host == "conductor.test" and path == "/query":
-                return httpx.Response(
+                return msgpack_response(
                     200,
-                    json={
+                    {
                         "instances": {
                             "prefill-a": {"longest_matched": 0},
                             "prefill-b": {"longest_matched": 0},

--- a/mooncake-conductor/tests/event_manager_test.cpp
+++ b/mooncake-conductor/tests/event_manager_test.cpp
@@ -5,6 +5,7 @@
 #include <glog/logging.h>
 #include <asio.hpp>
 #include <json/json.h>
+#include <msgpack.hpp>
 #include <ylt/coro_http/coro_http_client.hpp>
 #include <ylt/coro_http/coro_http_server.hpp>
 
@@ -198,12 +199,60 @@ HttpResponse ToHttpResponse(const Result& result) {
     return response;
 }
 
-HttpResponse HttpPostJson(uint16_t port, const std::string& path,
-                          const std::string& body) {
+// The conductor HTTP layer is msgpack-only. Tests still build bodies as
+// Json::Value for readability; MsgpackDocument converts them on the way out.
+void MsgpackPackValue(const Json::Value& value,
+                      msgpack::packer<msgpack::sbuffer>& packer) {
+    switch (value.type()) {
+        case Json::nullValue:
+            packer.pack_nil();
+            return;
+        case Json::intValue:
+            packer.pack(value.asInt64());
+            return;
+        case Json::uintValue:
+            packer.pack(value.asUInt64());
+            return;
+        case Json::realValue:
+            packer.pack(value.asDouble());
+            return;
+        case Json::stringValue:
+            packer.pack(value.asString());
+            return;
+        case Json::booleanValue:
+            packer.pack(value.asBool());
+            return;
+        case Json::arrayValue:
+            packer.pack_array(static_cast<uint32_t>(value.size()));
+            for (const auto& element : value) {
+                MsgpackPackValue(element, packer);
+            }
+            return;
+        case Json::objectValue:
+            packer.pack_map(
+                static_cast<uint32_t>(value.getMemberNames().size()));
+            for (const auto& name : value.getMemberNames()) {
+                packer.pack(name);
+                MsgpackPackValue(value[name], packer);
+            }
+            return;
+    }
+}
+
+std::string MsgpackDocument(const Json::Value& value) {
+    msgpack::sbuffer buffer;
+    msgpack::packer<msgpack::sbuffer> packer(&buffer);
+    MsgpackPackValue(value, packer);
+    return std::string(buffer.data(), buffer.size());
+}
+
+HttpResponse HttpPostMsgpack(uint16_t port, const std::string& path,
+                             const std::string& body) {
     coro_http::coro_http_client client;
     const std::string url = "http://127.0.0.1:" + std::to_string(port) + path;
     return ToHttpResponse(
-        client.post(url, body, coro_http::req_content_type::json));
+        client.post(url, body, coro_http::req_content_type::none,
+                    {{"Content-Type", "application/msgpack"}}));
 }
 
 HttpResponse HttpGet(uint16_t port, const std::string& path) {
@@ -218,12 +267,6 @@ bool ParseJsonDocument(const std::string& document, Json::Value* value,
     std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
     return reader->parse(document.data(), document.data() + document.size(),
                          value, errors);
-}
-
-std::string JsonDocument(const Json::Value& value) {
-    Json::StreamWriterBuilder builder;
-    builder["indentation"] = "";
-    return Json::writeString(builder, value);
 }
 
 Json::Value TokenArray(const std::vector<int32_t>& tokens) {
@@ -287,11 +330,65 @@ Json::Value ServiceJson(const ServiceConfig& service) {
     return value;
 }
 
-Json::Value ParseJsonResponse(const HttpResponse& response) {
-    Json::Value body;
-    std::string errors;
-    EXPECT_TRUE(ParseJsonDocument(response.body, &body, &errors)) << errors;
-    return body;
+// Decodes a msgpack response body into Json::Value so assertions stay
+// readable. The conductor HTTP layer is msgpack-only; Json::Value is used
+// here purely as a convenient assertion representation.
+Json::Value MsgpackObjectToJson(const msgpack::object& object) {
+    switch (object.type) {
+        case msgpack::type::NIL:
+            return Json::Value(Json::nullValue);
+        case msgpack::type::BOOLEAN:
+            return Json::Value(object.via.boolean);
+        case msgpack::type::POSITIVE_INTEGER:
+            // Match JsonCpp literal parsing, which produces intValue for
+            // in-range positives, so EXPECT_EQ stays type-consistent.
+            return Json::Value(Json::Int64(object.via.u64));
+        case msgpack::type::NEGATIVE_INTEGER:
+            return Json::Value(Json::Int64(object.via.i64));
+        case msgpack::type::FLOAT32:
+        case msgpack::type::FLOAT64:
+            return Json::Value(object.via.f64);
+        case msgpack::type::STR:
+            return Json::Value(
+                std::string(object.via.str.ptr, object.via.str.size));
+        case msgpack::type::BIN:
+            return Json::Value(
+                std::string(object.via.bin.ptr, object.via.bin.size));
+        case msgpack::type::ARRAY: {
+            Json::Value array(Json::arrayValue);
+            for (uint32_t i = 0; i < object.via.array.size; ++i) {
+                array.append(MsgpackObjectToJson(object.via.array.ptr[i]));
+            }
+            return array;
+        }
+        case msgpack::type::MAP: {
+            Json::Value map(Json::objectValue);
+            for (uint32_t i = 0; i < object.via.map.size; ++i) {
+                const auto& kv = object.via.map.ptr[i];
+                std::string key;
+                if (kv.key.type == msgpack::type::STR) {
+                    key.assign(kv.key.via.str.ptr, kv.key.via.str.size);
+                } else {
+                    key = "<non-string-key>";
+                }
+                map[key] = MsgpackObjectToJson(kv.val);
+            }
+            return map;
+        }
+        default:
+            return Json::Value(Json::nullValue);
+    }
+}
+
+Json::Value ParseMsgpackResponse(const HttpResponse& response) {
+    try {
+        const auto handle =
+            msgpack::unpack(response.body.data(), response.body.size());
+        return MsgpackObjectToJson(handle.get());
+    } catch (const std::exception& e) {
+        ADD_FAILURE() << "failed to decode msgpack response: " << e.what();
+        return Json::Value(Json::nullValue);
+    }
 }
 
 TEST(MakeServiceKey, IncludesRank) {
@@ -511,21 +608,20 @@ class QueryHttpTest : public ::testing::Test {
 
     HttpResponse Post(const Json::Value& body,
                       const std::string& path = "/query") const {
-        return HttpPostJson(port_, path, JsonDocument(body));
+        return HttpPostMsgpack(port_, path, MsgpackDocument(body));
     }
 
     Json::Value ValidQuery() const {
         return QueryJson(ContextFor(instance_one_), tokens_);
     }
 
-    void ExpectJsonStatus(const HttpResponse& response, int status,
-                          Json::Value* body) const {
+    void ExpectMsgpackStatus(const HttpResponse& response, int status,
+                             Json::Value* body) const {
         EXPECT_EQ(response.status, status);
         const auto content_type = response.headers.find("content-type");
         ASSERT_NE(content_type, response.headers.end());
-        EXPECT_EQ(content_type->second, "application/json");
-        std::string errors;
-        ASSERT_TRUE(ParseJsonDocument(response.body, body, &errors)) << errors;
+        EXPECT_EQ(content_type->second, "application/msgpack");
+        *body = ParseMsgpackResponse(response);
         ASSERT_TRUE(body->isObject());
     }
 
@@ -538,7 +634,8 @@ class QueryHttpTest : public ::testing::Test {
 
 TEST_F(QueryHttpTest, ReturnsExactSharedCacheResponse) {
     Json::Value body;
-    ASSERT_NO_FATAL_FAILURE(ExpectJsonStatus(Post(ValidQuery()), 200, &body));
+    ASSERT_NO_FATAL_FAILURE(
+        ExpectMsgpackStatus(Post(ValidQuery()), 200, &body));
 
     Json::Value expected;
     std::string errors;
@@ -577,7 +674,7 @@ TEST_F(QueryHttpTest, PickleProfileResolvesQueryHashes) {
 
     Json::Value body;
     ASSERT_NO_FATAL_FAILURE(
-        ExpectJsonStatus(Post(QueryJson(context, tokens_)), 200, &body));
+        ExpectMsgpackStatus(Post(QueryJson(context, tokens_)), 200, &body));
     ASSERT_TRUE(body["instances"].isMember("pickle"));
     const Json::Value& instance = body["instances"]["pickle"];
     EXPECT_EQ(instance["longest_matched"].asInt64(), 32);
@@ -589,7 +686,7 @@ TEST_F(QueryHttpTest, PickleProfileResolvesQueryHashes) {
     // their own registered profile.
     Json::Value cbor_body;
     ASSERT_NO_FATAL_FAILURE(
-        ExpectJsonStatus(Post(ValidQuery()), 200, &cbor_body));
+        ExpectMsgpackStatus(Post(ValidQuery()), 200, &cbor_body));
     EXPECT_EQ(cbor_body["instances"]["1"]["gpu"].asInt64(), 32);
 }
 
@@ -632,7 +729,7 @@ TEST_F(QueryHttpTest, ReturnsOrderedFourBlockTierBoundaries) {
                     .empty());
 
     const Json::Value body =
-        ParseJsonResponse(Post(QueryJson(ContextFor(service), tokens)));
+        ParseMsgpackResponse(Post(QueryJson(ContextFor(service), tokens)));
     Json::Value expected;
     std::string errors;
     ASSERT_TRUE(ParseJsonDocument(
@@ -645,24 +742,24 @@ TEST_F(QueryHttpTest, ReturnsOrderedFourBlockTierBoundaries) {
 }
 
 TEST_F(QueryHttpTest, FiltersCompatibleInstanceAndDropsUnknownFilter) {
-    const Json::Value unfiltered = ParseJsonResponse(Post(ValidQuery()));
+    const Json::Value unfiltered = ParseMsgpackResponse(Post(ValidQuery()));
     Json::Value query = ValidQuery();
     query["instance_id"] = "1";
-    const Json::Value selected = ParseJsonResponse(Post(query));
+    const Json::Value selected = ParseMsgpackResponse(Post(query));
     ASSERT_EQ(selected["instances"].getMemberNames(),
               (std::vector<std::string>{"1"}));
     EXPECT_EQ(selected["instances"]["1"], unfiltered["instances"]["1"]);
     ASSERT_NO_FATAL_FAILURE(ExpectRankMapsAligned(selected["instances"]["1"]));
 
     query["instance_id"] = "missing";
-    const Json::Value missing = ParseJsonResponse(Post(query));
+    const Json::Value missing = ParseMsgpackResponse(Post(query));
     EXPECT_TRUE(missing["instances"].isObject());
     EXPECT_TRUE(missing["instances"].empty());
 }
 
 TEST_F(QueryHttpTest, KeepsZeroHitRegisteredRanksInBothRankMaps) {
     const std::vector<int32_t> miss_tokens = Sequence(5000, 16);
-    const Json::Value body = ParseJsonResponse(
+    const Json::Value body = ParseMsgpackResponse(
         Post(QueryJson(ContextFor(instance_one_), miss_tokens)));
     ASSERT_EQ(body["instances"].getMemberNames(),
               (std::vector<std::string>{"1", "2"}));
@@ -687,19 +784,19 @@ TEST_F(QueryHttpTest, MissingContextReturnsEmptyWithoutCreatingState) {
     Json::Value query = ValidQuery();
     query["model"] = "missing-model";
     const auto before = manager_->GetIndexer()->GetGlobalView().context_count;
-    const Json::Value response = ParseJsonResponse(Post(query));
+    const Json::Value response = ParseMsgpackResponse(Post(query));
     EXPECT_TRUE(response["instances"].empty());
     EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, before);
 
     query = ValidQuery();
     query["tenant_id"] = "other-tenant";
-    EXPECT_TRUE(ParseJsonResponse(Post(query))["instances"].empty());
+    EXPECT_TRUE(ParseMsgpackResponse(Post(query))["instances"].empty());
     query = ValidQuery();
     query["lora_name"] = "other-lora";
-    EXPECT_TRUE(ParseJsonResponse(Post(query))["instances"].empty());
+    EXPECT_TRUE(ParseMsgpackResponse(Post(query))["instances"].empty());
     query = ValidQuery();
     query["block_size"] = 32;
-    EXPECT_TRUE(ParseJsonResponse(Post(query))["instances"].empty());
+    EXPECT_TRUE(ParseMsgpackResponse(Post(query))["instances"].empty());
     EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, before);
 }
 
@@ -723,22 +820,22 @@ TEST_F(QueryHttpTest, SaltIsRequestOnlyAndNullEmptyOmittedMeanNoSalt) {
 
     Json::Value query = QueryJson(ContextFor(salted_service), tokens);
     query["cache_salt"] = "pepper";
-    EXPECT_EQ(
-        ParseJsonResponse(Post(query))["instances"]["salted"]["gpu"].asInt64(),
-        8);
+    EXPECT_EQ(ParseMsgpackResponse(Post(query))["instances"]["salted"]["gpu"]
+                  .asInt64(),
+              8);
 
     query.removeMember("cache_salt");
-    EXPECT_EQ(
-        ParseJsonResponse(Post(query))["instances"]["salted"]["gpu"].asInt64(),
-        0);
+    EXPECT_EQ(ParseMsgpackResponse(Post(query))["instances"]["salted"]["gpu"]
+                  .asInt64(),
+              0);
     query["cache_salt"] = "";
-    EXPECT_EQ(
-        ParseJsonResponse(Post(query))["instances"]["salted"]["gpu"].asInt64(),
-        0);
+    EXPECT_EQ(ParseMsgpackResponse(Post(query))["instances"]["salted"]["gpu"]
+                  .asInt64(),
+              0);
     query["cache_salt"] = Json::Value(Json::nullValue);
-    EXPECT_EQ(
-        ParseJsonResponse(Post(query))["instances"]["salted"]["gpu"].asInt64(),
-        0);
+    EXPECT_EQ(ParseMsgpackResponse(Post(query))["instances"]["salted"]["gpu"]
+                  .asInt64(),
+              0);
 }
 
 TEST_F(QueryHttpTest, RejectsMalformedInputsBeforeLookup) {
@@ -785,32 +882,32 @@ TEST_F(QueryHttpTest, RejectsMalformedInputsBeforeLookup) {
     override_root["root_digest"] = std::string(kRootDigest);
 
     const std::vector<Case> cases = {
-        {"malformed JSON", "{not-json", "invalid_json"},
-        {"missing model", JsonDocument(missing_model), "missing"},
-        {"empty model", JsonDocument(empty_model), "invalid_value"},
-        {"wrong model", JsonDocument(wrong_model), "invalid_type"},
-        {"missing block", JsonDocument(missing_block), "missing"},
-        {"zero block", JsonDocument(zero_block), "out_of_range"},
-        {"fractional block", JsonDocument(fractional_block), "invalid_type"},
-        {"missing tokens", JsonDocument(missing_tokens), "missing"},
-        {"string token", JsonDocument(string_token), "invalid_type"},
-        {"large token", JsonDocument(large_token), "out_of_range"},
-        {"small token", JsonDocument(small_token), "out_of_range"},
-        {"bad salt", JsonDocument(bad_salt), "invalid_type"},
-        {"bad tenant", JsonDocument(bad_tenant), "invalid_type"},
-        {"bad lora", JsonDocument(bad_lora), "invalid_type"},
-        {"bad instance", JsonDocument(bad_instance), "invalid_type"},
-        {"seed override", JsonDocument(override_seed), "unknown_field"},
-        {"root override", JsonDocument(override_root), "unknown_field"},
+        {"malformed msgpack", std::string("\xc1", 1), "invalid_msgpack"},
+        {"missing model", MsgpackDocument(missing_model), "missing"},
+        {"empty model", MsgpackDocument(empty_model), "invalid_value"},
+        {"wrong model", MsgpackDocument(wrong_model), "invalid_type"},
+        {"missing block", MsgpackDocument(missing_block), "missing"},
+        {"zero block", MsgpackDocument(zero_block), "out_of_range"},
+        {"fractional block", MsgpackDocument(fractional_block), "invalid_type"},
+        {"missing tokens", MsgpackDocument(missing_tokens), "missing"},
+        {"string token", MsgpackDocument(string_token), "invalid_type"},
+        {"large token", MsgpackDocument(large_token), "out_of_range"},
+        {"small token", MsgpackDocument(small_token), "out_of_range"},
+        {"bad salt", MsgpackDocument(bad_salt), "invalid_type"},
+        {"bad tenant", MsgpackDocument(bad_tenant), "invalid_type"},
+        {"bad lora", MsgpackDocument(bad_lora), "invalid_type"},
+        {"bad instance", MsgpackDocument(bad_instance), "invalid_type"},
+        {"seed override", MsgpackDocument(override_seed), "unknown_field"},
+        {"root override", MsgpackDocument(override_root), "unknown_field"},
     };
 
     const auto before = manager_->GetIndexer()->GetGlobalView();
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
         const HttpResponse response =
-            HttpPostJson(port_, "/query", test_case.body);
+            HttpPostMsgpack(port_, "/query", test_case.body);
         EXPECT_EQ(response.status, 400);
-        const Json::Value error = ParseJsonResponse(response);
+        const Json::Value error = ParseMsgpackResponse(response);
         EXPECT_EQ(error["reason"].asString(), test_case.reason);
         const auto after = manager_->GetIndexer()->GetGlobalView();
         EXPECT_EQ(after.context_count, before.context_count);
@@ -825,7 +922,7 @@ TEST_F(QueryHttpTest, RejectsMalformedInputsBeforeLookup) {
 TEST_F(QueryHttpTest, AcceptsEmptyTokensAndSignedInt32Boundaries) {
     Json::Value query = ValidQuery();
     query["token_ids"] = Json::Value(Json::arrayValue);
-    Json::Value empty = ParseJsonResponse(Post(query));
+    Json::Value empty = ParseMsgpackResponse(Post(query));
     EXPECT_EQ(empty["instances"]["1"]["dp"]["0"].asInt64(), 0);
     EXPECT_EQ(empty["instances"]["2"]["dp"]["1"].asInt64(), 0);
     ASSERT_NO_FATAL_FAILURE(ExpectRankMapsAligned(empty["instances"]["1"]));
@@ -860,8 +957,8 @@ class RegistrationHttpTest : public ::testing::Test {
     }
 
     HttpResponse Register(const ServiceConfig& service) const {
-        return HttpPostJson(port_, "/register",
-                            JsonDocument(ServiceJson(service)));
+        return HttpPostMsgpack(port_, "/register",
+                               MsgpackDocument(ServiceJson(service)));
     }
 
     HttpResponse Unregister(const std::string& instance_id, int dp_rank) const {
@@ -869,12 +966,13 @@ class RegistrationHttpTest : public ::testing::Test {
         body["instance_id"] = instance_id;
         body["tenant_id"] = "default";
         body["dp_rank"] = dp_rank;
-        return HttpPostJson(port_, "/unregister", JsonDocument(body));
+        return HttpPostMsgpack(port_, "/unregister", MsgpackDocument(body));
     }
 
     Json::Value QueryEmpty(const ServiceConfig& service) const {
-        return ParseJsonResponse(HttpPostJson(
-            port_, "/query", JsonDocument(QueryJson(ContextFor(service), {}))));
+        return ParseMsgpackResponse(HttpPostMsgpack(
+            port_, "/query",
+            MsgpackDocument(QueryJson(ContextFor(service), {}))));
     }
 
     std::unique_ptr<EventManager> manager_;
@@ -889,7 +987,7 @@ TEST_F(RegistrationHttpTest, ResolvesReportsAndRetriesSeedProfile) {
 
     const HttpResponse services_response = HttpGet(port_, "/services");
     ASSERT_EQ(services_response.status, 200);
-    const Json::Value services = ParseJsonResponse(services_response);
+    const Json::Value services = ParseMsgpackResponse(services_response);
     ASSERT_EQ(services["count"].asInt(), 1);
     ASSERT_EQ(services["services"].size(), 1u);
     const Json::Value& service_profile = services["services"][0]["HashProfile"];
@@ -901,7 +999,7 @@ TEST_F(RegistrationHttpTest, ResolvesReportsAndRetriesSeedProfile) {
 
     const HttpResponse view_response = HttpGet(port_, "/global_view");
     ASSERT_EQ(view_response.status, 200);
-    const Json::Value view = ParseJsonResponse(view_response);
+    const Json::Value view = ParseMsgpackResponse(view_response);
     ASSERT_EQ(view["context_count"].asInt(), 1);
     ASSERT_EQ(view["contexts"].size(), 1u);
     const Json::Value& context_profile = view["contexts"][0]["hash_profile"];
@@ -918,7 +1016,7 @@ TEST_F(RegistrationHttpTest, ResolvesAndReportsPickleProfile) {
 
     const HttpResponse services_response = HttpGet(port_, "/services");
     ASSERT_EQ(services_response.status, 200);
-    const Json::Value services = ParseJsonResponse(services_response);
+    const Json::Value services = ParseMsgpackResponse(services_response);
     ASSERT_EQ(services["count"].asInt(), 1);
     ASSERT_EQ(services["services"].size(), 1u);
     const Json::Value& service_profile = services["services"][0]["HashProfile"];
@@ -930,7 +1028,7 @@ TEST_F(RegistrationHttpTest, ResolvesAndReportsPickleProfile) {
 
     const HttpResponse view_response = HttpGet(port_, "/global_view");
     ASSERT_EQ(view_response.status, 200);
-    const Json::Value view = ParseJsonResponse(view_response);
+    const Json::Value view = ParseMsgpackResponse(view_response);
     ASSERT_EQ(view["context_count"].asInt(), 1);
     ASSERT_EQ(view["contexts"].size(), 1u);
     const Json::Value& context_profile = view["contexts"][0]["hash_profile"];
@@ -950,9 +1048,9 @@ TEST_F(RegistrationHttpTest, RejectsUnsupportedAlgorithmWithoutMutation) {
         Json::Value body = ServiceJson(VllmService());
         body["hash_profile"]["algorithm"] = algorithm;
         const HttpResponse response =
-            HttpPostJson(port_, "/register", JsonDocument(body));
+            HttpPostMsgpack(port_, "/register", MsgpackDocument(body));
         EXPECT_EQ(response.status, 400);
-        const Json::Value error = ParseJsonResponse(response);
+        const Json::Value error = ParseMsgpackResponse(response);
         EXPECT_EQ(error["reason"].asString(), "invalid_value");
         EXPECT_EQ(error["field"].asString(), "algorithm");
         EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 0u);
@@ -968,7 +1066,7 @@ TEST_F(RegistrationHttpTest, MixedAlgorithmConflictIsAtomic) {
     conflicting.hash_profile = TestProfile("0", "sha256");
     const HttpResponse response = Register(conflicting);
     ASSERT_EQ(response.status, 400);
-    EXPECT_EQ(ParseJsonResponse(response)["reason"].asString(),
+    EXPECT_EQ(ParseMsgpackResponse(response)["reason"].asString(),
               "invalid_registration");
 
     EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 1u);
@@ -1036,10 +1134,10 @@ TEST_F(RegistrationHttpTest, RejectsInvalidSeedProfilesWithoutMutation) {
 
     for (const auto& test_case : cases) {
         SCOPED_TRACE(test_case.name);
-        const HttpResponse response =
-            HttpPostJson(port_, "/register", JsonDocument(test_case.body));
+        const HttpResponse response = HttpPostMsgpack(
+            port_, "/register", MsgpackDocument(test_case.body));
         EXPECT_EQ(response.status, 400);
-        const Json::Value error = ParseJsonResponse(response);
+        const Json::Value error = ParseMsgpackResponse(response);
         EXPECT_EQ(error["reason"].asString(), test_case.reason);
         EXPECT_EQ(error["field"].asString(), test_case.field);
         EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 0u);
@@ -1055,7 +1153,7 @@ TEST_F(RegistrationHttpTest, ContextProfileConflictIsAtomic) {
     conflicting.hash_profile = TestProfile("1");
     const HttpResponse response = Register(conflicting);
     ASSERT_EQ(response.status, 400);
-    EXPECT_EQ(ParseJsonResponse(response)["reason"].asString(),
+    EXPECT_EQ(ParseMsgpackResponse(response)["reason"].asString(),
               "invalid_registration");
 
     EXPECT_EQ(EventManagerTestPeer::SubscriberCount(*manager_), 1u);
@@ -1103,22 +1201,25 @@ TEST_F(RegistrationHttpTest, RejectsProfileConflictAndMalformedGroup) {
 
     Json::Value invalid = ServiceJson(VllmService("bad-group"));
     invalid["cache_group"] = 1;
-    EXPECT_EQ(HttpPostJson(port_, "/register", JsonDocument(invalid)).status,
-              400);
+    EXPECT_EQ(
+        HttpPostMsgpack(port_, "/register", MsgpackDocument(invalid)).status,
+        400);
     EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, 1);
 
     invalid = ServiceJson(VllmService("mixed-group"));
     invalid["cache_group"] = Json::Value(Json::arrayValue);
     invalid["cache_group"].append(0);
     invalid["cache_group"].append(1);
-    EXPECT_EQ(HttpPostJson(port_, "/register", JsonDocument(invalid)).status,
-              400);
+    EXPECT_EQ(
+        HttpPostMsgpack(port_, "/register", MsgpackDocument(invalid)).status,
+        400);
     EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, 1);
 
     invalid = ServiceJson(VllmService("bad-profile"));
     invalid["hash_profile"]["python_hash_seed"] = "not-a-seed";
-    EXPECT_EQ(HttpPostJson(port_, "/register", JsonDocument(invalid)).status,
-              400);
+    EXPECT_EQ(
+        HttpPostMsgpack(port_, "/register", MsgpackDocument(invalid)).status,
+        400);
     EXPECT_EQ(manager_->GetIndexer()->GetGlobalView().context_count, 1);
 }
 


### PR DESCRIPTION
## Description

Conductor's HTTP API previously used JSON for request/response bodies. At long context this is the dominant /query cost: parsing a 1M-token JSON token_ids array with JsonCpp takes ~360ms of the ~550ms end-to-end latency, and each hash-chain block paid a fresh buffer + EVP context allocation.

This PR switches all five endpoints (/register, /unregister, /query, /services, /global_view) to native msgpack for both requests and responses, and removes JsonCpp from the HTTP layer entirely (the static config file stays JSON):

Protocol changes (breaking)
- POST bodies must be msgpack maps with Content-Type: application/msgpack; any other content type is rejected with 400 unsupported_content_type
- /query token_ids accepts a msgpack bin of little-endian int32 (4 bytes/token, no per-element parsing) or an integer array
- Success responses and error envelopes are msgpack maps; previous plain-text errors (404/405/500) become uniform {error, reason, field, index} maps
- Request validation semantics are unchanged field-by-field (required fields, unknown-field rejection, int32 ranges, nested hash_profile)

Performance
- VllmV1HashStrategy::Compute: hoist the codec encode buffer out of the block loop and reuse one EVP context across the chain (Sha256Reuse)
- 1M-token /query end-to-end: ~550ms → ~180ms (3.1×, 5.8M tok/s); 8K: 4.3ms → 1.8ms

Clients & docs
- cache_aware_disagg_proxy example now speaks msgpack for /register and /query
- C++ tests gain MsgpackDocument request encoding and msgpack response decoding; error-case expectations aligned (malformed msgpack, unsupported content type)
- en/zh indexer-api-design.md, usage.md, example README.md, KNOWN_ISSUES.md, router-integration-design.md updated to the msgpack contract

## Module

- [x] Mooncake Store (mooncake-store) — mooncake-conductor
- [x] Docs

## Type of Change

- [x] Breaking change
- [x] Refactor
- [x] Performance improvement

## How Has This Been Tested?

Test commands:
cmake --build build -j8
./mooncake-conductor/build/tests/conductor_test
python3 -m unittest discover -s mooncake-conductor/tests/cache_aware_proxy -p 'test_*.py'
# docs
cd docs && .venv/bin/python -m sphinx -b html source build/html

Test results:
- [x] Unit tests pass — 158/158 conductor C++ tests
- [x] Integration tests pass — 36/36 cache-aware proxy tests
- [x] Manual testing done:
  - E2E with 2× vLLM (Qwen3-0.6B) + conductor + cache-aware router: identical routing stickiness before/after, longest_matched hits correct, zero event-decode errors
  - JSON/msgpack-bin/msgpack-array equivalence verified before JSON removal
  - 1M-token /query benchmark: parse ~18ms (was ~360ms), total ~180ms (was ~550ms)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have updated the documentation (en + zh)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — needs follow-up
- [ ] I have run pre-commit run --all-files

## AI Assistance Disclosure

- [x] AI tools were used (specify below)