### PR TITLE
[Store] Add P2P eviction and tier metrics

### DIFF
--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -1,11 +1,19 @@
 #pragma once
 
+#include <array>
+#include <memory>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
 #include <ylt/metric/gauge.hpp>
 
 #include "client_metric.h"
 #include "types.h"
 
 namespace mooncake {
+
+class CacheTier;  // Defined in tiered_cache/tiers/cache_tier.h
 
 // Read/write data metrics (per single-op dimension)
 struct DataMetric {
@@ -132,6 +140,47 @@ struct PeerRequestMetrics {
     std::string summary_metrics();
 };
 
+// Per-tier storage metrics (key count / capacity / current usage).
+struct TierMetric {
+    ylt::metric::dynamic_gauge_1t key_count{
+        "mooncake_p2p_tier_key_count",
+        "Number of committed keys (replicas) on each tier",
+        {"tier"}};
+    ylt::metric::dynamic_gauge_1t capacity_bytes{
+        "mooncake_p2p_tier_capacity_bytes",
+        "Total storage capacity of each tier in bytes",
+        {"tier"}};
+    ylt::metric::dynamic_gauge_1t used_bytes{
+        "mooncake_p2p_tier_used_bytes",
+        "Currently used bytes of each tier",
+        {"tier"}};
+
+    void RegisterTier(const UUID& tier_id, const std::string& label,
+                      const std::shared_ptr<CacheTier>& tier, int priority);
+
+    void OnReplicaAdded(const UUID& tier_id);
+    void OnReplicaRemoved(const UUID& tier_id);
+
+    void serialize(std::string& str);
+    std::string summary_metrics();
+
+   private:
+    struct TierEntry {
+        std::array<std::string, 1> label_array;  // cached gauge label value
+        MemoryType memory_type = MemoryType::UNKNOWN;
+        int priority = 0;
+        size_t capacity = 0;
+        std::weak_ptr<CacheTier> tier;
+    };
+
+    // Polls CacheTier::GetUsage() of every live tier into used_bytes. Only
+    // called from serialize()/summary_metrics(), never from the data path.
+    void RefreshUsage();
+
+    std::shared_mutex mutex_;  // guards tiers_; hot path takes shared lock
+    std::unordered_map<UUID, TierEntry> tiers_;
+};
+
 struct P2PClientMetric : public ClientMetric {
     // total_request is recorded at request (Batch) granularity:
     // BatchPut/BatchGet counts as one request, and every key in the batch
@@ -144,6 +193,8 @@ struct P2PClientMetric : public ClientMetric {
     RemoteRequestMetric remote_request;
     RollbackMetric rollback;
     PeerRequestMetrics peer_request_metrics;
+    // Per-tier storage metrics; initially empty
+    TierMetric tier_metric;
 
     static std::unique_ptr<P2PClientMetric> Create(
         const std::map<std::string, std::string>& labels = {}) {

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -2,7 +2,6 @@
 
 #include <array>
 #include <memory>
-#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 
@@ -155,11 +154,31 @@ struct TierMetric {
         "Currently used bytes of each tier",
         {"tier"}};
 
+    // Scheduler-driven key-movement counters
+    ylt::metric::dynamic_counter_1t evicted_keys{
+        "mooncake_p2p_tier_evicted_keys_total",
+        "Keys whose replica on each tier was evicted by the scheduler",
+        {"tier"}};
+    ylt::metric::dynamic_counter_1t offloaded_keys{
+        "mooncake_p2p_tier_offloaded_keys_total",
+        "Keys moved from each tier down to a lower-priority tier",
+        {"tier"}};
+    ylt::metric::dynamic_counter_1t onboarded_keys{
+        "mooncake_p2p_tier_onboarded_keys_total",
+        "Keys moved from each tier up to a higher-priority tier",
+        {"tier"}};
+
+    // NOT thread-safe
     void RegisterTier(const UUID& tier_id, const std::string& label,
                       const std::shared_ptr<CacheTier>& tier, int priority);
 
     void OnReplicaAdded(const UUID& tier_id);
     void OnReplicaRemoved(const UUID& tier_id);
+
+    void OnEvicted(const UUID& tier_id);
+    // OnMoved classifies by priority: down = offload, up = onboard, both
+    // counted on the source tier.
+    void OnMoved(const UUID& source_tier, const UUID& dest_tier);
 
     void serialize(std::string& str);
     std::string summary_metrics();
@@ -177,7 +196,6 @@ struct TierMetric {
     // called from serialize()/summary_metrics(), never from the data path.
     void RefreshUsage();
 
-    std::shared_mutex mutex_;  // guards tiers_; hot path takes shared lock
     std::unordered_map<UUID, TierEntry> tiers_;
 };
 
@@ -193,8 +211,8 @@ struct P2PClientMetric : public ClientMetric {
     RemoteRequestMetric remote_request;
     RollbackMetric rollback;
     PeerRequestMetrics peer_request_metrics;
-    // Per-tier storage metrics; initially empty
-    TierMetric tier_metric;
+    // Per-tier storage metrics; initially empty. Shared with TieredBackend.
+    std::shared_ptr<TierMetric> tier_metric;
 
     static std::unique_ptr<P2PClientMetric> Create(
         const std::map<std::string, std::string>& labels = {}) {

--- a/mooncake-store/include/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.h
+++ b/mooncake-store/include/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.h
@@ -62,9 +62,12 @@ class EventDrivenClientScheduler : public IClientScheduler {
     void
     ResolveRoles();  // resolve fast/slow from tier topology, Init the policy
 
-    // Execute a single policy-decided movement against the data plane. Returns
-    // true if the movement's source-side effect succeeded.
+    // Execute a single policy-decided movement against the data plane, then
+    // record per-tier movement metrics on success. Returns true if the
+    // movement's source-side effect succeeded.
     bool Execute(const MovementRequest& mv);
+    bool ExecuteMovement(const MovementRequest& mv);  // data-plane work
+    void RecordMovement(const MovementRequest& mv);   // TierMetric bookkeeping
 
     bool HasAvailableBytes(UUID tier_id, size_t required_bytes) const;
     void DispatchToPool(std::function<void()> fn);

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -21,6 +21,7 @@ namespace mooncake {
 
 class TieredBackend;     // Forward declaration
 class IClientScheduler;  // Forward declaration
+struct TierMetric;       // Optional per-tier metrics sink (p2p_client_metric.h)
 
 /**
  * @struct TieredLocation
@@ -45,6 +46,10 @@ struct TierView {
     size_t free_space;
     int priority;
     std::vector<std::string> tags;
+
+    // Segment name reported to Master ("tier_<uuid>"), also used as the
+    // per-tier metric label.
+    std::string GetName() const;
 };
 
 /**
@@ -142,7 +147,8 @@ class TieredBackend {
         Json::Value root, TransferEngine* engine,
         AddReplicaCallback add_replica_callback,
         RemoveReplicaCallback remove_replica_callback,
-        SegmentSyncCallback segment_sync_callback);
+        SegmentSyncCallback segment_sync_callback,
+        TierMetric* tier_metric = nullptr);
 
     // --- Client-Centric Operations ---
     // All the following operations are designed for Client-Centric, Client
@@ -378,6 +384,9 @@ class TieredBackend {
     RemoveReplicaCallback remove_replica_callback_;
     // Callback for segment lifecycle synchronization with Master
     SegmentSyncCallback segment_sync_callback_;
+    // Optional per-tier metrics sink (not owned); null when metric
+    // collection is disabled.
+    TierMetric* tier_metric_ = nullptr;
 
     // Scheduler
     std::unique_ptr<IClientScheduler> scheduler_;

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -148,7 +148,7 @@ class TieredBackend {
         AddReplicaCallback add_replica_callback,
         RemoveReplicaCallback remove_replica_callback,
         SegmentSyncCallback segment_sync_callback,
-        TierMetric* tier_metric = nullptr);
+        std::shared_ptr<TierMetric> tier_metric = nullptr);
 
     // --- Client-Centric Operations ---
     // All the following operations are designed for Client-Centric, Client
@@ -284,6 +284,8 @@ class TieredBackend {
     std::vector<TierView> GetTierViews() const;
     std::vector<UUID> GetReplicaTierIds(std::string_view key) const;
     const CacheTier* GetTier(UUID tier_id) const;
+    // Optional per-tier metrics sink; null when metric collection is off.
+    std::shared_ptr<TierMetric> GetTierMetric() const { return tier_metric_; }
 
     /**
      * @brief Id of the DRAM (fast) tier, for DRAM-only local writes.
@@ -384,9 +386,8 @@ class TieredBackend {
     RemoveReplicaCallback remove_replica_callback_;
     // Callback for segment lifecycle synchronization with Master
     SegmentSyncCallback segment_sync_callback_;
-    // Optional per-tier metrics sink (not owned); null when metric
-    // collection is disabled.
-    TierMetric* tier_metric_ = nullptr;
+    // Optional per-tier metrics; null when metric collection is disabled
+    std::shared_ptr<TierMetric> tier_metric_;
 
     // Scheduler
     std::unique_ptr<IClientScheduler> scheduler_;

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -456,8 +456,8 @@ std::string TierMetric::summary_metrics() {
         }
         ss << ", evicted_keys=" << evicted_keys.value(entry->label_array)
            << ", offloaded_keys=" << offloaded_keys.value(entry->label_array)
-           << ", onboarded_keys="
-           << onboarded_keys.value(entry->label_array) << "\n";
+           << ", onboarded_keys=" << onboarded_keys.value(entry->label_array)
+           << "\n";
     }
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -330,26 +330,25 @@ void TierMetric::RegisterTier(const UUID& tier_id, const std::string& label,
     entry.capacity = tier->GetCapacity();
     entry.tier = tier;
 
-    {
-        std::unique_lock<std::shared_mutex> lock(mutex_);
-        if (!tiers_.try_emplace(tier_id, std::move(entry)).second) {
-            LOG(ERROR) << "TierMetric::RegisterTier: tier already registered"
-                       << ", tier_id=" << TierIdToString(tier_id)
-                       << ", label=" << label;
-            return;
-        }
+    if (!tiers_.try_emplace(tier_id, std::move(entry)).second) {
+        LOG(ERROR) << "TierMetric::RegisterTier: tier already registered"
+                   << ", tier_id=" << TierIdToString(tier_id)
+                   << ", label=" << label;
+        return;
     }
 
-    // Initialize all gauges so an idle tier still shows up in /metrics.
+    // Initialize all series so an idle tier still shows up in /metrics.
     const std::array<std::string, 1> label_array = {label};
     key_count.inc(label_array, 0);
     capacity_bytes.update(label_array,
                           static_cast<int64_t>(tier->GetCapacity()));
     used_bytes.update(label_array, static_cast<int64_t>(tier->GetUsage()));
+    evicted_keys.inc(label_array, 0);
+    offloaded_keys.inc(label_array, 0);
+    onboarded_keys.inc(label_array, 0);
 }
 
 void TierMetric::OnReplicaAdded(const UUID& tier_id) {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     auto it = tiers_.find(tier_id);
     if (it == tiers_.end()) {
         LOG(ERROR) << "TierMetric::OnReplicaAdded: unregistered tier, tier_id="
@@ -360,7 +359,6 @@ void TierMetric::OnReplicaAdded(const UUID& tier_id) {
 }
 
 void TierMetric::OnReplicaRemoved(const UUID& tier_id) {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     auto it = tiers_.find(tier_id);
     if (it == tiers_.end()) {
         LOG(ERROR)
@@ -371,8 +369,34 @@ void TierMetric::OnReplicaRemoved(const UUID& tier_id) {
     key_count.dec(it->second.label_array, 1);
 }
 
+void TierMetric::OnEvicted(const UUID& tier_id) {
+    auto it = tiers_.find(tier_id);
+    if (it == tiers_.end()) {
+        LOG(ERROR) << "TierMetric::OnEvicted: unregistered tier, tier_id="
+                   << TierIdToString(tier_id);
+        return;
+    }
+    evicted_keys.inc(it->second.label_array, 1);
+}
+
+void TierMetric::OnMoved(const UUID& source_tier, const UUID& dest_tier) {
+    auto src = tiers_.find(source_tier);
+    auto dst = tiers_.find(dest_tier);
+    if (src == tiers_.end() || dst == tiers_.end()) {
+        LOG(ERROR) << "TierMetric::OnMoved: unregistered tier, source="
+                   << TierIdToString(source_tier)
+                   << ", dest=" << TierIdToString(dest_tier);
+        return;
+    }
+    if (src->second.priority > dst->second.priority) {
+        offloaded_keys.inc(src->second.label_array, 1);
+    } else if (src->second.priority < dst->second.priority) {
+        onboarded_keys.inc(src->second.label_array, 1);
+    }
+    // Same-priority movement is neither offload nor onboard; not counted.
+}
+
 void TierMetric::RefreshUsage() {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     for (const auto& [tier_id, entry] : tiers_) {
         auto tier = entry.tier.lock();
         if (!tier) {
@@ -389,13 +413,15 @@ void TierMetric::serialize(std::string& str) {
     key_count.serialize(str);
     capacity_bytes.serialize(str);
     used_bytes.serialize(str);
+    evicted_keys.serialize(str);
+    offloaded_keys.serialize(str);
+    onboarded_keys.serialize(str);
 }
 
 std::string TierMetric::summary_metrics() {
     RefreshUsage();
 
     std::stringstream ss;
-    std::shared_lock<std::shared_mutex> lock(mutex_);
     if (tiers_.empty()) {
         ss << "No tiers registered\n";
         return ss.str();
@@ -428,7 +454,10 @@ std::string TierMetric::summary_metrics() {
         if (capacity > 0) {
             ss << " (" << (used * 100 / capacity) << "%)";
         }
-        ss << "\n";
+        ss << ", evicted_keys=" << evicted_keys.value(entry->label_array)
+           << ", offloaded_keys=" << offloaded_keys.value(entry->label_array)
+           << ", onboarded_keys="
+           << onboarded_keys.value(entry->label_array) << "\n";
     }
     return ss.str();
 }
@@ -444,7 +473,8 @@ P2PClientMetric::P2PClientMetric(
       local_request("mooncake_p2p_local", labels),
       remote_request("mooncake_p2p_remote", labels),
       rollback("mooncake_p2p_rollback", labels),
-      peer_request_metrics("mooncake_p2p_peer", labels) {}
+      peer_request_metrics("mooncake_p2p_peer", labels),
+      tier_metric(std::make_shared<TierMetric>()) {}
 
 void P2PClientMetric::serialize(std::string& str) {
     ClientMetric::serialize(str);
@@ -453,7 +483,7 @@ void P2PClientMetric::serialize(std::string& str) {
     remote_request.serialize(str);
     rollback.serialize(str);
     peer_request_metrics.serialize(str);
-    tier_metric.serialize(str);
+    tier_metric->serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -478,7 +508,7 @@ std::string P2PClientMetric::summary_metrics() {
     ss << peer_request_metrics.summary_metrics();
 
     ss << "=== P2P Tier Metrics ===\n";
-    ss << tier_metric.summary_metrics();
+    ss << tier_metric->summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -1,5 +1,13 @@
 #include "p2p_client_metric.h"
 
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+#include "tiered_cache/tiers/cache_tier.h"
+
 namespace mooncake {
 
 // ============================================================================
@@ -297,6 +305,135 @@ std::string PeerRequestMetrics::summary_metrics() {
 }
 
 // ============================================================================
+// TierMetric
+// ============================================================================
+
+namespace {
+std::string TierIdToString(const UUID& tier_id) {
+    return std::to_string(tier_id.first) + "_" + std::to_string(tier_id.second);
+}
+}  // namespace
+
+void TierMetric::RegisterTier(const UUID& tier_id, const std::string& label,
+                              const std::shared_ptr<CacheTier>& tier,
+                              int priority) {
+    if (!tier) {
+        LOG(ERROR) << "TierMetric::RegisterTier: null tier, tier_id="
+                   << TierIdToString(tier_id);
+        return;
+    }
+
+    TierEntry entry;
+    entry.label_array = {label};
+    entry.memory_type = tier->GetMemoryType();
+    entry.priority = priority;
+    entry.capacity = tier->GetCapacity();
+    entry.tier = tier;
+
+    {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
+        if (!tiers_.try_emplace(tier_id, std::move(entry)).second) {
+            LOG(ERROR) << "TierMetric::RegisterTier: tier already registered"
+                       << ", tier_id=" << TierIdToString(tier_id)
+                       << ", label=" << label;
+            return;
+        }
+    }
+
+    // Initialize all gauges so an idle tier still shows up in /metrics.
+    const std::array<std::string, 1> label_array = {label};
+    key_count.inc(label_array, 0);
+    capacity_bytes.update(label_array,
+                          static_cast<int64_t>(tier->GetCapacity()));
+    used_bytes.update(label_array, static_cast<int64_t>(tier->GetUsage()));
+}
+
+void TierMetric::OnReplicaAdded(const UUID& tier_id) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    auto it = tiers_.find(tier_id);
+    if (it == tiers_.end()) {
+        LOG(ERROR) << "TierMetric::OnReplicaAdded: unregistered tier, tier_id="
+                   << TierIdToString(tier_id);
+        return;
+    }
+    key_count.inc(it->second.label_array, 1);
+}
+
+void TierMetric::OnReplicaRemoved(const UUID& tier_id) {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    auto it = tiers_.find(tier_id);
+    if (it == tiers_.end()) {
+        LOG(ERROR)
+            << "TierMetric::OnReplicaRemoved: unregistered tier, tier_id="
+            << TierIdToString(tier_id);
+        return;
+    }
+    key_count.dec(it->second.label_array, 1);
+}
+
+void TierMetric::RefreshUsage() {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    for (const auto& [tier_id, entry] : tiers_) {
+        auto tier = entry.tier.lock();
+        if (!tier) {
+            // Tier already destroyed; keep the last known value.
+            continue;
+        }
+        used_bytes.update(entry.label_array,
+                          static_cast<int64_t>(tier->GetUsage()));
+    }
+}
+
+void TierMetric::serialize(std::string& str) {
+    RefreshUsage();
+    key_count.serialize(str);
+    capacity_bytes.serialize(str);
+    used_bytes.serialize(str);
+}
+
+std::string TierMetric::summary_metrics() {
+    RefreshUsage();
+
+    std::stringstream ss;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    if (tiers_.empty()) {
+        ss << "No tiers registered\n";
+        return ss.str();
+    }
+
+    // Display tiers by priority (descending), then by label, for stable and
+    // readable output.
+    std::vector<const TierEntry*> sorted;
+    sorted.reserve(tiers_.size());
+    for (const auto& [tier_id, entry] : tiers_) {
+        sorted.push_back(&entry);
+    }
+    std::sort(sorted.begin(), sorted.end(),
+              [](const TierEntry* a, const TierEntry* b) {
+                  if (a->priority != b->priority) {
+                      return a->priority > b->priority;
+                  }
+                  return a->label_array[0] < b->label_array[0];
+              });
+
+    for (const auto* entry : sorted) {
+        const int64_t keys = key_count.value(entry->label_array);
+        const int64_t used = used_bytes.value(entry->label_array);
+        const int64_t capacity = static_cast<int64_t>(entry->capacity);
+        ss << "Tier " << entry->label_array[0] << " ("
+           << MemoryTypeToString(entry->memory_type)
+           << ", priority=" << entry->priority << "): keys=" << keys
+           << ", used=" << byte_size_to_string(used) << "/"
+           << byte_size_to_string(capacity);
+        if (capacity > 0) {
+            ss << " (" << (used * 100 / capacity) << "%)";
+        }
+        ss << "\n";
+    }
+    return ss.str();
+}
+
+// ============================================================================
 // P2PClientMetric
 // ============================================================================
 
@@ -316,6 +453,7 @@ void P2PClientMetric::serialize(std::string& str) {
     remote_request.serialize(str);
     rollback.serialize(str);
     peer_request_metrics.serialize(str);
+    tier_metric.serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -338,6 +476,9 @@ std::string P2PClientMetric::summary_metrics() {
 
     ss << "=== P2P Peer Request Metrics ===\n";
     ss << peer_request_metrics.summary_metrics();
+
+    ss << "=== P2P Tier Metrics ===\n";
+    ss << tier_metric.summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -316,7 +316,8 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
 
     auto init_result = tiered_backend->Init(
         config.tiered_backend_config, transfer_engine_.get(),
-        add_replica_callback, remove_replica_callback, segment_sync_callback);
+        add_replica_callback, remove_replica_callback, segment_sync_callback,
+        metrics_ ? &metrics_->tier_metric : nullptr);
     if (!init_result) {
         LOG(ERROR) << "Failed to init TieredBackend: " << init_result.error();
         return init_result.error();
@@ -547,8 +548,7 @@ std::vector<Segment> P2PClientService::CollectTierSegments() const {
     for (const auto& view : tier_views) {
         Segment seg;
         seg.id = view.id;
-        seg.name = "tier_" + std::to_string(view.id.first) + "_" +
-                   std::to_string(view.id.second);
+        seg.name = view.GetName();
         seg.size = view.capacity;
         auto& p2p_extra = seg.GetP2PExtra();
         p2p_extra.priority = view.priority;

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -317,7 +317,7 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
     auto init_result = tiered_backend->Init(
         config.tiered_backend_config, transfer_engine_.get(),
         add_replica_callback, remove_replica_callback, segment_sync_callback,
-        metrics_ ? &metrics_->tier_metric : nullptr);
+        metrics_ ? metrics_->tier_metric : nullptr);
     if (!init_result) {
         LOG(ERROR) << "Failed to init TieredBackend: " << init_result.error();
         return init_result.error();

--- a/mooncake-store/src/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.cpp
+++ b/mooncake-store/src/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.cpp
@@ -4,7 +4,9 @@
 
 #include <algorithm>
 #include <chrono>
+#include <iomanip>
 #include <limits>
+#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -15,6 +17,41 @@
 #include "tiered_cache/tiers/cache_tier.h"
 
 namespace mooncake {
+
+namespace {
+
+// Render one "[Eviction] ..." line for the event-driven paths: the current
+// tier watermark (usage/capacity, read from the tier view) and how much data
+// this eviction reclaimed.
+std::string MakeEvictionLog(TieredBackend* backend, std::string_view path,
+                            UUID tier_id, size_t evicted_keys,
+                            size_t evicted_bytes) {
+    size_t usage = 0;
+    size_t capacity = 0;
+    for (const auto& view : backend->GetTierViews()) {
+        if (view.id == tier_id) {
+            usage = view.usage;
+            capacity = view.capacity;
+            break;
+        }
+    }
+    std::ostringstream ss;
+    ss << "[Eviction] path=" << path << " tier=" << tier_id
+       << " usage=" << usage << "/" << capacity << " (";
+    if (capacity == 0) {
+        ss << "n/a)";
+    } else {
+        ss << std::fixed << std::setprecision(1)
+           << (100.0 * static_cast<double>(usage) /
+               static_cast<double>(capacity))
+           << "%)";
+    }
+    ss << " evicted_keys=" << evicted_keys
+       << " evicted_bytes=" << evicted_bytes;
+    return ss.str();
+}
+
+}  // namespace
 
 EventDrivenClientScheduler::EventDrivenClientScheduler(
     TieredBackend* backend, const Json::Value& config,
@@ -154,13 +191,24 @@ bool EventDrivenClientScheduler::OnAllocationFailure(
 
     const auto movements = policy_->DecideEvict(ctx.required_bytes);
     size_t reclaimed = 0;
+    size_t evicted_keys = 0;
+    size_t evicted_bytes = 0;
     for (const auto& mv : movements) {
         if (reclaimed >= ctx.required_bytes || !running_.load()) {
             break;
         }
         if (Execute(mv)) {
             reclaimed += mv.size_bytes;
+            // kReplicate only adds a copy; it reclaims no space.
+            if (mv.kind != MovementRequest::Kind::kReplicate) {
+                ++evicted_keys;
+                evicted_bytes += mv.size_bytes;
+            }
         }
+    }
+    if (!movements.empty()) {
+        LOG(INFO) << MakeEvictionLog(backend_, "sync_alloc_failure",
+                                     ctx.tier_id, evicted_keys, evicted_bytes);
     }
     return HasAvailableBytes(ctx.tier_id, ctx.required_bytes);
 }
@@ -190,12 +238,22 @@ void EventDrivenClientScheduler::EvictLoop() {
             continue;
         }
         const auto movements = policy_->DecideEvict(/*min_reclaim_bytes=*/0);
+        if (movements.empty()) {
+            continue;
+        }
+        size_t evicted_keys = 0;
+        size_t evicted_bytes = 0;
         for (const auto& mv : movements) {
             if (!running_.load()) {
                 return;
             }
-            Execute(mv);
+            if (Execute(mv) && mv.kind != MovementRequest::Kind::kReplicate) {
+                ++evicted_keys;
+                evicted_bytes += mv.size_bytes;
+            }
         }
+        LOG(INFO) << MakeEvictionLog(backend_, "async_periodic", fast_tier_id_,
+                                     evicted_keys, evicted_bytes);
     }
 }
 

--- a/mooncake-store/src/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.cpp
+++ b/mooncake-store/src/tiered_cache/event_driven_scheduler/event_driven_client_scheduler.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 #include <vector>
 
+#include "p2p_client_metric.h"
 #include "tiered_cache/event_driven_scheduler/json_config_util.h"
 #include "tiered_cache/tiered_backend.h"
 #include "tiered_cache/tiers/cache_tier.h"
@@ -258,6 +259,26 @@ void EventDrivenClientScheduler::EvictLoop() {
 }
 
 bool EventDrivenClientScheduler::Execute(const MovementRequest& mv) {
+    const bool ok = ExecuteMovement(mv);
+    if (ok) {
+        RecordMovement(mv);
+    }
+    return ok;
+}
+
+void EventDrivenClientScheduler::RecordMovement(const MovementRequest& mv) {
+    std::shared_ptr<TierMetric> metric = backend_->GetTierMetric();
+    if (!metric) {
+        return;
+    }
+    if (mv.kind == MovementRequest::Kind::kEvict) {
+        metric->OnEvicted(mv.source_tier);
+    } else {
+        metric->OnMoved(mv.source_tier, mv.dest_tier);
+    }
+}
+
+bool EventDrivenClientScheduler::ExecuteMovement(const MovementRequest& mv) {
     switch (mv.kind) {
         case MovementRequest::Kind::kReplicate: {
             // Copy source -> dest, retaining the source (e.g. pre-demote). The

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <limits>
 
+#include "p2p_client_metric.h"
 #include "tiered_cache/tiered_backend.h"
 #include "tiered_cache/tiers/cache_tier.h"
 #include "tiered_cache/tiers/dram_tier.h"
@@ -22,6 +23,12 @@ static size_t ParseByteSize(const Json::Value& v) {
     }
     return static_cast<size_t>(v.asUInt64());
 }
+
+static std::string MakeTierSegmentName(const UUID& id) {
+    return "tier_" + std::to_string(id.first) + "_" + std::to_string(id.second);
+}
+
+std::string TierView::GetName() const { return MakeTierSegmentName(id); }
 
 AllocationEntry::~AllocationEntry() {
     if (loc.tier) {
@@ -115,8 +122,7 @@ void TieredBackend::Destroy() {
         Segment segment;
         segment.extra = P2PSegmentExtraData{};
         segment.id = id;
-        segment.name = "tier_" + std::to_string(id.first) + "_" +
-                       std::to_string(id.second);
+        segment.name = MakeTierSegmentName(id);
         segment.size = tier->GetCapacity();
         auto& p2p_extra = segment.GetP2PExtra();
         p2p_extra.priority = info.priority;
@@ -141,7 +147,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     Json::Value root, TransferEngine* engine,
     AddReplicaCallback add_replica_callback,
     RemoveReplicaCallback remove_replica_callback,
-    SegmentSyncCallback segment_sync_callback) {
+    SegmentSyncCallback segment_sync_callback, TierMetric* tier_metric) {
     // Initialize DataCopier
     try {
         DataCopierBuilder builder;
@@ -156,6 +162,8 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     remove_replica_callback_ = remove_replica_callback;
     // Register callback for segment lifecycle synchronization with Master
     segment_sync_callback_ = segment_sync_callback;
+    // Optional per-tier metrics sink
+    tier_metric_ = tier_metric;
 
     // Initialize Tiers
     if (!root.isMember("tiers")) {
@@ -303,6 +311,13 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
 
+        // Expose per-tier metrics before mounting so an early metrics read
+        // already sees this tier.
+        if (tier_metric_) {
+            tier_metric_->RegisterTier(id, MakeTierSegmentName(id), tiers_[id],
+                                       priority);
+        }
+
         auto mount_result =
             MountSegment(id, capacity, priority, tags, memory_type);
         if (!mount_result) {
@@ -341,8 +356,7 @@ tl::expected<void, ErrorCode> TieredBackend::MountSegment(
     Segment segment;
     segment.extra = P2PSegmentExtraData{};
     segment.id = id;
-    segment.name =
-        "tier_" + std::to_string(id.first) + "_" + std::to_string(id.second);
+    segment.name = MakeTierSegmentName(id);
     segment.size = capacity;
     auto& p2p_extra = segment.GetP2PExtra();
     p2p_extra.priority = priority;
@@ -571,6 +585,7 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
     size_t handle_size =
         handle->loc.data.buffer ? handle->loc.data.buffer->size() : 0;
     uint64_t committed_version = 0;
+    bool replica_added = false;
 
     // Update Entry (Entry Write Lock)
     {
@@ -601,11 +616,16 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
                           return tier_info_.at(a.first).priority >
                                  tier_info_.at(b.first).priority;
                       });
+            replica_added = true;
         }
 
         // Increment Version on modification
         entry->version++;
         committed_version = entry->version;
+    }
+
+    if (replica_added && tier_metric_) {
+        tier_metric_->OnReplicaAdded(current_tier_id);
     }
 
     if (scheduler_) {
@@ -729,6 +749,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
     // locks This is crucial for non-blocking deletions.
     AllocationHandle handle_ref = nullptr;
     std::vector<AllocationHandle> handles_to_free;
+    std::vector<UUID> removed_tier_ids;
 
     if (tier_id.has_value()) {
         // Delete Specific Replica
@@ -804,6 +825,9 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
         }
 
         if (found_tier) {
+            if (tier_metric_) {
+                tier_metric_->OnReplicaRemoved(*tier_id);
+            }
             if (scheduler_) {
                 scheduler_->OnDelete(DeleteContext{key, *tier_id});
             }
@@ -841,11 +865,19 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
                     }
                 }
                 handles_to_free.push_back(replica.second);
+                removed_tier_ids.push_back(replica.first);
             }
             entry->replicas.clear();
         }
 
         shard.index.erase(it);
+    }
+
+    // Per-tier key-count accounting for the removed replicas.
+    if (tier_metric_) {
+        for (const auto& removed_tier_id : removed_tier_ids) {
+            tier_metric_->OnReplicaRemoved(removed_tier_id);
+        }
     }
 
     // Handles go out of scope here.
@@ -922,6 +954,9 @@ size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
 
         if (found_tier) {
             ++removed;
+            if (tier_metric_) {
+                tier_metric_->OnReplicaRemoved(tier_id);
+            }
             // Notify Master that the replica on this tier is gone. Best-effort:
             // the eviction is irreversible, so log failures and continue.
             if (remove_replica_callback_) {
@@ -992,6 +1027,12 @@ tl::expected<long, ErrorCode> TieredBackend::RemoveAll() {
                             << ", key=" << key << ", segment_id=" << segment_id
                             << ", error_code=" << result.error();
                     }
+                }
+            }
+
+            if (tier_metric_) {
+                for (const auto& [tier_id, handle] : replicas) {
+                    tier_metric_->OnReplicaRemoved(tier_id);
                 }
             }
 

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -147,7 +147,8 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     Json::Value root, TransferEngine* engine,
     AddReplicaCallback add_replica_callback,
     RemoveReplicaCallback remove_replica_callback,
-    SegmentSyncCallback segment_sync_callback, TierMetric* tier_metric) {
+    SegmentSyncCallback segment_sync_callback,
+    std::shared_ptr<TierMetric> tier_metric) {
     // Initialize DataCopier
     try {
         DataCopierBuilder builder;
@@ -163,7 +164,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     // Register callback for segment lifecycle synchronization with Master
     segment_sync_callback_ = segment_sync_callback;
     // Optional per-tier metrics sink
-    tier_metric_ = tier_metric;
+    tier_metric_ = std::move(tier_metric);
 
     // Initialize Tiers
     if (!root.isMember("tiers")) {
@@ -889,6 +890,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
     return tl::expected<void, ErrorCode>{};
 }
 
+// TODO: move the logic into the storage_tier
 size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
                                            const UUID& tier_id) {
     // Capture handle references locally so the actual resource release (and the
@@ -956,6 +958,7 @@ size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
             ++removed;
             if (tier_metric_) {
                 tier_metric_->OnReplicaRemoved(tier_id);
+                tier_metric_->OnEvicted(tier_id);
             }
             // Notify Master that the replica on this tier is gone. Best-effort:
             // the eviction is irreversible, so log failures and continue.

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -788,4 +788,65 @@ TEST_F(ClientMetricsTest, P2PClientMetricTierSectionTest) {
     metrics.serialize(serialized);  // must not crash with empty tier metric
 }
 
+TEST_F(ClientMetricsTest, TierMetricMovementCountersTest) {
+    TierMetric metric;
+    const UUID high{1, 1};
+    const UUID low{2, 2};
+    auto high_tier = std::make_shared<StubStatsTier>(
+        high, /*capacity=*/1024, /*usage=*/0, MemoryType::DRAM);
+    auto low_tier = std::make_shared<StubStatsTier>(
+        low, /*capacity=*/2048, /*usage=*/0, MemoryType::NVME);
+
+    metric.RegisterTier(high, "tier_1_1", high_tier, /*priority=*/20);
+    metric.RegisterTier(low, "tier_2_2", low_tier, /*priority=*/10);
+
+    std::array<std::string, 1> high_label = {"tier_1_1"};
+    std::array<std::string, 1> low_label = {"tier_2_2"};
+
+    // Counters start at zero at registration.
+    EXPECT_EQ(metric.evicted_keys.value(high_label), 0);
+    EXPECT_EQ(metric.offloaded_keys.value(high_label), 0);
+    EXPECT_EQ(metric.onboarded_keys.value(high_label), 0);
+
+    // Evictions are counted on the tier losing the replica.
+    metric.OnEvicted(high);
+    metric.OnEvicted(high);
+    EXPECT_EQ(metric.evicted_keys.value(high_label), 2);
+    EXPECT_EQ(metric.evicted_keys.value(low_label), 0);
+
+    // A downward movement counts as an offload on the source tier.
+    metric.OnMoved(high, low);
+    EXPECT_EQ(metric.offloaded_keys.value(high_label), 1);
+    EXPECT_EQ(metric.onboarded_keys.value(low_label), 0);
+
+    // An upward movement counts as an onboard on the source tier.
+    metric.OnMoved(low, high);
+    metric.OnMoved(low, high);
+    EXPECT_EQ(metric.onboarded_keys.value(low_label), 2);
+    EXPECT_EQ(metric.offloaded_keys.value(high_label), 1);
+
+    // Same-priority movements are neither offload nor onboard.
+    const UUID peer{3, 3};
+    auto peer_tier = std::make_shared<StubStatsTier>(
+        peer, /*capacity=*/512, /*usage=*/0, MemoryType::DRAM);
+    metric.RegisterTier(peer, "tier_3_3", peer_tier, /*priority=*/20);
+    metric.OnMoved(high, peer);
+    std::array<std::string, 1> peer_label = {"tier_3_3"};
+    EXPECT_EQ(metric.offloaded_keys.value(high_label), 1);
+    EXPECT_EQ(metric.onboarded_keys.value(high_label), 0);
+    EXPECT_EQ(metric.offloaded_keys.value(peer_label), 0);
+
+    // Summary exposes the new counters.
+    std::string summary = metric.summary_metrics();
+    EXPECT_TRUE(summary.find("evicted_keys=2") != std::string::npos);
+    EXPECT_TRUE(summary.find("offloaded_keys=1") != std::string::npos);
+    EXPECT_TRUE(summary.find("onboarded_keys=2") != std::string::npos);
+
+    // Serialized output contains the counter series.
+    std::string serialized;
+    metric.serialize(serialized);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_tier_evicted_keys_total") !=
+                std::string::npos);
+}
+
 }  // namespace mooncake::test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -1,12 +1,16 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <array>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "client_metric.h"
 #include "p2p_client_metric.h"
+#include "tiered_cache/tiers/cache_tier.h"
 
 namespace mooncake::test {
 
@@ -640,6 +644,148 @@ TEST_F(ClientMetricsTest, P2PClientMetricRetryCountersTest) {
 
     std::string summary = metrics.summary_metrics();
     EXPECT_TRUE(summary.find("Retries: write=3, read=2") != std::string::npos);
+}
+
+namespace {
+// Minimal CacheTier stub with fixed capacity/usage for TierMetric tests.
+class StubStatsTier : public CacheTier {
+   public:
+    StubStatsTier(UUID id, size_t capacity, size_t usage, MemoryType type)
+        : id_(id), capacity_(capacity), usage_(usage), type_(type) {}
+
+    tl::expected<void, ErrorCode> Init(TieredBackend*,
+                                       TransferEngine*) override {
+        return {};
+    }
+    tl::expected<void, ErrorCode> Allocate(size_t, DataSource&) override {
+        return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+    }
+    tl::expected<void, ErrorCode> Free(DataSource) override { return {}; }
+    UUID GetTierId() const override { return id_; }
+    size_t GetCapacity() const override { return capacity_; }
+    size_t GetUsage() const override { return usage_; }
+    MemoryType GetMemoryType() const override { return type_; }
+    const std::vector<std::string>& GetTags() const override { return tags_; }
+
+    void SetUsage(size_t usage) { usage_ = usage; }
+
+   private:
+    UUID id_;
+    size_t capacity_;
+    size_t usage_;
+    MemoryType type_;
+    std::vector<std::string> tags_;
+};
+}  // namespace
+
+TEST_F(ClientMetricsTest, TierMetricEmptyTest) {
+    TierMetric metric;
+
+    std::string summary = metric.summary_metrics();
+    EXPECT_TRUE(summary.find("No tiers registered") != std::string::npos);
+
+    // No tier registered -> no tier series serialized.
+    std::string serialized;
+    metric.serialize(serialized);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_tier") == std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, TierMetricRegisterAndCountTest) {
+    TierMetric metric;
+    const UUID tier_id{1, 2};
+    const std::string label = "tier_1_2";
+    auto tier =
+        std::make_shared<StubStatsTier>(tier_id, /*capacity=*/1024,
+                                        /*usage=*/256, MemoryType::DRAM);
+
+    metric.RegisterTier(tier_id, label, tier, /*priority=*/10);
+
+    std::array<std::string, 1> label_array = {label};
+    EXPECT_EQ(metric.capacity_bytes.value(label_array), 1024);
+    // Usage is captured at registration and only refreshed on read.
+    EXPECT_EQ(metric.used_bytes.value(label_array), 256);
+    EXPECT_EQ(metric.key_count.value(label_array), 0);
+
+    // Key count follows replica add/remove.
+    metric.OnReplicaAdded(tier_id);
+    metric.OnReplicaAdded(tier_id);
+    metric.OnReplicaAdded(tier_id);
+    metric.OnReplicaRemoved(tier_id);
+    EXPECT_EQ(metric.key_count.value(label_array), 2);
+
+    // Usage is refreshed from the tier only on serialize/summary reads.
+    tier->SetUsage(512);
+    EXPECT_EQ(metric.used_bytes.value(label_array), 256);  // stale before read
+    std::string serialized;
+    metric.serialize(serialized);
+    EXPECT_EQ(metric.used_bytes.value(label_array), 512);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_tier_key_count") !=
+                std::string::npos);
+
+    // Summary contains label, memory type, priority and counters.
+    std::string summary = metric.summary_metrics();
+    EXPECT_TRUE(summary.find(label) != std::string::npos);
+    EXPECT_TRUE(summary.find("DRAM") != std::string::npos);
+    EXPECT_TRUE(summary.find("priority=10") != std::string::npos);
+    EXPECT_TRUE(summary.find("keys=2") != std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, TierMetricUnregisteredTierTest) {
+    TierMetric metric;
+
+    // Hooks on unknown tiers must not crash nor create series.
+    metric.OnReplicaAdded(UUID{9, 9});
+    metric.OnReplicaRemoved(UUID{9, 9});
+
+    std::string serialized;
+    metric.serialize(serialized);
+    EXPECT_TRUE(serialized.find("mooncake_p2p_tier") == std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, TierMetricExpiredTierKeepsLastUsageTest) {
+    TierMetric metric;
+    const UUID tier_id{3, 4};
+    const std::string label = "tier_3_4";
+    auto tier =
+        std::make_shared<StubStatsTier>(tier_id, /*capacity=*/2048,
+                                        /*usage=*/100, MemoryType::NVME);
+    metric.RegisterTier(tier_id, label, tier, /*priority=*/5);
+
+    tier->SetUsage(999);
+    std::string serialized;
+    metric.serialize(serialized);  // refresh while the tier is alive
+
+    tier.reset();                  // destroy the tier
+    metric.serialize(serialized);  // must not crash on the expired weak_ptr
+
+    std::array<std::string, 1> label_array = {label};
+    EXPECT_EQ(metric.used_bytes.value(label_array), 999);  // last known value
+}
+
+TEST_F(ClientMetricsTest, TierMetricDuplicateRegistrationTest) {
+    TierMetric metric;
+    const UUID tier_id{5, 6};
+    auto tier = std::make_shared<StubStatsTier>(tier_id, /*capacity=*/1024,
+                                                /*usage=*/0, MemoryType::DRAM);
+
+    metric.RegisterTier(tier_id, "tier_5_6", tier, /*priority=*/1);
+    metric.RegisterTier(tier_id, "tier_5_6_dup", tier, /*priority=*/1);
+
+    // The duplicate registration is rejected; only the first label exists.
+    std::string summary = metric.summary_metrics();
+    EXPECT_TRUE(summary.find("tier_5_6") != std::string::npos);
+    EXPECT_TRUE(summary.find("tier_5_6_dup") == std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, P2PClientMetricTierSectionTest) {
+    P2PClientMetric metrics;
+
+    std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("=== P2P Tier Metrics ===") != std::string::npos);
+    EXPECT_TRUE(summary.find("No tiers registered") != std::string::npos);
+
+    std::string serialized;
+    metrics.serialize(serialized);  // must not crash with empty tier metric
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/event_driven_scheduler_test.cpp
+++ b/mooncake-store/tests/event_driven_scheduler_test.cpp
@@ -366,8 +366,9 @@ TEST_F(EventDrivenSchedulerTest, TierMetricsCountOffloadKeys) {
     // scheduler threads regardless of local destruction order.
     auto tier_metric = std::make_shared<TierMetric>();
     TieredBackend backend;
-    ASSERT_TRUE(backend.Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
-                             nullptr, nullptr, tier_metric)
+    ASSERT_TRUE(backend
+                    .Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
+                          nullptr, nullptr, tier_metric)
                     .has_value());
     const UUID fast = FastTier(backend);
     const UUID slow = SlowTier(backend);
@@ -397,8 +398,9 @@ TEST_F(EventDrivenSchedulerTest, TierMetricsCountOnboardKeys) {
     // scheduler threads regardless of local destruction order.
     auto tier_metric = std::make_shared<TierMetric>();
     TieredBackend backend;
-    ASSERT_TRUE(backend.Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
-                             nullptr, nullptr, tier_metric)
+    ASSERT_TRUE(backend
+                    .Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
+                          nullptr, nullptr, tier_metric)
                     .has_value());
     const UUID fast = FastTier(backend);
     const UUID slow = SlowTier(backend);
@@ -428,10 +430,11 @@ TEST_F(EventDrivenSchedulerTest, TierMetricsCountEvictedKeys) {
     // scheduler threads regardless of local destruction order.
     auto tier_metric = std::make_shared<TierMetric>();
     TieredBackend backend;
-    ASSERT_TRUE(backend.Init(MakeConfig(4 * kMB, 64 * kMB,
-                                        /*evict_wm_high=*/0.50,
-                                        /*evict_wm_low=*/0.40),
-                             nullptr, nullptr, nullptr, nullptr, tier_metric)
+    ASSERT_TRUE(backend
+                    .Init(MakeConfig(4 * kMB, 64 * kMB,
+                                     /*evict_wm_high=*/0.50,
+                                     /*evict_wm_low=*/0.40),
+                          nullptr, nullptr, nullptr, nullptr, tier_metric)
                     .has_value());
     const UUID fast = FastTier(backend);
 

--- a/mooncake-store/tests/event_driven_scheduler_test.cpp
+++ b/mooncake-store/tests/event_driven_scheduler_test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <json/json.h>
 
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <limits>
@@ -9,6 +10,7 @@
 #include <thread>
 #include <vector>
 
+#include "p2p_client_metric.h"
 #include "tiered_cache/tiered_backend.h"
 #include "tiered_cache/tiers/cache_tier.h"  // TempDRAMBuffer
 #include "utils/common.h"                   // InitTieredBackendForTest
@@ -88,6 +90,15 @@ class EventDrivenSchedulerTest : public ::testing::Test {
             }
         }
         return 0;
+    }
+
+    static std::string TierLabel(const TieredBackend& b, UUID tier) {
+        for (const auto& v : b.GetTierViews()) {
+            if (v.id == tier) {
+                return v.GetName();
+            }
+        }
+        return {};
     }
 
     static bool Put(TieredBackend& b, const std::string& key, UUID tier,
@@ -344,6 +355,104 @@ TEST_F(EventDrivenSchedulerTest, StopUnderLoadIsClean) {
     // backend goes out of scope here -> TieredBackend::Stop()/dtor ->
     // scheduler Stop() drains the pool and joins the evict thread cleanly.
     SUCCEED();
+}
+
+// ============================================================================
+// Tier movement metric tests (event_driven path only)
+// ============================================================================
+
+TEST_F(EventDrivenSchedulerTest, TierMetricsCountOffloadKeys) {
+    // Shared ownership: TieredBackend keeps the metric alive for its
+    // scheduler threads regardless of local destruction order.
+    auto tier_metric = std::make_shared<TierMetric>();
+    TieredBackend backend;
+    ASSERT_TRUE(backend.Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
+                             nullptr, nullptr, tier_metric)
+                    .has_value());
+    const UUID fast = FastTier(backend);
+    const UUID slow = SlowTier(backend);
+
+    ASSERT_TRUE(Put(backend, "k", fast, 64 * 1024));
+    // Exactly 3 accesses: freq crosses the offload threshold (>2) on the 3rd,
+    // so exactly one offload movement is ever enqueued for this key.
+    for (int i = 0; i < 3; ++i) {
+        Access(backend, "k", fast);
+    }
+
+    std::array<std::string, 1> fast_label = {TierLabel(backend, fast)};
+    std::array<std::string, 1> slow_label = {TierLabel(backend, slow)};
+    // Wait on the counter itself: it is incremented right after the movement
+    // succeeds, so no state check can race ahead of the accounting.
+    EXPECT_TRUE(WaitUntil(
+        [&] { return tier_metric->offloaded_keys.value(fast_label) == 1; },
+        5000));
+    EXPECT_TRUE(backend.Exist("k", slow));
+    EXPECT_EQ(tier_metric->onboarded_keys.value(fast_label), 0);
+    EXPECT_EQ(tier_metric->offloaded_keys.value(slow_label), 0);
+    EXPECT_EQ(tier_metric->evicted_keys.value(fast_label), 0);
+}
+
+TEST_F(EventDrivenSchedulerTest, TierMetricsCountOnboardKeys) {
+    // Shared ownership: TieredBackend keeps the metric alive for its
+    // scheduler threads regardless of local destruction order.
+    auto tier_metric = std::make_shared<TierMetric>();
+    TieredBackend backend;
+    ASSERT_TRUE(backend.Init(MakeConfig(16 * kMB, 64 * kMB), nullptr, nullptr,
+                             nullptr, nullptr, tier_metric)
+                    .has_value());
+    const UUID fast = FastTier(backend);
+    const UUID slow = SlowTier(backend);
+
+    ASSERT_TRUE(Put(backend, "k", slow, 64 * 1024));
+    // Exactly 3 accesses: freq crosses the onboard threshold (>2) on the 3rd,
+    // so exactly one onboard movement is ever enqueued for this key.
+    for (int i = 0; i < 3; ++i) {
+        Access(backend, "k", slow);
+    }
+
+    std::array<std::string, 1> fast_label = {TierLabel(backend, fast)};
+    std::array<std::string, 1> slow_label = {TierLabel(backend, slow)};
+    // Wait on the counter itself (incremented right after the movement
+    // succeeds), then verify the migration's state effects.
+    EXPECT_TRUE(WaitUntil(
+        [&] { return tier_metric->onboarded_keys.value(slow_label) == 1; },
+        5000));
+    EXPECT_TRUE(backend.Exist("k", fast));
+    EXPECT_FALSE(backend.Exist("k", slow));
+    EXPECT_EQ(tier_metric->offloaded_keys.value(slow_label), 0);
+    EXPECT_EQ(tier_metric->onboarded_keys.value(fast_label), 0);
+}
+
+TEST_F(EventDrivenSchedulerTest, TierMetricsCountEvictedKeys) {
+    // Shared ownership: TieredBackend keeps the metric alive for its
+    // scheduler threads regardless of local destruction order.
+    auto tier_metric = std::make_shared<TierMetric>();
+    TieredBackend backend;
+    ASSERT_TRUE(backend.Init(MakeConfig(4 * kMB, 64 * kMB,
+                                        /*evict_wm_high=*/0.50,
+                                        /*evict_wm_low=*/0.40),
+                             nullptr, nullptr, nullptr, nullptr, tier_metric)
+                    .has_value());
+    const UUID fast = FastTier(backend);
+
+    std::vector<std::string> keys;
+    for (int i = 0; i < 14; ++i) {
+        const std::string k = "e" + std::to_string(i);
+        if (Put(backend, k, fast, 256 * 1024)) {
+            keys.push_back(k);
+        }
+    }
+    ASSERT_FALSE(keys.empty());
+
+    std::array<std::string, 1> fast_label = {TierLabel(backend, fast)};
+    // Wait on the counter itself: it is incremented right after each
+    // successful eviction, ahead of any Exist-based state observation.
+    EXPECT_TRUE(WaitUntil(
+        [&] { return tier_metric->evicted_keys.value(fast_label) >= 1; },
+        5000));
+    // Eviction never moves data between tiers.
+    EXPECT_EQ(tier_metric->offloaded_keys.value(fast_label), 0);
+    EXPECT_EQ(tier_metric->onboarded_keys.value(fast_label), 0);
 }
 
 }  // namespace

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1,6 +1,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <json/json.h>
+#include <array>
 #include <fstream>
 #include <filesystem>
 #include <cstdlib>
@@ -11,6 +12,7 @@
 #include "acl/acl.h"
 #endif
 
+#include "p2p_client_metric.h"
 #include "tiered_cache/tiered_backend.h"
 #include "tiered_cache/tiers/cache_tier.h"
 #include "utils/common.h"
@@ -1522,6 +1524,122 @@ TEST_F(TieredBackendTest, CapacityAsPlainInteger) {
     auto tier_views = backend.GetTierViews();
     ASSERT_EQ(tier_views.size(), 1u);
     EXPECT_EQ(tier_views[0].capacity, 512ULL * 1024 * 1024);
+}
+
+// ============================================================================
+// TierMetric Integration Tests
+// ============================================================================
+
+// Init registers every created tier into the TierMetric, and Commit/Delete
+// maintain the per-tier key count; usage is refreshed on metrics reads.
+TEST_F(TieredBackendTest, TierMetricRegistrationAndKeyCount) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    TierMetric tier_metric;
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr,
+                          /*tier_metric=*/&tier_metric)
+                    .has_value());
+
+    // The tier is registered under its segment-name label.
+    auto views = backend.GetTierViews();
+    ASSERT_EQ(views.size(), 1u);
+    const std::string label = "tier_" + std::to_string(views[0].id.first) +
+                              "_" + std::to_string(views[0].id.second);
+    std::array<std::string, 1> label_array = {label};
+    EXPECT_EQ(tier_metric.capacity_bytes.value(label_array),
+              static_cast<int64_t>(views[0].capacity));
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
+
+    // Commit adds the key to the tier's count.
+    auto test_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle_result =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
+    ASSERT_TRUE(handle_result.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle_result.value()).has_value());
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 1);
+
+    // A metrics read refreshes usage from the tier.
+    std::string serialized;
+    tier_metric.serialize(serialized);
+    EXPECT_GE(tier_metric.used_bytes.value(label_array),
+              static_cast<int64_t>(SMALL_DATA_SIZE));
+
+    // Re-committing the same key on the same tier replaces the replica and
+    // keeps the count unchanged.
+    auto handle2_result =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
+    ASSERT_TRUE(handle2_result.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle2_result.value()).has_value());
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 1);
+
+    // Deleting the key removes it from the tier's count.
+    ASSERT_TRUE(backend.Delete("key1").has_value());
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
+}
+
+// RemoveAll drains every replica and resets all per-tier key counts.
+TEST_F(TieredBackendTest, TierMetricRemoveAllResetsKeyCount) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    TierMetric tier_metric;
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr,
+                          /*tier_metric=*/&tier_metric)
+                    .has_value());
+
+    auto views = backend.GetTierViews();
+    ASSERT_EQ(views.size(), 1u);
+    std::array<std::string, 1> label_array = {
+        "tier_" + std::to_string(views[0].id.first) + "_" +
+        std::to_string(views[0].id.second)};
+
+    auto buffer1 = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle1 = AllocateAndWrite(backend, SMALL_DATA_SIZE, buffer1.get());
+    ASSERT_TRUE(handle1.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle1.value()).has_value());
+
+    auto buffer2 = CreateTestBuffer(MEDIUM_DATA_SIZE);
+    auto handle2 = AllocateAndWrite(backend, MEDIUM_DATA_SIZE, buffer2.get());
+    ASSERT_TRUE(handle2.has_value());
+    ASSERT_TRUE(backend.Commit("key2", handle2.value()).has_value());
+
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 2);
+
+    auto removed = backend.RemoveAll();
+    ASSERT_TRUE(removed.has_value());
+    EXPECT_EQ(removed.value(), 2);
+    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1668,10 +1668,11 @@ TEST_F(TieredBackendTest, TierMetricCountsStorageSelfEviction) {
 
     auto tier_metric = std::make_shared<TierMetric>();
     TieredBackend backend;
-    ASSERT_TRUE(backend.Init(config, /*engine=*/nullptr,
-                             /*add_replica_callback=*/nullptr,
-                             /*remove_replica_callback=*/nullptr,
-                             /*segment_sync_callback=*/nullptr, tier_metric)
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr, tier_metric)
                     .has_value());
 
     auto views = backend.GetTierViews();
