### PR TITLE
fix: resolve nightly CI failures

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -253,7 +253,7 @@ jobs:
           cd build
           export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}
           cmake --build . -j$(nproc)
-          sudo cmake --install .
+          sudo -E cmake --install .
 
       - name: Build nvlink_allocator.so
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -251,6 +251,7 @@ jobs:
       - name: Build project
         run: |
           cd build
+          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}
           cmake --build . -j$(nproc)
           sudo cmake --install .
 

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -257,7 +257,7 @@ int EfaContext::buildSharedEndpoint(size_t max_wr, size_t max_inline) {
     //
     // Read-back rather than a hint: asking for more than the device supports
     // makes the EFA provider fail fi_getinfo() with -FI_ENODATA, turning a
-    // mis-set MC_MAX_WR into a failure to initialize.  MC_MAX_WR still
+    // misconfigured MC_MAX_WR into a failure to initialize.  MC_MAX_WR still
     // throttles a NIC when it asks for less; it can no longer ask for more.
     const size_t provider_tx_depth =
         fi_info_ && fi_info_->tx_attr ? fi_info_->tx_attr->size : 0;

--- a/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_large_mr_test.cpp
@@ -54,9 +54,6 @@ using namespace mooncake;
 
 namespace mooncake {
 
-DEFINE_string(metadata_server, "127.0.0.1:2379",
-              "central metadata server for transfer engine");
-
 // Small max_mr_size so the >max_mr_size path is exercised without needing a
 // multi-GB allocation. Must be set before TransferEngine init (config reads
 // env).


### PR DESCRIPTION
## Description

Fix #3290.

Provide the CUDA driver stub path before the nightly source build and remove the unused gflags definition that fails in the CUDA 13 arm64 build.
Correct the existing EFA configuration comment that blocks the repository-wide spell check.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/nightly.yml'))"
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing done: verified the test does not reference the removed flag.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable; no formatting changes)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (`pre-commit` is unavailable on the local host)
- [ ] I have updated the documentation (not applicable)
- [ ] I have added tests to prove my changes are effective (covered by the next nightly run)
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex inspected the nightly failures, implemented the focused CI and test-source fixes, and ran static validation.
