### PR TITLE
[store]  perf: lazy hash chain evaluation with early exit in /query

### DIFF
--- a/mooncake-conductor/include/conductor/prefixindex/hash_strategy.h
+++ b/mooncake-conductor/include/conductor/prefixindex/hash_strategy.h
@@ -20,6 +20,25 @@ struct HashBlock {
     bool operator==(const HashBlock&) const = default;
 };
 
+// A lazily-evaluated block-hash chain. Blocks are hashed on demand: asking
+// for block i hashes (and caches) every block up to i, so a caller that
+// stops early — e.g. a prefix-index walk whose cursors have all stalled —
+// never pays for the untouched tail.
+class HashChain {
+   public:
+    virtual ~HashChain() = default;
+
+    // Number of complete blocks the chain can produce.
+    virtual size_t BlockCount() const = 0;
+
+    // Number of blocks hashed so far (observability/testing hook).
+    virtual size_t ComputedCount() const = 0;
+
+    // Returns block index, hashing any uncomputed prefix first. Returns
+    // nullptr and sets error on failure; the error is sticky across calls.
+    virtual const HashBlock* At(size_t index, std::string* error) = 0;
+};
+
 class HashStrategy {
    public:
     virtual ~HashStrategy() = default;
@@ -30,6 +49,13 @@ class HashStrategy {
                                 std::span<const int32_t> token_ids,
                                 std::optional<std::string> cache_salt,
                                 std::vector<HashBlock>* out) const = 0;
+
+    // Creates a lazy hash chain over the same inputs as Compute. The chain
+    // borrows token_ids; the caller must keep it alive for the chain's
+    // lifetime. Returns nullptr and sets error when the inputs are invalid.
+    virtual std::unique_ptr<HashChain> CreateChain(
+        const ContextKey& context, std::span<const int32_t> token_ids,
+        std::optional<std::string> cache_salt, std::string* error) const = 0;
 };
 
 // Resolves a supported source profile and derives its root digest. Returns an

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -626,6 +626,131 @@ ProjectedPrefix ProjectDigest(
     return ProjectedPrefix{value};
 }
 
