### PR TITLE
[Store] Fix current-stream readiness for DummyClient CUDA IPC tensor writes

### DIFF
--- a/mooncake-integration/store/store_py_parallel_write.h
+++ b/mooncake-integration/store/store_py_parallel_write.h
@@ -19,16 +19,38 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
     const std::vector<PyTensorInfo> &infos, const ReplicateConfig &config) {
     if (!use_dummy_client_ || keys.size() != infos.size()) return std::nullopt;
 
+    struct CudaStreamContext {
+        int32_t device_id;
+        uintptr_t stream_handle;
+    };
+    std::vector<std::optional<CudaStreamContext>> cuda_stream_contexts(
+        infos.size());
+    for (size_t i = 0; i < infos.size(); ++i) {
+        const py::object &owner = infos[i].owner;
+        if (!infos[i].valid() || !owner || owner.is_none()) continue;
+
+        try {
+            if (!owner.attr("is_cuda").cast<bool>()) continue;
+            cuda_stream_contexts[i] = CudaStreamContext{
+                .device_id = owner.attr("get_device")().cast<int32_t>(),
+                .stream_handle =
+                    torch_module()
+                        .attr("cuda")
+                        .attr("current_stream")(owner.attr("device"))
+                        .attr("cuda_stream")
+                        .cast<uintptr_t>(),
+            };
+        } catch (const py::error_already_set &) {
+            PyErr_Clear();
+        } catch (const py::cast_error &) {
+            PyErr_Clear();
+        }
+    }
+
     std::vector<int> results(keys.size(), 0);
     py::gil_scoped_release release_gil;
 
-    std::vector<CudaIpcWriteRequest> write_requests;
-    std::vector<size_t> original_indices;
-    std::vector<std::unique_ptr<BufferHandle>> metadata_allocations;
-    write_requests.reserve(infos.size());
-    original_indices.reserve(infos.size());
-    metadata_allocations.reserve(infos.size());
-
+    std::vector<std::optional<CudaIpcBufferHandle>> ipc_payloads(infos.size());
     for (size_t i = 0; i < infos.size(); ++i) {
         if (!infos[i].valid()) {
             results[i] = to_py_ret(ErrorCode::INVALID_PARAMS);
@@ -40,6 +62,39 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
             reinterpret_cast<const void *>(infos[i].data_ptr),
             infos[i].tensor_size);
         if (!payload) return std::nullopt;
+        ipc_payloads[i] = std::move(*payload);
+    }
+
+    bool stream_context_invalid = false;
+    for (size_t i = 0; i < infos.size(); ++i) {
+        if (!ipc_payloads[i].has_value()) continue;
+        if (!cuda_stream_contexts[i].has_value() ||
+            cuda_stream_contexts[i]->device_id != ipc_payloads[i]->device_id) {
+            results[i] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+            stream_context_invalid = true;
+        }
+    }
+    if (stream_context_invalid) {
+        LOG(ERROR) << "CUDA IPC tensor stream context validation failed";
+        for (size_t i = 0; i < infos.size(); ++i) {
+            if (ipc_payloads[i].has_value()) {
+                results[i] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+            }
+        }
+        return results;
+    }
+
+    std::vector<CudaIpcWriteRequest> write_requests;
+    std::vector<size_t> original_indices;
+    std::vector<std::unique_ptr<BufferHandle>> metadata_allocations;
+    std::vector<std::pair<int32_t, uintptr_t>> unique_streams;
+    write_requests.reserve(infos.size());
+    original_indices.reserve(infos.size());
+    metadata_allocations.reserve(infos.size());
+    unique_streams.reserve(infos.size());
+
+    for (size_t i = 0; i < infos.size(); ++i) {
+        if (!ipc_payloads[i].has_value()) continue;
 
         size_t metadata_size = infos[i].metadata.header.data_offset;
         auto metadata = store_->allocate_client_buffer(metadata_size);
@@ -56,17 +111,41 @@ std::optional<std::vector<int>> try_dummy_cuda_ipc_batch_put_tensor_impl(
                     .ptr = reinterpret_cast<uint64_t>(metadata->ptr()),
                     .size = static_cast<uint64_t>(metadata_size),
                 },
-            .payload = *payload,
+            .payload = *ipc_payloads[i],
         });
         original_indices.push_back(i);
         metadata_allocations.push_back(
             std::make_unique<BufferHandle>(std::move(*metadata)));
