### PR TITLE
[Store] Add fatal crash stack traces

### DIFF
--- a/mooncake-common/include/crash_handler.h
+++ b/mooncake-common/include/crash_handler.h
@@ -1,0 +1,26 @@
+// Copyright 2026 Mooncake Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace mooncake {
+
+// Installs best-effort stderr stack traces for fatal crash signals. The
+// installation is process-global and idempotent. It deliberately leaves
+// SIGINT and SIGTERM unchanged so host applications retain shutdown ownership.
+// After reporting, the original fatal signal is re-raised by glog's handler,
+// preserving normal signal termination and operating-system core-dump policy.
+void InstallCrashHandler();
+
+}  // namespace mooncake

--- a/mooncake-common/src/CMakeLists.txt
+++ b/mooncake-common/src/CMakeLists.txt
@@ -1,7 +1,8 @@
 find_package(yaml-cpp REQUIRED)
 
-set(MOONCAKE_COMMON_SOURCES crc_checksum.cpp default_config.cpp environ.cpp
-                            rpc_client_io_context.cpp)
+set(MOONCAKE_COMMON_SOURCES
+    crash_handler.cpp crc_checksum.cpp default_config.cpp environ.cpp
+    rpc_client_io_context.cpp)
 
 add_library(asio_shared SHARED asio_impl.cpp)
 
@@ -39,8 +40,9 @@ target_include_directories(
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
          $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(mooncake_common PUBLIC asio_shared yaml-cpp jsoncpp
-                                             yalantinglibs::yalantinglibs)
+target_link_libraries(
+  mooncake_common PUBLIC asio_shared yaml-cpp jsoncpp
+                         yalantinglibs::yalantinglibs glog::glog)
 
 if(BUILD_SHARED_LIBS)
   install(TARGETS mooncake_common DESTINATION lib)

--- a/mooncake-common/src/crash_handler.cpp
+++ b/mooncake-common/src/crash_handler.cpp
@@ -1,0 +1,38 @@
+// Copyright 2026 Mooncake Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "crash_handler.h"
+
+#include <mutex>
+#include <signal.h>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+void InstallCrashHandler() {
+    static std::once_flag install_once;
+    std::call_once(install_once, []() {
+        // glog versions supported by Mooncake also register SIGTERM as a
+        // failure signal. Preserve the host's current disposition across the
+        // installation: SIGTERM is a shutdown request, not a crash.
+        struct sigaction previous_sigterm{};
+        if (sigaction(SIGTERM, nullptr, &previous_sigterm) != 0) return;
+
+        google::InstallFailureSignalHandler();
+        sigaction(SIGTERM, &previous_sigterm, nullptr);
+    });
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -13,6 +13,7 @@
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 #include <ylt/easylog/record.hpp>
 
+#include "crash_handler.h"
 #include "default_config.h"
 #include "duration_utils.h"
 #include "ha/leadership/master_service_supervisor.h"
@@ -1285,6 +1286,7 @@ std::unique_ptr<mooncake::HttpMetadataServer> StartHttpMetadataServer(
 }
 
 int main(int argc, char* argv[]) {
+    mooncake::InstallCrashHandler();
     mooncake::init_ylt_log_level();
     // Initialize gflags
     gflags::SetVersionString(mooncake::MOONCAKE_DISPLAY_VERSION);

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -5,6 +5,7 @@
 #include "client_service.h"
 #include "common.h"
 #include "config.h"
+#include "crash_handler.h"
 #include "real_client.h"
 
 using namespace mooncake;
@@ -99,6 +100,7 @@ int main(int argc, char *argv[]) {
     // Otherwise, the main thread will not apply signal mask before other
     // spawning threads, leading to missing signal processing.
     mooncake::ResourceTracker::getInstance();
+    mooncake::InstallCrashHandler();
 
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     if (!FLAGS_log_dir.empty()) {


### PR DESCRIPTION
## Description

Add a small, centralized crash handler for the standalone Mooncake Store processes.

- Install glog's failure signal handler during `mooncake_master` and `mooncake_client` startup, before normal service work begins.
- Cover `SIGSEGV`, `SIGABRT` (including standard C/C++ `assert()`), `SIGBUS`, `SIGFPE`, and `SIGILL`.
- Write fatal-signal diagnostics directly to stderr, independent of `FLAGS_log_dir` and `MC_LOG_DIR`.
- Preserve the existing `SIGTERM` disposition because glog 0.4.0 also treats `SIGTERM` as a failure signal. `SIGINT` is not modified.
- Re-raise the original fatal signal after reporting, preserving signal-based termination and the host's core-dump policy.
- Keep Python extensions and general Transfer Engine/Store library use free of automatic process-global signal-handler changes.

No existing open issue or PR was found for this change.

### stderr output

A native crash produces a best-effort failure header and native stack trace similar to:

```text
*** Aborted at <unix-time> (unix time) ***
PC: @ <address> <symbol-or-unknown>
*** SIGSEGV (...) received by PID <pid> (TID <tid>); stack trace: ***
    @ <address> <frame>
    @ <address> <frame>
    @ <address> main
    @ <address> __libc_start_main
    @ <address> _start
```

A standard assertion first emits the libc assertion message, followed by the `SIGABRT` trace:

```text
mooncake_client: <file>:<line>: Assertion `<expression>` failed.
*** Aborted at <unix-time> (unix time) ***
PC: @ <address> <symbol-or-unknown>
*** SIGABRT (...) received by PID <pid> (TID <tid>); stack trace: ***
    @ <address> raise
    @ <address> abort
    @ <address> __assert_fail
    @ <address> <Mooncake frame>
```

Stack walking and symbolization are best effort under severe memory or stack corruption. After printing, the process still terminates from the original signal (for example, shell status 139 for `SIGSEGV` or 134 for `SIGABRT`), and a core dump is produced when enabled by the OS/container configuration.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Common (`mooncake-common`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-crash-handler-services \
  -DBUILD_UNIT_TESTS=OFF \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF \
  -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build-crash-handler-services \
  --target mooncake_master mooncake_client \
  --parallel 128
pre-commit run --files \
  mooncake-common/include/crash_handler.h \
  mooncake-common/src/crash_handler.cpp \
  mooncake-common/src/CMakeLists.txt \
  mooncake-store/src/master.cpp \
  mooncake-store/src/real_client_main.cpp
git diff --check
```

**Test results:**
- [x] `mooncake_master` and `mooncake_client` build successfully.
- [x] Manual glog 0.4.0 signal validation confirmed stderr stack output and original-signal exit statuses.
- [x] Pre-commit passes on every changed file.
- [x] `git diff --check` passes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using the repository formatting hook
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] Documentation is not required; the behavior and output are documented in this PR
- [ ] I have added tests to prove my changes are effective
- [x] An RFC issue is not required because this change is under 500 LOC

## AI Assistance Disclosure

- [x] AI tools were used

Codex helped inspect signal ownership, implement the centralized wrapper, run builds and formatting checks, and draft this PR description. The human submitter reviewed the resulting scope and explicitly limited automatic installation to the standalone master and client service processes.