### PR TITLE
[Bugfix][Store] Fix VRAM segment deallocation

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -807,11 +807,11 @@ class RealClient : public PyClient {
 
 #ifdef USE_VRAM_SEGMENT
     struct VRAMSegmentDeleter {
-        std::string protocol;
+        bool use_intra_nvlink = false;
 
-        void operator()(void *ptr) {
+        void operator()(void *ptr) const {
             if (ptr) {
-                free_memory(protocol, ptr);
+                free_memory(use_intra_nvlink ? "nvlink_intra" : "vram", ptr);
             }
         }
     };

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -807,9 +807,11 @@ class RealClient : public PyClient {
 
 #ifdef USE_VRAM_SEGMENT
     struct VRAMSegmentDeleter {
+        std::string protocol;
+
         void operator()(void *ptr) {
             if (ptr) {
-                free_memory("vram", ptr);
+                free_memory(protocol, ptr);
             }
         }
     };

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -910,7 +910,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             } else {
 #ifdef USE_VRAM_SEGMENT
                 vram_segment_ptrs_.emplace_back(
-                    ptr, VRAMSegmentDeleter{this->protocol});
+                    ptr, VRAMSegmentDeleter{this->protocol == "nvlink_intra"});
 #else
                 segment_ptrs_.emplace_back(ptr);
 #endif

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -909,7 +909,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                     ptr, HugepageSegmentDeleter{mapped_size});
             } else {
 #ifdef USE_VRAM_SEGMENT
-                vram_segment_ptrs_.emplace_back(ptr);
+                vram_segment_ptrs_.emplace_back(
+                    ptr, VRAMSegmentDeleter{this->protocol});
 #else
                 segment_ptrs_.emplace_back(ptr);
 #endif

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -599,10 +599,12 @@ void free_memory(const std::string &protocol, void *ptr, bool use_spdk_dma) {
 #endif
 #ifdef USE_VRAM_SEGMENT
 #ifdef USE_INTRA_NVLINK
-    freeFabricMemory_intra(ptr);
-#else
-    cudaFree(ptr);
+    if (protocol == "nvlink_intra") {
+        freeFabricMemory_intra(ptr);
+        return;
+    }
 #endif
+    cudaFree(ptr);
     return;
 #endif
     free(ptr);


### PR DESCRIPTION
## Description

Fix allocator/deallocator mismatches when `USE_VRAM_SEGMENT` and `USE_INTRA_NVLINK` are enabled together.

VRAM allocation uses fabric memory only for the `nvlink_intra` protocol and falls back to `cudaMalloc` for other protocols. The release path previously selected `freeFabricMemory_intra` solely from compile-time flags, so non-`nvlink_intra` allocations were freed by the wrong allocator. In addition, the setup-segment deleter discarded which allocator had been selected.

This change stores a lightweight `use_intra_nvlink` boolean in `VRAMSegmentDeleter` and dispatches to `freeFabricMemory_intra` only for `nvlink_intra`; all other VRAM segments use `cudaFree`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Configured with both affected feature flags, then compiled both changed translation units directly. The full `mooncake_store` target was also attempted, but the host CUDA 11.5 SDK lacks unrelated Fabric and DMA-BUF APIs used by existing Transfer Engine sources.

**Test commands:**
```bash
cmake -S . -B /tmp/mooncake-vram-nvlink-build \
  -DUSE_VRAM_SEGMENT=ON \
  -DUSE_INTRA_NVLINK=ON \
  -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=OFF
make -C /tmp/mooncake-vram-nvlink-build/mooncake-store/src utils.cpp.o -j128
make -C /tmp/mooncake-vram-nvlink-build/mooncake-store/src real_client.cpp.o -j128
pre-commit run
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (dual-flag compilation of affected translation units)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on all files touched by this change and all hooks pass
- [x] Documentation is not applicable because this corrects internal resource cleanup without changing user-facing behavior
- [ ] I have added tests to prove my changes are effective
- [x] RFC is not applicable because this change is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex helped locate the mismatched allocation/free paths, implement the fix, and run validation. The human submitter is responsible for reviewing and defending all changed lines.