### PR TITLE
[Build] conductor: default RelWithDebInfo for standalone builds

### DIFF
--- a/mooncake-conductor/CMakeLists.txt
+++ b/mooncake-conductor/CMakeLists.txt
@@ -6,6 +6,10 @@ if(NOT GLOBAL_CONFIG)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   include(../mooncake-common/FindJsonCpp.cmake)
   include(../mooncake-common/FindGLOG.cmake)
+  # Match the top-level common.cmake policy: keep debuginfo by default.
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+  endif()
 endif()
 
 find_package(cppzmq REQUIRED)


### PR DESCRIPTION
## Description

Standalone conductor builds (`mooncake-conductor/CMakeLists.txt`, `NOT GLOBAL_CONFIG`) never included `mooncake-common/common.cmake`, whose fallback sets `CMAKE_BUILD_TYPE=RelWithDebInfo`. As a result, a standalone conductor build got **no optimization flags at all (-O0)** while every top-level component built with -O2.

This was the dominant factor in conductor `/query` latency: the vLLM v1 hash chain costs **2311 ns/block at -O0 vs 344 ns/block at -O2 (6.7×)** — an optimization-level gap, not an API gap. End-to-end, a 1M-token 100%-hit `/query` drops from 185.9 ms to ~28 ms with this fix alone (cold 1M: 18.7 → 4.4 ms).

Debug info (`-g`) is preserved. The source tree contains no `assert()`/`DCHECK`, so `NDEBUG` changes nothing. When built via the top-level project (`GLOBAL_CONFIG`), the new fallback never runs and behavior is unchanged.

The SHA-256 API swap that was originally in this PR has been split out to a follow-up PR per review feedback.

## Module

- [x] Other — `mooncake-conductor`

## Type of Change

- [x] Performance improvement
- [x] Other: build fix (default build type for standalone conductor)

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build mooncake-conductor/build -j2 && ./mooncake-conductor/build/tests/conductor_test
pre-commit run --files mooncake-conductor/CMakeLists.txt
```

**Test results:**
- [x] Unit tests pass — 161/161
- [x] Integration tests pass — vLLM ×2 + mooncake_master + conductor topology: tiered-hit routing, stickiness, zero rejected KV events
- [x] Manual testing done — `/query` latency bench cold vs 100%-hot (numbers above); verified generated flags are `-O2 -g -DNDEBUG`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass (on touched files)
- [x] I have updated the documentation (if applicable) — N/A
- [x] I have added tests to prove my changes are effective — N/A (build-system only; covered by existing tests)
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (6 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code: root-cause analysis (-O0 build identified as the dominant cost via micro-benchmark), implementation, measurement. The human submitter has reviewed every changed line.