+
+        const CudaStreamContext &stream_context = *cuda_stream_contexts[i];
+        bool stream_is_unique = true;
+        for (const auto &[device_id, stream_handle] : unique_streams) {
+            if (device_id == stream_context.device_id &&
+                stream_handle == stream_context.stream_handle) {
+                stream_is_unique = false;
+                break;
+            }
+        }
+        if (stream_is_unique) {
+            unique_streams.emplace_back(stream_context.device_id,
+                                        stream_context.stream_handle);
+        }
     }
 
     if (!write_requests.empty()) {
         ReplicateConfig write_config =
             MakeIndexedConfig(config, original_indices);
         auto dummy_client = std::static_pointer_cast<DummyClient>(store_);
+        for (const auto &[device_id, stream_handle] : unique_streams) {
+            if (!mooncake::device::SynchronizeCudaStream(device_id,
+                                                         stream_handle)) {
+                LOG(ERROR) << "CUDA IPC tensor stream synchronization failed";
+                for (size_t index : original_indices) {
+                    results[index] = to_py_ret(ErrorCode::INTERNAL_ERROR);
+                }
+                return results;
+            }
+        }
         std::vector<int> op_results =
             dummy_client->batch_put_from_cuda_ipc(write_requests, write_config);
         if (!apply_indexed_results("put", op_results, original_indices,

--- a/mooncake-store/include/device/cuda_ipc_buffer.h
+++ b/mooncake-store/include/device/cuda_ipc_buffer.h
@@ -11,6 +11,9 @@ namespace device {
 tl::expected<CudaIpcBufferHandle, ErrorCode> ExportCudaIpcBuffer(
     const void *ptr, size_t size);
 
+tl::expected<void, ErrorCode> SynchronizeCudaStream(int32_t device_id,
+                                                    uintptr_t stream_handle);
+
 class CudaIpcBufferMapping {
    public:
     CudaIpcBufferMapping() = default;

--- a/mooncake-store/src/device/cuda_ipc_buffer.cpp
+++ b/mooncake-store/src/device/cuda_ipc_buffer.cpp
@@ -122,6 +122,37 @@ tl::expected<CudaIpcBufferHandle, ErrorCode> ExportCudaIpcBuffer(
 #endif
 }
 
+tl::expected<void, ErrorCode> SynchronizeCudaStream(int32_t device_id,
+                                                    uintptr_t stream_handle) {
+#if defined(USE_CUDA)
+    int current_device = -1;
+    if (cudaGetDevice(&current_device) != cudaSuccess) {
+        ClearCudaError();
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+
+    cudaError_t operation_status = cudaSetDevice(device_id);
+    if (operation_status == cudaSuccess) {
+        const cudaStream_t stream =
+            stream_handle == 0 ? nullptr
+                               : reinterpret_cast<cudaStream_t>(stream_handle);
+        operation_status = cudaStreamSynchronize(stream);
+    }
+    if (operation_status != cudaSuccess) ClearCudaError();
+
+    const cudaError_t restore_status = cudaSetDevice(current_device);
+    if (restore_status != cudaSuccess) ClearCudaError();
+    if (operation_status != cudaSuccess || restore_status != cudaSuccess) {
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return {};
+#else
+    (void)device_id;
+    (void)stream_handle;
+    return tl::unexpected(ErrorCode::INVALID_PARAMS);
+#endif
+}
+
 CudaIpcBufferMapping::~CudaIpcBufferMapping() { Close(); }
 
 CudaIpcBufferMapping::CudaIpcBufferMapping(

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -7,7 +7,9 @@ import unittest
 
 try:
     import torch
-except ImportError:
+except ModuleNotFoundError as error:
+    if error.name != "torch":
+        raise
     torch = None
 
 from mooncake.store import MooncakeDistributedStore
@@ -230,7 +232,7 @@ def _run_dummy_cuda_ipc_stream_readiness_case(
                                 (time.perf_counter() - put_started) * 1000.0, 3
                             )
                         diagnostics["ready_at_return"] = bool(ready.query())
-                        if not put_ok:
+                        if not put_ok or not diagnostics["ready_at_return"]:
                             primary_failed = True
                 finally:
                     producer.synchronize()

--- a/mooncake-wheel/tests/test_dummy_client.py
+++ b/mooncake-wheel/tests/test_dummy_client.py
@@ -1,7 +1,9 @@
-import unittest
+import json
+import math
 import os
-import time
 import threading
+import time
+import unittest
 
 try:
     import torch
@@ -15,6 +17,262 @@ from mooncake.store import MooncakeDistributedStore
 DEFAULT_DEFAULT_KV_LEASE_TTL = 5000 # 5000 milliseconds
 # Use environment variable if set, otherwise use default
 default_kv_lease_ttl = int(os.getenv("DEFAULT_KV_LEASE_TTL", DEFAULT_DEFAULT_KV_LEASE_TTL))
+
+CUDA_IPC_STREAM_READINESS_PAYLOAD_BYTES = 16 * 1024 * 1024
+_CUDA_IPC_INITIAL_BYTE = 0x31
+_CUDA_IPC_FINAL_BYTE = 0xA7
+_CUDA_LAUNCH_BLOCKING_DISABLED_VALUES = {"", "0", "false", "no", "off"}
+
+
+class _CudaIpcStreamReadinessFailure(AssertionError):
+    """A CUDA readiness failure whose diagnostics are safe to publish."""
+
+    def __init__(self, diagnostics):
+        self.diagnostics = diagnostics
+        compact = json.dumps(diagnostics, sort_keys=True, separators=(",", ":"))
+        super().__init__(f"CUDA IPC stream readiness case failed: {compact}")
+
+
+def _cuda_launch_blocking_is_active():
+    value = os.environ.get("CUDA_LAUNCH_BLOCKING")
+    return (
+        value is not None
+        and value.strip().lower() not in _CUDA_LAUNCH_BLOCKING_DISABLED_VALUES
+    )
+
+
+def _cuda_stream_readiness_skip_reason():
+    if torch is None:
+        return "PyTorch is not available"
+    if getattr(torch.version, "cuda", None) is None:
+        return "PyTorch does not have CUDA support"
+    if not torch.cuda.is_available():
+        return "CUDA is not available"
+    if not callable(getattr(torch.cuda, "_sleep", None)):
+        return "torch.cuda._sleep is not available"
+    if _cuda_launch_blocking_is_active():
+        return "CUDA_LAUNCH_BLOCKING disables the asynchronous window"
+    return None
+
+
+def _calibrate_cuda_sleep_cycles():
+    target_ms = 300.0
+    minimum_ms = 200.0
+    maximum_ms = 750.0
+    minimum_cycles = 1
+    maximum_cycles = 2_000_000_000
+    cycles = 1_000_000
+    device = torch.device("cuda", torch.cuda.current_device())
+    calibration_stream = torch.cuda.Stream(device=device)
+
+    for _ in range(6):
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
+        with torch.cuda.stream(calibration_stream):
+            start.record()
+            torch.cuda._sleep(cycles)
+            end.record()
+        end.synchronize()
+        elapsed_ms = float(start.elapsed_time(end))
+        if minimum_ms <= elapsed_ms <= maximum_ms:
+            return cycles
+        if not math.isfinite(elapsed_ms) or elapsed_ms <= 0.0:
+            break
+        cycles = round(cycles * target_ms / elapsed_ms)
+        cycles = max(minimum_cycles, min(maximum_cycles, cycles))
+
+    raise AssertionError("Unable to establish the CUDA asynchronous window")
+
+
+def _put_cuda_readiness_tensors(store, keys, tensors, batch_width):
+    if batch_width == 1:
+        return store.put_tensor(keys[0], tensors[0]) == 0
+    return list(store.batch_put_tensor(keys, tensors)) == [0] * batch_width
+
+
+def _get_cuda_readiness_tensors(store, keys, batch_width):
+    if batch_width == 1:
+        return [store.get_tensor(keys[0])]
+    return list(store.batch_get_tensor(keys))
+
+
+def _validate_cuda_readiness_payloads(
+    retrieved, batch_width, payload_bytes, expected_byte
+):
+    if len(retrieved) != batch_width:
+        return False, -1, 0
+
+    metadata_ok = True
+    mismatch_count = 0
+    checksum = 0
+    for actual in retrieved:
+        if not isinstance(actual, torch.Tensor):
+            metadata_ok = False
+            mismatch_count = -1
+            continue
+        actual_cpu = actual.detach().cpu()
+        checksum += int(actual_cpu.sum(dtype=torch.int64).item())
+        if actual_cpu.dtype != torch.uint8 or tuple(actual_cpu.shape) != (
+            payload_bytes,
+        ):
+            metadata_ok = False
+            mismatch_count = -1
+            continue
+        if mismatch_count >= 0:
+            mismatch_count += int(
+                torch.count_nonzero(actual_cpu != expected_byte).item()
+            )
+    return metadata_ok, mismatch_count, checksum
+
+
+def _new_cuda_readiness_diagnostics(batch_width, explicit_sync):
+    return {
+        "mode": "control" if explicit_sync else "async",
+        "batch_width": batch_width,
+        "pending_at_call": None,
+        "ready_at_return": None,
+        "latency_ms": None,
+        "mismatch_count": None,
+        "checksum": None,
+    }
+
+
+def _run_dummy_cuda_ipc_stream_readiness_case(
+    store,
+    batch_width,
+    explicit_sync,
+    sleep_cycles,
+    payload_bytes=CUDA_IPC_STREAM_READINESS_PAYLOAD_BYTES,
+):
+    if batch_width not in (1, 2) or payload_bytes <= 0:
+        raise ValueError("invalid synthetic CUDA readiness parameters")
+
+    diagnostics = _new_cuda_readiness_diagnostics(batch_width, explicit_sync)
+    prefix = f"dummy_cuda_ipc_readiness_{os.getpid()}_{time.monotonic_ns()}"
+    warm_keys = [f"{prefix}_warm_{index}" for index in range(batch_width)]
+    measured_keys = [f"{prefix}_measured_{index}" for index in range(batch_width)]
+    cleanup_keys = [*warm_keys, *measured_keys]
+    tensors = []
+    primary_failed = False
+    cleanup_failed = False
+
+    try:
+        device = torch.device("cuda", torch.cuda.current_device())
+        with torch.cuda.device(device):
+            current = torch.cuda.current_stream(device)
+            tensors = [
+                torch.full(
+                    (payload_bytes,),
+                    _CUDA_IPC_INITIAL_BYTE,
+                    dtype=torch.uint8,
+                    device=device,
+                ).contiguous()
+                for _ in range(batch_width)
+            ]
+
+            # Make the initial value host-ready before opening the async window.
+            current.synchronize()
+            if not all(
+                tensor.is_contiguous()
+                and tensor.dtype == torch.uint8
+                and tuple(tensor.shape) == (payload_bytes,)
+                for tensor in tensors
+            ):
+                primary_failed = True
+
+            if not primary_failed:
+                warm_ok = _put_cuda_readiness_tensors(
+                    store, warm_keys, tensors, batch_width
+                )
+                warm_payloads = _get_cuda_readiness_tensors(
+                    store, warm_keys, batch_width
+                )
+                warm_metadata_ok, warm_mismatch_count, _ = (
+                    _validate_cuda_readiness_payloads(
+                        warm_payloads,
+                        batch_width,
+                        payload_bytes,
+                        _CUDA_IPC_INITIAL_BYTE,
+                    )
+                )
+                if not warm_ok or not warm_metadata_ok or warm_mismatch_count != 0:
+                    primary_failed = True
+
+            if not primary_failed:
+                producer = torch.cuda.Stream(device=device)
+                ready = torch.cuda.Event()
+                try:
+                    with torch.cuda.stream(producer):
+                        torch.cuda._sleep(sleep_cycles)
+                        for tensor in tensors:
+                            tensor.fill_(_CUDA_IPC_FINAL_BYTE)
+                        ready.record(producer)
+
+                    current.wait_stream(producer)
+                    if explicit_sync:
+                        current.synchronize()
+
+                    ready_before_put = bool(ready.query())
+                    diagnostics["pending_at_call"] = not ready_before_put
+                    valid_window = (
+                        ready_before_put if explicit_sync else not ready_before_put
+                    )
+                    if not valid_window:
+                        primary_failed = True
+                    else:
+                        put_started = time.perf_counter()
+                        try:
+                            put_ok = _put_cuda_readiness_tensors(
+                                store, measured_keys, tensors, batch_width
+                            )
+                        finally:
+                            diagnostics["latency_ms"] = round(
+                                (time.perf_counter() - put_started) * 1000.0, 3
+                            )
+                        diagnostics["ready_at_return"] = bool(ready.query())
+                        if not put_ok:
+                            primary_failed = True
+                finally:
+                    producer.synchronize()
+
+            if not primary_failed:
+                retrieved = _get_cuda_readiness_tensors(
+                    store, measured_keys, batch_width
+                )
+                metadata_ok, mismatch_count, checksum = (
+                    _validate_cuda_readiness_payloads(
+                        retrieved,
+                        batch_width,
+                        payload_bytes,
+                        _CUDA_IPC_FINAL_BYTE,
+                    )
+                )
+                diagnostics["mismatch_count"] = mismatch_count
+                diagnostics["checksum"] = checksum
+                expected_checksum = _CUDA_IPC_FINAL_BYTE * payload_bytes * batch_width
+                if (
+                    not metadata_ok
+                    or mismatch_count != 0
+                    or checksum != expected_checksum
+                ):
+                    primary_failed = True
+    except Exception:
+        primary_failed = True
+    finally:
+        for key in cleanup_keys:
+            try:
+                if store.remove(key, force=True) != 0:
+                    cleanup_failed = True
+            except Exception:
+                cleanup_failed = True
+
+    # Preserve primary failure precedence while suppressing raw exception text,
+    # which may contain identifiers forbidden from public diagnostics.
+    if primary_failed:
+        raise _CudaIpcStreamReadinessFailure(diagnostics) from None
+    if cleanup_failed:
+        raise _CudaIpcStreamReadinessFailure(diagnostics) from None
+    return diagnostics
 
 
 def get_client(store, local_buffer_size_param=None):
@@ -482,6 +740,28 @@ class TestDistributedObjectStoreSingleStore(unittest.TestCase):
             self.store.unregister_buffer(buffer_ptr)
             for cleanup_key in cleanup_keys:
                 self.store.remove(cleanup_key)
+
+    def _run_dummy_cuda_ipc_stream_readiness_regression(self, batch_width):
+        skip_reason = _cuda_stream_readiness_skip_reason()
+        if skip_reason is not None:
+            self.skipTest(skip_reason)
+
+        sleep_cycles = _calibrate_cuda_sleep_cycles()
+        for explicit_sync in (False, True):
+            mode = "control" if explicit_sync else "async"
+            with self.subTest(mode=mode, batch_width=batch_width):
+                _run_dummy_cuda_ipc_stream_readiness_case(
+                    self.store,
+                    batch_width=batch_width,
+                    explicit_sync=explicit_sync,
+                    sleep_cycles=sleep_cycles,
+                )
+
+    def test_dummy_cuda_ipc_put_tensor_waits_for_current_stream(self):
+        self._run_dummy_cuda_ipc_stream_readiness_regression(batch_width=1)
+
+    def test_dummy_cuda_ipc_batch_put_tensor_waits_for_current_stream(self):
+        self._run_dummy_cuda_ipc_stream_readiness_regression(batch_width=2)
 
     def test_00_mixed_put_and_put_tensor_concurrency(self):
         """Regression test for regular put and tensor put sharing dummy SHM."""


### PR DESCRIPTION
## Description

The DummyClient CUDA IPC tensor-write fast path can expose a tensor allocation to the receiver before work queued on the caller's PyTorch current stream has completed. For example, after `current.wait_stream(producer)`, the dependency exists on `current`, but the existing path exports the memory handle and starts the RPC without observing that dependency. The receiver can therefore consume stale or partially written data.

This change:

- captures each CUDA tensor's device and PyTorch current stream while holding the GIL;
- exports all CUDA IPC memory handles first, preserving the existing whole-batch staging fallback for non-exportable and zero-sized payloads;
- validates the captured device against the exported allocation;
- deduplicates `(device_id, stream_handle)` pairs and synchronizes only streams associated with requests that will be sent;
- completes synchronization before invoking the existing RPC; and
- returns an error without issuing the RPC if stream validation or synchronization fails.

Callers remain responsible for joining work from other producer streams into the current stream, for example with `current.wait_stream(producer)`.

This is deliberately narrow: CPU tensors and the staging fallback are unchanged, and the patch adds no device-wide synchronization, wire-format field, RPC endpoint, serialized ABI change, or capability negotiation.


**Related work:** #3234 introduced the DummyClient CUDA IPC tensor path fixed here. #1946 targets registered Store buffers and the local-replica GPU/CPU transfer path, while #3159 targets CUDA IPC upsert. Neither covers PyTorch current-stream readiness for the existing `put_tensor`, batch, and TP write path. This PR does not modify either path or any wire/RPC schema.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Test environment: NVIDIA B300, CUDA 12.8, PyTorch 2.11.0+cu128.

**Test commands:**
```bash
./scripts/code_format.sh --check --changed-lines --base origin/main
python -m pytest -q \
  mooncake-wheel/tests/test_dummy_client.py::TestDistributedObjectStoreSingleStore::test_dummy_cuda_ipc_put_tensor_waits_for_current_stream \
  mooncake-wheel/tests/test_dummy_client.py::TestDistributedObjectStoreSingleStore::test_dummy_cuda_ipc_batch_put_tensor_waits_for_current_stream
```

**Correctness results:**

| Asynchronous case | Pre-fix `main` (`a6b4db4`) | This PR |
|---|---:|---:|
| Single tensor | 0/20 correct | 20/20 correct |
| Batch tensor | 0/20 correct | 20/20 correct |

A separate synthetic matrix using a non-default current stream covered async/control and single/batch cases at 20 trials each: 80/80 correct with zero payload mismatches.

Fresh CUDA and no-CUDA configurations built successfully, and the Python extension imported successfully from both builds.

**Ready-tensor performance:**

- At 4 KiB, differences were noise-dominated; the worst observed P95 increase was 3.1%.
- At 16 MiB, no performance regression was observed.

**Pre-commit:**

Every changed-file hook except `ruff-format` passed. `ruff check` reports zero findings on both `origin/main` and this branch. `ruff format --check` has the same whole-file failure on both revisions, so that hook was skipped to avoid an unrelated full-file reformat.

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable: no public API or configuration change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable: the change is below 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with source inspection, CUDA stream-ordering analysis, test design, implementation, validation, and review. The submitter remains responsible for understanding and defending the change.