### PR TITLE
[Bugfix][TENT] Keep context_set_ and buffer keys NicID-indexed

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -56,6 +56,7 @@ struct RdmaSubBatch : public Transport::SubBatch {
 class RdmaTransport : public Transport {
     friend class Workers;
     friend class RdmaEndPoint;
+    friend class RdmaTransportTestPeer;
 
    public:
     RdmaTransport();
@@ -122,6 +123,11 @@ class RdmaTransport : public Transport {
     Status setupLocalSegment();
 
     std::shared_ptr<Config> config() const { return conf_; }
+
+   private:
+    // Builds context_set_ with one slot per NicID; returns how many RNICs
+    // came up. Remaining slots hold inert contexts.
+    size_t initializeContexts();
 
    private:
     bool installed_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -38,6 +38,8 @@ class RdmaTransport;
 class DeviceSelector;
 
 class Workers {
+    friend class RdmaTransportTestPeer;
+
    public:
     static constexpr size_t kCapacity = 1024 * 8;
     using BoundedSliceQueue = BoundedMPSCQueue<RdmaSliceList, kCapacity>;
@@ -74,6 +76,11 @@ class Workers {
     void releaseSliceQuota(RdmaSlice* slice, double latency = 0.0);
 
     void monitorThread();
+
+    // 1 Hz heartbeat from monitorThread(): drains every context's retiring
+    // endpoints so reclaim is not gated on new insertions, which stall under
+    // failure load.
+    void reclaimEndpoints();
 
     int handleContextEvents(std::shared_ptr<RdmaContext>& context);
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/buffers.cpp
@@ -141,6 +141,11 @@ Status LocalBufferManager::addBufferInternal(BufferDesc& desc,
                 context->registerMemReg((void*)desc.addr, desc.length, access);
         }
     }
+    // NicID-keyed like context_list_, not compacted: slice dispatch subscripts
+    // these with a dev_id from the topology, so gaps must stay in place.
+    // Devices with no context contribute a zero key that is never selected.
+    desc.lkey.assign(context_list_.size(), 0);
+    desc.rkey.assign(context_list_.size(), 0);
     for (size_t id = 0; id < context_list_.size(); ++id) {
         if (!context_list_[id]) continue;
         if (!mem_reg_list[id]) {
@@ -149,8 +154,8 @@ Status LocalBufferManager::addBufferInternal(BufferDesc& desc,
         }
         staging.mem_reg_map[context_list_[id]] = mem_reg_list[id];
         auto keys = context_list_[id]->queryMemRegKey(mem_reg_list[id]);
-        desc.lkey.push_back(keys.first);
-        desc.rkey.push_back(keys.second);
+        desc.lkey[id] = keys.first;
+        desc.rkey[id] = keys.second;
     }
     staging.options = options;
     RWSpinlock::WriteGuard guard(lock_);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -637,7 +637,9 @@ std::string RdmaContext::gid() const {
 }
 
 RdmaCQ* RdmaContext::cq(int index) {
-    if (index < 0 || index >= params_->device.num_cq_list) return nullptr;
+    // params_ is null until construct(): an inert context has no CQs.
+    if (!params_ || index < 0 || index >= params_->device.num_cq_list)
+        return nullptr;
     return cq_list_.empty() ? nullptr : cq_list_[index];
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -268,6 +268,32 @@ RdmaTransport::RdmaTransport()
 
 RdmaTransport::~RdmaTransport() { uninstall(); }
 
+size_t RdmaTransport::initializeContexts() {
+    context_set_.clear();
+    context_name_lookup_.clear();
+    // One slot per NicID: dev_id arrives as a NicID and subscripts both this
+    // and BufferDesc::lkey, so a compacted layout would name the wrong RNIC.
+    // Skipped NICs keep an inert context, which consumers reject via status().
+    context_set_.reserve(local_topology_->getNicCount());
+    size_t context_count = 0;
+    for (size_t i = 0; i < local_topology_->getNicCount(); ++i) {
+        auto entry = local_topology_->getNicEntry(i);
+        auto context = std::make_shared<RdmaContext>(*this);
+        context_set_.push_back(context);
+        if (entry->type != Topology::NIC_RDMA) continue;
+        int ret = context->construct(entry->name, params_);
+        if (ret) {
+            LOG(WARNING) << "Disable RDMA device " << entry->name << " because "
+                         << "of initialization failure";
+            continue;
+        }
+        context_name_lookup_[entry->name] = i;
+        ++context_count;
+        local_buffer_manager_.addDevice(context.get());
+    }
+    return context_count;
+}
+
 Status RdmaTransport::install(std::string& local_segment_name,
                               std::shared_ptr<ControlService> metadata,
                               std::shared_ptr<Topology> local_topology,
@@ -313,22 +339,7 @@ Status RdmaTransport::install(std::string& local_segment_name,
     }
 
     local_buffer_manager_.setTopology(local_topology);
-    context_set_.clear();
-    for (size_t i = 0; i < local_topology_->getNicCount(); ++i) {
-        auto entry = local_topology_->getNicEntry(i);
-        if (entry->type != Topology::NIC_RDMA) continue;
-        auto context = std::make_shared<RdmaContext>(*this);
-        int ret = context->construct(entry->name, params_);
-        if (ret) {
-            LOG(WARNING) << "Disable RDMA device " << entry->name << " because "
-                         << "of initialization failure";
-            continue;
-        }
-        context_name_lookup_[entry->name] = context_set_.size();
-        context_set_.push_back(context);
-        local_buffer_manager_.addDevice(context.get());
-    }
-    const bool context_empty = context_set_.empty();
+    const bool context_empty = initializeContexts() == 0;
     const bool topology_empty = local_topology_->empty();
     if (context_empty || topology_empty) {
         const char* error_message = "No RDMA device initialized successfully";
@@ -704,8 +715,16 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
         return nullptr;
     }
 
-    auto context = context_set_[0].get();
-    if (context->status() != RdmaContext::DEVICE_ENABLED) {
+    // context_set_ is NicID-indexed, so slot 0 may be inert; take the first
+    // enabled context instead.
+    RdmaContext* context = nullptr;
+    for (auto& ctx : context_set_) {
+        if (ctx->status() == RdmaContext::DEVICE_ENABLED) {
+            context = ctx.get();
+            break;
+        }
+    }
+    if (!context) {
         return nullptr;
     }
     std::shared_ptr<RdmaEndPoint> endpoint;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -637,6 +637,7 @@ void Workers::asyncPollCq() {
     for (int index = 0; index < num_contexts; index++) {
         auto& context = transport_->context_set_[index];
         auto cq = context->cq(tl_wid % num_cq_list);
+        if (!cq) continue;  // inert context for a non-RDMA or failed NIC
         ibv_wc wc[kPollCount];
         int nr_poll = cq->poll(kPollCount, wc);
         if (nr_poll < 0) continue;
@@ -781,6 +782,14 @@ int Workers::handleContextEvents(std::shared_ptr<RdmaContext>& context) {
     return 0;
 }
 
+void Workers::reclaimEndpoints() {
+    for (auto& context : transport_->context_set_) {
+        // Inert contexts never built an endpoint store.
+        auto store = context->endpointStore();
+        if (store) store->reclaim();
+    }
+}
+
 void Workers::monitorThread() {
     // Track time for periodic endpoint reclaim (1 Hz heartbeat)
     auto last_reclaim_time = std::chrono::steady_clock::now();
@@ -795,9 +804,7 @@ void Workers::monitorThread() {
                 .count();
 
         if (time_since_last_reclaim >= 1000) {  // 1 second = 1000 ms
-            for (auto& context : transport_->context_set_) {
-                context->endpointStore()->reclaim();
-            }
+            reclaimEndpoints();
             last_reclaim_time = current_time;
         }
 

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -29,11 +29,43 @@
 #include "tent/common/config.h"
 #include "tent/common/types.h"
 #include "tent/transfer_engine.h"
+#include "tent/runtime/topology.h"
+#include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/ibv_loader.h"
 #include "tent/transport/rdma/params.h"
 #include "tent/transport/rdma/rdma_transport.h"
+#include "tent/transport/rdma/workers.h"
 
 namespace mooncake {
 namespace tent {
+
+// Friend accessor for driving initializeContexts() without a full install().
+class RdmaTransportTestPeer {
+   public:
+    static void bindTopology(RdmaTransport& transport,
+                             std::shared_ptr<Topology> topology) {
+        transport.local_topology_ = topology;
+        transport.local_buffer_manager_.setTopology(topology);
+        transport.params_ = std::make_shared<RdmaParams>();
+        transport.conf_ = std::make_shared<Config>();
+    }
+
+    // Runs the monitorThread() 1 Hz reclaim tick without starting any worker
+    // threads.
+    static void reclaimEndpoints(RdmaTransport& transport) {
+        Workers workers(&transport);
+        workers.reclaimEndpoints();
+    }
+
+    static size_t initializeContexts(RdmaTransport& transport) {
+        return transport.initializeContexts();
+    }
+
+    static const RdmaContextSet& contextSet(const RdmaTransport& transport) {
+        return transport.context_set_;
+    }
+};
+
 namespace {
 
 bool hasRdmaDevice() {
@@ -119,6 +151,92 @@ TEST(RdmaSubBatchTest, ReportsTaskCount) {
     batch.task_list.push_back(nullptr);
     batch.task_list.push_back(nullptr);
     EXPECT_EQ(batch.size(), 2);
+}
+
+// context_set_ is subscripted by NicID, so it must keep one slot per NIC even
+// when a device is skipped. It used to push_back only on the success path,
+// compacting the array so a later dev_id named the wrong RNIC or ran off it.
+void expectInertContextPerNic(const RdmaContextSet& contexts, size_t expected) {
+    ASSERT_EQ(contexts.size(), expected);
+    for (size_t i = 0; i < contexts.size(); ++i) {
+        ASSERT_NE(contexts[i], nullptr) << "slot " << i << " must be occupied";
+        EXPECT_NE(contexts[i]->status(), RdmaContext::DEVICE_ENABLED)
+            << "slot " << i << " must not report itself usable";
+        // Inert contexts must stay safe for the whole-list consumers.
+        EXPECT_EQ(contexts[i]->cq(0), nullptr);
+        EXPECT_EQ(contexts[i]->notifyCq(), nullptr);
+    }
+}
+
+// Non-RDMA entries are skipped before construct() is ever called, so this runs
+// without libibverbs devices.
+TEST(RdmaNicIndexAlignmentTest, ContextSetKeepsOneSlotPerNonRdmaNic) {
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-unknown-1","type":2,"numa_node":0},
+                        {"name":"mc-tcp-2","type":1,"numa_node":0}]})")
+                    .ok());
+    ASSERT_EQ(topology->getNicCount(), static_cast<size_t>(3));
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+
+    EXPECT_EQ(RdmaTransportTestPeer::initializeContexts(transport),
+              static_cast<size_t>(0));
+    expectInertContextPerNic(RdmaTransportTestPeer::contextSet(transport),
+                             topology->getNicCount());
+}
+
+// monitorThread()'s 1 Hz tick walks every slot. An inert context never built
+// an endpoint store, so an unguarded endpointStore()->reclaim() would crash --
+// and only on the first heartbeat, well after startup.
+TEST(RdmaNicIndexAlignmentTest, ReclaimTickSkipsInertContexts) {
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-unknown-1","type":2,"numa_node":0}]})")
+                    .ok());
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport),
+              static_cast<size_t>(0));
+
+    // Precondition that makes the unguarded call fatal.
+    for (const auto& context : RdmaTransportTestPeer::contextSet(transport)) {
+        ASSERT_EQ(context->endpointStore(), nullptr);
+    }
+
+    RdmaTransportTestPeer::reclaimEndpoints(transport);
+}
+
+// The construct()-failure branch. IbvLoader dlcloses libibverbs when no device
+// is present, so construct() cannot be driven safely in that state.
+TEST(RdmaNicIndexAlignmentTest, ContextSetKeepsOneSlotWhenConstructFails) {
+    if (!IbvLoader::Instance().available())
+        GTEST_SKIP() << "no usable libibverbs; construct() cannot be driven";
+
+    // Device names that resolve to no real RNIC, so construct() fails on any
+    // host, with a non-RDMA entry in the middle to offset the indexes.
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-absent-rnic-0","type":0,"numa_node":0},
+                        {"name":"mc-tcp-1","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-2","type":0,"numa_node":0}]})")
+                    .ok());
+    ASSERT_EQ(topology->getNicCount(), static_cast<size_t>(3));
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+
+    EXPECT_EQ(RdmaTransportTestPeer::initializeContexts(transport),
+              static_cast<size_t>(0));
+    expectInertContextPerNic(RdmaTransportTestPeer::contextSet(transport),
+                             topology->getNicCount());
 }
 
 TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {


### PR DESCRIPTION
Description

  A device id in TENT is a Topology NicID — DeviceSelector::devices_ is keyed by it, MemEntry::device_list holds them, and both feed slice->source_dev_id / target_dev_id. Two arrays that this id subscripts were built compacted instead:

  - install() appended to context_set_ only for entries that were NIC_RDMA and whose construct() succeeded.
  - addBufferInternal() push_back'd into BufferDesc::lkey/rkey only for slots holding a context.

  One skipped NIC shifts every higher id: context_set_[dev_id] names a different RNIC, or runs past the end — an out-of-bounds read on a vector<shared_ptr> immediately followed by ->status(). The shift also applies remotely, since rkey is published in the segment descriptor and the peer subscripts it with a NicID from our device_list.

  Unlike the classic TE, TENT has no disableDevice() equivalent — the "Disable RDMA device" warning only skips a push_back, so a failed device stays in the topology and is still handed out. The non-RDMA branch needs no failure at all: a single NIC_TCP or type-less entry in the topology JSON shifts the indexes.

  Fix: give every NicID a slot. Skipped NICs hold an inert RdmaContext (DEVICE_UNINIT, or DEVICE_DISABLED after a failed construct), which consumers already reject via status(), so the hot path gains no checks. lkey/rkey are sized to context_list_ and filled by index, leaving a zero key in the gaps that no context backs. Three sites unsafe against an inert context are guarded: RdmaContext::cq() (dereferenced a null params_), Workers::asyncPollCq() (cq->poll() unchecked), and the monitorThread() reclaim tick (endpointStore()->reclaim() — an inert context never built a store, and this only fires on the first 1 Hz heartbeat, so it crashes well after a clean startup). getEndpoint() took context_set_[0], which may now be inert; it takes the first enabled context instead.

  The install loop and reclaim tick are extracted into initializeContexts() and reclaimEndpoints() so tests can drive them without a metadata service or worker threads.

  Wire format is unchanged in a healthy cluster — with all NICs up the sparse and compacted vectors are identical — and a longer rkey vector fixes rather than breaks an unpatched peer's lookup.

  Counterpart to the classic-TE fix ([Bugfix][TE] Keep context_list_ index-aligned when an RNIC fails to init); same defect class, different mechanism.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other
  
  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Three tests in tent/tests/rdma_transport_test.cpp, two of them verified against the unpatched code:

  - ContextSetKeepsOneSlotPerNonRdmaNic — the NIC_RDMA branch, which never touches libibverbs, so it runs anywhere. Reverting the push_back ordering makes it fail.
  - ReclaimTickSkipsInertContexts — asserts endpointStore() is null on every inert slot, then runs the tick. Removing the guard makes the binary exit 139 (SIGSEGV).
  - ContextSetKeepsOneSlotWhenConstructFails — the construct()-failure branch. Self-skips without RDMA hardware: IbvLoader dlcloses libibverbs when no device is present while keeping its symbol table, so construct() cannot be driven safely in that state.

  Test commands:
  Linux container (host is macOS; TE needs libibverbs + glibc headers)
  cmake -S . -B build-tent -DBUILD_UNIT_TESTS=ON -DWITH_TE=ON \
        -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DUSE_TENT=ON
  cmake --build build-tent -j2
  ./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test \
        --gtest_filter='RdmaNicIndexAlignmentTest.*'
  cd build-tent && ctest --output-on-failure
  ./scripts/code_format.sh --check

  Test results:
  - tent_rdma_transport_test: 2 pass, 1 skipped (no RDMA hardware).
  - ctest: 60/63. tcp_transport_test and transfer_metadata_test abort on a missing etcd metadata plugin; memory_location_test on mbind EPERM. All three fail identically without this change.
  - ./scripts/code_format.sh --check: 7 files OK (clang-format 20.1.8). pre-commit on the touched files: all hooks pass, no rewrites.
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable) — not run; needs RDMA hardware
  - [x] Manual testing done (describe below)

  Manual verification = the two revert experiments above (test fails / segfaults without the fix, passes with it).

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable) — n/a, no user-facing behavior change
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue — n/a, 188 lines

Unchecked on purpose: self-review is the submitter's own attestation; --all-files was not run (only pre-commit run --files on the 7 touched files, all passing) because AGENTS.md warns it may rewrite unrelated files.
  
  Known gap, not addressed here: workers.cpp subscripts a peer's rkey vector without a bounds check, so an unpatched peer can still drive an out-of-bounds read during a rolling upgrade. Pre-existing; needs its own hardening, in the spirit of #3209 on the classic TE.

  AI Assistance Disclosure
  
  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)