+// Lazily-hashed vLLM v1 block chain. Hashing is incremental: block i is
+// computed only when first requested via At(), and every block up to i is
+// cached, so prefix-index walks that stall early never hash the tail.
+class VllmV1HashChain final : public HashChain {
+   public:
+    VllmV1HashChain(const VllmValueCodec* codec,
+                    std::array<uint8_t, kSha256DigestSize> root_digest,
+                    const ContextKey& context,
+                    std::span<const int32_t> token_ids,
+                    std::optional<std::string> cache_salt)
+        : codec_(codec),
+          parent_(std::move(root_digest)),
+          lora_name_(context.lora_name),
+          cache_salt_(std::move(cache_salt)),
+          token_ids_(token_ids),
+          block_size_(static_cast<size_t>(context.block_size)),
+          block_count_(token_ids.size() / block_size_) {
+        computed_.reserve(block_count_);
+        // Reused across blocks: every codec clears the buffer at the start of
+        // EncodeBlock, so a single allocation with worst-case capacity avoids
+        // a malloc/free per block (dominant cost at large block counts).
+        encoded_.reserve(64 + block_size_ * 9);
+    }
+
+    // Validates inputs eagerly (same contract as Compute). Returns an empty
+    // string on success.
+    static std::string ValidateInputs(const ContextKey& context,
+                                      std::optional<std::string> cache_salt) {
+        if (context.block_size <= 0 ||
+            static_cast<uint64_t>(context.block_size) >
+                std::numeric_limits<size_t>::max()) {
+            return "block_size must be a positive size_t value";
+        }
+        if (!IsValidUtf8(context.lora_name)) {
+            return "lora_name must contain valid UTF-8";
+        }
+        if (cache_salt.has_value() && !IsValidUtf8(*cache_salt)) {
+            return "cache_salt must contain valid UTF-8";
+        }
+        return "";
+    }
+
+    size_t BlockCount() const override { return block_count_; }
+
+    size_t ComputedCount() const override { return computed_.size(); }
+
+    const HashBlock* At(size_t index, std::string* error) override {
+        if (index >= block_count_) {
+            if (error != nullptr) {
+                *error = "hash chain index out of range";
+            }
+            return nullptr;
+        }
+        if (!sticky_error_.empty()) {
+            if (error != nullptr) {
+                *error = sticky_error_;
+            }
+            return nullptr;
+        }
+        if (!EnsureEvp()) {
+            if (error != nullptr) {
+                *error = sticky_error_;
+            }
+            return nullptr;
+        }
+        while (computed_.size() <= index) {
+            const size_t block_index = computed_.size();
+            const bool has_lora = !lora_name_.empty();
+            const bool has_salt = block_index == 0 && cache_salt_.has_value() &&
+                                  !cache_salt_->empty();
+            const VllmBlockValues values{
+                .parent_digest = parent_,
+                .token_ids =
+                    token_ids_.subspan(block_index * block_size_, block_size_),
+                .lora_name = has_lora ? &lora_name_ : nullptr,
+                .cache_salt = has_salt ? &*cache_salt_ : nullptr,
+            };
+
+            codec_->EncodeBlock(values, &encoded_);
+
+            HashBlock block;
+            if (std::string hash_error =
+                    Sha256Reuse(evp_.get(), encoded_, &block.digest);
+                !hash_error.empty()) {
+                sticky_error_ = std::move(hash_error);
+                if (error != nullptr) {
+                    *error = sticky_error_;
+                }
+                return nullptr;
+            }
+            block.projected = ProjectDigest(block.digest);
+            parent_ = block.digest;
+            computed_.push_back(std::move(block));
+        }
+        return &computed_[index];
+    }
+
+   private:
+    bool EnsureEvp() {
+        if (evp_) {
+            return true;
+        }
+        evp_ = EvpContext(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+        if (!evp_) {
+            sticky_error_ = "OpenSSL EVP MD context allocation failed";
+            return false;
+        }
+        return true;
+    }
+
+    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+
+    const VllmValueCodec* codec_;
+    std::array<uint8_t, kSha256DigestSize> parent_;
+    std::string lora_name_;
+    std::optional<std::string> cache_salt_;
+    std::span<const int32_t> token_ids_;
+    size_t block_size_;
+    size_t block_count_;
+    std::vector<HashBlock> computed_;
+    std::vector<uint8_t> encoded_;
+    EvpContext evp_{nullptr, EVP_MD_CTX_free};
+    std::string sticky_error_;
+};
+
 class VllmV1HashStrategy final : public HashStrategy {
    public:
     VllmV1HashStrategy(const VllmValueCodec* codec,
@@ -641,65 +766,40 @@ class VllmV1HashStrategy final : public HashStrategy {
         }
         out->clear();
 
-        if (context.block_size <= 0 ||
-            static_cast<uint64_t>(context.block_size) >
-                std::numeric_limits<size_t>::max()) {
-            return "block_size must be a positive size_t value";
+        std::string error;
+        auto chain =
+            CreateChain(context, token_ids, std::move(cache_salt), &error);
+        if (!chain) {
+            return error;
         }
-        if (!IsValidUtf8(context.lora_name)) {
-            return "lora_name must contain valid UTF-8";
-        }
-        if (cache_salt.has_value() && !IsValidUtf8(*cache_salt)) {
-            return "cache_salt must contain valid UTF-8";
-        }
-
-        const size_t block_size = static_cast<size_t>(context.block_size);
-        const size_t block_count = token_ids.size() / block_size;
         std::vector<HashBlock> computed;
-        computed.reserve(block_count);
-
-        // Reused across blocks: every codec clears the buffer at the start of
-        // EncodeBlock, so a single allocation with worst-case capacity avoids
-        // a malloc/free per block (dominant cost at large block counts).
-        std::vector<uint8_t> encoded;
-        encoded.reserve(64 + block_size * 9);
-
-        // One EVP context for the whole chain, reset per block.
-        using EvpContext =
-            std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
-        EvpContext evp(EVP_MD_CTX_new(), EVP_MD_CTX_free);
-        if (!evp) {
-            return "OpenSSL EVP MD context allocation failed";
-        }
-
-        std::array<uint8_t, kSha256DigestSize> parent = root_digest_;
-        for (size_t block_index = 0; block_index < block_count; ++block_index) {
-            const bool has_lora = !context.lora_name.empty();
-            const bool has_salt = block_index == 0 && cache_salt.has_value() &&
-                                  !cache_salt->empty();
-            const VllmBlockValues values{
-                .parent_digest = parent,
-                .token_ids =
-                    token_ids.subspan(block_index * block_size, block_size),
-                .lora_name = has_lora ? &context.lora_name : nullptr,
-                .cache_salt = has_salt ? &*cache_salt : nullptr,
-            };
-
-            codec_->EncodeBlock(values, &encoded);
-
-            HashBlock block;
-            if (std::string error =
-                    Sha256Reuse(evp.get(), encoded, &block.digest);
-                !error.empty()) {
+        computed.reserve(chain->BlockCount());
+        for (size_t index = 0; index < chain->BlockCount(); ++index) {
+            const HashBlock* block = chain->At(index, &error);
+            if (block == nullptr) {
                 return error;
             }
-            block.projected = ProjectDigest(block.digest);
-            parent = block.digest;
-            computed.push_back(std::move(block));
+            computed.push_back(*block);
         }
 
         *out = std::move(computed);
         return "";
+    }
+
+    std::unique_ptr<HashChain> CreateChain(
+        const ContextKey& context, std::span<const int32_t> token_ids,
+        std::optional<std::string> cache_salt,
+        std::string* error) const override {
+        if (std::string validation_error =
+                VllmV1HashChain::ValidateInputs(context, cache_salt);
+            !validation_error.empty()) {
+            if (error != nullptr) {
+                *error = std::move(validation_error);
+            }
+            return nullptr;
+        }
+        return std::make_unique<VllmV1HashChain>(
+            codec_, root_digest_, context, token_ids, std::move(cache_salt));
     }
 
    private:

--- a/mooncake-conductor/src/prefixindex/prefix_indexer.cpp
+++ b/mooncake-conductor/src/prefixindex/prefix_indexer.cpp
@@ -410,17 +410,26 @@ std::map<std::string, CacheHitResult> PrefixCacheTable::Query(
         return results;
     }
 
-    std::vector<HashBlock> hashes;
-    if (auto error = strategy->Compute(context, token_ids,
-                                       std::move(cache_salt), &hashes);
-        !error.empty()) {
-        LOG(ERROR) << "Query hash computation failed: " << error;
+    std::string chain_error;
+    auto chain = strategy->CreateChain(context, token_ids,
+                                       std::move(cache_salt), &chain_error);
+    if (!chain) {
+        LOG(ERROR) << "Query hash chain setup failed: " << chain_error;
         return results;
     }
+    const size_t block_count = chain->BlockCount();
 
+    // The chain hashes lazily: blocks are only hashed as cursors reach them,
+    // so queries that stall early (cold or short-matching prefixes) never
+    // pay for hashing the untouched tail.
     auto advance_cursor = [&](size_t& cursor, const auto& present) {
-        while (cursor < hashes.size()) {
-            auto block = state->blocks.find(hashes[cursor].projected);
+        while (cursor < block_count) {
+            const HashBlock* hashed = chain->At(cursor, &chain_error);
+            if (hashed == nullptr) {
+                cursor = block_count;  // stall every remaining walk
+                return;
+            }
+            auto block = state->blocks.find(hashed->projected);
             if (block == state->blocks.end() || !present(block->second)) {
                 break;
             }
@@ -465,6 +474,10 @@ std::map<std::string, CacheHitResult> PrefixCacheTable::Query(
         }
         result.longest_match_tokens = result.disk;
         results.emplace(instance_id, std::move(result));
+    }
+    if (!chain_error.empty()) {
+        LOG(ERROR) << "Query hash computation failed: " << chain_error;
+        return {};
     }
     return results;
 }

--- a/mooncake-conductor/tests/compute_hash_test.cpp
+++ b/mooncake-conductor/tests/compute_hash_test.cpp
@@ -690,4 +690,97 @@ TEST(HashStrategy, DigestToHexPreservesLeadingZerosAndUsesLowercase) {
     EXPECT_EQ(encoded.substr(60), "cdef");
 }
 
+TEST(HashChain, MatchesEagerCompute) {
+    for (const HashProfile& profile : {ValidProfile(), ValidPickleProfile()}) {
+        SCOPED_TRACE(profile.algorithm);
+        std::string factory_error;
+        auto strategy = CreateHashStrategy(profile, &factory_error);
+        ASSERT_NE(strategy, nullptr) << factory_error;
+
+        ContextKey context{
+            .tenant_id = "default",
+            .model_name = "model",
+            .lora_name = "lora-a",
+            .block_size = 4,
+        };
+        const std::vector<int32_t> tokens{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+        const std::string salt = "salty";
+
+        std::vector<HashBlock> eager;
+        ASSERT_TRUE(strategy->Compute(context, tokens, salt, &eager).empty());
+        ASSERT_EQ(eager.size(), 2u);
+
+        std::string chain_error;
+        auto chain = strategy->CreateChain(context, tokens, salt, &chain_error);
+        ASSERT_NE(chain, nullptr) << chain_error;
+        EXPECT_EQ(chain->BlockCount(), eager.size());
+        for (size_t index = 0; index < eager.size(); ++index) {
+            const HashBlock* block = chain->At(index, &chain_error);
+            ASSERT_NE(block, nullptr) << chain_error;
+            EXPECT_EQ(*block, eager[index]) << "block=" << index;
+        }
+    }
+}
+
+TEST(HashChain, ComputesOnlyRequestedPrefix) {
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 4,
+    };
+    const std::vector<int32_t> tokens(400, 7);  // 100 complete blocks
+
+    std::string chain_error;
+    auto chain =
+        strategy->CreateChain(context, tokens, std::nullopt, &chain_error);
+    ASSERT_NE(chain, nullptr) << chain_error;
+    EXPECT_EQ(chain->BlockCount(), 100u);
+    EXPECT_EQ(chain->ComputedCount(), 0u);
+
+    ASSERT_NE(chain->At(0, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 1u);
+
+    ASSERT_NE(chain->At(2, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+
+    // Already-computed blocks must not be rehashed.
+    ASSERT_NE(chain->At(2, &chain_error), nullptr) << chain_error;
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+
+    EXPECT_EQ(chain->At(100, &chain_error), nullptr);
+    EXPECT_FALSE(chain_error.empty());
+    EXPECT_EQ(chain->ComputedCount(), 3u);
+}
+
+TEST(HashChain, RejectsInvalidInputsAtSetup) {
+    std::string factory_error;
+    auto strategy = CreateHashStrategy(ValidProfile(), &factory_error);
+    ASSERT_NE(strategy, nullptr) << factory_error;
+
+    ContextKey context{
+        .tenant_id = "default",
+        .model_name = "model",
+        .lora_name = "",
+        .block_size = 0,
+    };
+    const std::vector<int32_t> tokens{1, 2, 3, 4};
+
+    std::string chain_error;
+    EXPECT_EQ(
+        strategy->CreateChain(context, tokens, std::nullopt, &chain_error),
+        nullptr);
+    EXPECT_FALSE(chain_error.empty());
+
+    context.block_size = 4;
+    const std::string invalid_salt("\xed\xa0\x80", 3);
+    EXPECT_EQ(
+        strategy->CreateChain(context, tokens, invalid_salt, &chain_error),
+        nullptr);
+}
+
 }  // namespace


### PR DESCRIPTION
## Description

`/query` previously computed the full block-hash chain for every request
(`HashStrategy::Compute` over all complete blocks) before walking the prefix
index, even though the walk typically stalls early — a cold or short-matching
query paid the full chain cost regardless of hit length. Measured on a
single-core WSL2 box: a 1M-token query with **zero** matching blocks cost
~172ms.

This PR makes hash-chain evaluation lazy and demand-driven:

- New `HashChain` abstraction (`At(i)` hashes and caches blocks up to `i` on
  first request) and `HashStrategy::CreateChain`. Inputs are validated eagerly
  at chain construction (same contract as `Compute`); hash failures are sticky.
- `VllmV1HashStrategy::Compute` is reimplemented as a thin eager wrapper over
  the chain, so there is a single hashing code path.
- `PrefixCacheTable::Query` walks tier cursors against the lazy chain: hashing
  stops as soon as every gpu/cpu/disk cursorys
  hashing the whole prompt.

Query cost becomes O(matched blocks) insteadit
worst case is unchanged by design (the full  the
match); the win is on cold/partial-hit traff
queries.

Measured (same box, msgpack `/query`, 16-tokile):

| tokens | 0% hit (before → after) | 100% hit (after) |
|---|---|---|
| 8K   | 1.8ms → 0.6ms   | 2.4ms   |
| 32K  | 5.5ms → 1.0ms   | 6.7ms   |
| 128K | 22ms  → 2.9ms   | 23.6ms  |
| 1M   | 172ms → 18.7ms  | 185.9ms |

(0%-hit residual is msgpack body parse + RTTs
full-chain cost, as expected.)

## Module

- [x] Other (`mooncake-conductor`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build mooncake-conductor/build -j2
./mooncake-conductor/build/tests/conductor_test
```
Test results:
- [x] Unit tests pass — 161/161 (3 new HashC
eager Compute, lazy-prefix computation accou
validation)
- [x] Manual testing — end-to-end on a 2×vLLr
cluster: tiered gpu/cpu/disk matching, stick
rejections all unchanged; latency numbers ab
cold-token /query sweeps and a synthetic 1M-
- [x] pre-commit run --files <touched files> passes (clang-format etc.)

Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using ./scrip
- [x] I have run pre-commit on the touched f
- [x] I have added tests to prove my changes
- [ ] For changes >500 LOC: I have filed an . tests)

AI Assistance Disclosure

- [x] AI tools were used (Claude Code: tests, and benchmarks;
every changed line reviewed by the human submitter)