### PR TITLE
[TENT] Add native UB foundation and URMA resource management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,6 +766,12 @@ jobs:
             cmake_flags: '-DUSE_CUDA=OFF'
             need_cuda: false
             metrics_flags: '-DTENT_METRICS_ENABLED=ON'
+          # Exercise the native UB target with its injected mock adapter. A
+          # Debug build also catches ODR/link errors hidden by optimization.
+          - name: ub-mock
+            cmake_flags: '-DUSE_CUDA=OFF -DUSE_UB=ON -DCMAKE_BUILD_TYPE=Debug'
+            need_cuda: false
+            metrics_flags: ''
     name: tent-ci (${{ matrix.name }})
     env:
       CI: "true"

--- a/mooncake-common/FindUrma.cmake
+++ b/mooncake-common/FindUrma.cmake
@@ -1,20 +1,46 @@
 include(FetchContent)
 
-# UMDK 头文件库
-FetchContent_Declare(
-        urma
-        GIT_REPOSITORY https://atomgit.com/openeuler/umdk.git
-        GIT_TAG        v25.12.0.B081
-)
+# Prefer a system UMDK installation so configure works without downloading a
+# second copy and the headers match the liburma ABI used at runtime.
+find_path(
+  URMA_SYSTEM_INCLUDE_DIR
+  NAMES urma_api.h
+  PATHS /usr/include /usr/local/include
+  PATH_SUFFIXES urma umdk src/urma/lib/urma/core/include)
+find_library(
+  URMA_LIBRARY
+  NAMES urma
+  PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
 
-FetchContent_MakeAvailable(urma)
+if(URMA_SYSTEM_INCLUDE_DIR)
+  set(urma_INCLUDE_DIR "${URMA_SYSTEM_INCLUDE_DIR}")
+else()
+  # The source fallback supplies headers only. Production TENT UB remains
+  # disabled at runtime when no real liburma is present; tests inject their own
+  # adapter instead of defining a second set of global urma_* mock symbols.
+  FetchContent_Declare(
+    urma
+    GIT_REPOSITORY https://atomgit.com/openeuler/umdk.git
+    GIT_TAG v25.12.0.B081)
+  FetchContent_MakeAvailable(urma)
+  set(urma_INCLUDE_DIR "${urma_SOURCE_DIR}/src/urma/lib/urma/core/include")
+endif()
 
-# 输出实际路径，确认位置
-message(STATUS "URMA source dir: ${urma_SOURCE_DIR}")
-message(STATUS "URMA binary dir: ${urma_BINARY_DIR}")
+if(NOT TARGET Urma::urma)
+  add_library(Urma::urma INTERFACE IMPORTED GLOBAL)
+  set_property(TARGET Urma::urma PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                                          "${urma_INCLUDE_DIR}")
+  if(URMA_LIBRARY)
+    set_property(TARGET Urma::urma PROPERTY INTERFACE_LINK_LIBRARIES
+                                            "${URMA_LIBRARY}")
+  endif()
+endif()
 
-# 假设 UMDK 头文件在其 include 目录下
-set(urma_INCLUDE_DIR ${urma_SOURCE_DIR}/src/urma/lib/urma/core/include)
-
-# 添加到需要的目标
-message(STATUS "urma_INCLUDE_DIR: ${urma_INCLUDE_DIR}")
+set(URMA_INCLUDE_DIR "${urma_INCLUDE_DIR}")
+set(URMA_FOUND TRUE)
+message(STATUS "URMA include directory: ${URMA_INCLUDE_DIR}")
+if(URMA_LIBRARY)
+  message(STATUS "URMA library: ${URMA_LIBRARY}")
+else()
+  message(STATUS "URMA library not found; real UB backends will be unavailable")
+endif()

--- a/mooncake-transfer-engine/src/transport/kunpeng_transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/transport/kunpeng_transport/CMakeLists.txt
@@ -1,32 +1,20 @@
 file(GLOB UB_SOURCES "*.cpp" "urma/urma_endpoint.cpp" "ub_allocator.cpp")
 
-# Check if liburma.so exists
-find_library(URMA_LIBRARY urma PATHS /usr/lib64)
-
-# Build ub_transport with real URMA library if available
-# Never include mock_urma_api.cpp in ub_transport library
-# For test, we will use mock_urma_api.cpp directly
-if (URMA_LIBRARY)
-    add_library(ub_transport OBJECT ${UB_SOURCES})
-    target_link_libraries(ub_transport
-            PUBLIC
-            ${URMA_LIBRARY}
-    )
-    message(STATUS "Using real URMA library: ${URMA_LIBRARY}")
+# Build ub_transport with real URMA library if available Never include
+# mock_urma_api.cpp in ub_transport library For test, we will use
+# mock_urma_api.cpp directly
+if(URMA_LIBRARY)
+  add_library(ub_transport OBJECT ${UB_SOURCES})
+  message(STATUS "Using real URMA library: ${URMA_LIBRARY}")
 else()
-    # If liburma.so not found, we'll need to handle this differently
-    # For now, just build without mock_urma_api.cpp
-    list(APPEND UB_SOURCES "urma/mock_urma.cpp")
-    add_library(ub_transport OBJECT ${UB_SOURCES})
-    message(WARNING "Not Found liburma.so building ub_transport with Mock URMA library")
+  # If liburma.so not found, we'll need to handle this differently For now, just
+  # build without mock_urma_api.cpp
+  list(APPEND UB_SOURCES "urma/mock_urma.cpp")
+  add_library(ub_transport OBJECT ${UB_SOURCES})
+  message(
+    WARNING "Not Found liburma.so building ub_transport with Mock URMA library")
 endif()
-target_include_directories(ub_transport
-        PUBLIC
-        ${urma_INCLUDE_DIR}
-)
-target_link_libraries(ub_transport
-        PRIVATE
-        JsonCpp::JsonCpp
-        glog::glog
-        pthread
-)
+target_link_libraries(
+  ub_transport
+  PUBLIC Urma::urma
+  PRIVATE JsonCpp::JsonCpp glog::glog pthread)

--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -60,6 +60,21 @@
                 "rail_topo_path": "/path/to/rail_topo.json"
             }
         },
+        "ub": {
+            "enable": false,
+            "device_filter": [],
+            "worker_count": 4,
+            "poller_count": 1,
+            "jfc_per_context": 1,
+            "jetty_per_endpoint": 4,
+            "max_endpoints": 4096,
+            "slice_size": 65536,
+            "max_retries": 3,
+            "slice_timeout_ms": 10000,
+            "endpoint_cooldown_ms": 30000,
+            "enable_bandwidth_estimation": true,
+            "enable_notifications": false
+        },
         "tcp": {
             "enable": true,
             "max_retry_count": 3,

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -55,6 +55,7 @@ enum TransportType : int {
     AscendDirect,
     SUNRISE_LINK,
     TPU,
+    UB,
     // Sentinel: must remain the last enumerator.
     kNumTransportTypes,
 };
@@ -90,6 +91,8 @@ inline const char* transportTypeName(TransportType type) {
             return "sunrise_link";
         case TPU:
             return "tpu";
+        case UB:
+            return "ub";
         case kNumTransportTypes:
             return "unknown";
     }
@@ -108,6 +111,7 @@ inline TransportType parseTransportType(const std::string& str) {
     if (str == "ascend") return AscendDirect;
     if (str == "sunrise_link") return SUNRISE_LINK;
     if (str == "tpu") return TPU;
+    if (str == "ub") return UB;
     return UNSPEC;
 }
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
@@ -36,17 +36,29 @@ namespace tent {
 class Platform;
 class Topology {
    public:
-    const static size_t DevicePriorityRanks = 3;
+    inline static constexpr size_t DevicePriorityRanks = 3;
 
-    enum NicType { NIC_RDMA, NIC_TCP, NIC_UNKNOWN };
+    // Keep the existing RDMA/TCP numeric values stable for serialized
+    // topologies. UB is a distinct link type and must never be selected as an
+    // RDMA verbs device.
+    enum NicType {
+        NIC_RDMA = 0,
+        NIC_TCP = 1,
+        NIC_UNKNOWN = 2,
+        NIC_UB = 3,
+    };
     enum MemType { MEM_HOST, MEM_CUDA, MEM_ROCM, MEM_ASCEND, MEM_UNKNOWN };
 
     using NicID = int;
     struct NicEntry {
         std::string name;
         std::string pci_bus_id;
-        NicType type;
-        int numa_node;
+        NicType type{NIC_UNKNOWN};
+        int numa_node{-1};
+
+        // Hardware-specific discovery metadata is opaque to the common
+        // topology layer. Transports own namespaced keys and interpretation.
+        std::unordered_map<std::string, std::string> device_attrs{};
     };
 
     using MemID = int;
@@ -67,7 +79,11 @@ class Topology {
 
     void clear();
 
+    // Preserve the original one-argument symbol for source and binary
+    // compatibility with callers that do not opt into UB discovery.
     Status discover(const std::vector<Platform*>& platforms);
+
+    Status discover(const std::vector<Platform*>& platforms, bool discover_ub);
 
     Status parse(const std::string& json_content);
 

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -109,6 +109,8 @@ typedef struct tent_notifi_info tent_notifi_info;
 #define TRANSPORT_TCP (7)
 #define TRANSPORT_ASCEND_DIRECT (8)
 #define TRANSPORT_SUNRISE_LINK (9)
+#define TRANSPORT_TPU (10)
+#define TRANSPORT_UB (11)
 
 struct tent_memory_options {
     char location[64];

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/buffers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/buffers.h
@@ -1,0 +1,158 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENT_TRANSPORT_UB_BUFFERS_H_
+#define TENT_TRANSPORT_UB_BUFFERS_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tent/common/status.h"
+#include "tent/runtime/segment.h"
+#include "tent/transport/ub/context.h"
+#include "tent/transport/ub/urma_adapter.h"
+
+namespace mooncake::tent::ub {
+
+struct UbBufferSegmentMetadata {
+    Topology::NicID topology_id{-1};
+    std::string device_name;
+    std::string eid;
+    int eid_index{-1};
+    SegmentDescriptor descriptor;
+};
+
+struct UbBufferMetadata {
+    static constexpr uint32_t kSchemaVersion = 1;
+
+    uint32_t schema_version{kSchemaVersion};
+    uint64_t generation{0};
+    uint64_t base{0};
+    uint64_t length{0};
+    std::string location;
+    Permission permission{kLocalReadWrite};
+    std::vector<UbBufferSegmentMetadata> segments;
+};
+
+Status encodeBufferMetadata(const UbBufferMetadata& metadata,
+                            std::string& encoded);
+Status decodeBufferMetadata(std::string_view encoded,
+                            UbBufferMetadata& metadata);
+
+struct LocalSegmentRef {
+    UbContextPtr context;
+    LocalSegmentPtr segment;
+    uint64_t generation{0};
+    uint64_t buffer_base{0};
+    uint64_t buffer_length{0};
+};
+
+struct ImportedSegmentRef {
+    UbContextPtr context;
+    RemoteSegmentPtr segment;
+    uint64_t generation{0};
+    uint64_t buffer_base{0};
+    uint64_t buffer_length{0};
+    Topology::NicID remote_topology_id{-1};
+};
+
+// Owns registrations and imports independently from Classic TE.  Every
+// adapter handle is shared with completion tokens, so removal invalidates the
+// metadata immediately while native destruction is deferred until in-flight
+// work releases its last reference.
+class UbBufferManager final {
+   public:
+    UbBufferManager(std::shared_ptr<UrmaAdapter> adapter,
+                    std::vector<UbContextPtr> contexts);
+    ~UbBufferManager();
+
+    UbBufferManager(const UbBufferManager&) = delete;
+    UbBufferManager& operator=(const UbBufferManager&) = delete;
+
+    Status addBuffer(BufferDesc& desc, const MemoryOptions& options);
+    Status addBuffers(std::vector<BufferDesc>& descs,
+                      const MemoryOptions& options);
+    Status removeBuffer(BufferDesc& desc);
+    Status clear();
+
+    Status findLocal(uint64_t address, size_t length,
+                     Topology::NicID local_topology_id,
+                     LocalSegmentRef& result) const;
+
+    Status importRemote(SegmentID remote_segment_id,
+                        Topology::NicID local_topology_id,
+                        Topology::NicID remote_topology_id,
+                        const BufferDesc& remote_buffer, Request::OpCode opcode,
+                        uint64_t address, size_t length,
+                        ImportedSegmentRef& result);
+
+    [[nodiscard]] size_t localBufferCount() const;
+    [[nodiscard]] size_t importedSegmentCount() const;
+
+   private:
+    struct AddressRange {
+        uint64_t base{0};
+        uint64_t length{0};
+
+        bool operator<(const AddressRange& rhs) const {
+            return base < rhs.base || (base == rhs.base && length < rhs.length);
+        }
+        [[nodiscard]] bool contains(uint64_t address, size_t size) const;
+    };
+
+    struct LocalRecord {
+        MemoryOptions options;
+        uint64_t generation{0};
+        std::unordered_map<Topology::NicID, LocalSegmentPtr> segments;
+    };
+
+    struct ImportKey {
+        Topology::NicID local_topology_id{-1};
+        SegmentID remote_segment_id{LOCAL_SEGMENT_ID};
+        Topology::NicID remote_topology_id{-1};
+        uint64_t buffer_base{0};
+        uint64_t generation{0};
+
+        bool operator==(const ImportKey&) const = default;
+    };
+
+    struct ImportKeyHash {
+        size_t operator()(const ImportKey& key) const noexcept;
+    };
+
+    Status addBufferInternal(BufferDesc& desc, const MemoryOptions& options);
+    Status unregisterRecord(LocalRecord& record);
+    void retainPendingRecord(LocalRecord& record);
+    static uint32_t segmentAccess(Permission permission);
+    static bool permissionAllows(Permission permission, Request::OpCode opcode);
+    UbContextPtr findContext(Topology::NicID topology_id) const;
+
+    std::shared_ptr<UrmaAdapter> adapter_;
+    std::vector<UbContextPtr> contexts_;
+    std::unordered_map<Topology::NicID, UbContextPtr> context_by_topology_id_;
+
+    mutable std::shared_mutex local_mutex_;
+    std::map<AddressRange, LocalRecord> local_buffers_;
+    // Registrations created by an add/transaction rollback stay owned here
+    // when the provider refuses the first unregister attempt. clear() retries
+    // them before the manager can be destroyed.
+    std::vector<LocalSegmentPtr> pending_local_segments_;
+
+    mutable std::shared_mutex import_mutex_;
+    std::unordered_map<ImportKey, RemoteSegmentPtr, ImportKeyHash> imports_;
+    // Partial imports returned alongside a provider error have no usable cache
+    // key, but still need stable ownership until unimport succeeds.
+    std::vector<RemoteSegmentPtr> pending_remote_segments_;
+    std::atomic<uint64_t> next_generation_{1};
+};
+
+}  // namespace mooncake::tent::ub
+
+#endif  // TENT_TRANSPORT_UB_BUFFERS_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/context.h
@@ -1,0 +1,112 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENT_TRANSPORT_UB_CONTEXT_H_
+#define TENT_TRANSPORT_UB_CONTEXT_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "tent/common/status.h"
+#include "tent/runtime/topology.h"
+#include "tent/transport/ub/jfc.h"
+#include "tent/transport/ub/urma_adapter.h"
+
+namespace mooncake::tent::ub {
+
+class UbContext final : public std::enable_shared_from_this<UbContext> {
+   public:
+    enum class State : uint8_t {
+        kUninitialized,
+        kActive,
+        kFailed,
+        kDraining,
+        kClosed,
+    };
+
+    UbContext(Topology::NicID topology_id, DeviceInfo device,
+              std::shared_ptr<UrmaAdapter> adapter);
+    ~UbContext();
+
+    UbContext(const UbContext&) = delete;
+    UbContext& operator=(const UbContext&) = delete;
+
+    Status initialize(uint32_t jfc_count, const JfcOptions& options);
+    Status shutdown();
+    // Returns true only for the Active -> Failed transition. Every subsequent
+    // poll error advances the failure epoch so stale successes from another
+    // JFC can never reactivate the device.
+    [[nodiscard]] bool markUnavailable() noexcept;
+    // The failure owner calls this only after every endpoint backed by this
+    // device has been unpublished and has reached Destroyed. Pending native
+    // cleanup remains quarantined and keeps this recovery barrier incomplete.
+    void completeFailureCleanup() noexcept;
+    // Pollers continue probing every JFC. A transiently failed context becomes
+    // active only after all JFCs have succeeded in the current failure epoch,
+    // the error-free cooldown has elapsed, old WRs have drained, and endpoint
+    // unpublication has completed.
+    [[nodiscard]] bool recordPollSuccess(size_t jfc_index,
+                                         uint64_t cooldown_ns) noexcept;
+
+    [[nodiscard]] Topology::NicID topologyId() const noexcept {
+        return topology_id_;
+    }
+    [[nodiscard]] const DeviceInfo& deviceInfo() const noexcept {
+        return device_;
+    }
+    [[nodiscard]] const ContextPtr& handle() const noexcept { return handle_; }
+    [[nodiscard]] State state() const noexcept {
+        return state_.load(std::memory_order_acquire);
+    }
+    [[nodiscard]] bool active() const noexcept {
+        return state() == State::kActive;
+    }
+    [[nodiscard]] const std::vector<std::shared_ptr<UbJfc>>& jfcs() const {
+        return jfcs_;
+    }
+    [[nodiscard]] std::shared_ptr<UbJfc> jfc(size_t index) const;
+
+    void addInflight(uint64_t bytes) noexcept;
+    void removeInflight(uint64_t bytes) noexcept;
+    [[nodiscard]] uint64_t inflightBytes() const noexcept {
+        return inflight_bytes_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] uint64_t outstandingWrs() const noexcept {
+        return outstanding_wrs_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] uint64_t recoveryCount() const noexcept {
+        return recovery_count_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] uint64_t failureStartedNs() const noexcept {
+        return failure_started_ns_.load(std::memory_order_acquire);
+    }
+
+   private:
+    Status shutdownLocked();
+
+    const Topology::NicID topology_id_;
+    const DeviceInfo device_;
+    std::shared_ptr<UrmaAdapter> adapter_;
+    ContextPtr handle_;
+    std::vector<std::shared_ptr<UbJfc>> jfcs_;
+    mutable std::mutex lifecycle_mutex_;
+    std::atomic<State> state_{State::kUninitialized};
+    std::atomic<uint64_t> inflight_bytes_{0};
+    std::atomic<uint64_t> outstanding_wrs_{0};
+    std::atomic<uint64_t> failure_started_ns_{0};
+    std::atomic<uint64_t> last_failure_ns_{0};
+    std::atomic<uint64_t> recovery_count_{0};
+    uint64_t failure_epoch_{0};
+    std::vector<uint64_t> jfc_success_epochs_;
+    bool failure_cleanup_complete_{false};
+};
+
+using UbContextPtr = std::shared_ptr<UbContext>;
+
+}  // namespace mooncake::tent::ub
+
+#endif  // TENT_TRANSPORT_UB_CONTEXT_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/jfc.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/jfc.h
@@ -1,0 +1,58 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENT_TRANSPORT_UB_JFC_H_
+#define TENT_TRANSPORT_UB_JFC_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "tent/common/status.h"
+#include "tent/transport/ub/urma_adapter.h"
+
+namespace mooncake::tent::ub {
+
+// TENT-facing completion queue.  Native JFC handles stay behind the adapter;
+// this object only adds stable ownership and transport telemetry.
+class UbJfc final {
+   public:
+    UbJfc(size_t index, std::shared_ptr<UrmaAdapter> adapter, JfcPtr handle)
+        : index_(index),
+          adapter_(std::move(adapter)),
+          handle_(std::move(handle)) {}
+
+    UbJfc(const UbJfc&) = delete;
+    UbJfc& operator=(const UbJfc&) = delete;
+
+    ~UbJfc();
+
+    [[nodiscard]] size_t index() const noexcept { return index_; }
+    [[nodiscard]] const JfcPtr& handle() const noexcept { return handle_; }
+    [[nodiscard]] bool valid() const noexcept {
+        return handle_ && handle_->valid();
+    }
+
+    Status poll(size_t max_completions, std::vector<Completion>& completions);
+    Status close();
+
+    [[nodiscard]] uint64_t completionCount() const noexcept {
+        return completion_count_.load(std::memory_order_relaxed);
+    }
+    [[nodiscard]] uint64_t pollErrorCount() const noexcept {
+        return poll_error_count_.load(std::memory_order_relaxed);
+    }
+
+   private:
+    const size_t index_;
+    std::shared_ptr<UrmaAdapter> adapter_;
+    JfcPtr handle_;
+    std::atomic<uint64_t> completion_count_{0};
+    std::atomic<uint64_t> poll_error_count_{0};
+};
+
+}  // namespace mooncake::tent::ub
+
+#endif  // TENT_TRANSPORT_UB_JFC_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/params.h
@@ -1,0 +1,219 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_TRANSPORT_UB_PARAMS_H_
+#define TENT_TRANSPORT_UB_PARAMS_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/status.h"
+
+namespace mooncake {
+namespace tent {
+namespace ub {
+
+struct UbParams {
+    // UB is opt-in until a real URMA provider and NIC topology are present.
+    bool enable = false;
+    std::vector<std::string> device_filter;
+
+    uint32_t worker_count = 6;
+    uint32_t poller_count = 2;
+    uint32_t jfc_per_context = 6;
+    uint32_t jetty_per_endpoint = 6;
+    uint32_t max_endpoints = 65536;
+    size_t slice_size = 64 * 1024;
+    uint32_t max_retries = 8;
+    uint32_t slice_timeout_ms = 5000;
+    uint32_t endpoint_cooldown_ms = 1000;
+
+    bool enable_bandwidth_estimation = true;
+    bool enable_notifications = false;
+
+    // Reads every UB setting from transports/ub/*. Numeric settings are
+    // deliberately read as signed JSON integers first so a negative value is
+    // rejected rather than silently converted to an unsigned default.
+    static Status FromConfig(const Config& config, UbParams& output) {
+        UbParams parsed;
+
+        CHECK_STATUS(readBool(config, "transports/ub/enable", parsed.enable,
+                              parsed.enable));
+        CHECK_STATUS(readDeviceFilter(config, parsed.device_filter));
+        CHECK_STATUS(readPositive(config, "transports/ub/worker_count",
+                                  parsed.worker_count, parsed.worker_count));
+        CHECK_STATUS(readPositive(config, "transports/ub/poller_count",
+                                  parsed.poller_count, parsed.poller_count));
+        CHECK_STATUS(readPositive(config, "transports/ub/jfc_per_context",
+                                  parsed.jfc_per_context,
+                                  parsed.jfc_per_context));
+        CHECK_STATUS(readPositive(config, "transports/ub/jetty_per_endpoint",
+                                  parsed.jetty_per_endpoint,
+                                  parsed.jetty_per_endpoint));
+        CHECK_STATUS(readPositive(config, "transports/ub/max_endpoints",
+                                  parsed.max_endpoints, parsed.max_endpoints));
+
+        uint64_t slice_size = parsed.slice_size;
+        CHECK_STATUS(readPositive(config, "transports/ub/slice_size",
+                                  slice_size, slice_size));
+        if (slice_size > std::numeric_limits<uint32_t>::max()) {
+            return Status::InvalidArgument(
+                "transports/ub/slice_size exceeds the URMA SGE length limit");
+        }
+        parsed.slice_size = static_cast<size_t>(slice_size);
+
+        CHECK_STATUS(readNonNegative(config, "transports/ub/max_retries",
+                                     parsed.max_retries, parsed.max_retries));
+        CHECK_STATUS(readPositive(config, "transports/ub/slice_timeout_ms",
+                                  parsed.slice_timeout_ms,
+                                  parsed.slice_timeout_ms));
+        CHECK_STATUS(readPositive(config, "transports/ub/endpoint_cooldown_ms",
+                                  parsed.endpoint_cooldown_ms,
+                                  parsed.endpoint_cooldown_ms));
+        CHECK_STATUS(readBool(config,
+                              "transports/ub/enable_bandwidth_estimation",
+                              parsed.enable_bandwidth_estimation,
+                              parsed.enable_bandwidth_estimation));
+        CHECK_STATUS(readBool(config, "transports/ub/enable_notifications",
+                              parsed.enable_notifications,
+                              parsed.enable_notifications));
+
+        output = std::move(parsed);
+        return Status::OK();
+    }
+
+   private:
+    template <typename T>
+    static Status readPositive(const Config& config, const char* key,
+                               T default_value, T& output) {
+        const json value = config.get<json>(key, json());
+        if (value.is_null()) {
+            output = default_value;
+            return Status::OK();
+        }
+        if (!value.is_number_integer()) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " must be a positive integer");
+        }
+
+        int64_t signed_value = 0;
+        try {
+            signed_value = value.get<int64_t>();
+        } catch (...) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " is outside the supported range");
+        }
+        if (signed_value <= 0 ||
+            static_cast<uint64_t>(signed_value) >
+                static_cast<uint64_t>(std::numeric_limits<T>::max())) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " must be a positive integer in "
+                                           "the supported range");
+        }
+        output = static_cast<T>(signed_value);
+        return Status::OK();
+    }
+
+    template <typename T>
+    static Status readNonNegative(const Config& config, const char* key,
+                                  T default_value, T& output) {
+        const json value = config.get<json>(key, json());
+        if (value.is_null()) {
+            output = default_value;
+            return Status::OK();
+        }
+        if (!value.is_number_integer()) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " must be a non-negative integer");
+        }
+        int64_t signed_value = 0;
+        try {
+            signed_value = value.get<int64_t>();
+        } catch (...) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " is outside the supported range");
+        }
+        if (signed_value < 0 ||
+            static_cast<uint64_t>(signed_value) >
+                static_cast<uint64_t>(std::numeric_limits<T>::max())) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " must be a non-negative integer "
+                                           "in the supported range");
+        }
+        output = static_cast<T>(signed_value);
+        return Status::OK();
+    }
+
+    static Status readBool(const Config& config, const char* key,
+                           bool default_value, bool& output) {
+        const json value = config.get<json>(key, json());
+        if (value.is_null()) {
+            output = default_value;
+            return Status::OK();
+        }
+        if (!value.is_boolean()) {
+            return Status::InvalidArgument(std::string(key) +
+                                           " must be a boolean");
+        }
+        output = value.get<bool>();
+        return Status::OK();
+    }
+
+    static Status readDeviceFilter(const Config& config,
+                                   std::vector<std::string>& output) {
+        static constexpr const char* kKey = "transports/ub/device_filter";
+        const json value = config.get<json>(kKey, json());
+        if (value.is_null()) {
+            output.clear();
+            return Status::OK();
+        }
+
+        std::vector<std::string> parsed;
+        if (value.is_string()) {
+            parsed.push_back(value.get<std::string>());
+        } else if (value.is_array()) {
+            for (const auto& entry : value) {
+                if (!entry.is_string()) {
+                    return Status::InvalidArgument(
+                        "transports/ub/device_filter entries must be strings");
+                }
+                parsed.push_back(entry.get<std::string>());
+            }
+        } else {
+            return Status::InvalidArgument(
+                "transports/ub/device_filter must be a string or string "
+                "array");
+        }
+
+        for (const auto& entry : parsed) {
+            if (entry.empty()) {
+                return Status::InvalidArgument(
+                    "transports/ub/device_filter entries must not be empty");
+            }
+        }
+        output = std::move(parsed);
+        return Status::OK();
+    }
+};
+
+}  // namespace ub
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_TRANSPORT_UB_PARAMS_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/topology_attrs.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/topology_attrs.h
@@ -1,0 +1,38 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef TENT_TRANSPORT_UB_TOPOLOGY_ATTRS_H_
+#define TENT_TRANSPORT_UB_TOPOLOGY_ATTRS_H_
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include "tent/transport/ub/urma_adapter.h"
+
+namespace mooncake::tent::ub {
+
+inline constexpr std::string_view kTopologyNativeNameAttr = "ub.native_name";
+inline constexpr std::string_view kTopologyDeviceIndexAttr = "ub.device_index";
+inline constexpr std::string_view kTopologyEidIndexAttr = "ub.eid_index";
+inline constexpr std::string_view kTopologyEidAttr = "ub.eid";
+inline constexpr std::string_view kTopologyDiscoveryActiveAttr =
+    "ub.discovery_active";
+
+inline void encodeTopologyDeviceAttributes(
+    const DeviceInfo& device, int device_index,
+    std::unordered_map<std::string, std::string>& attributes) {
+    attributes[std::string(kTopologyNativeNameAttr)] =
+        device.native_device_name;
+    attributes[std::string(kTopologyDeviceIndexAttr)] =
+        std::to_string(device_index);
+    attributes[std::string(kTopologyEidIndexAttr)] =
+        std::to_string(device.eid_index);
+    attributes[std::string(kTopologyEidAttr)] = device.eid;
+    attributes[std::string(kTopologyDiscoveryActiveAttr)] =
+        device.active ? "true" : "false";
+}
+
+}  // namespace mooncake::tent::ub
+
+#endif  // TENT_TRANSPORT_UB_TOPOLOGY_ATTRS_H_

