### PR TITLE
[Bugfix][TE] Keep context_list_ index-aligned when an RNIC fails to init

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -606,6 +606,8 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
 
 int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access,
                                       const DmabufExport &exp) {
+    // Placeholder context for a failed RNIC: no PD to register against.
+    if (!pd_) return 0;
     MemoryRegionMeta mrMeta;
     int ret = registerMemoryRegionInternal(addr, length, access, exp, mrMeta);
     if (ret != 0) {
@@ -617,6 +619,7 @@ int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access,
 }
 
 int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
+    if (!pd_) return 0;  // placeholder context: skip the dma_buf export too
     // Single-NIC convenience path: export, register, and close the fd here.
     // The shared-fd benefit only matters when a buffer is registered against
     // multiple NICs (see RdmaTransport::registerLocalMemoryInternal).
@@ -645,6 +648,7 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
 }
 
 int RdmaContext::preTouchMemory(void *addr, size_t length) {
+    if (!pd_) return 0;  // placeholder context
     DmabufExport exp;
     int ret = exportDmabuf(addr, exp);
     if (ret != 0) {
@@ -663,6 +667,8 @@ int RdmaContext::preTouchMemory(void *addr, size_t length) {
 }
 
 uint32_t RdmaContext::rkey(void *addr) {
+    // Placeholder context holds no MRs; its zero key is never selected.
+    if (!pd_) return 0;
     RWSpinlock::ReadGuard guard(memory_regions_lock_);
     auto iter = findMemoryRegionContaining(reinterpret_cast<uintptr_t>(addr));
     if (iter != memory_region_map_.end()) return iter->second.mr->rkey;
@@ -672,6 +678,7 @@ uint32_t RdmaContext::rkey(void *addr) {
 }
 
 uint32_t RdmaContext::lkey(void *addr) {
+    if (!pd_) return 0;  // see rkey()
     RWSpinlock::ReadGuard guard(memory_regions_lock_);
     auto iter = findMemoryRegionContaining(reinterpret_cast<uintptr_t>(addr));
     if (iter != memory_region_map_.end()) return iter->second.mr->lkey;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -1106,6 +1106,16 @@ int RdmaTransport::initializeRdmaResources() {
         if (ret) {
             local_topology_->disableDevice(device_name);
             LOG(WARNING) << "Disable device " << device_name;
+            // Keep context_list_ index-aligned with getHcaList(): both it and
+            // BufferDesc::lkey are subscripted by the HCA index, which
+            // disableDevice() leaves in place. Dropping a slot would make a
+            // later device_id name the wrong RNIC or run off the end. A
+            // never-constructed context is an inert placeholder; the partially
+            // built one is released so it does not pin an open uverbs fd.
+            auto placeholder =
+                std::make_shared<RdmaContext>(*this, device_name);
+            placeholder->set_active(false);
+            context_list_.push_back(std::move(placeholder));
         } else {
             context_list_.push_back(context);
         }

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <memory>
@@ -281,6 +282,72 @@ TEST_F(RdmaContextReprobeTest,
     EXPECT_EQ(context_->gid(), formatGid(kCurrentGid));
     auto after_desc = localDesc();
     EXPECT_EQ(after_desc.get(), before_desc.get());
+}
+
+// Regression tests for the HCA-index / context_list_ alignment invariant.
+// An HCA's id is its position in getHcaList(), and disableDevice() keeps the
+// surviving ids there. initializeRdmaResources() used to append a context only
+// for devices that came up, compacting context_list_ so a later device_id
+// named the wrong RNIC or ran past its end.
+
+constexpr const char *kAlignmentTopologyJson =
+    R"({"cpu:0": [["mlx5_0", "mlx5_1", "mlx5_2"], []]})";
+
+TEST(RdmaHcaIndexAlignmentTest, ContextListKeepsOneSlotPerHcaWhenInitFails) {
+#ifndef __linux__
+    GTEST_SKIP() << "Requires Linux libibverbs symbol interposition";
+#else
+    // No FakeVerbsDeviceScope: the interposed ibv_get_device_list reports zero
+    // devices, so every construct() fails regardless of the host's hardware.
+    auto topology = std::make_shared<Topology>();
+    ASSERT_EQ(topology->parse(kAlignmentTopologyJson), 0);
+    const auto hca_list = topology->getHcaList();
+    ASSERT_EQ(hca_list.size(), static_cast<size_t>(3));
+
+    auto metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindMetadata(transport, metadata,
+                                        "local-rdma-segment");
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+
+    // Every device fails, so the topology ends up empty -- the slot layout
+    // must line up with getHcaList() anyway.
+    EXPECT_EQ(RdmaTransportTestPeer::initializeResources(transport),
+              ERR_DEVICE_NOT_FOUND);
+
+    const auto &contexts = transport.getContextList();
+    ASSERT_EQ(contexts.size(), hca_list.size());
+    for (size_t i = 0; i < contexts.size(); ++i) {
+        ASSERT_NE(contexts[i], nullptr) << "slot " << i << " must be occupied";
+        EXPECT_EQ(contexts[i]->deviceName(), hca_list[i])
+            << "slot " << i << " names the wrong RNIC";
+        EXPECT_FALSE(contexts[i]->active())
+            << "placeholder for a failed RNIC must not report itself active";
+    }
+#endif  // __linux__
+}
+
+// Characterizes the contract the fix above relies on.
+TEST(RdmaHcaIndexAlignmentTest, DisabledDeviceKeepsRemainingHcaIndexesStable) {
+    Topology topology;
+    ASSERT_EQ(topology.parse(kAlignmentTopologyJson), 0);
+    const auto hca_list = topology.getHcaList();
+    ASSERT_EQ(hca_list.size(), static_cast<size_t>(3));
+    ASSERT_NE(std::find(hca_list.begin(), hca_list.end(), "mlx5_1"),
+              hca_list.end());
+
+    ASSERT_EQ(topology.disableDevice("mlx5_1"), 0);
+    // getHcaList() must not shrink: ids are positions in it.
+    ASSERT_EQ(topology.getHcaList().size(), hca_list.size());
+
+    for (int retry_count = 0; retry_count < 16; ++retry_count) {
+        const int device_id = topology.selectDevice("cpu:0", retry_count);
+        ASSERT_GE(device_id, 0);
+        ASSERT_LT(static_cast<size_t>(device_id), hca_list.size())
+            << "device_id must index an hca_list-sized context array";
+        EXPECT_NE(hca_list[device_id], "mlx5_1")
+            << "a disabled device must never be selected";
+    }
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tests/rdma_test_peers.h
+++ b/mooncake-transfer-engine/tests/rdma_test_peers.h
@@ -43,6 +43,17 @@ class RdmaTransportTestPeer {
                            std::shared_ptr<RdmaContext> context) {
         transport.context_list_.push_back(std::move(context));
     }
+
+    static void bindTopology(RdmaTransport &transport,
+                             std::shared_ptr<Topology> topology) {
+        transport.local_topology_ = std::move(topology);
+    }
+
+    // Drives the device-initialization loop directly so tests can assert on
+    // the resulting context_list_ layout without a full install().
+    static int initializeResources(RdmaTransport &transport) {
+        return transport.initializeRdmaResources();
+    }
 };
 
 class RdmaContextTestPeer {


### PR DESCRIPTION
Description
  
  Topology::resolve() gives each HCA an id equal to its position in getHcaList(), and disableDevice() deliberately keeps the surviving ids there rather than re-running resolve() — its comment notes that compacting would make the lkey/rkey and context arrays point at the wrong RNIC.

  initializeRdmaResources() broke that contract from the other side: it appended to context_list_ only for devices whose construct() succeeded, so one failed RNIC compacted the array while the topology kept the sparse ids. A device_id from selectDevice() then either named a different NIC (silently defeating the computed NUMA/PCIe affinity) or ran past the end of context_list_ — an unchecked out-of-bounds read, since the request-level lookup in submitTransferTask() has no bounds check and the per-slice one is only an assert. Reachable on any multi-NIC host where a NIC fails construct(): port not IBV_PORT_ACTIVE for the global MC_IB_PORT, no usable GID, or a failed DMA-BUF check.

  Fix: push a fresh, never-constructed RdmaContext as a placeholder instead of dropping the slot. It owns no ibv_context/PD, reports itself inactive, and no-ops registration, so the existing active() checks already handle it; the partially built context is released so a failed RNIC does not pin an open uverbs fd. Five entry points are guarded against a null pd_ (both registerMemoryRegion() overloads, preTouchMemory(), lkey(), rkey()) because ibv_reg_mr(nullptr, ...) segfaults. No hot-path changes — disableDevice() already keeps disabled ids out of selectDevice().

  Follow-up (separate PR): TENT has the same defect — context_set_ and BufferDesc::lkey are both compacted while dev_id stays a sparse topology NicID, with a wider trigger (any type != NIC_RDMA entry) and no disableDevice() equivalent.

  Module
  
  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other
  
  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Two tests added to rdma_context_reprobe_test.cpp, reusing its libibverbs symbol interposition so no RDMA hardware is needed:

  - ContextListKeepsOneSlotPerHcaWhenInitFails — drives initializeRdmaResources() and asserts slot count, per-slot device name, and inactive placeholders. Fails before this change with contexts.size()=0 vs hca_list.size()=3.
  - DisabledDeviceKeepsRemainingHcaIndexesStable — pins the disableDevice()/selectDevice() contract the fix relies on.

  Test commands:
  Linux container (host is macOS; TE needs libibverbs + glibc headers)
  cmake -S . -B build -DBUILD_UNIT_TESTS=ON -DWITH_TE=ON && cmake --build build -j"$(nproc)"
  ./build/mooncake-transfer-engine/tests/rdma_context_reprobe_test
  cd build && ctest --output-on-failure
  ./scripts/code_format.sh --check

  Test results:
  - rdma_context_reprobe_test: 7/7 pass (5 pre-existing + 2 new).
  - ctest: 28/31. The 3 failures — tcp_transport_test, transfer_metadata_test (Unable to find metadata storage plugin etcd), memory_location_test (mbind: Operation not permitted) — are environment-only and reproduce identically
  on the unpatched baseline, verified by stashing the change and re-running.
  - ./scripts/code_format.sh --check: all four files OK (clang-format 20.1.8). pre-commit on the touched files: all hooks pass, no rewrites.

  Coverage gap: the tests cover the "all devices fail" path. The mixed case is not covered end-to-end (making construct() succeed without hardware needs faked comp channels, epoll fds, CQs and a live WorkerPool); the two tests instead pin both halves of the invariant — context_list_.size() == getHcaList().size(), and every selectDevice() id falls inside that range.

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable) — not run; needs RDMA hardware + metadata server
  - [x] Manual testing done (describe below)

  Manual verification = the baseline comparison above: new test confirmed failing before the fix and passing after, with the 3 environment failures identical either way.

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable) — n/a, no user-facing behavior change
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue — n/a, 95 lines

Unchecked on purpose: self-review is the submitter's own attestation; --all-files was not run (only pre-commit run --files on the four touched files, all passing) because AGENTS.md warns it may rewrite unrelated files.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)