### PR TITLE
[Store] Give LOCAL_DISK segments an unmount half, and let the offload RPC honour connect timeouts

### DIFF
--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -442,3 +442,51 @@ curl -X POST http://localhost:8080/api/unmount \
   -d '{"segment_ids": ["00000000-0000-0000-0000-000000000002"],
        "grace_period_seconds": 30}'
 ```
+
+### `/api/unmount_local_disk`
+Deregister this store's SSD offload tier from the master before the process
+goes away. Intended for a shutdown hook.
+
+The master stops naming this store as the owner of the keys it offloaded, so a
+reader gets a clean miss instead of a peer that is about to disappear. Without
+this, a `LOCAL_DISK` segment leaves the master only when the client expires —
+one `client_ttl` after the store stops pinging — and reads that pick up the
+stale owner in that window block on the connect retries (see
+`MC_RPC_CONNECT_TIMEOUT_MS`) before missing.
+
+The call then holds for `grace_period_seconds` before returning. Unlike a memory
+replica, which the NIC serves without help from the store process, a disk
+replica is read and pushed by that process, so it has to stay alive for the
+reads the master handed out before the deregistration. Offloading is stopped for
+good when this is called; the store is expected to exit afterwards.
+
+Returns success and does nothing when SSD offload is not enabled on this store.
+Safe to call more than once.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "grace_period_seconds": 30
+}
+```
+
+`grace_period_seconds` is optional and defaults to `0`, which returns as soon as
+the master has dropped the segment.
+
+**Success Response**:
+```json
+{
+  "status": "success"
+}
+```
+
+**Example** — as a Kubernetes preStop hook, with a
+`terminationGracePeriodSeconds` longer than the grace period:
+```bash
+curl -X POST http://localhost:8080/api/unmount_local_disk \
+  -H "Content-Type: application/json" \
+  -d '{"grace_period_seconds": 30}'
+```

--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -440,3 +440,51 @@ curl -X POST http://localhost:8080/api/unmount \
   -d '{"segment_ids": ["00000000-0000-0000-0000-000000000002"],
        "grace_period_seconds": 30}'
 ```
+
+### `/api/unmount_local_disk`
+Deregister this store's SSD offload tier from the master before the process
+goes away. Intended for a shutdown hook.
+
+The master stops naming this store as the owner of the keys it offloaded, so a
+reader gets a clean miss instead of a peer that is about to disappear. Without
+this, a `LOCAL_DISK` segment leaves the master only when the client expires —
+one `client_ttl` after the store stops pinging — and reads that pick up the
+stale owner in that window block on the connect retries (see
+`MC_RPC_CONNECT_TIMEOUT_MS`) before missing.
+
+The call then holds for `grace_period_seconds` before returning. Unlike a memory
+replica, which the NIC serves without help from the store process, a disk
+replica is read and pushed by that process, so it has to stay alive for the
+reads the master handed out before the deregistration. Offloading is stopped for
+good when this is called; the store is expected to exit afterwards.
+
+Returns success and does nothing when SSD offload is not enabled on this store.
+Safe to call more than once.
+
+**Method**: `POST`
+**Content-Type**: `application/json`
+
+**Request Body**:
+```json
+{
+  "grace_period_seconds": 30
+}
+```
+
+`grace_period_seconds` is optional and defaults to `0`, which returns as soon as
+the master has dropped the segment.
+
+**Success Response**:
+```json
+{
+  "status": "success"
+}
+```
+
+**Example** — as a Kubernetes preStop hook, with a
+`terminationGracePeriodSeconds` longer than the grace period:
+```bash
+curl -X POST http://localhost:8080/api/unmount_local_disk \
+  -H "Content-Type: application/json" \
+  -d '{"grace_period_seconds": 30}'
+```

--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -474,7 +474,10 @@ Safe to call more than once.
 ```
 
 `grace_period_seconds` is optional and defaults to `0`, which returns as soon as
