### PR TITLE
Allow configuring master admin/metrics HTTP bind address

### DIFF
--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -23,7 +23,8 @@ class WrappedMasterService;
 
 class MasterAdminServer {
    public:
-    MasterAdminServer(uint16_t http_port, bool enable_metric_reporting);
+    MasterAdminServer(uint16_t http_port, bool enable_metric_reporting,
+                      std::string http_host = "0.0.0.0");
 
     ~MasterAdminServer();
 
@@ -107,6 +108,7 @@ class MasterAdminServer {
     void RegisterHandler();
 
     uint16_t http_port_;
+    std::string http_host_;
     bool enable_metric_reporting_ = false;
     coro_http::coro_http_server http_server_;
     std::thread metric_report_thread_;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -30,6 +30,7 @@ inline std::string ResolveConfiguredHABackendConnstring(
 struct MasterConfig {
     bool enable_metric_reporting;
     uint32_t metrics_port;
+    std::string metrics_host;
     uint32_t rpc_port;
     uint32_t rpc_thread_num;
     std::string rpc_address;
@@ -182,6 +183,7 @@ class MasterServiceSupervisorConfig {
 
     // Parameters with default values (optional parameters)
     std::string rpc_address = "0.0.0.0";
+    std::string metrics_host = "0.0.0.0";
     std::chrono::steady_clock::duration rpc_conn_timeout = std::chrono::seconds(
         0);  // Client connection timeout. 0 = no timeout (infinite)
     bool rpc_enable_tcp_no_delay = true;
@@ -269,6 +271,7 @@ class MasterServiceSupervisorConfig {
         // Set required parameters using RequiredParam
         enable_metric_reporting = config.enable_metric_reporting;
         metrics_port = static_cast<int>(config.metrics_port);
+        metrics_host = config.metrics_host;
         default_kv_lease_ttl = config.default_kv_lease_ttl;
         default_kv_soft_pin_ttl = config.default_kv_soft_pin_ttl;
         allow_evict_soft_pinned_objects =

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -516,7 +516,7 @@ int MasterServiceSupervisor::Start() {
 
     mooncake::MasterAdminServer admin_server(
         static_cast<uint16_t>(config_.metrics_port),
-        config_.enable_metric_reporting);
+        config_.enable_metric_reporting, config_.metrics_host);
     if (!admin_server.Start()) {
         LOG(ERROR) << "Failed to start master admin server, metrics_port="
                    << config_.metrics_port;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1552,8 +1552,7 @@ int main(int argc, char* argv[]) {
                 metadata_server_ptr, http_metadata_remote_url);
         mooncake::MasterAdminServer admin_server(
             static_cast<uint16_t>(master_config.metrics_port),
-            master_config.enable_metric_reporting,
-            master_config.metrics_host);
+            master_config.enable_metric_reporting, master_config.metrics_host);
         if (!admin_server.Start()) {
             LOG(ERROR) << "Failed to start master admin server";
             return 1;

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -118,6 +118,9 @@ DEFINE_int32(
     "Maximum number of threads to use (deprecated, use rpc_thread_num)");
 DEFINE_bool(enable_metric_reporting, true, "Enable periodic metric reporting");
 DEFINE_int32(metrics_port, 9003, "Port for HTTP metrics server to listen on");
+DEFINE_string(metrics_host, "0.0.0.0",
+              "Address for the HTTP metrics/admin server to listen on. "
+              "Use \"::\" to listen on IPv6 (and IPv4 on dual-stack hosts)");
 DEFINE_string(default_kv_lease_ttl, kDefaultKvLeaseTtlFlagValue,
               "Default lease time for kv objects. Supports raw milliseconds "
               "or duration strings with ms, s, m, or h suffixes");
@@ -440,6 +443,8 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                            FLAGS_enable_metric_reporting);
     default_config.GetUInt32("metrics_port", &master_config.metrics_port,
                              FLAGS_metrics_port);
+    default_config.GetString("metrics_host", &master_config.metrics_host,
+                             FLAGS_metrics_host);
     default_config.GetUInt32("rpc_port", &master_config.rpc_port,
                              FLAGS_rpc_port);
     default_config.GetUInt32("rpc_thread_num", &master_config.rpc_thread_num,
@@ -779,6 +784,11 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.metrics_port = FLAGS_metrics_port;
+    }
+    if ((google::GetCommandLineFlagInfo("metrics_host", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.metrics_host = FLAGS_metrics_host;
     }
     if ((google::GetCommandLineFlagInfo("default_kv_lease_ttl", &info) &&
          !info.is_default) ||
@@ -1421,6 +1431,7 @@ int main(int argc, char* argv[]) {
         << ", max_threads=" << master_config.rpc_thread_num
         << ", enable_metric_reporting=" << master_config.enable_metric_reporting
         << ", metrics_port=" << master_config.metrics_port
+        << ", metrics_host=" << master_config.metrics_host
         << ", default_kv_lease_ttl=" << master_config.default_kv_lease_ttl
         << ", default_kv_soft_pin_ttl=" << master_config.default_kv_soft_pin_ttl
         << ", allow_evict_soft_pinned_objects="
@@ -1541,7 +1552,8 @@ int main(int argc, char* argv[]) {
                 metadata_server_ptr, http_metadata_remote_url);
         mooncake::MasterAdminServer admin_server(
             static_cast<uint16_t>(master_config.metrics_port),
-            master_config.enable_metric_reporting);
+            master_config.enable_metric_reporting,
+            master_config.metrics_host);
         if (!admin_server.Start()) {
             LOG(ERROR) << "Failed to start master admin server";
             return 1;

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -252,10 +252,12 @@ tl::expected<HttpTenantQuotaPolicyRequest, std::string> ParseQuotaPolicyBody(
 }  // namespace
 
 MasterAdminServer::MasterAdminServer(uint16_t http_port,
-                                     bool enable_metric_reporting)
+                                     bool enable_metric_reporting,
+                                     std::string http_host)
     : http_port_(http_port),
+      http_host_(std::move(http_host)),
       enable_metric_reporting_(enable_metric_reporting),
-      http_server_(4, http_port) {}
+      http_server_(4, http_port, http_host_) {}
 
 MasterAdminServer::~MasterAdminServer() { Stop(); }
 
@@ -268,8 +270,8 @@ bool MasterAdminServer::Start() {
 
     auto ec = http_server_.async_start();
     if (ec.hasResult()) {
-        LOG(ERROR) << "Failed to start master admin server on port "
-                   << http_port_;
+        LOG(ERROR) << "Failed to start master admin server on " << http_host_
+                   << ":" << http_port_ << ": " << ec.value().message();
         return false;
     }
 


### PR DESCRIPTION
### Problem

`MasterAdminServer` always constructs `coro_http_server` using the 2-argument overload, so the admin/metrics HTTP server always binds to the default `0.0.0.0` address with no way to override it.

On IPv6-only hosts this causes the master to fail during startup. ylt's `listen()` resolves the bind address via `getaddrinfo(..., AI_ADDRCONFIG)`. Resolving `0.0.0.0` fails when the system has no non-loopback IPv4 address, causing `async_start()` to return an error. The master then exits and enters a restart loop.

`enable_metric_reporting=false` does not help because the admin server is constructed unconditionally in both the HA and non-HA code paths.

### Fix

Add a `metrics_host` option (gflag + config, defaulting to `0.0.0.0` for backward compatibility) and propagate it through `MasterConfig` and `MasterServiceSupervisorConfig` into `MasterAdminServer(http_port, enable_metric_reporting, http_host)`. The server then forwards it to the 3-argument `coro_http_server(thread_num, port, address)` overload.

Setting `metrics_host=::` makes the admin server bind to `[::]`. The startup failure log now also includes the configured host and the `async_start()` error message.

### Testing

On an IPv6-only host (no non-loopback IPv4 address, global IPv6 available):

* default `0.0.0.0` → startup fails because the admin server cannot bind;
* `metrics_host=::` → startup succeeds, the admin server binds to `[::]:<port>`, and `/metrics` is reachable over IPv6.

On dual-stack hosts, the default `0.0.0.0` behavior is unchanged.