### PR TITLE
[TE] Replace hardcoded cuda: location keys with GPU_PREFIX

### DIFF
--- a/mooncake-transfer-engine/example/nccl_host_transport_example.cpp
+++ b/mooncake-transfer-engine/example/nccl_host_transport_example.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "common.h"
+#include "cuda_alike.h"
 #include "transfer_engine.h"
 
 namespace {
@@ -179,8 +180,8 @@ int main(int argc, char** argv) {
                 0 ||
             !engines[rank]->installTransport("nccl", nullptr) ||
             engines[rank]->registerLocalMemory(
-                buffers[rank], kBufferBytes, "cuda:" + std::to_string(rank)) !=
-                0) {
+                buffers[rank], kBufferBytes,
+                GPU_PREFIX + std::to_string(rank)) != 0) {
             LOG(ERROR) << "Failed to initialize NCCL TE rank " << rank;
             return 1;
         }

--- a/mooncake-transfer-engine/example/transfer_engine_bench.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench.cpp
@@ -475,8 +475,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_notify.cpp
@@ -295,8 +295,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_bench_with_retry.cpp
@@ -266,8 +266,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/example/transfer_engine_heterogeneous_ascend_perf_initiator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_heterogeneous_ascend_perf_initiator.cpp
@@ -24,10 +24,11 @@
 #include <memory>
 #include <sstream>
 #include <unordered_map>
+#include "acl/acl.h"
 #include "common/base/status.h"
+#include "cuda_alike.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
-#include "acl/acl.h"
 
 DEFINE_string(local_server_name, "10.20.130.154:12345",
               "Local server name for segment discovery");
