### PR TITLE
[Bugfix][TE] Serialize libnuma's lazy cpumask cache fill in bindToSocket

### DIFF
--- a/mooncake-transfer-engine/include/common.h
+++ b/mooncake-transfer-engine/include/common.h
@@ -32,6 +32,7 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -76,6 +77,16 @@ static inline std::string getHostname() {
     return hostname;
 }
 
+// libnuma fills the cache numa_node_to_cpus() reads lazily and without locking,
+// so concurrent first callers each allocate it and all but one are orphaned --
+// a leak LeakSanitizer fails the build on. Worker pools bind every thread at
+// startup, so they hit that window. An inline function, not a static local:
+// bindToSocket() has internal linkage, so a static local would be per-TU.
+inline std::mutex &numaNodeCpuCacheMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
 static inline int bindToSocket(int socket_id) {
     if (unlikely(numa_available() < 0)) {
         LOG(WARNING) << "The platform does not support NUMA";
@@ -86,7 +97,10 @@ static inline int bindToSocket(int socket_id) {
     if (socket_id < 0 || socket_id >= numa_num_configured_nodes())
         socket_id = 0;
     struct bitmask *cpu_list = numa_allocate_cpumask();
-    numa_node_to_cpus(socket_id, cpu_list);
+    {
+        std::lock_guard<std::mutex> guard(numaNodeCpuCacheMutex());
+        numa_node_to_cpus(socket_id, cpu_list);
+    }
     int nr_possible_cpus = numa_num_possible_cpus();
     int nr_cpus = 0;
     for (int cpu = 0; cpu < nr_possible_cpus; ++cpu) {

--- a/mooncake-transfer-engine/tent/include/tent/common/utils/os.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/utils/os.h
@@ -27,6 +27,7 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <thread>
 
@@ -41,6 +42,16 @@
 
 namespace mooncake {
 namespace tent {
+// libnuma fills the cache numa_node_to_cpus() reads lazily and without locking,
+// so concurrent first callers each allocate it and all but one are orphaned --
+// a leak LeakSanitizer reports. Workers bind every thread at startup, so they
+// hit that window. An inline function, not a static local: bindToSocket() has
+// internal linkage, so a static local would be per-TU.
+inline std::mutex &numaNodeCpuCacheMutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
 static inline int bindToSocket(int socket_id) {
     if (numa_available() < 0) {
         LOG(WARNING) << "The platform does not support NUMA";
@@ -51,7 +62,10 @@ static inline int bindToSocket(int socket_id) {
     if (socket_id < 0 || socket_id >= numa_num_configured_nodes())
         socket_id = 0;
     struct bitmask *cpu_list = numa_allocate_cpumask();
-    numa_node_to_cpus(socket_id, cpu_list);
+    {
+        std::lock_guard<std::mutex> guard(numaNodeCpuCacheMutex());
+        numa_node_to_cpus(socket_id, cpu_list);
+    }
     int nr_possible_cpus = numa_num_possible_cpus();
     int nr_cpus = 0;
     for (int cpu = 0; cpu < nr_possible_cpus; ++cpu) {

--- a/mooncake-transfer-engine/tests/common_test.cpp
+++ b/mooncake-transfer-engine/tests/common_test.cpp
@@ -5,6 +5,7 @@
 #include <optional>
 #include <string>
 #include <thread>
+#include <vector>
 
 #include "common.h"
 
@@ -344,6 +345,42 @@ TEST(GetHandshakeMaxLengthTest, ReturnsSameValueOnMultipleCalls) {
     size_t first_call = getHandshakeMaxLength();
     size_t second_call = getHandshakeMaxLength();
     EXPECT_EQ(first_call, second_call);
+}
+
+//------------------------------------------------------------------------------
+// bindToSocket
+//------------------------------------------------------------------------------
+
+// Worker pools bind every thread they spawn, so bindToSocket() races inside
+// libnuma's unlocked lazy cache fill and orphans an allocation. The leak is
+// what this guards, so it only fails under ASAN/LSAN; the barrier is what makes
+// it reliable there.
+TEST(BindToSocketTest, ConcurrentCallsDoNotLeakNumaState) {
+    if (numa_available() < 0) GTEST_SKIP() << "platform does not support NUMA";
+
+    constexpr int kThreads = 32;
+    std::atomic<int> ready{0};
+    std::atomic<bool> go{false};
+    std::vector<std::thread> threads;
+    std::vector<int> results(kThreads, -1);
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!go.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            // Every thread races on the same node, maximizing the window.
+            results[i] = bindToSocket(0);
+        });
+    }
+    while (ready.load(std::memory_order_acquire) < kThreads)
+        std::this_thread::yield();
+    go.store(true, std::memory_order_release);
+    for (auto &thread : threads) thread.join();
+
+    // Serializing the cache fill must not change what callers observe.
+    for (int i = 0; i < kThreads; ++i)
+        EXPECT_EQ(results[i], 0) << "thread " << i << " failed to bind";
 }
 
 }  // namespace


### PR DESCRIPTION
Description

  bindToSocket() calls numa_node_to_cpus(), whose per-node cpumask cache libnuma builds lazily and without any locking. Upstream says so directly in libnuma.c:

  /* This would be better with some locking, but I don't want to make libnuma
     dependent on pthreads right now. The races are relatively harmless. */

  Worker pools bind every thread they spawn at startup, so several threads hit that cold-start path at once. Each allocates the cache and every allocation but the last is orphaned. LeakSanitizer reports the orphan and fails the whole test binary even when every assertion passed — which is what broke rdma_async_event_drain_test in CI:

  [  PASSED  ] 5 tests.
  ==16537==ERROR: LeakSanitizer: detected memory leaks
  Direct leak of 8192 byte(s) ... in numa_node_to_cpus (libnuma.so.1+0x69b9)

  This guards the one lazily-initialized call. Everything else bindToSocket() touches reads state set by libnuma's __attribute__((constructor)) numa_init(), which runs single-threaded at load time, so the lock is deliberately scoped to numa_node_to_cpus() alone.

  The mutex lives in an inline function rather than a static local inside bindToSocket(): that function is static inline, so a static local would be per-translation-unit and worker_pool.cpp, ub_context.cpp and transfer_task.cpp would each lock a different mutex.

  tent carries an independent copy of bindToSocket() with the same defect, fixed identically.

  Relationship to #3243. That PR already made CI green by suppressing the report via __lsan_default_suppressions() returning "leak:libnuma.so" — a fair call for the immediate failure, since the leak is bounded and one-shot.
  This change is complementary rather than a duplicate: it removes the race instead of hiding the symptom. Two practical differences: the suppression symbol is defined in rdma_async_event_drain_test.cpp and so only links into that one binary, leaving any other ASAN test that starts a WorkerPool unprotected; and concurrent unsynchronized writes to libnuma's globals are a data race, not only a leak. The suppression can stay — the two are independent.

  Module
  
  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other
  
  How Has This Been Tested?

  Test commands:
  cmake -G Ninja .. -DENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_UNIT_TESTS=ON
  cmake --build . --target common_test
  ./mooncake-transfer-engine/tests/common_test --gtest_filter='BindToSocketTest.*'

  Test results:

  Verified under ASAN in an ubuntu:22.04 container, driving 32 threads through bindToSocket() behind a barrier:

  │                 Subject                                              │      Result       │
  │ common.h, before the fix                                │ leaked 10/10 runs │
  │ common.h, after the fix                                   │ clean 12/12 runs  │
  │ tent/.../os.h, after the fix                                  │ clean 12/12 runs  │
  │ Minimal libnuma repro (no Mooncake code) │ leaked 8/8 runs   │

  The minimal repro isolates the defect to libnuma itself — the leak stack contains no Mooncake frames.

  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Not verified locally, please watch CI. A full CMake build of the test suite was not completed on my machine (Apple Silicon; dependencies.sh kept failing on ports.ubuntu.com 502s). The runs above compile the real headers under ASAN but do not link the full transfer_engine. Note also that nodemask_sz varies by host, so the leaked byte count on arm64 is not the 8192 seen on CI's x86_64 — same mechanism, different size.

  Known gaps. The tent fix ships without a test: the ASAN job does not set USE_TENT and the tent-ci job does not set ENABLE_ASAN, so a regression test there could never fail. Enabling ASAN on tent-ci looks feasible, but tent has never run under a sanitizer and may surface pre-existing leaks, so that belongs in its own PR. Separately, the two mutexes are distinct objects (mooncake:: and mooncake::tent::), leaving a theoretical window if a legacy pool and a tent pool cold-start simultaneously in one process.

  Checklist
  
  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)