### PR TITLE
feat(store): rebootstrap trimmed P2P standby from peer

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_store.h
+++ b/mooncake-store/include/ha/oplog/oplog_store.h
@@ -71,6 +71,10 @@ class OpLogStore {
     // Sequence ID management
     virtual ErrorCode GetLatestSequenceId(uint64_t& sequence_id) = 0;
     virtual ErrorCode GetMaxSequenceId(uint64_t& sequence_id) = 0;
+    virtual ErrorCode GetTrimmedSequenceId(uint64_t& sequence_id) {
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
     virtual ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) = 0;
 
     // Snapshot

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -111,12 +111,15 @@ class P2PHotStandbyService {
     void RestoreRecoveryWorker();
     void RequestRecovery();
     void RecoveryLoop();
-    ErrorCode BootstrapFromSnapshotSources(uint64_t& baseline_sequence_id);
+    ErrorCode BootstrapFromSnapshotSources(
+        uint64_t& baseline_sequence_id,
+        const std::vector<std::string>& discovered_endpoints = {});
     ErrorCode ResyncFromSnapshotLocked();
     ErrorCode GetLatestOpLogSequenceId(uint64_t& sequence_id) const;
     bool WaitForAppliedSequenceLocked(
         uint64_t sequence_id,
-        std::chrono::milliseconds timeout = std::chrono::seconds(30)) const;
+        std::chrono::milliseconds timeout = std::chrono::seconds(30),
+        bool stop_on_snapshot_resync = false) const;
     ErrorCode StartSnapshotServer();
     void StopSnapshotServer();
     std::vector<std::string> DiscoverSnapshotSources() const;

--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -36,10 +36,10 @@ struct P2PHotStandbyConfig {
     int reconnect_initial_backoff_ms{100};
     int reconnect_max_backoff_ms{5000};
     uint16_t snapshot_service_port{0};
-    // TODO: Discover alive snapshot sources from the Redis Master registry by
-    // default, while keeping explicit endpoints as an override.
+    std::string master_instance_id;
     std::vector<std::string> snapshot_source_endpoints;
     uint32_t snapshot_chunk_size{256};
+    int master_registry_ttl_sec{10};
 };
 
 struct P2PStandbySyncStatus {
@@ -98,7 +98,9 @@ class P2PHotStandbyService {
     bool IsReadyForSnapshot() const;
 
    private:
-    ErrorCode StartOplogFollowingLocked(uint64_t baseline_sequence_id);
+    ErrorCode StartOplogFollowingLocked(
+        uint64_t baseline_sequence_id,
+        std::unique_ptr<OpLogStore> prepared_reader_store = nullptr);
     std::unique_ptr<OpLogStore> CreateReaderStore() const;
     void ResetOplogFollowingLocked();
     ErrorCode FinalCatchUpForPromotionLocked(uint64_t current_applied_seq_id);
@@ -110,12 +112,14 @@ class P2PHotStandbyService {
     void RequestRecovery();
     void RecoveryLoop();
     ErrorCode BootstrapFromSnapshotSources(uint64_t& baseline_sequence_id);
+    ErrorCode ResyncFromSnapshotLocked();
     ErrorCode GetLatestOpLogSequenceId(uint64_t& sequence_id) const;
     bool WaitForAppliedSequenceLocked(
         uint64_t sequence_id,
         std::chrono::milliseconds timeout = std::chrono::seconds(30)) const;
     ErrorCode StartSnapshotServer();
     void StopSnapshotServer();
+    std::vector<std::string> DiscoverSnapshotSources() const;
 
     P2PHotStandbyConfig config_;
     ReaderStoreFactory reader_store_factory_;
@@ -136,6 +140,7 @@ class P2PHotStandbyService {
     std::thread recovery_thread_;
     bool recovery_requested_{false};
     bool recovery_stopping_{false};
+    std::atomic<bool> snapshot_resync_required_{false};
 
     std::unique_ptr<P2PStandbySnapshotService> snapshot_service_;
     std::unique_ptr<coro_rpc::coro_rpc_server> snapshot_server_;

--- a/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
@@ -4,6 +4,8 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -117,5 +119,65 @@ class P2PStandbySnapshotClient {
                         uint64_t& baseline_sequence_id,
                         uint32_t chunk_size = 256);
 };
+
+#ifdef STORE_USE_REDIS
+struct RedisMasterRegistryEntry {
+    std::string instance_id;
+    std::string master_endpoint;
+    std::string snapshot_endpoint;
+    std::string role;
+    bool snapshot_ready{false};
+    uint64_t applied_sequence_id{0};
+};
+
+class RedisMasterRegistry {
+   public:
+    RedisMasterRegistry(std::string cluster_id, std::string redis_endpoint,
+                        std::string username, std::string password,
+                        int db_index);
+
+    ErrorCode Refresh(const RedisMasterRegistryEntry& entry);
+    ErrorCode Remove(const std::string& instance_id);
+    ErrorCode DiscoverAlive(std::chrono::seconds ttl,
+                            std::vector<RedisMasterRegistryEntry>& entries);
+
+   private:
+    std::string heartbeat_key_;
+    std::string metadata_key_;
+    std::string redis_endpoint_;
+    std::string username_;
+    std::string password_;
+    int db_index_{0};
+};
+
+class RedisMasterRegistryHeartbeat {
+   public:
+    RedisMasterRegistryHeartbeat(
+        std::unique_ptr<RedisMasterRegistry> registry,
+        RedisMasterRegistryEntry entry,
+        std::chrono::seconds interval = std::chrono::seconds(2));
+    ~RedisMasterRegistryHeartbeat();
+
+    ErrorCode Start();
+    void UpdateRole(std::string role, bool snapshot_ready);
+    void SetAppliedSequenceProvider(std::function<uint64_t()> provider);
+    void SetSnapshotReadyProvider(std::function<bool()> provider);
+    void Stop();
+
+   private:
+    void Run();
+
+    std::unique_ptr<RedisMasterRegistry> registry_;
+    RedisMasterRegistryEntry entry_;
+    std::chrono::seconds interval_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::thread thread_;
+    std::function<uint64_t()> applied_sequence_provider_;
+    std::function<bool()> snapshot_ready_provider_;
+    bool refresh_requested_{false};
+    bool stopping_{false};
+};
+#endif
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_snapshot_service.h
@@ -175,6 +175,7 @@ class RedisMasterRegistryHeartbeat {
     std::thread thread_;
     std::function<uint64_t()> applied_sequence_provider_;
     std::function<bool()> snapshot_ready_provider_;
+    size_t provider_in_flight_{0};
     bool refresh_requested_{false};
     bool stopping_{false};
 };

--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -51,6 +51,7 @@ class RedisOpLogStore : public OpLogStore {
                                          OpLogReadProgress& progress) override;
     ErrorCode GetLatestSequenceId(uint64_t& sequence_id) override;
     ErrorCode GetMaxSequenceId(uint64_t& sequence_id) override;
+    ErrorCode GetTrimmedSequenceId(uint64_t& sequence_id) override;
     ErrorCode UpdateLatestSequenceId(uint64_t sequence_id) override;
     ErrorCode RecordSnapshotSequenceId(const std::string& snapshot_id,
                                        uint64_t sequence_id) override;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -36,7 +36,7 @@ struct MasterConfig {
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
     uint32_t standby_snapshot_service_port = 0;
-    std::string standby_snapshot_advertise_endpoint;
+    std::string standby_snapshot_service_endpoint;
     std::string standby_snapshot_sources;
     uint32_t standby_snapshot_chunk_size = 256;
     bool enable_offload;
@@ -138,7 +138,7 @@ class MasterServiceSupervisorConfig {
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
     uint32_t standby_snapshot_service_port = 0;
-    std::string standby_snapshot_advertise_endpoint;
+    std::string standby_snapshot_service_endpoint;
     std::string standby_snapshot_sources;
     uint32_t standby_snapshot_chunk_size = 256;
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
@@ -213,8 +213,8 @@ class MasterServiceSupervisorConfig {
             config.oplog_async_queue_overflow_mode;
         oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
         standby_snapshot_service_port = config.standby_snapshot_service_port;
-        standby_snapshot_advertise_endpoint =
-            config.standby_snapshot_advertise_endpoint;
+        standby_snapshot_service_endpoint =
+            config.standby_snapshot_service_endpoint;
         standby_snapshot_sources = config.standby_snapshot_sources;
         standby_snapshot_chunk_size = config.standby_snapshot_chunk_size;
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -36,6 +36,7 @@ struct MasterConfig {
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
     uint32_t standby_snapshot_service_port = 0;
+    std::string standby_snapshot_advertise_endpoint;
     std::string standby_snapshot_sources;
     uint32_t standby_snapshot_chunk_size = 256;
     bool enable_offload;
@@ -137,6 +138,7 @@ class MasterServiceSupervisorConfig {
     std::string oplog_async_queue_overflow_mode = "reject";
     uint64_t oplog_best_effort_max_retries = 3;
     uint32_t standby_snapshot_service_port = 0;
+    std::string standby_snapshot_advertise_endpoint;
     std::string standby_snapshot_sources;
     uint32_t standby_snapshot_chunk_size = 256;
     uint32_t max_total_finished_tasks = DEFAULT_MAX_TOTAL_FINISHED_TASKS;
@@ -211,6 +213,8 @@ class MasterServiceSupervisorConfig {
             config.oplog_async_queue_overflow_mode;
         oplog_best_effort_max_retries = config.oplog_best_effort_max_retries;
         standby_snapshot_service_port = config.standby_snapshot_service_port;
+        standby_snapshot_advertise_endpoint =
+            config.standby_snapshot_advertise_endpoint;
         standby_snapshot_sources = config.standby_snapshot_sources;
         standby_snapshot_chunk_size = config.standby_snapshot_chunk_size;
 

--- a/mooncake-store/include/standby_state_machine.h
+++ b/mooncake-store/include/standby_state_machine.h
@@ -123,8 +123,9 @@ enum class StandbyEvent : uint8_t {
     SYNC_FAILED,    // Sync failed
 
     // Watch events
-    WATCH_HEALTHY,  // Watch is healthy and receiving events
-    WATCH_BROKEN,   // Watch connection broken
+    WATCH_HEALTHY,    // Watch is healthy and receiving events
+    WATCH_BROKEN,     // Watch connection broken
+    RESYNC_REQUIRED,  // OpLog history was trimmed; full bootstrap is required
 
     // Recovery events
     RECOVERY_SUCCESS,  // Successfully recovered from error
@@ -163,6 +164,8 @@ inline const char* StandbyEventToString(StandbyEvent event) {
             return "WATCH_HEALTHY";
         case StandbyEvent::WATCH_BROKEN:
             return "WATCH_BROKEN";
+        case StandbyEvent::RESYNC_REQUIRED:
+            return "RESYNC_REQUIRED";
         case StandbyEvent::RECOVERY_SUCCESS:
             return "RECOVERY_SUCCESS";
         case StandbyEvent::RECOVERY_FAILED:

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -180,6 +180,7 @@ enum class ErrorCode : int32_t {
     ETCD_TRANSACTION_FAIL = -1002,  ///< etcd transaction failed.
     ETCD_CTX_CANCELLED = -1003,     ///< etcd context cancelled.
     OPLOG_ENTRY_NOT_FOUND = -1004,  ///< OpLog entry not found.
+    OPLOG_TRIMMED = -1005,          ///< Requested OpLog range was trimmed.
     UNAVAILABLE_IN_CURRENT_STATUS =
         -1010,  ///< Request cannot be done in current status.
     UNAVAILABLE_IN_CURRENT_MODE =

--- a/mooncake-store/src/ha/oplog/oplog_replicator.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_replicator.cpp
@@ -45,7 +45,9 @@ bool OpLogReplicator::StartFromSequenceId(uint64_t start_seq_id) {
     auto on_error = [this](ErrorCode err) {
         LOG(ERROR) << "OpLogReplicator: notifier error="
                    << static_cast<int>(err);
-        NotifyStateEvent(StandbyEvent::WATCH_BROKEN);
+        NotifyStateEvent(err == ErrorCode::OPLOG_TRIMMED
+                             ? StandbyEvent::RESYNC_REQUIRED
+                             : StandbyEvent::WATCH_BROKEN);
     };
 
     auto on_maintenance =

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -39,6 +39,7 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
     }
 
     state_machine_.ProcessEvent(StandbyEvent::CONNECTED);
+    snapshot_resync_required_.store(false);
     metadata_store_->RemoveAllMetadata();
     oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
                                                        config_.cluster_id);
@@ -52,11 +53,13 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
         return ErrorCode::INTERNAL_ERROR;
     }
-    const bool has_discovered_source =
-        config_.snapshot_source_endpoints.empty() &&
-        !DiscoverSnapshotSources().empty();
+    std::vector<std::string> discovered_snapshot_sources;
+    if (config_.snapshot_source_endpoints.empty()) {
+        discovered_snapshot_sources = DiscoverSnapshotSources();
+    }
     const bool bootstrap_requested =
-        !config_.snapshot_source_endpoints.empty() || has_discovered_source ||
+        !config_.snapshot_source_endpoints.empty() ||
+        !discovered_snapshot_sources.empty() ||
         baseline_sequence_id < trimmed_sequence_id;
     if (bootstrap_requested) {
         ErrorCode bootstrap_err = ErrorCode::INTERNAL_ERROR;
@@ -65,8 +68,15 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
             baseline_sequence_id < trimmed_sequence_id;
         const auto deadline =
             std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        const std::vector<std::string> empty_discovered_sources;
+        bool use_cached_discovered_sources =
+            !discovered_snapshot_sources.empty();
         do {
-            bootstrap_err = BootstrapFromSnapshotSources(baseline_sequence_id);
+            bootstrap_err = BootstrapFromSnapshotSources(
+                baseline_sequence_id, use_cached_discovered_sources
+                                          ? discovered_snapshot_sources
+                                          : empty_discovered_sources);
+            use_cached_discovered_sources = false;
             uint64_t current_trimmed_sequence_id = 0;
             if (bootstrap_err == ErrorCode::OK &&
                 (probe_store->GetTrimmedSequenceId(
@@ -119,24 +129,44 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         return err;
     }
 
-    if (!WaitForAppliedSequenceLocked(initial_sync_target)) {
-        if (oplog_applier_ && !oplog_applier_->IsHealthy() &&
-            state_machine_.GetState() == StandbyState::FAILED) {
-            // TODO(P2P HA): Decide whether supervisor startup should fail here
-            // instead of joining election with a FAILED standby.
-            LOG(ERROR) << "P2PHotStandbyService: initial apply failed; "
-                          "retaining FAILED state for operator action"
-                       << ", failed_sequence_id="
-                       << oplog_applier_->GetFailedSequenceId();
-            return ErrorCode::OK;
+    if (!WaitForAppliedSequenceLocked(initial_sync_target,
+                                      std::chrono::seconds(30),
+                                      /*stop_on_snapshot_resync=*/true)) {
+        if (snapshot_resync_required_.load()) {
+            LOG(WARNING) << "P2PHotStandbyService: initial OpLog catch-up "
+                            "was trimmed; switching to snapshot bootstrap"
+                         << ", target_sequence_id=" << initial_sync_target
+                         << ", applied_sequence_id="
+                         << GetLocalLastAppliedSequenceIdLocked();
+            auto resync_err = ResyncFromSnapshotLocked();
+            if (resync_err != ErrorCode::OK) {
+                LOG(ERROR) << "P2PHotStandbyService: initial snapshot resync "
+                              "failed"
+                           << ", error=" << toString(resync_err);
+                state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+                ResetOplogFollowingLocked();
+                return resync_err;
+            }
+            snapshot_resync_required_.store(false);
+        } else {
+            if (oplog_applier_ && !oplog_applier_->IsHealthy() &&
+                state_machine_.GetState() == StandbyState::FAILED) {
+                // TODO(P2P HA): Decide whether supervisor startup should fail
+                // here instead of joining election with a FAILED standby.
+                LOG(ERROR) << "P2PHotStandbyService: initial apply failed; "
+                              "retaining FAILED state for operator action"
+                           << ", failed_sequence_id="
+                           << oplog_applier_->GetFailedSequenceId();
+                return ErrorCode::OK;
+            }
+            LOG(ERROR) << "P2PHotStandbyService: initial sync timed out"
+                       << ", target_sequence_id=" << initial_sync_target
+                       << ", applied_sequence_id="
+                       << GetLocalLastAppliedSequenceIdLocked();
+            state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+            ResetOplogFollowingLocked();
+            return ErrorCode::INTERNAL_ERROR;
         }
-        LOG(ERROR) << "P2PHotStandbyService: initial sync timed out"
-                   << ", target_sequence_id=" << initial_sync_target
-                   << ", applied_sequence_id="
-                   << GetLocalLastAppliedSequenceIdLocked();
-        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
-        ResetOplogFollowingLocked();
-        return ErrorCode::INTERNAL_ERROR;
     }
     if (bootstrap_requested) {
         LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up completed"
@@ -352,7 +382,7 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
     static constexpr size_t kMaxCatchUpBatches = 100;
     // TODO: Add promotion readiness gating and a clear fail/continue policy for
     // incomplete catch-up: require initial sync completion, enforce max standby
-    // lag, handle final catch-up read failures, and monitor apply rate.
+    // lag, classify non-trimmed read failures, and monitor apply rate.
     uint64_t read_from_seq = current_applied_seq_id;
     size_t total_applied = 0;
     size_t batch_count = 0;
@@ -364,6 +394,13 @@ ErrorCode P2PHotStandbyService::FinalCatchUpForPromotionLocked(
             read_from_seq, kBatchSize, batch, progress);
         if (read_err != ErrorCode::OK) {
             HAMetricManager::instance().inc_promotion_catchup_incomplete();
+            if (read_err == ErrorCode::OPLOG_TRIMMED) {
+                LOG(ERROR)
+                    << "P2PHotStandbyService: final catch-up history was "
+                       "trimmed; aborting promotion"
+                    << ", from_seq=" << read_from_seq;
+                return read_err;
+            }
             LOG(WARNING) << "P2PHotStandbyService: final catch-up read failed"
                          << ", from_seq=" << read_from_seq
                          << ", error=" << toString(read_err)
@@ -441,15 +478,21 @@ bool P2PHotStandbyService::IsReadyForPromotion() const {
 }
 
 bool P2PHotStandbyService::IsReadyForSnapshot() const {
-    if (!IsReadyForPromotion() || !oplog_applier_ ||
-        !oplog_applier_->IsHealthy()) {
-        return false;
+    std::shared_ptr<OpLogStore> store;
+    uint64_t applied_sequence_id = 0;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!state_machine_.IsReadyForPromotion() || !oplog_applier_ ||
+            !oplog_applier_->IsHealthy() || !watcher_oplog_store_) {
+            return false;
+        }
+        store = watcher_oplog_store_;
+        applied_sequence_id = GetLocalLastAppliedSequenceIdLocked();
     }
-    auto store = CreateReaderStore();
+
     uint64_t trimmed_sequence_id = 0;
-    return store &&
-           store->GetTrimmedSequenceId(trimmed_sequence_id) == ErrorCode::OK &&
-           GetLatestAppliedSequenceId() >= trimmed_sequence_id;
+    return store->GetTrimmedSequenceId(trimmed_sequence_id) == ErrorCode::OK &&
+           applied_sequence_id >= trimmed_sequence_id;
 }
 
 uint64_t P2PHotStandbyService::GetLatestAppliedSequenceId() const {
@@ -484,11 +527,13 @@ bool P2PHotStandbyService::WaitForAppliedSequence(
 }
 
 ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
-    uint64_t& baseline_sequence_id) {
+    uint64_t& baseline_sequence_id,
+    const std::vector<std::string>& discovered_endpoints) {
     P2PStandbySnapshotClient client;
     auto endpoints = config_.snapshot_source_endpoints;
     if (endpoints.empty()) {
-        endpoints = DiscoverSnapshotSources();
+        endpoints = discovered_endpoints.empty() ? DiscoverSnapshotSources()
+                                                 : discovered_endpoints;
     }
     if (endpoints.size() > 1) {
         static thread_local std::mt19937 generator(std::random_device{}());
@@ -524,15 +569,36 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
     uint64_t baseline_sequence_id = 0;
     auto err = BootstrapFromSnapshotSources(baseline_sequence_id);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: snapshot resync bootstrap failed"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", error=" << toString(err);
         return err;
     }
 
     auto trim_store = CreateReaderStore();
+    if (!trim_store) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to create reader store "
+                      "while validating snapshot resync trim horizon"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", baseline_sequence_id=" << baseline_sequence_id;
+        return ErrorCode::OPLOG_TRIMMED;
+    }
     uint64_t trimmed_sequence_id = 0;
-    if (!trim_store ||
-        trim_store->GetTrimmedSequenceId(trimmed_sequence_id) !=
-            ErrorCode::OK ||
-        baseline_sequence_id < trimmed_sequence_id) {
+    err = trim_store->GetTrimmedSequenceId(trimmed_sequence_id);
+    if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to read trim horizon "
+                      "after snapshot resync"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", baseline_sequence_id=" << baseline_sequence_id
+                   << ", error=" << toString(err);
+        return ErrorCode::OPLOG_TRIMMED;
+    }
+    if (baseline_sequence_id < trimmed_sequence_id) {
+        LOG(ERROR) << "P2PHotStandbyService: snapshot resync baseline is "
+                      "behind trim horizon"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", baseline_sequence_id=" << baseline_sequence_id
+                   << ", trimmed_sequence_id=" << trimmed_sequence_id;
         return ErrorCode::OPLOG_TRIMMED;
     }
 
@@ -543,13 +609,29 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
     uint64_t catch_up_target = baseline_sequence_id;
     err = GetLatestOpLogSequenceId(catch_up_target);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to get snapshot resync "
+                      "catch-up target"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", baseline_sequence_id=" << baseline_sequence_id
+                   << ", error=" << toString(err);
         return err;
     }
     err = StartOplogFollowingLocked(baseline_sequence_id);
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to restart OpLog "
+                      "following after snapshot resync"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", baseline_sequence_id=" << baseline_sequence_id
+                   << ", catch_up_target=" << catch_up_target
+                   << ", error=" << toString(err);
         return err;
     }
     if (!WaitForAppliedSequenceLocked(catch_up_target)) {
+        LOG(ERROR) << "P2PHotStandbyService: snapshot resync catch-up timed out"
+                   << ", cluster_id=" << config_.cluster_id
+                   << ", catch_up_target=" << catch_up_target
+                   << ", applied_sequence_id="
+                   << GetLocalLastAppliedSequenceIdLocked();
         ResetOplogFollowingLocked();
         return ErrorCode::INTERNAL_ERROR;
     }
@@ -573,11 +655,15 @@ ErrorCode P2PHotStandbyService::GetLatestOpLogSequenceId(
 }
 
 bool P2PHotStandbyService::WaitForAppliedSequenceLocked(
-    uint64_t sequence_id, std::chrono::milliseconds timeout) const {
+    uint64_t sequence_id, std::chrono::milliseconds timeout,
+    bool stop_on_snapshot_resync) const {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
         if (GetLocalLastAppliedSequenceIdLocked() >= sequence_id) {
             return true;
+        }
+        if (stop_on_snapshot_resync && snapshot_resync_required_.load()) {
+            return false;
         }
         if (state_machine_.GetState() == StandbyState::FAILED) {
             return false;

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -44,27 +44,72 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
                                                        config_.cluster_id);
 
     uint64_t initial_sync_target = baseline_sequence_id;
-    if (!config_.snapshot_source_endpoints.empty()) {
-        auto bootstrap_err = BootstrapFromSnapshotSources(baseline_sequence_id);
-        if (bootstrap_err != ErrorCode::OK) {
-            LOG(ERROR) << "P2PHotStandbyService: snapshot bootstrap failed";
-            state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
-            return bootstrap_err;
-        }
-        bootstrap_err = GetLatestOpLogSequenceId(initial_sync_target);
-        if (bootstrap_err != ErrorCode::OK) {
-            LOG(ERROR) << "P2PHotStandbyService: failed to get initial sync "
-                          "target";
-            state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
-            return bootstrap_err;
-        }
-        LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up started"
-                  << ", baseline_sequence_id=" << baseline_sequence_id
-                  << ", target_sequence_id=" << initial_sync_target;
+    uint64_t trimmed_sequence_id = 0;
+    auto probe_store = CreateReaderStore();
+    if (!probe_store || probe_store->GetTrimmedSequenceId(
+                            trimmed_sequence_id) != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to read trim horizon";
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        return ErrorCode::INTERNAL_ERROR;
     }
+    const bool has_discovered_source =
+        config_.snapshot_source_endpoints.empty() &&
+        !DiscoverSnapshotSources().empty();
+    const bool bootstrap_requested =
+        !config_.snapshot_source_endpoints.empty() || has_discovered_source ||
+        baseline_sequence_id < trimmed_sequence_id;
+    if (bootstrap_requested) {
+        ErrorCode bootstrap_err = ErrorCode::INTERNAL_ERROR;
+        const bool bootstrap_required =
+            !config_.snapshot_source_endpoints.empty() ||
+            baseline_sequence_id < trimmed_sequence_id;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        do {
+            bootstrap_err = BootstrapFromSnapshotSources(baseline_sequence_id);
+            uint64_t current_trimmed_sequence_id = 0;
+            if (bootstrap_err == ErrorCode::OK &&
+                (probe_store->GetTrimmedSequenceId(
+                     current_trimmed_sequence_id) != ErrorCode::OK ||
+                 baseline_sequence_id < current_trimmed_sequence_id)) {
+                LOG(WARNING)
+                    << "P2PHotStandbyService: snapshot baseline is "
+                       "behind current trim horizon"
+                    << ", baseline_sequence_id=" << baseline_sequence_id
+                    << ", trimmed_sequence_id=" << current_trimmed_sequence_id;
+                bootstrap_err = ErrorCode::OPLOG_TRIMMED;
+            }
+            if (bootstrap_err == ErrorCode::OK || !bootstrap_required) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        } while (std::chrono::steady_clock::now() < deadline);
+        if (bootstrap_err != ErrorCode::OK) {
+            if (bootstrap_required) {
+                LOG(ERROR) << "P2PHotStandbyService: required snapshot "
+                              "bootstrap failed"
+                           << ", baseline_sequence_id=" << baseline_sequence_id
+                           << ", trimmed_sequence_id=" << trimmed_sequence_id;
+                state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+                return bootstrap_err;
+            }
+            LOG(WARNING) << "P2PHotStandbyService: optional peer bootstrap "
+                            "failed; falling back to OpLog replay";
+        }
+    }
+    auto latest_err = probe_store->GetLatestSequenceId(initial_sync_target);
+    if (latest_err != ErrorCode::OK) {
+        LOG(ERROR) << "P2PHotStandbyService: failed to get initial sync target";
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        return latest_err;
+    }
+    LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up started"
+              << ", baseline_sequence_id=" << baseline_sequence_id
+              << ", target_sequence_id=" << initial_sync_target;
     oplog_applier_->Recover(baseline_sequence_id);
 
-    auto err = StartOplogFollowingLocked(baseline_sequence_id);
+    auto err =
+        StartOplogFollowingLocked(baseline_sequence_id, std::move(probe_store));
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "P2PHotStandbyService: failed to start oplog following"
                    << ", baseline_sequence_id=" << baseline_sequence_id
@@ -75,6 +120,16 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
     }
 
     if (!WaitForAppliedSequenceLocked(initial_sync_target)) {
+        if (oplog_applier_ && !oplog_applier_->IsHealthy() &&
+            state_machine_.GetState() == StandbyState::FAILED) {
+            // TODO(P2P HA): Decide whether supervisor startup should fail here
+            // instead of joining election with a FAILED standby.
+            LOG(ERROR) << "P2PHotStandbyService: initial apply failed; "
+                          "retaining FAILED state for operator action"
+                       << ", failed_sequence_id="
+                       << oplog_applier_->GetFailedSequenceId();
+            return ErrorCode::OK;
+        }
         LOG(ERROR) << "P2PHotStandbyService: initial sync timed out"
                    << ", target_sequence_id=" << initial_sync_target
                    << ", applied_sequence_id="
@@ -83,7 +138,7 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         ResetOplogFollowingLocked();
         return ErrorCode::INTERNAL_ERROR;
     }
-    if (!config_.snapshot_source_endpoints.empty()) {
+    if (bootstrap_requested) {
         LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up completed"
                   << ", applied_sequence_id="
                   << GetLocalLastAppliedSequenceIdLocked();
@@ -105,10 +160,14 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
 }
 
 ErrorCode P2PHotStandbyService::StartOplogFollowingLocked(
-    uint64_t baseline_sequence_id) {
+    uint64_t baseline_sequence_id,
+    std::unique_ptr<OpLogStore> prepared_reader_store) {
     ResetOplogFollowingLocked();
 
-    watcher_oplog_store_ = CreateReaderStore();
+    watcher_oplog_store_ =
+        prepared_reader_store
+            ? std::shared_ptr<OpLogStore>(std::move(prepared_reader_store))
+            : CreateReaderStore();
     if (!watcher_oplog_store_) {
         LOG(ERROR) << "P2PHotStandbyService: failed to create reader store"
                    << ", cluster_id=" << config_.cluster_id;
@@ -382,8 +441,15 @@ bool P2PHotStandbyService::IsReadyForPromotion() const {
 }
 
 bool P2PHotStandbyService::IsReadyForSnapshot() const {
-    return IsReadyForPromotion() && oplog_applier_ &&
-           oplog_applier_->IsHealthy();
+    if (!IsReadyForPromotion() || !oplog_applier_ ||
+        !oplog_applier_->IsHealthy()) {
+        return false;
+    }
+    auto store = CreateReaderStore();
+    uint64_t trimmed_sequence_id = 0;
+    return store &&
+           store->GetTrimmedSequenceId(trimmed_sequence_id) == ErrorCode::OK &&
+           GetLatestAppliedSequenceId() >= trimmed_sequence_id;
 }
 
 uint64_t P2PHotStandbyService::GetLatestAppliedSequenceId() const {
@@ -420,13 +486,15 @@ bool P2PHotStandbyService::WaitForAppliedSequence(
 ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
     uint64_t& baseline_sequence_id) {
     P2PStandbySnapshotClient client;
-    auto snapshot_source_endpoints = config_.snapshot_source_endpoints;
-    if (snapshot_source_endpoints.size() > 1) {
-        static thread_local std::mt19937 generator(std::random_device{}());
-        std::shuffle(snapshot_source_endpoints.begin(),
-                     snapshot_source_endpoints.end(), generator);
+    auto endpoints = config_.snapshot_source_endpoints;
+    if (endpoints.empty()) {
+        endpoints = DiscoverSnapshotSources();
     }
-    for (const auto& endpoint : snapshot_source_endpoints) {
+    if (endpoints.size() > 1) {
+        static thread_local std::mt19937 generator(std::random_device{}());
+        std::shuffle(endpoints.begin(), endpoints.end(), generator);
+    }
+    for (const auto& endpoint : endpoints) {
         uint64_t source_sequence_id = 0;
         auto err = client.Bootstrap(endpoint, config_.cluster_id,
                                     metadata_store_.get(), source_sequence_id,
@@ -438,13 +506,58 @@ ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
                       << ", baseline_sequence_id=" << baseline_sequence_id;
             return ErrorCode::OK;
         }
-        LOG(WARNING) << "P2PHotStandbyService: snapshot source failed"
-                     << ", source=" << endpoint << ", error=" << toString(err);
+        VLOG(1) << "P2PHotStandbyService: snapshot source failed"
+                << ", source=" << endpoint << ", error=" << toString(err);
+    }
+    if (endpoints.empty()) {
+        VLOG(1) << "P2PHotStandbyService: no snapshot source available";
     }
     LOG(ERROR) << "P2PHotStandbyService: all snapshot sources failed"
                << ", cluster_id=" << config_.cluster_id
-               << ", source_count=" << snapshot_source_endpoints.size();
+               << ", source_count=" << endpoints.size();
     return ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
+    ResetOplogFollowingLocked();
+
+    uint64_t baseline_sequence_id = 0;
+    auto err = BootstrapFromSnapshotSources(baseline_sequence_id);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+
+    auto trim_store = CreateReaderStore();
+    uint64_t trimmed_sequence_id = 0;
+    if (!trim_store ||
+        trim_store->GetTrimmedSequenceId(trimmed_sequence_id) !=
+            ErrorCode::OK ||
+        baseline_sequence_id < trimmed_sequence_id) {
+        return ErrorCode::OPLOG_TRIMMED;
+    }
+
+    oplog_applier_ = std::make_unique<P2POpLogApplier>(metadata_store_.get(),
+                                                       config_.cluster_id);
+    oplog_applier_->Recover(baseline_sequence_id);
+
+    uint64_t catch_up_target = baseline_sequence_id;
+    err = GetLatestOpLogSequenceId(catch_up_target);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    err = StartOplogFollowingLocked(baseline_sequence_id);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (!WaitForAppliedSequenceLocked(catch_up_target)) {
+        ResetOplogFollowingLocked();
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    LOG(INFO) << "P2PHotStandbyService: snapshot resync completed"
+              << ", baseline_sequence_id=" << baseline_sequence_id
+              << ", applied_sequence_id="
+              << GetLocalLastAppliedSequenceIdLocked();
+    return ErrorCode::OK;
 }
 
 ErrorCode P2PHotStandbyService::GetLatestOpLogSequenceId(
@@ -465,6 +578,9 @@ bool P2PHotStandbyService::WaitForAppliedSequenceLocked(
     while (std::chrono::steady_clock::now() < deadline) {
         if (GetLocalLastAppliedSequenceIdLocked() >= sequence_id) {
             return true;
+        }
+        if (state_machine_.GetState() == StandbyState::FAILED) {
+            return false;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
@@ -506,6 +622,49 @@ void P2PHotStandbyService::StopSnapshotServer() {
     snapshot_service_.reset();
 }
 
+std::vector<std::string> P2PHotStandbyService::DiscoverSnapshotSources() const {
+    std::vector<std::string> endpoints;
+#ifdef STORE_USE_REDIS
+    if (config_.oplog_store_type != OpLogStoreType::REDIS) {
+        return endpoints;
+    }
+    auto store = CreateReaderStore();
+    uint64_t trimmed_sequence_id = 0;
+    if (!store ||
+        store->GetTrimmedSequenceId(trimmed_sequence_id) != ErrorCode::OK) {
+        LOG(WARNING) << "P2PHotStandbyService: failed to read trim horizon "
+                        "while discovering snapshot sources";
+        return endpoints;
+    }
+    RedisMasterRegistry registry(config_.cluster_id, config_.redis_endpoint,
+                                 config_.redis_username, config_.redis_password,
+                                 config_.redis_db_index);
+    std::vector<RedisMasterRegistryEntry> masters;
+    auto err = registry.DiscoverAlive(
+        std::chrono::seconds(config_.master_registry_ttl_sec), masters);
+    if (err != ErrorCode::OK) {
+        LOG(WARNING) << "P2PHotStandbyService: snapshot source discovery "
+                        "failed"
+                     << ", error=" << toString(err);
+        endpoints.clear();
+        return endpoints;
+    }
+    std::sort(masters.begin(), masters.end(),
+              [](const auto& lhs, const auto& rhs) {
+                  return lhs.applied_sequence_id > rhs.applied_sequence_id;
+              });
+    for (const auto& master : masters) {
+        if (master.instance_id != config_.master_instance_id &&
+            master.role == "standby" && master.snapshot_ready &&
+            master.applied_sequence_id >= trimmed_sequence_id &&
+            !master.snapshot_endpoint.empty()) {
+            endpoints.push_back(master.snapshot_endpoint);
+        }
+    }
+#endif
+    return endpoints;
+}
+
 void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {
     auto result = state_machine_.ProcessEvent(event);
     if (!result.allowed) {
@@ -513,7 +672,13 @@ void P2PHotStandbyService::OnWatcherEvent(StandbyEvent event) {
                 << ", event=" << StandbyEventToString(event)
                 << ", reason=" << result.reason;
     }
-    if (result.allowed && result.new_state == StandbyState::RECONNECTING) {
+    if (event == StandbyEvent::RESYNC_REQUIRED && result.allowed) {
+        snapshot_resync_required_.store(true);
+        LOG(WARNING) << "P2PHotStandbyService: OpLog trim horizon passed; "
+                        "switching to snapshot bootstrap";
+        RequestRecovery();
+    } else if (result.allowed &&
+               result.new_state == StandbyState::RECONNECTING) {
         RequestRecovery();
     }
 }
@@ -577,35 +742,71 @@ void P2PHotStandbyService::RecoveryLoop() {
 
             ErrorCode err = ErrorCode::INTERNAL_ERROR;
             uint64_t resume_sequence_id = 0;
+            bool attempted_snapshot_resync = false;
             {
                 std::lock_guard<std::mutex> lock(mutex_);
-                if (state_machine_.GetState() != StandbyState::RECONNECTING) {
+                const bool snapshot_resync = snapshot_resync_required_.load();
+                if (!snapshot_resync &&
+                    state_machine_.GetState() != StandbyState::RECONNECTING) {
                     recovery_lock.lock();
                     break;
                 }
-                resume_sequence_id = GetLocalLastAppliedSequenceIdLocked();
-                HAMetricManager::instance()
-                    .inc_oplog_reader_reconnect_attempts();
-                err = StartOplogFollowingLocked(resume_sequence_id);
-                if (err == ErrorCode::OK) {
-                    const bool watching =
-                        state_machine_.GetState() == StandbyState::WATCHING;
-                    const bool healthy =
-                        oplog_replicator_ && oplog_replicator_->IsHealthy();
-                    if (!watching || !healthy) {
-                        if (watching) {
-                            state_machine_.ProcessEvent(
-                                StandbyEvent::WATCH_BROKEN);
+                if (snapshot_resync) {
+                    attempted_snapshot_resync = true;
+                    // TODO(P2P HA): Move remote snapshot fetch out of mutex_
+                    // and swap the restored state under lock to keep Stop()
+                    // and Promote() responsive during long RPC waits.
+                    err = ResyncFromSnapshotLocked();
+                    if (err == ErrorCode::OK) {
+                        snapshot_resync_required_.store(false);
+                        auto result = state_machine_.ProcessEvent(
+                            StandbyEvent::SYNC_COMPLETE);
+                        const bool watching =
+                            state_machine_.GetState() == StandbyState::WATCHING;
+                        const bool healthy =
+                            oplog_replicator_ && oplog_replicator_->IsHealthy();
+                        if ((!result.allowed && !watching) || !healthy) {
+                            if (watching) {
+                                state_machine_.ProcessEvent(
+                                    StandbyEvent::WATCH_BROKEN);
+                            }
+                            LOG(ERROR)
+                                << "P2PHotStandbyService: snapshot resync "
+                                   "reader is not healthy"
+                                << ", state="
+                                << StandbyStateToString(
+                                       state_machine_.GetState())
+                                << ", transition_allowed=" << result.allowed;
+                            err = ErrorCode::INTERNAL_ERROR;
                         }
-                        LOG(ERROR)
-                            << "P2PHotStandbyService: recovered OpLog reader "
-                               "is not healthy"
-                            << ", state="
-                            << StandbyStateToString(state_machine_.GetState());
-                        err = ErrorCode::INTERNAL_ERROR;
                     }
                 } else {
-                    state_machine_.ProcessEvent(StandbyEvent::RECOVERY_FAILED);
+                    resume_sequence_id = GetLocalLastAppliedSequenceIdLocked();
+                    HAMetricManager::instance()
+                        .inc_oplog_reader_reconnect_attempts();
+                    err = StartOplogFollowingLocked(resume_sequence_id);
+                    if (err == ErrorCode::OK) {
+                        const bool watching =
+                            state_machine_.GetState() == StandbyState::WATCHING;
+                        const bool healthy =
+                            oplog_replicator_ && oplog_replicator_->IsHealthy();
+                        if (!watching || !healthy) {
+                            if (watching) {
+                                state_machine_.ProcessEvent(
+                                    StandbyEvent::WATCH_BROKEN);
+                            }
+                            LOG(ERROR)
+                                << "P2PHotStandbyService: recovered OpLog "
+                                   "reader is not healthy"
+                                << ", state="
+                                << StandbyStateToString(
+                                       state_machine_.GetState());
+                            err = ErrorCode::INTERNAL_ERROR;
+                        }
+                    } else {
+                        state_machine_.ProcessEvent(
+                            StandbyEvent::RECOVERY_FAILED);
+                    }
                 }
             }
 
@@ -614,15 +815,24 @@ void P2PHotStandbyService::RecoveryLoop() {
                 return;
             }
             if (err == ErrorCode::OK) {
-                HAMetricManager::instance().inc_oplog_reader_reconnects();
-                LOG(INFO) << "P2PHotStandbyService: OpLog reader reconnected"
-                          << ", resume_sequence_id=" << resume_sequence_id;
+                if (!attempted_snapshot_resync) {
+                    HAMetricManager::instance().inc_oplog_reader_reconnects();
+                    LOG(INFO)
+                        << "P2PHotStandbyService: OpLog reader reconnected"
+                        << ", resume_sequence_id=" << resume_sequence_id;
+                }
                 break;
             }
 
-            HAMetricManager::instance().inc_oplog_reader_reconnect_failures();
-            LOG(WARNING) << "P2PHotStandbyService: OpLog reader reconnect "
-                            "failed"
+            if (!attempted_snapshot_resync) {
+                HAMetricManager::instance()
+                    .inc_oplog_reader_reconnect_failures();
+            }
+            LOG(WARNING) << "P2PHotStandbyService: "
+                         << (attempted_snapshot_resync
+                                 ? "snapshot resync"
+                                 : "OpLog reader reconnect")
+                         << " failed, retrying"
                          << ", resume_sequence_id=" << resume_sequence_id
                          << ", retry_in_ms=" << backoff_ms;
             recovery_cv_.wait_for(recovery_lock,

--- a/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
@@ -383,6 +383,11 @@ bool ParseMasterRegistryEntry(const std::string& instance_id,
     }
     if ((fields.size() != 4 && fields.size() != 5) ||
         (fields[3] != "0" && fields[3] != "1")) {
+        LOG(WARNING) << "Redis Master registry entry has invalid metadata"
+                     << ", instance_id=" << instance_id
+                     << ", field_count=" << fields.size()
+                     << ", snapshot_ready_field="
+                     << (fields.size() > 3 ? fields[3] : "");
         return false;
     }
     uint64_t applied_sequence_id = 0;
@@ -392,6 +397,10 @@ bool ParseMasterRegistryEntry(const std::string& instance_id,
             applied_sequence_id);
         if (error != std::errc() ||
             end != fields[4].data() + fields[4].size()) {
+            LOG(WARNING)
+                << "Redis Master registry entry has invalid applied sequence"
+                << ", instance_id=" << instance_id
+                << ", applied_sequence_id_field=" << fields[4];
             return false;
         }
     }
@@ -419,6 +428,11 @@ RedisMasterRegistry::RedisMasterRegistry(std::string cluster_id,
 
 ErrorCode RedisMasterRegistry::Refresh(const RedisMasterRegistryEntry& entry) {
     if (entry.instance_id.empty() || entry.master_endpoint.empty()) {
+        LOG(ERROR) << "Redis Master registry refresh got invalid entry"
+                   << ", instance_id=" << entry.instance_id
+                   << ", master_endpoint=" << entry.master_endpoint
+                   << ", snapshot_endpoint=" << entry.snapshot_endpoint
+                   << ", role=" << entry.role;
         return ErrorCode::INVALID_PARAMS;
     }
     std::unique_ptr<redisContext, decltype(&redisFree)> ctx(
@@ -426,6 +440,9 @@ ErrorCode RedisMasterRegistry::Refresh(const RedisMasterRegistryEntry& entry) {
                                     db_index_),
         &redisFree);
     if (!ctx) {
+        LOG(ERROR) << "Redis Master registry refresh failed to connect"
+                   << ", instance_id=" << entry.instance_id
+                   << ", role=" << entry.role;
         return ErrorCode::INTERNAL_ERROR;
     }
     const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -449,6 +466,7 @@ ErrorCode RedisMasterRegistry::Refresh(const RedisMasterRegistryEntry& entry) {
 
 ErrorCode RedisMasterRegistry::Remove(const std::string& instance_id) {
     if (instance_id.empty()) {
+        LOG(ERROR) << "Redis Master registry remove got empty instance_id";
         return ErrorCode::INVALID_PARAMS;
     }
     std::unique_ptr<redisContext, decltype(&redisFree)> ctx(
@@ -456,6 +474,8 @@ ErrorCode RedisMasterRegistry::Remove(const std::string& instance_id) {
                                     db_index_),
         &redisFree);
     if (!ctx) {
+        LOG(ERROR) << "Redis Master registry remove failed to connect"
+                   << ", instance_id=" << instance_id;
         return ErrorCode::INTERNAL_ERROR;
     }
     static constexpr const char* kRemoveScript =
@@ -479,12 +499,15 @@ ErrorCode RedisMasterRegistry::DiscoverAlive(
                                     db_index_),
         &redisFree);
     if (!ctx) {
+        LOG(ERROR) << "Redis Master registry discover failed to connect"
+                   << ", ttl_sec=" << ttl.count();
         return ErrorCode::INTERNAL_ERROR;
     }
     const auto cutoff_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(
             std::chrono::system_clock::now().time_since_epoch() - ttl)
             .count();
+    // Entries exactly at cutoff are conservatively treated as stale.
     static constexpr const char* kDiscoverScript =
         "local stale = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1]); "
         "for _, id in ipairs(stale) do redis.call('HDEL', KEYS[2], id); end; "
@@ -502,6 +525,9 @@ ErrorCode RedisMasterRegistry::DiscoverAlive(
         metadata_key_.size(), static_cast<long long>(cutoff_ms)));
     if (!reply || reply->type != REDIS_REPLY_ARRAY ||
         reply->elements % 2 != 0) {
+        LOG(ERROR) << "Redis Master registry discover got invalid Redis reply"
+                   << ", reply_type=" << (reply ? reply->type : -1)
+                   << ", element_count=" << (reply ? reply->elements : 0);
         return ErrorCode::INTERNAL_ERROR;
     }
     for (size_t i = 0; i < reply->elements; i += 2) {
@@ -544,6 +570,12 @@ ErrorCode RedisMasterRegistryHeartbeat::Start() {
                   << ", master_endpoint=" << entry_.master_endpoint
                   << ", snapshot_endpoint=" << entry_.snapshot_endpoint
                   << ", role=" << entry_.role;
+    } else {
+        LOG(ERROR) << "Redis Master initial registration failed"
+                   << ", instance_id=" << entry_.instance_id
+                   << ", master_endpoint=" << entry_.master_endpoint
+                   << ", snapshot_endpoint=" << entry_.snapshot_endpoint
+                   << ", role=" << entry_.role << ", error=" << toString(err);
     }
     return err;
 }
@@ -559,18 +591,20 @@ void RedisMasterRegistryHeartbeat::UpdateRole(std::string role,
 
 void RedisMasterRegistryHeartbeat::SetAppliedSequenceProvider(
     std::function<uint64_t()> provider) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     applied_sequence_provider_ = std::move(provider);
     refresh_requested_ = true;
     cv_.notify_all();
+    cv_.wait(lock, [this] { return provider_in_flight_ == 0; });
 }
 
 void RedisMasterRegistryHeartbeat::SetSnapshotReadyProvider(
     std::function<bool()> provider) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     snapshot_ready_provider_ = std::move(provider);
     refresh_requested_ = true;
     cv_.notify_all();
+    cv_.wait(lock, [this] { return provider_in_flight_ == 0; });
 }
 
 void RedisMasterRegistryHeartbeat::Stop() {
@@ -597,13 +631,41 @@ void RedisMasterRegistryHeartbeat::Run() {
             break;
         }
         refresh_requested_ = false;
-        if (applied_sequence_provider_) {
-            entry_.applied_sequence_id = applied_sequence_provider_();
-        }
-        if (snapshot_ready_provider_) {
-            entry_.snapshot_ready = snapshot_ready_provider_();
-        }
+
         auto entry = entry_;
+        std::function<uint64_t()> applied_sequence_provider;
+        std::function<bool()> snapshot_ready_provider;
+        if (entry.role == "standby") {
+            applied_sequence_provider = applied_sequence_provider_;
+            snapshot_ready_provider = snapshot_ready_provider_;
+        }
+        bool has_provider =
+            applied_sequence_provider || snapshot_ready_provider;
+        if (has_provider) {
+            ++provider_in_flight_;
+        }
+
+        lock.unlock();
+        if (applied_sequence_provider) {
+            entry.applied_sequence_id = applied_sequence_provider();
+        }
+        if (snapshot_ready_provider) {
+            entry.snapshot_ready = snapshot_ready_provider();
+        }
+        lock.lock();
+
+        if (has_provider) {
+            --provider_in_flight_;
+            cv_.notify_all();
+        }
+        if (stopping_) {
+            break;
+        }
+        if (refresh_requested_) {
+            continue;
+        }
+        entry_ = entry;
+
         lock.unlock();
         if (registry_->Refresh(entry) != ErrorCode::OK) {
             LOG(WARNING) << "Redis Master registry heartbeat failed"

--- a/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <charconv>
 #include <chrono>
 #include <csignal>
 
@@ -10,6 +11,9 @@
 #include <ylt/coro_rpc/coro_rpc_client.hpp>
 
 #include "ha/oplog/p2p_hot_standby_service.h"
+#ifdef STORE_USE_REDIS
+#include "redis_util.h"
+#endif
 
 namespace mooncake {
 
@@ -61,6 +65,11 @@ BeginStandbySnapshotResponse P2PStandbySnapshotService::BeginSnapshot(
     // Correctness depends on idempotent OpLog replay, and the restored node
     // must catch up from baseline_sequence_id to converge to the final state.
     Session session;
+    // Snapshot chunks are read from the live metadata store after the baseline
+    // sequence ID is captured, so concurrent updates may be partially
+    // reflected. This is intentional: P2P metadata OpLog operations are
+    // designed to be idempotent, and replay from baseline_sequence_id + 1
+    // reconciles the snapshot for the asynchronous HA consistency model.
     session.baseline_sequence_id = standby_->GetLatestAppliedSequenceId();
     auto* store = standby_->GetMetadataStore();
     session.object_keys = store->ListObjectKeys();
@@ -347,5 +356,263 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
     }
     return result;
 }
+
+#ifdef STORE_USE_REDIS
+namespace {
+
+std::string SerializeMasterRegistryEntry(
+    const RedisMasterRegistryEntry& entry) {
+    return entry.master_endpoint + "\n" + entry.snapshot_endpoint + "\n" +
+           entry.role + "\n" + (entry.snapshot_ready ? "1" : "0") + "\n" +
+           std::to_string(entry.applied_sequence_id);
+}
+
+bool ParseMasterRegistryEntry(const std::string& instance_id,
+                              const std::string& value,
+                              RedisMasterRegistryEntry& entry) {
+    std::vector<std::string> fields;
+    size_t begin = 0;
+    while (true) {
+        const auto separator = value.find('\n', begin);
+        if (separator == std::string::npos) {
+            fields.emplace_back(value.substr(begin));
+            break;
+        }
+        fields.emplace_back(value.substr(begin, separator - begin));
+        begin = separator + 1;
+    }
+    if ((fields.size() != 4 && fields.size() != 5) ||
+        (fields[3] != "0" && fields[3] != "1")) {
+        return false;
+    }
+    uint64_t applied_sequence_id = 0;
+    if (fields.size() == 5) {
+        const auto [end, error] = std::from_chars(
+            fields[4].data(), fields[4].data() + fields[4].size(),
+            applied_sequence_id);
+        if (error != std::errc() ||
+            end != fields[4].data() + fields[4].size()) {
+            return false;
+        }
+    }
+    entry.instance_id = instance_id;
+    entry.master_endpoint = std::move(fields[0]);
+    entry.snapshot_endpoint = std::move(fields[1]);
+    entry.role = std::move(fields[2]);
+    entry.snapshot_ready = fields[3] == "1";
+    entry.applied_sequence_id = applied_sequence_id;
+    return true;
+}
+
+}  // namespace
+
+RedisMasterRegistry::RedisMasterRegistry(std::string cluster_id,
+                                         std::string redis_endpoint,
+                                         std::string username,
+                                         std::string password, int db_index)
+    : heartbeat_key_("mooncake:{" + cluster_id + "}:masters:heartbeat"),
+      metadata_key_("mooncake:{" + cluster_id + "}:masters:metadata"),
+      redis_endpoint_(std::move(redis_endpoint)),
+      username_(std::move(username)),
+      password_(std::move(password)),
+      db_index_(db_index) {}
+
+ErrorCode RedisMasterRegistry::Refresh(const RedisMasterRegistryEntry& entry) {
+    if (entry.instance_id.empty() || entry.master_endpoint.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    std::unique_ptr<redisContext, decltype(&redisFree)> ctx(
+        RedisUtil::CreateConnection(redis_endpoint_, username_, password_,
+                                    db_index_),
+        &redisFree);
+    if (!ctx) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    const auto now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            std::chrono::system_clock::now().time_since_epoch())
+                            .count();
+    const std::string metadata = SerializeMasterRegistryEntry(entry);
+    static constexpr const char* kRefreshScript =
+        "redis.call('HSET', KEYS[2], ARGV[1], ARGV[3]); "
+        "redis.call('ZADD', KEYS[1], ARGV[2], ARGV[1]); "
+        "return 1";
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx.get(), "EVAL %s 2 %b %b %b %lld %b", kRefreshScript,
+        heartbeat_key_.data(), heartbeat_key_.size(), metadata_key_.data(),
+        metadata_key_.size(), entry.instance_id.data(),
+        entry.instance_id.size(), static_cast<long long>(now_ms),
+        metadata.data(), metadata.size()));
+    return reply && reply->type != REDIS_REPLY_ERROR
+               ? ErrorCode::OK
+               : ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode RedisMasterRegistry::Remove(const std::string& instance_id) {
+    if (instance_id.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    std::unique_ptr<redisContext, decltype(&redisFree)> ctx(
+        RedisUtil::CreateConnection(redis_endpoint_, username_, password_,
+                                    db_index_),
+        &redisFree);
+    if (!ctx) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    static constexpr const char* kRemoveScript =
+        "redis.call('ZREM', KEYS[1], ARGV[1]); "
+        "redis.call('HDEL', KEYS[2], ARGV[1]); "
+        "return 1";
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx.get(), "EVAL %s 2 %b %b %b", kRemoveScript, heartbeat_key_.data(),
+        heartbeat_key_.size(), metadata_key_.data(), metadata_key_.size(),
+        instance_id.data(), instance_id.size()));
+    return reply && reply->type != REDIS_REPLY_ERROR
+               ? ErrorCode::OK
+               : ErrorCode::INTERNAL_ERROR;
+}
+
+ErrorCode RedisMasterRegistry::DiscoverAlive(
+    std::chrono::seconds ttl, std::vector<RedisMasterRegistryEntry>& entries) {
+    entries.clear();
+    std::unique_ptr<redisContext, decltype(&redisFree)> ctx(
+        RedisUtil::CreateConnection(redis_endpoint_, username_, password_,
+                                    db_index_),
+        &redisFree);
+    if (!ctx) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    const auto cutoff_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch() - ttl)
+            .count();
+    static constexpr const char* kDiscoverScript =
+        "local stale = redis.call('ZRANGEBYSCORE', KEYS[1], '-inf', ARGV[1]); "
+        "for _, id in ipairs(stale) do redis.call('HDEL', KEYS[2], id); end; "
+        "redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1]); "
+        "local alive = redis.call('ZRANGEBYSCORE', KEYS[1], ARGV[1], '+inf'); "
+        "local result = {}; "
+        "for _, id in ipairs(alive) do "
+        "local metadata = redis.call('HGET', KEYS[2], id); "
+        "if metadata then table.insert(result, id); "
+        "table.insert(result, metadata); end; end; "
+        "return result";
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx.get(), "EVAL %s 2 %b %b %lld", kDiscoverScript,
+        heartbeat_key_.data(), heartbeat_key_.size(), metadata_key_.data(),
+        metadata_key_.size(), static_cast<long long>(cutoff_ms)));
+    if (!reply || reply->type != REDIS_REPLY_ARRAY ||
+        reply->elements % 2 != 0) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    for (size_t i = 0; i < reply->elements; i += 2) {
+        auto* id = reply->element[i];
+        auto* metadata = reply->element[i + 1];
+        if (!id || id->type != REDIS_REPLY_STRING || !metadata ||
+            metadata->type != REDIS_REPLY_STRING) {
+            continue;
+        }
+        RedisMasterRegistryEntry entry;
+        if (ParseMasterRegistryEntry(std::string(id->str, id->len),
+                                     std::string(metadata->str, metadata->len),
+                                     entry)) {
+            entries.push_back(std::move(entry));
+        }
+    }
+    return ErrorCode::OK;
+}
+
+RedisMasterRegistryHeartbeat::RedisMasterRegistryHeartbeat(
+    std::unique_ptr<RedisMasterRegistry> registry,
+    RedisMasterRegistryEntry entry, std::chrono::seconds interval)
+    : registry_(std::move(registry)),
+      entry_(std::move(entry)),
+      interval_(interval) {}
+
+RedisMasterRegistryHeartbeat::~RedisMasterRegistryHeartbeat() { Stop(); }
+
+ErrorCode RedisMasterRegistryHeartbeat::Start() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (thread_.joinable()) {
+        return ErrorCode::OK;
+    }
+    stopping_ = false;
+    auto err = registry_->Refresh(entry_);
+    thread_ = std::thread(&RedisMasterRegistryHeartbeat::Run, this);
+    if (err == ErrorCode::OK) {
+        LOG(INFO) << "Redis Master registered"
+                  << ", instance_id=" << entry_.instance_id
+                  << ", master_endpoint=" << entry_.master_endpoint
+                  << ", snapshot_endpoint=" << entry_.snapshot_endpoint
+                  << ", role=" << entry_.role;
+    }
+    return err;
+}
+
+void RedisMasterRegistryHeartbeat::UpdateRole(std::string role,
+                                              bool snapshot_ready) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entry_.role = std::move(role);
+    entry_.snapshot_ready = snapshot_ready;
+    refresh_requested_ = true;
+    cv_.notify_all();
+}
+
+void RedisMasterRegistryHeartbeat::SetAppliedSequenceProvider(
+    std::function<uint64_t()> provider) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    applied_sequence_provider_ = std::move(provider);
+    refresh_requested_ = true;
+    cv_.notify_all();
+}
+
+void RedisMasterRegistryHeartbeat::SetSnapshotReadyProvider(
+    std::function<bool()> provider) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    snapshot_ready_provider_ = std::move(provider);
+    refresh_requested_ = true;
+    cv_.notify_all();
+}
+
+void RedisMasterRegistryHeartbeat::Stop() {
+    std::string instance_id;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!thread_.joinable()) {
+            return;
+        }
+        stopping_ = true;
+        instance_id = entry_.instance_id;
+    }
+    cv_.notify_all();
+    thread_.join();
+    (void)registry_->Remove(instance_id);
+}
+
+void RedisMasterRegistryHeartbeat::Run() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    while (!stopping_) {
+        cv_.wait_for(lock, interval_,
+                     [this] { return stopping_ || refresh_requested_; });
+        if (stopping_) {
+            break;
+        }
+        refresh_requested_ = false;
+        if (applied_sequence_provider_) {
+            entry_.applied_sequence_id = applied_sequence_provider_();
+        }
+        if (snapshot_ready_provider_) {
+            entry_.snapshot_ready = snapshot_ready_provider_();
+        }
+        auto entry = entry_;
+        lock.unlock();
+        if (registry_->Refresh(entry) != ErrorCode::OK) {
+            LOG(WARNING) << "Redis Master registry heartbeat failed"
+                         << ", instance_id=" << entry.instance_id
+                         << ", role=" << entry.role;
+        }
+        lock.lock();
+    }
+}
+#endif
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -722,6 +722,9 @@ ErrorCode RedisOpLogStore::GetTrimmedSequenceId(uint64_t& sequence_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto err = EnsureConnectedUnlocked();
     if (err != ErrorCode::OK) {
+        LOG(ERROR) << "RedisOpLogStore::GetTrimmedSequenceId: failed to "
+                      "ensure Redis connection"
+                   << ", error=" << toString(err);
         return err;
     }
     RedisReplyPtr reply((redisReply*)redisCommand(

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -586,11 +586,14 @@ ErrorCode RedisOpLogStore::ReadOpLogSinceWithProgress(
         return ErrorCode::INTERNAL_ERROR;
     }
 
-    // TODO(P2P HA): Do not silently advance a lagging standby past the trim
-    // horizon. Detect start_sequence_id < trimmed_sequence_id and handle it
-    // together with standby snapshot/bootstrap recovery.
-    const uint64_t effective_start =
-        std::max(start_sequence_id, trimmed_sequence_id);
+    if (start_sequence_id < trimmed_sequence_id) {
+        LOG(WARNING) << "RedisOpLogStore::ReadOpLogSince: requested range was "
+                        "trimmed"
+                     << ", start_sequence_id=" << start_sequence_id
+                     << ", trimmed_sequence_id=" << trimmed_sequence_id;
+        return ErrorCode::OPLOG_TRIMMED;
+    }
+    const uint64_t effective_start = start_sequence_id;
     progress.last_scanned_sequence_id = effective_start;
     if (effective_start >= latest_sequence_id) {
         return ErrorCode::OK;
@@ -711,6 +714,30 @@ ErrorCode RedisOpLogStore::GetMaxSequenceId(uint64_t& sequence_id) {
     }
     if (sequence_id == 0) {
         return ErrorCode::OPLOG_ENTRY_NOT_FOUND;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode RedisOpLogStore::GetTrimmedSequenceId(uint64_t& sequence_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto err = EnsureConnectedUnlocked();
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    RedisReplyPtr reply((redisReply*)redisCommand(
+        ctx_, "GET %b", trimmed_key_.data(), trimmed_key_.size()));
+    if (!reply || reply->type == REDIS_REPLY_ERROR) {
+        LOG(ERROR) << "RedisOpLogStore::GetTrimmedSequenceId: GET failed";
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (reply->type == REDIS_REPLY_NIL) {
+        sequence_id = 0;
+        return ErrorCode::OK;
+    }
+    if (reply->type != REDIS_REPLY_STRING ||
+        !ParseUint64(std::string(reply->str, reply->len), sequence_id)) {
+        LOG(ERROR) << "RedisOpLogStore::GetTrimmedSequenceId: invalid value";
+        return ErrorCode::INTERNAL_ERROR;
     }
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -220,7 +220,7 @@ int MasterServiceSupervisor::Start() {
             entry.master_endpoint = config_.local_hostname;
             entry.snapshot_endpoint = BuildSnapshotEndpoint(
                 config_.local_hostname, config_.standby_snapshot_service_port,
-                config_.standby_snapshot_advertise_endpoint);
+                config_.standby_snapshot_service_endpoint);
             entry.role = "starting";
             entry.snapshot_ready = false;
             master_registry_heartbeat =

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -10,8 +10,54 @@
 
 #include <limits>
 #include <optional>
+#include <iomanip>
+#include <random>
+#include <sstream>
 
 namespace mooncake {
+
+namespace {
+
+#ifdef STORE_USE_REDIS
+std::string GenerateMasterInstanceId() {
+    std::random_device random;
+    std::mt19937_64 generator(random());
+    std::ostringstream stream;
+    stream << std::hex << std::setfill('0') << std::setw(16) << generator()
+           << std::setw(16) << generator();
+    return stream.str();
+}
+
+std::string BuildSnapshotEndpoint(const std::string& master_endpoint,
+                                  uint32_t snapshot_port,
+                                  const std::string& override_endpoint) {
+    if (!override_endpoint.empty()) {
+        return override_endpoint;
+    }
+    if (snapshot_port == 0 || master_endpoint.empty()) {
+        return "";
+    }
+    std::string host;
+    if (master_endpoint.front() == '[') {
+        const auto closing_bracket = master_endpoint.find(']');
+        if (closing_bracket == std::string::npos) {
+            return "";
+        }
+        host = master_endpoint.substr(0, closing_bracket + 1);
+    } else {
+        const auto separator = master_endpoint.rfind(':');
+        host = separator == std::string::npos
+                   ? master_endpoint
+                   : master_endpoint.substr(0, separator);
+    }
+    if (host.empty() || host == "0.0.0.0" || host == "[::]") {
+        return "";
+    }
+    return host + ":" + std::to_string(snapshot_port);
+}
+#endif
+
+}  // namespace
 
 MasterViewHelper::MasterViewHelper() {
     std::string cluster_id;
@@ -162,6 +208,36 @@ int MasterServiceSupervisor::Start() {
             return -1;
         }
 
+#ifdef STORE_USE_REDIS
+        std::unique_ptr<RedisMasterRegistryHeartbeat> master_registry_heartbeat;
+        std::string master_instance_id;
+        if (config_.deployment_mode == DeploymentMode::P2P &&
+            config_.enable_oplog &&
+            config_.election_backend == ElectionBackend::REDIS) {
+            master_instance_id = GenerateMasterInstanceId();
+            RedisMasterRegistryEntry entry;
+            entry.instance_id = master_instance_id;
+            entry.master_endpoint = config_.local_hostname;
+            entry.snapshot_endpoint = BuildSnapshotEndpoint(
+                config_.local_hostname, config_.standby_snapshot_service_port,
+                config_.standby_snapshot_advertise_endpoint);
+            entry.role = "starting";
+            entry.snapshot_ready = false;
+            master_registry_heartbeat =
+                std::make_unique<RedisMasterRegistryHeartbeat>(
+                    std::make_unique<RedisMasterRegistry>(
+                        config_.cluster_id, config_.redis_endpoint,
+                        config_.redis_username, config_.redis_password,
+                        config_.redis_db_index),
+                    std::move(entry));
+            if (master_registry_heartbeat->Start() != ErrorCode::OK) {
+                LOG(WARNING) << "Initial Redis Master registration failed; "
+                                "heartbeat will retry"
+                             << ", instance_id=" << master_instance_id;
+            }
+        }
+#endif
+
         std::unique_ptr<P2PHotStandbyService> p2p_standby;
         if (config_.deployment_mode == DeploymentMode::P2P &&
             config_.enable_oplog) {
@@ -187,6 +263,9 @@ int MasterServiceSupervisor::Start() {
             standby_config.redis_db_index = config_.redis_db_index;
             standby_config.snapshot_service_port =
                 static_cast<uint16_t>(config_.standby_snapshot_service_port);
+#ifdef STORE_USE_REDIS
+            standby_config.master_instance_id = master_instance_id;
+#endif
             standby_config.snapshot_chunk_size =
                 config_.standby_snapshot_chunk_size;
             if (!config_.standby_snapshot_sources.empty()) {
@@ -202,6 +281,20 @@ int MasterServiceSupervisor::Start() {
                            << ", error=" << toString(standby_start);
                 return -1;
             }
+#ifdef STORE_USE_REDIS
+            if (master_registry_heartbeat) {
+                master_registry_heartbeat->SetAppliedSequenceProvider(
+                    [standby = p2p_standby.get()] {
+                        return standby->GetLatestAppliedSequenceId();
+                    });
+                master_registry_heartbeat->SetSnapshotReadyProvider(
+                    [standby = p2p_standby.get()] {
+                        return standby->IsReadyForSnapshot();
+                    });
+                master_registry_heartbeat->UpdateRole(
+                    "standby", p2p_standby->IsReadyForSnapshot());
+            }
+#endif
         }
 
         LOG(INFO) << "Trying to elect self as leader...";
@@ -228,6 +321,11 @@ int MasterServiceSupervisor::Start() {
             p2p_promoted_metadata;
         uint64_t p2p_promoted_sequence_id = 0;
         if (p2p_standby) {
+#ifdef STORE_USE_REDIS
+            if (master_registry_heartbeat) {
+                master_registry_heartbeat->UpdateRole("promoting", false);
+            }
+#endif
             auto promote_err = p2p_standby->Promote();
             if (promote_err != ErrorCode::OK) {
                 LOG(ERROR) << "Failed to promote P2P hot standby service"
@@ -239,6 +337,12 @@ int MasterServiceSupervisor::Start() {
             p2p_promoted_sequence_id =
                 p2p_standby->GetLatestAppliedSequenceId();
             p2p_promoted_metadata = p2p_standby->ExportMetadata();
+#ifdef STORE_USE_REDIS
+            if (master_registry_heartbeat) {
+                master_registry_heartbeat->SetAppliedSequenceProvider({});
+                master_registry_heartbeat->SetSnapshotReadyProvider({});
+            }
+#endif
             p2p_standby.reset();
         }
 
@@ -273,6 +377,11 @@ int MasterServiceSupervisor::Start() {
             RegisterP2PRpcService(server, *p2p_wrapped_service);
             wrapped_master_service = std::move(p2p_wrapped_service);
         }
+#ifdef STORE_USE_REDIS
+        if (master_registry_heartbeat) {
+            master_registry_heartbeat->UpdateRole("primary", false);
+        }
+#endif
         // Metric reporting is now handled by WrappedMasterService.
 
         async_simple::Future<coro_rpc::err_code> ec =

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -141,7 +141,7 @@ DEFINE_uint64(oplog_best_effort_max_retries, 3,
               "Maximum Redis attempts for best-effort OpLogs");
 DEFINE_uint32(standby_snapshot_service_port, 0,
               "RPC port used to serve Standby metadata snapshots; 0 disables");
-DEFINE_string(standby_snapshot_advertise_endpoint, "",
+DEFINE_string(standby_snapshot_service_endpoint, "",
               "Optional snapshot endpoint override; by default it is derived "
               "from the Master endpoint and snapshot service port");
 DEFINE_string(standby_snapshot_sources, "",
@@ -233,9 +233,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("standby_snapshot_service_port",
                              &master_config.standby_snapshot_service_port,
                              FLAGS_standby_snapshot_service_port);
-    default_config.GetString("standby_snapshot_advertise_endpoint",
-                             &master_config.standby_snapshot_advertise_endpoint,
-                             FLAGS_standby_snapshot_advertise_endpoint);
+    default_config.GetString("standby_snapshot_service_endpoint",
+                             &master_config.standby_snapshot_service_endpoint,
+                             FLAGS_standby_snapshot_service_endpoint);
     default_config.GetString("standby_snapshot_sources",
                              &master_config.standby_snapshot_sources,
                              FLAGS_standby_snapshot_sources);
@@ -481,12 +481,12 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         master_config.standby_snapshot_service_port =
             FLAGS_standby_snapshot_service_port;
     }
-    if ((google::GetCommandLineFlagInfo("standby_snapshot_advertise_endpoint",
+    if ((google::GetCommandLineFlagInfo("standby_snapshot_service_endpoint",
                                         &info) &&
          !info.is_default) ||
         !conf_set) {
-        master_config.standby_snapshot_advertise_endpoint =
-            FLAGS_standby_snapshot_advertise_endpoint;
+        master_config.standby_snapshot_service_endpoint =
+            FLAGS_standby_snapshot_service_endpoint;
     }
     if ((google::GetCommandLineFlagInfo("standby_snapshot_sources", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -141,8 +141,12 @@ DEFINE_uint64(oplog_best_effort_max_retries, 3,
               "Maximum Redis attempts for best-effort OpLogs");
 DEFINE_uint32(standby_snapshot_service_port, 0,
               "RPC port used to serve Standby metadata snapshots; 0 disables");
+DEFINE_string(standby_snapshot_advertise_endpoint, "",
+              "Optional snapshot endpoint override; by default it is derived "
+              "from the Master endpoint and snapshot service port");
 DEFINE_string(standby_snapshot_sources, "",
-              "Comma-separated explicit Standby snapshot source endpoints");
+              "Optional comma-separated snapshot source override; by default "
+              "sources are discovered from the Redis Master registry");
 DEFINE_uint32(standby_snapshot_chunk_size, 256,
               "Maximum metadata records per Standby snapshot RPC chunk");
 
@@ -229,6 +233,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("standby_snapshot_service_port",
                              &master_config.standby_snapshot_service_port,
                              FLAGS_standby_snapshot_service_port);
+    default_config.GetString("standby_snapshot_advertise_endpoint",
+                             &master_config.standby_snapshot_advertise_endpoint,
+                             FLAGS_standby_snapshot_advertise_endpoint);
     default_config.GetString("standby_snapshot_sources",
                              &master_config.standby_snapshot_sources,
                              FLAGS_standby_snapshot_sources);
@@ -473,6 +480,13 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.standby_snapshot_service_port =
             FLAGS_standby_snapshot_service_port;
+    }
+    if ((google::GetCommandLineFlagInfo("standby_snapshot_advertise_endpoint",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.standby_snapshot_advertise_endpoint =
+            FLAGS_standby_snapshot_advertise_endpoint;
     }
     if ((google::GetCommandLineFlagInfo("standby_snapshot_sources", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/standby_state_machine.cpp
+++ b/mooncake-store/src/standby_state_machine.cpp
@@ -76,6 +76,10 @@ StateTransitionResult StandbyStateMachine::ValidateTransition(
                     result.allowed = true;
                     result.new_state = StandbyState::RECONNECTING;
                     break;
+                case StandbyEvent::RESYNC_REQUIRED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::SYNCING;
+                    break;
                 case StandbyEvent::MAX_ERRORS_REACHED:
                     result.allowed = true;
                     result.new_state = StandbyState::RECOVERING;
@@ -128,6 +132,10 @@ StateTransitionResult StandbyStateMachine::ValidateTransition(
 
         case StandbyState::RECONNECTING:
             switch (event) {
+                case StandbyEvent::RESYNC_REQUIRED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::SYNCING;
+                    break;
                 case StandbyEvent::CONNECTED:
                     result.allowed = true;
                     result.new_state = StandbyState::SYNCING;

--- a/mooncake-store/src/standby_state_machine.cpp
+++ b/mooncake-store/src/standby_state_machine.cpp
@@ -56,6 +56,10 @@ StateTransitionResult StandbyStateMachine::ValidateTransition(
                     result.allowed = true;
                     result.new_state = StandbyState::RECONNECTING;
                     break;
+                case StandbyEvent::RESYNC_REQUIRED:
+                    result.allowed = true;
+                    result.new_state = StandbyState::SYNCING;
+                    break;
                 case StandbyEvent::STOP:
                     result.allowed = true;
                     result.new_state = StandbyState::STOPPED;

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -47,6 +47,8 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::ETCD_KEY_NOT_EXIST, "ETCD_KEY_NOT_EXIST"},
         {ErrorCode::ETCD_TRANSACTION_FAIL, "ETCD_TRANSACTION_FAIL"},
         {ErrorCode::ETCD_CTX_CANCELLED, "ETCD_CTX_CANCELLED"},
+        {ErrorCode::OPLOG_ENTRY_NOT_FOUND, "OPLOG_ENTRY_NOT_FOUND"},
+        {ErrorCode::OPLOG_TRIMMED, "OPLOG_TRIMMED"},
         {ErrorCode::CLIENT_ALREADY_EXISTS, "CLIENT_ALREADY_EXISTS"},
         {ErrorCode::CLIENT_UNHEALTHY, "CLIENT_UNHEALTHY"},
         {ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS,

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -142,7 +142,7 @@ bool MasterProcessHandler::start() {
                     config_.standby_snapshot_service_port_base + index_;
                 args.emplace_back("--standby-snapshot-service-port=" +
                                   std::to_string(snapshot_port));
-                args.emplace_back("--standby-snapshot-advertise-endpoint=" +
+                args.emplace_back("--standby-snapshot-service-endpoint=" +
                                   config_.rpc_address + ":" +
                                   std::to_string(snapshot_port));
             }

--- a/mooncake-store/tests/e2e/process_handler.cpp
+++ b/mooncake-store/tests/e2e/process_handler.cpp
@@ -137,6 +137,15 @@ bool MasterProcessHandler::start() {
             if (!config_.oplog_data_dir.empty()) {
                 args.emplace_back("--oplog-data-dir=" + config_.oplog_data_dir);
             }
+            if (config_.standby_snapshot_service_port_base != 0) {
+                const int snapshot_port =
+                    config_.standby_snapshot_service_port_base + index_;
+                args.emplace_back("--standby-snapshot-service-port=" +
+                                  std::to_string(snapshot_port));
+                args.emplace_back("--standby-snapshot-advertise-endpoint=" +
+                                  config_.rpc_address + ":" +
+                                  std::to_string(snapshot_port));
+            }
         }
 
         if (config_.election_backend == "redis") {

--- a/mooncake-store/tests/e2e/process_handler.h
+++ b/mooncake-store/tests/e2e/process_handler.h
@@ -42,6 +42,7 @@ struct MasterRunnerConfig {
     std::string oplog_store_type = "localfs";
     std::string oplog_data_dir;
     int max_client_per_key = 0;
+    int standby_snapshot_service_port_base = 0;
 };
 
 class MasterProcessHandler {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -18,7 +18,6 @@
 #include <thread>
 #include <vector>
 
-#include "client_wrapper.h"
 #include "e2e_utils.h"
 #include "ha/oplog/p2p_oplog_types.h"
 #include "ha/oplog/p2p_standby_snapshot_service.h"
@@ -454,59 +453,6 @@ class RedisChaosTest : public ::testing::Test {
             std::chrono::seconds(FLAGS_redis_master_view_ttl_sec + 1));
     }
 
-    std::shared_ptr<ClientTestWrapper> CreateRedisClient(
-        int index, std::chrono::seconds timeout) {
-        auto deadline = std::chrono::steady_clock::now() + timeout;
-        while (std::chrono::steady_clock::now() < deadline) {
-            auto client = ClientTestWrapper::CreateClientWrapper(
-                "127.0.0.1:" + std::to_string(kClientPortBase + index),
-                "P2PHANDSHAKE", "tcp", "", "redis://" + FLAGS_redis_endpoint,
-                /*local_buffer_size=*/1024 * 1024 * 128, FLAGS_redis_cluster_id,
-                /*enable_http_server=*/false, /*deployment_mode=*/"P2P",
-                /*p2p_local_transfer_mode=*/"memcpy",
-                static_cast<uint16_t>(kClientPortBase + index),
-                FLAGS_redis_username, FLAGS_redis_password);
-            if (client.has_value()) {
-                return client.value();
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
-        return nullptr;
-    }
-
-    bool WaitForClientPutGet(ClientTestWrapper& client,
-                             const std::string& key_prefix,
-                             const std::string& value,
-                             std::chrono::seconds timeout) {
-        auto deadline = std::chrono::steady_clock::now() + timeout;
-        int attempt = 0;
-        while (std::chrono::steady_clock::now() < deadline) {
-            std::string key = key_prefix + "_" + std::to_string(attempt++);
-            if (client.Put(key, value) == ErrorCode::OK) {
-                std::string got;
-                if (client.Get(key, got) == ErrorCode::OK && got == value) {
-                    return true;
-                }
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
-        return false;
-    }
-
-    bool WaitForClientGet(ClientTestWrapper& client, const std::string& key,
-                          const std::string& value,
-                          std::chrono::seconds timeout) {
-        auto deadline = std::chrono::steady_clock::now() + timeout;
-        while (std::chrono::steady_clock::now() < deadline) {
-            std::string got;
-            if (client.Get(key, got) == ErrorCode::OK && got == value) {
-                return true;
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        }
-        return false;
-    }
-
     bool WaitForReplicaOpLog(const std::string& key,
                              std::chrono::seconds timeout) {
         RedisOpLogStore store(FLAGS_redis_cluster_id, FLAGS_redis_endpoint,
@@ -555,11 +501,32 @@ class RedisChaosTest : public ::testing::Test {
 
     bool WaitForMasterLog(int index, const std::string& needle,
                           std::chrono::seconds timeout) {
+        return WaitForMasterLogSince(index, needle, std::streampos(0), timeout);
+    }
+
+    std::streampos MasterLogEndOffset(int index) {
+        const std::string path =
+            FLAGS_out_dir + "/master_" + std::to_string(index) + ".err";
+        std::ifstream input(path, std::ios::binary | std::ios::ate);
+        if (!input) {
+            return std::streampos(0);
+        }
+        return input.tellg();
+    }
+
+    bool WaitForMasterLogSince(int index, const std::string& needle,
+                               std::streampos offset,
+                               std::chrono::seconds timeout) {
         const std::string path =
             FLAGS_out_dir + "/master_" + std::to_string(index) + ".err";
         auto deadline = std::chrono::steady_clock::now() + timeout;
         while (std::chrono::steady_clock::now() < deadline) {
-            std::ifstream input(path);
+            std::ifstream input(path, std::ios::binary);
+            if (!input) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+                continue;
+            }
+            input.seekg(offset);
             std::string content((std::istreambuf_iterator<char>(input)),
                                 std::istreambuf_iterator<char>());
             if (content.find(needle) != std::string::npos) {
@@ -625,11 +592,16 @@ TEST_F(RedisChaosTest, TrimmedStandbyAutoDiscoversPeerAndBootstraps) {
                                  std::chrono::seconds(10)));
     ASSERT_TRUE(masters_[lagging_index]->kill());
 
-    auto client = CreateRedisClient(/*index=*/20, std::chrono::seconds(15));
-    ASSERT_NE(client, nullptr);
+    ClientCtlProcess client(/*index=*/20, FLAGS_out_dir);
+    ASSERT_TRUE(client.Start());
+    ASSERT_TRUE(client.SendAndWait(
+        "create c_trim " + std::to_string(kClientPortBase + 20),
+        "Successfully created client: c_trim", std::chrono::seconds(30)));
     const std::string key = "trim_rebootstrap_key";
     const std::string value = "trim_rebootstrap_value";
-    ASSERT_EQ(client->Put(key, value), ErrorCode::OK);
+    ASSERT_TRUE(client.SendAndWait("put c_trim " + key + " " + value,
+                                   "Successfully put value for key: " + key,
+                                   std::chrono::seconds(10)));
     ASSERT_TRUE(WaitForReplicaOpLog(key, std::chrono::seconds(10)));
 
     RedisOpLogStore store(FLAGS_redis_cluster_id, FLAGS_redis_endpoint,
@@ -643,10 +615,11 @@ TEST_F(RedisChaosTest, TrimmedStandbyAutoDiscoversPeerAndBootstraps) {
                                         std::chrono::seconds(10)));
     ASSERT_EQ(store.CleanupOpLogBefore(latest_sequence_id + 1), ErrorCode::OK);
 
+    auto lagging_log_offset = MasterLogEndOffset(lagging_index);
     ASSERT_TRUE(masters_[lagging_index]->start());
-    ASSERT_TRUE(WaitForMasterLog(lagging_index,
-                                 "Standby snapshot: bootstrap completed",
-                                 std::chrono::seconds(20)));
+    ASSERT_TRUE(WaitForMasterLogSince(
+        lagging_index, "Standby snapshot: bootstrap completed",
+        lagging_log_offset, std::chrono::seconds(20)));
 
     ASSERT_TRUE(masters_[source_index]->kill());
     ASSERT_TRUE(masters_[leader_index]->kill());
@@ -655,8 +628,10 @@ TEST_F(RedisChaosTest, TrimmedStandbyAutoDiscoversPeerAndBootstraps) {
     ASSERT_TRUE(
         WaitForNewLeader(leader_index, version, new_leader_index, new_version));
     ASSERT_EQ(new_leader_index, lagging_index);
-    ASSERT_TRUE(
-        WaitForClientGet(*client, key, value, std::chrono::seconds(20)));
+    ASSERT_TRUE(WaitForClientCtlCommand(
+        client, "expect_get c_trim " + key + " " + value,
+        "Successfully expected value for key: " + key,
+        std::chrono::seconds(60)));
 }
 
 TEST_F(RedisChaosTest, LeaderKeyDeletedTriggersReElection) {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <cerrno>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -20,6 +21,7 @@
 #include "client_wrapper.h"
 #include "e2e_utils.h"
 #include "ha/oplog/p2p_oplog_types.h"
+#include "ha/oplog/p2p_standby_snapshot_service.h"
 #include "ha/oplog/redis_oplog_store.h"
 #include "process_handler.h"
 #include "redis_master_view_helper.h"
@@ -48,6 +50,7 @@ DEFINE_int32(redis_heartbeat_interval_sec, 2,
 constexpr int kMasterPortBase = 51051;
 constexpr int kMasterNum = 3;
 constexpr int kClientPortBase = 52051;
+constexpr int kSnapshotPortBase = 53051;
 
 namespace mooncake {
 namespace testing {
@@ -109,6 +112,10 @@ void CleanupRedisKeys() {
     }
 
     std::vector<std::string> keys = {MasterViewKey(), MasterEpochKey()};
+    keys.push_back("mooncake:{" + FLAGS_redis_cluster_id +
+                   "}:masters:heartbeat");
+    keys.push_back("mooncake:{" + FLAGS_redis_cluster_id +
+                   "}:masters:metadata");
     std::string oplog_pattern =
         "mooncake:{" + FLAGS_redis_cluster_id + "}:oplog*";
     redisReply* keys_reply = static_cast<redisReply*>(redisCommand(
@@ -375,6 +382,7 @@ class RedisChaosTest : public ::testing::Test {
         config.oplog_store_type = "redis";
         config.oplog_data_dir = FLAGS_redis_endpoint;
         config.max_client_per_key = 0;
+        config.standby_snapshot_service_port_base = kSnapshotPortBase;
 
         for (int i = 0; i < kMasterNum; ++i) {
             masters_.emplace_back(std::make_unique<MasterProcessHandler>(
@@ -545,6 +553,44 @@ class RedisChaosTest : public ::testing::Test {
         return false;
     }
 
+    bool WaitForMasterLog(int index, const std::string& needle,
+                          std::chrono::seconds timeout) {
+        const std::string path =
+            FLAGS_out_dir + "/master_" + std::to_string(index) + ".err";
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            std::ifstream input(path);
+            std::string content((std::istreambuf_iterator<char>(input)),
+                                std::istreambuf_iterator<char>());
+            if (content.find(needle) != std::string::npos) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        return false;
+    }
+
+    bool WaitForSnapshotBaseline(int source_index, uint64_t expected_sequence,
+                                 std::chrono::seconds timeout) {
+        const std::string endpoint =
+            "127.0.0.1:" + std::to_string(kSnapshotPortBase + source_index);
+        auto deadline = std::chrono::steady_clock::now() + timeout;
+        while (std::chrono::steady_clock::now() < deadline) {
+            P2PStandbyMetadataStore metadata;
+            P2PStandbySnapshotClient snapshot_client;
+            uint64_t baseline_sequence_id = 0;
+            if (snapshot_client.Bootstrap(endpoint, FLAGS_redis_cluster_id,
+                                          &metadata, baseline_sequence_id,
+                                          /*chunk_size=*/256) ==
+                    ErrorCode::OK &&
+                baseline_sequence_id >= expected_sequence) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        return false;
+    }
+
     std::vector<std::unique_ptr<MasterProcessHandler>> masters_;
     std::unique_ptr<RedisMasterViewHelper> master_view_helper_;
     inline static struct sigaction old_sigpipe_action_ = {};
@@ -565,6 +611,52 @@ TEST_F(RedisChaosTest, LeaderKilledFailover) {
         WaitForNewLeader(leader_index, version, new_leader_index, new_version));
     EXPECT_NE(new_leader_index, leader_index);
     EXPECT_GT(new_version, version);
+}
+
+TEST_F(RedisChaosTest, TrimmedStandbyAutoDiscoversPeerAndBootstraps) {
+    int leader_index = -1;
+    ViewVersionId version = 0;
+    ASSERT_TRUE(WaitForLeader(leader_index, version, std::chrono::seconds(10)));
+    WaitForLeaderServiceReady();
+
+    const int lagging_index = (leader_index + 1) % kMasterNum;
+    const int source_index = (leader_index + 2) % kMasterNum;
+    ASSERT_TRUE(WaitForMasterLog(source_index, "Redis Master registered",
+                                 std::chrono::seconds(10)));
+    ASSERT_TRUE(masters_[lagging_index]->kill());
+
+    auto client = CreateRedisClient(/*index=*/20, std::chrono::seconds(15));
+    ASSERT_NE(client, nullptr);
+    const std::string key = "trim_rebootstrap_key";
+    const std::string value = "trim_rebootstrap_value";
+    ASSERT_EQ(client->Put(key, value), ErrorCode::OK);
+    ASSERT_TRUE(WaitForReplicaOpLog(key, std::chrono::seconds(10)));
+
+    RedisOpLogStore store(FLAGS_redis_cluster_id, FLAGS_redis_endpoint,
+                          /*enable_write=*/false, /*poll_interval_ms=*/100,
+                          FLAGS_redis_password, FLAGS_redis_username);
+    ASSERT_EQ(store.Init(), ErrorCode::OK);
+    uint64_t latest_sequence_id = 0;
+    ASSERT_EQ(store.GetLatestSequenceId(latest_sequence_id), ErrorCode::OK);
+    ASSERT_GT(latest_sequence_id, 0);
+    ASSERT_TRUE(WaitForSnapshotBaseline(source_index, latest_sequence_id,
+                                        std::chrono::seconds(10)));
+    ASSERT_EQ(store.CleanupOpLogBefore(latest_sequence_id + 1), ErrorCode::OK);
+
+    ASSERT_TRUE(masters_[lagging_index]->start());
+    ASSERT_TRUE(WaitForMasterLog(lagging_index,
+                                 "Standby snapshot: bootstrap completed",
+                                 std::chrono::seconds(20)));
+
+    ASSERT_TRUE(masters_[source_index]->kill());
+    ASSERT_TRUE(masters_[leader_index]->kill());
+    int new_leader_index = -1;
+    ViewVersionId new_version = 0;
+    ASSERT_TRUE(
+        WaitForNewLeader(leader_index, version, new_leader_index, new_version));
+    ASSERT_EQ(new_leader_index, lagging_index);
+    ASSERT_TRUE(
+        WaitForClientGet(*client, key, value, std::chrono::seconds(20)));
 }
 
 TEST_F(RedisChaosTest, LeaderKeyDeletedTriggersReElection) {

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -371,6 +371,64 @@ TEST_F(P2PHotStandbyServiceTest, SnapshotServerRejectsOccupiedPort) {
     first.Stop();
 }
 
+TEST_F(P2PHotStandbyServiceTest, TrimSignalSwitchesToSnapshotResync) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{31, 31};
+    const UUID segment_id{32, 32};
+    RegisterClient(master, client_id, MakeSegment(segment_id));
+    AddReplica(master, "trim-resync-key", client_id, segment_id, 4096);
+
+    auto source_config = MakeStandbyConfig();
+    source_config.snapshot_service_port =
+        static_cast<uint16_t>(50000 + (::getpid() % 1000));
+    P2PHotStandbyService source(source_config);
+    ASSERT_EQ(source.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        source.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+
+    std::mutex states_mutex;
+    std::vector<std::shared_ptr<ControlledNotifierState>> states;
+    auto factory = [&]() -> std::unique_ptr<OpLogStore> {
+        auto state = std::make_shared<ControlledNotifierState>();
+        {
+            std::lock_guard<std::mutex> lock(states_mutex);
+            states.push_back(state);
+        }
+        return std::make_unique<ControlledReaderStore>(state);
+    };
+
+    auto target_config = MakeStandbyConfig();
+    target_config.snapshot_source_endpoints = {
+        "127.0.0.1:" + std::to_string(source_config.snapshot_service_port)};
+    P2PHotStandbyService target(target_config, factory);
+    ASSERT_EQ(target.Start(), ErrorCode::OK);
+
+    std::shared_ptr<ControlledNotifierState> initial_state;
+    {
+        std::lock_guard<std::mutex> lock(states_mutex);
+        ASSERT_FALSE(states.empty());
+        initial_state = states.front();
+    }
+    InjectNotifierErrors(initial_state, ErrorCode::OPLOG_TRIMMED);
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline) {
+        size_t state_count = 0;
+        {
+            std::lock_guard<std::mutex> lock(states_mutex);
+            state_count = states.size();
+        }
+        if (state_count >= 3 && target.GetState() == StandbyState::WATCHING) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    EXPECT_EQ(target.GetState(), StandbyState::WATCHING);
+    auto exported = target.ExportMetadata();
+    EXPECT_NE(exported.objects.find("trim-resync-key"), exported.objects.end());
+}
+
 TEST_F(P2PHotStandbyServiceTest, ReconnectsFromLastAppliedSequence) {
     std::mutex states_mutex;
     std::vector<std::shared_ptr<ControlledNotifierState>> states;

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -2,6 +2,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <string>
@@ -12,6 +14,7 @@
 
 #include "ha/oplog/oplog_store_factory.h"
 #include "ha/oplog/redis_oplog_store.h"
+#include "ha/oplog/p2p_standby_snapshot_service.h"
 #include "p2p_master_service.h"
 #include "redis_util.h"
 #include "../../redis_test_utils.h"
@@ -374,7 +377,11 @@ TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {
     ASSERT_EQ(ErrorCode::OK, writer->ReadOpLog(4, entry));
 
     std::vector<OpLogEntry> entries;
-    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(0, 10, entries));
+    EXPECT_EQ(ErrorCode::OPLOG_TRIMMED, writer->ReadOpLogSince(0, 10, entries));
+    uint64_t trimmed_sequence_id = 0;
+    ASSERT_EQ(ErrorCode::OK, writer->GetTrimmedSequenceId(trimmed_sequence_id));
+    EXPECT_EQ(3u, trimmed_sequence_id);
+    ASSERT_EQ(ErrorCode::OK, writer->ReadOpLogSince(3, 10, entries));
     ASSERT_EQ(2u, entries.size());
     EXPECT_EQ(4u, entries[0].sequence_id);
     EXPECT_EQ(5u, entries[1].sequence_id);
@@ -382,6 +389,85 @@ TEST_F(RedisOpLogStoreTest, CleanupRemovesOldEntries) {
     uint64_t max_sequence_id = 0;
     ASSERT_EQ(ErrorCode::OK, writer->GetMaxSequenceId(max_sequence_id));
     EXPECT_EQ(5u, max_sequence_id);
+}
+
+TEST_F(RedisOpLogStoreTest, MasterRegistryDiscoversAliveInstances) {
+    RedisMasterRegistry registry(cluster_id_, redis_endpoint_, redis_username_,
+                                 redis_password_, 0);
+    RedisMasterRegistryEntry standby{"instance-a",
+                                     "127.0.0.1:51051",
+                                     "127.0.0.1:53051",
+                                     "standby",
+                                     true,
+                                     42};
+    RedisMasterRegistryEntry primary{"instance-b",
+                                     "127.0.0.1:51052",
+                                     "127.0.0.1:53052",
+                                     "primary",
+                                     false,
+                                     43};
+    ASSERT_EQ(registry.Refresh(standby), ErrorCode::OK);
+    ASSERT_EQ(registry.Refresh(primary), ErrorCode::OK);
+
+    std::vector<RedisMasterRegistryEntry> masters;
+    ASSERT_EQ(registry.DiscoverAlive(std::chrono::seconds(10), masters),
+              ErrorCode::OK);
+    ASSERT_EQ(masters.size(), 2);
+    auto standby_it = std::find_if(
+        masters.begin(), masters.end(),
+        [](const auto& master) { return master.instance_id == "instance-a"; });
+    ASSERT_NE(standby_it, masters.end());
+    EXPECT_EQ(standby_it->master_endpoint, standby.master_endpoint);
+    EXPECT_EQ(standby_it->snapshot_endpoint, standby.snapshot_endpoint);
+    EXPECT_EQ(standby_it->role, "standby");
+    EXPECT_TRUE(standby_it->snapshot_ready);
+    EXPECT_EQ(standby_it->applied_sequence_id, 42);
+
+    EXPECT_EQ(registry.Remove(standby.instance_id), ErrorCode::OK);
+    EXPECT_EQ(registry.Remove(primary.instance_id), ErrorCode::OK);
+}
+
+TEST_F(RedisOpLogStoreTest, MasterRegistryHeartbeatUpdatesAndUnregisters) {
+    auto registry = std::make_unique<RedisMasterRegistry>(
+        cluster_id_, redis_endpoint_, redis_username_, redis_password_, 0);
+    RedisMasterRegistryHeartbeat heartbeat(
+        std::move(registry),
+        RedisMasterRegistryEntry{"heartbeat-instance", "127.0.0.1:51051",
+                                 "127.0.0.1:53051", "starting", false},
+        std::chrono::seconds(10));
+    ASSERT_EQ(heartbeat.Start(), ErrorCode::OK);
+    std::atomic<bool> snapshot_ready{false};
+    heartbeat.SetAppliedSequenceProvider([] { return 42; });
+    heartbeat.SetSnapshotReadyProvider(
+        [&snapshot_ready] { return snapshot_ready.load(); });
+    snapshot_ready.store(true);
+    heartbeat.UpdateRole("standby", false);
+
+    RedisMasterRegistry reader(cluster_id_, redis_endpoint_, redis_username_,
+                               redis_password_, 0);
+    std::vector<RedisMasterRegistryEntry> masters;
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    do {
+        ASSERT_EQ(reader.DiscoverAlive(std::chrono::seconds(10), masters),
+                  ErrorCode::OK);
+        if (masters.size() == 1 && masters.front().role == "standby" &&
+            masters.front().snapshot_ready &&
+            masters.front().applied_sequence_id == 42) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    } while (std::chrono::steady_clock::now() < deadline);
+    ASSERT_EQ(masters.size(), 1);
+    EXPECT_EQ(masters.front().instance_id, "heartbeat-instance");
+    EXPECT_EQ(masters.front().role, "standby");
+    EXPECT_TRUE(masters.front().snapshot_ready);
+    EXPECT_EQ(masters.front().applied_sequence_id, 42);
+
+    heartbeat.Stop();
+    ASSERT_EQ(reader.DiscoverAlive(std::chrono::seconds(10), masters),
+              ErrorCode::OK);
+    EXPECT_TRUE(masters.empty());
 }
 
 TEST_F(RedisOpLogStoreTest, SnapshotSequenceRoundTrip) {

--- a/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
+++ b/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
@@ -115,6 +115,17 @@ TEST_F(StandbyStateMachineTest, TestWatchBrokenTransition) {
     EXPECT_FALSE(machine_->IsReadyForPromotion());
 }
 
+TEST_F(StandbyStateMachineTest, TestResyncRequiredTransition) {
+    ReachWatchingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::RESYNC_REQUIRED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::WATCHING, result.old_state);
+    EXPECT_EQ(StandbyState::SYNCING, result.new_state);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+    EXPECT_FALSE(machine_->IsReadyForPromotion());
+}
+
 TEST_F(StandbyStateMachineTest, TestDisconnectedFromWatching) {
     ReachWatchingState();
 

--- a/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
+++ b/mooncake-store/tests/ha/oplog/standby_state_machine_test.cpp
@@ -126,6 +126,16 @@ TEST_F(StandbyStateMachineTest, TestResyncRequiredTransition) {
     EXPECT_FALSE(machine_->IsReadyForPromotion());
 }
 
+TEST_F(StandbyStateMachineTest, TestResyncRequiredWhileSyncing) {
+    ReachSyncingState();
+
+    auto result = machine_->ProcessEvent(StandbyEvent::RESYNC_REQUIRED);
+    EXPECT_TRUE(result.allowed);
+    EXPECT_EQ(StandbyState::SYNCING, result.old_state);
+    EXPECT_EQ(StandbyState::SYNCING, result.new_state);
+    EXPECT_EQ(StandbyState::SYNCING, machine_->GetState());
+}
+
 TEST_F(StandbyStateMachineTest, TestDisconnectedFromWatching) {
     ReachWatchingState();
 


### PR DESCRIPTION
## Description

  Add P2P hot standby rebootstrap support when the Redis OpLog has been trimmed before a standby can catch up.

  This change lets a standby detect `OPLOG_TRIMMED` / `RESYNC_REQUIRED`, discover a snapshot-ready peer from the Redis master registry, fetch a peer snapshot, reset local replicated state, and resume applying OpLog entries from the restored sequence. It
  also extends the Redis registry heartbeat to publish live `snapshot_ready` state instead of only the initial value, so peers do not select a stale or not-yet-ready snapshot source.

  Follow-up TODOs are left for two non-blocking cleanup decisions:
  - Avoid holding `P2PHotStandbyService::mutex_` across long remote snapshot fetch waits.
  - Decide whether supervisor startup should fail hard when initial standby apply fails.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  ./scripts/code_format.sh --base P2P-Mooncake-Store
  cmake --build build-redis-oplog --target mooncake_store p2p_oplog_test redis_oplog_store_test standby_state_machine_test redis_chaos_test -j 8
  ctest --test-dir build-redis-oplog -R 'p2p_oplog_test|redis_oplog_store_test|standby_state_machine_test|redis_chaos_test' --output-on-failure
```
  Test results:

  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Format result:

  - ./scripts/code_format.sh --base P2P-Mooncake-Store completed successfully.
  - All changed C/C++ files were already formatted (Formatted 0 file(s)).

  Build/test result:

  - Build is currently running in the local mooncake-dev container.
  - Test result is pending build completion.

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to inspect the change, apply a small follow-up fix, run formatting/build/test commands, and draft the PR message. The human submitter is responsible for reviewing and defending the final changes.