### PR TITLE
[feat] conductor: low-level SHA-256 backend for the vLLM v1 hash chain

### DIFF
--- a/mooncake-conductor/CMakeLists.txt
+++ b/mooncake-conductor/CMakeLists.txt
@@ -61,6 +61,37 @@ endif()
 add_executable(mooncake_conductor src/main.cpp)
 target_link_libraries(mooncake_conductor PRIVATE conductor_cpp_core)
 
+# The /query hash chain prefers the low-level SHA256_* API (stack context, ~3x
+# cheaper per block than EVP per-call setup). Those declarations are hidden in
+# OpenSSL no-deprecated builds, so probe for them and fall back to the EVP
+# backend when unavailable. FIPS deployments should force the EVP path
+# explicitly with -DCONDUCTOR_FORCE_EVP_SHA256=ON.
+option(CONDUCTOR_FORCE_EVP_SHA256 "Force the EVP SHA-256 backend (e.g. FIPS)"
+       OFF)
+if(NOT CONDUCTOR_FORCE_EVP_SHA256)
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${OPENSSL_INCLUDE_DIR})
+  set(CMAKE_REQUIRED_LIBRARIES OpenSSL::Crypto)
+  check_cxx_source_compiles(
+    "
+    #define OPENSSL_SUPPRESS_DEPRECATED
+    #include <openssl/sha.h>
+    int main() { SHA256_CTX c; return SHA256_Init(&c); }
+  "
+    CONDUCTOR_HAS_LOWLEVEL_SHA256)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+if(CONDUCTOR_HAS_LOWLEVEL_SHA256)
+  target_compile_definitions(conductor_cpp_core
+                             PRIVATE CONDUCTOR_HAS_LOWLEVEL_SHA256=1)
+  message(STATUS "conductor: SHA-256 backend = low-level SHA256_*")
+else()
+  message(
+    STATUS
+      "conductor: SHA-256 backend = EVP (low-level API unavailable or forced)")
+endif()
+
 install(TARGETS mooncake_conductor DESTINATION bin)
 
 if(BUILD_UNIT_TESTS)

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -1,11 +1,17 @@
 #include "conductor/prefixindex/hash_strategy.h"
 
-// The per-block hot path uses the low-level SHA256_* API with a stack
-// context: on ~100-byte block encodings the EVP per-call setup costs ~3x the
-// compression itself (measured on SHA-NI hardware), while both paths dispatch
-// to the same OpenSSL backend and produce byte-identical digests.
+// Two SHA-256 backends, selected by CONDUCTOR_HAS_LOWLEVEL_SHA256 (probed by
+// CMake): the low-level SHA256_* API with a stack context is ~3x cheaper per
+// call than EVP per-call setup on ~100-byte block encodings, but its
+// declarations are hidden in OpenSSL no-deprecated builds and it bypasses
+// the provider framework required by FIPS.  Both backends dispatch to the
+// same OpenSSL implementation and produce byte-identical digests.
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
 #define OPENSSL_SUPPRESS_DEPRECATED
 #include <openssl/sha.h>
+#else
+#include <openssl/evp.h>
+#endif
 
 #include <cstddef>
 #include <limits>
@@ -496,6 +502,8 @@ bool IsValidUtf8(std::string_view value) {
     return true;
 }
 
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
+
 std::string Sha256(std::span<const uint8_t> input,
                    std::array<uint8_t, kSha256DigestSize>* digest) {
     SHA256_CTX context;
@@ -506,6 +514,46 @@ std::string Sha256(std::span<const uint8_t> input,
     }
     return "";
 }
