### PR TITLE
fix(transfer-engine): block SIGTERM/SIGINT for the shutdown watcher

### DIFF
--- a/mooncake-transfer-engine/src/graceful_shutdown.cpp
+++ b/mooncake-transfer-engine/src/graceful_shutdown.cpp
@@ -15,6 +15,7 @@
 #include "graceful_shutdown.h"
 
 #include <errno.h>
+#include <pthread.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -103,9 +104,30 @@ bool startSignalWatcherLocked(pid_t current_pid) {
 
     if (pipe(g_signal_pipe) != 0) return false;
 
+    // The watcher must never take SIGTERM/SIGINT itself: the handler writes
+    // to the pipe and then pauses forever, so if it ran on the watcher
+    // thread no reader would be left and cleanup would never run. Block both
+    // signals around thread creation so the watcher inherits the mask, and
+    // restore the caller's original mask on every path (it may have had its
+    // own reasons to block these signals).
+    sigset_t watcher_block_set;
+    sigset_t saved_mask;
+    sigemptyset(&watcher_block_set);
+    sigaddset(&watcher_block_set, SIGTERM);
+    sigaddset(&watcher_block_set, SIGINT);
+    const bool mask_blocked =
+        pthread_sigmask(SIG_BLOCK, &watcher_block_set, &saved_mask) == 0;
+
+    bool watcher_started = false;
     try {
         std::thread(signalWatcher).detach();
+        watcher_started = true;
     } catch (...) {
+    }
+
+    if (mask_blocked) pthread_sigmask(SIG_SETMASK, &saved_mask, nullptr);
+
+    if (!watcher_started) {
         close(g_signal_pipe[0]);
         close(g_signal_pipe[1]);
         g_signal_pipe[0] = -1;

--- a/mooncake-transfer-engine/src/graceful_shutdown.cpp
+++ b/mooncake-transfer-engine/src/graceful_shutdown.cpp
@@ -123,7 +123,8 @@ bool startSignalWatcherLocked(pid_t current_pid) {
         std::thread(signalWatcher).detach();
         watcher_started = true;
     } catch (const std::exception& e) {
-        LOG(WARNING) << "action=start_signal_watcher_failed, error=" << e.what();
+        LOG(WARNING) << "action=start_signal_watcher_failed, error="
+                     << e.what();
     } catch (...) {
     }
 

--- a/mooncake-transfer-engine/src/graceful_shutdown.cpp
+++ b/mooncake-transfer-engine/src/graceful_shutdown.cpp
@@ -122,6 +122,8 @@ bool startSignalWatcherLocked(pid_t current_pid) {
     try {
         std::thread(signalWatcher).detach();
         watcher_started = true;
+    } catch (const std::exception& e) {
+        LOG(WARNING) << "action=start_signal_watcher_failed, error=" << e.what();
     } catch (...) {
     }
 


### PR DESCRIPTION
Fixes #3271.

The graceful-shutdown self-pipe can deadlock when a process-directed signal is delivered to the watcher thread itself. `shutdownSignalHandler` writes one byte into the pipe and then waits in `pause()` forever; if it ran on the watcher thread, the only pipe reader is the thread now suspended inside the handler, so `cleanupEngines()` never runs and the process hangs until something SIGKILLs it. The fork guard (`g_handlers_pid != getpid()`) covers children, not this case.

The fix blocks SIGTERM and SIGINT around `std::thread(signalWatcher)` creation in `startSignalWatcherLocked()`, so the watcher inherits the blocked mask for its whole lifetime and the signal always lands on some other thread. The creator's original mask is restored afterwards on every path, including the thread-creation failure path, since the caller may have its own reasons to block these signals and `installGracefulShutdownHandlers()` runs per engine. If `pthread_sigmask` itself fails, install proceeds with today's exposure instead of refusing to install handlers.

@00fish0 analyzed this in the issue and sketched the same approach; I checked with them first and picked it up after no reply.

## Verification

No local build tree here (the repo build dirs point at container paths), so the change is validated two ways and CI runs the real suite:

- Standalone g++ -Wall -Wextra -Werror build of the extracted `startSignalWatcherLocked()` shape: mask restore verified (the calling thread is not left with SIGTERM blocked), and the pipe protocol still drives a 128+SIGTERM exit.
- A second standalone run proves the watcher thread really inherits the blocked mask: the watcher checks `sigismember` for both signals on entry and would exit with a distinctive code if either were unblocked; it exits 143 instead.

The existing graceful_shutdown tests keep their meaning: every scenario still has at least one unblocked thread, so the signal always has somewhere to land.

Signed-off-by: Yufeng He <40085740+he-yufeng@users.noreply.github.com>