--- a/mooncake-transfer-engine/tent/include/tent/transport/ub/urma_adapter.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/ub/urma_adapter.h
@@ -1,0 +1,284 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_TRANSPORT_UB_URMA_ADAPTER_H_
+#define TENT_TRANSPORT_UB_URMA_ADAPTER_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tent/common/status.h"
+
+namespace mooncake {
+namespace tent {
+namespace ub {
+
+// Adapter-neutral subset of the capabilities needed by the TENT UB data
+// plane. Values of zero mean that the provider did not report a limit.
+struct DeviceCapabilities {
+    uint32_t max_jfc = 0;
+    uint32_t max_jfc_depth = 0;
+    uint32_t max_jfr_depth = 0;
+    uint32_t max_jetty = 0;
+    uint32_t max_jetty_depth = 0;
+    uint32_t max_send_sge = 0;
+    uint32_t max_remote_sge = 0;
+    uint64_t max_message_size = 0;
+    uint32_t max_read_size = 0;
+    uint32_t max_write_size = 0;
+    uint32_t feature_flags = 0;
+    uint16_t transport_modes = 0;
+};
+
+// One DeviceInfo represents one native URMA device/EID pair. A native device
+// with multiple EIDs therefore produces multiple entries. topology_name is a
+// stable TENT-facing identity and native_device_name is passed only to URMA.
+struct DeviceInfo {
+    std::string topology_name;
+    std::string native_device_name;
+    std::string native_device_path;
+    uint32_t eid_index = 0;
+    std::string eid;
+    bool active = false;
+    DeviceCapabilities capabilities;
+};
+
+// The segment descriptor is intentionally an explicit envelope. Raw
+// urma_seg_t bytes are ABI-specific; import must reject a different API
+// version, structure size, schema, or malformed hex instead of copying an
+// arbitrary byte sequence into a native structure.
+struct SegmentDescriptor {
+    static constexpr uint32_t kSchemaVersion = 1;
+
+    uint32_t schema_version = kSchemaVersion;
+    uint32_t urma_api_version = 0;
+    uint32_t urma_abi_size = 0;
+    std::string hex;
+};
+
+// Native handles never escape through this interface. Concrete adapters own
+// their raw handles and make explicit release operations retryable. All typed
+// handles are reference counted so slices can retain segments until their
+// completion has been consumed.
+class OpaqueHandle {
+   public:
+    OpaqueHandle() = default;
+    virtual ~OpaqueHandle() = default;
+
+    OpaqueHandle(const OpaqueHandle&) = delete;
+    OpaqueHandle& operator=(const OpaqueHandle&) = delete;
+
+    [[nodiscard]] virtual bool valid() const noexcept = 0;
+};
+
+class Context : public OpaqueHandle {
+   public:
+    [[nodiscard]] virtual const DeviceInfo& deviceInfo() const noexcept = 0;
+    [[nodiscard]] virtual int asyncFd() const noexcept = 0;
+};
+
+class Jfc : public OpaqueHandle {
+   public:
+    // Returns -1 when completion events were not requested.
+    [[nodiscard]] virtual int eventFd() const noexcept = 0;
+};
+
+class LocalSegment : public OpaqueHandle {
+   public:
+    [[nodiscard]] virtual uint64_t address() const noexcept = 0;
+    [[nodiscard]] virtual uint64_t length() const noexcept = 0;
+    [[nodiscard]] virtual const SegmentDescriptor& descriptor()
+        const noexcept = 0;
+};
+
+class RemoteSegment : public OpaqueHandle {
+   public:
+    [[nodiscard]] virtual uint64_t address() const noexcept = 0;
+    [[nodiscard]] virtual uint64_t length() const noexcept = 0;
+    [[nodiscard]] virtual const SegmentDescriptor& descriptor()
+        const noexcept = 0;
+};
+
+class Jetty : public OpaqueHandle {
+   public:
+    [[nodiscard]] virtual uint32_t id() const noexcept = 0;
+    [[nodiscard]] virtual uint32_t uasid() const noexcept = 0;
+};
+
+using ContextPtr = std::shared_ptr<Context>;
+using JfcPtr = std::shared_ptr<Jfc>;
+using LocalSegmentPtr = std::shared_ptr<LocalSegment>;
+using RemoteSegmentPtr = std::shared_ptr<RemoteSegment>;
+using JettyPtr = std::shared_ptr<Jetty>;
+
+enum SegmentAccess : uint32_t {
+    SEGMENT_ACCESS_READ = 1U << 0,
+    SEGMENT_ACCESS_WRITE = 1U << 1,
+    SEGMENT_ACCESS_ATOMIC = 1U << 2,
+    // Local CPU/URMA access remains unrestricted, but the provider must reject
+    // every access initiated by a remote endpoint.
+    SEGMENT_ACCESS_LOCAL_ONLY = 1U << 3,
+};
+
+struct SegmentOptions {
+    uint32_t access = SEGMENT_ACCESS_READ | SEGMENT_ACCESS_WRITE;
+    uint32_t token = 0xACFE;
+    bool cacheable = false;
+};
+
+struct JfcOptions {
+    uint32_t depth = 4096;
+    uint32_t receiver_depth = 2048;
+    uint32_t token = 0xACFE;
+    bool enable_completion_events = false;
+};
+
+struct JettyOptions {
+    uint32_t depth = 256;
+    uint8_t priority = 15;
+    uint8_t max_sge = 1;
+    uint8_t rnr_retry = 7;
+    uint8_t error_timeout = 17;
+};
+
+struct RemoteJettyInfo {
+    std::string eid;
+    uint32_t id = 0;
+    uint32_t uasid = 0;
+    uint32_t token = 0xACFE;
+};
+
+enum class Operation : uint8_t {
+    READ,
+    WRITE,
+};
+
+struct WorkRequest {
+    Operation operation = Operation::READ;
+    uint64_t local_address = 0;
+    uint64_t remote_address = 0;
+    size_t length = 0;
+
+    // Zero is reserved for native completion records that do not correspond
+    // to a posted work request (for example a synthetic flush-done record).
+    uint64_t token = 0;
+
+    LocalSegmentPtr local_segment;
+    RemoteSegmentPtr remote_segment;
+};
+
+enum class CompletionCategory : uint8_t {
+    SUCCESS,
+    LOCAL_DEVICE_ERROR,
+    REMOTE_PATH_ERROR,
+    ENDPOINT_ERROR,
+    MEMORY_ERROR,
+    TIMEOUT,
+    UNKNOWN_ERROR,
+};
+
+struct Completion {
+    CompletionCategory category = CompletionCategory::UNKNOWN_ERROR;
+    int native_status = 0;
+    uint64_t token = 0;
+    uint32_t completed_bytes = 0;
+    // Native Jetty ID that produced the completion. This is also populated
+    // for entity-level flush markers whose token is deliberately zero.
+    uint32_t local_jetty_id = 0;
+};
+
+// Pure, injectable URMA boundary. It deliberately does not know about TENT
+// Request, SubBatch, UbTask, UbSlice, scheduling, retry, or rail health.
+class UrmaAdapter {
+   public:
+    virtual ~UrmaAdapter() = default;
+
+    [[nodiscard]] virtual bool available() const noexcept = 0;
+    [[nodiscard]] virtual uint32_t nativeApiVersion() const noexcept = 0;
+    [[nodiscard]] virtual size_t nativeSegmentDescriptorSize()
+        const noexcept = 0;
+
+    virtual Status initialize() = 0;
+    virtual Status shutdown() = 0;
+
+    virtual Status discoverDevices(std::vector<DeviceInfo>& devices) = 0;
+
+    virtual Status openContext(const DeviceInfo& device,
+                               ContextPtr& context) = 0;
+    // close/delete/unregister/unimport reset the caller's shared_ptr only after
+    // the provider has released the native resource. If another owner still
+    // retains the handle, or if the provider returns busy/error, the operation
+    // fails and leaves the shared_ptr intact for a later retry. Calling any of
+    // these methods again with a null handle is successful.
+    virtual Status closeContext(ContextPtr& context) = 0;
+
+    virtual Status createJfc(const ContextPtr& context,
+                             const JfcOptions& options, JfcPtr& jfc) = 0;
+    virtual Status deleteJfc(JfcPtr& jfc) = 0;
+
+    virtual Status registerLocalSegment(const ContextPtr& context,
+                                        uint64_t address, size_t length,
+                                        const SegmentOptions& options,
+                                        LocalSegmentPtr& segment) = 0;
+    virtual Status unregisterLocalSegment(LocalSegmentPtr& segment) = 0;
+
+    virtual Status importRemoteSegment(const ContextPtr& context,
+                                       const SegmentDescriptor& descriptor,
+                                       const SegmentOptions& options,
+                                       RemoteSegmentPtr& segment) = 0;
+    virtual Status unimportRemoteSegment(RemoteSegmentPtr& segment) = 0;
+
+    virtual Status createJetty(const ContextPtr& context, const JfcPtr& jfc,
+                               const JettyOptions& options,
+                               JettyPtr& jetty) = 0;
+    virtual Status deleteJetty(JettyPtr& jetty) = 0;
+    virtual Status bindJetty(const JettyPtr& jetty,
+                             const RemoteJettyInfo& remote) = 0;
+    virtual Status unbindJetty(const JettyPtr& jetty) = 0;
+    virtual Status resetJetty(const JettyPtr& jetty) = 0;
+
+    // Synchronously fences one Jetty. A successful return guarantees that no
+    // previously posted WR on this Jetty can perform any further DMA. The
+    // implementation transitions the native Jetty to ERROR, consumes the
+    // provider's flush-done marker, and returns both already-processed and
+    // unhandled WR completions. Callers must dispatch every non-zero token
+    // through their normal completion path before resetting or deleting the
+    // Jetty. On failure no drain guarantee is made and native resources must
+    // remain alive.
+    virtual Status quiesceJetty(const JettyPtr& jetty, uint32_t timeout_ms,
+                                std::vector<Completion>& completions) = 0;
+
+    // On a native post error, posted_count is the number of leading requests
+    // accepted before the provider's bad WR. Requests counted as posted must
+    // still be completed through poll().
+    virtual Status post(const JettyPtr& jetty,
+                        const std::vector<WorkRequest>& requests,
+                        size_t& posted_count) = 0;
+    virtual Status poll(const JfcPtr& jfc, size_t max_completions,
+                        std::vector<Completion>& completions) = 0;
+};
+
+// Returns the raw-liburma implementation when TENT_HAS_REAL_URMA is enabled;
+// otherwise returns an injectable-compatible stub whose operational methods
+// report Status::NotImplemented with an explicit unavailable message.
+std::shared_ptr<UrmaAdapter> createDefaultUrmaAdapter();
+
+}  // namespace ub
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_TRANSPORT_UB_URMA_ADAPTER_H_

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -141,6 +141,7 @@ foreach(
   tent_xport_rdma
   tent_xport_shm
   tent_xport_tcp
+  tent_xport_ub
   tent_xport_ascend_direct
   tent_xport_sunrise_link
   tent_xport_tpu

--- a/mooncake-transfer-engine/tent/src/platform/ascend/ascend_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/ascend/ascend_probe.cpp
@@ -67,7 +67,7 @@ static std::vector<Topology::NicEntry> listInfiniBandDevices() {
         std::ifstream(path) >> numa_node;
 
         devices.push_back(
-            Topology::NicEntry{.name = std::move(device_name),
+            Topology::NicEntry{.name = device_name,
                                .pci_bus_id = std::move(pci_bus_id),
                                .type = Topology::NIC_RDMA,
                                .numa_node = numa_node});

--- a/mooncake-transfer-engine/tent/src/platform/cpu_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cpu_probe.cpp
@@ -173,7 +173,7 @@ static std::vector<Topology::NicEntry> listInfiniBandDevices() {
         std::ifstream(path) >> numa_node;
 
         devices.push_back(
-            Topology::NicEntry{.name = std::move(device_name),
+            Topology::NicEntry{.name = device_name,
                                .pci_bus_id = std::move(pci_bus_id),
                                .type = Topology::NIC_RDMA,
                                .numa_node = numa_node});

--- a/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cuda/cuda_probe.cpp
@@ -69,7 +69,7 @@ static std::vector<Topology::NicEntry> listInfiniBandDevices() {
         std::ifstream(path) >> numa_node;
 
         devices.push_back(
-            Topology::NicEntry{.name = std::move(device_name),
+            Topology::NicEntry{.name = device_name,
                                .pci_bus_id = std::move(pci_bus_id),
                                .type = Topology::NIC_RDMA,
                                .numa_node = numa_node});

--- a/mooncake-transfer-engine/tent/src/platform/rocm/rocm_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/rocm/rocm_probe.cpp
@@ -65,7 +65,7 @@ static std::vector<Topology::NicEntry> listInfiniBandDevices() {
         std::ifstream(path) >> numa_node;
 
         devices.push_back(
-            Topology::NicEntry{.name = std::move(device_name),
+            Topology::NicEntry{.name = device_name,
                                .pci_bus_id = std::move(pci_bus_id),
                                .type = Topology::NIC_RDMA,
                                .numa_node = numa_node});

--- a/mooncake-transfer-engine/tent/src/platform/sunrise/sunrise_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/sunrise/sunrise_probe.cpp
@@ -109,7 +109,7 @@ static std::vector<Topology::NicEntry> listInfiniBandDevices() {
         std::ifstream(path) >> numa_node;
 
         devices.push_back(
-            Topology::NicEntry{.name = std::move(device_name),
+            Topology::NicEntry{.name = device_name,
                                .pci_bus_id = std::move(pci_bus_id),
                                .type = Topology::NIC_RDMA,
                                .numa_node = numa_node});

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -300,6 +300,8 @@ PYBIND11_MODULE(tent, m) {
         .value("TCP", TransportType::TCP)
         .value("AscendDirect", TransportType::AscendDirect)
         .value("SUNRISE_LINK", TransportType::SUNRISE_LINK)
+        .value("TPU", TransportType::TPU)
+        .value("UB", TransportType::UB)
         .export_values();
 
     py::enum_<IntentType>(m, "IntentType")

--- a/mooncake-transfer-engine/tent/src/runtime/topology.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/topology.cpp
@@ -14,19 +14,24 @@
 
 #include "tent/runtime/topology.h"
 
+#include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <map>
 #include <set>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <unordered_set>
 
 #include "tent/common/status.h"
 #include "tent/runtime/platform.h"
 #include "tent/common/utils/random.h"
 #include "tent/thirdparty/nlohmann/json.h"
+#ifdef USE_UB
+#include "tent/transport/ub/topology_attrs.h"
+#endif
 
 namespace mooncake {
 namespace tent {
@@ -50,6 +55,9 @@ std::string Topology::toString() const {
         nj["pci_bus_id"] = nic.pci_bus_id;
         nj["type"] = nic.type;
         nj["numa_node"] = nic.numa_node;
+        if (!nic.device_attrs.empty()) {
+            nj["device_attrs"] = nic.device_attrs;
+        }
         j["nics"].push_back(nj);
     }
 
@@ -99,10 +107,81 @@ void Topology::print() const {
 }
 
 Status Topology::discover(const std::vector<Platform*>& platforms) {
+    return discover(platforms, false);
+}
+
+Status Topology::discover(const std::vector<Platform*>& platforms,
+                          bool discover_ub) {
     clear();
     for (auto& entry : platforms) {
         CHECK_STATUS(entry->probe(nic_list_, mem_list_));
     }
+#ifdef USE_UB
+    // UB discovery is intentionally adapter-backed instead of inferring UB
+    // devices from verbs/sysfs names. One topology NIC is emitted per EID and
+    // carries both the globally serialized identity and the native URMA name.
+    auto adapter = discover_ub ? ub::createDefaultUrmaAdapter() : nullptr;
+    if (adapter && adapter->available()) {
+        auto status = adapter->initialize();
+        if (status.ok()) {
+            std::vector<ub::DeviceInfo> devices;
+            status = adapter->discoverDevices(devices);
+            if (status.ok()) {
+                std::unordered_map<std::string, int> native_device_indices;
+                for (const auto& device : devices) {
+                    auto [native_it, inserted] = native_device_indices.emplace(
+                        device.native_device_name,
+                        static_cast<int>(native_device_indices.size()));
+                    (void)inserted;
+
+                    int numa_node = -1;
+                    std::string pci_bus_id;
+                    if (!device.native_device_path.empty()) {
+                        std::error_code error;
+                        const auto device_path = std::filesystem::canonical(
+                            std::filesystem::path(device.native_device_path) /
+                                "device",
+                            error);
+                        if (!error) {
+                            pci_bus_id = device_path.filename().string();
+                            std::ifstream(device_path / "numa_node") >>
+                                numa_node;
+                        }
+                    }
+
+                    const NicID nic_id = static_cast<NicID>(nic_list_.size());
+                    NicEntry nic{.name = device.topology_name,
+                                 .pci_bus_id = std::move(pci_bus_id),
+                                 .type = NIC_UB,
+                                 .numa_node = numa_node};
+                    ub::encodeTopologyDeviceAttributes(
+                        device, native_it->second, nic.device_attrs);
+                    nic_list_.push_back(std::move(nic));
+
+                    for (auto& memory : mem_list_) {
+                        const size_t rank =
+                            numa_node >= 0 && memory.numa_node == numa_node
+                                ? 0
+                                : DevicePriorityRanks - 1;
+                        memory.device_list[rank].push_back(nic_id);
+                    }
+                }
+            } else {
+                LOG(WARNING) << "Unable to discover optional UB devices: "
+                             << status.ToString();
+            }
+            auto shutdown_status = adapter->shutdown();
+            if (!shutdown_status.ok()) {
+                LOG(WARNING) << "Unable to release UB discovery runtime: "
+                             << shutdown_status.ToString();
+            }
+        } else {
+            LOG(WARNING) << "Unable to initialize optional UB discovery: "
+                         << status.ToString();
+        }
+    }
+#endif
+    (void)discover_ub;
     return Status::OK();
 }
 
@@ -118,6 +197,12 @@ Status Topology::parse(const std::string& json_content) {
                 nic.type =
                     static_cast<NicType>(item.value("type", NIC_UNKNOWN));
                 nic.numa_node = item.value("numa_node", -1);
+                if (item.contains("device_attrs")) {
+                    nic.device_attrs =
+                        item.at("device_attrs")
+                            .get<
+                                std::unordered_map<std::string, std::string>>();
+                }
                 nic_list_.push_back(nic);
             }
         }

--- a/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(bufio)
 add_subdirectory(ascend)
 add_subdirectory(sunrise_link)
 add_subdirectory(tpu)
+add_subdirectory(ub)
 
 add_library(tent_transport_all INTERFACE)
 foreach(
@@ -21,6 +22,7 @@ foreach(
   tent_xport_rdma
   tent_xport_shm
   tent_xport_tcp
+  tent_xport_ub
   tent_xport_ascend_direct
   tent_xport_sunrise_link
   tent_xport_tpu)

--- a/mooncake-transfer-engine/tent/src/transport/ub/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/ub/CMakeLists.txt
@@ -1,0 +1,8 @@
+if(USE_UB)
+  file(GLOB TENT_UB_SOURCES CONFIGURE_DEPENDS "*.cpp")
+  add_library(tent_xport_ub STATIC ${TENT_UB_SOURCES})
+  target_link_libraries(tent_xport_ub PUBLIC tent_common Urma::urma)
+  if(URMA_LIBRARY)
+    target_compile_definitions(tent_xport_ub PRIVATE TENT_HAS_REAL_URMA=1)
+  endif()
+endif()

--- a/mooncake-transfer-engine/tent/src/transport/ub/buffers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ub/buffers.cpp
@@ -1,0 +1,610 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tent/transport/ub/buffers.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <mutex>
+#include <sstream>
+#include <unordered_set>
+
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake::tent::ub {
+namespace {
+
+using json = nlohmann::json;
+
+bool checkedEnd(uint64_t base, uint64_t length, uint64_t& end) {
+    if (length > std::numeric_limits<uint64_t>::max() - base) return false;
+    end = base + length;
+    return true;
+}
+
+uint64_t generationSeed() {
+    const auto wall = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count());
+    const auto steady = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+    const uint64_t seed =
+        (wall ^ (steady << 17) ^ (steady >> 11)) & 0x7fffffffffffffffULL;
+    return seed == 0 ? 1 : seed;
+}
+
+}  // namespace
+
+Status encodeBufferMetadata(const UbBufferMetadata& metadata,
+                            std::string& encoded) {
+    if (metadata.schema_version != UbBufferMetadata::kSchemaVersion ||
+        metadata.generation == 0 || metadata.length == 0 ||
+        metadata.segments.empty()) {
+        return Status::InvalidArgument("Invalid UB buffer metadata" LOC_MARK);
+    }
+
+    uint64_t metadata_end = 0;
+    if (!checkedEnd(metadata.base, metadata.length, metadata_end)) {
+        return Status::InvalidArgument(
+            "UB buffer metadata range overflows" LOC_MARK);
+    }
+    json segments = json::array();
+    std::unordered_set<Topology::NicID> topology_ids;
+    for (const auto& segment : metadata.segments) {
+        if (segment.topology_id < 0 || segment.device_name.empty() ||
+            segment.eid.empty() || segment.descriptor.hex.empty() ||
+            segment.descriptor.urma_abi_size == 0 ||
+            !topology_ids.insert(segment.topology_id).second) {
+            return Status::InvalidArgument(
+                "Incomplete UB segment metadata" LOC_MARK);
+        }
+        segments.push_back(
+            {{"topology_id", segment.topology_id},
+             {"device_name", segment.device_name},
+             {"eid", segment.eid},
+             {"eid_index", segment.eid_index},
+             {"descriptor",
+              {{"schema_version", segment.descriptor.schema_version},
+               {"urma_api_version", segment.descriptor.urma_api_version},
+               {"urma_abi_size", segment.descriptor.urma_abi_size},
+               {"hex", segment.descriptor.hex}}}});
+    }
+    encoded = json{{"schema_version", metadata.schema_version},
+                   {"generation", metadata.generation},
+                   {"base", metadata.base},
+                   {"length", metadata.length},
+                   {"location", metadata.location},
+                   {"permission", static_cast<int>(metadata.permission)},
+                   {"segments", std::move(segments)}}
+                  .dump();
+    return Status::OK();
+}
+
+Status decodeBufferMetadata(std::string_view encoded,
+                            UbBufferMetadata& metadata) {
+    try {
+        const auto value = json::parse(encoded);
+        if (!value.is_object() || !value.contains("schema_version") ||
+            !value.contains("generation") || !value.contains("base") ||
+            !value.contains("length") || !value.contains("permission") ||
+            !value.contains("segments")) {
+            return Status::MalformedJson(
+                "Missing required UB buffer metadata field" LOC_MARK);
+        }
+
+        UbBufferMetadata parsed;
+        parsed.schema_version = value.at("schema_version").get<uint32_t>();
+        if (parsed.schema_version != UbBufferMetadata::kSchemaVersion) {
+            return Status::InvalidMetadataType(
+                "Unsupported UB buffer metadata version" LOC_MARK);
+        }
+        parsed.generation = value.at("generation").get<uint64_t>();
+        parsed.base = value.at("base").get<uint64_t>();
+        parsed.length = value.at("length").get<uint64_t>();
+        parsed.location = value.value("location", "");
+        const int permission = value.at("permission").get<int>();
+        if (permission < static_cast<int>(kLocalReadWrite) ||
+            permission > static_cast<int>(kGlobalReadWrite)) {
+            return Status::InvalidMetadataType(
+                "Invalid UB buffer permission" LOC_MARK);
+        }
+        parsed.permission = static_cast<Permission>(permission);
+        if (parsed.generation == 0 || parsed.length == 0 ||
+            !value.at("segments").is_array() || value.at("segments").empty()) {
+            return Status::InvalidMetadataType(
+                "Invalid UB buffer metadata values" LOC_MARK);
+        }
+        uint64_t metadata_end = 0;
+        if (!checkedEnd(parsed.base, parsed.length, metadata_end)) {
+            return Status::InvalidMetadataType(
+                "UB buffer metadata range overflows" LOC_MARK);
+        }
+
+        std::unordered_set<Topology::NicID> topology_ids;
+        for (const auto& item : value.at("segments")) {
+            UbBufferSegmentMetadata segment;
+            segment.topology_id = item.at("topology_id").get<int>();
+            segment.device_name = item.at("device_name").get<std::string>();
+            segment.eid = item.at("eid").get<std::string>();
+            segment.eid_index = item.at("eid_index").get<int>();
+            const auto& descriptor = item.at("descriptor");
+            segment.descriptor.schema_version =
+                descriptor.at("schema_version").get<uint32_t>();
+            segment.descriptor.urma_api_version =
+                descriptor.at("urma_api_version").get<uint32_t>();
+            segment.descriptor.urma_abi_size =
+                descriptor.at("urma_abi_size").get<uint32_t>();
+            segment.descriptor.hex = descriptor.at("hex").get<std::string>();
+            if (segment.topology_id < 0 || segment.device_name.empty() ||
+                segment.eid.empty() || segment.descriptor.hex.empty() ||
+                segment.descriptor.schema_version !=
+                    SegmentDescriptor::kSchemaVersion ||
+                segment.descriptor.urma_abi_size == 0 ||
+                !topology_ids.insert(segment.topology_id).second) {
+                return Status::InvalidMetadataType(
+                    "Invalid UB segment descriptor envelope" LOC_MARK);
+            }
+            parsed.segments.push_back(std::move(segment));
+        }
+        metadata = std::move(parsed);
+        return Status::OK();
+    } catch (const std::exception& error) {
+        return Status::MalformedJson(std::string("Malformed UB metadata: ") +
+                                     error.what() + LOC_MARK);
+    }
+}
+
+UbBufferManager::UbBufferManager(std::shared_ptr<UrmaAdapter> adapter,
+                                 std::vector<UbContextPtr> contexts)
+    : adapter_(std::move(adapter)), contexts_(std::move(contexts)) {
+    next_generation_.store(generationSeed(), std::memory_order_relaxed);
+    for (const auto& context : contexts_) {
+        if (context) context_by_topology_id_[context->topologyId()] = context;
+    }
+}
+
+UbBufferManager::~UbBufferManager() { (void)clear(); }
+
+bool UbBufferManager::AddressRange::contains(uint64_t address,
+                                             size_t size) const {
+    uint64_t this_end = 0;
+    uint64_t query_end = 0;
+    return checkedEnd(base, length, this_end) &&
+           checkedEnd(address, static_cast<uint64_t>(size), query_end) &&
+           address >= base && query_end <= this_end;
+}
+
+size_t UbBufferManager::ImportKeyHash::operator()(
+    const ImportKey& key) const noexcept {
+    size_t seed = std::hash<int>{}(key.local_topology_id);
+    auto combine = [&seed](size_t value) {
+        seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+    };
+    combine(std::hash<SegmentID>{}(key.remote_segment_id));
+    combine(std::hash<int>{}(key.remote_topology_id));
+    combine(std::hash<uint64_t>{}(key.buffer_base));
+    combine(std::hash<uint64_t>{}(key.generation));
+    return seed;
+}
+
+uint32_t UbBufferManager::segmentAccess(Permission permission) {
+    switch (permission) {
+        case kGlobalReadOnly:
+            return SEGMENT_ACCESS_READ;
+        case kLocalReadWrite:
+            return SEGMENT_ACCESS_LOCAL_ONLY;
+        case kGlobalReadWrite:
+        default:
+            return SEGMENT_ACCESS_READ | SEGMENT_ACCESS_WRITE;
+    }
+}
+
+bool UbBufferManager::permissionAllows(Permission permission,
+                                       Request::OpCode opcode) {
+    if (permission == kLocalReadWrite) return false;
+    return opcode == Request::READ || permission == kGlobalReadWrite;
+}
+
+UbContextPtr UbBufferManager::findContext(Topology::NicID topology_id) const {
+    auto it = context_by_topology_id_.find(topology_id);
+    return it == context_by_topology_id_.end() ? nullptr : it->second;
+}
+
+Status UbBufferManager::addBufferInternal(BufferDesc& desc,
+                                          const MemoryOptions& options) {
+    if (desc.length == 0 || contexts_.empty()) {
+        return Status::InvalidArgument(
+            "Cannot register an empty UB buffer or without contexts" LOC_MARK);
+    }
+    AddressRange range{desc.addr, desc.length};
+    uint64_t ignored = 0;
+    if (!checkedEnd(range.base, range.length, ignored)) {
+        return Status::InvalidArgument("UB buffer address overflow" LOC_MARK);
+    }
+
+    LocalRecord record;
+    record.options = options;
+    record.generation =
+        next_generation_.fetch_add(1, std::memory_order_relaxed);
+    if (record.generation == 0) {
+        record.generation =
+            next_generation_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    UbBufferMetadata metadata;
+    metadata.generation = record.generation;
+    metadata.base = desc.addr;
+    metadata.length = desc.length;
+    metadata.location = desc.location;
+    metadata.permission = options.perm;
+
+    SegmentOptions segment_options;
+    segment_options.access = segmentAccess(options.perm);
+    for (const auto& context : contexts_) {
+        if (!context || !context->active()) continue;
+        LocalSegmentPtr segment;
+        auto status = adapter_->registerLocalSegment(context->handle(),
+                                                     desc.addr, desc.length,
+                                                     segment_options, segment);
+        if (!status.ok()) {
+            if (segment) {
+                record.segments.emplace(context->topologyId(),
+                                        std::move(segment));
+            }
+            (void)unregisterRecord(record);
+            retainPendingRecord(record);
+            return status;
+        }
+        metadata.segments.push_back(UbBufferSegmentMetadata{
+            context->topologyId(), context->deviceInfo().native_device_name,
+            context->deviceInfo().eid,
+            static_cast<int>(context->deviceInfo().eid_index),
+            segment->descriptor()});
+        record.segments.emplace(context->topologyId(), std::move(segment));
+    }
+    if (record.segments.empty()) {
+        return Status::DeviceNotFound(
+            "No active UB context accepted the buffer" LOC_MARK);
+    }
+
+    std::string encoded;
+    auto status = encodeBufferMetadata(metadata, encoded);
+    if (!status.ok()) {
+        (void)unregisterRecord(record);
+        retainPendingRecord(record);
+        return status;
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> lock(local_mutex_);
+        auto next = local_buffers_.lower_bound(range);
+        if ((next != local_buffers_.end() &&
+             next->first.base < range.base + range.length) ||
+            (next != local_buffers_.begin() &&
+             std::prev(next)->first.base + std::prev(next)->first.length >
+                 range.base)) {
+            lock.unlock();
+            (void)unregisterRecord(record);
+            retainPendingRecord(record);
+            return Status::InvalidArgument(
+                "Overlapping UB buffer registration" LOC_MARK);
+        }
+        local_buffers_.emplace(range, std::move(record));
+    }
+    desc.transport_attrs[TransportType::UB] = std::move(encoded);
+    if (std::find(desc.transports.begin(), desc.transports.end(),
+                  TransportType::UB) == desc.transports.end()) {
+        desc.transports.push_back(TransportType::UB);
+    }
+    return Status::OK();
+}
+
+Status UbBufferManager::addBuffer(BufferDesc& desc,
+                                  const MemoryOptions& options) {
+    return addBufferInternal(desc, options);
+}
+
+Status UbBufferManager::addBuffers(std::vector<BufferDesc>& descs,
+                                   const MemoryOptions& options) {
+    std::vector<BufferDesc*> added;
+    added.reserve(descs.size());
+    for (auto& desc : descs) {
+        auto status = addBufferInternal(desc, options);
+        if (!status.ok()) {
+            for (auto it = added.rbegin(); it != added.rend(); ++it) {
+                (void)removeBuffer(**it);
+            }
+            return status;
+        }
+        added.push_back(&desc);
+    }
+    return Status::OK();
+}
+
+Status UbBufferManager::unregisterRecord(LocalRecord& record) {
+    Status first_error = Status::OK();
+    for (auto it = record.segments.begin(); it != record.segments.end();) {
+        auto status = adapter_->unregisterLocalSegment(it->second);
+        if (!status.ok()) {
+            if (first_error.ok()) first_error = status;
+            ++it;
+            continue;
+        }
+        if (it->second) {
+            if (first_error.ok()) {
+                first_error = Status::InternalError(
+                    "URMA adapter retained a local segment after successful "
+                    "unregister" LOC_MARK);
+            }
+            ++it;
+            continue;
+        }
+        it = record.segments.erase(it);
+    }
+    return first_error;
+}
+
+void UbBufferManager::retainPendingRecord(LocalRecord& record) {
+    if (record.segments.empty()) return;
+    std::unique_lock<std::shared_mutex> lock(local_mutex_);
+    for (auto& [_, segment] : record.segments) {
+        if (segment) pending_local_segments_.push_back(std::move(segment));
+    }
+    record.segments.clear();
+}
+
+Status UbBufferManager::removeBuffer(BufferDesc& desc) {
+    Status status = Status::OK();
+    bool removed = false;
+    {
+        std::unique_lock<std::shared_mutex> lock(local_mutex_);
+        auto it = local_buffers_.find(AddressRange{desc.addr, desc.length});
+        if (it != local_buffers_.end()) {
+            status = unregisterRecord(it->second);
+            if (status.ok() && it->second.segments.empty()) {
+                local_buffers_.erase(it);
+                removed = true;
+            }
+        } else {
+            // Idempotent retry after a previously successful removal.
+            removed = true;
+        }
+    }
+    if (!status.ok()) return status;
+    if (!removed) {
+        return Status::InternalError(
+            "UB local record still owns segments after unregister" LOC_MARK);
+    }
+    desc.transport_attrs.erase(TransportType::UB);
+    desc.transports.erase(std::remove(desc.transports.begin(),
+                                      desc.transports.end(), TransportType::UB),
+                          desc.transports.end());
+    return Status::OK();
+}
+
+Status UbBufferManager::clear() {
+    Status first_error = Status::OK();
+    {
+        std::unique_lock<std::shared_mutex> lock(local_mutex_);
+        for (auto it = local_buffers_.begin(); it != local_buffers_.end();) {
+            auto status = unregisterRecord(it->second);
+            if (!status.ok() && first_error.ok()) first_error = status;
+            if (status.ok() && it->second.segments.empty()) {
+                it = local_buffers_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        for (auto it = pending_local_segments_.begin();
+             it != pending_local_segments_.end();) {
+            auto status = adapter_->unregisterLocalSegment(*it);
+            if (!status.ok()) {
+                if (first_error.ok()) first_error = status;
+                ++it;
+            } else if (*it) {
+                if (first_error.ok()) {
+                    first_error = Status::InternalError(
+                        "URMA adapter retained a pending local segment after "
+                        "successful unregister" LOC_MARK);
+                }
+                ++it;
+            } else {
+                it = pending_local_segments_.erase(it);
+            }
+        }
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> lock(import_mutex_);
+        for (auto it = imports_.begin(); it != imports_.end();) {
+            auto status = adapter_->unimportRemoteSegment(it->second);
+            if (!status.ok()) {
+                if (first_error.ok()) first_error = status;
+                ++it;
+            } else if (it->second) {
+                if (first_error.ok()) {
+                    first_error = Status::InternalError(
+                        "URMA adapter retained a remote segment after "
+                        "successful unimport" LOC_MARK);
+                }
+                ++it;
+            } else {
+                it = imports_.erase(it);
+            }
+        }
+        for (auto it = pending_remote_segments_.begin();
+             it != pending_remote_segments_.end();) {
+            auto status = adapter_->unimportRemoteSegment(*it);
+            if (!status.ok()) {
+                if (first_error.ok()) first_error = status;
+                ++it;
+            } else if (*it) {
+                if (first_error.ok()) {
+                    first_error = Status::InternalError(
+                        "URMA adapter retained a pending remote segment after "
+                        "successful unimport" LOC_MARK);
+                }
+                ++it;
+            } else {
+                it = pending_remote_segments_.erase(it);
+            }
+        }
+    }
+    return first_error;
+}
+
+Status UbBufferManager::findLocal(uint64_t address, size_t length,
+                                  Topology::NicID local_topology_id,
+                                  LocalSegmentRef& result) const {
+    std::shared_lock<std::shared_mutex> lock(local_mutex_);
+    auto it = local_buffers_.upper_bound(
+        AddressRange{address, std::numeric_limits<uint64_t>::max()});
+    if (it == local_buffers_.begin()) {
+        return Status::AddressNotRegistered(
+            "Local UB address is not registered" LOC_MARK);
+    }
+    --it;
+    if (!it->first.contains(address, length)) {
+        return Status::AddressNotRegistered(
+            "Local UB range crosses a registration boundary" LOC_MARK);
+    }
+    auto segment = it->second.segments.find(local_topology_id);
+    if (segment == it->second.segments.end()) {
+        return Status::AddressNotRegistered(
+            "Local UB buffer is not registered on selected device" LOC_MARK);
+    }
+    result = LocalSegmentRef{findContext(local_topology_id), segment->second,
+                             it->second.generation, it->first.base,
+                             it->first.length};
+    return Status::OK();
+}
+
+Status UbBufferManager::importRemote(SegmentID remote_segment_id,
+                                     Topology::NicID local_topology_id,
+                                     Topology::NicID remote_topology_id,
+                                     const BufferDesc& remote_buffer,
+                                     Request::OpCode opcode, uint64_t address,
+                                     size_t length,
+                                     ImportedSegmentRef& result) {
+    auto attr = remote_buffer.transport_attrs.find(TransportType::UB);
+    if (attr == remote_buffer.transport_attrs.end()) {
+        return Status::NeedsRefreshCache(
+            "Remote buffer has no UB metadata" LOC_MARK);
+    }
+    UbBufferMetadata metadata;
+    CHECK_STATUS(decodeBufferMetadata(attr->second, metadata));
+    if (metadata.base != remote_buffer.addr ||
+        metadata.length != remote_buffer.length) {
+        return Status::NeedsRefreshCache(
+            "Remote UB metadata does not match BufferDesc" LOC_MARK);
+    }
+    uint64_t remote_end = 0;
+    uint64_t query_end = 0;
+    if (!checkedEnd(metadata.base, metadata.length, remote_end) ||
+        !checkedEnd(address, length, query_end) || address < metadata.base ||
+        query_end > remote_end) {
+        return Status::InvalidArgument(
+            "Remote UB request is outside the registered buffer" LOC_MARK);
+    }
+    if (!permissionAllows(metadata.permission, opcode)) {
+        return Status::InvalidArgument(
+            "Remote UB buffer permission rejects the operation" LOC_MARK);
+    }
+
+    auto descriptor = std::find_if(
+        metadata.segments.begin(), metadata.segments.end(),
+        [remote_topology_id](const UbBufferSegmentMetadata& segment) {
+            return segment.topology_id == remote_topology_id;
+        });
+    if (descriptor == metadata.segments.end()) {
+        return Status::NeedsRefreshCache(
+            "Remote UB buffer lacks selected device descriptor" LOC_MARK);
+    }
+    auto context = findContext(local_topology_id);
+    if (!context || !context->active()) {
+        return Status::DeviceNotFound(
+            "Selected local UB context is unavailable" LOC_MARK);
+    }
+
+    ImportKey key{local_topology_id, remote_segment_id, remote_topology_id,
+                  metadata.base, metadata.generation};
+    RemoteSegmentPtr imported;
+    {
+        // Serialize the provider import with the second cache lookup. This
+        // avoids creating a duplicate handle that has no cache key capable of
+        // retaining it when an immediate rollback fails.
+        std::unique_lock<std::shared_mutex> lock(import_mutex_);
+        auto current = imports_.find(key);
+        if (current == imports_.end()) {
+            SegmentOptions options;
+            options.access = segmentAccess(metadata.permission);
+            auto import_status = adapter_->importRemoteSegment(
+                context->handle(), descriptor->descriptor, options, imported);
+            if (!import_status.ok()) {
+                if (imported) {
+                    (void)adapter_->unimportRemoteSegment(imported);
+                    if (imported) {
+                        pending_remote_segments_.push_back(std::move(imported));
+                    }
+                }
+                return import_status;
+            }
+            if (!imported) {
+                return Status::InternalError(
+                    "URMA adapter returned no remote segment after successful "
+                    "import" LOC_MARK);
+            }
+            current = imports_.emplace(key, imported).first;
+        } else {
+            imported = current->second;
+        }
+
+        for (auto iter = imports_.begin(); iter != imports_.end();) {
+            const auto& candidate = iter->first;
+            const bool stale =
+                candidate.local_topology_id == local_topology_id &&
+                candidate.remote_segment_id == remote_segment_id &&
+                candidate.remote_topology_id == remote_topology_id &&
+                candidate.buffer_base == metadata.base &&
+                candidate.generation != metadata.generation;
+            if (!stale) {
+                ++iter;
+                continue;
+            }
+            auto status = adapter_->unimportRemoteSegment(iter->second);
+            if (!status.ok()) {
+                // The old generation may still be retained by an in-flight
+                // WR. Keep it cached for a later import/clear retry, but do
+                // not fail the current request after its new generation was
+                // imported successfully.
+                ++iter;
+            } else if (iter->second) {
+                // Treat an adapter that reports success without releasing the
+                // handle conservatively: retain ownership and retry later.
+                ++iter;
+            } else {
+                iter = imports_.erase(iter);
+            }
+        }
+    }
+    result =
+        ImportedSegmentRef{context,       imported,        metadata.generation,
+                           metadata.base, metadata.length, remote_topology_id};
+    return Status::OK();
+}
+
+size_t UbBufferManager::localBufferCount() const {
+    std::shared_lock<std::shared_mutex> lock(local_mutex_);
+    return local_buffers_.size();
+}
+
+size_t UbBufferManager::importedSegmentCount() const {
+    std::shared_lock<std::shared_mutex> lock(import_mutex_);
+    return imports_.size();
+}
+
+}  // namespace mooncake::tent::ub

--- a/mooncake-transfer-engine/tent/src/transport/ub/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ub/context.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tent/transport/ub/context.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+
+namespace mooncake::tent::ub {
+namespace {
+
+uint64_t steadyNowNs() noexcept {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+
+}  // namespace
+
+UbContext::UbContext(Topology::NicID topology_id, DeviceInfo device,
+                     std::shared_ptr<UrmaAdapter> adapter)
+    : topology_id_(topology_id),
+      device_(std::move(device)),
+      adapter_(std::move(adapter)) {}
+
+UbContext::~UbContext() { (void)shutdown(); }
+
+Status UbContext::initialize(uint32_t jfc_count, const JfcOptions& options) {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (state_.load(std::memory_order_relaxed) != State::kUninitialized) {
+        return Status::InvalidArgument(
+            "UB context can only be initialized once" LOC_MARK);
+    }
+    if (!adapter_ || !device_.active || jfc_count == 0) {
+        return Status::InvalidArgument(
+            "Invalid UB context device or JFC count" LOC_MARK);
+    }
+    // Each UbJfc owns one send JFC and one receive JFC/JFR.
+    if (device_.capabilities.max_jfc != 0 &&
+        (static_cast<uint64_t>(jfc_count) * 2U) >
+            device_.capabilities.max_jfc) {
+        return Status::InvalidArgument(
+            "Requested UB JFC count exceeds device capability" LOC_MARK);
+    }
+
+    auto status = adapter_->openContext(device_, handle_);
+    if (!status.ok()) {
+        // Providers are allowed to report an error together with a partially
+        // created handle. Adopt it and make cleanup retryable just like a
+        // later JFC creation failure.
+        if (handle_) {
+            state_.store(State::kDraining, std::memory_order_release);
+            (void)shutdownLocked();
+        }
+        return status;
+    }
+
+    jfcs_.reserve(jfc_count);
+    for (uint32_t i = 0; i < jfc_count; ++i) {
+        JfcPtr native_jfc;
+        status = adapter_->createJfc(handle_, options, native_jfc);
+        if (!status.ok()) {
+            // A provider may return an error after allocating a partial native
+            // JFC. Retain that handle as part of the same retryable ownership
+            // graph instead of letting a temporary shared_ptr destroy it.
+            if (native_jfc) {
+                jfcs_.push_back(std::make_shared<UbJfc>(jfcs_.size(), adapter_,
+                                                        std::move(native_jfc)));
+            }
+            state_.store(State::kDraining, std::memory_order_release);
+            (void)shutdownLocked();
+            return status;
+        }
+        jfcs_.push_back(
+            std::make_shared<UbJfc>(i, adapter_, std::move(native_jfc)));
+    }
+    jfc_success_epochs_.assign(jfcs_.size(), 0);
+    failure_cleanup_complete_ = false;
+    state_.store(State::kActive, std::memory_order_release);
+    return Status::OK();
+}
+
+Status UbContext::shutdown() {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    return shutdownLocked();
+}
+
+Status UbContext::shutdownLocked() {
+    auto current = state_.load(std::memory_order_relaxed);
+    if (current == State::kClosed) return Status::OK();
+    if (current == State::kUninitialized && !handle_ && jfcs_.empty()) {
+        state_.store(State::kClosed, std::memory_order_release);
+        return Status::OK();
+    }
+    state_.store(State::kDraining, std::memory_order_release);
+
+    Status first_error = Status::OK();
+    for (size_t index = jfcs_.size(); index > 0;) {
+        --index;
+        auto& jfc = jfcs_[index];
+        if (!jfc) {
+            jfcs_.erase(jfcs_.begin() + static_cast<std::ptrdiff_t>(index));
+            continue;
+        }
+        auto status = jfc->close();
+        if (!status.ok()) {
+            if (first_error.ok()) first_error = status;
+            continue;
+        }
+        if (jfc->handle()) {
+            if (first_error.ok()) {
+                first_error = Status::InternalError(
+                    "URMA adapter retained a JFC after successful "
+                    "delete" LOC_MARK);
+            }
+            continue;
+        }
+        jfcs_.erase(jfcs_.begin() + static_cast<std::ptrdiff_t>(index));
+    }
+    // A Context is the parent of every JFC. Never ask the provider to delete
+    // it while a failed JFC remains owned; the next shutdown call resumes at
+    // the first failed child.
+    if (!jfcs_.empty()) return first_error;
+
+    if (handle_) {
+        auto status = adapter_->closeContext(handle_);
+        if (!status.ok()) {
+            if (first_error.ok()) first_error = status;
+            return first_error;
+        }
+        if (handle_) {
+            return Status::InternalError(
+                "URMA adapter retained a Context after successful "
+                "close" LOC_MARK);
+        }
+    }
+    state_.store(State::kClosed, std::memory_order_release);
+    return first_error;
+}
+
+std::shared_ptr<UbJfc> UbContext::jfc(size_t index) const {
+    if (jfcs_.empty()) return nullptr;
+    return jfcs_[index % jfcs_.size()];
+}
+
+void UbContext::addInflight(uint64_t bytes) noexcept {
+    inflight_bytes_.fetch_add(bytes, std::memory_order_relaxed);
+    outstanding_wrs_.fetch_add(1, std::memory_order_relaxed);
+}
+
+bool UbContext::markUnavailable() noexcept {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    const auto current = state_.load(std::memory_order_relaxed);
+    if (current != State::kActive && current != State::kFailed) return false;
+
+    const bool newly_failed = current == State::kActive;
+    const uint64_t now_ns = steadyNowNs();
+    if (newly_failed) {
+        state_.store(State::kFailed, std::memory_order_release);
+        failure_cleanup_complete_ = false;
+        failure_started_ns_.store(now_ns, std::memory_order_release);
+    }
+    ++failure_epoch_;
+    if (failure_epoch_ == 0) ++failure_epoch_;
+    last_failure_ns_.store(now_ns, std::memory_order_release);
+    return newly_failed;
+}
+
+void UbContext::completeFailureCleanup() noexcept {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (state_.load(std::memory_order_relaxed) == State::kFailed) {
+        failure_cleanup_complete_ = true;
+    }
+}
+
+bool UbContext::recordPollSuccess(size_t jfc_index,
+                                  uint64_t cooldown_ns) noexcept {
+    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+    if (state_.load(std::memory_order_relaxed) != State::kFailed ||
+        !failure_cleanup_complete_ || jfc_index >= jfc_success_epochs_.size()) {
+        return false;
+    }
+    jfc_success_epochs_[jfc_index] = failure_epoch_;
+    if (outstanding_wrs_.load(std::memory_order_acquire) != 0) return false;
+
+    const uint64_t now_ns = steadyNowNs();
+    const uint64_t failed_ns = last_failure_ns_.load(std::memory_order_acquire);
+    if (failed_ns == 0 || now_ns < failed_ns ||
+        now_ns - failed_ns < cooldown_ns) {
+        return false;
+    }
+    if (!std::all_of(
+            jfc_success_epochs_.begin(), jfc_success_epochs_.end(),
+            [this](uint64_t epoch) { return epoch == failure_epoch_; })) {
+        return false;
+    }
+
+    state_.store(State::kActive, std::memory_order_release);
+    failure_cleanup_complete_ = false;
+    recovery_count_.fetch_add(1, std::memory_order_relaxed);
+    return true;
+}
+
+void UbContext::removeInflight(uint64_t bytes) noexcept {
+    auto current = inflight_bytes_.load(std::memory_order_relaxed);
+    while (!inflight_bytes_.compare_exchange_weak(
+        current, current >= bytes ? current - bytes : 0,
+        std::memory_order_relaxed)) {
+    }
+    current = outstanding_wrs_.load(std::memory_order_relaxed);
+    while (current != 0 &&
+           !outstanding_wrs_.compare_exchange_weak(current, current - 1,
+                                                   std::memory_order_relaxed)) {
+    }
+}
+
+}  // namespace mooncake::tent::ub

--- a/mooncake-transfer-engine/tent/src/transport/ub/jfc.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ub/jfc.cpp
@@ -1,0 +1,29 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#include "tent/transport/ub/jfc.h"
+
+namespace mooncake::tent::ub {
+
+UbJfc::~UbJfc() { (void)close(); }
+
+Status UbJfc::poll(size_t max_completions,
+                   std::vector<Completion>& completions) {
+    if (!valid()) {
+        return Status::InvalidArgument("UB JFC is not active" LOC_MARK);
+    }
+    auto status = adapter_->poll(handle_, max_completions, completions);
+    if (!status.ok()) {
+        poll_error_count_.fetch_add(1, std::memory_order_relaxed);
+        return status;
+    }
+    completion_count_.fetch_add(completions.size(), std::memory_order_relaxed);
+    return Status::OK();
+}
+
+Status UbJfc::close() {
+    if (!handle_) return Status::OK();
+    return adapter_->deleteJfc(handle_);
+}
+
+}  // namespace mooncake::tent::ub

--- a/mooncake-transfer-engine/tent/src/transport/ub/urma_adapter.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/ub/urma_adapter.cpp
@@ -1,0 +1,1626 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/ub/urma_adapter.h"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstring>
+#include <limits>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#if defined(TENT_HAS_REAL_URMA) && TENT_HAS_REAL_URMA
+#include <urma_api.h>
+#endif
+
+namespace mooncake {
+namespace tent {
+namespace ub {
+namespace {
+
+constexpr char kUnavailableMessage[] =
+    "native TENT UB is unavailable because this build has no liburma";
+
+class UnavailableUrmaAdapter final : public UrmaAdapter {
+   public:
+    bool available() const noexcept override { return false; }
+    uint32_t nativeApiVersion() const noexcept override { return 0; }
+    size_t nativeSegmentDescriptorSize() const noexcept override { return 0; }
+
+    Status initialize() override { return unavailable(); }
+    Status shutdown() override { return Status::OK(); }
+
+    Status discoverDevices(std::vector<DeviceInfo>& devices) override {
+        devices.clear();
+        return unavailable();
+    }
+
+    Status openContext(const DeviceInfo&, ContextPtr& context) override {
+        context.reset();
+        return unavailable();
+    }
+
+    Status closeContext(ContextPtr& context) override {
+        context.reset();
+        return Status::OK();
+    }
+
+    Status createJfc(const ContextPtr&, const JfcOptions&,
+                     JfcPtr& jfc) override {
+        jfc.reset();
+        return unavailable();
+    }
+
+    Status deleteJfc(JfcPtr& jfc) override {
+        jfc.reset();
+        return Status::OK();
+    }
+
+    Status registerLocalSegment(const ContextPtr&, uint64_t, size_t,
+                                const SegmentOptions&,
+                                LocalSegmentPtr& segment) override {
+        segment.reset();
+        return unavailable();
+    }
+
+    Status unregisterLocalSegment(LocalSegmentPtr& segment) override {
+        segment.reset();
+        return Status::OK();
+    }
+
+    Status importRemoteSegment(const ContextPtr&, const SegmentDescriptor&,
+                               const SegmentOptions&,
+                               RemoteSegmentPtr& segment) override {
+        segment.reset();
+        return unavailable();
+    }
+
+    Status unimportRemoteSegment(RemoteSegmentPtr& segment) override {
+        segment.reset();
+        return Status::OK();
+    }
+
+    Status createJetty(const ContextPtr&, const JfcPtr&, const JettyOptions&,
+                       JettyPtr& jetty) override {
+        jetty.reset();
+        return unavailable();
+    }
+
+    Status deleteJetty(JettyPtr& jetty) override {
+        jetty.reset();
+        return Status::OK();
+    }
+
+    Status bindJetty(const JettyPtr&, const RemoteJettyInfo&) override {
+        return unavailable();
+    }
+
+    Status unbindJetty(const JettyPtr& jetty) override {
+        return jetty ? unavailable() : Status::OK();
+    }
+
+    Status resetJetty(const JettyPtr& jetty) override {
+        return jetty ? unavailable() : Status::OK();
+    }
+
+    Status quiesceJetty(const JettyPtr& jetty, uint32_t,
+                        std::vector<Completion>& completions) override {
+        completions.clear();
+        return jetty ? unavailable() : Status::OK();
+    }
+
+    Status post(const JettyPtr&, const std::vector<WorkRequest>&,
+                size_t& posted_count) override {
+        posted_count = 0;
+        return unavailable();
+    }
+
+    Status poll(const JfcPtr&, size_t,
+                std::vector<Completion>& completions) override {
+        completions.clear();
+        return unavailable();
+    }
+
+   private:
+    static Status unavailable() {
+        return Status::NotImplemented(kUnavailableMessage);
+    }
+};
+
+#if defined(TENT_HAS_REAL_URMA) && TENT_HAS_REAL_URMA
+
+Status nativeError(const char* operation, int native_status) {
+    return Status::InternalError(std::string(operation) +
+                                 " failed with URMA status " +
+                                 std::to_string(native_status));
+}
+
+Status nativePointerError(const char* operation) {
+    const int native_status = errno == 0 ? URMA_FAIL : errno;
+    return nativeError(operation, native_status);
+}
+
+Status invalidHandle(const char* handle_name) {
+    return Status::InvalidArgument(std::string("invalid ") + handle_name +
+                                   " handle");
+}
+
+bool checkedRangeContains(uint64_t base, uint64_t range_length,
+                          uint64_t address, uint64_t requested_length) {
+    if (requested_length == 0 || address < base) return false;
+    const uint64_t offset = address - base;
+    return offset <= range_length && requested_length <= range_length - offset;
+}
+
+bool isAllZero(const urma_eid_t& eid) {
+    for (uint8_t byte : eid.raw) {
+        if (byte != 0) return false;
+    }
+    return true;
+}
+
+std::string formatEid(const urma_eid_t& eid) {
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(39);
+    for (size_t i = 0; i < URMA_EID_SIZE; ++i) {
+        if (i != 0 && i % 2 == 0) result.push_back(':');
+        result.push_back(kHex[(eid.raw[i] >> 4) & 0x0f]);
+        result.push_back(kHex[eid.raw[i] & 0x0f]);
+    }
+    return result;
+}
+
+int decodeHexDigit(char value) {
+    if (value >= '0' && value <= '9') return value - '0';
+    if (value >= 'a' && value <= 'f') return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F') return value - 'A' + 10;
+    return -1;
+}
+
+bool parseEid(std::string_view encoded, urma_eid_t& eid) {
+    // Canonical URMA EID form is eight groups of four hex digits.
+    if (encoded.size() != 39) return false;
+
+    urma_eid_t parsed{};
+    size_t cursor = 0;
+    for (size_t byte_index = 0; byte_index < URMA_EID_SIZE; ++byte_index) {
+        if (byte_index != 0 && byte_index % 2 == 0) {
+            if (cursor >= encoded.size() || encoded[cursor] != ':') {
+                return false;
+            }
+            ++cursor;
+        }
+        if (cursor + 2 > encoded.size()) return false;
+        const int high = decodeHexDigit(encoded[cursor]);
+        const int low = decodeHexDigit(encoded[cursor + 1]);
+        if (high < 0 || low < 0) return false;
+        parsed.raw[byte_index] = static_cast<uint8_t>((high << 4) | low);
+        cursor += 2;
+    }
+    if (cursor != encoded.size()) return false;
+    eid = parsed;
+    return true;
+}
+
+std::string encodeHex(const void* data, size_t length) {
+    static constexpr char kHex[] = "0123456789ABCDEF";
+    const auto* bytes = static_cast<const uint8_t*>(data);
+    std::string result;
+    result.resize(length * 2);
+    for (size_t i = 0; i < length; ++i) {
+        result[i * 2] = kHex[(bytes[i] >> 4) & 0x0f];
+        result[i * 2 + 1] = kHex[bytes[i] & 0x0f];
+    }
+    return result;
+}
+
+bool decodeHex(std::string_view encoded, void* output, size_t output_size) {
+    if (output == nullptr || encoded.size() != output_size * 2) return false;
+    auto* bytes = static_cast<uint8_t*>(output);
+    for (size_t i = 0; i < output_size; ++i) {
+        const int high = decodeHexDigit(encoded[i * 2]);
+        const int low = decodeHexDigit(encoded[i * 2 + 1]);
+        if (high < 0 || low < 0) return false;
+        bytes[i] = static_cast<uint8_t>((high << 4) | low);
+    }
+    return true;
+}
+
+std::string boundedString(const char* value, size_t capacity) {
+    return std::string(value, strnlen(value, capacity));
+}
+
+DeviceCapabilities convertCapabilities(const urma_device_attr_t& attr) {
+    DeviceCapabilities result;
+    result.max_jfc = attr.dev_cap.max_jfc;
+    result.max_jfc_depth = attr.dev_cap.max_jfc_depth;
+    result.max_jfr_depth = attr.dev_cap.max_jfr_depth;
+    result.max_jetty = attr.dev_cap.max_jetty;
+    result.max_jetty_depth = attr.dev_cap.max_jfs_depth;
+    result.max_send_sge = attr.dev_cap.max_jfs_sge;
+    result.max_remote_sge = attr.dev_cap.max_jfs_rsge;
+    result.max_message_size = attr.dev_cap.max_msg_size;
+    result.max_read_size = attr.dev_cap.max_read_size;
+    result.max_write_size = attr.dev_cap.max_write_size;
+    result.feature_flags = attr.dev_cap.feature.value;
+    result.transport_modes = attr.dev_cap.trans_mode;
+    return result;
+}
+
+bool deviceIsActive(const urma_device_attr_t& attr) {
+    if (attr.port_cnt == 0) return true;
+    const size_t port_count = std::min<size_t>(attr.port_cnt, MAX_PORT_CNT);
+    for (size_t i = 0; i < port_count; ++i) {
+        if (attr.port_attr[i].state == URMA_PORT_ACTIVE ||
+            attr.port_attr[i].state == URMA_PORT_ACTIVE_DEFER) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct DeviceListDeleter {
+    void operator()(urma_device_t** devices) const {
+        if (devices != nullptr) urma_free_device_list(devices);
+    }
+};
+using DeviceList = std::unique_ptr<urma_device_t*, DeviceListDeleter>;
+
+struct EidListDeleter {
+    void operator()(urma_eid_info_t* eids) const {
+        if (eids != nullptr) urma_free_eid_list(eids);
+    }
+};
+using EidList = std::unique_ptr<urma_eid_info_t, EidListDeleter>;
+
+std::mutex g_runtime_mutex;
+size_t g_runtime_reference_count = 0;
+bool g_runtime_owned = false;
+
+// One lease corresponds to one initialized adapter. Contexts retain their
+// adapter's lease, so shutdown cannot call urma_uninit before child handles
+// have released all native resources.
+class RuntimeLease {
+   public:
+    static Status Acquire(std::shared_ptr<RuntimeLease>& output) {
+        auto lease = std::shared_ptr<RuntimeLease>(new RuntimeLease());
+        std::lock_guard<std::mutex> lock(g_runtime_mutex);
+        if (g_runtime_reference_count == 0) {
+            urma_init_attr_t attributes{};
+            const int rc = urma_init(&attributes);
+            if (rc != URMA_SUCCESS && rc != URMA_EEXIST) {
+                return nativeError("urma_init", rc);
+            }
+            // EEXIST means another component owns the process-wide runtime.
+            // In that case this adapter must not uninitialize it.
+            g_runtime_owned = rc == URMA_SUCCESS;
+        }
+        ++g_runtime_reference_count;
+        lease->acquired_ = true;
+        output = std::move(lease);
+        return Status::OK();
+    }
+
+    ~RuntimeLease() { (void)release(); }
+
+    Status release() {
+        if (!acquired_) return Status::OK();
+        std::lock_guard<std::mutex> lock(g_runtime_mutex);
+        if (g_runtime_reference_count == 0) {
+            return Status::InternalError(
+                "URMA runtime reference count underflow");
+        }
+        if (g_runtime_reference_count == 1 && g_runtime_owned) {
+            const int rc = urma_uninit();
+            if (rc != URMA_SUCCESS) return nativeError("urma_uninit", rc);
+        }
+        --g_runtime_reference_count;
+        acquired_ = false;
+        if (g_runtime_reference_count == 0) {
+            g_runtime_owned = false;
+        }
+        return Status::OK();
+    }
+
+   private:
+    RuntimeLease() = default;
+    bool acquired_ = false;
+};
+
+class RealContext final : public Context {
+   public:
+    RealContext(std::shared_ptr<RuntimeLease> runtime, DeviceInfo info,
+                urma_context_t* native)
+        : runtime_(std::move(runtime)),
+          info_(std::move(info)),
+          native_(native) {}
+
+    ~RealContext() override { (void)close(); }
+
+    bool valid() const noexcept override { return native_ != nullptr; }
+    const DeviceInfo& deviceInfo() const noexcept override { return info_; }
+    int asyncFd() const noexcept override {
+        return native_ == nullptr ? -1 : native_->async_fd;
+    }
+
+    urma_context_t* native() const noexcept { return native_; }
+
+    Status close() {
+        if (native_ == nullptr) return Status::OK();
+        const int rc = urma_delete_context(native_);
+        if (rc != URMA_SUCCESS) return nativeError("urma_delete_context", rc);
+        native_ = nullptr;
+        return Status::OK();
+    }
+
+   private:
+    std::shared_ptr<RuntimeLease> runtime_;
+    DeviceInfo info_;
+    urma_context_t* native_ = nullptr;
+};
+
+class RealJfc final : public Jfc {
+   public:
+    explicit RealJfc(std::shared_ptr<RealContext> context)
+        : context_(std::move(context)) {}
+
+    ~RealJfc() override { (void)close(); }
+
+    Status initialize(const JfcOptions& options) {
+        if (options.enable_completion_events) {
+            jfce_ = urma_create_jfce(context_->native());
+            if (jfce_ == nullptr) return nativePointerError("urma_create_jfce");
+        }
+
+        urma_jfc_cfg_t send_cfg{};
+        send_cfg.depth = options.depth;
+        send_cfg.jfce = jfce_;
+        send_jfc_ = urma_create_jfc(context_->native(), &send_cfg);
+        if (send_jfc_ == nullptr)
+            return nativePointerError("urma_create_jfc(send)");
+
+        urma_jfc_cfg_t receive_cfg{};
+        receive_cfg.depth = options.receiver_depth;
+        receive_jfc_ = urma_create_jfc(context_->native(), &receive_cfg);
+        if (receive_jfc_ == nullptr) {
+            return nativePointerError("urma_create_jfc(receive)");
+        }
+
+        urma_jfr_cfg_t receiver_cfg{};
+        receiver_cfg.depth = options.receiver_depth;
+        receiver_cfg.flag.bs.tag_matching = 0;
+        receiver_cfg.trans_mode = URMA_TM_RC;
+        receiver_cfg.max_sge = 1;
+        receiver_cfg.min_rnr_timer = URMA_TYPICAL_MIN_RNR_TIMER;
+        receiver_cfg.jfc = receive_jfc_;
+        receiver_cfg.token_value.token = options.token;
+        receiver_jfr_ = urma_create_jfr(context_->native(), &receiver_cfg);
+        if (receiver_jfr_ == nullptr)
+            return nativePointerError("urma_create_jfr");
+        return Status::OK();
+    }
+
+    bool valid() const noexcept override {
+        return send_jfc_ != nullptr && receive_jfc_ != nullptr &&
+               receiver_jfr_ != nullptr;
+    }
+
+    int eventFd() const noexcept override {
+        return jfce_ == nullptr ? -1 : jfce_->fd;
+    }
+
+    urma_jfc_t* nativeSendJfc() const noexcept { return send_jfc_; }
+    urma_jfc_t* nativeReceiveJfc() const noexcept { return receive_jfc_; }
+    urma_jfr_t* nativeReceiver() const noexcept { return receiver_jfr_; }
+    const std::shared_ptr<RealContext>& context() const noexcept {
+        return context_;
+    }
+    std::mutex& pollMutex() noexcept { return poll_mutex_; }
+
+    // Callers hold pollMutex(). Markers must survive a failed quiesce call:
+    // another normal poller may consume FLUSH_ERR_DONE before shutdown retries
+    // the same Jetty.
+    void rememberFlushDone(uint32_t jetty_id) {
+        flush_done_jetty_ids_.insert(jetty_id);
+    }
+    bool hasFlushDone(uint32_t jetty_id) const {
+        return flush_done_jetty_ids_.count(jetty_id) != 0;
+    }
+    void clearFlushDone(uint32_t jetty_id) {
+        flush_done_jetty_ids_.erase(jetty_id);
+    }
+
+    Status retainSegments(uint32_t jetty_id,
+                          const std::vector<WorkRequest>& requests) {
+        std::lock_guard<std::mutex> lock(inflight_mutex_);
+        std::unordered_set<uint64_t> new_tokens;
+        new_tokens.reserve(requests.size());
+        for (const WorkRequest& request : requests) {
+            if (!new_tokens.insert(request.token).second ||
+                inflight_segments_.find(request.token) !=
+                    inflight_segments_.end()) {
+                return Status::InvalidArgument(
+                    "work request token is already in flight on this JFC");
+            }
+        }
+        for (const WorkRequest& request : requests) {
+            inflight_segments_.emplace(
+                request.token,
+                InflightSegments{request.local_segment, request.remote_segment,
+                                 jetty_id});
+        }
+        return Status::OK();
+    }
+
+    void releaseSegment(uint64_t token) {
+        if (token == 0) return;
+        std::lock_guard<std::mutex> lock(inflight_mutex_);
+        inflight_segments_.erase(token);
+    }
+
+    // A successful Jetty flush fence proves that no WR posted through that
+    // Jetty can touch its segments again. Providers are allowed to omit an
+    // individual completion after the fence, so drop any remaining retention
+    // entries by Jetty instead of waiting forever for a lost token.
+    void releaseSegmentsForJetty(uint32_t jetty_id) {
+        std::lock_guard<std::mutex> lock(inflight_mutex_);
+        for (auto it = inflight_segments_.begin();
+             it != inflight_segments_.end();) {
+            if (it->second.jetty_id == jetty_id) {
+                it = inflight_segments_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    Status close() {
+        std::lock_guard<std::mutex> lock(poll_mutex_);
+        {
+            std::lock_guard<std::mutex> inflight_lock(inflight_mutex_);
+            if (!inflight_segments_.empty()) {
+                return Status::TooManyRequests(
+                    "Jfc still retains in-flight segment handles");
+            }
+        }
+        if (receiver_jfr_ != nullptr) {
+            const int rc = urma_delete_jfr(receiver_jfr_);
+            if (rc != URMA_SUCCESS) return nativeError("urma_delete_jfr", rc);
+            receiver_jfr_ = nullptr;
+        }
+        if (receive_jfc_ != nullptr) {
+            const int rc = urma_delete_jfc(receive_jfc_);
+            if (rc != URMA_SUCCESS) {
+                return nativeError("urma_delete_jfc(receive)", rc);
+            }
+            receive_jfc_ = nullptr;
+        }
+        if (send_jfc_ != nullptr) {
+            const int rc = urma_delete_jfc(send_jfc_);
+            if (rc != URMA_SUCCESS) {
+                return nativeError("urma_delete_jfc(send)", rc);
+            }
+            send_jfc_ = nullptr;
+        }
+        if (jfce_ != nullptr) {
+            const int rc = urma_delete_jfce(jfce_);
+            if (rc != URMA_SUCCESS) return nativeError("urma_delete_jfce", rc);
+            jfce_ = nullptr;
+        }
+        return Status::OK();
+    }
+
+   private:
+    std::shared_ptr<RealContext> context_;
+    urma_jfce_t* jfce_ = nullptr;
+    urma_jfc_t* send_jfc_ = nullptr;
+    urma_jfc_t* receive_jfc_ = nullptr;
+    urma_jfr_t* receiver_jfr_ = nullptr;
+    std::mutex poll_mutex_;
+    std::unordered_set<uint32_t> flush_done_jetty_ids_;
+
+    struct InflightSegments {
+        LocalSegmentPtr local;
+        RemoteSegmentPtr remote;
+        uint32_t jetty_id{0};
+    };
+    std::mutex inflight_mutex_;
+    std::unordered_map<uint64_t, InflightSegments> inflight_segments_;
+};
+
+class RealLocalSegment final : public LocalSegment {
+   public:
+    RealLocalSegment(std::shared_ptr<RealContext> context,
+                     urma_target_seg_t* native, uint64_t address,
+                     uint64_t length, SegmentDescriptor descriptor)
+        : context_(std::move(context)),
+          native_(native),
+          address_(address),
+          length_(length),
+          descriptor_(std::move(descriptor)) {}
+
+    ~RealLocalSegment() override { (void)close(); }
+
+    bool valid() const noexcept override { return native_ != nullptr; }
+    uint64_t address() const noexcept override { return address_; }
+    uint64_t length() const noexcept override { return length_; }
+    const SegmentDescriptor& descriptor() const noexcept override {
+        return descriptor_;
+    }
+
+    urma_target_seg_t* native() const noexcept { return native_; }
+    const std::shared_ptr<RealContext>& context() const noexcept {
+        return context_;
+    }
+
+    Status close() {
+        if (native_ == nullptr) return Status::OK();
+        const int rc = urma_unregister_seg(native_);
+        if (rc != URMA_SUCCESS) return nativeError("urma_unregister_seg", rc);
+        native_ = nullptr;
+        return Status::OK();
+    }
+
+   private:
+    std::shared_ptr<RealContext> context_;
+    urma_target_seg_t* native_ = nullptr;
+    uint64_t address_ = 0;
+    uint64_t length_ = 0;
+    SegmentDescriptor descriptor_;
+};
+
+class RealRemoteSegment final : public RemoteSegment {
+   public:
+    RealRemoteSegment(std::shared_ptr<RealContext> context,
+                      urma_target_seg_t* native, uint64_t address,
+                      uint64_t length, SegmentDescriptor descriptor)
+        : context_(std::move(context)),
+          native_(native),
+          address_(address),
+          length_(length),
+          descriptor_(std::move(descriptor)) {}
+
+    ~RealRemoteSegment() override { (void)close(); }
+
+    bool valid() const noexcept override { return native_ != nullptr; }
+    uint64_t address() const noexcept override { return address_; }
+    uint64_t length() const noexcept override { return length_; }
+    const SegmentDescriptor& descriptor() const noexcept override {
+        return descriptor_;
+    }
+
+    urma_target_seg_t* native() const noexcept { return native_; }
+    const std::shared_ptr<RealContext>& context() const noexcept {
+        return context_;
+    }
+
+    Status close() {
+        if (native_ == nullptr) return Status::OK();
+        const int rc = urma_unimport_seg(native_);
+        if (rc != URMA_SUCCESS) return nativeError("urma_unimport_seg", rc);
+        native_ = nullptr;
+        return Status::OK();
+    }
+
+   private:
+    std::shared_ptr<RealContext> context_;
+    urma_target_seg_t* native_ = nullptr;
+    uint64_t address_ = 0;
+    uint64_t length_ = 0;
+    SegmentDescriptor descriptor_;
+};
+
+class RealJetty final : public Jetty {
+   public:
+    RealJetty(std::shared_ptr<RealContext> context,
+              std::shared_ptr<RealJfc> jfc)
+        : context_(std::move(context)), jfc_(std::move(jfc)) {}
+
+    ~RealJetty() override { cleanup(); }
+
+    Status initialize(const JettyOptions& options) {
+        urma_jetty_cfg_t config{};
+        config.flag.bs.share_jfr = 1;
+        config.jfs_cfg.depth = options.depth;
+        config.jfs_cfg.trans_mode = URMA_TM_RC;
+        config.jfs_cfg.priority = options.priority;
+        config.jfs_cfg.max_sge = options.max_sge;
+        config.jfs_cfg.max_rsge = options.max_sge;
+        config.jfs_cfg.rnr_retry = options.rnr_retry;
+        config.jfs_cfg.err_timeout = options.error_timeout;
+        config.jfs_cfg.jfc = jfc_->nativeSendJfc();
+        config.shared.jfr = jfc_->nativeReceiver();
+        config.shared.jfc = nullptr;
+
+        native_ = urma_create_jetty(context_->native(), &config);
+        if (native_ == nullptr) return nativePointerError("urma_create_jetty");
+        depth_ = options.depth;
+        return Status::OK();
+    }
+
+    bool valid() const noexcept override { return native_ != nullptr; }
+    uint32_t id() const noexcept override {
+        return native_ == nullptr ? 0 : native_->jetty_id.id;
+    }
+    uint32_t uasid() const noexcept override {
+        return native_ == nullptr ? 0 : native_->jetty_id.uasid;
+    }
+
+    const std::shared_ptr<RealContext>& context() const noexcept {
+        return context_;
+    }
+    const std::shared_ptr<RealJfc>& jfc() const noexcept { return jfc_; }
+    std::mutex& mutex() noexcept { return mutex_; }
+    urma_jetty_t* native() const noexcept { return native_; }
+    urma_target_jetty_t* remote() const noexcept { return remote_; }
+    bool postable() const noexcept { return state_ == State::BOUND; }
+    uint32_t depth() const noexcept { return depth_; }
+
+    Status beginError() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return invalidHandle("Jetty");
+        if (state_ == State::RESET) {
+            return Status::InvalidArgument("cannot quiesce a reset Jetty");
+        }
+        if (state_ == State::ERROR) return Status::OK();
+
+        urma_jetty_attr_t attributes{};
+        attributes.mask = JETTY_STATE;
+        attributes.state = URMA_JETTY_STATE_ERROR;
+        const int rc = urma_modify_jetty(native_, &attributes);
+        if (rc != URMA_SUCCESS) return nativeError("urma_modify_jetty", rc);
+        state_ = State::ERROR;
+        flush_fenced_ = false;
+        return Status::OK();
+    }
+
+    void markFlushFenced() noexcept {
+        std::lock_guard<std::mutex> lock(mutex_);
+        flush_fenced_ = true;
+    }
+
+    bool flushFenced() const noexcept {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return flush_fenced_;
+    }
+
+    bool errorStarted() const noexcept {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return state_ == State::ERROR;
+    }
+
+    Status bind(const RemoteJettyInfo& remote_info,
+                const urma_eid_t& remote_eid) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return invalidHandle("Jetty");
+        if (state_ == State::RESET) {
+            return Status::InvalidArgument("cannot bind a reset Jetty");
+        }
+        if (remote_ != nullptr) {
+            if (!needs_native_unbind_ || state_ != State::BOUND) {
+                return Status::TooManyRequests(
+                    "Jetty has an imported peer pending cleanup");
+            }
+            const bool same = remote_info.id == remote_id_ &&
+                              remote_info.uasid == remote_uasid_ &&
+                              std::memcmp(remote_eid.raw, remote_eid_.raw,
+                                          URMA_EID_SIZE) == 0;
+            return same ? Status::OK()
+                        : Status::InvalidArgument(
+                              "Jetty is already bound to another peer");
+        }
+
+        urma_rjetty_t descriptor{};
+        descriptor.jetty_id.eid = remote_eid;
+        descriptor.jetty_id.uasid = remote_info.uasid;
+        descriptor.jetty_id.id = remote_info.id;
+        descriptor.trans_mode = URMA_TM_RC;
+        descriptor.type = URMA_JETTY;
+        descriptor.tp_type = URMA_CTP;
+
+        urma_token_t token{.token = remote_info.token};
+        urma_target_jetty_t* imported =
+            urma_import_jetty(context_->native(), &descriptor, &token);
+        if (imported == nullptr) {
+            return nativePointerError("urma_import_jetty");
+        }
+
+        const int rc = urma_bind_jetty(native_, imported);
+        if (rc != URMA_SUCCESS && rc != URMA_EEXIST) {
+            const int rollback_rc = urma_unimport_jetty(imported);
+            if (rollback_rc != URMA_SUCCESS) {
+                // The target Jetty was imported but never bound. Preserve the
+                // raw handle as an explicit cleanup-only phase so endpoint
+                // failure teardown can retry unimport without issuing an
+                // invalid native unbind.
+                remote_ = imported;
+                remote_eid_ = remote_eid;
+                remote_id_ = remote_info.id;
+                remote_uasid_ = remote_info.uasid;
+                needs_native_unbind_ = false;
+                return Status::InternalError(
+                    "urma_bind_jetty failed with URMA status " +
+                    std::to_string(rc) +
+                    "; rollback urma_unimport_jetty failed with URMA status " +
+                    std::to_string(rollback_rc) +
+                    "; imported target retained for retry");
+            }
+            return nativeError("urma_bind_jetty", rc);
+        }
+
+        remote_ = imported;
+        remote_eid_ = remote_eid;
+        remote_id_ = remote_info.id;
+        remote_uasid_ = remote_info.uasid;
+        needs_native_unbind_ = true;
+        state_ = State::BOUND;
+        return Status::OK();
+    }
+
+    Status reset() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return invalidHandle("Jetty");
+        if (state_ == State::RESET) return Status::OK();
+        if (state_ == State::ERROR && !flush_fenced_) {
+            return Status::InvalidArgument(
+                "cannot reset an ERROR Jetty before its flush fence");
+        }
+
+        urma_jetty_attr_t attributes{};
+        attributes.mask = JETTY_STATE;
+        attributes.state = URMA_JETTY_STATE_RESET;
+        const int rc = urma_modify_jetty(native_, &attributes);
+        if (rc != URMA_SUCCESS) return nativeError("urma_modify_jetty", rc);
+        state_ = State::RESET;
+        return Status::OK();
+    }
+
+    Status unbind() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return invalidHandle("Jetty");
+        if (remote_ == nullptr) return Status::OK();
+
+        if (needs_native_unbind_) {
+            const int unbind_rc = urma_unbind_jetty(native_);
+            if (unbind_rc != URMA_SUCCESS) {
+                return nativeError("urma_unbind_jetty", unbind_rc);
+            }
+            // UMDK clears native_->remote_jetty on success. Preserve this
+            // phase across an unimport failure so a retry does not issue an
+            // invalid second unbind and can proceed directly to unimport.
+            needs_native_unbind_ = false;
+        }
+        const int unimport_rc = urma_unimport_jetty(remote_);
+        if (unimport_rc != URMA_SUCCESS) {
+            return nativeError("urma_unimport_jetty", unimport_rc);
+        }
+        remote_ = nullptr;
+        needs_native_unbind_ = false;
+        if (state_ != State::RESET) state_ = State::CREATED;
+        return Status::OK();
+    }
+
+    Status close() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return Status::OK();
+        if (remote_ != nullptr || state_ != State::RESET) {
+            return Status::InvalidArgument(
+                "Jetty must be reset and unbound before deletion");
+        }
+        const int rc = urma_delete_jetty(native_);
+        if (rc != URMA_SUCCESS) return nativeError("urma_delete_jetty", rc);
+        native_ = nullptr;
+        return Status::OK();
+    }
+
+   private:
+    enum class State : uint8_t { CREATED, BOUND, ERROR, RESET };
+
+    void cleanup() noexcept {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (native_ == nullptr) return;
+
+        if (state_ != State::RESET) {
+            urma_jetty_attr_t attributes{};
+            attributes.mask = JETTY_STATE;
+            attributes.state = URMA_JETTY_STATE_RESET;
+            (void)urma_modify_jetty(native_, &attributes);
+        }
+
+        if (remote_ != nullptr) {
+            if (!needs_native_unbind_ ||
+                urma_unbind_jetty(native_) == URMA_SUCCESS) {
+                needs_native_unbind_ = false;
+                (void)urma_unimport_jetty(remote_);
+                remote_ = nullptr;
+            }
+        }
+        (void)urma_delete_jetty(native_);
+        native_ = nullptr;
+
+        // If unbind failed, deleting the local Jetty has severed the binding;
+        // make a final best-effort attempt to release the imported peer.
+        if (remote_ != nullptr) {
+            (void)urma_unimport_jetty(remote_);
+            remote_ = nullptr;
+        }
+        state_ = State::RESET;
+    }
+
+    std::shared_ptr<RealContext> context_;
+    std::shared_ptr<RealJfc> jfc_;
+    urma_jetty_t* native_ = nullptr;
+    urma_target_jetty_t* remote_ = nullptr;
+    urma_eid_t remote_eid_{};
+    uint32_t remote_id_ = 0;
+    uint32_t remote_uasid_ = 0;
+    // True only while remote_ is natively bound. A non-null remote_ with this
+    // flag clear is an imported-only cleanup phase retained after rollback or
+    // after a successful unbind followed by a failed unimport.
+    bool needs_native_unbind_{false};
+    uint32_t depth_ = 0;
+    State state_ = State::CREATED;
+    bool flush_fenced_{false};
+    mutable std::mutex mutex_;
+};
+
+uint32_t nativeAccess(uint32_t access) {
+    uint32_t result = 0;
+    if ((access & SEGMENT_ACCESS_LOCAL_ONLY) != 0) {
+        result |= URMA_ACCESS_LOCAL_ONLY;
+    }
+    if ((access & SEGMENT_ACCESS_READ) != 0) result |= URMA_ACCESS_READ;
+    if ((access & SEGMENT_ACCESS_WRITE) != 0) result |= URMA_ACCESS_WRITE;
+    if ((access & SEGMENT_ACCESS_ATOMIC) != 0) result |= URMA_ACCESS_ATOMIC;
+    return result;
+}
+
+Status validateSegmentOptions(const SegmentOptions& options) {
+    constexpr uint32_t kAllAccess = SEGMENT_ACCESS_READ | SEGMENT_ACCESS_WRITE |
+                                    SEGMENT_ACCESS_ATOMIC |
+                                    SEGMENT_ACCESS_LOCAL_ONLY;
+    if (options.access == 0 || (options.access & ~kAllAccess) != 0) {
+        return Status::InvalidArgument("invalid segment access mask");
+    }
+    if ((options.access & SEGMENT_ACCESS_LOCAL_ONLY) != 0 &&
+        options.access != SEGMENT_ACCESS_LOCAL_ONLY) {
+        return Status::InvalidArgument(
+            "local-only segment access cannot include remote permissions");
+    }
+    return Status::OK();
+}
+
+CompletionCategory classifyCompletion(int status) {
+    switch (status) {
+        case URMA_CR_SUCCESS:
+            return CompletionCategory::SUCCESS;
+        case URMA_CR_LOC_OPERATION_ERR:
+            return CompletionCategory::LOCAL_DEVICE_ERROR;
+        case URMA_CR_LOC_LEN_ERR:
+        case URMA_CR_LOC_ACCESS_ERR:
+        case URMA_CR_LOC_DATA_POISON:
+            return CompletionCategory::MEMORY_ERROR;
+        case URMA_CR_REM_RESP_LEN_ERR:
+        case URMA_CR_REM_UNSUPPORTED_REQ_ERR:
+        case URMA_CR_REM_OPERATION_ERR:
+        case URMA_CR_REM_ACCESS_ABORT_ERR:
+        case URMA_CR_RNR_RETRY_CNT_EXC_ERR:
+        case URMA_CR_REM_DATA_POISON:
+            return CompletionCategory::REMOTE_PATH_ERROR;
+        case URMA_CR_ACK_TIMEOUT_ERR:
+            return CompletionCategory::TIMEOUT;
+        case URMA_CR_UNSUPPORTED_OPCODE_ERR:
+        case URMA_CR_WR_FLUSH_ERR:
+        case URMA_CR_WR_SUSPEND_DONE:
+        case URMA_CR_WR_FLUSH_ERR_DONE:
+        case URMA_CR_WR_UNHANDLED:
+            return CompletionCategory::ENDPOINT_ERROR;
+        default:
+            return CompletionCategory::UNKNOWN_ERROR;
+    }
+}
+
+bool isEntityMarker(const urma_cr_t& completion) {
+    return completion.status == URMA_CR_WR_SUSPEND_DONE ||
+           completion.status == URMA_CR_WR_FLUSH_ERR_DONE;
+}
+
+Completion convertCompletion(const urma_cr_t& native) {
+    Completion completion;
+    completion.category = classifyCompletion(native.status);
+    completion.native_status = native.status;
+    completion.completed_bytes = native.completion_len;
+    completion.local_jetty_id = native.local_id;
+    // UMDK v25.12 identifies entity markers by status. Their user_ctx is
+    // invalid; every other CR (including WR_UNHANDLED returned by flush) is a
+    // real WR completion and carries the original token.
+    completion.token = isEntityMarker(native) ? 0 : native.user_ctx;
+    return completion;
+}
+
+template <typename Native, typename Base>
+Status releaseTypedHandle(std::shared_ptr<Base>& handle, const char* name) {
+    if (!handle) return Status::OK();
+    if (handle.use_count() != 1) {
+        return Status::TooManyRequests(std::string(name) +
+                                       " handle is still retained");
+    }
+    auto native = std::dynamic_pointer_cast<Native>(handle);
+    if (!native) return invalidHandle(name);
+    CHECK_STATUS(native->close());
+    handle.reset();
+    return Status::OK();
+}
+
+class RealUrmaAdapter final : public UrmaAdapter {
+   public:
+    bool available() const noexcept override { return true; }
+    uint32_t nativeApiVersion() const noexcept override {
+        return URMA_API_VERSION;
+    }
+    size_t nativeSegmentDescriptorSize() const noexcept override {
+        return sizeof(urma_seg_t);
+    }
+
+    Status initialize() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (runtime_) return Status::OK();
+        return RuntimeLease::Acquire(runtime_);
+    }
+
+    Status shutdown() override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!runtime_) return Status::OK();
+        if (runtime_.use_count() != 1) {
+            return Status::TooManyRequests(
+                "URMA runtime is still retained by native handles");
+        }
+        CHECK_STATUS(runtime_->release());
+        runtime_.reset();
+        return Status::OK();
+    }
+
+    Status discoverDevices(std::vector<DeviceInfo>& devices) override {
+        devices.clear();
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+
+        int device_count = 0;
+        DeviceList native_devices(urma_get_device_list(&device_count));
+        if (!native_devices || device_count < 0) {
+            return nativePointerError("urma_get_device_list");
+        }
+
+        for (int i = 0; i < device_count; ++i) {
+            urma_device_t* native_device = native_devices.get()[i];
+            if (native_device == nullptr) continue;
+
+            urma_device_attr_t attributes{};
+            const int query_rc = urma_query_device(native_device, &attributes);
+            if (query_rc != URMA_SUCCESS) {
+                return nativeError("urma_query_device", query_rc);
+            }
+
+            uint32_t eid_count = 0;
+            EidList eids(urma_get_eid_list(native_device, &eid_count));
+            if (!eids && eid_count != 0) {
+                return nativePointerError("urma_get_eid_list");
+            }
+
+            const std::string native_name =
+                boundedString(native_device->name, URMA_MAX_NAME);
+            const std::string native_path =
+                boundedString(native_device->path, URMA_MAX_PATH);
+            for (uint32_t eid_position = 0; eid_position < eid_count;
+                 ++eid_position) {
+                const urma_eid_info_t& eid = eids.get()[eid_position];
+                DeviceInfo info;
+                info.native_device_name = native_name;
+                info.native_device_path = native_path;
+                info.eid_index = eid.eid_index;
+                info.eid = formatEid(eid.eid);
+                info.topology_name = "ub:" + native_name + ":eid" +
+                                     std::to_string(eid.eid_index);
+                info.active = deviceIsActive(attributes) && !isAllZero(eid.eid);
+                info.capabilities = convertCapabilities(attributes);
+                devices.push_back(std::move(info));
+            }
+        }
+        return Status::OK();
+    }
+
+    Status openContext(const DeviceInfo& requested,
+                       ContextPtr& output) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        if (requested.native_device_name.empty()) {
+            return Status::InvalidArgument("URMA native device name is empty");
+        }
+        urma_eid_t requested_eid{};
+        if (!parseEid(requested.eid, requested_eid) ||
+            isAllZero(requested_eid)) {
+            return Status::InvalidArgument("invalid or null URMA EID");
+        }
+
+        int device_count = 0;
+        DeviceList devices(urma_get_device_list(&device_count));
+        if (!devices || device_count < 0) {
+            return nativePointerError("urma_get_device_list");
+        }
+
+        for (int i = 0; i < device_count; ++i) {
+            urma_device_t* native_device = devices.get()[i];
+            if (native_device == nullptr ||
+                boundedString(native_device->name, URMA_MAX_NAME) !=
+                    requested.native_device_name) {
+                continue;
+            }
+
+            uint32_t eid_count = 0;
+            EidList eids(urma_get_eid_list(native_device, &eid_count));
+            if (!eids && eid_count != 0) {
+                return nativePointerError("urma_get_eid_list");
+            }
+            bool eid_found = false;
+            for (uint32_t j = 0; j < eid_count; ++j) {
+                if (eids.get()[j].eid_index == requested.eid_index &&
+                    std::memcmp(eids.get()[j].eid.raw, requested_eid.raw,
+                                URMA_EID_SIZE) == 0) {
+                    eid_found = true;
+                    break;
+                }
+            }
+            if (!eid_found) {
+                return Status::DeviceNotFound(
+                    "requested EID is no longer present on URMA device " +
+                    requested.native_device_name);
+            }
+
+            urma_device_attr_t attributes{};
+            const int query_rc = urma_query_device(native_device, &attributes);
+            if (query_rc != URMA_SUCCESS) {
+                return nativeError("urma_query_device", query_rc);
+            }
+            urma_context_t* native_context =
+                urma_create_context(native_device, requested.eid_index);
+            if (native_context == nullptr) {
+                return nativePointerError("urma_create_context");
+            }
+
+            DeviceInfo current = requested;
+            current.native_device_path =
+                boundedString(native_device->path, URMA_MAX_PATH);
+            current.active = deviceIsActive(attributes);
+            current.capabilities = convertCapabilities(attributes);
+            if (current.topology_name.empty()) {
+                current.topology_name = "ub:" + current.native_device_name +
+                                        ":eid" +
+                                        std::to_string(current.eid_index);
+            }
+            output = std::make_shared<RealContext>(
+                std::move(runtime), std::move(current), native_context);
+            return Status::OK();
+        }
+        return Status::DeviceNotFound("URMA device not found: " +
+                                      requested.native_device_name);
+    }
+
+    Status closeContext(ContextPtr& context) override {
+        return releaseTypedHandle<RealContext>(context, "Context");
+    }
+
+    Status createJfc(const ContextPtr& context, const JfcOptions& options,
+                     JfcPtr& output) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_context = std::dynamic_pointer_cast<RealContext>(context);
+        if (!real_context || !real_context->valid()) {
+            return invalidHandle("Context");
+        }
+        if (options.depth == 0 || options.receiver_depth == 0) {
+            return Status::InvalidArgument("JFC depths must be positive");
+        }
+        const auto& caps = real_context->deviceInfo().capabilities;
+        if (caps.max_jfc != 0 && caps.max_jfc < 2) {
+            return Status::InvalidArgument(
+                "URMA device cannot provide send and receive JFCs");
+        }
+        if (caps.max_jfc_depth != 0 &&
+            (options.depth > caps.max_jfc_depth ||
+             options.receiver_depth > caps.max_jfc_depth)) {
+            return Status::InvalidArgument(
+                "requested JFC depth exceeds device capability");
+        }
+        if (caps.max_jfr_depth != 0 &&
+            options.receiver_depth > caps.max_jfr_depth) {
+            return Status::InvalidArgument(
+                "requested JFR depth exceeds device capability");
+        }
+
+        auto jfc = std::make_shared<RealJfc>(std::move(real_context));
+        auto status = jfc->initialize(options);
+        if (!status.ok()) {
+            // initialize may already own a JFCE/JFC/JFR prefix. Return the
+            // wrapper alongside the error so the caller can retain it and
+            // drive retryable delete instead of relying on its destructor.
+            output = std::move(jfc);
+            return status;
+        }
+        output = std::move(jfc);
+        return Status::OK();
+    }
+
+    Status deleteJfc(JfcPtr& jfc) override {
+        return releaseTypedHandle<RealJfc>(jfc, "Jfc");
+    }
+
+    Status registerLocalSegment(const ContextPtr& context, uint64_t address,
+                                size_t length, const SegmentOptions& options,
+                                LocalSegmentPtr& output) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_context = std::dynamic_pointer_cast<RealContext>(context);
+        if (!real_context || !real_context->valid()) {
+            return invalidHandle("Context");
+        }
+        CHECK_STATUS(validateSegmentOptions(options));
+        if (address == 0 || length == 0 ||
+            length > std::numeric_limits<uint64_t>::max() - address) {
+            return Status::InvalidArgument("invalid local segment range");
+        }
+
+        urma_reg_seg_flag_t flags{};
+        flags.bs.token_policy = URMA_TOKEN_NONE;
+        flags.bs.cacheable =
+            options.cacheable ? URMA_CACHEABLE : URMA_NON_CACHEABLE;
+        flags.bs.access = nativeAccess(options.access);
+
+        urma_seg_cfg_t config{};
+        config.va = address;
+        config.len = length;
+        config.token_value.token = options.token;
+        config.flag = flags;
+        urma_target_seg_t* native_segment =
+            urma_register_seg(real_context->native(), &config);
+        if (native_segment == nullptr) {
+            return nativePointerError("urma_register_seg");
+        }
+
+        urma_seg_t wire_descriptor{};
+        wire_descriptor.ubva = native_segment->seg.ubva;
+        wire_descriptor.len = native_segment->seg.len;
+        wire_descriptor.attr = native_segment->seg.attr;
+        wire_descriptor.token_id = native_segment->seg.token_id;
+
+        SegmentDescriptor descriptor;
+        descriptor.urma_api_version = URMA_API_VERSION;
+        descriptor.urma_abi_size = sizeof(urma_seg_t);
+        descriptor.hex = encodeHex(&wire_descriptor, sizeof(wire_descriptor));
+        output = std::make_shared<RealLocalSegment>(
+            std::move(real_context), native_segment, address, length,
+            std::move(descriptor));
+        return Status::OK();
+    }
+
+    Status unregisterLocalSegment(LocalSegmentPtr& segment) override {
+        return releaseTypedHandle<RealLocalSegment>(segment, "LocalSegment");
+    }
+
+    Status importRemoteSegment(const ContextPtr& context,
+                               const SegmentDescriptor& descriptor,
+                               const SegmentOptions& options,
+                               RemoteSegmentPtr& output) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_context = std::dynamic_pointer_cast<RealContext>(context);
+        if (!real_context || !real_context->valid()) {
+            return invalidHandle("Context");
+        }
+        CHECK_STATUS(validateSegmentOptions(options));
+        if (descriptor.schema_version != SegmentDescriptor::kSchemaVersion) {
+            return Status::InvalidArgument(
+                "unsupported URMA segment descriptor schema");
+        }
+        if (descriptor.urma_api_version != URMA_API_VERSION) {
+            return Status::InvalidArgument(
+                "URMA segment descriptor API version mismatch");
+        }
+        if (descriptor.urma_abi_size != sizeof(urma_seg_t)) {
+            return Status::InvalidArgument(
+                "URMA segment descriptor ABI size mismatch");
+        }
+
+        urma_seg_t native_descriptor{};
+        if (!decodeHex(descriptor.hex, &native_descriptor,
+                       sizeof(native_descriptor))) {
+            return Status::InvalidArgument(
+                "malformed URMA segment descriptor hex");
+        }
+        if (native_descriptor.len == 0 ||
+            native_descriptor.len > std::numeric_limits<uint64_t>::max() -
+                                        native_descriptor.ubva.va ||
+            native_descriptor.attr.bs.reserved != 0) {
+            return Status::InvalidArgument(
+                "invalid URMA segment descriptor contents");
+        }
+
+        urma_import_seg_flag_t flags{};
+        flags.bs.cacheable =
+            options.cacheable ? URMA_CACHEABLE : URMA_NON_CACHEABLE;
+        flags.bs.access = nativeAccess(options.access);
+        flags.bs.mapping = URMA_SEG_NOMAP;
+        urma_token_t token{.token = options.token};
+        urma_target_seg_t* imported = urma_import_seg(
+            real_context->native(), &native_descriptor, &token, 0, flags);
+        if (imported == nullptr) return nativePointerError("urma_import_seg");
+
+        // urma_ubva_t is packed; copy its fields before passing them through
+        // forwarding references used by make_shared.
+        const uint64_t remote_address = native_descriptor.ubva.va;
+        const uint64_t remote_length = native_descriptor.len;
+        output = std::make_shared<RealRemoteSegment>(std::move(real_context),
+                                                     imported, remote_address,
+                                                     remote_length, descriptor);
+        return Status::OK();
+    }
+
+    Status unimportRemoteSegment(RemoteSegmentPtr& segment) override {
+        return releaseTypedHandle<RealRemoteSegment>(segment, "RemoteSegment");
+    }
+
+    Status createJetty(const ContextPtr& context, const JfcPtr& jfc,
+                       const JettyOptions& options, JettyPtr& output) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_context = std::dynamic_pointer_cast<RealContext>(context);
+        auto real_jfc = std::dynamic_pointer_cast<RealJfc>(jfc);
+        if (!real_context || !real_context->valid()) {
+            return invalidHandle("Context");
+        }
+        if (!real_jfc || !real_jfc->valid()) return invalidHandle("Jfc");
+        if (real_jfc->context().get() != real_context.get()) {
+            return Status::InvalidArgument(
+                "Jfc belongs to a different Context");
+        }
+        if (options.depth == 0 || options.max_sge == 0 ||
+            options.priority > URMA_MAX_PRIORITY || options.rnr_retry > 7 ||
+            options.error_timeout > 31) {
+            return Status::InvalidArgument("invalid Jetty options");
+        }
+        const auto& caps = real_context->deviceInfo().capabilities;
+        if (caps.max_jetty_depth != 0 && options.depth > caps.max_jetty_depth) {
+            return Status::InvalidArgument(
+                "requested Jetty depth exceeds device capability");
+        }
+        if ((caps.max_send_sge != 0 && options.max_sge > caps.max_send_sge) ||
+            (caps.max_remote_sge != 0 &&
+             options.max_sge > caps.max_remote_sge)) {
+            return Status::InvalidArgument(
+                "requested Jetty SGE count exceeds device capability");
+        }
+
+        auto jetty = std::make_shared<RealJetty>(std::move(real_context),
+                                                 std::move(real_jfc));
+        auto status = jetty->initialize(options);
+        if (!status.ok()) {
+            output = std::move(jetty);
+            return status;
+        }
+        output = std::move(jetty);
+        return Status::OK();
+    }
+
+    Status deleteJetty(JettyPtr& jetty) override {
+        return releaseTypedHandle<RealJetty>(jetty, "Jetty");
+    }
+
+    Status bindJetty(const JettyPtr& jetty,
+                     const RemoteJettyInfo& remote) override {
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_jetty = std::dynamic_pointer_cast<RealJetty>(jetty);
+        if (!real_jetty || !real_jetty->valid()) return invalidHandle("Jetty");
+        if (remote.id == 0) {
+            return Status::InvalidArgument("remote Jetty ID must be non-zero");
+        }
+        urma_eid_t remote_eid{};
+        if (!parseEid(remote.eid, remote_eid) || isAllZero(remote_eid)) {
+            return Status::InvalidArgument("invalid or null remote EID");
+        }
+        return real_jetty->bind(remote, remote_eid);
+    }
+
+    Status unbindJetty(const JettyPtr& jetty) override {
+        if (!jetty) return Status::OK();
+        auto real_jetty = std::dynamic_pointer_cast<RealJetty>(jetty);
+        if (!real_jetty || !real_jetty->valid()) return invalidHandle("Jetty");
+        return real_jetty->unbind();
+    }
+
+    Status resetJetty(const JettyPtr& jetty) override {
+        if (!jetty) return Status::OK();
+        auto real_jetty = std::dynamic_pointer_cast<RealJetty>(jetty);
+        if (!real_jetty || !real_jetty->valid()) return invalidHandle("Jetty");
+        return real_jetty->reset();
+    }
+
+    Status quiesceJetty(const JettyPtr& jetty, uint32_t timeout_ms,
+                        std::vector<Completion>& completions) override {
+        completions.clear();
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_jetty = std::dynamic_pointer_cast<RealJetty>(jetty);
+        if (!real_jetty || !real_jetty->valid()) return invalidHandle("Jetty");
+        if (timeout_ms == 0 || real_jetty->depth() == 0) {
+            return Status::InvalidArgument(
+                "Jetty quiesce requires a non-zero timeout and depth");
+        }
+        if (real_jetty->flushFenced()) return Status::OK();
+
+        auto real_jfc = real_jetty->jfc();
+        if (!real_jfc || !real_jfc->valid()) return invalidHandle("Jfc");
+
+        // Holding the JFC poll lock before entering ERROR makes consumption
+        // of the provider's fake FLUSH_ERR_DONE marker atomic with respect to
+        // normal pollers. Holding the Jetty's own lock inside beginError also
+        // fences a post already crossing the native boundary.
+        std::unique_lock<std::mutex> poll_lock(real_jfc->pollMutex());
+        if (real_jetty->flushFenced()) return Status::OK();
+        if (!real_jetty->errorStarted()) {
+            // Native Jetty IDs may be reused after deletion. Only discard a
+            // stale marker when starting a genuinely new ERROR epoch.
+            real_jfc->clearFlushDone(real_jetty->id());
+        }
+        CHECK_STATUS(real_jetty->beginError());
+
+        const auto deadline = std::chrono::steady_clock::now() +
+                              std::chrono::milliseconds(timeout_ms);
+        bool flush_done = real_jfc->hasFlushDone(real_jetty->id());
+        std::array<urma_cr_t, 64> polled{};
+        while (!flush_done) {
+            const int count =
+                urma_poll_jfc(real_jfc->nativeSendJfc(),
+                              static_cast<int>(polled.size()), polled.data());
+            if (count < 0) return nativeError("urma_poll_jfc", count);
+            for (int i = 0; i < count; ++i) {
+                const auto& native = polled[static_cast<size_t>(i)];
+                if (native.status == URMA_CR_WR_FLUSH_ERR_DONE) {
+                    real_jfc->rememberFlushDone(native.local_id);
+                }
+                auto completion = convertCompletion(native);
+                if (completion.token != 0) {
+                    real_jfc->releaseSegment(completion.token);
+                    completions.push_back(completion);
+                }
+            }
+            flush_done = flush_done || real_jfc->hasFlushDone(real_jetty->id());
+            if (flush_done) break;
+            if (std::chrono::steady_clock::now() >= deadline) {
+                return Status::RdmaError(
+                    "timed out waiting for URMA Jetty flush-done fence");
+            }
+            std::this_thread::sleep_for(std::chrono::microseconds(20));
+        }
+
+        const size_t flush_batch =
+            std::min<size_t>(real_jetty->depth(), polled.size());
+        size_t total_flushed = 0;
+        while (true) {
+            const int count =
+                urma_flush_jetty(real_jetty->native(),
+                                 static_cast<int>(flush_batch), polled.data());
+            if (count < 0) return nativeError("urma_flush_jetty", count);
+            if (count == 0) break;
+            total_flushed += static_cast<size_t>(count);
+            if (total_flushed > real_jetty->depth()) {
+                return Status::InternalError(
+                    "URMA Jetty flush exceeded its queue depth");
+            }
+            for (int i = 0; i < count; ++i) {
+                auto completion =
+                    convertCompletion(polled[static_cast<size_t>(i)]);
+                if (completion.token == 0) {
+                    return Status::InternalError(
+                        "URMA Jetty flush returned an entity marker");
+                }
+                real_jfc->releaseSegment(completion.token);
+                completions.push_back(completion);
+            }
+        }
+        real_jfc->clearFlushDone(real_jetty->id());
+        real_jfc->releaseSegmentsForJetty(real_jetty->id());
+        real_jetty->markFlushFenced();
+        return Status::OK();
+    }
+
+    Status post(const JettyPtr& jetty, const std::vector<WorkRequest>& requests,
+                size_t& posted_count) override {
+        posted_count = 0;
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_jetty = std::dynamic_pointer_cast<RealJetty>(jetty);
+        if (!real_jetty || !real_jetty->valid()) return invalidHandle("Jetty");
+        if (requests.empty()) return Status::OK();
+
+        struct NativeWorkRequest {
+            urma_jfs_wr_t wr{};
+            urma_sge_t local_sge{};
+            urma_sge_t remote_sge{};
+        };
+        std::vector<NativeWorkRequest> native_requests(requests.size());
+
+        std::lock_guard<std::mutex> jetty_lock(real_jetty->mutex());
+        if (!real_jetty->postable() || real_jetty->remote() == nullptr) {
+            return Status::InvalidArgument("Jetty is not bound and postable");
+        }
+        for (size_t i = 0; i < requests.size(); ++i) {
+            const WorkRequest& request = requests[i];
+            if (request.token == 0) {
+                return Status::InvalidArgument(
+                    "work request token zero is reserved");
+            }
+            if (request.length == 0 ||
+                request.length > std::numeric_limits<uint32_t>::max()) {
+                return Status::InvalidArgument("invalid work request length");
+            }
+
+            auto local = std::dynamic_pointer_cast<RealLocalSegment>(
+                request.local_segment);
+            auto remote = std::dynamic_pointer_cast<RealRemoteSegment>(
+                request.remote_segment);
+            if (!local || !local->valid()) return invalidHandle("LocalSegment");
+            if (!remote || !remote->valid()) {
+                return invalidHandle("RemoteSegment");
+            }
+            if (local->context().get() != real_jetty->context().get() ||
+                remote->context().get() != real_jetty->context().get()) {
+                return Status::InvalidArgument(
+                    "work request segments belong to another Context");
+            }
+            if (!checkedRangeContains(local->address(), local->length(),
+                                      request.local_address, request.length) ||
+                !checkedRangeContains(remote->address(), remote->length(),
+                                      request.remote_address, request.length)) {
+                return Status::InvalidArgument(
+                    "work request lies outside a registered segment");
+            }
+
+            NativeWorkRequest& native = native_requests[i];
+            native.local_sge.addr = request.local_address;
+            native.local_sge.len = static_cast<uint32_t>(request.length);
+            native.local_sge.tseg = local->native();
+            native.remote_sge.addr = request.remote_address;
+            native.remote_sge.len = static_cast<uint32_t>(request.length);
+            native.remote_sge.tseg = remote->native();
+
+            native.wr.opcode = request.operation == Operation::READ
+                                   ? URMA_OPC_READ
+                                   : URMA_OPC_WRITE;
+            native.wr.flag.bs.complete_enable = 1;
+            native.wr.tjetty = real_jetty->remote();
+            native.wr.user_ctx = request.token;
+            if (request.operation == Operation::READ) {
+                native.wr.rw.src.sge = &native.remote_sge;
+                native.wr.rw.dst.sge = &native.local_sge;
+            } else {
+                native.wr.rw.src.sge = &native.local_sge;
+                native.wr.rw.dst.sge = &native.remote_sge;
+            }
+            native.wr.rw.src.num_sge = 1;
+            native.wr.rw.dst.num_sge = 1;
+            native.wr.next =
+                i + 1 == requests.size() ? nullptr : &native_requests[i + 1].wr;
+        }
+
+        // Retain both segment handles before crossing the native post
+        // boundary. This prevents buffer removal from unregistering memory
+        // while a WR is still in flight. poll() releases the references by
+        // completion token.
+        CHECK_STATUS(
+            real_jetty->jfc()->retainSegments(real_jetty->id(), requests));
+
+        urma_jfs_wr_t* bad_wr = nullptr;
+        const int rc = urma_post_jetty_send_wr(
+            real_jetty->native(), &native_requests.front().wr, &bad_wr);
+        if (rc == URMA_SUCCESS) {
+            posted_count = requests.size();
+            return Status::OK();
+        }
+        if (bad_wr != nullptr) {
+            for (size_t i = 0; i < native_requests.size(); ++i) {
+                if (bad_wr == &native_requests[i].wr) {
+                    posted_count = i;
+                    break;
+                }
+            }
+        }
+        for (size_t i = posted_count; i < requests.size(); ++i) {
+            real_jetty->jfc()->releaseSegment(requests[i].token);
+        }
+        return nativeError("urma_post_jetty_send_wr", rc);
+    }
+
+    Status poll(const JfcPtr& jfc, size_t max_completions,
+                std::vector<Completion>& completions) override {
+        completions.clear();
+        std::shared_ptr<RuntimeLease> runtime;
+        CHECK_STATUS(getRuntime(runtime));
+        auto real_jfc = std::dynamic_pointer_cast<RealJfc>(jfc);
+        if (!real_jfc || !real_jfc->valid()) return invalidHandle("Jfc");
+        if (max_completions == 0 ||
+            max_completions > static_cast<size_t>(INT_MAX)) {
+            return Status::InvalidArgument("invalid maximum completion count");
+        }
+
+        std::vector<urma_cr_t> native_completions(max_completions);
+        std::lock_guard<std::mutex> lock(real_jfc->pollMutex());
+        const int count = urma_poll_jfc(real_jfc->nativeSendJfc(),
+                                        static_cast<int>(max_completions),
+                                        native_completions.data());
+        if (count < 0) return nativeError("urma_poll_jfc", count);
+
+        completions.reserve(static_cast<size_t>(count));
+        for (int i = 0; i < count; ++i) {
+            const urma_cr_t& native = native_completions[i];
+            Completion completion = convertCompletion(native);
+            if (native.status == URMA_CR_WR_FLUSH_ERR_DONE) {
+                real_jfc->rememberFlushDone(native.local_id);
+            }
+            completions.push_back(completion);
+            real_jfc->releaseSegment(completion.token);
+        }
+        return Status::OK();
+    }
+
+   private:
+    Status getRuntime(std::shared_ptr<RuntimeLease>& output) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!runtime_) {
+            return Status::InvalidArgument(
+                "URMA adapter is not initialized or has been shut down");
+        }
+        output = runtime_;
+        return Status::OK();
+    }
+
+    mutable std::mutex mutex_;
+    std::shared_ptr<RuntimeLease> runtime_;
+};
+
+#endif  // defined(TENT_HAS_REAL_URMA) && TENT_HAS_REAL_URMA
+
+}  // namespace
+
+std::shared_ptr<UrmaAdapter> createDefaultUrmaAdapter() {
+#if defined(TENT_HAS_REAL_URMA) && TENT_HAS_REAL_URMA
+    return std::make_shared<RealUrmaAdapter>();
+#else
+    return std::make_shared<UnavailableUrmaAdapter>();
+#endif
+}
+
+}  // namespace ub
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -246,6 +246,18 @@ target_include_directories(tent_transport_selector_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_transport_selector_test COMMAND tent_transport_selector_test)
 
+if(USE_UB)
+  add_executable(
+    tent_ub_teardown_test
+    ub_teardown_test.cpp ../src/transport/ub/buffers.cpp
+    ../src/transport/ub/context.cpp ../src/transport/ub/jfc.cpp)
+  target_link_libraries(tent_ub_teardown_test PRIVATE tent_common gtest
+                                                      gtest_main)
+  target_include_directories(tent_ub_teardown_test
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  add_test(NAME tent_ub_teardown_test COMMAND tent_ub_teardown_test)
+endif()
+
 # End-to-end failover test: drives real TransferEngineImpl with
 # FaultProxyTransport-wrapped fakes to exercise resubmitTransferTask.
 add_executable(tent_engine_failover_e2e_test engine_failover_e2e_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
@@ -185,6 +185,7 @@ TEST(TransportSelectorTest, TransportTypeNameMapping) {
     EXPECT_STREQ(transportTypeName(TCP), "tcp");
     EXPECT_STREQ(transportTypeName(AscendDirect), "ascend");
     EXPECT_STREQ(transportTypeName(SUNRISE_LINK), "sunrise_link");
+    EXPECT_STREQ(transportTypeName(UB), "ub");
 }
 
 TEST(TransportSelectorTest, ParseTransportType) {
@@ -198,7 +199,92 @@ TEST(TransportSelectorTest, ParseTransportType) {
     EXPECT_EQ(parseTransportType("tcp"), TCP);
     EXPECT_EQ(parseTransportType("ascend"), AscendDirect);
     EXPECT_EQ(parseTransportType("sunrise_link"), SUNRISE_LINK);
+    EXPECT_EQ(parseTransportType("ub"), UB);
     EXPECT_EQ(parseTransportType("unknown"), UNSPEC);
+}
+
+TEST(TransportSelectorTest, UbTransportNameRoundTrips) {
+    const auto name = transportTypeName(UB);
+    EXPECT_EQ(name, "ub");
+    EXPECT_EQ(parseTransportType(name), UB);
+}
+
+TEST(TransportTypeTest, WireValuesRemainStableWithUbAppended) {
+    EXPECT_EQ(static_cast<int>(UNSPEC), 0);
+    EXPECT_EQ(static_cast<int>(RDMA), 1);
+    EXPECT_EQ(static_cast<int>(MNNVL), 2);
+    EXPECT_EQ(static_cast<int>(SHM), 3);
+    EXPECT_EQ(static_cast<int>(NVLINK), 4);
+    EXPECT_EQ(static_cast<int>(GDS), 5);
+    EXPECT_EQ(static_cast<int>(IOURING), 6);
+    EXPECT_EQ(static_cast<int>(TCP), 7);
+    EXPECT_EQ(static_cast<int>(AscendDirect), 8);
+    EXPECT_EQ(static_cast<int>(SUNRISE_LINK), 9);
+    EXPECT_EQ(static_cast<int>(TPU), 10);
+    EXPECT_EQ(static_cast<int>(UB), 11);
+    EXPECT_EQ(static_cast<int>(kNumTransportTypes), 12);
+}
+
+// Topology::NicType is serialized as an integer. These values are therefore a
+// wire-compatibility contract, not merely an implementation detail.
+TEST(TopologyTest, NicTypeWireValuesRemainStableWithUbAppended) {
+    EXPECT_EQ(static_cast<int>(Topology::NIC_RDMA), 0);
+    EXPECT_EQ(static_cast<int>(Topology::NIC_TCP), 1);
+    EXPECT_EQ(static_cast<int>(Topology::NIC_UNKNOWN), 2);
+    EXPECT_EQ(static_cast<int>(Topology::NIC_UB), 3);
+}
+
+TEST(TopologyTest, LegacyJsonDefaultsDeviceAttributes) {
+    constexpr const char* kLegacyTopology = R"json(
+        {
+          "nics": [
+            {
+              "name": "legacy-nic",
+              "pci_bus_id": "0000:01:00.0",
+              "type": 2,
+              "numa_node": -1
+            }
+          ],
+          "mems": []
+        }
+    )json";
+
+    Topology topology;
+    ASSERT_TRUE(topology.parse(kLegacyTopology).ok());
+    ASSERT_EQ(topology.getNicCount(), 1u);
+    const auto* nic = topology.getNicEntry(0);
+    ASSERT_NE(nic, nullptr);
+    EXPECT_EQ(nic->type, Topology::NIC_UNKNOWN);
+    EXPECT_TRUE(nic->device_attrs.empty());
+    EXPECT_EQ(topology.toString().find("device_attrs"), std::string::npos);
+}
+
+TEST(TopologyTest, UbDeviceAttributesRoundTripThroughJson) {
+    Topology source;
+    Topology::NicEntry ub;
+    ub.name = "ub-device-0/eid-2";
+    ub.pci_bus_id = "0000:02:00.0";
+    ub.type = Topology::NIC_UB;
+    ub.numa_node = 1;
+    ub.device_attrs = {{"ub.native_name", "ub-device-0"},
+                       {"ub.device_index", "7"},
+                       {"ub.eid_index", "2"},
+                       {"ub.eid", "e1:02:03:04:05:06:07:08"},
+                       {"ub.discovery_active", "false"},
+                       {"vendor.future_attribute", "preserved"}};
+    source.nic_list_.push_back(ub);
+
+    Topology parsed;
+    ASSERT_TRUE(parsed.parse(source.toString()).ok());
+    ASSERT_EQ(parsed.getNicCount(), 1u);
+    ASSERT_EQ(parsed.getNicCount(Topology::NIC_UB), 1u);
+    const auto* round_tripped = parsed.getNicEntry(0);
+    ASSERT_NE(round_tripped, nullptr);
+    EXPECT_EQ(round_tripped->name, ub.name);
+    EXPECT_EQ(round_tripped->pci_bus_id, ub.pci_bus_id);
+    EXPECT_EQ(round_tripped->type, Topology::NIC_UB);
+    EXPECT_EQ(round_tripped->numa_node, ub.numa_node);
+    EXPECT_EQ(round_tripped->device_attrs, ub.device_attrs);
 }
 
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/ub_teardown_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/ub_teardown_test.cpp
@@ -1,0 +1,533 @@
+// Copyright 2026 KVCache.AI
+// SPDX-License-Identifier: Apache-2.0
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "tent/transport/ub/buffers.h"
+#include "tent/transport/ub/context.h"
+#include "tent/transport/ub/topology_attrs.h"
+
+namespace mooncake::tent::ub {
+namespace {
+
+SegmentDescriptor makeDescriptor(uint64_t address, uint64_t length) {
+    return SegmentDescriptor{
+        SegmentDescriptor::kSchemaVersion, 1, 16,
+        std::to_string(address) + ":" + std::to_string(length)};
+}
+
+DeviceInfo makeDevice(int index) {
+    DeviceInfo device;
+    device.topology_name = "ub:test:" + std::to_string(index);
+    device.native_device_name = "test" + std::to_string(index);
+    device.eid_index = static_cast<uint32_t>(index);
+    device.eid = "0001:0002:0003:0004:0005:0006:0007:0008";
+    device.active = true;
+    device.capabilities.max_jfc = 16;
+    return device;
+}
+
+TEST(UbTopologyAttributes, EncoderPreservesHardwareNeutralMap) {
+    auto device = makeDevice(2);
+    device.active = false;
+    std::unordered_map<std::string, std::string> attributes{
+        {"vendor.future_attribute", "preserved"}};
+    encodeTopologyDeviceAttributes(device, 7, attributes);
+
+    EXPECT_EQ(attributes.at(std::string(kTopologyNativeNameAttr)),
+              device.native_device_name);
+    EXPECT_EQ(attributes.at(std::string(kTopologyDeviceIndexAttr)), "7");
+    EXPECT_EQ(attributes.at(std::string(kTopologyEidIndexAttr)), "2");
+    EXPECT_EQ(attributes.at(std::string(kTopologyEidAttr)), device.eid);
+    EXPECT_EQ(attributes.at(std::string(kTopologyDiscoveryActiveAttr)),
+              "false");
+    EXPECT_EQ(attributes.at("vendor.future_attribute"), "preserved");
+}
+
+class FakeContext final : public Context {
+   public:
+    explicit FakeContext(DeviceInfo device) : device_(std::move(device)) {}
+
+    bool valid() const noexcept override { return valid_; }
+    const DeviceInfo& deviceInfo() const noexcept override { return device_; }
+    int asyncFd() const noexcept override { return -1; }
+    void close() noexcept { valid_ = false; }
+
+   private:
+    DeviceInfo device_;
+    bool valid_{true};
+};
+
+class FakeJfc final : public Jfc {
+   public:
+    bool valid() const noexcept override { return valid_; }
+    int eventFd() const noexcept override { return -1; }
+    void close() noexcept { valid_ = false; }
+
+   private:
+    bool valid_{true};
+};
+
+class FakeLocalSegment final : public LocalSegment {
+   public:
+    FakeLocalSegment(uint64_t address, uint64_t length)
+        : address_(address),
+          length_(length),
+          descriptor_(makeDescriptor(address, length)) {}
+
+    bool valid() const noexcept override { return valid_; }
+    uint64_t address() const noexcept override { return address_; }
+    uint64_t length() const noexcept override { return length_; }
+    const SegmentDescriptor& descriptor() const noexcept override {
+        return descriptor_;
+    }
+    void close() noexcept { valid_ = false; }
+
+   private:
+    uint64_t address_;
+    uint64_t length_;
+    SegmentDescriptor descriptor_;
+    bool valid_{true};
+};
+
+class FakeRemoteSegment final : public RemoteSegment {
+   public:
+    explicit FakeRemoteSegment(SegmentDescriptor descriptor)
+        : descriptor_(std::move(descriptor)) {}
+
+    bool valid() const noexcept override { return valid_; }
+    uint64_t address() const noexcept override { return 0x1000; }
+    uint64_t length() const noexcept override { return 0x1000; }
+    const SegmentDescriptor& descriptor() const noexcept override {
+        return descriptor_;
+    }
+    void close() noexcept { valid_ = false; }
+
+   private:
+    SegmentDescriptor descriptor_;
+    bool valid_{true};
+};
+
+class FakeJetty final : public Jetty {
+   public:
+    bool valid() const noexcept override { return valid_; }
+    uint32_t id() const noexcept override { return 1; }
+    uint32_t uasid() const noexcept override { return 0; }
+    void close() noexcept { valid_ = false; }
+
+   private:
+    bool valid_{true};
+};
+
+class FailOnceAdapter final : public UrmaAdapter {
+   public:
+    bool available() const noexcept override { return true; }
+    uint32_t nativeApiVersion() const noexcept override { return 1; }
+    size_t nativeSegmentDescriptorSize() const noexcept override { return 16; }
+
+    Status initialize() override { return Status::OK(); }
+    Status shutdown() override { return Status::OK(); }
+    Status discoverDevices(std::vector<DeviceInfo>& devices) override {
+        devices = {makeDevice(0), makeDevice(1)};
+        return Status::OK();
+    }
+
+    Status openContext(const DeviceInfo& device, ContextPtr& context) override {
+        context = std::make_shared<FakeContext>(device);
+        ++live_contexts;
+        return Status::OK();
+    }
+    Status closeContext(ContextPtr& context) override {
+        ++close_context_calls;
+        if (close_context_failures > 0) {
+            --close_context_failures;
+            return Status::InternalError("injected close Context failure");
+        }
+        if (auto fake = std::dynamic_pointer_cast<FakeContext>(context)) {
+            fake->close();
+        }
+        context.reset();
+        --live_contexts;
+        return Status::OK();
+    }
+
+    Status createJfc(const ContextPtr&, const JfcOptions&,
+                     JfcPtr& jfc) override {
+        jfc = std::make_shared<FakeJfc>();
+        ++live_jfcs;
+        return Status::OK();
+    }
+    Status deleteJfc(JfcPtr& jfc) override {
+        ++delete_jfc_calls;
+        if (delete_jfc_failures > 0) {
+            --delete_jfc_failures;
+            return Status::InternalError("injected delete JFC failure");
+        }
+        if (auto fake = std::dynamic_pointer_cast<FakeJfc>(jfc)) fake->close();
+        jfc.reset();
+        --live_jfcs;
+        return Status::OK();
+    }
+
+    Status registerLocalSegment(const ContextPtr&, uint64_t address,
+                                size_t length, const SegmentOptions&,
+                                LocalSegmentPtr& segment) override {
+        ++register_calls;
+        if (fail_register_call != 0 && register_calls == fail_register_call) {
+            if (partial_register_on_failure) {
+                segment = std::make_shared<FakeLocalSegment>(address, length);
+                ++live_local_segments;
+            }
+            return Status::InternalError("injected register failure");
+        }
+        segment = std::make_shared<FakeLocalSegment>(address, length);
+        ++live_local_segments;
+        return Status::OK();
+    }
+    Status unregisterLocalSegment(LocalSegmentPtr& segment) override {
+        ++unregister_calls;
+        if (unregister_failures > 0) {
+            --unregister_failures;
+            return Status::InternalError("injected unregister failure");
+        }
+        if (auto fake = std::dynamic_pointer_cast<FakeLocalSegment>(segment)) {
+            fake->close();
+        }
+        segment.reset();
+        --live_local_segments;
+        return Status::OK();
+    }
+
+    Status importRemoteSegment(const ContextPtr&,
+                               const SegmentDescriptor& descriptor,
+                               const SegmentOptions&,
+                               RemoteSegmentPtr& segment) override {
+        if (import_failures > 0) {
+            --import_failures;
+            if (partial_import_on_failure) {
+                segment = std::make_shared<FakeRemoteSegment>(descriptor);
+                ++live_remote_segments;
+            }
+            return Status::InternalError("injected import failure");
+        }
+        segment = std::make_shared<FakeRemoteSegment>(descriptor);
+        ++live_remote_segments;
+        return Status::OK();
+    }
+    Status unimportRemoteSegment(RemoteSegmentPtr& segment) override {
+        ++unimport_calls;
+        if (unimport_failures > 0) {
+            --unimport_failures;
+            return Status::InternalError("injected unimport failure");
+        }
+        if (auto fake = std::dynamic_pointer_cast<FakeRemoteSegment>(segment)) {
+            fake->close();
+        }
+        segment.reset();
+        --live_remote_segments;
+        return Status::OK();
+    }
+
+    Status createJetty(const ContextPtr&, const JfcPtr&, const JettyOptions&,
+                       JettyPtr& jetty) override {
+        jetty = std::make_shared<FakeJetty>();
+        return Status::OK();
+    }
+    Status deleteJetty(JettyPtr& jetty) override {
+        ++delete_jetty_calls;
+        if (delete_jetty_failures > 0) {
+            --delete_jetty_failures;
+            return Status::InternalError("injected delete Jetty failure");
+        }
+        if (auto fake = std::dynamic_pointer_cast<FakeJetty>(jetty)) {
+            fake->close();
+        }
+        jetty.reset();
+        return Status::OK();
+    }
+    Status bindJetty(const JettyPtr&, const RemoteJettyInfo&) override {
+        return Status::OK();
+    }
+    Status unbindJetty(const JettyPtr&) override { return Status::OK(); }
+    Status resetJetty(const JettyPtr&) override { return Status::OK(); }
+    Status quiesceJetty(const JettyPtr&, uint32_t,
+                        std::vector<Completion>& completions) override {
+        completions.clear();
+        return Status::OK();
+    }
+    Status post(const JettyPtr&, const std::vector<WorkRequest>& requests,
+                size_t& posted_count) override {
+        posted_count = requests.size();
+        return Status::OK();
+    }
+    Status poll(const JfcPtr&, size_t,
+                std::vector<Completion>& completions) override {
+        completions.clear();
+        return Status::OK();
+    }
+
+    int close_context_failures{0};
+    int delete_jfc_failures{0};
+    int unregister_failures{0};
+    int unimport_failures{0};
+    int import_failures{0};
+    int delete_jetty_failures{0};
+    int fail_register_call{0};
+    bool partial_register_on_failure{false};
+    bool partial_import_on_failure{false};
+    int close_context_calls{0};
+    int delete_jfc_calls{0};
+    int register_calls{0};
+    int unregister_calls{0};
+    int unimport_calls{0};
+    int delete_jetty_calls{0};
+    int live_contexts{0};
+    int live_jfcs{0};
+    int live_local_segments{0};
+    int live_remote_segments{0};
+};
+
+UbContextPtr makeActiveContext(const std::shared_ptr<FailOnceAdapter>& adapter,
+                               int topology_id, uint32_t jfc_count = 1) {
+    auto context = std::make_shared<UbContext>(
+        topology_id, makeDevice(topology_id), adapter);
+    EXPECT_TRUE(context->initialize(jfc_count, JfcOptions{}).ok());
+    return context;
+}
+
+BufferDesc makeLocalBuffer(uint64_t address) {
+    BufferDesc desc;
+    desc.addr = address;
+    desc.length = 4096;
+    desc.location = "cpu:0";
+    return desc;
+}
+
+TEST(UbTeardown, RemoveBufferRetainsOwnershipAndMetadataForRetry) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    UbBufferManager manager(adapter, {context});
+    auto desc = makeLocalBuffer(0x10000);
+    ASSERT_TRUE(manager.addBuffer(desc, MemoryOptions{}).ok());
+    ASSERT_EQ(manager.localBufferCount(), 1u);
+
+    adapter->unregister_failures = 1;
+    EXPECT_FALSE(manager.removeBuffer(desc).ok());
+    EXPECT_EQ(manager.localBufferCount(), 1u);
+    EXPECT_EQ(adapter->live_local_segments, 1);
+    EXPECT_TRUE(desc.transport_attrs.contains(TransportType::UB));
+    EXPECT_NE(std::find(desc.transports.begin(), desc.transports.end(),
+                        TransportType::UB),
+              desc.transports.end());
+
+    EXPECT_TRUE(manager.removeBuffer(desc).ok());
+    EXPECT_EQ(manager.localBufferCount(), 0u);
+    EXPECT_EQ(adapter->live_local_segments, 0);
+    EXPECT_FALSE(desc.transport_attrs.contains(TransportType::UB));
+    EXPECT_TRUE(context->shutdown().ok());
+}
+
+TEST(UbTeardown, ClearRetainsLocalAndImportedSegmentsForRetry) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    UbBufferManager manager(adapter, {context});
+    auto local = makeLocalBuffer(0x20000);
+    ASSERT_TRUE(manager.addBuffer(local, MemoryOptions{}).ok());
+
+    UbBufferMetadata metadata;
+    metadata.generation = 7;
+    metadata.base = 0x1000;
+    metadata.length = 0x1000;
+    metadata.permission = kGlobalReadWrite;
+    metadata.segments.push_back(UbBufferSegmentMetadata{
+        9, "remote", makeDevice(9).eid, 9,
+        makeDescriptor(metadata.base, metadata.length)});
+    BufferDesc remote;
+    remote.addr = metadata.base;
+    remote.length = metadata.length;
+    ASSERT_TRUE(encodeBufferMetadata(metadata,
+                                     remote.transport_attrs[TransportType::UB])
+                    .ok());
+    ImportedSegmentRef imported;
+    ASSERT_TRUE(manager
+                    .importRemote(123, 0, 9, remote, Request::READ,
+                                  metadata.base, 64, imported)
+                    .ok());
+    imported.segment.reset();
+    ASSERT_EQ(manager.importedSegmentCount(), 1u);
+
+    adapter->unregister_failures = 1;
+    adapter->unimport_failures = 1;
+    EXPECT_FALSE(manager.clear().ok());
+    EXPECT_EQ(manager.localBufferCount(), 1u);
+    EXPECT_EQ(manager.importedSegmentCount(), 1u);
+    EXPECT_EQ(adapter->live_local_segments, 1);
+    EXPECT_EQ(adapter->live_remote_segments, 1);
+
+    EXPECT_TRUE(manager.clear().ok());
+    EXPECT_EQ(manager.localBufferCount(), 0u);
+    EXPECT_EQ(manager.importedSegmentCount(), 0u);
+    EXPECT_EQ(adapter->live_local_segments, 0);
+    EXPECT_EQ(adapter->live_remote_segments, 0);
+    EXPECT_TRUE(context->shutdown().ok());
+}
+
+TEST(UbTeardown, NewGenerationProceedsWhileStaleImportCleanupRetries) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    UbBufferManager manager(adapter, {context});
+
+    UbBufferMetadata metadata;
+    metadata.generation = 7;
+    metadata.base = 0x1000;
+    metadata.length = 0x1000;
+    metadata.permission = kGlobalReadWrite;
+    metadata.segments.push_back(UbBufferSegmentMetadata{
+        9, "remote", makeDevice(9).eid, 9,
+        makeDescriptor(metadata.base, metadata.length)});
+    BufferDesc remote;
+    remote.addr = metadata.base;
+    remote.length = metadata.length;
+    ASSERT_TRUE(encodeBufferMetadata(metadata,
+                                     remote.transport_attrs[TransportType::UB])
+                    .ok());
+
+    ImportedSegmentRef old_generation;
+    ASSERT_TRUE(manager
+                    .importRemote(123, 0, 9, remote, Request::READ,
+                                  metadata.base, 64, old_generation)
+                    .ok());
+    metadata.generation = 8;
+    ASSERT_TRUE(encodeBufferMetadata(metadata,
+                                     remote.transport_attrs[TransportType::UB])
+                    .ok());
+    adapter->unimport_failures = 1;
+    ImportedSegmentRef new_generation;
+    EXPECT_TRUE(manager
+                    .importRemote(123, 0, 9, remote, Request::READ,
+                                  metadata.base, 64, new_generation)
+                    .ok());
+    EXPECT_EQ(new_generation.generation, 8u);
+    EXPECT_EQ(manager.importedSegmentCount(), 2u);
+    EXPECT_EQ(adapter->live_remote_segments, 2);
+
+    old_generation.segment.reset();
+    ImportedSegmentRef reused;
+    EXPECT_TRUE(manager
+                    .importRemote(123, 0, 9, remote, Request::READ,
+                                  metadata.base, 64, reused)
+                    .ok());
+    EXPECT_EQ(reused.segment, new_generation.segment);
+    EXPECT_EQ(manager.importedSegmentCount(), 1u);
+    EXPECT_EQ(adapter->live_remote_segments, 1);
+
+    reused.segment.reset();
+    new_generation.segment.reset();
+    EXPECT_TRUE(manager.clear().ok());
+    EXPECT_EQ(adapter->live_remote_segments, 0);
+    EXPECT_TRUE(context->shutdown().ok());
+}
+
+TEST(UbTeardown, FailedRegistrationRollbackIsRetainedUntilClear) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto first = makeActiveContext(adapter, 0);
+    auto second = makeActiveContext(adapter, 1);
+    UbBufferManager manager(adapter, {first, second});
+    auto desc = makeLocalBuffer(0x30000);
+    adapter->fail_register_call = 2;
+    adapter->partial_register_on_failure = true;
+    adapter->unregister_failures = 1;
+
+    EXPECT_FALSE(manager.addBuffer(desc, MemoryOptions{}).ok());
+    EXPECT_EQ(manager.localBufferCount(), 0u);
+    EXPECT_EQ(adapter->live_local_segments, 1);
+    EXPECT_TRUE(manager.clear().ok());
+    EXPECT_EQ(adapter->live_local_segments, 0);
+    EXPECT_TRUE(first->shutdown().ok());
+    EXPECT_TRUE(second->shutdown().ok());
+}
+
+TEST(UbTeardown, FailedPartialImportIsRetainedUntilClear) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    UbBufferManager manager(adapter, {context});
+
+    UbBufferMetadata metadata;
+    metadata.generation = 11;
+    metadata.base = 0x1000;
+    metadata.length = 0x1000;
+    metadata.permission = kGlobalReadWrite;
+    metadata.segments.push_back(UbBufferSegmentMetadata{
+        9, "remote", makeDevice(9).eid, 9,
+        makeDescriptor(metadata.base, metadata.length)});
+    BufferDesc remote;
+    remote.addr = metadata.base;
+    remote.length = metadata.length;
+    ASSERT_TRUE(encodeBufferMetadata(metadata,
+                                     remote.transport_attrs[TransportType::UB])
+                    .ok());
+
+    adapter->import_failures = 1;
+    adapter->partial_import_on_failure = true;
+    adapter->unimport_failures = 1;
+    ImportedSegmentRef imported;
+    EXPECT_FALSE(manager
+                     .importRemote(456, 0, 9, remote, Request::READ,
+                                   metadata.base, 64, imported)
+                     .ok());
+    EXPECT_EQ(manager.importedSegmentCount(), 0u);
+    EXPECT_EQ(adapter->live_remote_segments, 1);
+
+    EXPECT_TRUE(manager.clear().ok());
+    EXPECT_EQ(adapter->live_remote_segments, 0);
+    EXPECT_TRUE(context->shutdown().ok());
+}
+
+TEST(UbTeardown, ContextShutdownRetainsFailedJfcBeforeClosingContext) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    adapter->delete_jfc_failures = 1;
+
+    EXPECT_FALSE(context->shutdown().ok());
+    EXPECT_EQ(context->state(), UbContext::State::kDraining);
+    EXPECT_EQ(context->jfcs().size(), 1u);
+    EXPECT_TRUE(context->handle());
+    EXPECT_EQ(adapter->close_context_calls, 0);
+    EXPECT_EQ(adapter->live_jfcs, 1);
+
+    EXPECT_TRUE(context->shutdown().ok());
+    EXPECT_EQ(context->state(), UbContext::State::kClosed);
+    EXPECT_TRUE(context->jfcs().empty());
+    EXPECT_FALSE(context->handle());
+    EXPECT_EQ(adapter->close_context_calls, 1);
+    EXPECT_EQ(adapter->live_jfcs, 0);
+    EXPECT_EQ(adapter->live_contexts, 0);
+}
+
+TEST(UbTeardown, ContextShutdownRetainsContextAfterCloseFailure) {
+    auto adapter = std::make_shared<FailOnceAdapter>();
+    auto context = makeActiveContext(adapter, 0);
+    adapter->close_context_failures = 1;
+
+    EXPECT_FALSE(context->shutdown().ok());
+    EXPECT_EQ(context->state(), UbContext::State::kDraining);
+    EXPECT_TRUE(context->jfcs().empty());
+    EXPECT_TRUE(context->handle());
+    EXPECT_EQ(adapter->live_contexts, 1);
+
+    EXPECT_TRUE(context->shutdown().ok());
+    EXPECT_EQ(context->state(), UbContext::State::kClosed);
+    EXPECT_FALSE(context->handle());
+    EXPECT_EQ(adapter->live_contexts, 0);
+}
+
+}  // namespace
+}  // namespace mooncake::tent::ub


### PR DESCRIPTION
## Description

This PR introduces the foundation for a TENT-native UB transport backed by the openEuler UMDK URMA APIs.

It is the first implementation stage of RFC #3093 and establishes the native URMA abstraction, resource ownership model, UB topology representation, build integration, and deterministic mock-based validation required by the later endpoint and data-path stages.

This PR supersedes #2828 as part of the new implementation series. Unlike #2828, which adapted TENT to the existing Classic Transfer Engine UB data path, this series implements UB as a TENT-native transport. TENT owns transport-level policy and lifecycle, while the URMA adapter is limited to native URMA operations and resource management.

Related:

- RFC: #3093
- Superseded implementation: #2828

### Major changes

#### 1. Add UB identities to TENT

This PR adds UB as a distinct TENT transport and topology type:

- `TransportType::UB`
- `Topology::NIC_UB`
- `"ub"` transport-name parsing and round-trip conversion
- `TRANSPORT_UB` in the public C API
- UB transport exposure through Python bindings
- Default UB configuration entries

Existing transport and topology enum values remain unchanged. UB is appended as a new value to preserve the serialized numeric values used by existing transports.

#### 2. Extend topology metadata for native UB devices

The TENT topology model now supports the identity fields required by URMA device discovery:

- Native device name
- Device index
- EID index
- EID
- Active state
- PCI bus ID
- NUMA node

UB discovery is optional and adapter-backed. The existing one-argument `Topology::discover()` behavior is preserved, while UB-aware discovery must be explicitly enabled.

Topology JSON parsing remains backward-compatible: topology descriptions that do not contain the new fields continue to load with safe defaults. Serialization adds the new optional identity fields for all NIC entries.

#### 3. Add an injectable URMA adapter

This PR introduces a TENT-owned URMA adapter boundary covering low-level native operations such as:

- URMA runtime initialization and shutdown
- Device and EID discovery
- Context creation and destruction
- JFC and JFCE lifecycle management
- Local segment registration
- Remote segment import
- Jetty creation, binding, reset, quiesce, and destruction
- READ/WRITE work-request posting
- Completion polling

The adapter does not contain TENT scheduling, retry, transport selection, admission-control, or receiver-credit policy.

The injectable interface allows the resource lifecycle to be tested without UB hardware or a real `liburma` runtime.

#### 4. Add native context, JFC, and buffer resource management

This PR adds the resource-management components required by the later native UB transport:

- UB context ownership and shutdown
- JFC lifecycle and health tracking
- Local segment registration across UB contexts
- Remote segment import and generation-aware caching
- UB buffer metadata encoding and decoding
- Retryable teardown after provider cleanup failures
- Retention of partially created native resources until cleanup can be retried

Cleanup operations preserve native handles when unregister, unimport, JFC deletion, or context closure fails. This prevents failed cleanup attempts from losing ownership information and allows later teardown attempts to complete safely.

#### 5. Update URMA build integration

`FindUrma.cmake` now:

- Prefers an installed UMDK/URMA header and library pair
- Falls back to fetching UMDK headers when a system installation is unavailable
- Exposes a shared `Urma::urma` CMake target
- Allows mock-adapter builds without linking a second set of global mock URMA symbols

The existing Classic Transfer Engine UB target is updated to consume the same imported CMake target.

#### 6. Add tests and CI coverage

This PR adds mock-based tests for:

- UB transport-name and enum stability
- Backward-compatible topology JSON parsing
- UB topology metadata round trips
- Local registration rollback
- Remote import generation isolation
- Retryable unregister and unimport
- Partial registration and import failures
- JFC and context shutdown ordering
- Retryable resource teardown

A UB mock configuration is also added to the TENT CI matrix.

### Compatibility and impact

When `USE_UB=OFF`:

- The native UB target is not built.
- Existing TCP, RDMA, and other transport data paths are not changed.
- Existing transport and topology numeric values remain stable.
- Topology serialization includes additional optional NIC identity fields, while parsing remains backward-compatible.

When `USE_UB=ON`:

- The URMA build discovery path is shared by the Classic Transfer Engine UB backend and the new TENT-native UB components.
- A system URMA installation is preferred when available.
- Mock-based TENT UB tests can run without real UB hardware.

This PR does not replace or modify the existing TCP, RDMA, or other transport data paths.

### Out of scope

This PR does not yet provide:

- TENT UB endpoint bootstrap
- A complete `UbTransport` data path
- TENT UB task or slice execution
- End-to-end READ/WRITE through TENT
- Failover, telemetry, or receiver-credit integration
- Real-hardware production-readiness validation
- GPU or other non-host-memory validation

These capabilities are introduced in follow-up stages of RFC #3093.

### Review focus

Reviewers are especially invited to examine:

1. Whether the URMA adapter boundary keeps TENT policy out of the native adapter.
2. Native resource ownership and cleanup behavior after partial failures.
3. Compatibility of the appended transport and topology enum values.
4. Backward compatibility of topology JSON parsing and serialization.
5. The system-URMA and fetched-header CMake paths.
6. The effect of the shared `Urma::urma` target on the existing Classic Transfer Engine UB build.
7. Whether the mock tests sufficiently cover retryable teardown and partial initialization.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

### Build with UB disabled

```bash
cmake -S . -B build/ub-tent-1-off -G Ninja \
  -DUSE_TENT=ON \
  -DUSE_UB=OFF \
  -DUSE_CUDA=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Debug

cmake --build build/ub-tent-1-off -j"$(nproc)"
```

Result: passed.

This verifies that the existing TENT build continues to work without enabling UB.

### Build with the mock URMA adapter

```bash
cmake -S . -B build/ub-tent-1-on -G Ninja \
  -DUSE_TENT=ON \
  -DUSE_UB=ON \
  -DUSE_CUDA=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DCMAKE_BUILD_TYPE=Debug

cmake --build build/ub-tent-1-on -j"$(nproc)" --target \
  tent_transport_selector_test \
  tent_ub_teardown_test
```

Result: passed.

### Unit tests

```bash
ctest \
  --test-dir build/ub-tent-1-on/mooncake-transfer-engine/tent/tests \
  --output-on-failure \
  -R 'tent_(transport_selector|ub_teardown)_test'
```

Result: passed.

The tests cover enum stability, topology compatibility, resource rollback, generation-aware imports, partial initialization failures, and retryable teardown.

### Additional validation

```bash
git diff --check upstream/main...UB_TENT-1
```

Result: passed.

Changed-file pre-commit checks passed except for `codespell`, which reports the pre-existing word `crate` in `.github/workflows/ci.yml`. Those lines were introduced by upstream commit `8dd6306af` and are not modified by this PR.

Real UB hardware testing was not performed for this stage. This PR does not claim production readiness or end-to-end UB data-path validation.

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable to this foundation stage)
- [x] Manual testing done on real UB hardware

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (not applicable to this foundation stage)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3093)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI tools were used to help review the implementation structure, validate the PR decomposition, and draft the PR description. The human submitter has reviewed the final content and remains responsible for understanding, testing, and defending all changes.