@@ -1681,8 +1682,7 @@ TEST_F(TieredBackendTest, TierMetricCountsStorageSelfEviction) {
     // Fill the 20KB tier with twenty committed 1KB keys.
     for (int i = 0; i < 20; ++i) {
         auto test_buffer = CreateTestBuffer(1024);
-        auto handle_result =
-            AllocateAndWrite(backend, 1024, test_buffer.get());
+        auto handle_result = AllocateAndWrite(backend, 1024, test_buffer.get());
         ASSERT_TRUE(handle_result.has_value());
         const std::string key = "key_" + std::to_string(i);
         ASSERT_TRUE(backend.Commit(key, handle_result.value()).has_value());

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1547,13 +1547,13 @@ TEST_F(TieredBackendTest, TierMetricRegistrationAndKeyCount) {
     ASSERT_TRUE(parseJsonString(json_config_str, config));
 
     TieredBackend backend;
-    TierMetric tier_metric;
+    auto tier_metric = std::make_shared<TierMetric>();
     ASSERT_TRUE(backend
                     .Init(config, /*engine=*/nullptr,
                           /*add_replica_callback=*/nullptr,
                           /*remove_replica_callback=*/nullptr,
                           /*segment_sync_callback=*/nullptr,
-                          /*tier_metric=*/&tier_metric)
+                          /*tier_metric=*/tier_metric)
                     .has_value());
 
     // The tier is registered under its segment-name label.
@@ -1562,9 +1562,9 @@ TEST_F(TieredBackendTest, TierMetricRegistrationAndKeyCount) {
     const std::string label = "tier_" + std::to_string(views[0].id.first) +
                               "_" + std::to_string(views[0].id.second);
     std::array<std::string, 1> label_array = {label};
-    EXPECT_EQ(tier_metric.capacity_bytes.value(label_array),
+    EXPECT_EQ(tier_metric->capacity_bytes.value(label_array),
               static_cast<int64_t>(views[0].capacity));
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 0);
 
     // Commit adds the key to the tier's count.
     auto test_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
@@ -1572,12 +1572,12 @@ TEST_F(TieredBackendTest, TierMetricRegistrationAndKeyCount) {
         AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
     ASSERT_TRUE(handle_result.has_value());
     ASSERT_TRUE(backend.Commit("key1", handle_result.value()).has_value());
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 1);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 1);
 
     // A metrics read refreshes usage from the tier.
     std::string serialized;
-    tier_metric.serialize(serialized);
-    EXPECT_GE(tier_metric.used_bytes.value(label_array),
+    tier_metric->serialize(serialized);
+    EXPECT_GE(tier_metric->used_bytes.value(label_array),
               static_cast<int64_t>(SMALL_DATA_SIZE));
 
     // Re-committing the same key on the same tier replaces the replica and
@@ -1586,11 +1586,11 @@ TEST_F(TieredBackendTest, TierMetricRegistrationAndKeyCount) {
         AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
     ASSERT_TRUE(handle2_result.has_value());
     ASSERT_TRUE(backend.Commit("key1", handle2_result.value()).has_value());
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 1);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 1);
 
     // Deleting the key removes it from the tier's count.
     ASSERT_TRUE(backend.Delete("key1").has_value());
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 0);
 }
 
 // RemoveAll drains every replica and resets all per-tier key counts.
