### PR TITLE
[TENT] Fix double-free in HttpMetaStore under concurrent workers: a s…

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metastore/http.h
+++ b/mooncake-transfer-engine/tent/include/tent/metastore/http.h
@@ -45,8 +45,8 @@ class HttpMetaStore : public MetaStore {
         return size * nmemb;
     }
 
-    std::string encodeUrl(const std::string &key) {
-        char *newkey = curl_easy_escape(nullptr, key.c_str(), key.size());
+    std::string encodeUrl(CURL *curl, const std::string &key) {
+        char *newkey = curl_easy_escape(curl, key.c_str(), key.size());
         std::string encodedKey(newkey ? newkey : "");
         std::string url = endpoint_ + "?key=" + encodedKey;
         if (newkey) curl_free(newkey);

--- a/mooncake-transfer-engine/tent/include/tent/metastore/http.h
+++ b/mooncake-transfer-engine/tent/include/tent/metastore/http.h
@@ -46,16 +46,15 @@ class HttpMetaStore : public MetaStore {
     }
 
     std::string encodeUrl(const std::string &key) {
-        char *newkey = curl_easy_escape(client_, key.c_str(), key.size());
-        std::string encodedKey(newkey);
+        char *newkey = curl_easy_escape(nullptr, key.c_str(), key.size());
+        std::string encodedKey(newkey ? newkey : "");
         std::string url = endpoint_ + "?key=" + encodedKey;
-        curl_free(newkey);
+        if (newkey) curl_free(newkey);
         return url;
     }
 
    private:
     std::atomic<bool> connected_;
-    CURL *client_;
     std::string endpoint_;
 };
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/metastore/http.cpp
+++ b/mooncake-transfer-engine/tent/src/metastore/http.cpp
@@ -25,8 +25,7 @@ static void ensureCurlGlobalInit() {
     std::call_once(g_curl_global_init_flag, []() {
         CURLcode rc = curl_global_init(CURL_GLOBAL_ALL);
         if (rc != CURLE_OK) {
-            LOG(ERROR) << "curl_global_init failed: "
-                       << curl_easy_strerror(rc);
+            LOG(ERROR) << "curl_global_init failed: " << curl_easy_strerror(rc);
         }
     });
 }
@@ -55,7 +54,9 @@ namespace {
 struct ScopedCurl {
     CURL *h{nullptr};
     ScopedCurl() : h(curl_easy_init()) {}
-    ~ScopedCurl() { if (h) curl_easy_cleanup(h); }
+    ~ScopedCurl() {
+        if (h) curl_easy_cleanup(h);
+    }
     ScopedCurl(const ScopedCurl &) = delete;
     ScopedCurl &operator=(const ScopedCurl &) = delete;
     operator CURL *() const { return h; }

--- a/mooncake-transfer-engine/tent/src/metastore/http.cpp
+++ b/mooncake-transfer-engine/tent/src/metastore/http.cpp
@@ -15,9 +15,21 @@
 #include "tent/metastore/http.h"
 
 #include <glog/logging.h>
+#include <mutex>
 
 namespace mooncake {
 namespace tent {
+
+static std::once_flag g_curl_global_init_flag;
+static void ensureCurlGlobalInit() {
+    std::call_once(g_curl_global_init_flag, []() {
+        CURLcode rc = curl_global_init(CURL_GLOBAL_ALL);
+        if (rc != CURLE_OK) {
+            LOG(ERROR) << "curl_global_init failed: "
+                       << curl_easy_strerror(rc);
+        }
+    });
+}
 
 HttpMetaStore::HttpMetaStore() {}
 
@@ -28,42 +40,49 @@ Status HttpMetaStore::connect(const std::string &endpoint) {
         return Status::MetadataError(
             "HTTP connection already established" LOC_MARK);
     }
-    curl_global_init(CURL_GLOBAL_ALL);
-    client_ = curl_easy_init();
-    if (!client_) {
-        return Status::InternalError(
-            "HTTP cannot allocate curl objects" LOC_MARK);
-    }
+    ensureCurlGlobalInit();
     endpoint_ = endpoint;
     connected_ = true;
     return Status::OK();
 }
 
 Status HttpMetaStore::disconnect() {
-    if (connected_) {
-        curl_easy_cleanup(client_);
-        curl_global_cleanup();
-        connected_ = false;
-    }
+    connected_ = false;
     return Status::OK();
 }
+
+namespace {
+struct ScopedCurl {
+    CURL *h{nullptr};
+    ScopedCurl() : h(curl_easy_init()) {}
+    ~ScopedCurl() { if (h) curl_easy_cleanup(h); }
+    ScopedCurl(const ScopedCurl &) = delete;
+    ScopedCurl &operator=(const ScopedCurl &) = delete;
+    operator CURL *() const { return h; }
+    explicit operator bool() const { return h != nullptr; }
+};
+}  // namespace
 
 Status HttpMetaStore::get(const std::string &key, std::string &value) {
     if (!connected_) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }
 
-    curl_easy_reset(client_);
-    curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+    ScopedCurl client;
+    if (!client) {
+        return Status::InternalError(
+            "HTTP cannot allocate curl handle" LOC_MARK);
+    }
+    curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
     std::string url = encodeUrl(key);
-    curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
 
     // get response body
     std::string readBuffer;
-    curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
-    CURLcode res = curl_easy_perform(client_);
+    curl_easy_setopt(client.h, CURLOPT_WRITEDATA, &readBuffer);
+    CURLcode res = curl_easy_perform(client.h);
     if (res != CURLE_OK) {
         return Status::MetadataError(
             std::string("HTTP failed to post request: ") +
@@ -72,7 +91,7 @@ Status HttpMetaStore::get(const std::string &key, std::string &value) {
 
     // Get the HTTP response code
     long responseCode;
-    curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+    curl_easy_getinfo(client.h, CURLINFO_RESPONSE_CODE, &responseCode);
     if (responseCode == 404) {
         return Status::InvalidEntry(key);
     } else if (responseCode != 200) {
@@ -81,7 +100,7 @@ Status HttpMetaStore::get(const std::string &key, std::string &value) {
             std::string("HTTP received unexpected response: ") + message +
             LOC_MARK);
     }
-    value = std::string(readBuffer);
+    value = std::move(readBuffer);
     return Status::OK();
 }
 
@@ -90,25 +109,29 @@ Status HttpMetaStore::set(const std::string &key, const std::string &value) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }
 
-    curl_easy_reset(client_);
-    curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+    ScopedCurl client;
+    if (!client) {
+        return Status::InternalError(
+            "HTTP cannot allocate curl handle" LOC_MARK);
+    }
+    curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
     std::string url = encodeUrl(key);
-    curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
-    curl_easy_setopt(client_, CURLOPT_POSTFIELDS, value.c_str());
-    curl_easy_setopt(client_, CURLOPT_POSTFIELDSIZE, value.size());
-    curl_easy_setopt(client_, CURLOPT_CUSTOMREQUEST, "PUT");
+    curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(client.h, CURLOPT_POSTFIELDS, value.c_str());
+    curl_easy_setopt(client.h, CURLOPT_POSTFIELDSIZE, value.size());
+    curl_easy_setopt(client.h, CURLOPT_CUSTOMREQUEST, "PUT");
 
     // get response body
     std::string readBuffer;
-    curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
+    curl_easy_setopt(client.h, CURLOPT_WRITEDATA, &readBuffer);
 
     // set content-type to application/json
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Content-Type: application/json");
-    curl_easy_setopt(client_, CURLOPT_HTTPHEADER, headers);
-    CURLcode res = curl_easy_perform(client_);
+    curl_easy_setopt(client.h, CURLOPT_HTTPHEADER, headers);
+    CURLcode res = curl_easy_perform(client.h);
     curl_slist_free_all(headers);  // free headers
     if (res != CURLE_OK) {
         return Status::MetadataError(
@@ -117,7 +140,7 @@ Status HttpMetaStore::set(const std::string &key, const std::string &value) {
     }
 
     long responseCode;
-    curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+    curl_easy_getinfo(client.h, CURLINFO_RESPONSE_CODE, &responseCode);
     if (responseCode != 200) {
         std::string message = std::to_string(responseCode) + ": " + readBuffer;
         return Status::MetadataError(
@@ -133,18 +156,22 @@ Status HttpMetaStore::remove(const std::string &key) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }
 
-    curl_easy_reset(client_);
-    curl_easy_setopt(client_, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
+    ScopedCurl client;
+    if (!client) {
+        return Status::InternalError(
+            "HTTP cannot allocate curl handle" LOC_MARK);
+    }
+    curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
     std::string url = encodeUrl(key);
-    curl_easy_setopt(client_, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(client_, CURLOPT_WRITEFUNCTION, writeCallback);
-    curl_easy_setopt(client_, CURLOPT_CUSTOMREQUEST, "DELETE");
+    curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
+    curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
+    curl_easy_setopt(client.h, CURLOPT_CUSTOMREQUEST, "DELETE");
 
     // get response body
     std::string readBuffer;
-    curl_easy_setopt(client_, CURLOPT_WRITEDATA, &readBuffer);
-    CURLcode res = curl_easy_perform(client_);
+    curl_easy_setopt(client.h, CURLOPT_WRITEDATA, &readBuffer);
+    CURLcode res = curl_easy_perform(client.h);
     if (res != CURLE_OK) {
         return Status::MetadataError(
             std::string("HTTP failed to post request: ") +
@@ -152,7 +179,7 @@ Status HttpMetaStore::remove(const std::string &key) {
     }
 
     long responseCode;
-    curl_easy_getinfo(client_, CURLINFO_RESPONSE_CODE, &responseCode);
+    curl_easy_getinfo(client.h, CURLINFO_RESPONSE_CODE, &responseCode);
     if (responseCode != 200) {
         std::string message = std::to_string(responseCode) + ": " + readBuffer;
         return Status::MetadataError(

--- a/mooncake-transfer-engine/tent/src/metastore/http.cpp
+++ b/mooncake-transfer-engine/tent/src/metastore/http.cpp
@@ -75,7 +75,7 @@ Status HttpMetaStore::get(const std::string &key, std::string &value) {
     }
     curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
-    std::string url = encodeUrl(key);
+    std::string url = encodeUrl(client.h, key);
     curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
     curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
 
@@ -116,7 +116,7 @@ Status HttpMetaStore::set(const std::string &key, const std::string &value) {
     }
     curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
-    std::string url = encodeUrl(key);
+    std::string url = encodeUrl(client.h, key);
     curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
     curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
     curl_easy_setopt(client.h, CURLOPT_POSTFIELDS, value.c_str());
@@ -163,7 +163,7 @@ Status HttpMetaStore::remove(const std::string &key) {
     }
     curl_easy_setopt(client.h, CURLOPT_TIMEOUT_MS, 3000);  // 3s timeout
 
-    std::string url = encodeUrl(key);
+    std::string url = encodeUrl(client.h, key);
     curl_easy_setopt(client.h, CURLOPT_URL, url.c_str());
     curl_easy_setopt(client.h, CURLOPT_WRITEFUNCTION, writeCallback);
     curl_easy_setopt(client.h, CURLOPT_CUSTOMREQUEST, "DELETE");


### PR DESCRIPTION
## Description

`HttpMetaStore` shared a single `CURL*` easy handle across all worker threads.
libcurl documents that an easy handle must not be used from multiple threads
at the same time. Under concurrent `get()`/`set()` from worker threads (e.g.
16+ workers in the transfer benchmark), `curl_easy_reset()` double-freed
handle-owned strings that libcurl had `strdup`'d internally, corrupting the
glibc heap:

### Fix
- Allocate a per-request `CURL*` via a small RAII wrapper (`ScopedCurl`)
  instead of sharing one handle across threads — the pattern libcurl
  recommends for the easy interface.
- Guard `curl_global_init()` with `std::call_once` for a race-free lazy init,
  and report a failure from `curl_global_init()` instead of ignoring it.
- Use `curl_easy_escape(nullptr, ...)` for URL encoding (the handle argument
  is unused in modern libcurl and passing NULL is thread-safe).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## Testing

- Reproduced the double-free under an AddressSanitizer build with concurrent
  metadata workers; the ASan report on `HttpMetaStore::get` no longer fires
  after the fix.
- Verified transfers over RDMA with the HTTP metadata backend across two
  machines; sustained runs complete without heap corruption or crashes.

### Environment
- NVIDIA Blackwell RTX PRO, driver 580.65.06, CUDA 13.0
- Ubuntu, glibc 2.35, system libcurl