### PR TITLE
[TENT] cuda_probe: zero-init cudaPointerAttributes and warn on libcud…

### DIFF
--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -290,7 +290,7 @@ bool cudaProbeUsable() {
 }  // namespace
 
 MemoryType CudaPlatform::getMemoryType(void* addr) {
-    if (!cudaProbeUsable()) return MTYPE_CPU;
+    if (!cudaProbeUsable()) return MTYPE_UNKNOWN;
     cudaPointerAttributes attributes{};
     cudaError_t result = cudaPointerGetAttributes(&attributes, addr);
     if (result != cudaSuccess) {

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -36,7 +36,6 @@
 #include <unordered_set>
 
 #include <algorithm>
-#include <mutex>
 
 namespace mooncake {
 namespace tent {
@@ -264,23 +263,34 @@ Status CudaPlatform::probe(std::vector<Topology::NicEntry>& nic_list,
 }
 
 namespace {
-void checkCudartAbiOnce() {
-    static std::once_flag once;
-    std::call_once(once, [] {
+bool cudaProbeUsable() {
+    static const bool usable = [] {
+        int device_count = 0;
+        if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
+            device_count == 0) {
+            LOG(WARNING) << "No CUDA device detected; treating buffers as "
+                            "host memory";
+            return false;
+        }
         int runtime_version = 0;
-        if (cudaRuntimeGetVersion(&runtime_version) != cudaSuccess) return;
-        if (runtime_version / 1000 != CUDART_VERSION / 1000) {
+        // Major version only: struct layout changes across CUDA majors.
+        if (cudaRuntimeGetVersion(&runtime_version) == cudaSuccess &&
+            runtime_version / 1000 != CUDART_VERSION / 1000) {
             LOG(ERROR) << "CUDA ABI mismatch: built against CUDART "
                        << CUDART_VERSION << ", loaded libcudart is "
                        << runtime_version
-                       << "; rebuild against a matching CUDA toolkit.";
+                       << "; skipping pointer probe, rebuild against a "
+                          "matching CUDA toolkit.";
+            return false;
         }
-    });
+        return true;
+    }();
+    return usable;
 }
 }  // namespace
 
 MemoryType CudaPlatform::getMemoryType(void* addr) {
-    checkCudartAbiOnce();
+    if (!cudaProbeUsable()) return MTYPE_CPU;
     cudaPointerAttributes attributes{};
     cudaError_t result = cudaPointerGetAttributes(&attributes, addr);
     if (result != cudaSuccess) {
@@ -313,7 +323,10 @@ const std::vector<RangeLocation> CudaPlatform::getLocation(void* start,
     const static size_t kPageSize = 4096;
     std::vector<RangeLocation> entries;
 
-    checkCudartAbiOnce();
+    if (!cudaProbeUsable()) {
+        entries.push_back({(uint64_t)start, len, kWildcardLocation});
+        return entries;
+    }
     cudaPointerAttributes attributes{};
     cudaError_t result = cudaPointerGetAttributes(&attributes, start);
     if (result != cudaSuccess) {

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -36,6 +36,7 @@
 #include <unordered_set>
 
 #include <algorithm>
+#include <mutex>
 
 namespace mooncake {
 namespace tent {
@@ -262,10 +263,26 @@ Status CudaPlatform::probe(std::vector<Topology::NicEntry>& nic_list,
     return Status::OK();
 }
 
+namespace {
+void checkCudartAbiOnce() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        int runtime_version = 0;
+        if (cudaRuntimeGetVersion(&runtime_version) != cudaSuccess) return;
+        if (runtime_version / 1000 != CUDART_VERSION / 1000) {
+            LOG(ERROR) << "CUDA ABI mismatch: built against CUDART "
+                       << CUDART_VERSION << ", loaded libcudart is "
+                       << runtime_version
+                       << "; rebuild against a matching CUDA toolkit.";
+        }
+    });
+}
+}  // namespace
+
 MemoryType CudaPlatform::getMemoryType(void* addr) {
-    cudaPointerAttributes attributes;
-    cudaError_t result;
-    result = cudaPointerGetAttributes(&attributes, addr);
+    checkCudartAbiOnce();
+    cudaPointerAttributes attributes{};
+    cudaError_t result = cudaPointerGetAttributes(&attributes, addr);
     if (result != cudaSuccess) {
         LOG(WARNING) << "cudaPointerGetAttributes: "
                      << cudaGetErrorString(result);
@@ -296,10 +313,9 @@ const std::vector<RangeLocation> CudaPlatform::getLocation(void* start,
     const static size_t kPageSize = 4096;
     std::vector<RangeLocation> entries;
 
-    cudaPointerAttributes attributes;
-    cudaError_t result;
-
-    result = cudaPointerGetAttributes(&attributes, start);
+    checkCudartAbiOnce();
+    cudaPointerAttributes attributes{};
+    cudaError_t result = cudaPointerGetAttributes(&attributes, start);
     if (result != cudaSuccess) {
         LOG(WARNING) << "cudaPointerGetAttributes: "
                      << cudaGetErrorString(result);

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -263,8 +263,8 @@ Status CudaPlatform::probe(std::vector<Topology::NicEntry>& nic_list,
 }
 
 namespace {
-bool cudaProbeUsable() {
-    static const bool usable = [] {
+bool cudaDevicePresent() {
+    static const bool present = [] {
         int device_count = 0;
         if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
             device_count == 0) {
@@ -272,6 +272,13 @@ bool cudaProbeUsable() {
                             "host memory";
             return false;
         }
+        return true;
+    }();
+    return present;
+}
+
+bool cudaAbiMatches() {
+    static const bool matches = [] {
         int runtime_version = 0;
         // Major version only: struct layout changes across CUDA majors.
         if (cudaRuntimeGetVersion(&runtime_version) == cudaSuccess &&
@@ -285,12 +292,13 @@ bool cudaProbeUsable() {
         }
         return true;
     }();
-    return usable;
+    return matches;
 }
 }  // namespace
 
 MemoryType CudaPlatform::getMemoryType(void* addr) {
-    if (!cudaProbeUsable()) return MTYPE_UNKNOWN;
+    if (!cudaDevicePresent()) return MTYPE_CPU;
+    if (!cudaAbiMatches()) return MTYPE_UNKNOWN;
     cudaPointerAttributes attributes{};
     cudaError_t result = cudaPointerGetAttributes(&attributes, addr);
     if (result != cudaSuccess) {
@@ -323,23 +331,24 @@ const std::vector<RangeLocation> CudaPlatform::getLocation(void* start,
     const static size_t kPageSize = 4096;
     std::vector<RangeLocation> entries;
 
-    if (!cudaProbeUsable()) {
+    if (cudaDevicePresent() && !cudaAbiMatches()) {
         entries.push_back({(uint64_t)start, len, kWildcardLocation});
         return entries;
     }
-    cudaPointerAttributes attributes{};
-    cudaError_t result = cudaPointerGetAttributes(&attributes, start);
-    if (result != cudaSuccess) {
-        LOG(WARNING) << "cudaPointerGetAttributes: "
-                     << cudaGetErrorString(result);
-        entries.push_back({(uint64_t)start, len, kWildcardLocation});
-        return entries;
-    }
-
-    if (attributes.type == cudaMemoryTypeDevice) {
-        entries.push_back(
-            {(uint64_t)start, len, genCudaNodeName(attributes.device)});
-        return entries;
+    if (cudaDevicePresent()) {
+        cudaPointerAttributes attributes{};
+        cudaError_t result = cudaPointerGetAttributes(&attributes, start);
+        if (result != cudaSuccess) {
+            LOG(WARNING) << "cudaPointerGetAttributes: "
+                         << cudaGetErrorString(result);
+            entries.push_back({(uint64_t)start, len, kWildcardLocation});
+            return entries;
+        }
+        if (attributes.type == cudaMemoryTypeDevice) {
+            entries.push_back(
+                {(uint64_t)start, len, genCudaNodeName(attributes.device)});
+            return entries;
+        }
     }
 
     // start and end address may not be page aligned.


### PR DESCRIPTION
## Description

Follow-up to the review on the cuda_probe stack-smashing report, split out
per request.

This does NOT paper over the crash with a local buffer pad. Instead it targets
the ABI root cause:
- Zero-initialize `cudaPointerAttributes attributes{}` (docs require reserved
  fields to be zero).
- On first probe, compare the build-time `CUDART_VERSION` against the running
  `cudaRuntimeGetVersion()`; if the major versions differ, log a clear,
  actionable error pointing at the toolchain mismatch.

Rationale: `cudaPointerGetAttributes` takes no size argument and writes as many
bytes as the *running* cudart's struct. A binary built against older CUDA
headers (e.g. CUDA 12, no `reserved[8]`) but run against CUDA 13 cudart writes
past the stack object and smashes the canary. The durable fix is to build
against a matching CUDA toolkit; this change makes that failure diagnosable
instead of a mysterious "stack smashing detected".

## Module
- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change
- [x] Bug fix