### PR TITLE
[CI/Build] Restrict nightly workflow to upstream repository

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   SCCACHE_GHA_ENABLED: "true"
 
+# Gate the dependency root so all downstream jobs are skipped in forks.
 jobs:
   version-stamp:
     if: github.repository == 'kvcache-ai/Mooncake'
@@ -52,7 +53,6 @@ jobs:
           echo "Nightly version: $NIGHTLY_VERSION"
 
   build-cuda128-x86:
-    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -70,7 +70,6 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-cuda128-arm64:
-    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -87,7 +86,6 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-cuda13-x86:
-    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -106,7 +104,6 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-non-cuda-x86:
-    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -123,7 +120,7 @@ jobs:
 
   publish-testpypi:
     needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, nightly-test]
-    if: ${{ github.repository == 'kvcache-ai/Mooncake' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
+    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
     runs-on: ubuntu-22.04
     environment: nightly
     permissions:
@@ -165,7 +162,7 @@ jobs:
           twine upload --repository testpypi --skip-existing dist-publish/*.whl
 
   nightly-test:
-    if: github.repository == 'kvcache-ai/Mooncake'
+    needs: version-stamp
     runs-on: ubuntu-22.04
     env:
       CI: "true"
@@ -291,6 +288,7 @@ jobs:
           bash scripts/run_tests.sh
 
   nightly-gate:
+    # always() bypasses skipped dependencies, so this job needs its own guard.
     if: ${{ always() && github.repository == 'kvcache-ai/Mooncake' }}
     needs: [build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, publish-testpypi, nightly-test]
     runs-on: ubuntu-22.04
@@ -333,7 +331,7 @@ jobs:
           echo "All nightly jobs passed!"
 
   notify-failure:
-    if: ${{ always() && github.repository == 'kvcache-ai/Mooncake' && needs.nightly-gate.result == 'failure' }}
+    if: ${{ always() && needs.nightly-gate.result == 'failure' }}
     needs: [nightly-gate]
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,6 +31,7 @@ env:
 
 jobs:
   version-stamp:
+    if: github.repository == 'kvcache-ai/Mooncake'
     runs-on: ubuntu-22.04
     outputs:
       nightly_version: ${{ steps.version.outputs.nightly_version }}
@@ -51,6 +52,7 @@ jobs:
           echo "Nightly version: $NIGHTLY_VERSION"
 
   build-cuda128-x86:
+    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -68,6 +70,7 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-cuda128-arm64:
+    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -84,6 +87,7 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-cuda13-x86:
+    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -102,6 +106,7 @@ jobs:
       version-override: ${{ needs.version-stamp.outputs.nightly_version }}
 
   build-non-cuda-x86:
+    if: github.repository == 'kvcache-ai/Mooncake'
     needs: version-stamp
     uses: ./.github/workflows/_build-wheel.yaml
     with:
@@ -118,7 +123,7 @@ jobs:
 
   publish-testpypi:
     needs: [version-stamp, build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, nightly-test]
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
+    if: ${{ github.repository == 'kvcache-ai/Mooncake' && !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip_publish == 'true') }}
     runs-on: ubuntu-22.04
     environment: nightly
     permissions:
@@ -160,6 +165,7 @@ jobs:
           twine upload --repository testpypi --skip-existing dist-publish/*.whl
 
   nightly-test:
+    if: github.repository == 'kvcache-ai/Mooncake'
     runs-on: ubuntu-22.04
     env:
       CI: "true"
@@ -285,7 +291,7 @@ jobs:
           bash scripts/run_tests.sh
 
   nightly-gate:
-    if: always()
+    if: ${{ always() && github.repository == 'kvcache-ai/Mooncake' }}
     needs: [build-cuda128-x86, build-cuda128-arm64, build-cuda13-x86, build-non-cuda-x86, publish-testpypi, nightly-test]
     runs-on: ubuntu-22.04
     steps:
@@ -327,7 +333,7 @@ jobs:
           echo "All nightly jobs passed!"
 
   notify-failure:
-    if: ${{ always() && needs.nightly-gate.result == 'failure' }}
+    if: ${{ always() && github.repository == 'kvcache-ai/Mooncake' && needs.nightly-gate.result == 'failure' }}
     needs: [nightly-gate]
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
## Description

Restrict every job in the nightly workflow to the upstream `kvcache-ai/Mooncake` repository.

The workflow's scheduled trigger was copied into forks without a repository guard. Although scheduled workflows are disabled by default in new public forks, fork owners can enable them, causing the full nightly build and test matrix to consume Actions resources and eventually fail when upstream-only publishing credentials are unavailable.

With this change, fork workflow events may still be created by GitHub, but all nightly jobs are skipped. Nightly behavior in the upstream repository is unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/nightly.yml
git diff --check
```

**Test results:**
- [x] Relevant pre-commit hooks pass, including YAML validation and codespell
- [x] Git whitespace validation passes
- [ ] Integration tests pass (not applicable)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (ran on the touched file)
- [x] I have updated the documentation (not applicable)
- [ ] I have added tests to prove my changes are effective (workflow-only condition)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex identified the missing repository guards, implemented the workflow change, and ran the listed validation. This draft remains pending human review of every changed line.