@@ -1609,13 +1609,13 @@ TEST_F(TieredBackendTest, TierMetricRemoveAllResetsKeyCount) {
     ASSERT_TRUE(parseJsonString(json_config_str, config));
 
     TieredBackend backend;
-    TierMetric tier_metric;
+    auto tier_metric = std::make_shared<TierMetric>();
     ASSERT_TRUE(backend
                     .Init(config, /*engine=*/nullptr,
                           /*add_replica_callback=*/nullptr,
                           /*remove_replica_callback=*/nullptr,
                           /*segment_sync_callback=*/nullptr,
-                          /*tier_metric=*/&tier_metric)
+                          /*tier_metric=*/tier_metric)
                     .has_value());
 
     auto views = backend.GetTierViews();
@@ -1634,12 +1634,78 @@ TEST_F(TieredBackendTest, TierMetricRemoveAllResetsKeyCount) {
     ASSERT_TRUE(handle2.has_value());
     ASSERT_TRUE(backend.Commit("key2", handle2.value()).has_value());
 
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 2);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 2);
 
     auto removed = backend.RemoveAll();
     ASSERT_TRUE(removed.has_value());
     EXPECT_EQ(removed.value(), 2);
-    EXPECT_EQ(tier_metric.key_count.value(label_array), 0);
+    EXPECT_EQ(tier_metric->key_count.value(label_array), 0);
+}
+
+// Storage-tier capacity self-eviction (bucket eviction triggered inside
+// StorageTier::Allocate) also counts toward evicted_keys.
+TEST_F(TieredBackendTest, TierMetricCountsStorageSelfEviction) {
+    namespace fs = std::filesystem;
+    const std::string storage_path = "/tmp/mooncake_test_metric_eviction";
+    fs::remove_all(storage_path);
+    fs::create_directories(storage_path);
+    setenv("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+           "bucket_storage_backend", 1);
+    setenv("MOONCAKE_OFFLOAD_FILE_STORAGE_PATH", storage_path.c_str(), 1);
+
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "STORAGE",
+                "capacity": 20480,
+                "priority": 5,
+                "tags": ["ssd"]
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    auto tier_metric = std::make_shared<TierMetric>();
+    TieredBackend backend;
+    ASSERT_TRUE(backend.Init(config, /*engine=*/nullptr,
+                             /*add_replica_callback=*/nullptr,
+                             /*remove_replica_callback=*/nullptr,
+                             /*segment_sync_callback=*/nullptr, tier_metric)
+                    .has_value());
+
+    auto views = backend.GetTierViews();
+    ASSERT_EQ(views.size(), 1u);
+    std::array<std::string, 1> label_array = {views[0].GetName()};
+
+    // Fill the 20KB tier with twenty committed 1KB keys.
+    for (int i = 0; i < 20; ++i) {
+        auto test_buffer = CreateTestBuffer(1024);
+        auto handle_result =
+            AllocateAndWrite(backend, 1024, test_buffer.get());
+        ASSERT_TRUE(handle_result.has_value());
+        const std::string key = "key_" + std::to_string(i);
+        ASSERT_TRUE(backend.Commit(key, handle_result.value()).has_value());
+    }
+    ASSERT_EQ(tier_metric->key_count.value(label_array), 20);
+
+    // Persist committed data into buckets so self-eviction has victims.
+    auto tier = backend.GetTier(views[0].id);
+    ASSERT_NE(tier, nullptr);
+    ASSERT_TRUE(const_cast<CacheTier*>(tier)->Flush().has_value());
+
+    // Exceeds capacity -> StorageTier::Allocate triggers bucket eviction.
+    auto alloc_result = backend.Allocate(5 * 1024);
+    ASSERT_TRUE(alloc_result.has_value())
+        << "Should succeed after automatic eviction";
+
+    EXPECT_GE(tier_metric->evicted_keys.value(label_array), 1);
+    // Every evicted key leaves the tier key count exactly once.
+    EXPECT_EQ(tier_metric->key_count.value(label_array) +
+                  tier_metric->evicted_keys.value(label_array),
+              20);
+
+    fs::remove_all(storage_path);
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)