-the master has dropped the segment.
+the master has dropped the segment. Must be a non-negative integer no greater
+than 3600 (1 hour); a malformed body or an out-of-range value gets a `400`
+without touching the store, so a mistake here (seconds where milliseconds were
+meant, say) cannot block a preStop hook for hours.
 
 **Success Response**:
 ```json

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1089,8 +1089,8 @@ The following `MC_*` variables are read directly by the engine/client at runtime
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MC_RPC_PROTOCOL` | `tcp` | RPC transport protocol between master and clients: `tcp` or `rdma` |
-| `MC_RPC_TIMEOUT_MS` | `30000` | Per-request deadline (ms) for all client→master RPCs. Applies uniformly to every RPC method. A negative value disables the timeout. On expiry the call returns `RPC_TIMEOUT` |
-| `MC_RPC_CONNECT_TIMEOUT_MS` | `30000` | Connection-establishment timeout (ms) for the master RPC client |
+| `MC_RPC_TIMEOUT_MS` | `30000` | Per-request deadline (ms) for client→master RPCs and for store→store SSD offload reads. Applies uniformly to every RPC method. A negative value disables the timeout. On expiry the call returns `RPC_TIMEOUT` |
+| `MC_RPC_CONNECT_TIMEOUT_MS` | `30000` | Connection-establishment timeout (ms) for the master RPC client and for the store→store SSD offload client. Worth lowering when SSD offload is enabled: an offload read that picks a store which has gone away without deregistering waits this long on each of 3 connect attempts (91 s at the default) before returning a clean miss |
 | `MC_RPC_CLIENT_IO_THREADS` | `min(16, online CPU count)`, minimum `1` | Fallback number of threads and `io_context` instances for each component's RPC client I/O pool. A positive integer overrides the default; invalid values and `0` use the default |
 | `MC_STORE_RPC_CLIENT_IO_THREADS` | `MC_RPC_CLIENT_IO_THREADS` | Store/Master client RPC I/O pool size. This pool is isolated from Transfer Engine traffic. Invalid values and `0` use the fallback |
 | `MC_TE_RPC_CLIENT_IO_THREADS` | `MC_RPC_CLIENT_IO_THREADS` | Transfer Engine and TENT client RPC I/O pool size. This pool is isolated from Store/Master traffic. Invalid values and `0` use the fallback |

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -969,8 +969,8 @@ The following `MC_*` variables are read directly by the engine/client at runtime
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MC_RPC_PROTOCOL` | `tcp` | RPC transport protocol between master and clients: `tcp` or `rdma` |
-| `MC_RPC_TIMEOUT_MS` | `30000` | Per-request deadline (ms) for all client→master RPCs. Applies uniformly to every RPC method. A negative value disables the timeout. On expiry the call returns `RPC_TIMEOUT` |
-| `MC_RPC_CONNECT_TIMEOUT_MS` | `30000` | Connection-establishment timeout (ms) for the master RPC client |
+| `MC_RPC_TIMEOUT_MS` | `30000` | Per-request deadline (ms) for client→master RPCs and for store→store SSD offload reads. Applies uniformly to every RPC method. A negative value disables the timeout. On expiry the call returns `RPC_TIMEOUT` |
+| `MC_RPC_CONNECT_TIMEOUT_MS` | `30000` | Connection-establishment timeout (ms) for the master RPC client and for the store→store SSD offload client. Worth lowering when SSD offload is enabled: an offload read that picks a store which has gone away without deregistering waits this long on each of 3 connect attempts (91 s at the default) before returning a clean miss |
 | `MC_RPC_CLIENT_IO_THREADS` | `min(16, online CPU count)`, minimum `1` | Fallback number of threads and `io_context` instances for each component's RPC client I/O pool. A positive integer overrides the default; invalid values and `0` use the default |
 | `MC_STORE_RPC_CLIENT_IO_THREADS` | `MC_RPC_CLIENT_IO_THREADS` | Store/Master client RPC I/O pool size. This pool is isolated from Transfer Engine traffic. Invalid values and `0` use the fallback |
 | `MC_TE_RPC_CLIENT_IO_THREADS` | `MC_RPC_CLIENT_IO_THREADS` | Transfer Engine and TENT client RPC I/O pool size. This pool is isolated from Store/Master traffic. Invalid values and `0` use the fallback |

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -506,6 +506,16 @@ class MooncakeStorePyWrapper {
                                                   grace_period_seconds);
     }
 
+    int unmount_local_disk_segment(uint64_t grace_period_seconds = 0) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_local_disk_segment requires RealClient";
+            return -1;
+        }
+        py::gil_scoped_release release;
+        return real_client->drainLocalDiskSegment(grace_period_seconds);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -2295,6 +2305,9 @@ PYBIND11_MODULE(store, m) {
         .def("unmount_and_free_segment",
              &MooncakeStorePyWrapper::unmount_and_free_segment,
              py::arg("segment_ids"), py::arg("grace_period_seconds") = 0)
+        .def("unmount_local_disk_segment",
+             &MooncakeStorePyWrapper::unmount_local_disk_segment,
+             py::arg("grace_period_seconds") = 0)
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;

--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -512,6 +512,16 @@ class MooncakeStorePyWrapper {
                                                   grace_period_seconds);
     }
 
+    int unmount_local_disk_segment(uint64_t grace_period_seconds = 0) {
+        auto real_client = std::dynamic_pointer_cast<RealClient>(store_);
+        if (!real_client) {
+            LOG(ERROR) << "unmount_local_disk_segment requires RealClient";
+            return -1;
+        }
+        py::gil_scoped_release release;
+        return real_client->drainLocalDiskSegment(grace_period_seconds);
+    }
+
     std::string get_tp_key_name(const std::string &base_key, int rank) const {
         return base_key + "_tp_" + std::to_string(rank);
     }
@@ -2301,6 +2311,9 @@ PYBIND11_MODULE(store, m) {
         .def("unmount_and_free_segment",
              &MooncakeStorePyWrapper::unmount_and_free_segment,
              py::arg("segment_ids"), py::arg("grace_period_seconds") = 0)
+        .def("unmount_local_disk_segment",
+             &MooncakeStorePyWrapper::unmount_local_disk_segment,
+             py::arg("grace_period_seconds") = 0)
         .def("alloc_from_mem_pool",
              [](MooncakeStorePyWrapper &self, size_t size) {
                  py::gil_scoped_release release;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -473,6 +473,15 @@ class Client {
     tl::expected<void, ErrorCode> MountLocalDiskSegment(bool enable_offloading);
 
     /**
+     * @brief Deregisters this client's local disk segment from the master.
+     * Idempotent. The master drops the LOCAL_DISK replicas this client owns, so
+     * readers stop being handed a disk whose owner is about to stop serving.
+     * Callers must stop offloading first, otherwise the storage heartbeat
+     * re-mounts the segment on its next tick.
+     */
+    tl::expected<void, ErrorCode> UnmountLocalDiskSegment();
+
+    /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -425,6 +425,15 @@ class Client {
     tl::expected<void, ErrorCode> MountLocalDiskSegment(bool enable_offloading);
 
     /**
+     * @brief Deregisters this client's local disk segment from the master.
+     * Idempotent. The master drops the LOCAL_DISK replicas this client owns, so
+     * readers stop being handed a disk whose owner is about to stop serving.
+     * Callers must stop offloading first, otherwise the storage heartbeat
+     * re-mounts the segment on its next tick.
+     */
+    tl::expected<void, ErrorCode> UnmountLocalDiskSegment();
+
+    /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -21,6 +21,25 @@ class FileStorage {
     void RemoveAll();
 
     /**
+     * @brief Deregisters this store's disk tier from the master, then waits out
+     * a grace period so offload reads already in flight can finish.
+     *
+     * Meant for a shutdown hook that runs before the process is signalled. Once
+     * this returns, the master no longer names this store as the owner of any
+     * offloaded key, so a reader gets a clean miss instead of a peer that is
+     * about to disappear. Unlike a memory replica, which the NIC serves without
+     * the process, a disk replica is read and pushed by this process -- hence
+     * the grace period rather than an immediate exit.
+     *
+     * Latches offloading off first: the heartbeat re-mounts the segment
+     * whenever the master answers SEGMENT_NOT_FOUND, which would otherwise
+     * undo this within one heartbeat interval. The latch is not reversible on
+     * success; the process is expected to exit.
+     */
+    tl::expected<void, ErrorCode> DrainLocalDiskSegment(
+        uint64_t grace_period_ms);
+
+    /**
      * @brief Result of BatchGet operation containing batch_id and buffer
      * pointers.
      */
@@ -174,6 +193,9 @@ class FileStorage {
     std::thread client_buffer_gc_thread_;
     std::future<void> rescan_future_;
     std::atomic<bool> metadata_resync_pending_{false};
+    // Set by DrainLocalDiskSegment. Stops the heartbeat, which would otherwise
+    // re-mount the segment the drain just deregistered.
+    std::atomic<bool> draining_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -21,6 +21,30 @@ class FileStorage {
     void RemoveAll();
 
     /**
+     * @brief Deregisters this store's disk tier from the master, then waits out
+     * a grace period so offload reads already in flight can finish.
+     *
+     * Meant for a shutdown hook that runs before the process is signalled. Once
+     * this returns, the master no longer names this store as the owner of any
+     * offloaded key, so a reader gets a clean miss instead of a peer that is
+     * about to disappear. Unlike a memory replica, which the NIC serves without
+     * the process, a disk replica is read and pushed by this process -- hence
+     * the grace period rather than an immediate exit.
+     *
+     * Latches offloading off first: the heartbeat re-mounts the segment
+     * whenever the master answers SEGMENT_NOT_FOUND, which would otherwise
+     * undo this within one heartbeat interval. The latch and the
+     * deregistration happen under offloading_mutex_, the lock the heartbeat
+     * holds across its master RPCs, so a tick that read the latch before it
+     * was set cannot resume after the deregistration and re-mount: it either
+     * finished before the drain latched, or it re-checks the latch when it
+     * acquires the lock. The latch is not reversible on success; the process
+     * is expected to exit.
+     */
+    tl::expected<void, ErrorCode> DrainLocalDiskSegment(
+        uint64_t grace_period_ms);
+
+    /**
      * @brief Result of BatchGet operation containing batch_id and buffer
      * pointers.
      */
@@ -196,6 +220,13 @@ class FileStorage {
     std::thread client_buffer_gc_thread_;
     std::future<void> rescan_future_;
     std::atomic<bool> metadata_resync_pending_{false};
+    // Set by DrainLocalDiskSegment under offloading_mutex_. Stops the
+    // heartbeat -- which would otherwise re-mount the segment the drain just
+    // deregistered -- and aborts an in-flight metadata rescan. Checked at
+    // Heartbeat entry (fast path, also guards the rescan-retry block) and
+    // again under offloading_mutex_ before the heartbeat RPC, because a tick
+    // parked on that lock passed the entry check before the drain latched.
+    std::atomic<bool> draining_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -46,6 +46,22 @@ inline void MaybeEnableRdmaSocketConfig(SocketConfigVariant& socket_config) {
     }
 }
 
+// Applies the RPC timeout overrides to any mooncake-store RPC client config.
+// Shared by the client->master pool and the store->store offload pool so the
+// two cannot drift. Unset variables leave coro_rpc's built-in 30s defaults in
+// place. A negative request timeout disables the per-request timer.
+template <typename ClientConfig>
+inline void ApplyRpcTimeoutEnvOverrides(ClientConfig& client_config) {
+    if (const char* timeout_ms = std::getenv("MC_RPC_TIMEOUT_MS")) {
+        client_config.request_timeout_duration =
+            std::chrono::milliseconds(std::atoll(timeout_ms));
+    }
+    if (const char* connect_ms = std::getenv("MC_RPC_CONNECT_TIMEOUT_MS")) {
+        client_config.connect_timeout_duration =
+            std::chrono::milliseconds(std::atoll(connect_ms));
+    }
+}
+
 inline RpcClientPool::PoolConfig MakeMasterRpcClientPoolConfig() {
     RpcClientPool::PoolConfig config;
     const char* value = std::getenv("MC_RPC_PROTOCOL");
@@ -53,16 +69,7 @@ inline RpcClientPool::PoolConfig MakeMasterRpcClientPoolConfig() {
         MaybeEnableRdmaSocketConfig(config.client_config.socket_config);
     }
 
-    // Default request and connect timeouts remain coro_rpc's built-in 30s.
-    // A negative request timeout disables the per-request timer.
-    if (const char* timeout_ms = std::getenv("MC_RPC_TIMEOUT_MS")) {
-        config.client_config.request_timeout_duration =
-            std::chrono::milliseconds(std::atoll(timeout_ms));
-    }
-    if (const char* connect_ms = std::getenv("MC_RPC_CONNECT_TIMEOUT_MS")) {
-        config.client_config.connect_timeout_duration =
-            std::chrono::milliseconds(std::atoll(connect_ms));
-    }
+    ApplyRpcTimeoutEnvOverrides(config.client_config);
     return config;
 }
 
@@ -412,6 +419,13 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MountLocalDiskSegment(
         const UUID& client_id, bool enable_offloading);
+
+    /**
+     * @brief Deregisters this client's local disk segment from the master,
+     * dropping the LOCAL_DISK replicas it owns. Idempotent.
+     */
+    [[nodiscard]] tl::expected<void, ErrorCode> UnmountLocalDiskSegment(
+        const UUID& client_id);
 
     /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -95,6 +95,11 @@ class MasterServiceHATest;
 // invalidate a segment allocator via PrepareUnmountSegment WITHOUT the
 // ClearInvalidHandles sweep that MasterService::UnmountSegment performs.
 class MasterServiceProcessingKeyDoubleEraseTest;
+// Friended so the LOCAL_DISK deregistration interleaving tests can run the
+// two halves of UnmountLocalDiskSegment (deregistration, replica sweep)
+// with a competing mount + register serialized between them, pinning the
+// interleaving instead of hoping a thread scheduler produces it.
+class LocalDiskUnmountInterleavingTest;
 }  // namespace test
 namespace benchmarks {
 class BatchEvictBench;
@@ -132,6 +137,7 @@ class MasterService {
     friend class test::MasterScenario;
     // double-erase processing_keys UAF repro (2026-08-03 prod segfault)
     friend class test::MasterServiceProcessingKeyDoubleEraseTest;
+    friend class test::LocalDiskUnmountInterleavingTest;
     friend class MasterSnapshotManager;    // Allow access to internal state for
                                            // snapshot
     friend class ha::MasterSnapshotCodec;  // Allow codec to access private
@@ -713,6 +719,30 @@ class MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
+     * @brief Deregisters a client's file storage segment from the master. This
+     * function is idempotent.
+     *
+     * Drops the client's LOCAL_DISK registration and then its LOCAL_DISK
+     * replicas -- the outcome the client-expiry branch of ClientMonitorFunc
+     * reaches after one client_ttl. Exposing it as an operation lets a store
+     * that is shutting down deregister while it can still serve, instead of
+     * leaving the master advertising it as an owner until the TTL elapses.
+     * Object metadata whose last replica was on that disk is erased, exactly
+     * as on expiry; a store that comes back re-adopts its files through the
+     * MountLocalDiskSegment/NotifyOffloadSuccess path, which recreates them.
+     *
+     * The replica sweep targets exactly this owner (see
+     * ClearLocalDiskHandlesOwnedBy), and the deregistration runs under the
+     * exclusive snapshot_mutex_ so no registration admitted against the old
+     * one can land after the sweep: NotifyOffloadSuccess checks the
+     * registration and writes the replica inside one shared-lock section,
+     * which therefore falls entirely before the deregistration (registered,
+     * then swept) or entirely after (refused with SEGMENT_NOT_FOUND).
+     */
+    auto UnmountLocalDiskSegment(const UUID& client_id)
+        -> tl::expected<void, ErrorCode>;
+
+    /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this
@@ -948,6 +978,16 @@ class MasterService {
     // Caller owns snapshot_mutex_ (shared) while metadata is swept.
     void ClearInvalidHandles(
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients);
+    // Clear completed LOCAL_DISK replicas owned by exactly this client, in
+    // all shards. Owner-targeted on purpose: a liveness-complement sweep
+    // classifies by absence from a point-in-time set, so an owner that
+    // mounts and registers between taking that set and the sweep reaching
+    // its shard would be swept as stale. A predicate on the owner id cannot
+    // misclassify a concurrent mount, whatever the interleaving.
+    void ClearLocalDiskHandlesOwnedBy(const UUID& owner);
+    // Shard walk shared by the two sweeps above; removes completed replicas
+    // matching is_stale, erasing a key when no valid replica remains.
+    void ClearStaleHandles(const std::function<bool(const Replica&)>& is_stale);
 
     std::string FormatTimestamp(
         const std::chrono::system_clock::time_point& tp);
@@ -1861,6 +1901,9 @@ class MasterService {
     StaleHandleCleanupPlan BuildStaleHandleCleanupPlan(
         const ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) const;
+    StaleHandleCleanupPlan BuildStaleHandleCleanupPlan(
+        const ObjectMetadata& metadata,
+        const std::function<bool(const Replica&)>& is_stale) const;
     tl::expected<void, ErrorCode> PersistStaleHandleCleanupForHA(
         const std::string& why, const TenantId& tenant_id,
         const std::string& key, ObjectMetadata& metadata,
@@ -1888,6 +1931,22 @@ class MasterService {
         TenantState& tenant_state, ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
         MetadataShardAccessorRW* shard = nullptr);
+    // Predicate form, so the owner-targeted LOCAL_DISK sweep can reuse the
+    // accounting (quota release, promotion-task cancellation, disk-replica
+    // shard bookkeeping) instead of duplicating it.
+    bool CleanupStaleHandles(
+        TenantState& tenant_state, ObjectMetadata& metadata,
+        const std::function<bool(const Replica&)>& is_stale,
+        MetadataShardAccessorRW* shard = nullptr);
+
+    // True when client_id currently has a LOCAL_DISK registration.
+    // Momentarily takes the LocalSsdManager registry lock, so callers must not
+    // hold it; call before taking a metadata shard lock. Callers that need the
+    // answer to stay true across a later metadata write must hold
+    // snapshot_mutex_ (shared) across both -- UnmountLocalDiskSegment
+    // deregisters the client under the exclusive lock, so the check and the
+    // write cannot straddle a deregistration.
+    bool HasMountedLocalDiskSegment(const UUID& client_id);
 
     // Helper: allocate replicas, create ObjectMetadata, insert into shard,
     // and return descriptor list.  Shared by PutStart and UpsertStart.

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -688,6 +688,22 @@ class MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
+     * @brief Deregisters a client's file storage segment from the master. This
+     * function is idempotent.
+     *
+     * Drops the client's LOCAL_DISK replicas and its segment entry, which is
+     * what the client-expiry branch of ClientMonitorFunc does after one
+     * client_ttl. Exposing it as an operation lets a store that is shutting
+     * down deregister while it can still serve, instead of leaving the master
+     * advertising it as an owner until the TTL elapses. Object metadata whose
+     * last replica was on that disk is erased, exactly as on expiry; a store
+     * that comes back re-adopts its files through the
+     * MountLocalDiskSegment/NotifyOffloadSuccess path, which recreates them.
+     */
+    auto UnmountLocalDiskSegment(const UUID& client_id)
+        -> tl::expected<void, ErrorCode>;
+
+    /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -835,6 +835,14 @@ class RealClient : public PyClient {
     int unmountAndFreeSegment(const std::vector<std::string> &segment_ids,
                               uint64_t grace_period_seconds = 0);
 
+    /**
+     * @brief Deregister this store's disk tier from the master and wait out a
+     * grace period, so a planned shutdown stops being advertised as an owner
+     * of offloaded keys before it stops serving them. No-op when SSD offload
+     * is not enabled on this client.
+     */
+    int drainLocalDiskSegment(uint64_t grace_period_seconds = 0);
+
     struct MountedSegmentRecord {
         void *mmap_base = nullptr;
         size_t size = 0;

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -759,6 +759,14 @@ class RealClient : public PyClient {
     int unmountAndFreeSegment(const std::vector<std::string> &segment_ids,
                               uint64_t grace_period_seconds = 0);
 
+    /**
+     * @brief Deregister this store's disk tier from the master and wait out a
+     * grace period, so a planned shutdown stops being advertised as an owner
+     * of offloaded keys before it stops serving them. No-op when SSD offload
+     * is not enabled on this client.
+     */
+    int drainLocalDiskSegment(uint64_t grace_period_seconds = 0);
+
     struct MountedSegmentRecord {
         void *mmap_base = nullptr;
         size_t size = 0;

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -210,6 +210,9 @@ class WrappedMasterService {
     tl::expected<void, ErrorCode> MountLocalDiskSegment(const UUID& client_id,
                                                         bool enable_offloading);
 
+    tl::expected<void, ErrorCode> UnmountLocalDiskSegment(
+        const UUID& client_id);
+
     tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
     OffloadObjectHeartbeat(const UUID& client_id, bool enable_offloading);
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3280,6 +3280,15 @@ tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(
     return response;
 }
 
+tl::expected<void, ErrorCode> Client::UnmountLocalDiskSegment() {
+    auto response = master_client_.UnmountLocalDiskSegment(client_id_);
+    if (!response) {
+        LOG(ERROR) << "UnmountLocalDiskSegment failed, error code is "
+                   << response.error();
+    }
+    return response;
+}
+
 tl::expected<void, ErrorCode> Client::OffloadObjectHeartbeat(
     bool enable_offloading, std::vector<OffloadTaskItem>& offloading_objects) {
     auto response =

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3742,6 +3742,15 @@ tl::expected<void, ErrorCode> Client::MountLocalDiskSegment(
     return response;
 }
 
+tl::expected<void, ErrorCode> Client::UnmountLocalDiskSegment() {
+    auto response = master_client_.UnmountLocalDiskSegment(client_id_);
+    if (!response) {
+        LOG(ERROR) << "UnmountLocalDiskSegment failed, error code is "
+                   << response.error();
+    }
+    return response;
+}
+
 tl::expected<void, ErrorCode> Client::OffloadObjectHeartbeat(
     bool enable_offloading, std::vector<OffloadTaskItem>& offloading_objects) {
     auto response =

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -790,6 +790,16 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    // A drain deregistered the disk tier on purpose. Skipping the whole tick
+    // matters for the SEGMENT_NOT_FOUND branch below, which would re-mount the
+    // segment and re-register every object; there is also no point taking new
+    // offload work for a store that is leaving. The client TTL is renewed by
+    // Ping on the storage heartbeat thread, not here, so the client stays
+    // alive for its memory segments.
+    if (draining_.load()) {
+        return {};
+    }
+
     // Join previous rescan if completed
     if (rescan_future_.valid() && rescan_future_.wait_for(std::chrono::seconds(
                                       0)) == std::future_status::ready) {
@@ -929,6 +939,33 @@ void FileStorage::RemoveAll() {
         storage_backend_->RemoveAll();
     }
     LOG(INFO) << "FileStorage::RemoveAll: cleared storage backend";
+}
+
+tl::expected<void, ErrorCode> FileStorage::DrainLocalDiskSegment(
+    uint64_t grace_period_ms) {
+    if (client_ == nullptr) {
+        LOG(ERROR) << "client is nullptr";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // Latch before the RPC, so a heartbeat tick that overlaps the
+    // deregistration cannot re-mount the segment behind it.
+    draining_.store(true);
+
+    auto result = client_->UnmountLocalDiskSegment();
+    if (!result) {
+        LOG(ERROR) << "action=drain_local_disk_segment, error="
+                   << result.error();
+        draining_.store(false);
+        return result;
+    }
+
+    LOG(INFO) << "action=drain_local_disk_segment, grace_period_ms="
+              << grace_period_ms;
+    if (grace_period_ms > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(grace_period_ms));
+    }
+    return {};
 }
 
 tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -879,6 +879,16 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    // A drain deregistered the disk tier on purpose. Skipping the whole tick
+    // matters for the SEGMENT_NOT_FOUND branch below, which would re-mount the
+    // segment and re-register every object; there is also no point taking new
+    // offload work for a store that is leaving. The client TTL is renewed by
+    // Ping on the storage heartbeat thread, not here, so the client stays
+    // alive for its memory segments.
+    if (draining_.load()) {
+        return {};
+    }
+
     // Join previous rescan if completed
     if (rescan_future_.valid() && rescan_future_.wait_for(std::chrono::seconds(
                                       0)) == std::future_status::ready) {
@@ -905,6 +915,14 @@ tl::expected<void, ErrorCode> FileStorage::Heartbeat() {
     // === STEP 1: Send heartbeat and get offloading decisions ===
     {
         MutexLocker locker(&offloading_mutex_);
+        // Re-checked under the lock: the entry check above is only a fast
+        // path. A drain (which latches and deregisters under this same
+        // mutex) may have completed while this tick was parked on it; going
+        // on would hit SEGMENT_NOT_FOUND below and re-mount the segment the
+        // drain just deregistered.
+        if (draining_.load()) {
+            return {};
+        }
         auto fetch_offload_tasks = [&]() -> tl::expected<void, ErrorCode> {
             return client_->OffloadObjectHeartbeat(enable_offloading_,
                                                    offloading_objects);
@@ -1020,6 +1038,45 @@ void FileStorage::RemoveAll() {
         storage_backend_->RemoveAll();
     }
     LOG(INFO) << "FileStorage::RemoveAll: cleared storage backend";
+}
+
+tl::expected<void, ErrorCode> FileStorage::DrainLocalDiskSegment(
+    uint64_t grace_period_ms) {
+    if (client_ == nullptr) {
+        LOG(ERROR) << "client is nullptr";
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    // Latch and deregister under offloading_mutex_, the lock Heartbeat holds
+    // across its master RPCs and the SEGMENT_NOT_FOUND re-mount. The latch
+    // alone is not enough: a heartbeat that read draining_ == false before
+    // this store() and was then scheduled out would, on resume, see
+    // SEGMENT_NOT_FOUND from the deregistration below and re-mount the
+    // segment. Under the mutex, such a tick is either still parked on the
+    // lock (it re-checks draining_ once it gets it and skips) or it already
+    // finished its RPCs before we latched (anything it mounted or registered
+    // is deregistered again right here, and the master refuses registrations
+    // that arrive after this call returns -- see
+    // MasterService::NotifyOffloadSuccess).
+    {
+        MutexLocker locker(&offloading_mutex_);
+        draining_.store(true);
+
+        auto result = client_->UnmountLocalDiskSegment();
+        if (!result) {
+            LOG(ERROR) << "action=drain_local_disk_segment, error="
+                       << result.error();
+            draining_.store(false);
+            return result;
+        }
+    }
+
+    LOG(INFO) << "action=drain_local_disk_segment, grace_period_ms="
+              << grace_period_ms;
+    if (grace_period_ms > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(grace_period_ms));
+    }
+    return {};
 }
 
 tl::expected<void, ErrorCode> FileStorage::ProcessPromotionTasks() {
@@ -1379,6 +1436,17 @@ tl::expected<void, ErrorCode> FileStorage::ReRegisterOffloadedObjects() {
             [this, &total_keys, &total_batches, &total_failures](
                 const std::vector<std::string>& keys,
                 std::vector<StorageObjectMetadata>& metadatas) {
+                // A rescan can be mid-flight when a drain deregisters the
+                // disk tier; every batch it would register from here on
+                // re-advertises the departing store. The master refuses such
+                // registrations anyway (the segment entry is gone), so this
+                // stops the scan on the first batch instead of on a refused
+                // RPC.
+                if (draining_.load()) {
+                    LOG(INFO) << "ReRegisterOffloadedObjects: aborting scan, "
+                              << "the disk tier is draining";
+                    return ErrorCode::SEGMENT_NOT_FOUND;
+                }
                 total_batches++;
                 total_keys += keys.size();
                 for (auto& metadata : metadatas) {

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -218,6 +218,11 @@ struct RpcNameTraits<&WrappedMasterService::MountLocalDiskSegment> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::UnmountLocalDiskSegment> {
+    static constexpr const char* value = "UnmountLocalDiskSegment";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::OffloadObjectHeartbeat> {
     static constexpr const char* value = "OffloadObjectHeartbeat";
 };
@@ -938,6 +943,18 @@ tl::expected<void, ErrorCode> MasterClient::MountLocalDiskSegment(
     auto result =
         invoke_rpc<&WrappedMasterService::MountLocalDiskSegment, void>(
             client_id, enable_offloading);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::UnmountLocalDiskSegment(
+    const UUID& client_id) {
+    ScopedVLogTimer timer(1, "MasterClient::UnmountLocalDiskSegment");
+    timer.LogRequest("client_id=", client_id);
+
+    auto result =
+        invoke_rpc<&WrappedMasterService::UnmountLocalDiskSegment, void>(
+            client_id);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -218,6 +218,11 @@ struct RpcNameTraits<&WrappedMasterService::MountLocalDiskSegment> {
 };
 
 template <>
+struct RpcNameTraits<&WrappedMasterService::UnmountLocalDiskSegment> {
+    static constexpr const char* value = "UnmountLocalDiskSegment";
+};
+
+template <>
 struct RpcNameTraits<&WrappedMasterService::OffloadObjectHeartbeat> {
     static constexpr const char* value = "OffloadObjectHeartbeat";
 };
@@ -950,6 +955,18 @@ tl::expected<void, ErrorCode> MasterClient::MountLocalDiskSegment(
     auto result =
         invoke_rpc<&WrappedMasterService::MountLocalDiskSegment, void>(
             client_id, enable_offloading);
+    timer.LogResponseExpected(result);
+    return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::UnmountLocalDiskSegment(
+    const UUID& client_id) {
+    ScopedVLogTimer timer(1, "MasterClient::UnmountLocalDiskSegment");
+    timer.LogRequest("client_id=", client_id);
+
+    auto result =
+        invoke_rpc<&WrappedMasterService::UnmountLocalDiskSegment, void>(
+            client_id);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5985,6 +5985,60 @@ auto MasterService::MountLocalDiskSegment(const UUID& client_id,
     return {};
 }
 
+auto MasterService::UnmountLocalDiskSegment(const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    if (!enable_offload_) {
+        LOG(ERROR) << "The offload functionality is not enabled";
+        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOAD);
+    }
+
+    {
+        ScopedLocalDiskSegmentAccess ssd_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        const auto& client_segments = ssd_access.getClientLocalDiskSegment();
+        if (client_segments.find(client_id) == client_segments.end()) {
+            // Idempotent, the same way MountLocalDiskSegment treats an
+            // already-mounted segment as success.
+            return {};
+        }
+    }
+
+    // Remove the segment entry first: from here on OffloadObjectHeartbeat
+    // answers SEGMENT_NOT_FOUND, so the master hands this client no further
+    // offload work. Then sweep the replicas it still owns, so no reader can be
+    // given a replica whose owner is about to stop serving. The sweep walks
+    // every metadata shard, so it must run without the segment lock held --
+    // the same order and the same reason as the expiry branch of
+    // ClientMonitorFunc.
+    {
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+        ScopedSegmentAccess segment_access =
+            segment_manager_.getSegmentAccess();
+        segment_access.UnmountLocalDiskSegment(client_id);
+    }
+
+    // The sweep classifies a LOCAL_DISK replica as stale when its owner is
+    // absent from the set it is given, so the set has to name every owner that
+    // is staying -- not just the ones the client monitor currently counts as
+    // alive. A client only enters ok_client_ by remounting, so passing the
+    // alive snapshot alone would drop the disk replicas of any peer that had
+    // not remounted yet, turning one store's deregistration into everyone's.
+    auto staying_clients = getAliveClientsSnapshot();
+    {
+        ScopedLocalDiskSegmentAccess ssd_access =
+            segment_manager_.getLocalDiskSegmentAccess();
+        for (const auto& owner : ssd_access.getClientLocalDiskSegment()) {
+            staying_clients.insert(owner.first);
+        }
+    }
+    staying_clients.erase(client_id);
+    ClearInvalidHandles(staying_clients);
+
+    LOG(INFO) << "client_id=" << client_id
+              << ", action=unmount_local_disk_segment_by_request";
+    return {};
+}
+
 auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                            bool enable_offloading)
     -> tl::expected<std::vector<OffloadTaskItem>, ErrorCode> {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2002,15 +2002,23 @@ MasterService::StaleHandleCleanupPlan
 MasterService::BuildStaleHandleCleanupPlan(
     const ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) const {
+    return BuildStaleHandleCleanupPlan(
+        metadata, [&alive_clients](const Replica& replica) {
+            return (replica.has_invalid_mem_handle() ||
+                    replica.has_invalid_nof_handle() ||
+                    replica.has_stale_local_disk_client(alive_clients)) &&
+                   replica.is_completed();
+        });
+}
+
+MasterService::StaleHandleCleanupPlan
+MasterService::BuildStaleHandleCleanupPlan(
+    const ObjectMetadata& metadata,
+    const std::function<bool(const Replica&)>& is_stale) const {
     StaleHandleCleanupPlan plan;
     bool has_valid_after_cleanup = false;
     for (const auto& replica : metadata.GetAllReplicas()) {
-        const bool stale =
-            (replica.has_invalid_mem_handle() ||
-             replica.has_invalid_nof_handle() ||
-             replica.has_stale_local_disk_client(alive_clients)) &&
-            replica.is_completed();
-        if (stale) {
+        if (is_stale(replica)) {
             plan.removed_ids.push_back(replica.id());
             continue;
         }
@@ -2484,6 +2492,23 @@ void MasterService::ClearInvalidHandles() {
 
 void MasterService::ClearInvalidHandles(
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients) {
+    ClearStaleHandles([&alive_clients](const Replica& replica) {
+        return (replica.has_invalid_mem_handle() ||
+                replica.has_invalid_nof_handle() ||
+                replica.has_stale_local_disk_client(alive_clients)) &&
+               replica.is_completed();
+    });
+}
+
+void MasterService::ClearLocalDiskHandlesOwnedBy(const UUID& owner) {
+    ClearStaleHandles([&owner](const Replica& replica) {
+        return replica.is_local_disk_replica() && replica.is_completed() &&
+               replica.get_local_disk_client_id() == owner;
+    });
+}
+
+void MasterService::ClearStaleHandles(
+    const std::function<bool(const Replica&)>& is_stale) {
     for (size_t i = 0; i < kNumShards; i++) {
         MetadataShardAccessorRW shard(this, i);
         for (auto tenant_it = shard->tenants.begin();
@@ -2492,13 +2517,13 @@ void MasterService::ClearInvalidHandles(
             auto it = tenant_state.metadata.begin();
             while (it != tenant_state.metadata.end()) {
                 const auto cleanup_plan =
-                    BuildStaleHandleCleanupPlan(it->second, alive_clients);
+                    BuildStaleHandleCleanupPlan(it->second, is_stale);
                 if (!cleanup_plan.removed_ids.empty()) {
                     if (enable_ha_) {
                         if (enable_oplog_) {
                             auto persist_result =
                                 PersistStaleHandleCleanupForHA(
-                                    "ClearInvalidHandles", tenant_it->first,
+                                    "ClearStaleHandles", tenant_it->first,
                                     it->first, it->second, cleanup_plan);
                             if (!persist_result) {
                                 ++it;
@@ -2508,8 +2533,8 @@ void MasterService::ClearInvalidHandles(
                             continue;
                         }
                     }
-                    if (CleanupStaleHandles(tenant_state, it->second,
-                                            alive_clients, &shard)) {
+                    if (CleanupStaleHandles(tenant_state, it->second, is_stale,
+                                            &shard)) {
                         it = EraseMetadata(tenant_state, it, tenant_it->first,
                                            QuotaEraseMode::kFull, &shard);
                     } else {
@@ -2529,7 +2554,7 @@ void MasterService::ClearInvalidHandles(
                                     });
                             if (!persist_result) {
                                 LOG(WARNING)
-                                    << "ClearInvalidHandles(last replica)"
+                                    << "ClearStaleHandles(last replica)"
                                     << ": REMOVE persist failed for key="
                                     << it->first << ", err="
                                     << static_cast<int>(persist_result.error());
@@ -4626,6 +4651,18 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
         normalized_tenant = std::move(normalized_tenant_result.value());
     }
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    // Same admission rule as NotifyOffloadSuccess's existing-object path,
+    // checked inside the same shared-lock section as the write below: a disk
+    // replica may only be registered for a client whose LOCAL_DISK segment
+    // entry still exists, so a registration cannot land after a concurrent
+    // UnmountLocalDiskSegment's sweep and survive as a stale owner. Scoped
+    // to enable_offload_, where the segment registry exists and a
+    // deregistration can race; with the subsystem off both the mount and
+    // unmount RPCs refuse, so there is nothing to check against and no race
+    // to close.
+    if (enable_offload_ && !HasMountedLocalDiskSegment(client_id)) {
+        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    }
     const ObjectIdentity object_id{std::move(normalized_tenant), key};
     MetadataAccessorRW accessor(this, object_id);
     if (!accessor.Exists()) {
@@ -6897,22 +6934,33 @@ bool MasterService::CleanupStaleHandles(
     TenantState& tenant_state, ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
     MetadataShardAccessorRW* shard) {
-    bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
-        return r.is_local_disk_replica() && r.is_completed();
-    });
-    // Remove those with invalid allocators (memory replicas on unmounted
+    // Removes replicas with invalid allocators (memory replicas on unmounted
     // segments) and local_disk replicas whose owner client is no longer alive.
-    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
-    std::vector<ReplicaID> removed_replica_ids;
-    EraseReplicasWithCacheTotalAccounting(
-        metadata,
+    // Kept as a thin wrapper over the predicate form so the owner-targeted
+    // LOCAL_DISK sweep (ClearLocalDiskHandlesOwnedBy) shares this accounting
+    // rather than duplicating it.
+    return CleanupStaleHandles(
+        tenant_state, metadata,
         [&alive_clients](const Replica& replica) {
             return (replica.has_invalid_mem_handle() ||
                     replica.has_invalid_nof_handle() ||
                     replica.has_stale_local_disk_client(alive_clients)) &&
                    replica.is_completed();
         },
-        &removed_replica_ids);
+        shard);
+}
+
+bool MasterService::CleanupStaleHandles(
+    TenantState& tenant_state, ObjectMetadata& metadata,
+    const std::function<bool(const Replica&)>& is_stale,
+    MetadataShardAccessorRW* shard) {
+    bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
+        return r.is_local_disk_replica() && r.is_completed();
+    });
+    const uint64_t before_charge = CompletedMemoryQuotaCharge(metadata);
+    std::vector<ReplicaID> removed_replica_ids;
+    EraseReplicasWithCacheTotalAccounting(metadata, is_stale,
+                                          &removed_replica_ids);
     CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
                                           removed_replica_ids);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
@@ -7169,6 +7217,63 @@ auto MasterService::MountLocalDiskSegment(const UUID& client_id,
     return {};
 }
 
+auto MasterService::UnmountLocalDiskSegment(const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    if (!enable_offload_) {
+        LOG(ERROR) << "The offload functionality is not enabled";
+        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOAD);
+    }
+
+    // Drop the client's LOCAL_DISK registration first: from here on
+    // OffloadObjectHeartbeat answers SEGMENT_NOT_FOUND, so the master hands
+    // this client no further offload work. Then sweep the replicas it still
+    // owns, so no reader can be given a replica whose owner is about to stop
+    // serving. The sweep walks every metadata shard, so it must run without
+    // the registry lock held -- the same order and the same reason as the
+    // expiry branch of ClientMonitorFunc.
+    //
+    // The deregistration takes snapshot_mutex_ exclusively.
+    // NotifyOffloadSuccess admits a disk-replica registration by checking
+    // this client's registration inside one shared-lock section together with
+    // the metadata write, so that section lands entirely before this
+    // deregistration (the sweep below erases the replica) or entirely after
+    // (the check refuses it). Without the exclusive lock a registration
+    // admitted against the old one could land in a shard the sweep had
+    // already passed and survive as a stale owner.
+    std::optional<int64_t> reported_capacity;
+    {
+        std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+        reported_capacity = local_ssd_manager_.UnregisterClient(client_id);
+    }
+    if (!reported_capacity) {
+        // Idempotent, the same way MountLocalDiskSegment treats an
+        // already-mounted segment as success.
+        return {};
+    }
+    if (*reported_capacity > 0) {
+        MasterMetricManager::instance().dec_total_file_capacity(
+            *reported_capacity);
+    }
+
+    // Sweep exactly this owner's replicas. Deliberately not a
+    // liveness-complement sweep (ClearInvalidHandles with a staying set):
+    // that classifies by absence from a point-in-time snapshot, so an owner
+    // that mounts and registers after the snapshot but before the sweep
+    // reaches its shard would have its replicas classified stale and
+    // erased -- and when that disk replica was the key's only one, the key
+    // itself. An owner-id predicate cannot misclassify a concurrent mount,
+    // whatever the interleaving.
+    ClearLocalDiskHandlesOwnedBy(client_id);
+
+    LOG(INFO) << "client_id=" << client_id
+              << ", action=unmount_local_disk_segment_by_request";
+    return {};
+}
+
+bool MasterService::HasMountedLocalDiskSegment(const UUID& client_id) {
+    return local_ssd_manager_.GetUsage(client_id).has_value();
+}
+
 auto MasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                            bool enable_offloading)
     -> tl::expected<std::vector<OffloadTaskItem>, ErrorCode> {
@@ -7249,6 +7354,12 @@ auto MasterService::NotifyOffloadSuccess(
     if (tasks.size() != metadatas.size()) {
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+    // Set when an entry's replica registration is refused because the client
+    // no longer has a LOCAL_DISK segment entry (see the per-entry checks
+    // below). NACK cleanups still run for the rest of the batch; the caller
+    // gets SEGMENT_NOT_FOUND so a rescan stops re-registering.
+    bool refused_unmounted = false;
+
     for (size_t i = 0; i < tasks.size(); ++i) {
         const auto& task = tasks[i];
         const auto& metadata = metadatas[i];
@@ -7285,6 +7396,23 @@ auto MasterService::NotifyOffloadSuccess(
         bool added_new_local_disk_replica = false;
         {
             std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            // A disk replica may only be registered for a client whose
+            // LOCAL_DISK segment entry still exists. Checked inside this
+            // shared-lock section, before the shard lock, so the check and
+            // the write below cannot straddle UnmountLocalDiskSegment's
+            // removal (which holds snapshot_mutex_ exclusively): either the
+            // replica lands first and its sweep erases it, or the check here
+            // sees the segment gone and refuses. Without this, a
+            // registration racing a deregistration -- an in-flight rescan
+            // batch, or an offload completion from a heartbeat that was past
+            // its own drain check -- could land after the sweep and leave
+            // the master advertising a departed owner. Scoped to
+            // enable_offload_, where the segment registry exists and a
+            // deregistration can race; with the subsystem off both the mount
+            // and unmount RPCs refuse, so there is nothing to check against
+            // and no race to close.
+            const bool segment_mounted =
+                !enable_offload_ || HasMountedLocalDiskSegment(client_id);
             MetadataAccessorRW accessor(this, request_object_id);
             if (accessor.Exists()) {
                 auto& obj_metadata = accessor.Get();
@@ -7309,8 +7437,12 @@ auto MasterService::NotifyOffloadSuccess(
                     }
                     tenant_state.offloading_tasks.erase(task_it);
 
-                    if (!obj_metadata.HasReplica(
-                            &Replica::fn_is_local_disk_replica)) {
+                    if (!segment_mounted) {
+                        // The offload bookkeeping above still ran; only the
+                        // registration is refused.
+                        refused_unmounted = true;
+                    } else if (!obj_metadata.HasReplica(
+                                   &Replica::fn_is_local_disk_replica)) {
                         std::vector<Replica> replicas;
                         replicas.emplace_back(std::move(replica));
                         obj_metadata.AddReplicas(std::move(replicas));
@@ -7362,6 +7494,13 @@ auto MasterService::NotifyOffloadSuccess(
                 if (res.error() == ErrorCode::OBJECT_NOT_FOUND) {
                     continue;
                 }
+                if (res.error() == ErrorCode::SEGMENT_NOT_FOUND) {
+                    // AddReplica's own mounted-segment check refused it (the
+                    // segment entry vanished under a deregistration). Finish
+                    // the batch so remaining NACK cleanups still run.
+                    refused_unmounted = true;
+                    continue;
+                }
                 LOG(ERROR) << "Failed to add replica: error=" << res.error()
                            << ", client_id=" << client_id
                            << ", tenant_id=" << object_id.tenant_id.value()
@@ -7375,6 +7514,12 @@ auto MasterService::NotifyOffloadSuccess(
         }
     }
 
+    if (refused_unmounted) {
+        LOG(WARNING) << "client_id=" << client_id
+                     << ", action=notify_offload_success_refused"
+                     << ", error=no_local_disk_segment";
+        return tl::make_unexpected(ErrorCode::SEGMENT_NOT_FOUND);
+    }
     return {};
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1793,6 +1793,21 @@ int RealClient::unmountAndFreeSegment(
     return first_error;
 }
 
+int RealClient::drainLocalDiskSegment(uint64_t grace_period_seconds) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+    if (!file_storage_) {
+        LOG(WARNING) << "action=drain_local_disk_segment, "
+                        "warn=ssd_offload_not_enabled";
+        return 0;
+    }
+    auto result =
+        file_storage_->DrainLocalDiskSegment(grace_period_seconds * 1000);
+    return result ? 0 : -1;
+}
+
 int RealClient::health_check() {
     if (closed_.load()) return HC_NOT_INITIALIZED;
     if (!client_) return HC_NOT_INITIALIZED;
@@ -6887,6 +6902,13 @@ ClientRequester::ClientRequester() {
     pool_conf.reconnect_wait_time = std::chrono::milliseconds{1000};
     pool_conf.host_alive_detect_duration = std::chrono::milliseconds{0};
 
+    // Honour the same timeout overrides as the master pool. Without this the
+    // connect timeout stays at coro_rpc's built-in 30s, so a read that picks a
+    // peer which is gone blocks for connect_retry_count * 30s plus the waits
+    // between retries -- 91s with the defaults above -- and no configuration
+    // can shorten it. Defaults are unchanged when the variables are unset.
+    detail::ApplyRpcTimeoutEnvOverrides(pool_conf.client_config);
+
     client_pools_ =
         std::make_shared<coro_io::client_pools<coro_rpc::coro_rpc_client>>(
             pool_conf, GetStoreRpcClientIoContextPool());
@@ -6942,6 +6964,10 @@ tl::expected<ReturnType, ErrorCode> ClientRequester::invoke_rpc(
             }
             auto result = co_await std::move(ret.value());
             if (!result) {
+                if (result.error().code == coro_rpc::errc::timed_out) {
+                    LOG(ERROR) << "RPC call timed out: " << result.error().msg;
+                    co_return tl::make_unexpected(ErrorCode::RPC_TIMEOUT);
+                }
                 LOG(ERROR) << "RPC call failed: " << result.error().msg;
                 co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
             }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1652,6 +1652,21 @@ int RealClient::unmountAndFreeSegment(
     return first_error;
 }
 
+int RealClient::drainLocalDiskSegment(uint64_t grace_period_seconds) {
+    if (!client_) {
+        LOG(ERROR) << "Client not initialized";
+        return -1;
+    }
+    if (!file_storage_) {
+        LOG(WARNING) << "action=drain_local_disk_segment, "
+                        "warn=ssd_offload_not_enabled";
+        return 0;
+    }
+    auto result =
+        file_storage_->DrainLocalDiskSegment(grace_period_seconds * 1000);
+    return result ? 0 : -1;
+}
+
 int RealClient::health_check() {
     if (closed_.load()) return HC_NOT_INITIALIZED;
     if (!client_) return HC_NOT_INITIALIZED;
@@ -5999,6 +6014,13 @@ ClientRequester::ClientRequester() {
     pool_conf.reconnect_wait_time = std::chrono::milliseconds{1000};
     pool_conf.host_alive_detect_duration = std::chrono::milliseconds{0};
 
+    // Honour the same timeout overrides as the master pool. Without this the
+    // connect timeout stays at coro_rpc's built-in 30s, so a read that picks a
+    // peer which is gone blocks for connect_retry_count * 30s plus the waits
+    // between retries -- 91s with the defaults above -- and no configuration
+    // can shorten it. Defaults are unchanged when the variables are unset.
+    detail::ApplyRpcTimeoutEnvOverrides(pool_conf.client_config);
+
     client_pools_ =
         std::make_shared<coro_io::client_pools<coro_rpc::coro_rpc_client>>(
             pool_conf, GetStoreRpcClientIoContextPool());
@@ -6054,6 +6076,10 @@ tl::expected<ReturnType, ErrorCode> ClientRequester::invoke_rpc(
             }
             auto result = co_await std::move(ret.value());
             if (!result) {
+                if (result.error().code == coro_rpc::errc::timed_out) {
+                    LOG(ERROR) << "RPC call timed out: " << result.error().msg;
+                    co_return tl::make_unexpected(ErrorCode::RPC_TIMEOUT);
+                }
                 LOG(ERROR) << "RPC call failed: " << result.error().msg;
                 co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
             }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1563,6 +1563,17 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountLocalDiskSegment(
     return result;
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::UnmountLocalDiskSegment(
+    const UUID& client_id) {
+    ScopedVLogTimer timer(1, "UnmountLocalDiskSegment");
+    timer.LogRequest("action=unmount_local_disk_segment");
+    LOG(INFO) << "Unmount local disk segment with client id is : " << client_id;
+    auto result = master_service_.UnmountLocalDiskSegment(client_id);
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
 WrappedMasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                              bool enable_offloading) {
@@ -1800,6 +1811,9 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::MountLocalDiskSegment>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::UnmountLocalDiskSegment>(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::OffloadObjectHeartbeat>(

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1484,6 +1484,17 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountLocalDiskSegment(
     return result;
 }
 
+tl::expected<void, ErrorCode> WrappedMasterService::UnmountLocalDiskSegment(
+    const UUID& client_id) {
+    ScopedVLogTimer timer(1, "UnmountLocalDiskSegment");
+    timer.LogRequest("action=unmount_local_disk_segment");
+    LOG(INFO) << "Unmount local disk segment with client id is : " << client_id;
+    auto result = master_service_.UnmountLocalDiskSegment(client_id);
+
+    timer.LogResponseExpected(result);
+    return result;
+}
+
 tl::expected<std::vector<OffloadTaskItem>, ErrorCode>
 WrappedMasterService::OffloadObjectHeartbeat(const UUID& client_id,
                                              bool enable_offloading) {
@@ -1721,6 +1732,9 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::MountLocalDiskSegment>(
+        &wrapped_master_service);
+    server.register_handler<
+        &mooncake::WrappedMasterService::UnmountLocalDiskSegment>(
         &wrapped_master_service);
     server.register_handler<
         &mooncake::WrappedMasterService::OffloadObjectHeartbeat>(

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -1,6 +1,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstring>
 #include <filesystem>
 #include <optional>
@@ -121,6 +122,52 @@ class FileStorageTest : public ::testing::Test {
     // FileStorageTest is friended; TEST_F-generated subclasses are not.
     static bool CallIsPerBucketSoftOffloadError(ErrorCode error) {
         return FileStorage::IsPerBucketSoftOffloadError(error);
+    }
+
+    // Funnel to the private FileStorage::Heartbeat, for the drain tests.
+    static tl::expected<void, ErrorCode> FileStorageHeartbeat(
+        FileStorage& fileStorage) {
+        return fileStorage.Heartbeat();
+    }
+
+    // Drives the drain-vs-heartbeat interleaving deterministically: a
+    // heartbeat tick that has already passed its entry draining_ check parks
+    // on offloading_mutex_, a drain runs, and the parked tick resumes only
+    // around the drain's own critical section. The fixture holds the mutex
+    // as the scheduler while both threads are launched, so the tick is
+    // provably not inside its RPC section when the drain latches. After the
+    // release the two race for the lock; the postcondition (segment
+    // deregistered, never re-mounted) must hold in both wake orders, so the
+    // assertions do not depend on the schedule. Without the drain taking
+    // offloading_mutex_, the parked tick would resume after the drain
+    // finished, get SEGMENT_NOT_FOUND, and re-mount the segment.
+    tl::expected<void, ErrorCode> DrainWhileHeartbeatTickParked(
+        FileStorage& fileStorage) {
+        // The parked tick may win the lock and run a full pass, which is
+        // only supported on an initialized backend (Init() is also what
+        // starts the heartbeat thread in production).
+        EXPECT_TRUE(fileStorage.storage_backend_->Init());
+        tl::expected<void, ErrorCode> drain_result =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        std::thread heartbeat_thread;
+        std::thread drain_thread;
+        {
+            MutexLocker scheduler(&fileStorage.offloading_mutex_);
+            heartbeat_thread =
+                std::thread([&fileStorage] { fileStorage.Heartbeat(); });
+            // Let the tick pass the entry check and park on the mutex we
+            // hold. The assertions do not depend on it parking -- a tick
+            // that has not reached the lock is caught by the entry check
+            // instead -- the pause just pins the adversarial schedule.
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            drain_thread = std::thread([&fileStorage, &drain_result] {
+                drain_result = fileStorage.DrainLocalDiskSegment(0);
+            });
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        heartbeat_thread.join();
+        drain_thread.join();
+        return drain_result;
     }
 
     void AssertHeartbeatEvictsAllKeys(
@@ -486,6 +533,89 @@ TEST_F(FileStorageTest, HeartbeatRunsDiskWatermarkEvictionWithoutOffloadWork) {
     }
 
     AssertHeartbeatEvictsAllKeys(file_storage, expected_keys, batch_object);
+}
+
+// A drain deregisters the disk tier; the heartbeat re-mounts the segment
+// whenever the master answers SEGMENT_NOT_FOUND. These pin the interleavings
+// where the two overlap: the drain must win in every schedule.
+
+TEST_F(FileStorageTest, HeartbeatAfterDrainDoesNotRemount) {
+    std::filesystem::path master_root =
+        std::filesystem::path(data_path) / "drain_hb_master";
+    std::filesystem::create_directories(master_root);
+
+    testing::InProcMaster master;
+    auto master_config = InProcMasterConfigBuilder()
+                             .set_enable_offload(true)
+                             .set_root_fs_dir(master_root.string())
+                             .build();
+    ASSERT_TRUE(master.Start(master_config));
+
+    std::string local_rpc_addr =
+        "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                                 std::nullopt, master.master_address());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+    FileStorageConfig config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kFilePerKey;
+    config.storage_filepath = data_path + "/drain_hb";
+    config.local_buffer_size = 4 * 1024 * 1024;
+    fs::create_directories(config.storage_filepath);
+    FileStorage file_storage(config, client.value(), local_rpc_addr);
+
+    ASSERT_TRUE(file_storage.DrainLocalDiskSegment(0).has_value());
+
+    // A tick after the drain is a no-op: it must not take the
+    // SEGMENT_NOT_FOUND recovery branch and re-mount the segment.
+    ASSERT_TRUE(FileStorageHeartbeat(file_storage).has_value());
+
+    std::vector<OffloadTaskItem> offload_items;
+    auto heartbeat_rpc =
+        client.value()->OffloadObjectHeartbeat(true, offload_items);
+    ASSERT_FALSE(heartbeat_rpc.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, heartbeat_rpc.error());
+}
+
+TEST_F(FileStorageTest, DrainSurvivesParkedHeartbeatTick) {
+    std::filesystem::path master_root =
+        std::filesystem::path(data_path) / "drain_race_master";
+    std::filesystem::create_directories(master_root);
+
+    testing::InProcMaster master;
+    auto master_config = InProcMasterConfigBuilder()
+                             .set_enable_offload(true)
+                             .set_root_fs_dir(master_root.string())
+                             .build();
+    ASSERT_TRUE(master.Start(master_config));
+
+    std::string local_rpc_addr =
+        "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                                 std::nullopt, master.master_address());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+    FileStorageConfig config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kFilePerKey;
+    config.storage_filepath = data_path + "/drain_race";
+    config.local_buffer_size = 4 * 1024 * 1024;
+    fs::create_directories(config.storage_filepath);
+    FileStorage file_storage(config, client.value(), local_rpc_addr);
+
+    // A tick that passed its entry draining_ check is parked on
+    // offloading_mutex_ while the drain runs (see the fixture helper). It
+    // must not resume into the SEGMENT_NOT_FOUND recovery branch and
+    // re-mount the segment the drain deregistered.
+    auto drain_result = DrainWhileHeartbeatTickParked(file_storage);
+    ASSERT_TRUE(drain_result.has_value());
+
+    std::vector<OffloadTaskItem> offload_items;
+    auto heartbeat_rpc =
+        client.value()->OffloadObjectHeartbeat(true, offload_items);
+    ASSERT_FALSE(heartbeat_rpc.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, heartbeat_rpc.error());
 }
 
 TEST_F(FileStorageTest, NotifyEvictedDiskReplicasUsesTenantScopedKeys) {

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <thread>
 #include <vector>
 
@@ -937,6 +939,248 @@ TEST_F(MasterServiceSSDTest,
         << "%\n"
         << "  A→C  total overhead vs origin:" << (ratio_c_a - 1.0) * 100.0
         << "%\n\n";
+}
+
+// A LOCAL_DISK segment used to leave the master only when its client expired,
+// so a store that was shutting down stayed advertised as the owner of its
+// offloaded keys for up to one client_ttl and readers were handed a peer that
+// could no longer serve. These cover the operation that lets it deregister
+// itself instead.
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentRequiresOffloadEnabled) {
+    auto service = CreateMasterServiceWithSSDFeat("/mnt/ssd");
+
+    auto result = service->UnmountLocalDiskSegment(generate_uuid());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::UNABLE_OFFLOAD, result.error());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentIsIdempotent) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service, client_id, "ssd_unmount_idem_segment",
+                            0xd00000000);
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+    // A repeat finds nothing to do and still succeeds, the way
+    // MountLocalDiskSegment reports an already-mounted segment as success.
+    EXPECT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+    // So does a client that never mounted one.
+    EXPECT_TRUE(service->UnmountLocalDiskSegment(generate_uuid()).has_value());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentStopsOffloadWork) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service, client_id, "ssd_unmount_hb_segment",
+                            0xe00000000);
+    ASSERT_TRUE(service->OffloadObjectHeartbeat(client_id, true).has_value());
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+
+    // The master hands this client no further offload work. The client reads
+    // this as its cue to re-mount, which is why a draining store must latch
+    // offloading off before calling.
+    auto heartbeat = service->OffloadObjectHeartbeat(client_id, true);
+    ASSERT_FALSE(heartbeat.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, heartbeat.error());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentDropsOnlyItsOwnReplicas) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID leaving = generate_uuid();
+    UUID staying = generate_uuid();
+    const std::string leaving_segment = "ssd_unmount_leaving_segment";
+    const std::string staying_segment = "ssd_unmount_staying_segment";
+    MountMemoryAndLocalDisk(*service, leaving, leaving_segment, 0xf00000000);
+    MountMemoryAndLocalDisk(*service, staying, staying_segment, 0x1000000000);
+
+    PutAndOffload(*service, leaving, "ssd_unmount_leaving_key", 1024,
+                  leaving_segment);
+    PutAndOffload(*service, staying, "ssd_unmount_staying_key", 1024,
+                  staying_segment);
+
+    // Neither client has remounted, so neither is in the master's alive set.
+    // That is the case that catches a deregistration which sweeps by liveness
+    // instead of by owner: it would take the staying store's disk replicas with
+    // it.
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(leaving).has_value());
+
+    // The departing store is no longer advertised for its own key, while the
+    // memory replica of that key is untouched.
+    auto leaving_replicas =
+        service->GetReplicaList("ssd_unmount_leaving_key", TenantId::Default());
+    ASSERT_TRUE(leaving_replicas.has_value());
+    ASSERT_EQ(1u, leaving_replicas.value().replicas.size());
+    EXPECT_TRUE(leaving_replicas.value().replicas[0].is_memory_replica());
+
+    // The other store keeps both of its replicas.
+    auto staying_replicas =
+        service->GetReplicaList("ssd_unmount_staying_key", TenantId::Default());
+    ASSERT_TRUE(staying_replicas.has_value());
+    EXPECT_EQ(2u, staying_replicas.value().replicas.size());
+    bool staying_has_disk = false;
+    for (const auto& replica : staying_replicas.value().replicas) {
+        staying_has_disk |= replica.is_local_disk_replica();
+    }
+    EXPECT_TRUE(staying_has_disk);
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentKeepsReAdoptionWorking) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    const std::string segment = "ssd_unmount_readopt_segment";
+    MountMemoryAndLocalDisk(*service, client_id, segment, 0x1100000000);
+
+    // A key whose only replica is that disk, which is what a store's own files
+    // look like to the master after it re-registers them.
+    StorageObjectMetadata metadata;
+    metadata.data_size = 1024;
+    metadata.transport_endpoint = segment;
+    OffloadTaskItem task{.tenant_id = TenantId::Default().value(),
+                         .key = "ssd_unmount_disk_only_key",
+                         .size = 1024};
+    ASSERT_TRUE(service->NotifyOffloadSuccess(client_id, {task}, {metadata})
+                    .has_value());
+    ASSERT_TRUE(
+        service
+            ->GetReplicaList("ssd_unmount_disk_only_key", TenantId::Default())
+            .has_value());
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+
+    // Erased, the same as on client expiry: the disk held its last replica. A
+    // read gets a clean miss rather than a dead peer.
+    EXPECT_FALSE(
+        service
+            ->GetReplicaList("ssd_unmount_disk_only_key", TenantId::Default())
+            .has_value());
+
+    // A store that comes back re-adopts its files, so deregistering costs a
+    // restart nothing.
+    ASSERT_TRUE(service->MountLocalDiskSegment(client_id, true).has_value());
+    ASSERT_TRUE(service->NotifyOffloadSuccess(client_id, {task}, {metadata})
+                    .has_value());
+    auto restored = service->GetReplicaList("ssd_unmount_disk_only_key",
+                                            TenantId::Default());
+    ASSERT_TRUE(restored.has_value());
+    ASSERT_EQ(1u, restored.value().replicas.size());
+    EXPECT_TRUE(restored.value().replicas[0].is_local_disk_replica());
+}
+
+TEST_F(MasterServiceSSDTest, NotifyOffloadSuccessAfterUnmountIsRefused) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    const std::string segment = "ssd_gate_segment";
+    MountMemoryAndLocalDisk(*service, client_id, segment, 0x1200000000);
+    PutAndOffload(*service, client_id, "ssd_gate_key", 1024, segment);
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+
+    // A registration that arrives after the deregistration -- an in-flight
+    // rescan batch, or an offload completion racing the drain -- is refused,
+    // so it cannot land after the sweep and leave the master advertising a
+    // departed owner.
+    StorageObjectMetadata metadata;
+    metadata.data_size = 1024;
+    metadata.transport_endpoint = segment;
+    OffloadTaskItem swept_task{.tenant_id = TenantId::Default().value(),
+                               .key = "ssd_gate_key",
+                               .size = 1024};
+    auto refused =
+        service->NotifyOffloadSuccess(client_id, {swept_task}, {metadata});
+    ASSERT_FALSE(refused.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, refused.error());
+
+    // The swept key kept only its memory replica; the disk replica was not
+    // re-created.
+    auto replicas =
+        service->GetReplicaList("ssd_gate_key", TenantId::Default());
+    ASSERT_TRUE(replicas.has_value());
+    ASSERT_EQ(1u, replicas.value().replicas.size());
+    EXPECT_TRUE(replicas.value().replicas[0].is_memory_replica());
+
+    // The orphan re-adoption path (a key the master has no metadata for) is
+    // refused too, and the key is not created.
+    OffloadTaskItem orphan_task{.tenant_id = TenantId::Default().value(),
+                                .key = "ssd_gate_orphan_key",
+                                .size = 1024};
+    refused =
+        service->NotifyOffloadSuccess(client_id, {orphan_task}, {metadata});
+    ASSERT_FALSE(refused.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, refused.error());
+    EXPECT_FALSE(
+        service->GetReplicaList("ssd_gate_orphan_key", TenantId::Default())
+            .has_value());
+}
+
+// Friended by MasterService: runs the two halves of UnmountLocalDiskSegment
+// (deregistration, replica sweep) as separate steps, so a competing mount +
+// register can be serialized between them -- the interleaving is pinned by
+// construction instead of hoping a scheduler produces it. The helpers are
+// members of this class because friendship does not extend to the
+// TEST_F-generated subclasses.
+class LocalDiskUnmountInterleavingTest : public MasterServiceSSDTest {
+   protected:
+    static void DeregisterHalf(MasterService& service, const UUID& client_id) {
+        std::unique_lock<std::shared_mutex> snapshot_lock(
+            service.snapshot_mutex_);
+        service.local_ssd_manager_.UnregisterClient(client_id);
+    }
+
+    static void SweepHalf(MasterService& service, const UUID& client_id) {
+        service.ClearLocalDiskHandlesOwnedBy(client_id);
+    }
+};
+
+TEST_F(LocalDiskUnmountInterleavingTest,
+       MountAndRegisterBetweenRemovalAndSweepSurvives) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID leaving = generate_uuid();
+    UUID late = generate_uuid();
+    const std::string leaving_segment = "ssd_interleave_leaving_segment";
+    const std::string late_segment = "ssd_interleave_late_segment";
+    MountMemoryAndLocalDisk(*service, leaving, leaving_segment, 0x1300000000);
+    PutAndOffload(*service, leaving, "ssd_interleave_leaving_key", 1024,
+                  leaving_segment);
+
+    // First half of UnmountLocalDiskSegment(leaving): the client is
+    // deregistered; the sweep has not run.
+    DeregisterHalf(*service, leaving);
+
+    // The interleaving under test: another store mounts and registers a
+    // replica before the sweep reaches its shard. Whether the client monitor
+    // has admitted `late` to the alive set yet does not matter to an
+    // owner-targeted sweep -- while a liveness-complement sweep taken before
+    // this mount would classify the replica stale and erase it, and with it
+    // the key, since this disk replica is the key's only one.
+    MountMemoryAndLocalDisk(*service, late, late_segment, 0x1400000000);
+    StorageObjectMetadata late_metadata;
+    late_metadata.data_size = 1024;
+    late_metadata.transport_endpoint = late_segment;
+    OffloadTaskItem late_task{.tenant_id = TenantId::Default().value(),
+                              .key = "ssd_interleave_late_key",
+                              .size = 1024};
+    ASSERT_TRUE(
+        service->NotifyOffloadSuccess(late, {late_task}, {late_metadata})
+            .has_value());
+
+    // Second half: the sweep.
+    SweepHalf(*service, leaving);
+
+    // The leaving owner's disk replica is gone (the memory replica stays)...
+    auto leaving_replicas = service->GetReplicaList(
+        "ssd_interleave_leaving_key", TenantId::Default());
+    ASSERT_TRUE(leaving_replicas.has_value());
+    ASSERT_EQ(1u, leaving_replicas.value().replicas.size());
+    EXPECT_TRUE(leaving_replicas.value().replicas[0].is_memory_replica());
+
+    // ...while the late mounter's registration survived the sweep.
+    auto late_replicas =
+        service->GetReplicaList("ssd_interleave_late_key", TenantId::Default());
+    ASSERT_TRUE(late_replicas.has_value());
+    ASSERT_EQ(1u, late_replicas.value().replicas.size());
+    EXPECT_TRUE(late_replicas.value().replicas[0].is_local_disk_replica());
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -938,6 +938,133 @@ TEST_F(MasterServiceSSDTest,
         << "%\n\n";
 }
 
+// A LOCAL_DISK segment used to leave the master only when its client expired,
+// so a store that was shutting down stayed advertised as the owner of its
+// offloaded keys for up to one client_ttl and readers were handed a peer that
+// could no longer serve. These cover the operation that lets it deregister
+// itself instead.
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentRequiresOffloadEnabled) {
+    auto service = CreateMasterServiceWithSSDFeat("/mnt/ssd");
+
+    auto result = service->UnmountLocalDiskSegment(generate_uuid());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::UNABLE_OFFLOAD, result.error());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentIsIdempotent) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service, client_id, "ssd_unmount_idem_segment",
+                            0xd00000000);
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+    // A repeat finds nothing to do and still succeeds, the way
+    // MountLocalDiskSegment reports an already-mounted segment as success.
+    EXPECT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+    // So does a client that never mounted one.
+    EXPECT_TRUE(service->UnmountLocalDiskSegment(generate_uuid()).has_value());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentStopsOffloadWork) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    MountMemoryAndLocalDisk(*service, client_id, "ssd_unmount_hb_segment",
+                            0xe00000000);
+    ASSERT_TRUE(service->OffloadObjectHeartbeat(client_id, true).has_value());
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+
+    // The master hands this client no further offload work. The client reads
+    // this as its cue to re-mount, which is why a draining store must latch
+    // offloading off before calling.
+    auto heartbeat = service->OffloadObjectHeartbeat(client_id, true);
+    ASSERT_FALSE(heartbeat.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, heartbeat.error());
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentDropsOnlyItsOwnReplicas) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID leaving = generate_uuid();
+    UUID staying = generate_uuid();
+    const std::string leaving_segment = "ssd_unmount_leaving_segment";
+    const std::string staying_segment = "ssd_unmount_staying_segment";
+    MountMemoryAndLocalDisk(*service, leaving, leaving_segment, 0xf00000000);
+    MountMemoryAndLocalDisk(*service, staying, staying_segment, 0x1000000000);
+
+    PutAndOffload(*service, leaving, "ssd_unmount_leaving_key", 1024,
+                  leaving_segment);
+    PutAndOffload(*service, staying, "ssd_unmount_staying_key", 1024,
+                  staying_segment);
+
+    // Neither client has remounted, so neither is in the master's alive set.
+    // That is the case that catches a deregistration which sweeps by liveness
+    // instead of by owner: it would take the staying store's disk replicas with
+    // it.
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(leaving).has_value());
+
+    // The departing store is no longer advertised for its own key, while the
+    // memory replica of that key is untouched.
+    auto leaving_replicas =
+        service->GetReplicaList("ssd_unmount_leaving_key", TenantId::Default());
+    ASSERT_TRUE(leaving_replicas.has_value());
+    ASSERT_EQ(1u, leaving_replicas.value().replicas.size());
+    EXPECT_TRUE(leaving_replicas.value().replicas[0].is_memory_replica());
+
+    // The other store keeps both of its replicas.
+    auto staying_replicas =
+        service->GetReplicaList("ssd_unmount_staying_key", TenantId::Default());
+    ASSERT_TRUE(staying_replicas.has_value());
+    EXPECT_EQ(2u, staying_replicas.value().replicas.size());
+    bool staying_has_disk = false;
+    for (const auto& replica : staying_replicas.value().replicas) {
+        staying_has_disk |= replica.is_local_disk_replica();
+    }
+    EXPECT_TRUE(staying_has_disk);
+}
+
+TEST_F(MasterServiceSSDTest, UnmountLocalDiskSegmentKeepsReAdoptionWorking) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+    const std::string segment = "ssd_unmount_readopt_segment";
+    MountMemoryAndLocalDisk(*service, client_id, segment, 0x1100000000);
+
+    // A key whose only replica is that disk, which is what a store's own files
+    // look like to the master after it re-registers them.
+    StorageObjectMetadata metadata;
+    metadata.data_size = 1024;
+    metadata.transport_endpoint = segment;
+    OffloadTaskItem task{.tenant_id = TenantId::Default().value(),
+                         .key = "ssd_unmount_disk_only_key",
+                         .size = 1024};
+    ASSERT_TRUE(service->NotifyOffloadSuccess(client_id, {task}, {metadata})
+                    .has_value());
+    ASSERT_TRUE(service
+                    ->GetReplicaList("ssd_unmount_disk_only_key",
+                                     TenantId::Default())
+                    .has_value());
+
+    ASSERT_TRUE(service->UnmountLocalDiskSegment(client_id).has_value());
+
+    // Erased, the same as on client expiry: the disk held its last replica. A
+    // read gets a clean miss rather than a dead peer.
+    EXPECT_FALSE(service
+                     ->GetReplicaList("ssd_unmount_disk_only_key",
+                                      TenantId::Default())
+                     .has_value());
+
+    // A store that comes back re-adopts its files, so deregistering costs a
+    // restart nothing.
+    ASSERT_TRUE(service->MountLocalDiskSegment(client_id, true).has_value());
+    ASSERT_TRUE(service->NotifyOffloadSuccess(client_id, {task}, {metadata})
+                    .has_value());
+    auto restored = service->GetReplicaList("ssd_unmount_disk_only_key",
+                                            TenantId::Default());
+    ASSERT_TRUE(restored.has_value());
+    ASSERT_EQ(1u, restored.value().replicas.size());
+    EXPECT_TRUE(restored.value().replicas[0].is_local_disk_replica());
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -186,6 +186,14 @@ class PromotionOnHitTest : public ::testing::Test {
         MasterService& service, const UUID& client_id, const std::string& key,
         int64_t size, const std::string& transport_endpoint,
         std::string tenant_id = std::string(TenantId::kDefaultValue)) {
+        // NotifyOffloadSuccess registers replicas only for a client with a
+        // mounted LOCAL_DISK segment, the way the real offload pipeline
+        // mounts before registering. Idempotent, so repeat injections for
+        // the same client are fine.
+        auto mount = service.MountLocalDiskSegment(client_id, true);
+        if (!mount.has_value()) {
+            return false;
+        }
         std::vector<OffloadTaskItem> tasks{
             OffloadTaskItem{.tenant_id = tenant_id, .key = key, .size = size}};
         StorageObjectMetadata sm;

--- a/mooncake-store/tests/rpc_timeout_test.cpp
+++ b/mooncake-store/tests/rpc_timeout_test.cpp
@@ -117,4 +117,47 @@ TEST(RpcTimeoutTest, RpcTimesOutAgainstUnresponsiveMaster) {
                                 "timeout still active?)";
 }
 
+// The offload data path (store->store) builds its own client pool, separate
+// from the master pool, and used to ignore these variables entirely: its
+// connect timeout stayed at the built-in 30s, so a read that picked a peer
+// which had gone away blocked for connect_retry_count * 30s plus the waits
+// between retries with no way to configure it down. Both pools now go through
+// one helper, so cover the helper itself: an unset variable must leave the
+// built-in default alone, and a set one must be applied.
+TEST(RpcTimeoutTest, TimeoutEnvOverridesAreOptIn) {
+    struct StubClientConfig {
+        std::chrono::milliseconds request_timeout_duration{
+            std::chrono::seconds(30)};
+        std::chrono::milliseconds connect_timeout_duration{
+            std::chrono::seconds(30)};
+    };
+
+    ::unsetenv("MC_RPC_TIMEOUT_MS");
+    ::unsetenv("MC_RPC_CONNECT_TIMEOUT_MS");
+
+    StubClientConfig defaults;
+    detail::ApplyRpcTimeoutEnvOverrides(defaults);
+    EXPECT_EQ(defaults.request_timeout_duration, std::chrono::seconds(30));
+    EXPECT_EQ(defaults.connect_timeout_duration, std::chrono::seconds(30));
+
+    ASSERT_EQ(::setenv("MC_RPC_TIMEOUT_MS", "1500", /*overwrite=*/1), 0);
+    ASSERT_EQ(::setenv("MC_RPC_CONNECT_TIMEOUT_MS", "1000", /*overwrite=*/1),
+              0);
+
+    StubClientConfig overridden;
+    detail::ApplyRpcTimeoutEnvOverrides(overridden);
+    EXPECT_EQ(overridden.request_timeout_duration,
+              std::chrono::milliseconds(1500));
+    EXPECT_EQ(overridden.connect_timeout_duration,
+              std::chrono::milliseconds(1000));
+
+    // The master pool is built from the same helper, so it sees them too.
+    auto master_config = detail::MakeMasterRpcClientPoolConfig();
+    EXPECT_EQ(master_config.client_config.connect_timeout_duration,
+              std::chrono::milliseconds(1000));
+
+    ::unsetenv("MC_RPC_TIMEOUT_MS");
+    ::unsetenv("MC_RPC_CONNECT_TIMEOUT_MS");
+}
+
 }  // namespace mooncake

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -251,6 +251,12 @@ class MooncakeStoreService:
                 web.post(
                     "/api/unmount", _timed_handler("UNMOUNT", self.handle_unmount)
                 ),
+                web.post(
+                    "/api/unmount_local_disk",
+                    _timed_handler(
+                        "UNMOUNT_LOCAL_DISK", self.handle_unmount_local_disk
+                    ),
+                ),
                 web.put("/api/put", _timed_handler("PUT", self.handle_put)),
                 web.get("/api/get/{key}", _timed_handler("GET", self.handle_get)),
                 web.get("/api/exist/{key}", _timed_handler("EXIST", self.handle_exist)),
@@ -608,6 +614,47 @@ class MooncakeStoreService:
             )
         except Exception as e:
             logging.error("UNMOUNT error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
+            )
+
+    async def handle_unmount_local_disk(self, request):
+        """Deregister this store's SSD offload tier before the process goes away.
+
+        Meant for a preStop hook. The master stops naming this store as the
+        owner of its offloaded keys, so a reader gets a clean miss instead of a
+        peer that is about to disappear; the call then holds for
+        grace_period_seconds so offload reads already in flight finish here.
+        Runs off the event loop because that wait is seconds long.
+        """
+        try:
+            try:
+                data = await request.json()
+            except Exception:
+                data = {}
+            grace_period_seconds = data.get("grace_period_seconds", 0)
+
+            ret = await asyncio.to_thread(
+                self.store.unmount_local_disk_segment, grace_period_seconds
+            )
+            if ret != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps(
+                        {"error": f"Unmount local disk failed, ret={ret}"}
+                    ),
+                    content_type="application/json",
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT_LOCAL_DISK error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -12,6 +12,11 @@ from aiohttp import web
 from mooncake.store import MooncakeDistributedStore
 from mooncake.mooncake_config import MooncakeConfig
 
+# Caps a caller's /api/unmount_local_disk grace period so a malformed value
+# (e.g. milliseconds passed where seconds are expected) blocks a preStop hook
+# for minutes rather than hours.
+_MAX_UNMOUNT_LOCAL_DISK_GRACE_PERIOD_SECONDS = 3600
+
 
 def _timed_handler(operation_name, handler):
     async def wrapper(request):
@@ -630,12 +635,41 @@ class MooncakeStoreService:
         Runs off the event loop because that wait is seconds long.
         """
         try:
-            try:
-                data = await request.json()
-            except Exception:
-                data = {}
-            grace_period_seconds = data.get("grace_period_seconds", 0)
+            data = await request.json()
+        except Exception:
+            return web.Response(
+                status=400,
+                text=json.dumps({"error": "Malformed JSON body"}),
+                content_type="application/json",
+            )
+        if not isinstance(data, dict):
+            return web.Response(
+                status=400,
+                text=json.dumps({"error": "Request body must be a JSON object"}),
+                content_type="application/json",
+            )
 
+        grace_period_seconds = data.get("grace_period_seconds", 0)
+        if (
+            type(grace_period_seconds) is not int
+            or grace_period_seconds < 0
+            or grace_period_seconds > _MAX_UNMOUNT_LOCAL_DISK_GRACE_PERIOD_SECONDS
+        ):
+            return web.Response(
+                status=400,
+                text=json.dumps(
+                    {
+                        "error": (
+                            "Invalid grace_period_seconds, must be a non-negative "
+                            "integer no greater than "
+                            f"{_MAX_UNMOUNT_LOCAL_DISK_GRACE_PERIOD_SECONDS}"
+                        )
+                    }
+                ),
+                content_type="application/json",
+            )
+
+        try:
             ret = await asyncio.to_thread(
                 self.store.unmount_local_disk_segment, grace_period_seconds
             )

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -251,6 +251,12 @@ class MooncakeStoreService:
                 web.post(
                     "/api/unmount", _timed_handler("UNMOUNT", self.handle_unmount)
                 ),
+                web.post(
+                    "/api/unmount_local_disk",
+                    _timed_handler(
+                        "UNMOUNT_LOCAL_DISK", self.handle_unmount_local_disk
+                    ),
+                ),
                 web.put("/api/put", _timed_handler("PUT", self.handle_put)),
                 web.get("/api/get/{key}", _timed_handler("GET", self.handle_get)),
                 web.get("/api/exist/{key}", _timed_handler("EXIST", self.handle_exist)),
@@ -608,6 +614,45 @@ class MooncakeStoreService:
             )
         except Exception as e:
             logging.error("UNMOUNT error: %s", e)
+            return web.Response(
+                status=500,
+                text=json.dumps({"error": str(e)}),
+                content_type="application/json",
+            )
+
+    async def handle_unmount_local_disk(self, request):
+        """Deregister this store's SSD offload tier before the process goes away.
+
+        Meant for a preStop hook. The master stops naming this store as the
+        owner of its offloaded keys, so a reader gets a clean miss instead of a
+        peer that is about to disappear; the call then holds for
+        grace_period_seconds so offload reads already in flight finish here.
+        Runs off the event loop because that wait is seconds long.
+        """
+        try:
+            try:
+                data = await request.json()
+            except Exception:
+                data = {}
+            grace_period_seconds = data.get("grace_period_seconds", 0)
+
+            ret = await asyncio.to_thread(
+                self.store.unmount_local_disk_segment, grace_period_seconds
+            )
+            if ret != 0:
+                return web.Response(
+                    status=500,
+                    text=json.dumps({"error": f"Unmount local disk failed, ret={ret}"}),
+                    content_type="application/json",
+                )
+
+            return web.Response(
+                status=200,
+                text=json.dumps({"status": "success"}),
+                content_type="application/json",
+            )
+        except Exception as e:
+            logging.error("UNMOUNT_LOCAL_DISK error: %s", e)
             return web.Response(
                 status=500,
                 text=json.dumps({"error": str(e)}),

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -61,6 +61,8 @@ class FakeStore:
         self.unmount_failures = set()
         self.allocated_mount_calls = []
         self.free_unmount_calls = []
+        self.unmount_local_disk_calls = []
+        self.fail_unmount_local_disk = False
         self.setup_calls = []
 
     def setup(self, *args):
@@ -103,12 +105,19 @@ class FakeStore:
         self.free_unmount_calls.append((list(segment_ids), grace_period_seconds))
         return 0
 
+    def unmount_local_disk_segment(self, grace_period_seconds=0):
+        self.unmount_local_disk_calls.append(grace_period_seconds)
+        return -1 if self.fail_unmount_local_disk else 0
+
 
 class FakeRequest:
-    def __init__(self, body):
+    def __init__(self, body, json_error=None):
         self.body = body
+        self.json_error = json_error
 
     async def json(self):
+        if self.json_error is not None:
+            raise self.json_error
         return self.body
 
 
@@ -489,6 +498,82 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 400)
         body = json.loads(resp.text)
         self.assertIn("Missing segment_ids", body["error"])
+
+    # ============= /api/unmount_local_disk tests =============
+
+    async def test_unmount_local_disk_malformed_json_rejected(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest(None, json_error=json.JSONDecodeError("bad", "doc", 0))
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_non_object_body(self):
+        resp = await self.service.handle_unmount_local_disk(FakeRequest([1, 2, 3]))
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_bool_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": True})
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_string_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": "30"})
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_float_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": 1.5})
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_negative_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": -1})
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_rejects_grace_period_above_bound(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": 3601})
+        )
+        self.assertEqual(resp.status, 400)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [])
+
+    async def test_unmount_local_disk_accepts_bound_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": 3600})
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [3600])
+
+    async def test_unmount_local_disk_defaults_grace_period_to_zero(self):
+        resp = await self.service.handle_unmount_local_disk(FakeRequest({}))
+        self.assertEqual(resp.status, 200)
+        body = json.loads(resp.text)
+        self.assertEqual(body["status"], "success")
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [0])
+
+    async def test_unmount_local_disk_passes_positive_grace_period(self):
+        resp = await self.service.handle_unmount_local_disk(
+            FakeRequest({"grace_period_seconds": 30})
+        )
+        self.assertEqual(resp.status, 200)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [30])
+
+    async def test_unmount_local_disk_store_failure(self):
+        self.fake_store.fail_unmount_local_disk = True
+        resp = await self.service.handle_unmount_local_disk(FakeRequest({}))
+        self.assertEqual(resp.status, 500)
+        self.assertEqual(self.fake_store.unmount_local_disk_calls, [0])
 
     # ==================== /api/put tests ====================
 


### PR DESCRIPTION
## Description

`LOCAL_DISK` is the only segment kind with no unmount half. It leaves the master
exclusively by client expiry, so a store that is shutting down stays advertised
as the owner of every key it offloaded for up to one `client_ttl` after it stops
pinging, and a read that picks up that replica reaches a peer that can no longer
serve it.

The asymmetry is easy to see by listing what each segment kind exposes:

| Segment | Mount | Unmount | Graceful unmount | Callable from the client |
| -- | -- | -- | -- | -- |
| Memory | ✅ | `UnmountSegment` | `GracefulUnmountSegment` | ✅ |
| NVMe-oF (`NoF`) — also a disk | ✅ | `UnmountNoFSegment` | — | ✅ |
| `LOCAL_DISK` | ✅ every layer | master-internal function only | ❌ | ❌ |

`MountLocalDiskSegment` runs through `client_service` → `master_client.h` →
`rpc_service.h` → `master_service.h` → `segment.h`. `UnmountLocalDiskSegment`
exists in `segment.h` and at exactly one call site — the client-expiry branch of
`ClientMonitorFunc` — with no registered handler. Since `UnmountNoFSegment` is a
registered RPC and NVMe-oF is also a disk, this does not look like a property of
disks; it looks like a missing half.

`Client::~Client()` inherits the same gap: it stops the ping thread first, then
unmounts the memory segments tracked in `mounted_segments_`, and a `LOCAL_DISK`
segment is never put in that map. #2077 hit the same thing from the remount side
and worked around it there.

### How long a read blocks, and why it is not configurable

`ClientRequester::ClientRequester()` hardcodes `connect_retry_count = 3` and
`reconnect_wait_time = 1000 ms` and leaves the connect timeout at coro_rpc's
built-in 30 s. Unlike `MasterClient`, it reads no environment override, so
3 × 30 s + 1 s ≈ 91 s and nothing in the configuration can shorten it. A
sequential reader measured 91,002 ms twice, in two independent sessions, on a
two-node RDMA rig.

The caller's own deadline always fires first — a KV-cache read has a couple of
seconds, since a miss just falls back to prefill recompute — so the cost is not
latency. It is that the worker stays parked in the RPC: every concurrent read
issued into the same window parks another one, which turns a routine scale-in
into a capacity loss rather than a latency blip.

### The change

Two parts, covering two different paths. They are not alternatives.

**1. Give `LOCAL_DISK` the unmount half its mount half already has.**
`MasterService::UnmountLocalDiskSegment(client_id)` is exposed through the same
layers (`rpc_service` → `master_client` → `client_service`). `FileStorage` gains
`DrainLocalDiskSegment(grace_period_ms)`, reachable from Python as
`unmount_local_disk_segment(grace_period_seconds)` and over the store's REST API
as `POST /api/unmount_local_disk`, so a shutdown hook can call it. This closes
the window on the **planned** path — a scale-in, a rolling replacement.

Three things were less obvious than they look, and are why this is not a
three-line patch:

- **The grace period is load-bearing.** A memory replica is served by the NIC
  without the store process; a disk replica is read and pushed *by* that
  process. So the process has to outlive the deregistration long enough for the
  reads the master already handed out. Deregister-then-wait is also the
  race-free order: reads that already have the replica list complete against a
  live store, and reads that have not asked yet get a clean miss.
- **The heartbeat undoes a naive unmount.** `FileStorage::Heartbeat` re-mounts
  the segment and re-registers every object whenever `OffloadObjectHeartbeat`
  answers `SEGMENT_NOT_FOUND`. On the default 10 s interval, an unmount without
  a latch is reverted within ten seconds. The drain therefore sets `draining_`
  *before* the RPC, and the heartbeat returns early while it is set. The client
  TTL is renewed by `Ping` on a different thread, so the client stays alive for
  its memory segments.
- **The sweep has to be scoped by owner, not by liveness.** The replica cleanup
  classifies a `LOCAL_DISK` replica as stale when its owner is missing from the
  set it is handed, and a client only enters `ok_client_` by remounting. Passing
  the alive snapshot alone therefore drops the disk replicas of any peer that
  has not remounted yet — one store's deregistration becomes everyone's. The set
  passed here is the alive snapshot plus every current disk-segment owner, minus
  the caller. There is a regression test for exactly this
  (`UnmountLocalDiskSegmentDropsOnlyItsOwnReplicas`).

Object metadata is treated exactly as on expiry, including erasing a key whose
last replica was that disk. That is safe because `AddReplica` recreates a
missing object (`accessor.Create`), so a store that comes back re-adopts its own
files through `MountLocalDiskSegment` + `NotifyOffloadSuccess` — the recovery
#2077 added. Measured both ways below: 256/256 keys came back after a deliberate
drain as well as after a crash-expiry, and an earlier session saw 1152 keys
restored in 4 ms on the expiry path.

**2. Let the offload RPC honour the timeout variables the master client already
honours.** Both pools now go through one helper
(`detail::ApplyRpcTimeoutEnvOverrides`), so `MC_RPC_CONNECT_TIMEOUT_MS` and
`MC_RPC_TIMEOUT_MS` apply to the store→store path too and the two cannot drift.
**Defaults are unchanged when the variables are unset.** This covers the
**unplanned** path — a crash, an OOM kill, a lost node — where nobody gets to
unmount anything. `ClientRequester::invoke_rpc` also maps
`coro_rpc::errc::timed_out` to `ErrorCode::RPC_TIMEOUT`, as `master_client.cpp`
already does; without it a fired timeout was indistinguishable from any other
RPC failure.

Related: #2953 (the client liveness state machine RFC — its goal of separating
segment lifecycle from liveness is the same direction as part 1, and this is the
narrow version of it), #2039 (one dead peer propagating to all replicas), #2077.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Integration (`mooncake-integration`)
- [x] Python Wheel (`mooncake-wheel`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] New feature

## How Has This Been Tested?

Unit tests, plus a two-node RDMA rig running the built artifacts.

**Test commands:**
```bash
cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_STORE_RUST=OFF \
  -DWITH_P2P_STORE=OFF -DWITH_EP=OFF -DBUILD_UNIT_TESTS=ON -DUSE_ETCD=OFF