+
+#else  // EVP backend: no-deprecated builds and FIPS-forced configurations.
+
+std::string Sha256(std::span<const uint8_t> input,
+                   std::array<uint8_t, kSha256DigestSize>* digest) {
+    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+    EvpContext context(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+    if (!context ||
+        EVP_DigestInit_ex(context.get(), EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(context.get(), input.data(), input.size()) != 1) {
+        return "OpenSSL EVP SHA-256 initialization failed";
+    }
+
+    unsigned int digest_size = 0;
+    if (EVP_DigestFinal_ex(context.get(), digest->data(), &digest_size) != 1 ||
+        digest_size != digest->size()) {
+        return "OpenSSL EVP SHA-256 finalization failed";
+    }
+    return "";
+}
+
+// Same as Sha256 but reuses a caller-owned context across invocations,
+// avoiding an EVP_MD_CTX allocation per hashed block in long hash chains.
+std::string Sha256Reuse(EVP_MD_CTX* context, std::span<const uint8_t> input,
+                        std::array<uint8_t, kSha256DigestSize>* digest) {
+    if (EVP_MD_CTX_reset(context) != 1 ||
+        EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1 ||
+        EVP_DigestUpdate(context, input.data(), input.size()) != 1) {
+        return "OpenSSL EVP SHA-256 initialization failed";
+    }
+
+    unsigned int digest_size = 0;
+    if (EVP_DigestFinal_ex(context, digest->data(), &digest_size) != 1 ||
+        digest_size != digest->size()) {
+        return "OpenSSL EVP SHA-256 finalization failed";
+    }
+    return "";
+}
+
+#endif
 
 int LowerHexValue(char value) {
     if (value >= '0' && value <= '9') {
@@ -665,6 +713,14 @@ class VllmV1HashChain final : public HashChain {
             }
             return nullptr;
         }
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+        if (!EnsureEvp()) {
+            if (error != nullptr) {
+                *error = sticky_error_;
+            }
+            return nullptr;
+        }
+#endif
         while (computed_.size() <= index) {
             const size_t block_index = computed_.size();
             const bool has_lora = !lora_name_.empty();
@@ -681,8 +737,13 @@ class VllmV1HashChain final : public HashChain {
             codec_->EncodeBlock(values, &encoded_);
 
             HashBlock block;
-            if (std::string hash_error = Sha256(encoded_, &block.digest);
-                !hash_error.empty()) {
+#if CONDUCTOR_HAS_LOWLEVEL_SHA256
+            std::string hash_error = Sha256(encoded_, &block.digest);
+#else
+            std::string hash_error =
+                Sha256Reuse(evp_.get(), encoded_, &block.digest);
+#endif
+            if (!hash_error.empty()) {
                 sticky_error_ = std::move(hash_error);
                 if (error != nullptr) {
                     *error = sticky_error_;
@@ -697,6 +758,22 @@ class VllmV1HashChain final : public HashChain {
     }
 
    private:
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+    bool EnsureEvp() {
+        if (evp_) {
+            return true;
+        }
+        evp_ = EvpContext(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+        if (!evp_) {
+            sticky_error_ = "OpenSSL EVP MD context allocation failed";
+            return false;
+        }
+        return true;
+    }
+
+    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
+#endif
+
     const VllmValueCodec* codec_;
     std::array<uint8_t, kSha256DigestSize> parent_;
     std::string lora_name_;
@@ -706,6 +783,9 @@ class VllmV1HashChain final : public HashChain {
     size_t block_count_;
     std::vector<HashBlock> computed_;
     std::vector<uint8_t> encoded_;
+#if !CONDUCTOR_HAS_LOWLEVEL_SHA256
+    EvpContext evp_{nullptr, EVP_MD_CTX_free};
+#endif
     std::string sticky_error_;
 };
 

--- a/mooncake-conductor/src/prefixindex/hash_strategy.cpp
+++ b/mooncake-conductor/src/prefixindex/hash_strategy.cpp
@@ -1,6 +1,11 @@
 #include "conductor/prefixindex/hash_strategy.h"
 
-#include <openssl/evp.h>
+// The per-block hot path uses the low-level SHA256_* API with a stack
+// context: on ~100-byte block encodings the EVP per-call setup costs ~3x the
+// compression itself (measured on SHA-NI hardware), while both paths dispatch
+// to the same OpenSSL backend and produce byte-identical digests.
+#define OPENSSL_SUPPRESS_DEPRECATED
+#include <openssl/sha.h>
 
 #include <cstddef>
 #include <limits>
@@ -493,36 +498,11 @@ bool IsValidUtf8(std::string_view value) {
 
 std::string Sha256(std::span<const uint8_t> input,
                    std::array<uint8_t, kSha256DigestSize>* digest) {
-    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
-    EvpContext context(EVP_MD_CTX_new(), EVP_MD_CTX_free);
-    if (!context ||
-        EVP_DigestInit_ex(context.get(), EVP_sha256(), nullptr) != 1 ||
-        EVP_DigestUpdate(context.get(), input.data(), input.size()) != 1) {
-        return "OpenSSL EVP SHA-256 initialization failed";
-    }
-
-    unsigned int digest_size = 0;
-    if (EVP_DigestFinal_ex(context.get(), digest->data(), &digest_size) != 1 ||
-        digest_size != digest->size()) {
-        return "OpenSSL EVP SHA-256 finalization failed";
-    }
-    return "";
-}
-
-// Same as Sha256 but reuses a caller-owned context across invocations,
-// avoiding an EVP_MD_CTX allocation per hashed block in long hash chains.
-std::string Sha256Reuse(EVP_MD_CTX* context, std::span<const uint8_t> input,
-                        std::array<uint8_t, kSha256DigestSize>* digest) {
-    if (EVP_MD_CTX_reset(context) != 1 ||
-        EVP_DigestInit_ex(context, EVP_sha256(), nullptr) != 1 ||
-        EVP_DigestUpdate(context, input.data(), input.size()) != 1) {
-        return "OpenSSL EVP SHA-256 initialization failed";
-    }
-
-    unsigned int digest_size = 0;
-    if (EVP_DigestFinal_ex(context, digest->data(), &digest_size) != 1 ||
-        digest_size != digest->size()) {
-        return "OpenSSL EVP SHA-256 finalization failed";
+    SHA256_CTX context;
+    if (SHA256_Init(&context) != 1 ||
+        SHA256_Update(&context, input.data(), input.size()) != 1 ||
+        SHA256_Final(digest->data(), &context) != 1) {
+        return "OpenSSL SHA-256 computation failed";
     }
     return "";
 }
@@ -685,12 +665,6 @@ class VllmV1HashChain final : public HashChain {
             }
             return nullptr;
         }
-        if (!EnsureEvp()) {
-            if (error != nullptr) {
-                *error = sticky_error_;
-            }
-            return nullptr;
-        }
         while (computed_.size() <= index) {
             const size_t block_index = computed_.size();
             const bool has_lora = !lora_name_.empty();
@@ -707,8 +681,7 @@ class VllmV1HashChain final : public HashChain {
             codec_->EncodeBlock(values, &encoded_);
 
             HashBlock block;
-            if (std::string hash_error =
-                    Sha256Reuse(evp_.get(), encoded_, &block.digest);
+            if (std::string hash_error = Sha256(encoded_, &block.digest);
                 !hash_error.empty()) {
                 sticky_error_ = std::move(hash_error);
                 if (error != nullptr) {
@@ -724,20 +697,6 @@ class VllmV1HashChain final : public HashChain {
     }
 
    private:
-    bool EnsureEvp() {
-        if (evp_) {
-            return true;
-        }
-        evp_ = EvpContext(EVP_MD_CTX_new(), EVP_MD_CTX_free);
-        if (!evp_) {
-            sticky_error_ = "OpenSSL EVP MD context allocation failed";
-            return false;
-        }
-        return true;
-    }
-
-    using EvpContext = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
-
     const VllmValueCodec* codec_;
     std::array<uint8_t, kSha256DigestSize> parent_;
     std::string lora_name_;
@@ -747,7 +706,6 @@ class VllmV1HashChain final : public HashChain {
     size_t block_count_;
     std::vector<HashBlock> computed_;
     std::vector<uint8_t> encoded_;
-    EvpContext evp_{nullptr, EVP_MD_CTX_free};
     std::string sticky_error_;
 };
 


### PR DESCRIPTION
## Description

Speeds up the conductor `/query` hot path (vLLM v1 hash chain) by replacing per-block EVP digest calls with the low-level `SHA256_Init/Update/Final` API on a stack context — with an automatic fallback so no platform regresses.

**Benchmark (against the fair baseline).** The previous code already reused one `EVP_MD_CTX` across the whole chain (`Sha256Reuse`, reset+init per block) — the numbers below compare exactly that pattern, not fresh-per-block EVP
(best-of-5, 200K blocks, ~100-byte pickled block encodings, OpenSSL 3.5, SHA-NI CPU, -O2 build):

| variant | ns/block |
|---|---|
| EVP reused ctx (= old `Sha256Reuse`) | 197 |
| EVP fresh ctx per block | 205 |
| `EVP_Q_digest` one-shot | 204 |
| **low-level `SHA256_Init/Update/Final`** | **68** |

Note reuse ≈ fresh: the heap allocation `Sha256Reuse` amortized was only ~4% of EVP overhead; the per-block reset+init (pt
dispatch) dominates on ~100-byte inputs. Full chain (encode + hash): 344 → 176 ns/block. End-to-end 1M-token 100%-hit ` 28.6 → 19.2 ms.

Both backends dispatch to the same OpenSSL SHA-256 implementation, so digests are **byte-identical** — enforced by tests under both configurations.

**Portability (no-deprecated / FIPS).** `SHA256_Init/Update/Final` are deprecated since OpenSSL 3.0: declarations a builds (`OPENSSL_NO_DEPRECATED_3_0`) and the API bypasses the provider framework required by FIPS. This PR handles

- A CMake compile probe (`check_cxx_source_c
  low-level API is available. Where it isn't, the build automatically falls
  back to the previous EVP-reuse implementat
  platforms is current performance, never a broken build.
- `CONDUCTOR_FORCE_EVP_SHA256=ON` forces the
  FIPS-conscious deployments, which a compile probe cannot detect.

The benchmark numbers above were measured on an -O2 build, which is what #3286 standalone conductor builds.

## Module

- [x] Other — `mooncake-conductor`

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build mooncake-conductor/build -j2 && ./mooncake-conductor/build/tests/conductor_test
# fallback path:
cmake -S mooncake-conductor -B mooncake-conductor/build-evp \
  -DCONDUCTOR_FORCE_EVP_SHA256=ON && cmake -ld-evp -j2
./mooncake-conductor/build-evp/tests/conductor_test
pre-commit run --files mooncake-conductor/CMor/src/prefixindex/hash_strategy.cpp
```

**Test results:**
- [x] Unit tests pass — 161/161 under **both
      (probe-hit low-level and forced-EVP)
- [x] Integration tests pass — vLLM ×2 + moo
      topology: tiered-hit routing, stickiness, zero rejected KV events
- [x] Manual testing done — micro-bench of 5
      `/query` latency bench cold vs 100%-hit (28.6 → 19.2 ms)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scri
- [x] I have run `pre-commit run --all-files` and all hooks pass (on touched files)
- [x] I have updated the documentation (if a
- [x] I have added tests to prove my changes are effective — existing
      golden-vector tests cover digest equal
- [x] For changes >500 LOC: I have filed an RFC issue — N/A (~180 LOC incl. fallback)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code: micro-benchmarking, CMake probe, measurement.