### PR TITLE
[CI][TE] Stabilize graceful shutdown signal tests

### DIFF
--- a/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
+++ b/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
@@ -37,20 +37,39 @@ void waitChildWithTimeout(pid_t pid, int* status) {
     FAIL() << "child did not exit before timeout";
 }
 
+void notifyParentReady(int fd) {
+    const char ready = '1';
+    if (write(fd, &ready, 1) != 1) _exit(111);
+    close(fd);
+}
+
+void waitForChildReady(int fd) {
+    char ready = 0;
+    ASSERT_EQ(read(fd, &ready, 1), 1) << "child did not report readiness";
+    EXPECT_EQ(ready, '1');
+    close(fd);
+}
+
 }  // namespace
 
 TEST(GracefulShutdownTest, SigtermTriggersCleanExit) {
+    int ready_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0) << "pipe() failed";
+
     pid_t pid = fork();
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
+        close(ready_pipe[0]);
         auto engine = std::make_unique<TransferEngine>(false);
         engine->enableGracefulShutdown();
+        notifyParentReady(ready_pipe[1]);
         pause();
         _exit(99);
     }
 
-    usleep(100000);
+    close(ready_pipe[1]);
+    waitForChildReady(ready_pipe[0]);
     kill(pid, SIGTERM);
 
     int status;
@@ -62,17 +81,23 @@ TEST(GracefulShutdownTest, SigtermTriggersCleanExit) {
 }
 
 TEST(GracefulShutdownTest, SigintTriggersCleanExit) {
+    int ready_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0) << "pipe() failed";
+
     pid_t pid = fork();
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
+        close(ready_pipe[0]);
         auto engine = std::make_unique<TransferEngine>(false);
         engine->enableGracefulShutdown();
+        notifyParentReady(ready_pipe[1]);
         pause();
         _exit(99);
     }
 
-    usleep(100000);
+    close(ready_pipe[1]);
+    waitForChildReady(ready_pipe[0]);
     kill(pid, SIGINT);
 
     int status;
@@ -89,19 +114,25 @@ TEST(GracefulShutdownTest, IdempotentEnable) {
 }
 
 TEST(GracefulShutdownTest, EngineDestroyedBeforeSignal) {
+    int ready_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0) << "pipe() failed";
+
     pid_t pid = fork();
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
+        close(ready_pipe[0]);
         {
             auto engine = std::make_unique<TransferEngine>(false);
             engine->enableGracefulShutdown();
         }
+        notifyParentReady(ready_pipe[1]);
         pause();
         _exit(99);
     }
 
-    usleep(100000);
+    close(ready_pipe[1]);
+    waitForChildReady(ready_pipe[0]);
     kill(pid, SIGTERM);
 
     int status;
@@ -114,15 +145,21 @@ TEST(GracefulShutdownTest, ForkAfterInstallDoesNotHangChildSignal) {
     auto engine = std::make_unique<TransferEngine>(false);
     engine->enableGracefulShutdown();
 
+    int ready_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0) << "pipe() failed";
+
     pid_t pid = fork();
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
+        close(ready_pipe[0]);
+        notifyParentReady(ready_pipe[1]);
         pause();
         _exit(99);
     }
 
-    usleep(100000);
+    close(ready_pipe[1]);
+    waitForChildReady(ready_pipe[0]);
     kill(pid, SIGTERM);
 
     int status;
@@ -134,19 +171,25 @@ TEST(GracefulShutdownTest, ForkAfterInstallDoesNotHangChildSignal) {
 }
 
 TEST(GracefulShutdownTest, MultipleEngines) {
+    int ready_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0) << "pipe() failed";
+
     pid_t pid = fork();
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
+        close(ready_pipe[0]);
         auto engine1 = std::make_unique<TransferEngine>(false);
         auto engine2 = std::make_unique<TransferEngine>(false);
         engine1->enableGracefulShutdown();
         engine2->enableGracefulShutdown();
+        notifyParentReady(ready_pipe[1]);
         pause();
         _exit(99);
     }
 
-    usleep(100000);
+    close(ready_pipe[1]);
+    waitForChildReady(ready_pipe[0]);
     kill(pid, SIGTERM);
 
     int status;


### PR DESCRIPTION
## Description

graceful_shutdown_test currently waits for a fixed 100 ms before sending a signal to the child process. On a busy CI runner, the child may still be creating the TransferEngine and may not have installed its signal handlers yet. In that case, SIGTERM terminates the child directly and the test fails.

This change replaces the fixed sleep with a small readiness pipe. The child reports ready only after `enableGracefulShutdown()` returns, and the parent waits for that notification before sending the signal.

There is no production behavior change; this only makes the tests wait for the condition they actually depend on.

## Module

- [xz] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
cmake --build build --target graceful_shutdown_test -j2
ctest --test-dir build -R '^graceful_shutdown_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped investigate the CI failure, identify the test race, prepare the change, and run the relevant checks.