### PR TITLE
[PG] Support inplace rejoin and fix p2p recovery

### DIFF
--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -31,8 +31,12 @@ class MooncakeCommunicator;
 //   Isolated --(Active view)--> Normal
 //
 // Joining member:
-//   Isolated --(joinGroup: drain preparation collectives)--> Quiescing
+//   Isolated ---------(joinGroup: drain operations)--------> Quiescing
 //            -----------------(Active view)----------------> Normal
+//
+// In-place rejoining member:
+//   Normal + inactive --(joinGroup: drain operations)------> Quiescing
+//                     ---------(Active view)---------------> Normal
 //
 // Isolated admits local-only collectives with an {self} active ranks mask.
 // Quiescing rejects new collectives while waiting for activation. Normal uses

--- a/mooncake-pg/include/p2p_proxy.h
+++ b/mooncake-pg/include/p2p_proxy.h
@@ -335,15 +335,6 @@ class P2PProxy {
      */
     void abandonResources();
 
-    // Epoch for fault recovery.  All control slots carry this
-    // value so that stale messages from before a Reset can be detected.
-    uint32_t getEpoch(int peer_rank) const {
-        return peer_epoch_[peer_rank].load(std::memory_order_acquire);
-    }
-    void setEpoch(int peer_rank, uint32_t epoch) {
-        peer_epoch_[peer_rank].store(epoch, std::memory_order_release);
-    }
-
    private:
     // Sender-side per-chunk state machine.
     enum class SendTaskState {
@@ -375,7 +366,7 @@ class P2PProxy {
         SendTransferTask() = default;
         SendTransferTask(uint64_t buffer_offset_in, uint32_t chunk_len_in,
                          void* staging_addr_in, uint64_t remote_addr_in,
-                         uint32_t sequence_in, uint32_t epoch_in);
+                         uint32_t sequence_in);
 
         SendTaskState state_ = SendTaskState::kCopyIn;
         uint64_t buffer_offset_ = 0;  // Offset inside the user buffer.
@@ -383,7 +374,6 @@ class P2PProxy {
         void* staging_addr_ = nullptr;  // Address inside SendPool.
         uint64_t remote_addr_ = 0;      // Address inside REMOTE RecvPool.
         uint32_t sequence_ = 0;         // Sequence number in the control ring.
-        uint32_t epoch_ = 0;            // Epoch for Reset detection.
         std::optional<BatchID> transfer_batch_id_;  // RDMA Write batch id.
         std::optional<BatchID> ack_batch_id_;       // AckSlot write batch id.
         cudaEvent_t copy_ready_event_ = nullptr;  // Signals Copy-In done (GPU).
@@ -420,15 +410,13 @@ class P2PProxy {
     struct RecvTransferTask {
         RecvTransferTask() = default;
         RecvTransferTask(uint64_t buffer_offset_in, uint32_t chunk_len_in,
-                         void* local_addr_in, uint32_t sequence_in,
-                         uint32_t epoch_in);
+                         void* local_addr_in, uint32_t sequence_in);
 
         RecvTaskState state_ = RecvTaskState::kIssueCredit;
         uint64_t buffer_offset_ = 0;  // Offset inside the user buffer.
         uint32_t chunk_len_ = 0;      // Bytes in this chunk.
         void* local_addr_ = nullptr;  // Address inside local RecvPool.
         uint32_t sequence_ = 0;       // Sequence number in the control ring.
-        uint32_t epoch_ = 0;          // Epoch for Reset detection.
         std::optional<BatchID>
             credit_batch_id_;  // CreditSlot RDMA Write batch id.
         cudaEvent_t copy_ready_event_ =
@@ -590,11 +578,6 @@ class P2PProxy {
 
     std::atomic<int> active_send_tasks_{0};
     std::atomic<int> active_recv_tasks_{0};
-
-    // Per-peer epoch for fault recovery.  Incremented in resetPeerState
-    // and performSend/RecvReset so that stale messages from a previous epoch
-    // can be detected on a per-peer basis.
-    std::array<std::atomic<uint32_t>, kMaxNumRanks> peer_epoch_;
 
     std::array<SendPeerLane, kMaxNumRanks> send_peer_lanes_;
     std::array<RecvPeerLane, kMaxNumRanks> recv_peer_lanes_;

--- a/mooncake-pg/src/mooncake_communicator.cpp
+++ b/mooncake-pg/src/mooncake_communicator.cpp
@@ -616,15 +616,16 @@ PGResult<void> MooncakeCommunicator::checkOpState(OpType op) const {
             "rank " + std::to_string(meta_->globalRank) +
                 " is offline and cannot perform operations");
     }
-    // P2P operations don't require the rank to be active in the group.
+    PG_VALIDATE_STATE(mode != CollectiveExtensionState::Quiescing,
+                      "rank is quiescing and cannot issue operations");
+
     const bool is_p2p = op == OpType::Send || op == OpType::Recv;
-    if (!isValidGroup() && is_p2p) {
-        return makePGError(PGErrorCode::NotSupported,
-                           "P2P is unavailable for an invalid Mooncake group");
-    }
-    if (!is_p2p) {
-        PG_VALIDATE_STATE(mode != CollectiveExtensionState::Quiescing,
-                          "rank is quiescing and cannot issue collectives");
+    if (is_p2p) {
+        // P2P operations require an valid group
+        PG_VALIDATE_STATE(isValidGroup(),
+                          "P2P is unavailable for an invalid group");
+    } else {
+        // Collectives in an invalid group remain local-only
         PG_VALIDATE_STATE(mode == CollectiveExtensionState::Isolated ||
                               meta_->activeRanks[rank_],
                           "rank is not active in this group");
@@ -1433,18 +1434,31 @@ PGResult<ProposeViewUpdateResponse> MooncakeCommunicator::deactivateRanks(
 PGResult<void> MooncakeCommunicator::joinGroup() {
     PG_TRY(checkValidGroup("joinGroup"));
     auto mode = meta_->extensionMode.load(std::memory_order_acquire);
-    PG_VALIDATE_STATE(
-        mode == CollectiveExtensionState::Isolated,
-        "joinGroup may only be called once on an isolated joining "
-        "communicator");
-    // Stop admitting isolated collectives before advertising readiness.
+    const bool is_initial_join = mode == CollectiveExtensionState::Isolated;
+    const bool is_inplace_rejoin =
+        mode == CollectiveExtensionState::Normal && !meta_->activeRanks[rank_];
+    PG_VALIDATE_STATE(is_initial_join || is_inplace_rejoin,
+                      "joinGroup requires an isolated or inactive rank");
+    // Stop admitting operations before advertising readiness.
     meta_->extensionMode.store(CollectiveExtensionState::Quiescing,
                                std::memory_order_release);
+    if (!p2p_proxy_->drainTasks()) {
+        return makePGError(PGErrorCode::Timeout,
+                           "timed out draining join preparation P2P tasks for "
+                           "rank " +
+                               std::to_string(meta_->globalRank));
+    }
     if (!worker_->drainTasks(meta_.get())) {
         return makePGError(
             PGErrorCode::Timeout,
             "timed out draining join preparation collectives for rank " +
                 std::to_string(meta_->globalRank));
+    }
+    // Auto-deactivation removes the old endpoint from the GroupView. The
+    // process and its registered buffers are still alive, so republish the
+    // current endpoint under a fresh endpoint epoch before declaring ready.
+    if (is_inplace_rejoin) {
+        PG_TRY(agent_.publishLocalEndpoint(buildEndpointMetadata()));
     }
     PG_TRY(agent_.confirmReadyForActivation(meta_->group_id));
     // Block until the Coordinator activates this rank in the group.

--- a/mooncake-pg/src/p2p_proxy.cpp
+++ b/mooncake-pg/src/p2p_proxy.cpp
@@ -219,10 +219,6 @@ void P2PProxy::allocateResources() {
     }
 
     for (size_t i = 0; i < kMaxNumRanks; ++i) {
-        peer_epoch_[i].store(1, std::memory_order_release);
-    }
-
-    for (size_t i = 0; i < kMaxNumRanks; ++i) {
         send_peer_lanes_[i].pending_send_ops_.clear();
         send_peer_lanes_[i].active_send_op_.reset();
         send_peer_lanes_[i].credit_consume_seq_ = 0;
@@ -287,12 +283,6 @@ void P2PProxy::resetPeerState(int peer_rank) {
               "ResetPeerState: peer_rank out of range: ", peer_rank,
               " size: ", size_);
 
-    // Epoch update:
-    //   We bump epoch_ so that any slots still in flight from the
-    //   old session (written by the sender/receiver before it learned about
-    //   the Reset) are recognized as stale and skipped.
-    peer_epoch_[peer_rank].fetch_add(1, std::memory_order_acq_rel);
-
     // Request reset
     reset_send_req_[peer_rank].store(true, std::memory_order_release);
     reset_recv_req_[peer_rank].store(true, std::memory_order_release);
@@ -332,22 +322,35 @@ void P2PProxy::cleanupFailedRecvOp(RecvOpContext& op_ctx) {
     active_recv_tasks_.fetch_sub(1, std::memory_order_release);
 }
 
+void P2PProxy::reportPeerFailure(int peer_rank) {
+    // Reset P2P session state (epoch, lanes).
+    resetPeerState(peer_rank);
+    // link event vector is indexed by GlobalRank.
+    const auto peer_global = meta_->rank_order[peer_rank];
+    const auto target_rank_epoch = meta_->rankEpochs[peer_global];
+    auto* communicator = meta_->communicator;
+    if (!communicator) return;
+
+    LinkEvent event;
+    event.events.assign(kMaxNumRanks, LinkEvent::EventType::None);
+    event.target_rank_epochs.assign(kMaxNumRanks, 0);
+    event.events[peer_global] = LinkEvent::EventType::Failure;
+    event.target_rank_epochs[peer_global] = target_rank_epoch;
+    communicator->getAgent().pushLinkEvent(event);
+
+    if (meta_->autoSyncOnFailure) {
+        auto result = communicator->syncAfterFailure();
+        PG_ASSERT(result.has_value() &&
+                      result.value().status != SyncAfterFailureStatus::Rejected,
+                  "syncAfterFailure failed for rank ", meta_->globalRank);
+    }
+}
+
 void P2PProxy::handleFailedSendOp(SendOpContext& op_ctx) {
     cleanupFailedSendOp(op_ctx);
     op_ctx.failed_ranks_hint_[op_ctx.peer_rank_] = 1;
-    // Reset P2P session state (epoch, lanes).
-    resetPeerState(op_ctx.peer_rank_);
-    // link event vector is indexed by GlobalRank.
+    reportPeerFailure(op_ctx.peer_rank_);
     const auto peer_global = meta_->rank_order[op_ctx.peer_rank_];
-    const auto target_rank_epoch = meta_->rankEpochs[peer_global];
-    if (meta_->communicator) {
-        LinkEvent event;
-        event.events.assign(kMaxNumRanks, LinkEvent::EventType::None);
-        event.target_rank_epochs.assign(kMaxNumRanks, 0);
-        event.events[peer_global] = LinkEvent::EventType::Failure;
-        event.target_rank_epochs[peer_global] = target_rank_epoch;
-        meta_->communicator->getAgent().pushLinkEvent(event);
-    }
     op_ctx.completion_->set_value();
     LOG(ERROR) << "Rank " << meta_->rank << ": P2P SendOp to peer "
                << op_ctx.peer_rank_ << " (global=" << peer_global
@@ -357,19 +360,8 @@ void P2PProxy::handleFailedSendOp(SendOpContext& op_ctx) {
 void P2PProxy::handleFailedRecvOp(RecvOpContext& op_ctx) {
     cleanupFailedRecvOp(op_ctx);
     op_ctx.failed_ranks_hint_[op_ctx.peer_rank_] = 1;
-    // Reset P2P session state (epoch, lanes).
-    resetPeerState(op_ctx.peer_rank_);
-    // link event vector is indexed by GlobalRank.
+    reportPeerFailure(op_ctx.peer_rank_);
     const auto peer_global = meta_->rank_order[op_ctx.peer_rank_];
-    const auto target_rank_epoch = meta_->rankEpochs[peer_global];
-    if (meta_->communicator) {
-        LinkEvent event;
-        event.events.assign(kMaxNumRanks, LinkEvent::EventType::None);
-        event.target_rank_epochs.assign(kMaxNumRanks, 0);
-        event.events[peer_global] = LinkEvent::EventType::Failure;
-        event.target_rank_epochs[peer_global] = target_rank_epoch;
-        meta_->communicator->getAgent().pushLinkEvent(event);
-    }
     op_ctx.completion_->set_value();
     LOG(ERROR) << "Rank " << meta_->rank << ": P2P RecvOp from peer "
                << op_ctx.peer_rank_ << " (global=" << peer_global
@@ -518,15 +510,16 @@ void P2PProxy::enqueueRecv(RecvOp op) {
     if (device_worker_) device_worker_->wakeUpRecv();
 }
 
-P2PProxy::SendTransferTask::SendTransferTask(
-    uint64_t buffer_offset_in, uint32_t chunk_len_in, void* staging_addr_in,
-    uint64_t remote_addr_in, uint32_t sequence_in, uint32_t epoch_in)
+P2PProxy::SendTransferTask::SendTransferTask(uint64_t buffer_offset_in,
+                                             uint32_t chunk_len_in,
+                                             void* staging_addr_in,
+                                             uint64_t remote_addr_in,
+                                             uint32_t sequence_in)
     : buffer_offset_(buffer_offset_in),
       chunk_len_(chunk_len_in),
       staging_addr_(staging_addr_in),
       remote_addr_(remote_addr_in),
-      sequence_(sequence_in),
-      epoch_(epoch_in) {
+      sequence_(sequence_in) {
     last_update_time_ = std::chrono::steady_clock::now();
 }
 
@@ -543,13 +536,11 @@ P2PProxy::SendOpContext::SendOpContext(SendOp&& op_in)
 P2PProxy::RecvTransferTask::RecvTransferTask(uint64_t buffer_offset_in,
                                              uint32_t chunk_len_in,
                                              void* local_addr_in,
-                                             uint32_t sequence_in,
-                                             uint32_t epoch_in)
+                                             uint32_t sequence_in)
     : buffer_offset_(buffer_offset_in),
       chunk_len_(chunk_len_in),
       local_addr_(local_addr_in),
-      sequence_(sequence_in),
-      epoch_(epoch_in) {
+      sequence_(sequence_in) {
     last_update_time_ = std::chrono::steady_clock::now();
 }
 
@@ -632,15 +623,15 @@ bool P2PProxy::tryIssueRecvTask(RecvOpContext& op_ctx, RecvPeerLane& lane) {
     const uint64_t remote_credit_offset =
         getRemoteCreditSlot(op_ctx.peer_rank_, seq);
 
-    const uint32_t curr_epoch =
-        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
+    const uint32_t group_epoch =
+        static_cast<uint32_t>(meta_->epoch.load(std::memory_order_acquire));
     op_ctx.tasks_.emplace_back(op_ctx.bytes_credited_, chunk_len, local_addr,
-                               seq, curr_epoch);
+                               seq);
     auto& task = op_ctx.tasks_.back();
 
     auto* credit_staging_buf = getLocalCreditStagingBuf(op_ctx.peer_rank_, seq);
     credit_staging_buf->publish(
-        curr_epoch, seq, reinterpret_cast<uint64_t>(local_addr), chunk_len);
+        group_epoch, seq, reinterpret_cast<uint64_t>(local_addr), chunk_len);
     const BatchID batch_id = engine_->allocateBatchID(1);
     engine_->submitTransfer(
         batch_id, {TransferRequest{
@@ -768,15 +759,15 @@ P2PProxy::IssueResult P2PProxy::tryIssueSendTask(SendOpContext& op_ctx,
         return IssueResult::kNoCredit;
     }
 
-    // Step 2 -- Stale packet: the slot carries data from a previous epoch
-    // (before a Reset).  Clear it so the fresh credit can land safely.
-    const uint32_t curr_epoch =
-        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
-    if (slot_epoch != curr_epoch) {
+    // Step 2 -- Stale packet: the slot belongs to an older group view. Clear it
+    // so the fresh credit can land safely.
+    const uint32_t group_epoch =
+        static_cast<uint32_t>(meta_->epoch.load(std::memory_order_acquire));
+    if (slot_epoch != group_epoch) {
         LOG(WARNING) << "[P2PProxy][Send] tryIssueSendTask peer="
                      << op_ctx.peer_rank_ << " STALE_EPOCH seq=" << seq
                      << " slot.epoch=" << slot_epoch
-                     << " curr_epoch=" << curr_epoch;
+                     << " group_epoch=" << group_epoch;
         slot.reset();
         return IssueResult::kIssued;
     }
@@ -798,7 +789,7 @@ P2PProxy::IssueResult P2PProxy::tryIssueSendTask(SendOpContext& op_ctx,
               "P2P send got invalid chunk_len in credit slot.");
 
     op_ctx.tasks_.emplace_back(op_ctx.bytes_staged_, chunk_len, staging_addr,
-                               recv_addr, seq, slot_epoch);
+                               recv_addr, seq);
     auto& task = op_ctx.tasks_.back();
 
     slot.reset();
@@ -939,7 +930,9 @@ bool P2PProxy::stepSendAck(SendOpContext& op_ctx, SendTransferTask& task) {
     if (!task.ack_batch_id_.has_value()) {
         auto* ack_staging_buf =
             getLocalAckStagingBuf(op_ctx.peer_rank_, task.sequence_);
-        ack_staging_buf->publish(task.epoch_, task.sequence_, task.chunk_len_);
+        const uint32_t group_epoch =
+            static_cast<uint32_t>(meta_->epoch.load(std::memory_order_acquire));
+        ack_staging_buf->publish(group_epoch, task.sequence_, task.chunk_len_);
 
         const BatchID batch_id = engine_->allocateBatchID(1);
         engine_->submitTransfer(
@@ -1123,17 +1116,17 @@ bool P2PProxy::pollRecvAckSlot(RecvOpContext& op_ctx, RecvPeerLane& lane,
         return false;
     }
 
-    const uint32_t curr_epoch =
-        peer_epoch_[op_ctx.peer_rank_].load(std::memory_order_acquire);
+    const uint32_t group_epoch =
+        static_cast<uint32_t>(meta_->epoch.load(std::memory_order_acquire));
 
-    // Step 2 -- Stale packet: data from a previous epoch (before Reset).
-    // Clear the slot so the fresh ack can land safely.
-    if (slot_epoch != curr_epoch) {
+    // Step 2 -- Stale packet from an older group view. Clear the slot so the
+    // fresh ack can land safely.
+    if (slot_epoch != group_epoch) {
         LOG(WARNING) << "[P2PProxy][Recv] pollRecvAckSlot peer="
                      << op_ctx.peer_rank_
                      << " front-seq=" << head_task.sequence_
                      << " EPOCH_MISMATCH slot.epoch=" << slot_epoch
-                     << " curr_epoch=" << curr_epoch;
+                     << " group_epoch=" << group_epoch;
         slot.reset();
         return true;
     }

--- a/mooncake-pg/tests/test_pg_elastic.py
+++ b/mooncake-pg/tests/test_pg_elastic.py
@@ -15,6 +15,10 @@ from pg_test_utils import (
     require_test_device,
     wait_until,
 )
+from transfer_fault_injection import (
+    TransferFault,
+    preload_transfer_fault,
+)
 
 
 BROKEN_RANK = 1
@@ -775,6 +779,250 @@ def _replacement_recovery_worker(
         ctx.record_result({"role": "replacement"})
 
 
+def _run_p2p_ping_pong(
+    ctx: MooncakePGWorkerContext,
+    device: torch.device,
+    logical_rank: int,
+) -> None:
+    """Exchange one message in each direction between two logical ranks."""
+    if ctx.world_size != 2:
+        raise AssertionError("recovery P2P test expects exactly two ranks")
+
+    peer = 1 - logical_rank
+    send_tensor = torch.tensor(
+        [logical_rank], dtype=torch.int64, device=device
+    )
+    recv_tensor = torch.empty_like(send_tensor)
+    works = dist.batch_isend_irecv(
+        [
+            dist.P2POp(op=dist.isend, tensor=send_tensor, peer=peer),
+            dist.P2POp(op=dist.irecv, tensor=recv_tensor, peer=peer),
+        ]
+    )
+    for work in works:
+        work.wait()
+
+    if not all(pg.get_local_success(work) for work in works):
+        raise AssertionError(
+            f"rank {logical_rank}: P2P with rank {peer} failed"
+        )
+    received = int(recv_tensor.cpu().item())
+    if received != peer:
+        raise AssertionError(
+            f"rank {logical_rank}: expected {peer}, received {received}"
+        )
+
+
+def _recovery_p2p_worker(
+    ctx: MooncakePGWorkerContext,
+    broken_exited: mp.Event,
+    start_recovery: mp.Event,
+    graceful_group_destroy: bool,
+) -> None:
+    """Replace logical rank 1, then repeat its P2P exchange with rank 0."""
+    logical_rank = ctx.rank if ctx.proc_rank < ctx.world_size else BROKEN_RANK
+
+    if ctx.proc_rank < ctx.world_size:
+        device = ctx.init_group(rank=logical_rank)
+        backend = ctx.get_backend()
+        _run_p2p_ping_pong(ctx, device, logical_rank)
+
+        if logical_rank == BROKEN_RANK:
+            if graceful_group_destroy:
+                resp = pg.deactivate_ranks(backend, [logical_rank])
+                assert resp.status == pg.ProposalStatus.Applied, \
+                    "graceful self-deactivation should apply, " \
+                    f"got {resp.status}: {resp.reject_reason}"
+
+                dist.destroy_process_group()
+                ctx.record_result({"role": "gracefully_removed"})
+                return
+
+            ctx.record_result({"role": "broken"})
+            broken_exited.set()
+            os._exit(0)
+
+        if not broken_exited.wait(timeout=120.0):
+            raise TimeoutError("timed out waiting for departed rank")
+
+        if not graceful_group_destroy:
+            probe = torch.tensor([logical_rank], device=device)
+            work = dist.isend(probe, dst=BROKEN_RANK)
+            work.wait()
+            if pg.get_local_success(work):
+                raise AssertionError(
+                    "P2P probe to the departed rank unexpectedly succeeded"
+                )
+
+        active_ranks = pg.get_active_ranks(backend).cpu().tolist()
+        assert active_ranks == [1, 0], (
+            "new group view should be applied before p2p completes, "
+            f"got active_ranks={active_ranks}"
+        )
+
+        start_recovery.set()
+
+        wait_until(
+            lambda: pg.get_peer_state(backend, [BROKEN_RANK])[0],
+            timeout_s=30.0,
+            poll_interval_s=0.05,
+            description=f"rank {logical_rank} waiting for replacement",
+        )
+        resp = pg.recover_ranks(backend, [BROKEN_RANK])
+        assert resp.status == pg.ProposalStatus.Applied, \
+            f"rank {logical_rank}: recover_ranks should apply, got {resp.status}"
+
+        role = "survivor"
+    else:
+        if not start_recovery.wait(timeout=60.0):
+            raise TimeoutError("timed out waiting to start replacement")
+
+        device = ctx.init_group(rank=logical_rank, is_extension=True)
+        backend = ctx.get_backend()
+        pg.join_group(backend)
+        role = "replacement"
+
+    _run_p2p_ping_pong(ctx, device, logical_rank)
+    ctx.record_result({"role": role})
+
+
+def _run_rejoin_operation(
+    ctx: MooncakePGWorkerContext,
+    device: torch.device,
+    operation: str,
+    *,
+    verify: bool,
+):
+    if operation == "collective":
+        tensor = torch.tensor(
+            [ctx.rank + 1], dtype=torch.int32, device=device
+        )
+        works = [
+            dist.all_reduce(tensor, op=dist.ReduceOp.SUM, async_op=True)
+        ]
+        for work in works:
+            work.wait()
+
+        if verify:
+            if not pg.get_local_success(works[0]):
+                raise AssertionError("collective failed locally")
+            expected = ctx.world_size * (ctx.world_size + 1) // 2
+            actual = int(tensor.cpu().item())
+            if actual != expected:
+                raise AssertionError(
+                    f"collective expected {expected}, got {actual}"
+                )
+        return works
+
+    if operation == "p2p":
+        peer = 1 - ctx.rank
+        send_tensor = torch.tensor(
+            [ctx.rank], dtype=torch.int64, device=device
+        )
+        recv_tensor = torch.empty_like(send_tensor)
+        works = dist.batch_isend_irecv(
+            [
+                dist.P2POp(op=dist.isend, tensor=send_tensor, peer=peer),
+                dist.P2POp(op=dist.irecv, tensor=recv_tensor, peer=peer),
+            ]
+        )
+        for work in works:
+            work.wait()
+
+        if verify:
+            if not all(pg.get_local_success(work) for work in works):
+                raise AssertionError(f"P2P with rank {peer} failed locally")
+            actual = int(recv_tensor.cpu().item())
+            if actual != peer:
+                raise AssertionError(f"expected {peer}, received {actual}")
+        return works
+
+    raise ValueError(f"unsupported in-place rejoin operation: {operation}")
+
+
+def _run_fault_round(
+    ctx: MooncakePGWorkerContext,
+    device: torch.device,
+    backend,
+    operation: str,
+    fault_library: str,
+    fault_started: mp.Event,
+) -> None:
+    fault = TransferFault(fault_library, local_rank=ctx.rank)
+    with fault.failing_link(BROKEN_RANK, 0):
+        if ctx.rank != BROKEN_RANK:
+            if not fault_started.wait(timeout=30.0):
+                raise TimeoutError("timed out waiting for fault injection")
+            _run_rejoin_operation(ctx, device, operation, verify=False)
+            return
+
+        fault_started.set()
+        works = _run_rejoin_operation(
+            ctx, device, operation, verify=False
+        )
+
+        if all(pg.get_local_success(work) for work in works):
+            raise AssertionError(f"injected {operation} unexpectedly succeeded")
+        if fault.injected_count == 0:
+            raise AssertionError("transfer fault was not injected")
+
+        active_ranks = pg.get_active_ranks(backend).cpu().tolist()
+        assert active_ranks == [1, 0], (
+            "auto sync should make the transiently failed rank inactive "
+            f"before {operation} completion, got {active_ranks}"
+        )
+
+
+def _inplace_rejoin_worker(
+    ctx: MooncakePGWorkerContext,
+    operation: str,
+    fault_library: str,
+    fault_started: mp.Event,
+) -> None:
+    """Temporarily fail rank 1's data plane, then rejoin the same process."""
+    if ctx.world_size != 2:
+        raise AssertionError("in-place rejoin test expects exactly two ranks")
+
+    device = ctx.init_group()
+    backend = ctx.get_backend()
+
+    # 1. Establish a healthy baseline on the selected data path.
+    _run_rejoin_operation(ctx, device, operation, verify=True)
+    epoch_before_failure = pg.get_current_epoch(backend)
+
+    # 2. Fail rank 1's data plane. Auto sync must make it inactive.
+    _run_fault_round(
+        ctx, device, backend, operation, fault_library, fault_started
+    )
+
+    # 3. At an application-selected safe point, the failed rank declares
+    # itself ready to rejoin.
+    if ctx.rank == BROKEN_RANK:
+        pg.join_group(backend)
+    else:
+        wait_until(
+            lambda: pg.get_current_epoch(backend) > epoch_before_failure,
+            timeout_s=60.0,
+            poll_interval_s=0.05,
+            description="waiting for the post-failure group view",
+        )
+        wait_until(
+            lambda: pg.get_peer_state(backend, [BROKEN_RANK])[0],
+            timeout_s=30.0,
+            poll_interval_s=0.05,
+            description="waiting for the original rank to become activatable",
+        )
+        response = pg.activate_ranks(backend, [BROKEN_RANK])
+        assert response.status == pg.ProposalStatus.Applied, (
+            "in-place activation should apply, "
+            f"got {response.status}: {response.reject_reason}"
+        )
+
+    # 4. Verify the same communicator can use the same data path again.
+    _run_rejoin_operation(ctx, device, operation, verify=True)
+    ctx.record_result({"operation": operation})
+
+
 def _manual_deactivate_recovery_worker(
     ctx: MooncakePGWorkerContext,
     broken_exited: mp.Event,
@@ -993,6 +1241,61 @@ class _ElasticMixin:
         self.assertEqual(len(survivor_rows), self.world_size - 1)
         self.assertEqual(len(replacement_rows), 1)
         self.assertEqual(len(removed_rows), 1)
+
+    def _run_recovery_p2p(self, graceful_group_destroy: bool) -> None:
+        recovery_world_size = 2
+        spawn_ctx = mp.get_context("spawn")
+        broken_exited = spawn_ctx.Event()
+        start_recovery = spawn_ctx.Event()
+
+        rows = self.spawn_backend_and_collect(
+            _recovery_p2p_worker,
+            broken_exited,
+            start_recovery,
+            graceful_group_destroy,
+            world_size=recovery_world_size,
+            nprocs=recovery_world_size + 1,
+            timeout_s=75.0,
+            process_exit_events=(
+                {BROKEN_RANK: broken_exited}
+                if graceful_group_destroy
+                else None
+            ),
+        )
+
+        self.assert_all_ok(rows)
+
+    def test_recovery_p2p(self) -> None:
+        """P2P remains usable after an abruptly failed rank is replaced."""
+        self._run_recovery_p2p(graceful_group_destroy=False)
+
+    def test_recovery_p2p_after_graceful_group_destroy(self) -> None:
+        """P2P remains usable after a gracefully removed rank is replaced."""
+        self._run_recovery_p2p(graceful_group_destroy=True)
+
+    def _run_inplace_rejoin(self, operation: str) -> None:
+        spawn_ctx = mp.get_context("spawn")
+
+        with preload_transfer_fault() as fault_library:
+            fault_started = spawn_ctx.Event()
+            rows = self.spawn_backend_and_collect(
+                _inplace_rejoin_worker,
+                operation,
+                str(fault_library),
+                fault_started,
+                world_size=2,
+                nprocs=2,
+                timeout_s=75.0,
+            )
+            self.assert_all_ok(rows)
+
+    def test_inplace_rejoin_collective(self) -> None:
+        """Collectives recover when the same live process rejoins."""
+        self._run_inplace_rejoin("collective")
+
+    def test_inplace_rejoin_p2p(self) -> None:
+        """P2P recovers when the same live process rejoins."""
+        self._run_inplace_rejoin("p2p")
 
     def test_extension(self) -> None:
         """Test extension mode allows new ranks to join existing group."""

--- a/mooncake-pg/tests/test_pg_p2p.py
+++ b/mooncake-pg/tests/test_pg_p2p.py
@@ -151,6 +151,7 @@ def _p2p_fault_detection_worker(
         return dist.batch_isend_irecv(ops)
 
     device = ctx.init_group()
+    backend = ctx.get_backend()
 
     # Round 1: all healthy
     works = p2p_all_to_all(ctx, device)
@@ -190,6 +191,14 @@ def _p2p_fault_detection_worker(
         if peer == BROKEN_RANK:
             assert not pg.get_local_success(w), \
                 f"rank {ctx.rank} round 2: P2P with broken peer should fail locally"
+
+    expected_active_ranks = [1] * ctx.world_size
+    expected_active_ranks[BROKEN_RANK] = 0
+    active_ranks = pg.get_active_ranks(backend).cpu().tolist()
+    assert active_ranks == expected_active_ranks, (
+        "auto_sync_on_failure should apply the group view before "
+        f"failed P2P completion, got active_ranks={active_ranks}"
+    )
 
     ctx.record_result({"role": "survivor"})
 

--- a/mooncake-pg/tests/transfer_fault_injection.py
+++ b/mooncake-pg/tests/transfer_fault_injection.py
@@ -1,0 +1,231 @@
+"""Test-only transfer fault injection for Mooncake PG workers."""
+
+import ctypes
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from collections.abc import Generator, Iterable
+from contextlib import contextmanager
+from pathlib import Path
+
+from pg_test_utils import temporary_env
+
+RankPair = tuple[int, int]
+
+
+def _build_preload(output: Path) -> None:
+    source = Path(__file__).with_name("transfer_fault_preload.cpp")
+    repository_root = Path(__file__).resolve().parents[2]
+    transfer_engine_include = (
+        repository_root / "mooncake-transfer-engine" / "include"
+    )
+    process_group_include = repository_root / "mooncake-pg" / "include"
+    command = [
+        os.environ.get("CXX", "c++"),
+        "-std=c++20",
+        "-O2",
+        "-shared",
+        "-fPIC",
+        f"-I{transfer_engine_include}",
+        f"-I{process_group_include}",
+        str(source),
+        "-ldl",
+        "-o",
+        str(output),
+    ]
+    try:
+        subprocess.run(command, check=True, capture_output=True, text=True)
+    except OSError as error:
+        raise unittest.SkipTest(
+            f"transfer fault injection cannot invoke the compiler: {error}"
+        ) from error
+    except subprocess.CalledProcessError as error:
+        reason = (error.stderr or "").strip()
+        raise unittest.SkipTest(
+            "transfer fault injection cannot build its preload shim: "
+            f"{reason or error}"
+        ) from error
+
+
+def _verify_preload(library: Path, preload: str) -> None:
+    """Verify LD_PRELOAD and symbol resolution in a fresh process."""
+    probe = """
+import ctypes
+import sys
+
+from mooncake import pg
+
+library = ctypes.CDLL(sys.argv[1])
+available = library.mooncakePgTestFaultAvailable
+available.argtypes = []
+available.restype = ctypes.c_int
+if not available():
+    print("required fault-injection symbols not found", file=sys.stderr)
+    raise SystemExit(1)
+clear_targets = library.mooncakePgTestClearFailedTargets
+clear_targets.argtypes = []
+clear_targets.restype = None
+add_target = library.mooncakePgTestAddFailedTarget
+add_target.argtypes = [ctypes.c_int]
+add_target.restype = None
+setter = library.mooncakePgTestSetFaultEnabled
+setter.argtypes = [ctypes.c_int]
+setter.restype = None
+reset_counter = library.mooncakePgTestResetFailureCount
+reset_counter.argtypes = []
+reset_counter.restype = None
+counter = library.mooncakePgTestGetFailureCount
+counter.argtypes = []
+counter.restype = ctypes.c_uint64
+setter(0)
+clear_targets()
+add_target(1)
+reset_counter()
+setter(1)
+setter(0)
+clear_targets()
+counter()
+"""
+    environment = os.environ.copy()
+    environment["LD_PRELOAD"] = preload
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", probe, str(library)],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30.0,
+            env=environment,
+        )
+    except (OSError, subprocess.TimeoutExpired) as error:
+        raise unittest.SkipTest(
+            f"transfer fault injection is unavailable: {error}"
+        ) from error
+
+    if result.returncode != 0:
+        reason = result.stderr.strip() or result.stdout.strip()
+        if not reason:
+            reason = f"exit code {result.returncode}"
+        raise unittest.SkipTest(
+            f"transfer fault injection is unavailable: {reason}"
+        )
+
+
+@contextmanager
+def preload_transfer_fault() -> Generator[Path, None, None]:
+    """Preload the transfer fault shim into spawned workers."""
+    if not sys.platform.startswith("linux"):
+        raise unittest.SkipTest("LD_PRELOAD fault injection requires Linux")
+
+    with tempfile.TemporaryDirectory(prefix="mooncake-pg-fault-") as temp_dir:
+        library = Path(temp_dir) / "libmooncake_pg_fault.so"
+        _build_preload(library)
+
+        preload_entries = [str(library)]
+        if previous_preload := os.environ.get("LD_PRELOAD"):
+            preload_entries.append(previous_preload)
+
+        preload = os.pathsep.join(preload_entries)
+        _verify_preload(library, preload)
+
+        with temporary_env({"LD_PRELOAD": preload}):
+            yield library
+
+
+class TransferFault:
+    """Coordinate directed link failures across worker processes."""
+
+    def __init__(self, library: str | Path, *, local_rank: int) -> None:
+        self._library = ctypes.CDLL(str(library))
+        is_available = self._library.mooncakePgTestFaultAvailable
+        is_available.argtypes = []
+        is_available.restype = ctypes.c_int
+        if not is_available():
+            raise RuntimeError(
+                "preloaded transfer fault shim cannot resolve its "
+                "required symbols"
+            )
+        self._clear_failed_targets = (
+            self._library.mooncakePgTestClearFailedTargets
+        )
+        self._clear_failed_targets.argtypes = []
+        self._clear_failed_targets.restype = None
+        self._add_failed_target = self._library.mooncakePgTestAddFailedTarget
+        self._add_failed_target.argtypes = [ctypes.c_int]
+        self._add_failed_target.restype = None
+        self._set_enabled = self._library.mooncakePgTestSetFaultEnabled
+        self._set_enabled.argtypes = [ctypes.c_int]
+        self._set_enabled.restype = None
+        self._reset_count = self._library.mooncakePgTestResetFailureCount
+        self._reset_count.argtypes = []
+        self._reset_count.restype = None
+        self._get_count = self._library.mooncakePgTestGetFailureCount
+        self._get_count.argtypes = []
+        self._get_count.restype = ctypes.c_uint64
+        if local_rank < 0:
+            raise ValueError("local rank must be non-negative")
+        self._local_rank = local_rank
+        self._set_enabled(0)
+        self._clear_failed_targets()
+        self._reset_count()
+        self._active = False
+
+    @staticmethod
+    def _normalize_links(
+        links: Iterable[RankPair],
+    ) -> tuple[RankPair, ...]:
+        normalized = tuple(dict.fromkeys(links))
+        if not normalized:
+            raise ValueError("at least one failed link is required")
+        for source_rank, target_rank in normalized:
+            if (
+                source_rank < 0
+                or target_rank < 0
+                or source_rank == target_rank
+            ):
+                raise ValueError(
+                    "failed links require distinct, non-negative ranks"
+                )
+        return normalized
+
+    @contextmanager
+    def failing_links(
+        self, links: Iterable[RankPair]
+    ) -> Generator[None, None, None]:
+        """Fail directed links whose source is this worker's rank."""
+        if self._active:
+            raise RuntimeError("fault scopes cannot be nested")
+        normalized = self._normalize_links(links)
+        local_targets = {
+            target_rank
+            for source_rank, target_rank in normalized
+            if source_rank == self._local_rank
+        }
+
+        self._set_enabled(0)
+        self._clear_failed_targets()
+        for target_rank in local_targets:
+            self._add_failed_target(target_rank)
+        self._reset_count()
+        self._set_enabled(bool(local_targets))
+        self._active = True
+        try:
+            yield
+        finally:
+            self._set_enabled(0)
+            self._clear_failed_targets()
+            self._active = False
+
+    @contextmanager
+    def failing_link(
+        self, source_rank: int, target_rank: int
+    ) -> Generator[None, None, None]:
+        """Fail one directed global-rank link within this scope."""
+        with self.failing_links(((source_rank, target_rank),)):
+            yield
+
+    @property
+    def injected_count(self) -> int:
+        return int(self._get_count())

--- a/mooncake-pg/tests/transfer_fault_preload.cpp
+++ b/mooncake-pg/tests/transfer_fault_preload.cpp
@@ -1,0 +1,189 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <dlfcn.h>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "control_plane/link_manager.h"
+#include "transfer_engine.h"
+
+namespace {
+
+std::atomic<bool> fault_enabled{false};
+std::atomic<uint64_t> injected_failure_count{0};
+
+std::mutex fault_config_mutex;
+std::set<mooncake::GlobalRank> failed_targets;
+
+// Fault rules use global ranks, while transfer requests identify targets by
+// segment ID. Capture both mappings so we can apply rank-level rules to
+// individual transfer tasks.
+std::mutex mapping_mutex;
+std::unordered_map<mooncake::SegmentID, mooncake::GlobalRank>
+    segment_id_to_rank;
+std::unordered_map<mooncake::BatchID, std::vector<mooncake::GlobalRank>>
+    batch_id_to_target_ranks;
+
+constexpr char kGetTransferStatusSymbol[] =
+    "_ZN8mooncake14TransferEngine17getTransferStatusEmmRNS_"
+    "9Transport14TransferStatusE";
+constexpr char kSubmitTransferSymbol[] =
+    "_ZN8mooncake14TransferEngine14submitTransferEmRKSt6vectorINS_"
+    "9Transport15TransferRequestESaIS3_EE";
+constexpr char kResolvePeerSymbol[] =
+    "_ZNK8mooncake11LinkManager11resolvePeerEi";
+
+using GetTransferStatus = mooncake::Status (*)(mooncake::TransferEngine*,
+                                               mooncake::BatchID, size_t,
+                                               mooncake::TransferStatus&);
+using SubmitTransfer =
+    mooncake::Status (*)(mooncake::TransferEngine*, mooncake::BatchID,
+                         const std::vector<mooncake::TransferRequest>&);
+using ResolvePeer = std::optional<mooncake::SegmentID> (*)(
+    const mooncake::LinkManager*, mooncake::GlobalRank);
+
+void* findRealSymbol(const char* name) {
+    if (auto symbol = dlsym(RTLD_NEXT, name)) return symbol;
+
+    // Python loads extension dependencies in a local ELF scope, where
+    // RTLD_NEXT cannot see libmooncake_pg even though interposition still
+    // applies to its PLT calls. Look up the original definition directly
+    // from the already-loaded library in that case.
+    static auto handle = dlopen("libmooncake_pg.so", RTLD_LAZY | RTLD_NOLOAD);
+    return handle ? dlsym(handle, name) : nullptr;
+}
+
+GetTransferStatus findRealGetTransferStatus() {
+    static auto real = reinterpret_cast<GetTransferStatus>(
+        findRealSymbol(kGetTransferStatusSymbol));
+    return real;
+}
+
+SubmitTransfer findRealSubmitTransfer() {
+    static auto real =
+        reinterpret_cast<SubmitTransfer>(findRealSymbol(kSubmitTransferSymbol));
+    return real;
+}
+
+ResolvePeer findRealResolvePeer() {
+    static auto real =
+        reinterpret_cast<ResolvePeer>(findRealSymbol(kResolvePeerSymbol));
+    return real;
+}
+
+bool shouldInjectFailure(mooncake::GlobalRank target_rank) {
+    if (!fault_enabled.load(std::memory_order_acquire)) return false;
+
+    std::lock_guard<std::mutex> lock(fault_config_mutex);
+    return failed_targets.contains(target_rank);
+}
+
+}  // namespace
+
+namespace mooncake {
+
+std::optional<TransferMetadata::SegmentID> LinkManager::resolvePeer(
+    GlobalRank peer) const {
+    auto real = findRealResolvePeer();
+    if (!real) std::abort();
+    auto target_id = real(this, peer);
+    if (target_id.has_value()) {
+        std::lock_guard<std::mutex> lock(mapping_mutex);
+        segment_id_to_rank[*target_id] = peer;
+    }
+    return target_id;
+}
+
+Status TransferEngine::submitTransfer(
+    BatchID batch_id, const std::vector<TransferRequest>& entries) {
+    auto real = findRealSubmitTransfer();
+    if (!real) std::abort();
+    auto result = real(this, batch_id, entries);
+    if (result.ok()) {
+        std::vector<GlobalRank> target_ranks(entries.size(),
+                                             kInvalidGlobalRank);
+        std::lock_guard<std::mutex> lock(mapping_mutex);
+        for (size_t task_id = 0; task_id < entries.size(); ++task_id) {
+            auto rank_it = segment_id_to_rank.find(entries[task_id].target_id);
+            if (rank_it != segment_id_to_rank.end()) {
+                target_ranks[task_id] = rank_it->second;
+            }
+        }
+        batch_id_to_target_ranks.insert_or_assign(batch_id,
+                                                  std::move(target_ranks));
+    }
+    return result;
+}
+
+Status TransferEngine::getTransferStatus(BatchID batch_id, size_t task_id,
+                                         TransferStatus& status) {
+    auto real = findRealGetTransferStatus();
+    if (!real) std::abort();
+    auto result = real(this, batch_id, task_id, status);
+    if (result.ok() && status.s == TransferStatusEnum::COMPLETED &&
+        fault_enabled.load(std::memory_order_acquire)) {
+        GlobalRank target_rank = kInvalidGlobalRank;
+        {
+            std::lock_guard<std::mutex> lock(mapping_mutex);
+            auto batch_it = batch_id_to_target_ranks.find(batch_id);
+            if (batch_it != batch_id_to_target_ranks.end() &&
+                task_id < batch_it->second.size()) {
+                target_rank = batch_it->second[task_id];
+            }
+        }
+        if (shouldInjectFailure(target_rank)) {
+            status.s = TransferStatusEnum::FAILED;
+            injected_failure_count.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    return result;
+}
+
+}  // namespace mooncake
+
+extern "C" int mooncakePgTestFaultAvailable() {
+    return findRealGetTransferStatus() != nullptr &&
+           findRealSubmitTransfer() != nullptr &&
+           findRealResolvePeer() != nullptr;
+}
+
+extern "C" void mooncakePgTestClearFailedTargets() {
+    std::lock_guard<std::mutex> lock(fault_config_mutex);
+    failed_targets.clear();
+}
+
+extern "C" void mooncakePgTestAddFailedTarget(int target_rank) {
+    std::lock_guard<std::mutex> lock(fault_config_mutex);
+    failed_targets.insert(target_rank);
+}
+
+extern "C" void mooncakePgTestSetFaultEnabled(int enabled) {
+    fault_enabled.store(enabled != 0, std::memory_order_release);
+}
+
+extern "C" void mooncakePgTestResetFailureCount() {
+    injected_failure_count.store(0, std::memory_order_release);
+}
+
+extern "C" uint64_t mooncakePgTestGetFailureCount() {
+    return injected_failure_count.load(std::memory_order_acquire);
+}


### PR DESCRIPTION
## Description

This PR allows an auto-deactivated rank to rejoin the group in place without recreating a replacement process, and fixes P2P operations after recovery.


### In-place rejoin

* Allow `joinGroup()` to be called by a live rank that has been marked inactive.
* Republish the existing process endpoint with a fresh endpoint epoch.
* Reuse the existing two-phase activation protocol to reactivate the original rank and resume communication on the same communicator.

### P2P recovery fixes

* Use the `GroupView` epoch, instead of independent per-peer epochs, to identify and discard stale P2P packet.
* When `auto_sync_on_failure` is enabled, call `syncAfterFailure` before completing the failed P2P operation.

### New tests

The recovery coverage is extended with:

- P2P operations before and after recovery from an abrupt rank failure or a graceful leave.
- Collective and P2P in-place rejoin scenarios using the same process and communicator.
- A Linux-only, test-local `LD_PRELOAD` fault injector that can inject directed failures in each worker process.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

- All tests under `mooncake-pg/tests` passed.
- recovery and scale-up e2e tests also passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to assist in designing and implementing this PR. All code changes have been thoroughly reviewed and verified by me in person.