### PR TITLE
[TE] Fix compiler warnings in IBGDA transport

### DIFF
--- a/mooncake-transfer-engine/include/transport/device/ibgda/os.h
+++ b/mooncake-transfer-engine/include/transport/device/ibgda/os.h
@@ -20,7 +20,7 @@ static inline int close_ret(int fd) {
 static inline ssize_t read_all(int fd, void *buf, size_t len) {
     size_t total = 0;
     while (total < len) {
-        ssize_t n = read(fd, buf + total, len - total);
+        ssize_t n = read(fd, static_cast<char *>(buf) + total, len - total);
         if (n == -1) {
             return -1;
         }
@@ -35,7 +35,8 @@ static inline ssize_t read_all(int fd, void *buf, size_t len) {
 static inline ssize_t write_all(int fd, const void *buf, size_t len) {
     size_t total = 0;
     while (total < len) {
-        ssize_t n = write(fd, buf + total, len - total);
+        ssize_t n =
+            write(fd, static_cast<const char *>(buf) + total, len - total);
         if (n == -1) {
             return -1;
         }

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
@@ -291,6 +291,7 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
             mlx5gda_qp_devctx devctx{
                 .qpn = qp->qpn,
                 .wqeid_mask = qp->num_wqebb - 1,
+                .mutex = 0,
                 .wq = split_regions ? reinterpret_cast<mlx5gda_wqebb*>(qp->wq)
                                     : reinterpret_cast<mlx5gda_wqebb*>(
                                           static_cast<char*>(ctrl_buf_dev_) +
@@ -306,6 +307,9 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
                                  static_cast<char*>(ctrl_buf_dev_) +
                                  qp->dbr_offset),
                 .bf = static_cast<char*>(qp->uar->reg_addr),
+                .bf_offset = 0,
+                .wq_head = 0,
+                .wq_tail = 0,
             };
             cudaMemcpy(
                 static_cast<char*>(qp_devctxs_) + i * sizeof(mlx5gda_qp_devctx),

--- a/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
+++ b/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
@@ -199,13 +199,13 @@ struct mlx5gda_cq* mlx5gda_create_cq(
         cq_offset = memheap_aligned_alloc(ctrl_buf_heap,
                                           num_cqe * sizeof(struct mlx5_cqe64),
                                           (size_t)1 << MLX5_ADAPTER_PAGE_SHIFT);
-        if (cq_offset == -1) {
+        if (cq_offset == (size_t)-1) {
             perror("Failed to allocate CQ memory");
             goto fail;
         }
         dbr_offset =
             memheap_alloc(ctrl_buf_heap, sizeof(struct mlx5gda_cq_dbr));
-        if (dbr_offset == -1) {
+        if (dbr_offset == (size_t)-1) {
             perror("Failed to allocate CQ DBR memory");
             goto fail;
         }
@@ -287,8 +287,8 @@ fail:
         free(cq);
     }
     if (!split_regions) {
-        if (cq_offset != -1) memheap_free(ctrl_buf_heap, cq_offset);
-        if (dbr_offset != -1) memheap_free(ctrl_buf_heap, dbr_offset);
+        if (cq_offset != (size_t)-1) memheap_free(ctrl_buf_heap, cq_offset);
+        if (dbr_offset != (size_t)-1) memheap_free(ctrl_buf_heap, dbr_offset);
     }
     errno = saved_errno;
     return NULL;
@@ -418,14 +418,14 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
         wq_offset = memheap_aligned_alloc(
             ctrl_buf_heap, num_wqebb * sizeof(struct mlx5gda_wqebb),
             (size_t)1 << MLX5_ADAPTER_PAGE_SHIFT);
-        if (wq_offset == -1) {
+        if (wq_offset == (size_t)-1) {
             perror("Failed to allocate WQ memory");
             goto fail;
         }
 
         dbr_offset =
             memheap_alloc(ctrl_buf_heap, sizeof(struct mlx5gda_wq_dbr));
-        if (dbr_offset == -1) {
+        if (dbr_offset == (size_t)-1) {
             perror("Failed to allocate DBR memory");
             goto fail;
         }
@@ -518,10 +518,10 @@ fail:
     if (qp) {
         free(qp);
     }
-    if (!split_regions && wq_offset != -1) {
+    if (!split_regions && wq_offset != (size_t)-1) {
         memheap_free(ctrl_buf_heap, wq_offset);
     }
-    if (!split_regions && dbr_offset != -1) {
+    if (!split_regions && dbr_offset != (size_t)-1) {
         memheap_free(ctrl_buf_heap, dbr_offset);
     }
     errno = saved_errno;
@@ -542,10 +542,10 @@ void mlx5gda_destroy_qp(struct memheap* ctrl_buf_heap, struct mlx5gda_qp* qp) {
         release_control_region(&qp->region_allocator, &qp->dbr_region);
         release_control_region(&qp->region_allocator, &qp->wq_region);
     } else {
-        if (qp->wq_offset != -1) {
+        if (qp->wq_offset != (size_t)-1) {
             memheap_free(ctrl_buf_heap, qp->wq_offset);
         }
-        if (qp->dbr_offset != -1) {
+        if (qp->dbr_offset != (size_t)-1) {
             memheap_free(ctrl_buf_heap, qp->dbr_offset);
         }
     }


### PR DESCRIPTION
Fix three categories of compiler warnings in `mooncake-transfer-engine`:

1. **`-Wpointer-arith`** in `ibgda/os.h`: `void*` pointer arithmetic in `read_all()` and `write_all()` — cast to `char*` before arithmetic.

2. **`-Wsign-compare`** in `mlx5gda.cpp`: `size_t` offset variables compared with `int` literal `-1` — use `(size_t)-1` to match the variable type.

3. **`-Wmissing-field-initializers`** in `ibgda_device_transport.cpp`: designated initializer for `mlx5gda_qp_devctx` omitted `mutex`, `bf_offset`, `wq_head`, `wq_tail` — add explicit zero initializers.

## Description

During compilation of `mooncake-transfer-engine`, the following warnings are emitted by GCC:

```
mooncake-transfer-engine/include/transport/device/ibgda/os.h:23:34: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
mooncake-transfer-engine/include/transport/device/ibgda/os.h:38:35: warning: pointer of type 'void *' used in arithmetic [-Wpointer-arith]
mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp:235:13: warning: missing initializer for member 'mlx5gda_qp_devctx::mutex' [-Wmissing-field-initializers]
mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp:235:13: warning: missing initializer for member 'mlx5gda_qp_devctx::bf_offset' [-Wmissing-field-initializers]
mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp:235:13: warning: missing initializer for member 'mlx5gda_qp_devctx::wq_head' [-Wmissing-field-initializers]
mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp:235:13: warning: missing initializer for member 'mlx5gda_qp_devctx::wq_tail' [-Wmissing-field-initializers]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:158:19: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:178:20: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:336:19: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:342:20: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:428:19: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:431:20: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:448:23: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
mooncake-transfer-engine/src/transport/device/mlx5gda.cpp:451:24: warning: comparison of integer expressions of different signedness: 'size_t' and 'int' [-Wsign-compare]
```

This PR fixes the first three categories (14 warnings). The fixes are purely cosmetic — no behavioral changes:

- **`os.h`**: GCC allows `void*` arithmetic as a non-standard extension but warns. Cast to `char*` (byte-level pointer) before arithmetic, matching standard C behavior.
- **`mlx5gda.cpp`**: `size_t` is unsigned; comparing with `int` literal `-1` triggers `-Wsign-compare`. Since `(size_t)-1 == SIZE_MAX`, the comparison is semantically correct, but casting to `(size_t)-1` makes the types match explicitly.
- **`ibgda_device_transport.cpp`**: C++ designated initializers value-initialize omitted fields to zero, but GCC warns about each missing field. Add explicit `= 0` for `mutex`, `bf_offset`, `wq_head`, `wq_tail` to suppress the warning and make the intent clear.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Build verified — all three warning categories are eliminated after applying the patch. No functional changes.

**Test commands:**
```bash
# Build mooncake-transfer-engine and check for warnings
mkdir build && cd build
cmake .. -DCMAKE_BUILD_TYPE=Release
make -j$(nproc) 2>&1 | grep -E "warning:.*(Wpointer-arith|Wsign-compare|Wmissing-field-initializers)"
# Expected: no output (all warnings fixed)
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (build passes with no new warnings)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI coding assistant (CodeBuddy) assisted with identifying warning categories from build logs and drafting fixes. The human submitter reviewed, tested, and is responsible for all changes.