### PR TITLE
[Bugfix] clean up partially initialized TENT RDMA contexts

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -123,9 +124,9 @@ class RdmaContext {
    private:
     int openDevice(const std::string &device_name, uint8_t port);
 
-    // Release every resource currently owned by this context in reverse
-    // construction order. This is intentionally state-independent so it can
-    // clean up a partially completed enable() and can safely be retried.
+    // Release every resource currently owned by this context. This is
+    // intentionally state-independent so it can clean up a partially completed
+    // enable() and can safely be retried.
     void cleanupResources();
 
    private:

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -66,6 +66,7 @@ class RdmaContext {
     enum DeviceStatus {
         DEVICE_UNINIT,
         DEVICE_DISABLED,
+        DEVICE_INITIALIZING,
         DEVICE_ENABLED,
         DEVICE_PAUSED
     };
@@ -122,6 +123,13 @@ class RdmaContext {
 
    private:
     int openDevice(const std::string &device_name, uint8_t port);
+
+    // Release every resource currently owned by this context in reverse
+    // construction order. This is intentionally state-independent so it can
+    // roll back a partially completed enable() and can safely be retried.
+    void cleanupResources();
+
+    void rollbackEnable();
 
    private:
     // initialized during ctor, will never be changed during the context's

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -66,7 +66,6 @@ class RdmaContext {
     enum DeviceStatus {
         DEVICE_UNINIT,
         DEVICE_DISABLED,
-        DEVICE_INITIALIZING,
         DEVICE_ENABLED,
         DEVICE_PAUSED
     };
@@ -126,10 +125,8 @@ class RdmaContext {
 
     // Release every resource currently owned by this context in reverse
     // construction order. This is intentionally state-independent so it can
-    // roll back a partially completed enable() and can safely be retried.
+    // clean up a partially completed enable() and can safely be retried.
     void cleanupResources();
-
-    void rollbackEnable();
 
    private:
     // initialized during ctor, will never be changed during the context's

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -385,13 +385,13 @@ int RdmaContext::enable() {
     }
 
     for (int i = 0; i < params_->device.num_cq_list; ++i) {
-        auto cq = new RdmaCQ();
+        auto cq = std::make_unique<RdmaCQ>();
         int ret = cq->construct(this, params_->device.max_cqe, i);
         if (ret) {
             rollbackEnable();
             return ret;
         }
-        cq_list_.push_back(cq);
+        cq_list_.push_back(cq.release());
     }
 
     // Create dedicated notification CQ

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -457,11 +457,14 @@ int RdmaContext::disable() {
 }
 
 void RdmaContext::cleanupResources() {
-    for (auto& entry : mr_set_) {
-        int ret = verbs_.ibv_dereg_mr(entry);
-        if (ret) PLOG(ERROR) << "ibv_dereg_mr";
+    {
+        std::lock_guard<std::mutex> lock(mr_set_mutex_);
+        for (auto& entry : mr_set_) {
+            int ret = verbs_.ibv_dereg_mr(entry);
+            if (ret) PLOG(ERROR) << "ibv_dereg_mr";
+        }
+        mr_set_.clear();
     }
-    mr_set_.clear();
     for (auto& entry : cq_list_) {
         delete entry;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -283,6 +283,8 @@ static inline const std::string statusToString(
             return "DEVICE_ENABLED";
         case RdmaContext::DEVICE_DISABLED:
             return "DEVICE_DISABLED";
+        case RdmaContext::DEVICE_INITIALIZING:
+            return "DEVICE_INITIALIZING";
         case RdmaContext::DEVICE_PAUSED:
             return "DEVICE_PAUSED";
     }
@@ -302,7 +304,15 @@ RdmaContext::RdmaContext(RdmaTransport& transport)
 }
 
 RdmaContext::~RdmaContext() {
-    if (status_ != DEVICE_UNINIT) disable();
+    if (status_ == DEVICE_INITIALIZING) {
+        rollbackEnable();
+        return;
+    }
+    if (status_ != DEVICE_UNINIT || native_context_ || native_pd_ ||
+        event_fd_ >= 0 || !comp_channel_.empty() || !cq_list_.empty() ||
+        notify_cq_) {
+        disable();
+    }
 }
 
 int RdmaContext::construct(const std::string& device_name,
@@ -320,34 +330,40 @@ int RdmaContext::construct(const std::string& device_name,
 }
 
 int RdmaContext::enable() {
-    if (status_ != DEVICE_DISABLED) {
-        LOG(WARNING) << "RDMA context " << name() << " has been enabled";
-        return 0;
+    DeviceStatus expected = DEVICE_DISABLED;
+    if (!status_.compare_exchange_strong(expected, DEVICE_INITIALIZING)) {
+        if (expected == DEVICE_ENABLED || expected == DEVICE_PAUSED) {
+            LOG(WARNING) << "RDMA context " << name() << " has been enabled";
+            return 0;
+        }
+        LOG(ERROR) << "RDMA context " << name() << " cannot be enabled from "
+                   << statusToString(expected);
+        return -1;
     }
     if (openDevice(device_name_, params_->device.port)) {
         LOG(ERROR) << "Failed to open device [" << device_name_ << "] on port ["
                    << params_->device.port << "] with GID index ["
                    << params_->device.gid_index << "]";
-        disable();
+        rollbackEnable();
         return -1;
     }
 
     native_pd_ = verbs_.ibv_alloc_pd(native_context_);
     if (!native_pd_) {
         PLOG(ERROR) << "ibv_alloc_pd";
-        disable();
+        rollbackEnable();
         return -1;
     }
 
     event_fd_ = epoll_create1(0);
     if (event_fd_ < 0) {
         PLOG(ERROR) << "epoll_create1";
-        disable();
+        rollbackEnable();
         return -1;
     }
 
     if (joinNonblockingPollList(event_fd_, native_context_->async_fd)) {
-        disable();
+        rollbackEnable();
         return -1;
     }
 
@@ -358,12 +374,12 @@ int RdmaContext::enable() {
         comp_channel_[i] = verbs_.ibv_create_comp_channel(native_context_);
         if (!comp_channel_[i]) {
             PLOG(ERROR) << "ibv_create_comp_channel";
-            disable();
+            rollbackEnable();
             return -1;
         }
 
         if (joinNonblockingPollList(event_fd_, comp_channel_[i]->fd)) {
-            disable();
+            rollbackEnable();
             return -1;
         }
     }
@@ -372,7 +388,7 @@ int RdmaContext::enable() {
         auto cq = new RdmaCQ();
         int ret = cq->construct(this, params_->device.max_cqe, i);
         if (ret) {
-            disable();
+            rollbackEnable();
             return ret;
         }
         cq_list_.push_back(cq);
@@ -384,7 +400,7 @@ int RdmaContext::enable() {
                                            params_->device.num_cq_list);
     if (notify_ret) {
         LOG(ERROR) << "Failed to create notification CQ for " << device_name_;
-        disable();
+        rollbackEnable();
         return notify_ret;
     }
 
@@ -419,9 +435,7 @@ int RdmaContext::enable() {
     if (ret) {
         PLOG(ERROR) << "Failed to query port " << params_->device.port << " on "
                     << device_name_;
-        if (verbs_.ibv_close_device(native_context_)) {
-            PLOG(ERROR) << "ibv_close_device";
-        }
+        rollbackEnable();
         return -1;
     }
 
@@ -439,16 +453,34 @@ int RdmaContext::enable() {
 }
 
 int RdmaContext::disable() {
-    if (status_ == DEVICE_UNINIT || status_ == DEVICE_DISABLED) {
+    if (status_ == DEVICE_INITIALIZING) {
+        LOG(ERROR) << "RDMA context " << name()
+                   << " cannot be disabled while it is initializing";
+        return -1;
+    }
+    if (status_ == DEVICE_UNINIT && !native_context_ && !native_pd_ &&
+        event_fd_ < 0 && comp_channel_.empty() && cq_list_.empty() &&
+        !notify_cq_) {
         LOG(WARNING) << "RDMA context " << name() << " has been deconstructed";
         return 0;
     }
-    if (endpoint_store_->clear()) {
+    if (endpoint_store_ && endpoint_store_->clear()) {
         LOG(ERROR) << "Failed to destroy all endpoints for context " << name()
                    << "; preserving CQ, PD and device resources for retry";
         return -1;
     }
 
+    cleanupResources();
+    status_ = DEVICE_DISABLED;
+    return 0;
+}
+
+void RdmaContext::rollbackEnable() {
+    cleanupResources();
+    status_ = DEVICE_DISABLED;
+}
+
+void RdmaContext::cleanupResources() {
     for (auto& entry : mr_set_) {
         int ret = verbs_.ibv_dereg_mr(entry);
         if (ret) PLOG(ERROR) << "ibv_dereg_mr";
@@ -486,9 +518,6 @@ int RdmaContext::disable() {
             PLOG(ERROR) << "ibv_close_device";
         native_context_ = nullptr;
     }
-
-    status_ = DEVICE_DISABLED;
-    return 0;
 }
 
 int RdmaContext::pause() {
@@ -505,7 +534,8 @@ int RdmaContext::resume() {
 
 RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
                                                 int access) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
+        status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return nullptr;
     }
@@ -583,7 +613,8 @@ RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
 }
 
 int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
+        status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return -1;
     }
@@ -607,7 +638,8 @@ int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
 }
 
 int RdmaContext::unregisterMemReg(MemReg id) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
+        status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return -1;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -283,8 +283,6 @@ static inline const std::string statusToString(
             return "DEVICE_ENABLED";
         case RdmaContext::DEVICE_DISABLED:
             return "DEVICE_DISABLED";
-        case RdmaContext::DEVICE_INITIALIZING:
-            return "DEVICE_INITIALIZING";
         case RdmaContext::DEVICE_PAUSED:
             return "DEVICE_PAUSED";
     }
@@ -303,17 +301,7 @@ RdmaContext::RdmaContext(RdmaTransport& transport)
     std::call_once(g_once_flag, fork_init);
 }
 
-RdmaContext::~RdmaContext() {
-    if (status_ == DEVICE_INITIALIZING) {
-        rollbackEnable();
-        return;
-    }
-    if (status_ != DEVICE_UNINIT || native_context_ || native_pd_ ||
-        event_fd_ >= 0 || !comp_channel_.empty() || !cq_list_.empty() ||
-        notify_cq_) {
-        disable();
-    }
-}
+RdmaContext::~RdmaContext() { disable(); }
 
 int RdmaContext::construct(const std::string& device_name,
                            std::shared_ptr<RdmaParams> params) {
@@ -330,40 +318,39 @@ int RdmaContext::construct(const std::string& device_name,
 }
 
 int RdmaContext::enable() {
-    DeviceStatus expected = DEVICE_DISABLED;
-    if (!status_.compare_exchange_strong(expected, DEVICE_INITIALIZING)) {
-        if (expected == DEVICE_ENABLED || expected == DEVICE_PAUSED) {
-            LOG(WARNING) << "RDMA context " << name() << " has been enabled";
-            return 0;
-        }
+    if (status_ == DEVICE_ENABLED || status_ == DEVICE_PAUSED) {
+        LOG(WARNING) << "RDMA context " << name() << " has been enabled";
+        return 0;
+    }
+    if (status_ != DEVICE_DISABLED) {
         LOG(ERROR) << "RDMA context " << name() << " cannot be enabled from "
-                   << statusToString(expected);
+                   << statusToString(status_);
         return -1;
     }
     if (openDevice(device_name_, params_->device.port)) {
         LOG(ERROR) << "Failed to open device [" << device_name_ << "] on port ["
                    << params_->device.port << "] with GID index ["
                    << params_->device.gid_index << "]";
-        rollbackEnable();
+        disable();
         return -1;
     }
 
     native_pd_ = verbs_.ibv_alloc_pd(native_context_);
     if (!native_pd_) {
         PLOG(ERROR) << "ibv_alloc_pd";
-        rollbackEnable();
+        disable();
         return -1;
     }
 
     event_fd_ = epoll_create1(0);
     if (event_fd_ < 0) {
         PLOG(ERROR) << "epoll_create1";
-        rollbackEnable();
+        disable();
         return -1;
     }
 
     if (joinNonblockingPollList(event_fd_, native_context_->async_fd)) {
-        rollbackEnable();
+        disable();
         return -1;
     }
 
@@ -374,12 +361,12 @@ int RdmaContext::enable() {
         comp_channel_[i] = verbs_.ibv_create_comp_channel(native_context_);
         if (!comp_channel_[i]) {
             PLOG(ERROR) << "ibv_create_comp_channel";
-            rollbackEnable();
+            disable();
             return -1;
         }
 
         if (joinNonblockingPollList(event_fd_, comp_channel_[i]->fd)) {
-            rollbackEnable();
+            disable();
             return -1;
         }
     }
@@ -388,7 +375,7 @@ int RdmaContext::enable() {
         auto cq = std::make_unique<RdmaCQ>();
         int ret = cq->construct(this, params_->device.max_cqe, i);
         if (ret) {
-            rollbackEnable();
+            disable();
             return ret;
         }
         cq_list_.push_back(cq.release());
@@ -400,7 +387,7 @@ int RdmaContext::enable() {
                                            params_->device.num_cq_list);
     if (notify_ret) {
         LOG(ERROR) << "Failed to create notification CQ for " << device_name_;
-        rollbackEnable();
+        disable();
         return notify_ret;
     }
 
@@ -435,7 +422,7 @@ int RdmaContext::enable() {
     if (ret) {
         PLOG(ERROR) << "Failed to query port " << params_->device.port << " on "
                     << device_name_;
-        rollbackEnable();
+        disable();
         return -1;
     }
 
@@ -453,14 +440,8 @@ int RdmaContext::enable() {
 }
 
 int RdmaContext::disable() {
-    if (status_ == DEVICE_INITIALIZING) {
-        LOG(ERROR) << "RDMA context " << name()
-                   << " cannot be disabled while it is initializing";
-        return -1;
-    }
-    if (status_ == DEVICE_UNINIT && !native_context_ && !native_pd_ &&
-        event_fd_ < 0 && comp_channel_.empty() && cq_list_.empty() &&
-        !notify_cq_) {
+    if (!native_context_ && !native_pd_ && event_fd_ < 0 &&
+        comp_channel_.empty() && cq_list_.empty() && !notify_cq_) {
         LOG(WARNING) << "RDMA context " << name() << " has been deconstructed";
         return 0;
     }
@@ -473,11 +454,6 @@ int RdmaContext::disable() {
     cleanupResources();
     status_ = DEVICE_DISABLED;
     return 0;
-}
-
-void RdmaContext::rollbackEnable() {
-    cleanupResources();
-    status_ = DEVICE_DISABLED;
 }
 
 void RdmaContext::cleanupResources() {
@@ -534,8 +510,7 @@ int RdmaContext::resume() {
 
 RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
                                                 int access) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
-        status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return nullptr;
     }
@@ -613,8 +588,7 @@ RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,
 }
 
 int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
-        status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return -1;
     }
@@ -638,8 +612,7 @@ int RdmaContext::warmupMrRegistration(void* addr, size_t length) {
 }
 
 int RdmaContext::unregisterMemReg(MemReg id) {
-    if (status_ == DEVICE_DISABLED || status_ == DEVICE_INITIALIZING ||
-        status_ == DEVICE_UNINIT) {
+    if (status_ == DEVICE_DISABLED || status_ == DEVICE_UNINIT) {
         LOG(FATAL) << "RDMA context " << name() << " not constructed";
         return -1;
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -654,7 +654,8 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     }
     auto index = context_name_lookup_[local_nic_name];
     auto context = context_set_[index];
-    if (context->status() == RdmaContext::DEVICE_DISABLED) {
+    if (context->status() != RdmaContext::DEVICE_ENABLED &&
+        context->status() != RdmaContext::DEVICE_PAUSED) {
         std::stringstream ss;
         ss << "Device is down: " << peer_desc.local_nic_path;
         LOG(ERROR) << ss.str();

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -654,8 +654,9 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
     }
     auto index = context_name_lookup_[local_nic_name];
     auto context = context_set_[index];
-    if (context->status() != RdmaContext::DEVICE_ENABLED &&
-        context->status() != RdmaContext::DEVICE_PAUSED) {
+    auto ctx_status = context->status();
+    if (ctx_status != RdmaContext::DEVICE_ENABLED &&
+        ctx_status != RdmaContext::DEVICE_PAUSED) {
         std::stringstream ss;
         ss << "Device is down: " << peer_desc.local_nic_path;
         LOG(ERROR) << ss.str();


### PR DESCRIPTION
## Description

During `RdmaContext` initialization, the context remained in the `DEVICE_DISABLED` state while RDMA resources were being allocated. If initialization failed after partially creating resources, the error path called `disable()` for rollback. However, `disable()` returned immediately for a `DEVICE_DISABLED` context, leaving resources such as the device context, protection domain, epoll file descriptor, completion channels, and completion queues unreleased.

Because the state machine had no explicit initialization state, it could not distinguish a fully disabled context from a partially initialized one. Cleanup therefore relied on an inaccurate logical state instead of the resources actually owned by the context, potentially causing resource leaks and inconsistent lifecycle behavior after initialization failures.

To fix it, I've made the following changes:

- add an explicit `DEVICE_INITIALIZING` state
- roll back partially initialized RDMA resources based on actual handles
- make context cleanup idempotent and independent of disabled state
- prevent inbound connections and MR operations during initialization
- clean up residual resources during context destruction

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?


**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

The test I've performed manually is described below:

Mock or wrap the `ibv_*` calls used by `RdmaContext::enable()` and inject failures at each initialization stage, including PD, epoll, completion channel, CQ, notification CQ, and port query creation.

For each failure, verify that:

initialization returns an error;
context status returns to `DEVICE_DISABLED`;
all previously created resources are released exactly once;
all handles, pointers, and containers are reset.
Call `disable()` again to verify idempotent cleanup, then remove the failure and call `enable()` to verify successful retry.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

VSCode Copilot assisted with reading and editing the source files. I have reviewed every changed line and can defend the change end-to-end.