### PR TITLE
[Bugfix][TENT] Bound peer key lookups by the published vector length

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -992,8 +992,8 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
         if (reachable) {
             slice->source_dev_id = sdev;
             slice->target_dev_id = tdev;
-            slice->source_lkey = source.buffer->lkey[slice->source_dev_id];
-            slice->target_rkey = target.buffer->rkey[slice->target_dev_id];
+            // Keys are assigned by generatePostPath() once the device pair is
+            // settled.
             return Status::OK();
         }
 
@@ -1016,8 +1016,19 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
         CHECK_STATUS(selectOptimalDevice(source, target, slice));
     else
         CHECK_STATUS(selectFallbackDevice(source, target, slice));
-    slice->source_lkey = source.buffer->lkey[slice->source_dev_id];
-    slice->target_rkey = target.buffer->rkey[slice->target_dev_id];
+    // Keys are NicID-indexed. A peer running an older build publishes a
+    // compacted rkey vector, so a NicID from its device_list can point past the
+    // end; fail the slice instead of reading out of bounds.
+    const auto& lkeys = source.buffer->lkey;
+    const auto& rkeys = target.buffer->rkey;
+    if (slice->source_dev_id < 0 ||
+        (size_t)slice->source_dev_id >= lkeys.size() ||
+        slice->target_dev_id < 0 ||
+        (size_t)slice->target_dev_id >= rkeys.size())
+        return Status::DeviceNotFound(
+            "Selected device has no registered memory key" LOC_MARK);
+    slice->source_lkey = lkeys[slice->source_dev_id];
+    slice->target_rkey = rkeys[slice->target_dev_id];
     // Cache the RailMonitor pointer so asyncPollCq / disableEndpoint can
     // update rail state without a segment lookup or string-keyed map
     // lookup on the hot path.


### PR DESCRIPTION
Description

  BufferDesc::lkey and rkey are subscripted with slice->source_dev_id / target_dev_id, which are Topology NicIDs — the local one from DeviceSelector, the remote one from the peer's MemEntry::device_list. Neither lookup was bounds-checked.

  The vectors are built by LocalBufferManager::addBufferInternal(), which push_backs one entry per context that came up rather than one per NicID. A node that skips any NIC therefore publishes a vector shorter than its own NicID space, and rkey travels to peers in the segment descriptor. A NicID picked out of that node's device_list can then point past the end, and generatePostPath() reads it as a uint32_t memory key — yielding either a bogus rkey on the wire (IBV_WC_REM_ACCESS_ERR, or worse, silently matching an unrelated MR) or a heap read out of bounds.

  Fix: validate both ids against the vector actually received and fail the slice instead. The caller already handles this cleanly — logs, releases the quota, marks the slice FAILED. Cost is four integer comparisons per slice, against one RDMA post.

  Also drops the key assignment in selectFallbackDevice(). It is dead: the function is reachable only from selectOptimalDevice() and generatePostPath(), and both return into generatePostPath(), which overwrites both fields two
  lines later. Keeping it would have required a second copy of the bounds check for a value that is always discarded — while the out-of-bounds read still happened.

  Companion to [Bugfix][TENT] Keep context_set_ and buffer keys NicID-indexed, which makes this node publish NicID-indexed vectors. That removes the mismatch between two patched peers; this PR is what protects a patched node talking to an unpatched one. Independent — either can land first, and skipping this one leaves the out-of-bounds read live during a rolling upgrade.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Build and full regression only — no test was added. Driving generatePostPath() requires a segment manager, a live worker context and thread-local worker state; the guard was verified by code inspection and compilation, and no
  existing test exercises it.

  Test commands:
  Linux container (host is macOS; TE needs libibverbs + glibc headers)
  cmake -S . -B build-tent -DBUILD_UNIT_TESTS=ON -DWITH_TE=ON \
        -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DUSE_TENT=ON
  cmake --build build-tent -j2
  cd build-tent && ctest
  ./scripts/code_format.sh --check

  Test results:
  - ctest: 60/63. tcp_transport_test and transfer_metadata_test abort on a missing etcd metadata plugin; memory_location_test on mbind EPERM. All three fail identically without this change.
  - pre-commit on the touched file: all hooks pass, no rewrites.
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable) — not run; needs RDMA hardware and two peers on different builds
  - [ ] Manual testing done

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable) — n/a, no user-facing behavior change
  - [ ] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue — n/a, 19 lines

Unchecked on purpose: self-review is the submitter's own attestation. --all-files was not run (only pre-commit run --files on the touched file, passing) because AGENTS.md warns it may rewrite unrelated files. Tests — see 
 above; the deliberate gap is stated rather than papered over.

  Reviewer attention: the riskiest line is the deletion in selectFallbackDevice(). It rests on an exhaustive argument about that function's two call sites, with no test backing it.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)