### PR TITLE
[Doc] Align pre-commit guidance to PR-changed files

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@
 
 - [ ] I have performed a self-review of my own code
 - [ ] I have formatted my code using `./scripts/code_format.sh`
-- [ ] I have run `pre-commit run --all-files` and all hooks pass
+- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
 - [ ] I have updated the documentation (if applicable)
 - [ ] I have added tests to prove my changes are effective
 - [ ] For changes >500 LOC: I have filed an RFC issue

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,8 @@
 # Pre-commit hooks configuration for Mooncake
 # Install: pip install -r requirements-dev.txt && pre-commit install
-# Run manually on all files: pre-commit run --all-files
+# Staged files: pre-commit run
+# PR-changed files: pre-commit run --files $(git diff --name-only --diff-filter=ACMR main...HEAD)
+# Full-repo (intentional cleanup only): pre-commit run --all-files
 # Format all C/C++ files explicitly: ./scripts/code_format.sh --all
 # Note: clang-format should already be available (installed via system packages or dependencies.sh)
 # Exclusions: build artifacts, vendored extern code, generated wheels.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # Pre-commit hooks configuration for Mooncake
 # Install: pip install -r requirements-dev.txt && pre-commit install
 # Staged files: pre-commit run
-# PR-changed files: pre-commit run --files $(git diff --name-only --diff-filter=ACMR main...HEAD)
+# PR-changed files: git fetch origin main && pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
 # Full-repo (intentional cleanup only): pre-commit run --all-files
 # Format all C/C++ files explicitly: ./scripts/code_format.sh --all
 # Note: clang-format should already be available (installed via system packages or dependencies.sh)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,10 @@
   checklist, and AI assistance disclosure.
 - For AI-assisted changes, make sure the human submitter has reviewed every
   changed line and can defend the change end-to-end.
-- Run pre-commit locally on the files touched by the change before handoff when
-  the toolchain is available. If broader hooks or `pre-commit run --all-files`
-  rewrite unrelated files, do not include those unrelated edits in the PR.
+- Before handoff, run pre-commit on the files touched by the change when the
+  toolchain is available (see `CONTRIBUTING.md` for the PR-scoped
+  `pre-commit run --files ...` command). Do not use
+  `pre-commit run --all-files` for routine PRs; if it rewrites unrelated
+  files, leave those edits out of the PR.
 - Keep PRs lean: review `git diff` before staging, and include only changes
   required for the requested task.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,9 +65,20 @@ committing again. Use `./scripts/code_format.sh --all` only when intentionally
 formatting the whole project.
 
 #### Usage
-Run hooks on all files (the first run installs hook environments). The C/C++
-hook remains limited to staged line ranges; use `./scripts/code_format.sh --all`
-for an intentional whole-project C/C++ format:
+After `pre-commit install`, hooks run on each commit. To run them manually on
+staged files (the first run may install hook environments):
+```bash
+pre-commit run
+```
+Before opening a PR, run hooks only on files changed against the PR base
+(default `main`). The C/C++ hook remains limited to staged or changed line
+ranges:
+```bash
+pre-commit run --files $(git diff --name-only --diff-filter=ACMR main...HEAD)
+```
+Use full-repo checks only for intentional whole-project cleanup; do not fold
+unrelated rewrites into a feature PR. Prefer `./scripts/code_format.sh --all`
+for a deliberate whole-project C/C++ format:
 ```bash
 pre-commit run --all-files
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,10 +71,11 @@ staged files (the first run may install hook environments):
 pre-commit run
 ```
 Before opening a PR, run hooks only on files changed against the PR base
-(default `main`). The C/C++ hook remains limited to staged or changed line
-ranges:
+(default `origin/main`). The C/C++ hook remains limited to staged or changed
+line ranges:
 ```bash
-pre-commit run --files $(git diff --name-only --diff-filter=ACMR main...HEAD)
+git fetch origin main
+pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
 ```
 Use full-repo checks only for intentional whole-project cleanup; do not fold
 unrelated rewrites into a feature PR. Prefer `./scripts/code_format.sh --all`


### PR DESCRIPTION
## Description

Unify contributor guidance so routine PRs run pre-commit only on files changed in the PR (or staged files), instead of requiring `pre-commit run --all-files`.

`--all-files` remains documented for intentional whole-repo cleanup. This matches existing C++ formatting / CI behavior, which already scopes checks to changed files or lines, and avoids folding unrelated historical rewrites into feature PRs.

Touched docs/comments:
- `.github/pull_request_template.md` — checklist item
- `CONTRIBUTING.md` — Usage section
- `AGENTS.md` — handoff guidance
- `.pre-commit-config.yaml` — header comments

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Docs/comments only; no runtime or CI workflow changes.

**Test commands:**
```bash
# N/A — documentation-only change
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Reviewed the four-file diff for consistency of the staged / PR-scoped / `--all-files` guidance.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor assisted with drafting and aligning the documentation wording across the PR template, CONTRIBUTING, AGENTS, and pre-commit config comments.


Made with [Cursor](https://cursor.com)