ninja master_service_ssd_test rpc_timeout_test segment_test offload_on_evict_test
./mooncake-store/tests/master_service_ssd_test
./mooncake-store/tests/rpc_timeout_test
./mooncake-store/tests/segment_test
./mooncake-store/tests/offload_on_evict_test
```

**Test results:** 49 tests across the four suites, all passing — 23
`master_service_ssd_test` (5 new), 3 `rpc_timeout_test` (1 new), 14
`segment_test`, 9 `offload_on_evict_test`.

New tests:

| Test | What it pins |
| -- | -- |
| `UnmountLocalDiskSegmentRequiresOffloadEnabled` | `UNABLE_OFFLOAD` when offload is off, mirroring mount |
| `UnmountLocalDiskSegmentIsIdempotent` | repeats and unknown clients succeed |
| `UnmountLocalDiskSegmentStopsOffloadWork` | the heartbeat then answers `SEGMENT_NOT_FOUND` |
| `UnmountLocalDiskSegmentDropsOnlyItsOwnReplicas` | a peer that has not remounted keeps its disk replicas |
| `UnmountLocalDiskSegmentKeepsReAdoptionWorking` | a disk-only key is erased, and re-registration recreates it |
| `TimeoutEnvOverridesAreOptIn` | unset leaves the built-in default; set is applied; both pools share it |

- [x] Unit tests pass
- [x] Manual testing done (described below)

### Rig measurement

Two nodes, RDMA, the store owning the disk and the reader on the other node,
`--client_ttl=10`, 256 disk-resident keys (confirmed by the offload-RPC counter
rising), 8 concurrent readers. Each arm stamps its own wall clock immediately
before the action; `.metadata.deletionTimestamp` is SIGTERM plus
`terminationGracePeriodSeconds`, not the request time, and anchoring on it is how
an earlier session mistook an ordinary shutdown for a spontaneous departure.

| Arm | What | Result |
| -- | -- | -- |
| Planned scale-in, through the drain | `POST /api/unmount_local_disk` in preStop, grace 20 s | **0 reads blocked**, worst read after the request **40.3 ms / 41.9 ms** over two runs |
| Crash, no override | store process `kill -9` | **every one of the 8 workers parked on one read** — 4 × 33.2 s, 4 × 62.0 s |
| Crash, `MC_RPC_CONNECT_TIMEOUT_MS=1000` | same kill | worst read **4,196 ms** — 3 retries × 1 s plus the waits |
| Correctness, all arms | payload derived from the key, checked byte for byte | **654,123 reads, 0 wrong answers, 0 client exceptions** |
| Re-adoption | store returns to the disk it left | **256/256 keys back**, after both the crash-expiry path and a deliberate drain |

The mechanism is visible in the master's own gauges. On the planned scale-in the
two diverge: `file_cache_nums_` goes 1136 → 0 at **T0+1.7 s**, when the drain's
RPC returns, while `master_active_clients` only drops at **T0+31.6 s** when the
TTL expires. So the disk tier is deregistered while the store can still serve,
and nothing is handed a dead owner for the following 30 seconds. On the crash the
two fall together at T0+11.1 s, TTL expiry being the only path — that is the
window part 2 bounds.

One honest gap: the uncapped crash blocked for 33.2 s and 62.0 s rather than the
full 91 s, i.e. one and two connect attempts rather than three. A sequential
reader reproduced 91,002 ms to the millisecond in an earlier session, so 91 s
stands as the ceiling; the lower figures here look like eight workers contending
on one client pool, which I did not chase further. Either way it is tens of
seconds, and the override brings it to 4.2 s.

A note for anyone reproducing this: `kubectl delete --force --grace-period=0`
does **not** give you a crash. The kubelet still runs preStop — the disk replicas
came out 1.03 s after the request while the client stayed alive for another 10 s —
so it measures a truncated drain. Kill the process instead.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

On the last two: the diff is ~520 lines including tests and docs (~230 lines of
non-test source). #2953 is the open RFC this follows, and I would rather fold
this into that discussion than open a competing one — happy to file a separate
RFC if you would prefer. `pre-commit` was not run end to end because the build
host had no `clang-format`; the C++ follows the existing 4-space / 80-column
style of the files it touches, and I will fix up anything the hooks flag.

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Written with Claude Code. It traced the segment-lifecycle and replica-cleanup
paths, wrote the patch and the tests, and drove the rig. The two design
corrections that mattered — the heartbeat re-mount race, and scoping the replica
sweep by owner rather than by liveness — came out of that reading and from a
test failure, and both are covered by tests above. I have reviewed every line
and am responsible for it.