### PR TITLE
[Store] Fix stale per-segment metric labels after segment unmount

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -92,6 +92,11 @@ class MasterMetricManager {
     void reset_segment_total_mem_capacity(const std::string& segment);
     int64_t get_segment_allocated_mem_size(const std::string& segment);
     int64_t get_segment_total_mem_capacity(const std::string& segment);
+    // Remove all per-segment metric labels for the given segment.
+    // Called when a segment is unmounted to prevent stale 0-value entries
+    // from persisting in Prometheus output (e.g. after snapshot restore
+    // followed by client expiry / reaper cleanup).
+    void remove_segment_metrics(const std::string& segment);
 
     // NoF segment Metrics
     void inc_allocated_nof_size(int64_t val = 1);
@@ -103,6 +108,8 @@ class MasterMetricManager {
     double get_segment_nof_used_ratio(const std::string& segment);
     int64_t get_segment_allocated_nof_size(const std::string& segment);
     int64_t get_segment_total_nof_capacity(const std::string& segment);
+    // Remove all per-segment NoF metric labels for the given segment.
+    void remove_nof_segment_metrics(const std::string& segment);
 
     // File Storage Metrics
     void inc_allocated_file_size(int64_t val = 1);

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -705,6 +705,11 @@ int64_t MasterMetricManager::get_segment_total_mem_capacity(
     return mem_total_capacity_per_segment_.value({segment});
 }
 
+void MasterMetricManager::remove_segment_metrics(const std::string& segment) {
+    mem_allocated_size_per_segment_.remove_label_value({{"segment", segment}});
+    mem_total_capacity_per_segment_.remove_label_value({{"segment", segment}});
+}
+
 double MasterMetricManager::get_segment_mem_used_ratio(
     const std::string& segment) {
     double allocated = get_segment_allocated_mem_size(segment);
@@ -773,6 +778,12 @@ int64_t MasterMetricManager::get_segment_allocated_nof_size(
 int64_t MasterMetricManager::get_segment_total_nof_capacity(
     const std::string& segment) {
     return nof_total_capacity_per_segment_.value({segment});
+}
+
+void MasterMetricManager::remove_nof_segment_metrics(
+    const std::string& segment) {
+    nof_allocated_size_per_segment_.remove_label_value({{"segment", segment}});
+    nof_total_capacity_per_segment_.remove_label_value({{"segment", segment}});
 }
 
 double MasterMetricManager::get_segment_nof_used_ratio(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -603,6 +603,7 @@ MasterService::~MasterService() {
     for (const auto& [segment, bytes] : standby_accounted_memory_bytes_) {
         MasterMetricManager::instance().dec_allocated_mem_size(
             segment, static_cast<int64_t>(bytes));
+        MasterMetricManager::instance().remove_segment_metrics(segment);
     }
 
     // Segments still mounted here never went through CommitUnmountSegment;

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -463,6 +463,10 @@ ErrorCode ScopedSegmentAccess::CommitUnmountSegment(
     if (!is_cxl) {
         MasterMetricManager::instance().dec_total_mem_capacity(
             segment_name, metrics_dec_capacity);
+        // Remove per-segment metric labels entirely to avoid stale 0-value
+        // entries persisting in Prometheus output (e.g. after snapshot
+        // restore followed by client expiry / reaper cleanup).
+        MasterMetricManager::instance().remove_segment_metrics(segment_name);
     }
 
     return ErrorCode::OK;
@@ -1474,6 +1478,7 @@ ErrorCode ScopedNoFSegmentAccess::CommitUnmountSegment(
     nof_segment_manager_->mounted_segments_.erase(segment_id);
     MasterMetricManager::instance().dec_total_nof_capacity(
         segment_name, metrics_dec_capacity);
+    MasterMetricManager::instance().remove_nof_segment_metrics(segment_name);
 
     return ErrorCode::OK;
 }
@@ -1572,6 +1577,7 @@ void SegmentManager::releaseCapacityMetrics() {
         }
         MasterMetricManager::instance().dec_total_mem_capacity(segment.name,
                                                                segment.size);
+        MasterMetricManager::instance().remove_segment_metrics(segment.name);
     }
 }
 


### PR DESCRIPTION
## Problem

`MasterMetricManager` uses yalantinglibs `dynamic_gauge_1t` for per-segment metrics (`mem_allocated_size_per_segment_`, `mem_total_capacity_per_segment_`, `nof_allocated_size_per_segment_`, `nof_total_capacity_per_segment_`). When a segment is unmounted via `CommitUnmountSegment`, `dec_total_mem_capacity()` and `dec_allocated_nof_size()` only decrement the gauge value to 0 but do not remove the label entry from the gauge's internal map.

This causes stale 0-value entries to persist indefinitely in Prometheus output. The problem is especially visible after a master restart with snapshot restore: the restored segments carry old client IDs, the reaper eventually expires those clients and calls `CommitUnmountSegment`, which decrements capacity to 0 but leaves the label behind. After clients remount with new IDs, the old segment names linger as capacity=0 entries.

Fix: add `remove_segment_metrics()` and `remove_nof_segment_metrics()` that call `remove_label_value()` on the per-segment gauges, and invoke them in:

- `ScopedSegmentAccess::CommitUnmountSegment` (memory segments)
- `ScopedNoFSegmentAccess::CommitUnmountSegment` (NoF segments)
- `SegmentManager::releaseCapacityMetrics()` (HA teardown)
- `~MasterService()` standby allocated-size cleanup (HA teardown)

## Description

Per-segment Prometheus gauges (`segment_total_capacity_bytes`, `segment_allocated_bytes`, `nof_segment_total_capacity_bytes`, `nof_segment_allocated_bytes`) are backed by yalantinglibs `dynamic_gauge_1t`, which stores one labeled entry per unique segment name in an internal map. The existing unmount path calls `dec_total_mem_capacity()` / `dec_allocated_nof_size()`, which decrement the value to 0 but leave the label entry in the map. Over time — especially after master restart with snapshot restore + reaper cleanup — stale entries accumulate as `capacity=0` rows in Prometheus, making dashboards misleading.

This PR adds `remove_segment_metrics()` and `remove_nof_segment_metrics()` to `MasterMetricManager`, both using the public `remove_label_value()` API to fully evict the label entry. These are called at every segment teardown path: `CommitUnmountSegment` (memory + NoF), `releaseCapacityMetrics()` (HA teardown), and `~MasterService()` standby cleanup.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Verified in a production-like HA deployment (8 Prefill + 8 Decode nodes) with snapshot restore enabled. After master restart, observed stale `segment_total_capacity_bytes` entries with `capacity=0` persisting in Prometheus after the reaper cleaned up expired clients. After applying this fix, restarting the master and waiting for reaper cleanup confirmed the stale entries are fully removed — only active segments appear in the metrics output.

**Before fix** — stale `capacity=0` entries mixed with active segments:

```
segment_total_capacity_bytes{segment="10.x.x.x:13732"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13103"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13910"} 0
segment_total_capacity_bytes{segment="10.x.x.x:12858"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13448"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13926"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:12693"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13124"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13613"} 0
segment_total_capacity_bytes{segment="10.x.x.x:14052"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13000"} 0
segment_total_capacity_bytes{segment="10.x.x.x:12570"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13950"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:12604"} 0
segment_total_capacity_bytes{segment="10.x.x.x:12920"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13978"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13172"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13493"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13817"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13990"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13830"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13832"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:12797"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:12794"} 0
segment_total_capacity_bytes{segment="10.x.x.x:12497"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13684"} 0
segment_total_capacity_bytes{segment="10.x.x.x:12327"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13087"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13869"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13551"} 0
segment_total_capacity_bytes{segment="10.x.x.x:13867"} 60397977600
segment_total_capacity_bytes{segment="10.x.x.x:13409"} 60397977600
```

17 out of 32 entries show `capacity=0` — these are stale labels left behind after the reaper cleaned up expired clients from the snapshot restore.

**Test commands:**

```bash
# Build and deploy master with the fix
# 1. Restart master (triggers snapshot restore)
# 2. Wait for clients to reconnect with new IDs
# 3. Wait for reaper to expire old clients (~TTL)
# 4. Query metrics endpoint and verify no capacity=0 entries remain
curl -s http://<master>:<port>/metrics | grep segment_total_capacity_bytes
```

**Test results:**

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (described above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI coding assistant (CodeBuddy) assisted with code exploration, identifying the root cause of stale per-segment metric labels, and drafting the fix. The human submitter reviewed, tested, and is responsible for all changes.