### PR TITLE
[Store] Remove transient MasterService config fields

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -875,7 +875,8 @@ class MasterService {
     void setHttpMetadataRemoteUrl(const std::string& metadata_connstring);
 
    private:
-    std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore();
+    std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore(
+        const MasterServiceConfig& config);
 
     // Restore master state
     void RestoreState();
@@ -2075,9 +2076,6 @@ class MasterService {
     // from any GetReplicaList caller without additional locking.
     std::unique_ptr<CountMinSketch> promotion_sketch_;
 
-    const std::string ha_backend_type_;
-
-    const std::string ha_backend_connstring_;
     const bool enable_oplog_;
     const uint32_t oplog_batch_max_entries_;
 
@@ -2085,14 +2083,10 @@ class MasterService {
     const std::string cluster_id_;
     // root filesystem directory for persistent storage
     const std::string root_fs_dir_;
-    // global 3fs/nfs segment size
-    int64_t global_file_segment_size_;
     // storage backend eviction configuration
     const bool enable_disk_eviction_;
     const uint64_t quota_bytes_;
     const bool enable_multi_tenants_;
-    const std::string tenant_quota_connector_type_;
-    const std::string tenant_quota_connector_uri_;
     std::unique_ptr<TenantQuotaPolicyStore> tenant_quota_policy_store_;
     mutable std::mutex tenant_quota_policy_mutex_;
     mutable std::mutex tenant_quota_recompute_mutex_;
@@ -2133,17 +2127,6 @@ class MasterService {
     const AllocationStrategyType allocation_strategy_type_;
     std::shared_ptr<AllocationStrategy> allocation_strategy_;
 
-    bool enable_snapshot_restore_ = false;
-
-    bool enable_snapshot_ = false;
-    std::string snapshot_backup_dir_;
-    bool use_snapshot_backup_dir_{false};
-    uint64_t snapshot_interval_seconds_ = DEFAULT_SNAPSHOT_INTERVAL_SEC;
-    uint64_t snapshot_child_timeout_seconds_ =
-        DEFAULT_SNAPSHOT_CHILD_TIMEOUT_SEC;
-    uint32_t snapshot_retention_count_ = DEFAULT_SNAPSHOT_RETENTION_COUNT;
-    std::string snapshot_catalog_store_type_{};
-    std::string snapshot_catalog_store_connstring_;
     std::unique_ptr<SnapshotObjectStore> snapshot_object_store_;
     std::unique_ptr<ha::SnapshotCatalogStore> snapshot_catalog_store_;
     std::unique_ptr<MasterSnapshotRepository> snapshot_repository_;
@@ -2153,10 +2136,6 @@ class MasterService {
     // Discarded replicas management
     const std::chrono::seconds put_start_discard_timeout_sec_;
     const std::chrono::seconds put_start_release_timeout_sec_;
-    const std::string cxl_path_;
-    const size_t cxl_size_;
-    bool enable_cxl_;
-
     class DiscardedReplicas {
        public:
         DiscardedReplicas() = delete;

--- a/mooncake-store/include/master_snapshot_manager.h
+++ b/mooncake-store/include/master_snapshot_manager.h
@@ -31,18 +31,11 @@ class SnapshotChildProcessTest;
 }  // namespace test
 
 struct MasterSnapshotManagerOptions {
-    bool enable_snapshot{false};
     uint64_t snapshot_interval_seconds{0};
     uint64_t snapshot_child_timeout_seconds{0};
     uint32_t snapshot_retention_count{0};
     std::string snapshot_backup_dir;
     bool use_snapshot_backup_dir{false};
-    std::string snapshot_catalog_store_type;
-    std::string snapshot_catalog_store_connstring;
-    std::string ha_backend_type;
-    std::string ha_backend_connstring;
-    std::string cluster_id;
-    bool enable_ha{false};
 };
 
 /**

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -181,19 +181,14 @@ MasterService::MasterService(const MasterServiceConfig& config)
           config.nof_heartbeat_failures_threshold),
       enable_ha_(config.enable_ha),
       enable_offload_(config.enable_offload),
-      ha_backend_type_(config.ha_backend_type),
-      ha_backend_connstring_(config.ha_backend_connstring),
       enable_oplog_(config.enable_ha && config.enable_oplog &&
                     config.ha_backend_type == "etcd"),
       oplog_batch_max_entries_(config.oplog_batch_max_entries),
       cluster_id_(config.cluster_id),
       root_fs_dir_(config.root_fs_dir),
-      global_file_segment_size_(config.global_file_segment_size),
       enable_disk_eviction_(config.enable_disk_eviction),
       quota_bytes_(config.quota_bytes),
       enable_multi_tenants_(config.enable_multi_tenants),
-      tenant_quota_connector_type_(config.tenant_quota_connector_type),
-      tenant_quota_connector_uri_(config.tenant_quota_connector_uri),
       segment_manager_(config.memory_allocator, config.enable_cxl),
       nof_segment_manager_(config.memory_allocator),
       memory_allocator_type_(config.memory_allocator),
@@ -201,20 +196,8 @@ MasterService::MasterService(const MasterServiceConfig& config)
                                     ? AllocationStrategyType::CXL
                                     : config.allocation_strategy_type),
       allocation_strategy_(CreateAllocationStrategy(allocation_strategy_type_)),
-      enable_snapshot_restore_(config.enable_snapshot_restore),
-      enable_snapshot_(config.enable_snapshot),
-      snapshot_backup_dir_(config.snapshot_backup_dir),
-      snapshot_interval_seconds_(config.snapshot_interval_seconds),
-      snapshot_child_timeout_seconds_(config.snapshot_child_timeout_seconds),
-      snapshot_retention_count_(config.snapshot_retention_count),
-      snapshot_catalog_store_type_(config.snapshot_catalog_store_type),
-      snapshot_catalog_store_connstring_(
-          config.snapshot_catalog_store_connstring),
       put_start_discard_timeout_sec_(config.put_start_discard_timeout_sec),
       put_start_release_timeout_sec_(config.put_start_release_timeout_sec),
-      cxl_path_(config.cxl_path),
-      cxl_size_(config.cxl_size),
-      enable_cxl_(config.enable_cxl),
       offloading_queue_limit_(config.offloading_queue_limit),
       offload_cap_ratio_(config.offload_cap_ratio),
       task_manager_(config.task_manager_config) {
@@ -232,47 +215,44 @@ MasterService::MasterService(const MasterServiceConfig& config)
         LOG(INFO) << "Local-first allocation strategy enabled";
     }
 
-    if (enable_snapshot_ || enable_snapshot_restore_) {
+    const bool use_snapshot_backup_dir = !config.snapshot_backup_dir.empty();
+    if (config.enable_snapshot || config.enable_snapshot_restore) {
         try {
             auto object_store_type =
                 ParseSnapshotObjectStoreType(config.snapshot_object_store_type);
             snapshot_object_store_ =
                 SnapshotObjectStore::Create(object_store_type);
-            snapshot_catalog_store_ = CreateSnapshotCatalogStore();
+            snapshot_catalog_store_ = CreateSnapshotCatalogStore(config);
         } catch (const std::exception& e) {
             LOG(ERROR) << "Failed to create snapshot stores: " << e.what();
             throw std::runtime_error(
                 fmt::format("Failed to create snapshot stores: {}", e.what()));
         }
-        if (!snapshot_backup_dir_.empty()) {
-            use_snapshot_backup_dir_ = true;
-        }
-
         // Initialize repository and codec for both save and restore
         snapshot_repository_ = std::make_unique<MasterSnapshotRepository>(
             snapshot_object_store_.get(), snapshot_catalog_store_.get(),
-            snapshot_backup_dir_, use_snapshot_backup_dir_);
+            config.snapshot_backup_dir, use_snapshot_backup_dir);
         snapshot_codec_ = std::make_unique<ha::MasterSnapshotCodec>();
     }
 
     if (enable_multi_tenants_) {
-        auto store = CreateTenantQuotaPolicyStore(tenant_quota_connector_type_,
-                                                  tenant_quota_connector_uri_,
-                                                  cluster_id_);
+        auto store = CreateTenantQuotaPolicyStore(
+            config.tenant_quota_connector_type,
+            config.tenant_quota_connector_uri, cluster_id_);
         if (!store) {
             throw std::invalid_argument(store.error());
         }
         tenant_quota_policy_store_ = std::move(store.value());
     }
 
-    if (enable_snapshot_restore_) {
+    if (config.enable_snapshot_restore) {
         RestoreState();
     }
     if (enable_multi_tenants_) {
         LoadTenantQuotaPoliciesFromStoreOrThrow();
         RebuildTenantQuotaUsageFromMetadata();
     }
-    if (enable_snapshot_ && snapshot_retention_count_ == 0) {
+    if (config.enable_snapshot && config.snapshot_retention_count == 0) {
         LOG(ERROR) << "snapshot_retention_count must be greater than 0";
         throw std::invalid_argument("snapshot_retention_count must be > 0");
     }
@@ -398,12 +378,12 @@ MasterService::MasterService(const MasterServiceConfig& config)
 
     if (enable_oplog_ && !cluster_id_.empty()) {
 #ifdef STORE_USE_ETCD
-        if (ha_backend_connstring_.empty()) {
+        if (config.ha_backend_connstring.empty()) {
             LOG(INFO) << "Skipping automatic batch-record OpLog writer "
                          "initialization; no HA backend connstring configured";
         } else {
             ErrorCode connect_err = EtcdHelper::ConnectToEtcdStoreClient(
-                ha_backend_connstring_.c_str());
+                config.ha_backend_connstring.c_str());
             if (connect_err != ErrorCode::OK) {
                 throw std::runtime_error(fmt::format(
                     "failed to connect HA batch-record OpLog writer to etcd: "
@@ -419,7 +399,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
             }
         }
 #else
-        if (ha_backend_connstring_.empty()) {
+        if (config.ha_backend_connstring.empty()) {
             LOG(INFO) << "Skipping automatic batch-record OpLog writer "
                          "initialization; no HA backend connstring configured";
         } else {
@@ -465,56 +445,50 @@ MasterService::MasterService(const MasterServiceConfig& config)
 
     if (!root_fs_dir_.empty()) {
         use_disk_replica_ = true;
-        if (global_file_segment_size_ == std::numeric_limits<int64_t>::max()) {
+        if (config.global_file_segment_size ==
+            std::numeric_limits<int64_t>::max()) {
             MasterMetricManager::instance().set_dfs_capacity_unlimited(true);
         } else {
             MasterMetricManager::instance().inc_total_file_capacity(
-                global_file_segment_size_);
+                config.global_file_segment_size);
         }
     }
 
-    if (enable_snapshot_ && !enable_oplog_) {
+    if (config.enable_snapshot && !enable_oplog_) {
         if (memory_allocator_type_ == BufferAllocatorType::OFFSET) {
             // Initialize and start snapshot manager
             MasterSnapshotManagerOptions snapshot_options;
-            snapshot_options.enable_snapshot = enable_snapshot_;
             snapshot_options.snapshot_interval_seconds =
-                snapshot_interval_seconds_;
+                config.snapshot_interval_seconds;
             snapshot_options.snapshot_child_timeout_seconds =
-                snapshot_child_timeout_seconds_;
+                config.snapshot_child_timeout_seconds;
             snapshot_options.snapshot_retention_count =
-                snapshot_retention_count_;
-            snapshot_options.snapshot_backup_dir = snapshot_backup_dir_;
-            snapshot_options.use_snapshot_backup_dir = use_snapshot_backup_dir_;
-            snapshot_options.snapshot_catalog_store_type =
-                snapshot_catalog_store_type_;
-            snapshot_options.snapshot_catalog_store_connstring =
-                snapshot_catalog_store_connstring_;
-            snapshot_options.ha_backend_type = ha_backend_type_;
-            snapshot_options.ha_backend_connstring = ha_backend_connstring_;
-            snapshot_options.cluster_id = cluster_id_;
-            snapshot_options.enable_ha = enable_ha_;
+                config.snapshot_retention_count;
+            snapshot_options.snapshot_backup_dir = config.snapshot_backup_dir;
+            snapshot_options.use_snapshot_backup_dir = use_snapshot_backup_dir;
 
             snapshot_manager_ = std::make_unique<MasterSnapshotManager>(
                 this, snapshot_options, snapshot_mutex_,
                 snapshot_object_store_.get(), snapshot_catalog_store_.get());
             snapshot_manager_->Start();
         }
-    } else if (enable_snapshot_ && enable_oplog_) {
+    } else if (config.enable_snapshot && enable_oplog_) {
         LOG(INFO) << "Skipping primary snapshot generation in batch-record "
                      "OpLog mode; snapshots are owned by standby";
     }
 
-    if (enable_cxl_) {
+    if (config.enable_cxl) {
         allocation_strategy_ = std::make_shared<CxlAllocationStrategy>();
-        segment_manager_.initializeCxlAllocator(cxl_path_, cxl_size_);
+        segment_manager_.initializeCxlAllocator(config.cxl_path,
+                                                config.cxl_size);
         VLOG(1) << "action=start_cxl_global_allocator";
     }
 }
 
 std::unique_ptr<ha::SnapshotCatalogStore>
-MasterService::CreateSnapshotCatalogStore() {
-    auto catalog_kind = ParseSnapshotCatalogKind(snapshot_catalog_store_type_);
+MasterService::CreateSnapshotCatalogStore(const MasterServiceConfig& config) {
+    auto catalog_kind =
+        ParseSnapshotCatalogKind(config.snapshot_catalog_store_type);
     if (!catalog_kind) {
         throw std::invalid_argument(catalog_kind.error());
     }
@@ -530,9 +504,10 @@ MasterService::CreateSnapshotCatalogStore() {
                 "redis snapshot catalog store is unavailable in the current "
                 "build");
 #else
-            const auto connstring = !snapshot_catalog_store_connstring_.empty()
-                                        ? snapshot_catalog_store_connstring_
-                                        : ha_backend_connstring_;
+            const auto connstring =
+                !config.snapshot_catalog_store_connstring.empty()
+                    ? config.snapshot_catalog_store_connstring
+                    : config.ha_backend_connstring;
             if (connstring.empty()) {
                 throw std::invalid_argument(
                     "redis snapshot catalog store requires a connection "

--- a/mooncake-store/src/master_snapshot_manager.cpp
+++ b/mooncake-store/src/master_snapshot_manager.cpp
@@ -108,12 +108,6 @@ void MasterSnapshotManager::SnapshotThreadFunc() {
             break;
         }
 
-        if (!options_.enable_snapshot) {
-            // Snapshot is disabled
-            LOG(INFO)
-                << "[Snapshot] Snapshot is disabled, waiting for next cycle";
-            continue;
-        }
         // Fork a child process to save current state
 
         std::string snapshot_id =
@@ -362,7 +356,7 @@ void MasterSnapshotManager::HandleChildExit(pid_t pid, int status,
 
 tl::expected<ha::OpLogSequenceId, SerializationError>
 MasterSnapshotManager::ResolveSnapshotSequenceId() const {
-    if (!options_.enable_ha || !master_service_->enable_oplog_) {
+    if (!master_service_->enable_ha_ || !master_service_->enable_oplog_) {
         // OpLog sequence ids start at 1. Returning 0 here is a sentinel that
         // means "no persisted OpLog boundary", so a standby that later calls
         // Recover(0) will replay from the first entry when oplog following is

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -176,20 +176,11 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         EnsureSnapshotStores(service);
 
         MasterSnapshotManagerOptions options;
-        options.enable_snapshot = true;
         options.snapshot_interval_seconds = 300;
         options.snapshot_child_timeout_seconds = 300;
         options.snapshot_retention_count = 3;
         options.snapshot_backup_dir = "";
         options.use_snapshot_backup_dir = false;
-        options.snapshot_catalog_store_type =
-            service->snapshot_catalog_store_type_;
-        options.snapshot_catalog_store_connstring =
-            service->snapshot_catalog_store_connstring_;
-        options.ha_backend_type = service->ha_backend_type_;
-        options.ha_backend_connstring = service->ha_backend_connstring_;
-        options.cluster_id = service->cluster_id_;
-        options.enable_ha = service->enable_ha_;
 
         auto temp_manager = std::make_unique<MasterSnapshotManager>(
             service, options, service->snapshot_mutex_,
@@ -207,7 +198,7 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
         if (!service->snapshot_catalog_store_ &&
             service->snapshot_object_store_) {
             service->snapshot_catalog_store_ =
-                service->CreateSnapshotCatalogStore();
+                service->CreateSnapshotCatalogStore(MasterServiceConfig{});
         }
     }
 

--- a/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
@@ -45,9 +45,15 @@ class SnapshotChildProcessTest : public ::testing::Test {
     }
 
     std::unique_ptr<MasterService> service_;
+    MasterServiceConfig service_config_;
 
     static constexpr const char* kEnvSnapshotLocalPath =
         "MOONCAKE_SNAPSHOT_LOCAL_PATH";
+
+    void CreateService(MasterServiceConfig config) {
+        service_config_ = std::move(config);
+        service_ = std::make_unique<MasterService>(service_config_);
+    }
 
     void SetUp() override {
         google::InitGoogleLogging("SnapshotChildProcessTest");
@@ -90,7 +96,7 @@ class SnapshotChildProcessTest : public ::testing::Test {
                           .set_snapshot_object_store_type("local")
                           .set_view_version(view_version)
                           .build();
-        service_ = std::make_unique<MasterService>(config);
+        CreateService(std::move(config));
     }
 
 #ifdef STORE_USE_ETCD
@@ -112,7 +118,7 @@ class SnapshotChildProcessTest : public ::testing::Test {
                           .set_snapshot_object_store_type("local")
                           .set_view_version(view_version)
                           .build();
-        service_ = std::make_unique<MasterService>(config);
+        CreateService(std::move(config));
     }
 
     void CreateBatchEtcdHASnapshotService(const std::string& cluster_id,
@@ -133,7 +139,7 @@ class SnapshotChildProcessTest : public ::testing::Test {
                           .set_snapshot_object_store_type("local")
                           .set_view_version(view_version)
                           .build();
-        service_ = std::make_unique<MasterService>(config);
+        CreateService(std::move(config));
     }
 #endif
 
@@ -222,10 +228,6 @@ class SnapshotChildProcessTest : public ::testing::Test {
         }
     }
 
-    bool GetUseSnapshotBackupDir() {
-        return service_->use_snapshot_backup_dir_;
-    }
-
     // Check if a key exists in raw metadata (regardless of replica status)
     bool KeyExistsInMetadata(MasterService* svc, const std::string& key) {
         size_t shard_idx = svc->getShardIndex(key);
@@ -277,22 +279,15 @@ class SnapshotChildProcessTest : public ::testing::Test {
         EnsureSnapshotStores();
 
         MasterSnapshotManagerOptions options;
-        options.enable_snapshot = true;
         options.snapshot_interval_seconds =
-            service_->snapshot_interval_seconds_;
+            service_config_.snapshot_interval_seconds;
         options.snapshot_child_timeout_seconds =
-            service_->snapshot_child_timeout_seconds_;
-        options.snapshot_retention_count = service_->snapshot_retention_count_;
-        options.snapshot_backup_dir = service_->snapshot_backup_dir_;
-        options.use_snapshot_backup_dir = service_->use_snapshot_backup_dir_;
-        options.snapshot_catalog_store_type =
-            service_->snapshot_catalog_store_type_;
-        options.snapshot_catalog_store_connstring =
-            service_->snapshot_catalog_store_connstring_;
-        options.ha_backend_type = service_->ha_backend_type_;
-        options.ha_backend_connstring = service_->ha_backend_connstring_;
-        options.cluster_id = service_->cluster_id_;
-        options.enable_ha = service_->enable_ha_;
+            service_config_.snapshot_child_timeout_seconds;
+        options.snapshot_retention_count =
+            service_config_.snapshot_retention_count;
+        options.snapshot_backup_dir = service_config_.snapshot_backup_dir;
+        options.use_snapshot_backup_dir =
+            !service_config_.snapshot_backup_dir.empty();
 
         return std::make_unique<MasterSnapshotManager>(
             service_.get(), options, service_->snapshot_mutex_,
@@ -308,7 +303,7 @@ class SnapshotChildProcessTest : public ::testing::Test {
         if (!service_->snapshot_catalog_store_ &&
             service_->snapshot_object_store_) {
             service_->snapshot_catalog_store_ =
-                service_->CreateSnapshotCatalogStore();
+                service_->CreateSnapshotCatalogStore(service_config_);
         }
     }
 
@@ -598,7 +593,7 @@ TEST_F(SnapshotChildProcessTest, RestoreRebuildsGroupedObjectRouting) {
             .set_default_kv_lease_ttl(600000)
             .build();
     };
-    service_ = std::make_unique<MasterService>(make_config());
+    CreateService(make_config());
 
     Segment segment;
     segment.id = generate_uuid();
@@ -629,7 +624,7 @@ TEST_F(SnapshotChildProcessTest, RestoreRebuildsGroupedObjectRouting) {
         << "PersistState failed: " << persist_result.error().message;
 
     service_.reset();
-    service_ = std::make_unique<MasterService>(make_config());
+    CreateService(make_config());
 
     auto restored_replicas = service_->GetReplicaList(key, TenantId::Default());
     ASSERT_TRUE(restored_replicas.has_value())
@@ -652,7 +647,7 @@ TEST_F(SnapshotChildProcessTest, RestorePreservesObjectChecksum) {
             .set_default_kv_lease_ttl(600000)
             .build();
     };
-    service_ = std::make_unique<MasterService>(make_config());
+    CreateService(make_config());
 
     Segment segment;
     segment.id = generate_uuid();
@@ -681,7 +676,7 @@ TEST_F(SnapshotChildProcessTest, RestorePreservesObjectChecksum) {
         << "PersistState failed: " << persist_result.error().message;
 
     service_.reset();
-    service_ = std::make_unique<MasterService>(make_config());
+    CreateService(make_config());
 
     auto restored = service_->GetReplicaList(key, TenantId::Default());
     ASSERT_TRUE(restored.has_value());
@@ -922,7 +917,7 @@ TEST_F(SnapshotChildProcessTest, RestoreWithoutBackupDir_NoBackupFiles) {
     auto restore_service = std::make_unique<MasterService>(config);
 
     // Step 3: Verify NO backup directory was created
-    // With empty backup_dir, use_snapshot_backup_dir_ should be false
+    // With an empty backup_dir, no restore directory should be created.
     // and no restore directory should exist anywhere in tmp_dir()
     bool any_restore_dir_found = false;
     for (auto& entry : fs::recursive_directory_iterator(tmp_dir())) {
@@ -1070,7 +1065,7 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansNonCompleteReplica) {
                       .set_snapshot_retention_count(3)
                       .set_snapshot_object_store_type("local")
                       .build();
-    service_ = std::make_unique<MasterService>(config);
+    CreateService(std::move(config));
 
     // Mount a segment
     Segment segment;
@@ -1145,7 +1140,7 @@ TEST_F(SnapshotChildProcessTest, RestoreCleansExpiredLease) {
                       .set_snapshot_object_store_type("local")
                       .set_default_kv_lease_ttl(600000)  // 10 min lease
                       .build();
-    service_ = std::make_unique<MasterService>(config);
+    CreateService(std::move(config));
 
     // Mount a segment
     Segment segment;
@@ -1228,7 +1223,7 @@ TEST_F(SnapshotChildProcessTest, PersistState_FailFast_StopsOnFirstError) {
             .set_snapshot_retention_count(3)
             .set_snapshot_object_store_type("local")
             .build();
-    service_ = std::make_unique<MasterService>(config);
+    CreateService(std::move(config));
 
     // Mount a segment to have some data to serialize
     Segment segment;
@@ -1296,7 +1291,7 @@ TEST_F(SnapshotChildProcessTest, UploadFail_WithBackupDir_SavesAllFiles) {
                       .set_snapshot_retention_count(3)
                       .set_snapshot_object_store_type("local")
                       .build();
-    service_ = std::make_unique<MasterService>(config);
+    CreateService(std::move(config));
 
     // Mount a segment to have some data to serialize
     Segment segment;


### PR DESCRIPTION
## Description

Remove configuration values that `MasterService` retained only to forward during construction.

- consume snapshot, HA backend, tenant connector, CXL, and file-capacity settings directly from `MasterServiceConfig` during initialization
- remove 17 construction-only `MasterService` members
- remove unused and redundant fields from `MasterSnapshotManagerOptions`
- keep snapshot test helpers independent of removed service internals by retaining their source configuration

This reduces duplicated state and coupling without changing user-facing behavior.

No existing issue or open PR was found for this focused cleanup.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build /tmp/mooncake-fece-build \
  --target snapshot_child_process_test master_service_test_for_snapshot \
  --parallel 128

ctest --test-dir /tmp/mooncake-fece-build \
  -R '^(snapshot_child_process_test|master_service_test_for_snapshot)$' \
  --output-on-failure -j2

pre-commit run --files \
  mooncake-store/include/master_service.h \
  mooncake-store/include/master_snapshot_manager.h \
  mooncake-store/src/master_service.cpp \
  mooncake-store/src/master_snapshot_manager.cpp \
  mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h \
  mooncake-store/tests/ha/snapshot/snapshot_child_process_test.cpp
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done

Both selected CTest targets passed with zero failures. Targeted pre-commit hooks and `git diff --check` also passed.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (targeted hooks pass)
- [x] I have updated the documentation (not applicable; internal refactor)
- [ ] I have added tests to prove my changes are effective (existing snapshot suites cover the refactor)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex identified construction-only configuration state, implemented the cleanup, updated affected test helpers, and ran the validation above. The human submitter is responsible for reviewing every changed line and being able to defend the change end-to-end before marking this PR ready for review.