### PR TITLE
[Store] Fix race in HA durable-finalization tests (#3332)

### DIFF
--- a/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
+++ b/mooncake-store/include/ha/oplog/ordered_oplog_writer.h
@@ -54,18 +54,17 @@ class OrderedOpLogWriter {
 
     OrderedOpLogWriter(OrderedOpLogWriterConfig config,
                        WriteBatchFn write_batch);
-    ~OrderedOpLogWriter();
+    virtual ~OrderedOpLogWriter();
 
     tl::expected<Reservation, ErrorCode> Reserve();
-    tl::expected<PendingHandle, ErrorCode> Commit(Reservation&& reservation,
-                                                  OpLogEntry entry,
-                                                  DurableCallback callback);
+    virtual tl::expected<PendingHandle, ErrorCode> Commit(
+        Reservation&& reservation, OpLogEntry entry, DurableCallback callback);
     void Abort(Reservation&& reservation);
 
     bool IsAccepting() const;
     ErrorCode LastError() const;
     void Start();
-    void Stop();
+    virtual void Stop();
 
    private:
     struct Impl;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -130,6 +130,9 @@ class MasterService {
         std::function<bool(const std::string&, uint32_t, std::string*)>;
     using DurableFinalizeCallback =
         std::function<void(const OpLogEntry& durable_entry)>;
+    using BatchOpLogWriterFactory =
+        std::function<std::unique_ptr<OrderedOpLogWriter>(
+            OrderedOpLogWriterConfig, OrderedOpLogWriter::WriteBatchFn)>;
 
     MasterService();
     MasterService(const MasterServiceConfig& config);
@@ -152,6 +155,7 @@ class MasterService {
 
     ErrorCode SetBatchOpLogBackendForTesting(
         std::shared_ptr<HaKvBackend> backend);
+    void SetBatchOpLogWriterFactoryForTesting(BatchOpLogWriterFactory factory);
 
     /**
      * @brief Test-only wrapper around BatchEvict / NoFBatchEvict so that
@@ -2288,6 +2292,7 @@ class MasterService {
     std::shared_ptr<HaKvBackend> batch_oplog_kv_backend_;
     std::unique_ptr<OpLogBatchStorage> batch_oplog_storage_;
     std::unique_ptr<OrderedOpLogWriter> ordered_oplog_writer_;
+    BatchOpLogWriterFactory batch_oplog_writer_factory_;
 
     // OpLog publishing helpers
     std::string SerializeMetadataForOpLog(const ObjectMetadata& metadata) const;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -618,6 +618,12 @@ ErrorCode MasterService::SetBatchOpLogBackendForTesting(
     return InitializeBatchOpLogWriter(std::move(backend));
 }
 
+void MasterService::SetBatchOpLogWriterFactoryForTesting(
+    BatchOpLogWriterFactory factory) {
+    assert(!ordered_oplog_writer_);
+    batch_oplog_writer_factory_ = std::move(factory);
+}
+
 void MasterService::RunBatchEvictForTesting(double evict_ratio_target,
                                             double evict_ratio_lowerbound) {
     BatchEvict(evict_ratio_target, evict_ratio_lowerbound);
@@ -11121,12 +11127,20 @@ ErrorCode MasterService::InitializeBatchOpLogWriter(
     writer_config.max_entries_per_batch = oplog_batch_max_entries_;
     writer_config.initial_durable_prefix = durable_prefix;
     OpLogBatchStorage* storage_ptr = storage.get();
-    auto writer = std::make_unique<OrderedOpLogWriter>(
-        writer_config, [storage_ptr](const OpLogBatchRecord& batch,
-                                     const DurablePrefix& expected_prefix) {
+    OrderedOpLogWriter::WriteBatchFn write_batch =
+        [storage_ptr](const OpLogBatchRecord& batch,
+                      const DurablePrefix& expected_prefix) {
             return storage_ptr->WriteBatchAndAdvancePrefix(batch,
                                                            expected_prefix);
-        });
+        };
+    auto writer =
+        batch_oplog_writer_factory_
+            ? batch_oplog_writer_factory_(writer_config, std::move(write_batch))
+            : std::make_unique<OrderedOpLogWriter>(writer_config,
+                                                   std::move(write_batch));
+    if (!writer) {
+        return ErrorCode::INVALID_PARAMS;
+    }
     if (!writer->IsAccepting()) {
         return writer->LastError();
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -217,7 +217,13 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_cxl_(config.enable_cxl),
       offloading_queue_limit_(config.offloading_queue_limit),
       offload_cap_ratio_(config.offload_cap_ratio),
-      task_manager_(config.task_manager_config) {
+      task_manager_(config.task_manager_config),
+      batch_oplog_writer_factory_(
+          [](OrderedOpLogWriterConfig writer_config,
+             OrderedOpLogWriter::WriteBatchFn write_batch) {
+              return std::make_unique<OrderedOpLogWriter>(
+                  std::move(writer_config), std::move(write_batch));
+          }) {
     // Initialize HTTP metadata key prefix (read env var once at startup)
     const char* custom_prefix = std::getenv("MC_METADATA_CLUSTER_ID");
     if (custom_prefix && std::strlen(custom_prefix) > 0) {
@@ -620,6 +626,7 @@ ErrorCode MasterService::SetBatchOpLogBackendForTesting(
 
 void MasterService::SetBatchOpLogWriterFactoryForTesting(
     BatchOpLogWriterFactory factory) {
+    assert(factory);
     assert(!ordered_oplog_writer_);
     batch_oplog_writer_factory_ = std::move(factory);
 }
@@ -11134,10 +11141,7 @@ ErrorCode MasterService::InitializeBatchOpLogWriter(
                                                            expected_prefix);
         };
     auto writer =
-        batch_oplog_writer_factory_
-            ? batch_oplog_writer_factory_(writer_config, std::move(write_batch))
-            : std::make_unique<OrderedOpLogWriter>(writer_config,
-                                                   std::move(write_batch));
+        batch_oplog_writer_factory_(writer_config, std::move(write_batch));
     if (!writer) {
         return ErrorCode::INVALID_PARAMS;
     }

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <chrono>
 #include <condition_variable>
 #include <filesystem>
@@ -147,6 +148,74 @@ class FailingBatchHaKvBackend : public FakeBatchHaKvBackend {
     std::condition_variable cv_;
     ErrorCode txn_error_{ErrorCode::OK};
     size_t txn_calls_{0};
+};
+
+class GatedOrderedOpLogWriter : public OrderedOpLogWriter {
+   public:
+    GatedOrderedOpLogWriter(OrderedOpLogWriterConfig config,
+                            WriteBatchFn write_batch)
+        : OrderedOpLogWriter(std::move(config), std::move(write_batch)) {}
+
+    ~GatedOrderedOpLogWriter() override { Stop(); }
+
+    tl::expected<PendingHandle, ErrorCode> Commit(
+        Reservation&& reservation, OpLogEntry entry,
+        DurableCallback callback) override {
+        return OrderedOpLogWriter::Commit(
+            std::move(reservation), std::move(entry),
+            [this, callback = std::move(callback)](const OpLogEntry& durable) {
+                {
+                    std::unique_lock<std::mutex> lock(mutex_);
+                    cv_.wait(lock, [&] {
+                        return stopping_ ||
+                               durable.sequence_id <= released_through_;
+                    });
+                }
+                if (callback) {
+                    callback(durable);
+                }
+                {
+                    std::lock_guard<std::mutex> lock(mutex_);
+                    completed_through_ = durable.sequence_id;
+                }
+                cv_.notify_all();
+            });
+    }
+
+    bool PauseCallbacksAfter(
+        uint64_t sequence_id,
+        std::chrono::milliseconds timeout = std::chrono::seconds(1)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        released_through_ = sequence_id;
+        return cv_.wait_for(lock, timeout,
+                            [&] { return completed_through_ >= sequence_id; });
+    }
+
+    bool RunCallbacksThrough(
+        uint64_t sequence_id,
+        std::chrono::milliseconds timeout = std::chrono::seconds(1)) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        released_through_ = std::max(released_through_, sequence_id);
+        cv_.notify_all();
+        return cv_.wait_for(lock, timeout,
+                            [&] { return completed_through_ >= sequence_id; });
+    }
+
+    void Stop() override {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        cv_.notify_all();
+        OrderedOpLogWriter::Stop();
+    }
+
+   private:
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    uint64_t released_through_{UINT64_MAX};
+    uint64_t completed_through_{0};
+    bool stopping_{false};
 };
 
 class MasterServiceHATest : public ::testing::Test {
@@ -320,16 +389,24 @@ class MasterServiceHATest : public ::testing::Test {
         ASSERT_EQ(ErrorCode::OK, read_err);
     }
 
-    bool PutStartEventually(MasterService& service, const UUID& client_id,
-                            const std::string& key, const TenantId& tenant,
-                            const ReplicateConfig& config) const {
-        for (int attempt = 0; attempt < 50; ++attempt) {
-            if (service.PutStart(client_id, key, tenant, 1024, config)) {
-                return true;
-            }
-            std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        }
-        return false;
+    static GatedOrderedOpLogWriter* InstallGatedWriter(
+        MasterService& service, std::shared_ptr<HaKvBackend> backend) {
+        service.SetBatchOpLogWriterFactoryForTesting(
+            [](OrderedOpLogWriterConfig config,
+               OrderedOpLogWriter::WriteBatchFn write_batch) {
+                return std::make_unique<GatedOrderedOpLogWriter>(
+                    std::move(config), std::move(write_batch));
+            });
+        EXPECT_EQ(ErrorCode::OK,
+                  service.SetBatchOpLogBackendForTesting(std::move(backend)));
+        return static_cast<GatedOrderedOpLogWriter*>(
+            service.ordered_oplog_writer_.get());
+    }
+
+    static uint64_t TenantUsedBytes(MasterService& service) {
+        auto snapshot = service.GetTenantQuotaSnapshot(kDefaultTenant);
+        EXPECT_TRUE(snapshot.has_value());
+        return snapshot ? snapshot->used_bytes : 0;
     }
 
     void ReadRemoveBatchEventually(OpLogBatchStorage& storage,
@@ -1711,7 +1788,7 @@ TEST_F(MasterServiceBatchRecordE2ETest,
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted =
         PrepareSimpleSegment(service, "batch_e2e_remove_finalize_segment");
@@ -1723,6 +1800,7 @@ TEST_F(MasterServiceBatchRecordE2ETest,
     PutObjectOnSegment(service, mounted.client_id, key,
                        "batch_e2e_remove_finalize_segment");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     backend->BlockTxn();
     ASSERT_TRUE(
@@ -1737,14 +1815,18 @@ TEST_F(MasterServiceBatchRecordE2ETest,
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
     auto removed = service.ExistKey(key, kDefaultTenant);
     ASSERT_TRUE(removed.has_value());
     EXPECT_FALSE(removed.value());
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "batch_e2e_after_remove_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize = service.PutStart(
+        mounted.client_id, "batch_e2e_after_remove_finalize_key",
+        kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceBatchRecordE2ETest,
@@ -2791,7 +2873,7 @@ TEST_F(MasterServiceHATest, RemoveHidesBeforeDurableAndReleasesAfterFinalize) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted = PrepareSimpleSegment(service, "batch_remove_finalize_seg");
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -2802,6 +2884,7 @@ TEST_F(MasterServiceHATest, RemoveHidesBeforeDurableAndReleasesAfterFinalize) {
     PutObjectOnSegment(service, mounted.client_id, key,
                        "batch_remove_finalize_seg");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     backend->BlockTxn();
     ASSERT_TRUE(
@@ -2817,10 +2900,14 @@ TEST_F(MasterServiceHATest, RemoveHidesBeforeDurableAndReleasesAfterFinalize) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_remove_finalize_key", kDefaultTenant,
-                                   config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_remove_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, BatchRemoveWritesBatchRecordOpLog) {
@@ -2874,7 +2961,7 @@ TEST_F(MasterServiceHATest, BatchRemoveFinalizesEachObjectAfterDurable) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted =
         PrepareSimpleSegment(service, "batch_remove_finalize_segment");
@@ -2886,6 +2973,7 @@ TEST_F(MasterServiceHATest, BatchRemoveFinalizesEachObjectAfterDurable) {
     PutObjectOnSegment(service, mounted.client_id, key,
                        "batch_remove_finalize_segment");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     backend->BlockTxn();
     auto results = service.BatchRemove({key}, kDefaultTenant, /*force=*/true);
@@ -2902,10 +2990,14 @@ TEST_F(MasterServiceHATest, BatchRemoveFinalizesEachObjectAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_batch_remove_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_batch_remove_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, RemoveAllWritesBatchRecordOpLog) {
@@ -2957,7 +3049,7 @@ TEST_F(MasterServiceHATest, RemoveAllFinalizesAfterDurable) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted = PrepareSimpleSegment(service, "remove_all_finalize_segment");
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -2968,6 +3060,7 @@ TEST_F(MasterServiceHATest, RemoveAllFinalizesAfterDurable) {
     PutObjectOnSegment(service, mounted.client_id, key,
                        "remove_all_finalize_segment");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     backend->BlockTxn();
     EXPECT_EQ(1, service.RemoveAll(kDefaultTenant, /*force=*/true));
@@ -2982,10 +3075,14 @@ TEST_F(MasterServiceHATest, RemoveAllFinalizesAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_remove_all_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_remove_all_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, BatchReplicaClearAllWritesBatchRecordOpLog) {
@@ -3090,7 +3187,7 @@ TEST_F(MasterServiceHATest, BatchReplicaClearAllReleasesAfterDurable) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted = PrepareSimpleSegment(service, "clear_all_finalize_segment");
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -3101,6 +3198,7 @@ TEST_F(MasterServiceHATest, BatchReplicaClearAllReleasesAfterDurable) {
     PutObjectOnSegment(service, mounted.client_id, key,
                        "clear_all_finalize_segment");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(60));
     backend->BlockTxn();
@@ -3119,10 +3217,14 @@ TEST_F(MasterServiceHATest, BatchReplicaClearAllReleasesAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_clear_all_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_clear_all_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
@@ -3141,7 +3243,7 @@ TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 2048}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted = PrepareSimpleSegment(service, "clear_finalize_seg1");
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -3174,6 +3276,7 @@ TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
     ASSERT_TRUE(
         service.CopyEnd(mounted.client_id, key, kDefaultTenant).has_value());
     ReadBatchEventually(storage, 4, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(60));
     backend->BlockTxn();
@@ -3192,10 +3295,14 @@ TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 5, batch);
+    EXPECT_EQ(2048, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(1024, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_clear_segment_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_clear_segment_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, BatchEvictWritesBatchRecordOpLog) {
@@ -3248,7 +3355,7 @@ TEST_F(MasterServiceHATest, BatchEvictReleasesMemoryAfterDurable) {
                 WriteTenantPolicyFile({{kDefaultTenant.value(), 1024}}))
             .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     auto mounted = PrepareSimpleSegment(service, "batch_evict_finalize_seg");
     OpLogBatchStorage storage(cluster_id, *backend);
@@ -3259,6 +3366,7 @@ TEST_F(MasterServiceHATest, BatchEvictReleasesMemoryAfterDurable) {
     PutObjectOnSegment(service, mounted.client_id, key,
                        "batch_evict_finalize_seg");
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(60));
     backend->BlockTxn();
@@ -3275,10 +3383,14 @@ TEST_F(MasterServiceHATest, BatchEvictReleasesMemoryAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
+    EXPECT_EQ(1024, TenantUsedBytes(service));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, TenantUsedBytes(service));
 
-    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
-                                   "after_batch_evict_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(mounted.client_id, "after_batch_evict_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 
 TEST_F(MasterServiceHATest, EvictDiskReplicaWritesBatchRecordOpLog) {
@@ -3339,7 +3451,7 @@ TEST_F(MasterServiceHATest, EvictDiskReplicaReleasesLocalDiskAfterDurable) {
                               .set_enable_offload(true)
                               .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     const std::string segment_name = "batch_disk_evict_finalize_segment";
     auto mounted = PrepareSimpleSegment(service, segment_name);
@@ -3362,6 +3474,7 @@ TEST_F(MasterServiceHATest, EvictDiskReplicaReleasesLocalDiskAfterDurable) {
                                 local_disk_replica)
                     .has_value());
     ReadBatchEventually(storage, 3, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
     SetLocalDiskUsedBytesForTesting(service, mounted.client_id, 1024);
 
     backend->BlockTxn();
@@ -3381,14 +3494,9 @@ TEST_F(MasterServiceHATest, EvictDiskReplicaReleasesLocalDiskAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 4, batch);
-    bool reclaimed = false;
-    for (int attempt = 0; attempt < 50 && !reclaimed; ++attempt) {
-        reclaimed = GetLocalDiskUsedBytesForTesting(service, segment_name) == 0;
-        if (!reclaimed) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(20));
-        }
-    }
-    EXPECT_TRUE(reclaimed);
+    EXPECT_EQ(1024, GetLocalDiskUsedBytesForTesting(service, segment_name));
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0, GetLocalDiskUsedBytesForTesting(service, segment_name));
 }
 
 #ifdef USE_NOF
@@ -3448,7 +3556,7 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
                               .set_oplog_batch_max_entries(1)
                               .build();
     MasterService service(service_config);
-    ASSERT_EQ(ErrorCode::OK, service.SetBatchOpLogBackendForTesting(backend));
+    auto* writer = InstallGatedWriter(service, backend);
 
     NoFSegment nof_segment = MakeNoFSegment("batch_nof_evict_finalize_segment",
                                             "batch_nof_evict_finalize_endpoint",
@@ -3468,6 +3576,7 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
     OpLogBatchStorage storage(cluster_id, *backend);
     OpLogBatchRecord batch;
     ReadBatchEventually(storage, 1, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
 
     std::this_thread::sleep_for(std::chrono::milliseconds(60));
     backend->BlockTxn();
@@ -3483,10 +3592,12 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 2, batch);
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
 
-    EXPECT_TRUE(PutStartEventually(service, client_id,
-                                   "after_batch_nof_evict_finalize_key",
-                                   kDefaultTenant, config));
+    auto after_finalize =
+        service.PutStart(client_id, "after_batch_nof_evict_finalize_key",
+                         kDefaultTenant, 1024, config);
+    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 #endif
 

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -320,6 +320,18 @@ class MasterServiceHATest : public ::testing::Test {
         ASSERT_EQ(ErrorCode::OK, read_err);
     }
 
+    bool PutStartEventually(MasterService& service, const UUID& client_id,
+                            const std::string& key, const TenantId& tenant,
+                            const ReplicateConfig& config) const {
+        for (int attempt = 0; attempt < 50; ++attempt) {
+            if (service.PutStart(client_id, key, tenant, 1024, config)) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+        return false;
+    }
+
     void ReadRemoveBatchEventually(OpLogBatchStorage& storage,
                                    uint64_t first_batch_id,
                                    const std::string& key,
@@ -1730,10 +1742,9 @@ TEST_F(MasterServiceBatchRecordE2ETest,
     ASSERT_TRUE(removed.has_value());
     EXPECT_FALSE(removed.value());
 
-    auto after_finalize = service.PutStart(
-        mounted.client_id, "batch_e2e_after_remove_finalize_key",
-        kDefaultTenant, 1024, config);
-    EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "batch_e2e_after_remove_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceBatchRecordE2ETest,
@@ -2807,14 +2818,9 @@ TEST_F(MasterServiceHATest, RemoveHidesBeforeDurableAndReleasesAfterFinalize) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key = "after_remove_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_remove_finalize_key", kDefaultTenant,
+                                   config));
 }
 
 TEST_F(MasterServiceHATest, BatchRemoveWritesBatchRecordOpLog) {
@@ -2897,15 +2903,9 @@ TEST_F(MasterServiceHATest, BatchRemoveFinalizesEachObjectAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key =
-            "after_batch_remove_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_batch_remove_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceHATest, RemoveAllWritesBatchRecordOpLog) {
@@ -2983,14 +2983,9 @@ TEST_F(MasterServiceHATest, RemoveAllFinalizesAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key = "after_remove_all_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_remove_all_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceHATest, BatchReplicaClearAllWritesBatchRecordOpLog) {
@@ -3125,14 +3120,9 @@ TEST_F(MasterServiceHATest, BatchReplicaClearAllReleasesAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key = "after_clear_all_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_clear_all_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
@@ -3203,15 +3193,9 @@ TEST_F(MasterServiceHATest, BatchReplicaClearSegmentReleasesAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 5, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key =
-            "after_clear_segment_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_clear_segment_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceHATest, BatchEvictWritesBatchRecordOpLog) {
@@ -3292,14 +3276,9 @@ TEST_F(MasterServiceHATest, BatchEvictReleasesMemoryAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key = "after_batch_evict_finalize_key";
-        auto after_finalize =
-            service.PutStart(mounted.client_id, after_finalize_key,
-                             kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, mounted.client_id,
+                                   "after_batch_evict_finalize_key",
+                                   kDefaultTenant, config));
 }
 
 TEST_F(MasterServiceHATest, EvictDiskReplicaWritesBatchRecordOpLog) {
@@ -3402,7 +3381,14 @@ TEST_F(MasterServiceHATest, EvictDiskReplicaReleasesLocalDiskAfterDurable) {
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 4, batch);
-    EXPECT_EQ(0, GetLocalDiskUsedBytesForTesting(service, segment_name));
+    bool reclaimed = false;
+    for (int attempt = 0; attempt < 50 && !reclaimed; ++attempt) {
+        reclaimed = GetLocalDiskUsedBytesForTesting(service, segment_name) == 0;
+        if (!reclaimed) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+    }
+    EXPECT_TRUE(reclaimed);
 }
 
 #ifdef USE_NOF
@@ -3498,14 +3484,9 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
     backend->AllowTxn();
     ReadBatchEventually(storage, 2, batch);
 
-    if (!before_finalize.has_value()) {
-        const std::string after_finalize_key =
-            "after_batch_nof_evict_finalize_key";
-        auto after_finalize = service.PutStart(client_id, after_finalize_key,
-                                               kDefaultTenant, 1024, config);
-        EXPECT_TRUE(after_finalize.has_value())
-            << toString(after_finalize.error());
-    }
+    EXPECT_TRUE(PutStartEventually(service, client_id,
+                                   "after_batch_nof_evict_finalize_key",
+                                   kDefaultTenant, config));
 }
 #endif
 


### PR DESCRIPTION
## Description

Fixes #3332.

Several HA tests assumed that an OpLog batch being readable from the backend meant that the durable-finalize callback had already completed. Since persistence and callback execution occur asynchronously, the tests could attempt to allocate resources too early and intermittently fail with `TENANT_QUOTA_EXCEEDED`.

This change:

- Adds a bounded `PutStartEventually` helper for quota/resource reclamation checks.
- Updates remove, batch remove, remove-all, replica-clear, batch-evict, and NoF batch-evict tests to wait for successful allocation after durable finalization.
- Polls local-disk usage until reclaimed in the disk eviction test.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
SKIP=cmake-format pre-commit run --files mooncake-store/tests/ha/master_service_ha_test.cpp
```

**Test results:**

- [x] Targeted pre-commit checks pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using the project hooks
- [x] I have run `pre-commit run --all-files`
- [x] I have added test synchronization to cover the reported race
- [x] No documentation update is required

## AI Assistance Disclosure

- [x] AI tools were used.

AI assistance was used to inspect issue #3332, audit the affected HA tests, implement the minimal synchronization changes, and run formatting and pre-commit checks. The human submitter has reviewed the changes and is responsible for understanding and defending them.