### PR TITLE
[Store] Fix flaky standby catch-up test

### DIFF
--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -558,6 +559,7 @@ std::string MakeValidPayload(uint64_t client_id_first = 1,
 class FakeHaKvBackend : public HaKvBackend {
    public:
     ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
         if (next_get_error_ != ErrorCode::OK) {
             auto error = next_get_error_;
             next_get_error_ = ErrorCode::OK;
@@ -574,11 +576,13 @@ class FakeHaKvBackend : public HaKvBackend {
         return ErrorCode::OK;
     }
     ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
         values_[std::string(key)] = std::string(value);
         return ErrorCode::OK;
     }
     ErrorCode Range(std::string_view begin_key, std::string_view end_key,
                     size_t limit, std::vector<KvPair>& kvs) override {
+        std::lock_guard<std::mutex> lock(mutex_);
         if (range_error_ != ErrorCode::OK) {
             return range_error_;
         }
@@ -592,12 +596,39 @@ class FakeHaKvBackend : public HaKvBackend {
         return ErrorCode::OK;
     }
     bool SupportsTxn() const override { return true; }
-    ErrorCode Txn(const KvTxn&) override { return ErrorCode::OK; }
-    void SetGetError(ErrorCode err) { get_error_ = err; }
-    void SetRangeError(ErrorCode err) { range_error_ = err; }
-    void FailNextGet(ErrorCode err) { next_get_error_ = err; }
+    ErrorCode Txn(const KvTxn& txn) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& compare : txn.compares) {
+            auto it = values_.find(compare.key);
+            if (compare.kind == KvCompareKind::kKeyNotExists) {
+                if (it != values_.end()) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
+            } else if (it == values_.end() ||
+                       it->second != compare.expected_value) {
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+        }
+        for (const auto& put : txn.puts) {
+            values_[put.key] = put.value;
+        }
+        return ErrorCode::OK;
+    }
+    void SetGetError(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        get_error_ = err;
+    }
+    void SetRangeError(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        range_error_ = err;
+    }
+    void FailNextGet(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        next_get_error_ = err;
+    }
 
    private:
+    mutable std::mutex mutex_;
     std::map<std::string, std::string> values_;
     ErrorCode get_error_{ErrorCode::OK};
     ErrorCode range_error_{ErrorCode::OK};
@@ -870,16 +901,17 @@ TEST_F(PromotionCatchUpTest, MissingDurablePrefixRejectsNonzeroSequence) {
 }
 
 TEST_F(PromotionCatchUpTest, CatchesUpPrefixThatAppearsBeforePromotion) {
+    const DurablePrefix initial_prefix{.batch_id = 0, .last_seq = 0};
+    ASSERT_EQ(ErrorCode::OK,
+              batch_backend_->Put(BuildDurablePrefixKey(cluster_id_),
+                                  EncodeDurablePrefix(initial_prefix)));
     ASSERT_EQ(ErrorCode::OK,
               service_->Start("", oplog_endpoints_, cluster_id_));
     ASSERT_EQ(StandbyState::WATCHING, service_->GetState());
-    ASSERT_EQ(ErrorCode::OK,
-              batch_backend_->Put(
-                  BuildDurablePrefixKey(cluster_id_),
-                  EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
-    ASSERT_EQ(ErrorCode::OK,
-              batch_backend_->Put(BuildBatchRecordKey(cluster_id_, 1),
-                                  EncodeOpLogBatchRecord(MakeBatch(1, 1, 1))));
+
+    OpLogBatchStorage storage(cluster_id_, *batch_backend_);
+    ASSERT_EQ(ErrorCode::OK, storage.WriteBatchAndAdvancePrefix(
+                                 MakeBatch(1, 1, 1), initial_prefix));
 
     StandbySnapshot out;
     ASSERT_EQ(ErrorCode::OK, service_->PromoteAndExportSnapshot(out));


### PR DESCRIPTION
## Description

Fix the flaky `PromotionCatchUpTest.CatchesUpPrefixThatAppearsBeforePromotion` failure reported by PR #3222 CI.

The test used an unsynchronized fake `HaKvBackend` while the replication thread and the test thread accessed it concurrently. It also published the durable prefix and batch record through two independent `Put` calls. The replication thread could observe the updated prefix before the corresponding batch record, receive `ETCD_KEY_NOT_EXIST (-1001)`, and transition the standby service to `FAILED`.

The same failure was reproduced on the base branch, so this was an existing test race rather than a regression introduced by PR #3222.

This change is test-only:

- Protect fake backend state and injected errors with a mutex.
- Implement compare-and-put transaction semantics in the fake backend.
- Publish the batch record and updated durable prefix atomically with `WriteBatchAndAdvancePrefix`.
- Keep the production missing-batch error handling unchanged.

## Module

- [x] Mooncake Store

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target hot_standby_service_test -j32

env LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/hot_standby_service_test \
  --gtest_filter=PromotionCatchUpTest.CatchesUpPrefixThatAppearsBeforePromotion \
  --gtest_repeat=100 \
  --gtest_brief=1

env LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/hot_standby_service_test \
  --gtest_brief=1

pre-commit run --files \
  mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
```

**Test results:**

- The flaky test passed all 100 repeated iterations.
- The full test binary passed 28 tests, with 15 tests skipped by configuration.
- All targeted pre-commit hooks passed.
- `LSAN_OPTIONS=detect_leaks=0` was used because LeakSanitizer exits with a ptrace-related runtime error in the local environment.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted the changed code.
- [x] I have run `pre-commit run --all-files` (targeted pre-commit hooks passed for the changed file).
- [x] Documentation update is not applicable because this is a test-only change.
- [x] I have added test coverage for the flaky scenario.
- [x] This change is below 500 LOC and does not require an RFC.

## AI Assistance Disclosure

- [ ] No AI tools were used.
- [x] AI tools were used.

Codex assisted with CI failure analysis, race reproduction, implementation, and verification. The human submitter reviewed every changed line and is responsible for the final change.