@@ -163,8 +164,8 @@ std::string loadNicPriorityMatrix() {
            " \"npu:0\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/example/transfer_engine_validator.cpp
+++ b/mooncake-transfer-engine/example/transfer_engine_validator.cpp
@@ -381,8 +381,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
@@ -76,7 +76,7 @@ static std::string autoDetectNic(const std::vector<std::string>& filter) {
     // topologically closest NIC.  Fall back to wildcard if cudaGetDevice fails.
     int device_id = 0;
     cudaGetDevice(&device_id);
-    std::string location = "cuda:" + std::to_string(device_id);
+    std::string location = GPU_PREFIX + std::to_string(device_id);
 
     int idx = topo.selectDevice(location);
     if (idx < 0) idx = topo.selectDevice("*");  // wildcard fallback

--- a/mooncake-transfer-engine/tent/tests/sunrise_link_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/sunrise_link_transport_test.cpp
@@ -62,7 +62,7 @@ void RunWriteReadCase(int server_gpu, int client_gpu) {
         if (tangSetDevice(server_gpu) != tangSuccess) _exit(3);
         if (tangMalloc(&server_buf, kDataLength * 2) != tangSuccess) _exit(4);
         MemoryOptions server_opts;
-        server_opts.location = "cuda:" + std::to_string(server_gpu);
+        server_opts.location = GPU_PREFIX + std::to_string(server_gpu);
         auto s = server_engine->registerLocalMemory(server_buf, kDataLength * 2,
                                                     server_opts);
         if (!s.ok()) _exit(5);
@@ -130,7 +130,7 @@ void RunWriteReadCase(int server_gpu, int client_gpu) {
     CheckTangError(tangMalloc(&client_buf, kDataLength * 2),
                    "tangMalloc(client)");
     MemoryOptions client_opts;
-    client_opts.location = "cuda:" + std::to_string(client_gpu);
+    client_opts.location = GPU_PREFIX + std::to_string(client_gpu);
     auto s = client_engine->registerLocalMemory(client_buf, kDataLength * 2,
                                                 client_opts);
     ASSERT_TRUE(s.ok()) << s.ToString();

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -39,6 +39,7 @@
 #include <memory>
 #include <vector>
 
+#include "cuda_alike.h"
 #include "transfer_engine.h"
 #include "transport/efa_transport/efa_transport.h"
 #include "transport/transport.h"
@@ -108,8 +109,9 @@ class EFAGpuLoopbackTest : public ::testing::Test {
 
         // Register as GPU memory so the EFA transport tags the MR with
         // FI_HMEM_CUDA (the registration path under test).
-        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, "cuda:0");
-        EXPECT_EQ(rc, 0) << "registerLocalMemory(cuda:0) failed";
+        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size,
+                                           GPU_PREFIX + "0");
+        EXPECT_EQ(rc, 0) << "registerLocalMemory(" << GPU_PREFIX << "0) failed";
         if (rc != 0) return s;
 
         auto actual_addr = s.engine->getLocalIpAndPort();

--- a/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvlink_transport_test.cpp
@@ -58,7 +58,7 @@ TEST(NvlinkTransportTest, WriteAndRead) {
 
     void* server_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
     int rc = server_engine->registerLocalMemory(server_buffer, kDataLength * 2,
-                                                "cuda:0");
+                                                GPU_PREFIX + "0");
     ASSERT_EQ(rc, 0);
 
     auto segment_id = server_engine->openSegment(FLAGS_segment_id);
@@ -73,8 +73,8 @@ TEST(NvlinkTransportTest, WriteAndRead) {
     ASSERT_NE(client_transport, nullptr);
 
     void* client_buffer = allocateCudaBuffer(kDataLength * 2, gpu_id);
-    rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
-                                            "cuda:" + std::to_string(gpu_id));
+    rc = client_engine->registerLocalMemory(
+        client_buffer, kDataLength * 2, GPU_PREFIX + std::to_string(gpu_id));
     ASSERT_EQ(rc, 0);
 
     // Write: client -> server

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -22,9 +22,10 @@
 #include <iomanip>
 #include <memory>
 
+#include "common.h"
+#include "cuda_alike.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
-#include "common.h"
 
 using namespace mooncake;
 
@@ -82,8 +83,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names +

--- a/mooncake-transfer-engine/tests/sunrise_link_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/sunrise_link_transport_test.cpp
@@ -48,7 +48,7 @@ TEST(SunriseLinkTransportTest, WriteAndRead) {
 
     void* server_buffer = allocateSunriseBuffer(kDataLength * 2, gpu_id);
     int rc = server_engine->registerLocalMemory(
-        server_buffer, kDataLength * 2, "cuda:" + std::to_string(gpu_id));
+        server_buffer, kDataLength * 2, GPU_PREFIX + std::to_string(gpu_id));
     ASSERT_EQ(rc, 0);
 
     auto segment_id = server_engine->openSegment(FLAGS_segment_id);
@@ -60,8 +60,8 @@ TEST(SunriseLinkTransportTest, WriteAndRead) {
     ASSERT_NE(client_transport, nullptr);
 
     void* client_buffer = allocateSunriseBuffer(kDataLength * 2, gpu_id);
-    rc = client_engine->registerLocalMemory(client_buffer, kDataLength * 2,
-                                            "cuda:" + std::to_string(gpu_id));
+    rc = client_engine->registerLocalMemory(
+        client_buffer, kDataLength * 2, GPU_PREFIX + std::to_string(gpu_id));
     ASSERT_EQ(rc, 0);
 
     {

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -28,6 +28,7 @@
 
 #include "common.h"
 #include "config.h"
+#include "cuda_alike.h"
 #include "transfer_metadata_plugin.h"
 #include "transport/transport.h"
 
@@ -126,14 +127,14 @@ TEST_F(TransferMetadataTest, NcclMetadataAndHandshakePayloadRoundTrip) {
     server_segment->name = maybeWrapIpV6(host) + ":" + std::to_string(port);
     server_segment->protocol = "nccl";
     TransferMetadata::BufferDesc server_buffer;
-    server_buffer.name = "cuda:2";
+    server_buffer.name = GPU_PREFIX + "2";
     server_buffer.addr = 0x10000;
     server_buffer.length = 4096;
     server_buffer.device_id = 2;
     server_segment->buffers.push_back(server_buffer);
     const std::string server_name = server_segment->name;
     TransferMetadata::BufferDesc server_buffer_2;
-    server_buffer_2.name = "cuda:2-aux";
+    server_buffer_2.name = GPU_PREFIX + "2-aux";
     server_buffer_2.addr = 0x08000;
     server_buffer_2.length = 8192;
     server_buffer_2.device_id = 2;
@@ -168,11 +169,11 @@ TEST_F(TransferMetadataTest, NcclMetadataAndHandshakePayloadRoundTrip) {
     ASSERT_NE(peer_segment, nullptr);
     ASSERT_EQ(peer_segment->protocol, "nccl");
     ASSERT_EQ(peer_segment->buffers.size(), 2U);
-    EXPECT_EQ(peer_segment->buffers[0].name, "cuda:2");
+    EXPECT_EQ(peer_segment->buffers[0].name, GPU_PREFIX + "2");
     EXPECT_EQ(peer_segment->buffers[0].addr, 0x10000U);
     EXPECT_EQ(peer_segment->buffers[0].length, 4096U);
     EXPECT_EQ(peer_segment->buffers[0].device_id, 2);
-    EXPECT_EQ(peer_segment->buffers[1].name, "cuda:2-aux");
+    EXPECT_EQ(peer_segment->buffers[1].name, GPU_PREFIX + "2-aux");
     EXPECT_EQ(peer_segment->buffers[1].addr, 0x08000U);
     EXPECT_EQ(peer_segment->buffers[1].length, 8192U);
     EXPECT_EQ(peer_segment->buffers[1].device_id, 2);

--- a/mooncake-transfer-engine/tests/ub_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ub_transport_test.cpp
@@ -22,9 +22,10 @@
 #include <iomanip>
 #include <memory>
 
+#include "common.h"
+#include "cuda_alike.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
-#include "common.h"
 
 using namespace mooncake;
 
@@ -82,8 +83,8 @@ std::string loadNicPriorityMatrix() {
            " \"cpu:1\": [[" +
            device_names +
            "], []], "
-           " \"cuda:0\": [[" +
-           device_names +
+           " \"" +
+           GPU_PREFIX + "0\": [[" + device_names +
            "], []], "
            " \"musa:0\": [[" +
            device_names + "], []]}";


### PR DESCRIPTION
## Description

Follow-up to #3248: audit remaining hardcoded `"cuda:"` Mooncake location / topology keys in Transfer Engine examples, tests, and IBGDA NIC selection.

These paths build under multi-vendor configs (`USE_HIP` / `USE_MUSA`) but still embedded `"cuda:0"` (or `"cuda:" + id`) while registration / discovery already use `GPU_PREFIX` (`hip:` / `musa:`). That can make NIC priority matrices miss the active GPU key.

This PR switches those call sites to `GPU_PREFIX`. Intentionally left unchanged:
- `GPU_PREFIX` definitions themselves
- TENT CUDA / Sunrise platform probes & plugins (vendor-native `cuda:`)
- Sunrise parser unit tests that assert `"cuda:"` parsing
- Docs and `torch.device("cuda:N")` strings

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja .. -DUSE_HIP=ON -DUSE_CUDA=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON ...
cmake --build . -j"$(nproc)" --target \
  transfer_metadata_test topology_test rdma_transport_test2 \
  transfer_engine_bench transfer_engine_validator hip_transport_test

MC_METADATA_SERVER=P2PHANDSHAKE \
  ./mooncake-transfer-engine/tests/transfer_metadata_test \
  --gtest_filter='TransferMetadataTest.NcclMetadataAndHandshakePayloadRoundTrip'

./mooncake-transfer-engine/tests/topology_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- Build (USE_HIP): related tests/examples compiled successfully
- `topology_test`: 13/13 passed
- `NcclMetadataAndHandshakePayloadRoundTrip` (GPU_PREFIX buffer names): passed
- Full `transfer_metadata_test`: 13 passed / 1 failed (`RpcMetaEntryTest` listen EBADF — unrelated env)
- `hip_transport_test`: failed on P2P listen/connect port mismatch (pre-existing; registration succeeded)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Agent assisted with repo-wide `"cuda:"` audit, `GPU_PREFIX` replacements, and local USE_HIP validation. Human submitter reviewed all changed lines.

Made with [Cursor](https://cursor.com)