### PR TITLE
[Store] Fix CUDA IPC ranged read build

### DIFF
--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -4609,7 +4609,7 @@ RealClient::batch_get_into_cuda_ipc_dummy_helper(
 
     auto range_results = get_into_ranges_internal(
         buffers, all_keys, all_dst_offsets, all_src_offsets, all_sizes,
-        &buffer_capacities, nullptr, nullptr, nullptr);
+        &buffer_capacities, nullptr);
     for (size_t i = 0; i < original_indices.size(); ++i) {
         if (i < range_results.size() && range_results[i].size() == 1 &&
             range_results[i][0].size() == 1) {


### PR DESCRIPTION
## Description

Fix a build regression caused by a semantic merge conflict while merging the latest `main` into #3000. Git completed the textual merge without reporting a conflict, but retained incompatible code from both sides: the new seven-argument API from #3000 and a caller on `main` that still used the old nine-argument form.

`batch_get_into_cuda_ipc_dummy_helper` was added on `main` and still called the old nine-argument `get_into_ranges_internal` API. PR #3000 reduced that API to seven arguments by moving request preparation into the new implementation. Remove the two obsolete null arguments for `prepared_results` and `valid_fragments` while preserving the null query-result cache.

The two removed parameters were Store-side pre-validation artifacts rather than transfer inputs: `prepared_results` carried the prebuilt result shape and validation errors, while `valid_fragments` carried a per-fragment validity mask. PR #3000 consolidated result construction and fragment shape/bounds validation inside `get_into_ranges_internal`; SHM and CUDA IPC callers now provide the actual buffer capacities and no longer inject partially prepared internal state. The remaining seven parameters are the operation inputs plus the optional buffer-capacity and query-result-cache context.

This fix has no runtime behavior impact for the CUDA IPC path because that caller always passed both removed parameters as null, which already selected internal request preparation in the old implementation. Buffers, keys, offsets, lengths, capacities, metadata caching, and Transfer Engine scatter execution are unchanged; the change only aligns the call with the new interface and restores compilation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-cpu -G Ninja -DCMAKE_BUILD_TYPE=Release \
  -DBUILD_UNIT_TESTS=ON -DUSE_CUDA=OFF -DUSE_TENT=OFF \
  -DENABLE_MULTI_PROTOCOL=ON -DUSE_HTTP=ON -DUSE_TCP=ON \
  -DWITH_METRICS=ON
cmake --build build-cpu -j2 --target transfer_task_test
./build-cpu/mooncake-store/tests/transfer_task_test
./scripts/code_format.sh --check -- mooncake-store/src/real_client.cpp
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

The clean CPU multi-protocol build completed successfully, including `real_client.cpp`, and `transfer_task_test` passed 7/7 cases.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools were used to diagnose the semantic merge conflict, implement the one-line fix, and run validation. The human submitter is responsible for reviewing and defending the change.
