### PR TITLE
[TE] Support split IBGDA control memory for MUSA

### DIFF
--- a/mooncake-transfer-engine/include/gpu_vendor/musa.h
+++ b/mooncake-transfer-engine/include/gpu_vendor/musa.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <musa.h>
+#include <musa_bf16.h>
 #include <musa_runtime.h>
 
 const static std::string GPU_PREFIX = "musa:";
@@ -60,6 +61,7 @@ const static std::string GPU_PREFIX = "musa:";
 #define CUDA_ERROR_NOT_SUPPORTED MUSA_ERROR_NOT_SUPPORTED
 #define cudaDeviceCanAccessPeer musaDeviceCanAccessPeer
 #define cudaDeviceEnablePeerAccess musaDeviceEnablePeerAccess
+#define cudaDeviceGetStreamPriorityRange musaDeviceGetStreamPriorityRange
 #define cudaDeviceGetPCIBusId musaDeviceGetPCIBusId
 #define cudaErrorPeerAccessAlreadyEnabled musaErrorPeerAccessAlreadyEnabled
 #define cudaError_t musaError_t
@@ -67,10 +69,14 @@ const static std::string GPU_PREFIX = "musa:";
 #define cudaFreeHost musaFreeHost
 #define cudaGetDevice musaGetDevice
 #define cudaGetDeviceCount musaGetDeviceCount
+#define cudaGetErrorName musaGetErrorName
 #define cudaGetErrorString musaGetErrorString
 #define cudaGetLastError musaGetLastError
 #define cudaHostAlloc musaHostAlloc
+#define cudaHostAllocDefault musaHostAllocDefault
 #define cudaHostAllocMapped musaHostAllocMapped
+#define cudaHostAllocPortable musaHostAllocPortable
+#define cudaHostAllocWriteCombined musaHostAllocWriteCombined
 #define cudaHostRegister musaHostRegister
 #define cudaHostRegisterPortable musaHostRegisterPortable
 #define cudaHostUnregister musaHostUnregister
@@ -97,6 +103,7 @@ const static std::string GPU_PREFIX = "musa:";
 #define cudaSetDevice musaSetDevice
 #define cudaStreamCreate musaStreamCreate
 #define cudaStreamCreateWithFlags musaStreamCreateWithFlags
+#define cudaStreamCreateWithPriority musaStreamCreateWithPriority
 #define cudaStreamNonBlocking musaStreamNonBlocking
 #define cudaStreamDestroy musaStreamDestroy
 #define cudaStreamPerThread musaStreamPerThread
@@ -122,12 +129,19 @@ const static std::string GPU_PREFIX = "musa:";
 #define cudaGetDeviceProperties musaGetDeviceProperties
 #define cudaMemcpyDeviceToDevice musaMemcpyDeviceToDevice
 #define cudaDevAttrClockRate musaDevAttrClockRate
+#define cudaDevAttrMaxSharedMemoryPerBlockOptin \
+    musaDevAttrMaxSharedMemoryPerBlockOptin
+#define cudaEventCreate musaEventCreate
+#define cudaEventElapsedTime musaEventElapsedTime
 #define cudaLaunchConfig_t musaLaunchConfig_t
 #define cudaLaunchAttribute musaLaunchAttribute
 #define cudaLaunchAttributeCooperative musaLaunchAttributeCooperative
 #define cudaLaunchKernelEx musaLaunchKernelEx
 #define CUDA_R_16BF MUSA_R_16BF
 #define CUDA_R_32F MUSA_R_32F
+
+#define nv_bfloat16 __mt_bfloat16
+#define nv_bfloat162 __mt_bfloat162
 
 // IBGDA-specific mappings
 #define cuInit muInit

--- a/mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h
+++ b/mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h
@@ -3,12 +3,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#ifdef USE_MUSA
-#include <musa_runtime.h>
-#define cudaStream_t musaStream_t
-#else
-#include <cuda_runtime.h>
-#endif
+#include "cuda_alike.h"
 #include <infiniband/verbs.h>
 #include <infiniband/mlx5dv.h>
 
@@ -40,6 +35,13 @@ struct mlx5gda_control_region_allocator {
     void (*release)(void *context, struct mlx5gda_control_region *region);
 };
 
+struct mlx5gda_control_buffer {
+    void *addr;
+    void *dev_addr;
+    struct mlx5dv_devx_umem *umem;
+    struct memheap *heap;
+};
+
 struct mlx5gda_rdma_write_wqe {
     struct mlx5_wqe_ctrl_seg ctrl;
     struct mlx5_wqe_raddr_seg raddr;
@@ -58,6 +60,9 @@ struct mlx5gda_cq {
     struct mlx5dv_devx_uar *uar;  // uar is allocated but not used
     uint32_t cqn;
     uint32_t cqe;
+    void *dev_base;
+    void *dev_cq_buf;
+    struct memheap *heap;
     size_t cq_offset;
     size_t dbr_offset;
     void *cq_buf;
@@ -70,9 +75,10 @@ struct mlx5gda_cq {
 struct mlx5gda_cq *mlx5gda_create_cq(
     void *ctrl_buf, struct mlx5dv_devx_umem *ctrl_buf_umem,
     struct memheap *ctrl_buf_heap, struct ibv_pd *pd, int num_cqe,
-    cudaStream_t stream,
-    const struct mlx5gda_control_region_allocator *region_allocator);
-void mlx5gda_destroy_cq(struct memheap *ctrl_buf_heap, struct mlx5gda_cq *cq);
+    cudaStream_t stream, void *cq_buf, void *cq_buf_dev,
+    struct mlx5dv_devx_umem *cq_buf_umem, struct memheap *cq_buf_heap,
+    const struct mlx5gda_control_region_allocator *cq_region_allocator);
+void mlx5gda_destroy_cq(struct mlx5gda_cq *cq);
 
 static const size_t MLX5GDA_BF_SIZE = 256;
 
@@ -80,6 +86,9 @@ struct mlx5gda_qp {
     struct mlx5dv_devx_obj *mqp;
     struct mlx5gda_cq *send_cq;
     struct mlx5dv_devx_uar *uar;
+    void *bf_host_base;
+    char *bf_device_addr;
+    bool bf_host_registration_owner;
 
     uint8_t port_num;
     struct ibv_port_attr port_attr;
@@ -90,8 +99,11 @@ struct mlx5gda_qp {
     uint32_t num_wqebb;
     size_t wq_offset;
     size_t dbr_offset;
+    struct memheap *wq_heap;
     void *wq;
     void *dbr;
+    void *dev_wq;
+    void *dev_dbr;
     struct mlx5gda_control_region wq_region;
     struct mlx5gda_control_region dbr_region;
     struct mlx5gda_control_region_allocator region_allocator;
@@ -121,11 +133,12 @@ void mlx5gda_reset_create_qp_failure();
 mlx5gda_create_qp_failure mlx5gda_last_create_qp_failure();
 
 struct mlx5gda_qp *mlx5gda_create_rc_qp(
-    struct mlx5dv_pd mpd, void *ctrl_buf,
-    struct mlx5dv_devx_umem *ctrl_buf_umem, struct memheap *ctrl_buf_heap,
-    struct ibv_pd *pd, int wqe, uint8_t port_num, cudaStream_t stream,
-    const struct mlx5gda_control_region_allocator *region_allocator);
-void mlx5gda_destroy_qp(struct memheap *ctrl_buf_heap, struct mlx5gda_qp *qp);
+    struct mlx5dv_pd mpd, const struct mlx5gda_control_buffer *ctrl,
+    const struct mlx5gda_control_buffer *cq, struct ibv_pd *pd, int wqe,
+    uint8_t port_num, cudaStream_t stream,
+    const struct mlx5gda_control_region_allocator *cq_region_allocator,
+    const struct mlx5gda_control_region_allocator *qp_region_allocator);
+void mlx5gda_destroy_qp(struct mlx5gda_qp *qp);
 
 int mlx5gda_modify_rc_qp_rst2init(struct mlx5gda_qp *qp, uint16_t pkey_index);
 int mlx5gda_modify_rc_qp_init2rtr(struct mlx5gda_qp *qp,

--- a/mooncake-transfer-engine/include/transport/device/ibgda_device.cuh
+++ b/mooncake-transfer-engine/include/transport/device/ibgda_device.cuh
@@ -118,16 +118,41 @@ __device__ __forceinline__ void mc_ibgda_poll_cq(mlx5gda_qp_devctx* qp,
 __device__ __forceinline__ void mc_ibgda_post_send_db(mlx5gda_qp_devctx* qp) {
     uint32_t num_posted = static_cast<uint32_t>(qp->wq_head);
     // DBR write — always done (NIC polls doorbell record in GPU memory)
+#if defined(MOONCAKE_EP_USE_MUSA) && __MUSA_ARCH__ == 310
+    // Match mtshmem's IBGDA publish sequence. The bypass atomic exchange makes
+    // the GPU-memory doorbell record visible to the NIC rather than retaining
+    // the write in the GPU cache hierarchy.
+    const uint32_t dbr_value = mc_bswap32(num_posted);
+    __threadfence_system_noflush();
+    asm volatile("LSU.ATOM_32.XCHG %0, %1, slc=byp;"
+                 :
+                 : "R"(reinterpret_cast<uint32_t*>(&qp->dbr->send_counter)),
+                   "R"(dbr_value));
+#else
     mc_st_release_u32(reinterpret_cast<uint32_t*>(&qp->dbr->send_counter),
                       mc_bswap32(num_posted));
+#endif
     // BF (Blue Flame) doorbell — only if BF register is mapped into GPU VA.
-    // On MUSA, musaHostRegisterIoMemory fails for MMIO addresses, so bf is
-    // NULL and we rely on DBR-only mode (slightly higher latency).
     if (qp->bf != nullptr) {
+#if defined(MOONCAKE_EP_USE_MUSA) && __MUSA_ARCH__ == 310
+        struct {
+            __be32 opmod_idx_opcode;
+            __be32 qpn_ds;
+        } doorbell{
+            mc_bswap32(num_posted << 8),
+            mc_bswap32(qp->qpn << 8),
+        };
+        __threadfence_system_noflush();
+        asm volatile("LSU.ATOM_64.XCHG %0, %1, slc=byp;"
+                     :
+                     : "R"(reinterpret_cast<uint64_t*>(qp->bf)),
+                       "R"(*reinterpret_cast<uint64_t*>(&doorbell)));
+#else
         auto* last_wqe = qp->wq + ((num_posted - 1) & qp->wqeid_mask);
         mc_st_release_u64(reinterpret_cast<uint64_t*>(qp->bf + qp->bf_offset),
                           *reinterpret_cast<uint64_t*>(last_wqe));
         qp->bf_offset ^= MLX5GDA_BF_SIZE;
+#endif
     }
 }
 

--- a/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp
@@ -26,6 +26,7 @@
 #include <infiniband/mlx5dv.h>
 #include <infiniband/verbs.h>
 
+#include <algorithm>
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
@@ -42,11 +43,14 @@ namespace mooncake {
 namespace device {
 
 static constexpr size_t kCtrlBufSize = 1024ULL * 1024 * 1024;  // 1 GiB
+static constexpr size_t kHostMappedCqMinSize = 256ULL * 1024 * 1024;
+static constexpr size_t kIbgdaQpWqebbCount = 16384;
 
 enum class ControlMemoryMode {
     kGpuDmabuf,
     kGpuVa,
     kHostMapped,
+    kPerQpGpuVaHostMappedCq,
 };
 
 static const char* controlMemoryModeName(ControlMemoryMode mode) {
@@ -57,6 +61,8 @@ static const char* controlMemoryModeName(ControlMemoryMode mode) {
             return "gpu-va";
         case ControlMemoryMode::kHostMapped:
             return "host-mapped";
+        case ControlMemoryMode::kPerQpGpuVaHostMappedCq:
+            return "per-qp-gpu-va-host-mapped-cq";
     }
     return "unknown";
 }
@@ -256,23 +262,53 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
                "trying GPU-VA control buffer";
         return allocateGpuVaOrHostControlBuffer();
 #endif
+#if defined(USE_MUSA)
+        return allocatePerQpGpuVaControlBuffers();
+#else
         return allocateControlBuffer(ControlMemoryMode::kGpuVa);
+#endif
     }
 
     int createQueuePairs(void* stream_ptr) override {
         auto stream = static_cast<cudaStream_t>(stream_ptr);
-        mlx5gda_control_region_allocator region_allocator{
+        mlx5gda_control_region_allocator dmabuf_region_allocator{
             .context = this,
             .allocate = allocateDmabufControlRegionThunk,
             .release = releaseDmabufControlRegionThunk,
         };
-        const mlx5gda_control_region_allocator* allocator =
-            ctrl_buf_mode_ == ControlMemoryMode::kGpuDmabuf ? &region_allocator
-                                                            : nullptr;
+        mlx5gda_control_region_allocator gpu_va_region_allocator{
+            .context = this,
+            .allocate = allocateGpuVaControlRegionThunk,
+            .release = releaseGpuVaControlRegionThunk,
+        };
+        const mlx5gda_control_region_allocator* cq_region_allocator =
+            ctrl_buf_mode_ == ControlMemoryMode::kGpuDmabuf
+                ? &dmabuf_region_allocator
+                : nullptr;
+        const mlx5gda_control_region_allocator* qp_region_allocator =
+            ctrl_buf_mode_ == ControlMemoryMode::kGpuDmabuf
+                ? &dmabuf_region_allocator
+            : ctrl_buf_mode_ == ControlMemoryMode::kPerQpGpuVaHostMappedCq
+                ? &gpu_va_region_allocator
+                : nullptr;
+        const mlx5gda_control_buffer ctrl{
+            .addr = ctrl_buf_,
+            .dev_addr = ctrl_buf_dev_,
+            .umem = ctrl_buf_umem_,
+            .heap = ctrl_buf_heap_,
+        };
+        const mlx5gda_control_buffer cq =
+            cq_buf_ ? mlx5gda_control_buffer{
+                          .addr = cq_buf_,
+                          .dev_addr = cq_buf_dev_,
+                          .umem = cq_buf_umem_,
+                          .heap = cq_buf_heap_,
+                      }
+                    : ctrl;
         for (int i = 0; i < num_qps_; ++i) {
             mlx5gda_qp* qp = mlx5gda_create_rc_qp(
-                mpd_, ctrl_buf_, ctrl_buf_umem_, ctrl_buf_heap_, pd_, 16384, 1,
-                stream, allocator);
+                mpd_, &ctrl, &cq, pd_, kIbgdaQpWqebbCount, 1, stream,
+                cq_region_allocator, qp_region_allocator);
             if (!qp) {
                 const int qp_errno = errno;
                 LOG(ERROR) << "[EP IBGDA] mlx5gda_create_rc_qp failed at " << i;
@@ -282,31 +318,18 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
             }
             if (mlx5gda_modify_rc_qp_rst2init(qp, 0)) {
                 LOG(ERROR) << "[EP IBGDA] rst2init failed at " << i;
-                mlx5gda_destroy_qp(ctrl_buf_heap_, qp);
+                mlx5gda_destroy_qp(qp);
                 return -1;
             }
             cudaStreamSynchronize(stream);
-            const bool split_regions =
-                ctrl_buf_mode_ == ControlMemoryMode::kGpuDmabuf;
             mlx5gda_qp_devctx devctx{
                 .qpn = qp->qpn,
                 .wqeid_mask = qp->num_wqebb - 1,
                 .mutex = 0,
-                .wq = split_regions ? reinterpret_cast<mlx5gda_wqebb*>(qp->wq)
-                                    : reinterpret_cast<mlx5gda_wqebb*>(
-                                          static_cast<char*>(ctrl_buf_dev_) +
-                                          qp->wq_offset),
-                .cq = split_regions
-                          ? reinterpret_cast<mlx5_cqe64*>(qp->send_cq->cq_buf)
-                          : reinterpret_cast<mlx5_cqe64*>(
-                                static_cast<char*>(ctrl_buf_dev_) +
-                                qp->send_cq->cq_offset),
-                .dbr = split_regions
-                           ? reinterpret_cast<mlx5gda_wq_dbr*>(qp->dbr)
-                           : reinterpret_cast<mlx5gda_wq_dbr*>(
-                                 static_cast<char*>(ctrl_buf_dev_) +
-                                 qp->dbr_offset),
-                .bf = static_cast<char*>(qp->uar->reg_addr),
+                .wq = reinterpret_cast<mlx5gda_wqebb*>(qp->dev_wq),
+                .cq = reinterpret_cast<mlx5_cqe64*>(qp->send_cq->dev_cq_buf),
+                .dbr = reinterpret_cast<mlx5gda_wq_dbr*>(qp->dev_dbr),
+                .bf = qp->bf_device_addr,
                 .bf_offset = 0,
                 .wq_head = 0,
                 .wq_tail = 0,
@@ -492,7 +515,7 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
             LOG(ERROR) << "[EP IBGDA] cudaMalloc failed for DMA-BUF control "
                           "region size="
                        << size << ": " << cudaGetErrorString(cuda_error);
-            errno = cuda_error == cudaErrorMemoryAllocation ? ENOMEM : EIO;
+            errno = EIO;
             return -1;
         }
 
@@ -565,6 +588,54 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
         *region = {};
     }
 
+    int allocateGpuVaControlRegion(size_t requested_size,
+                                   mlx5gda_control_region* region) {
+        if (!region || requested_size == 0) {
+            errno = EINVAL;
+            return -1;
+        }
+
+        const long page_size = sysconf(_SC_PAGESIZE);
+        if (page_size <= 0) {
+            errno = EIO;
+            return -1;
+        }
+        const size_t page_mask = static_cast<size_t>(page_size) - 1;
+        const size_t size = (requested_size + page_mask) & ~page_mask;
+
+        void* addr = nullptr;
+        const cudaError_t cuda_error = cudaMalloc(&addr, size);
+        if (cuda_error != cudaSuccess) {
+            LOG(ERROR) << "[EP IBGDA] cudaMalloc failed for per-QP GPU-VA "
+                          "control region size="
+                       << size << ": " << cudaGetErrorString(cuda_error);
+            errno = EIO;
+            return -1;
+        }
+
+        mlx5dv_devx_umem* umem =
+            mlx5dv_devx_umem_reg(ctx_, addr, size, IBV_ACCESS_LOCAL_WRITE);
+        if (!umem) {
+            PLOG(ERROR) << "[EP IBGDA] Control UMEM registration failed for "
+                           "per-QP GPU-VA region";
+            cudaFree(addr);
+            return -1;
+        }
+        *region = mlx5gda_control_region{
+            .addr = addr,
+            .size = size,
+            .umem = umem,
+        };
+        return 0;
+    }
+
+    void releaseGpuVaControlRegion(mlx5gda_control_region* region) {
+        if (!region) return;
+        if (region->umem) mlx5dv_devx_umem_dereg(region->umem);
+        if (region->addr) cudaFree(region->addr);
+        *region = {};
+    }
+
     static int allocateDmabufControlRegionThunk(
         void* context, size_t size, mlx5gda_control_region* region) {
         return static_cast<IbgdaDeviceTransportImpl*>(context)
@@ -575,6 +646,18 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
         void* context, mlx5gda_control_region* region) {
         static_cast<IbgdaDeviceTransportImpl*>(context)
             ->releaseDmabufControlRegion(region);
+    }
+
+    static int allocateGpuVaControlRegionThunk(void* context, size_t size,
+                                               mlx5gda_control_region* region) {
+        return static_cast<IbgdaDeviceTransportImpl*>(context)
+            ->allocateGpuVaControlRegion(size, region);
+    }
+
+    static void releaseGpuVaControlRegionThunk(void* context,
+                                               mlx5gda_control_region* region) {
+        static_cast<IbgdaDeviceTransportImpl*>(context)
+            ->releaseGpuVaControlRegion(region);
     }
 
     int allocateControlBuffer(ControlMemoryMode mode) {
@@ -644,6 +727,79 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
         return 0;
     }
 
+    int allocatePerQpGpuVaControlBuffers() {
+        ctrl_buf_mode_ = ControlMemoryMode::kPerQpGpuVaHostMappedCq;
+        if (allocateHostMappedCqBuffer() != 0) {
+            freeControlBuffer();
+            return -1;
+        }
+        LOG(INFO) << "[EP IBGDA] Using per-QP GPU WQ/DBR regions and "
+                     "host-backed mapped CQ buffer";
+        return 0;
+    }
+
+    int allocateHostMappedCqBuffer() {
+        // Each QP owns a 16K-entry CQ.  A CQ consumes exactly 1 MiB, but its
+        // trailing DBR makes the next CQ start on a fresh adapter page.  The
+        // fixed 256 MiB baseline therefore cannot hold 256 QPs.
+        constexpr size_t kAdapterPageSize = 4096;
+        constexpr size_t kCqBytesPerQp =
+            kIbgdaQpWqebbCount * sizeof(mlx5_cqe64) + kAdapterPageSize;
+        const size_t cq_buf_size =
+            std::max(kHostMappedCqMinSize,
+                     static_cast<size_t>(num_qps_) * kCqBytesPerQp);
+        void* ptr = nullptr;
+        const int ret = posix_memalign(&ptr, 4096, cq_buf_size);
+        if (ret != 0) {
+            LOG(ERROR) << "[EP IBGDA] posix_memalign cq_buf failed: " << ret;
+            return -1;
+        }
+        cq_buf_ = ptr;
+        std::memset(cq_buf_, 0, cq_buf_size);
+        cudaError_t err =
+            cudaHostRegister(cq_buf_, cq_buf_size,
+                             cudaHostRegisterPortable | cudaHostRegisterMapped);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "[EP IBGDA] cudaHostRegister cq_buf failed: "
+                       << cudaGetErrorString(err);
+            free(cq_buf_);
+            cq_buf_ = nullptr;
+            return -1;
+        }
+        err = cudaHostGetDevicePointer(&cq_buf_dev_, cq_buf_, 0);
+        if (err != cudaSuccess) {
+            LOG(ERROR) << "[EP IBGDA] cudaHostGetDevicePointer cq_buf failed: "
+                       << cudaGetErrorString(err);
+            cudaHostUnregister(cq_buf_);
+            free(cq_buf_);
+            cq_buf_ = nullptr;
+            return -1;
+        }
+        cq_buf_umem_ = mlx5dv_devx_umem_reg(ctx_, cq_buf_, cq_buf_size,
+                                            IBV_ACCESS_LOCAL_WRITE);
+        if (!cq_buf_umem_) {
+            LOG(ERROR) << "[EP IBGDA] CQ UMEM registration failed (errno="
+                       << errno << ")";
+            cudaHostUnregister(cq_buf_);
+            free(cq_buf_);
+            cq_buf_ = nullptr;
+            cq_buf_dev_ = nullptr;
+            return -1;
+        }
+        cq_buf_heap_ = memheap_create(cq_buf_size);
+        if (!cq_buf_heap_) {
+            LOG(ERROR) << "[EP IBGDA] memheap_create cq_buf failed";
+            mlx5dv_devx_umem_dereg(cq_buf_umem_);
+            cq_buf_umem_ = nullptr;
+            cudaHostUnregister(cq_buf_);
+            free(cq_buf_);
+            cq_buf_ = nullptr;
+            cq_buf_dev_ = nullptr;
+            return -1;
+        }
+        return 0;
+    }
+
     int allocateGpuVaOrHostControlBuffer() {
         if (allocateControlBuffer(ControlMemoryMode::kGpuVa) == 0) return 0;
 
@@ -657,6 +813,7 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
         const bool using_dmabuf_control_regions =
             ctrl_buf_mode_ == ControlMemoryMode::kGpuDmabuf;
         if (ctrl_buf_mode_ == ControlMemoryMode::kHostMapped ||
+            ctrl_buf_mode_ == ControlMemoryMode::kPerQpGpuVaHostMappedCq ||
             (!isCreateQpBadParam(failure) && !using_dmabuf_control_regions))
             return false;
 
@@ -685,12 +842,26 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
 
     void destroyQueuePairs() {
         for (auto* qp : qps_) {
-            if (qp) mlx5gda_destroy_qp(ctrl_buf_heap_, qp);
+            if (qp) mlx5gda_destroy_qp(qp);
         }
         qps_.clear();
     }
 
     void freeControlBuffer() {
+        if (cq_buf_heap_) {
+            memheap_destroy(cq_buf_heap_);
+            cq_buf_heap_ = nullptr;
+        }
+        if (cq_buf_umem_) {
+            mlx5dv_devx_umem_dereg(cq_buf_umem_);
+            cq_buf_umem_ = nullptr;
+        }
+        if (cq_buf_) {
+            cudaHostUnregister(cq_buf_);
+            free(cq_buf_);
+            cq_buf_ = nullptr;
+            cq_buf_dev_ = nullptr;
+        }
         if (ctrl_buf_heap_) {
             memheap_destroy(ctrl_buf_heap_);
             ctrl_buf_heap_ = nullptr;
@@ -760,6 +931,10 @@ class IbgdaDeviceTransportImpl : public RdmaTransport {
     ControlMemoryMode ctrl_buf_mode_ = ControlMemoryMode::kGpuVa;
     mlx5dv_devx_umem* ctrl_buf_umem_ = nullptr;
     memheap* ctrl_buf_heap_ = nullptr;
+    void* cq_buf_ = nullptr;
+    void* cq_buf_dev_ = nullptr;
+    mlx5dv_devx_umem* cq_buf_umem_ = nullptr;
+    memheap* cq_buf_heap_ = nullptr;
 
     // QPs
     std::vector<mlx5gda_qp*> qps_;

--- a/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
+++ b/mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
@@ -1,4 +1,6 @@
 #include <cmath>
+#include <cstdint>
+#include <unistd.h>
 
 #include "cuda_alike.h"
 
@@ -31,11 +33,7 @@ constexpr T round_up_pow2(T n) {
 #define IBGDA_ROUND_UP_POW2_OR_0(_n) (((_n) == 0) ? 0 : round_up_pow2(_n))
 
 static void print_cuda_error(const char* msg) {
-#ifdef USE_MUSA
-    const char* err_str = musaGetErrorString(musaGetLastError());
-#else
     const char* err_str = cudaGetErrorString(cudaGetLastError());
-#endif
     fprintf(stderr, "%s: %s\n", msg, err_str);
 }
 
@@ -81,14 +79,6 @@ static void print_devx_create_qp_failure(const uint8_t* cmd_out,
             dbr_offset);
 }
 
-// Create UAR for BF (Blue Flame) doorbell ringing.
-// On CUDA: registers the BF MMIO region into GPU address space so the
-//          GPU kernel can directly write the doorbell (lowest latency).
-// On MUSA: musaHostRegisterIoMemory is not supported for MMIO addresses,
-//          so we skip BF registration and return a UAR with reg_addr=NULL.
-//          The GPU kernel will use DBR-only mode (write to memory-mapped
-//          doorbell record, NIC polls it) — slightly higher latency but
-//          functionally correct.
 static struct mlx5dv_devx_uar* create_uar(struct ibv_context* ctx) {
     struct mlx5dv_devx_uar* uar =
         mlx5dv_devx_alloc_uar(ctx, MLX5DV_UAR_ALLOC_TYPE_BF);
@@ -96,25 +86,35 @@ static struct mlx5dv_devx_uar* create_uar(struct ibv_context* ctx) {
         errno = EIO;
         return NULL;
     }
-#ifdef USE_MUSA
-    // MUSA cannot map MMIO addresses into GPU VA.  Skip the
-    // musaHostRegister(IoMemory) call entirely — attempting it
-    // corrupts the MUSA runtime, causing all subsequent device-side
-    // fill operations to fail with "illegal memory access".
-    // Use DBR-only mode: the kernel writes to the doorbell record
-    // in GPU memory instead of the BF MMIO register.
-    uar->reg_addr = NULL;
-#else
-    if (cudaHostRegister(uar->reg_addr, MLX5GDA_BF_SIZE * 2,
-                         cudaHostRegisterPortable | cudaHostRegisterMapped |
-                             cudaHostRegisterIoMemory) != cudaSuccess) {
-        print_cuda_error("Failed to register MMIO memory");
-        errno = EIO;
-        mlx5dv_devx_free_uar(uar);
-        return NULL;
-    }
-#endif
     return uar;
+}
+
+static int map_uar_for_device(struct mlx5dv_devx_uar* uar,
+                              struct mlx5gda_qp* qp) {
+    const cudaError_t register_result =
+        cudaHostRegister(uar->reg_addr, MLX5GDA_BF_SIZE * 2,
+                         cudaHostRegisterMapped | cudaHostRegisterIoMemory);
+    void* device_base = nullptr;
+    if (cudaHostGetDevicePointer(&device_base, uar->reg_addr, 0) !=
+        cudaSuccess) {
+        if (register_result == cudaSuccess) cudaHostUnregister(uar->reg_addr);
+        print_cuda_error("Failed to map BF MMIO page");
+        errno = EIO;
+        return -1;
+    }
+    qp->bf_host_base = uar->reg_addr;
+    qp->bf_device_addr = static_cast<char*>(device_base);
+    qp->bf_host_registration_owner = register_result == cudaSuccess;
+    return 0;
+}
+
+static void unmap_uar_for_device(struct mlx5gda_qp* qp) {
+    if (qp->bf_host_registration_owner) {
+        cudaHostUnregister(qp->bf_host_base);
+        qp->bf_host_registration_owner = false;
+    }
+    qp->bf_host_base = nullptr;
+    qp->bf_device_addr = nullptr;
 }
 
 static bool uses_control_regions(
@@ -133,19 +133,15 @@ static void release_control_region(
 
 static void destroy_uar(struct mlx5dv_devx_uar* uar) {
     if (!uar) return;
-    if (uar->reg_addr) {
-        if (cudaHostUnregister(uar->reg_addr) != cudaSuccess) {
-            print_cuda_error("Failed to unregister MMIO memory");
-        }
-    }
     mlx5dv_devx_free_uar(uar);
 }
 
 struct mlx5gda_cq* mlx5gda_create_cq(
     void* ctrl_buf, struct mlx5dv_devx_umem* ctrl_buf_umem,
     struct memheap* ctrl_buf_heap, struct ibv_pd* pd, int cqe,
-    cudaStream_t stream,
-    const struct mlx5gda_control_region_allocator* region_allocator) {
+    cudaStream_t stream, void* cq_buf_arg, void* cq_buf_dev,
+    struct mlx5dv_devx_umem* cq_buf_umem, struct memheap* cq_buf_heap,
+    const struct mlx5gda_control_region_allocator* cq_region_allocator) {
     struct mlx5gda_cq* cq = NULL;
     struct mlx5dv_devx_uar* uar = NULL;
     uint32_t eqn = 0;
@@ -153,15 +149,17 @@ struct mlx5gda_cq* mlx5gda_create_cq(
     size_t dbr_offset = -1;
     struct mlx5dv_devx_obj* mlx5_cq = NULL;
     uint32_t cqn = 0;
-    void* cq_buf = ctrl_buf;
-    void* dbr = ctrl_buf;
-    struct mlx5dv_devx_umem* cq_umem = ctrl_buf_umem;
-    struct mlx5dv_devx_umem* dbr_umem = ctrl_buf_umem;
-    const bool split_regions = uses_control_regions(region_allocator);
+    void* cq_buf = cq_buf_arg ? cq_buf_arg : ctrl_buf;
+    void* dbr = cq_buf;
+    struct mlx5dv_devx_umem* cq_umem =
+        cq_buf_umem ? cq_buf_umem : ctrl_buf_umem;
+    struct mlx5dv_devx_umem* dbr_umem = cq_umem;
+    struct memheap* cq_heap = cq_buf_heap ? cq_buf_heap : ctrl_buf_heap;
+    const bool split_regions = uses_control_regions(cq_region_allocator);
 
     struct ibv_context* ctx = pd->context;
     void* cq_context = NULL;
-    bool ctrl_host = !split_regions && is_host_control_buffer(ctrl_buf);
+    bool ctrl_host = !split_regions && is_host_control_buffer(cq_buf);
 
     if (cqe <= 0) {
         errno = EINVAL;
@@ -176,16 +174,16 @@ struct mlx5gda_cq* mlx5gda_create_cq(
     if (!cq) goto fail;
 
     if (split_regions) {
-        cq->region_allocator = *region_allocator;
-        if (region_allocator->allocate(region_allocator->context,
-                                       num_cqe * sizeof(struct mlx5_cqe64),
-                                       &cq->cq_region) != 0) {
+        cq->region_allocator = *cq_region_allocator;
+        if (cq_region_allocator->allocate(cq_region_allocator->context,
+                                          num_cqe * sizeof(struct mlx5_cqe64),
+                                          &cq->cq_region) != 0) {
             perror("Failed to allocate CQ control region");
             goto fail;
         }
-        if (region_allocator->allocate(region_allocator->context,
-                                       sizeof(struct mlx5gda_cq_dbr),
-                                       &cq->dbr_region) != 0) {
+        if (cq_region_allocator->allocate(cq_region_allocator->context,
+                                          sizeof(struct mlx5gda_cq_dbr),
+                                          &cq->dbr_region) != 0) {
             perror("Failed to allocate CQ DBR control region");
             goto fail;
         }
@@ -196,15 +194,14 @@ struct mlx5gda_cq* mlx5gda_create_cq(
         cq_offset = 0;
         dbr_offset = 0;
     } else {
-        cq_offset = memheap_aligned_alloc(ctrl_buf_heap,
-                                          num_cqe * sizeof(struct mlx5_cqe64),
-                                          (size_t)1 << MLX5_ADAPTER_PAGE_SHIFT);
+        cq_offset =
+            memheap_aligned_alloc(cq_heap, num_cqe * sizeof(struct mlx5_cqe64),
+                                  (size_t)1 << MLX5_ADAPTER_PAGE_SHIFT);
         if (cq_offset == (size_t)-1) {
             perror("Failed to allocate CQ memory");
             goto fail;
         }
-        dbr_offset =
-            memheap_alloc(ctrl_buf_heap, sizeof(struct mlx5gda_cq_dbr));
+        dbr_offset = memheap_alloc(cq_heap, sizeof(struct mlx5gda_cq_dbr));
         if (dbr_offset == (size_t)-1) {
             perror("Failed to allocate CQ DBR memory");
             goto fail;
@@ -271,7 +268,12 @@ struct mlx5gda_cq* mlx5gda_create_cq(
 
     cq->cq_offset = cq_offset;
     cq->dbr_offset = dbr_offset;
+    cq->dev_base = cq_buf_dev ? cq_buf_dev : ctrl_buf;
+    cq->heap = cq_heap;
     cq->cq_buf = static_cast<char*>(cq_buf) + cq_offset;
+    cq->dev_cq_buf = split_regions
+                         ? cq->cq_buf
+                         : static_cast<char*>(cq->dev_base) + cq_offset;
     cq->dbr = static_cast<char*>(dbr) + dbr_offset;
     cq->cqe = num_cqe;
     cq->cqn = cqn;
@@ -287,14 +289,14 @@ fail:
         free(cq);
     }
     if (!split_regions) {
-        if (cq_offset != (size_t)-1) memheap_free(ctrl_buf_heap, cq_offset);
-        if (dbr_offset != (size_t)-1) memheap_free(ctrl_buf_heap, dbr_offset);
+        if (cq_offset != (size_t)-1) memheap_free(cq_heap, cq_offset);
+        if (dbr_offset != (size_t)-1) memheap_free(cq_heap, dbr_offset);
     }
     errno = saved_errno;
     return NULL;
 }
 
-void mlx5gda_destroy_cq(struct memheap* ctrl_buf_heap, struct mlx5gda_cq* cq) {
+void mlx5gda_destroy_cq(struct mlx5gda_cq* cq) {
     if (!cq) return;
     if (cq->mcq) {
         mlx5dv_devx_obj_destroy(cq->mcq);
@@ -306,17 +308,18 @@ void mlx5gda_destroy_cq(struct memheap* ctrl_buf_heap, struct mlx5gda_cq* cq) {
         release_control_region(&cq->region_allocator, &cq->dbr_region);
         release_control_region(&cq->region_allocator, &cq->cq_region);
     } else {
-        memheap_free(ctrl_buf_heap, cq->cq_offset);
-        memheap_free(ctrl_buf_heap, cq->dbr_offset);
+        memheap_free(cq->heap, cq->cq_offset);
+        memheap_free(cq->heap, cq->dbr_offset);
     }
     free(cq);
 }
 
 struct mlx5gda_qp* mlx5gda_create_rc_qp(
-    struct mlx5dv_pd mpd, void* ctrl_buf,
-    struct mlx5dv_devx_umem* ctrl_buf_umem, struct memheap* ctrl_buf_heap,
-    struct ibv_pd* pd, int wqe, uint8_t port_num, cudaStream_t stream,
-    const struct mlx5gda_control_region_allocator* region_allocator) {
+    struct mlx5dv_pd mpd, const struct mlx5gda_control_buffer* ctrl,
+    const struct mlx5gda_control_buffer* cq, struct ibv_pd* pd, int wqe,
+    uint8_t port_num, cudaStream_t stream,
+    const struct mlx5gda_control_region_allocator* cq_region_allocator,
+    const struct mlx5gda_control_region_allocator* qp_region_allocator) {
     mlx5gda_reset_create_qp_failure();
 
     struct mlx5gda_qp* qp = NULL;
@@ -325,17 +328,17 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
     struct mlx5dv_devx_obj* mlx5_qp = NULL;
     size_t wq_offset = -1;
     size_t dbr_offset = -1;
-    void* wq = ctrl_buf;
-    void* dbr = ctrl_buf;
-    struct mlx5dv_devx_umem* wq_umem = ctrl_buf_umem;
-    struct mlx5dv_devx_umem* dbr_umem = ctrl_buf_umem;
-    const bool split_regions = uses_control_regions(region_allocator);
+    void* wq = ctrl->addr;
+    void* dbr = ctrl->addr;
+    struct mlx5dv_devx_umem* wq_umem = ctrl->umem;
+    struct mlx5dv_devx_umem* dbr_umem = ctrl->umem;
+    const bool split_regions = uses_control_regions(qp_region_allocator);
 
     struct ibv_context* ctx = pd->context;
     void* qp_context = NULL;
     void* cap = NULL;
     uint32_t cqe_version = 0;
-    bool ctrl_host = !split_regions && is_host_control_buffer(ctrl_buf);
+    bool ctrl_host = !split_regions && is_host_control_buffer(ctrl->addr);
 
     if (wqe <= 0) {
         errno = EINVAL;
@@ -354,7 +357,7 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
         perror("Failed to allocate QP memory");
         goto fail;
     }
-    if (split_regions) qp->region_allocator = *region_allocator;
+    if (split_regions) qp->region_allocator = *qp_region_allocator;
 
     qp->port_num = port_num;
     if (ibv_query_port(ctx, port_num, &qp->port_attr) != 0) {
@@ -382,8 +385,9 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
     }
 
     // Create send_cq on GPU memory.
-    send_cq = mlx5gda_create_cq(ctrl_buf, ctrl_buf_umem, ctrl_buf_heap, pd, wqe,
-                                stream, region_allocator);
+    send_cq = mlx5gda_create_cq(ctrl->addr, ctrl->umem, ctrl->heap, pd, wqe,
+                                stream, cq->addr, cq->dev_addr, cq->umem,
+                                cq->heap, cq_region_allocator);
     if (send_cq == NULL) {
         perror("mlx5gda_create_cq failed");
         goto fail;
@@ -394,17 +398,19 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
         perror("Failed to create UAR");
         goto fail;
     }
+    if (map_uar_for_device(uar, qp) != 0) goto fail;
 
     if (split_regions) {
-        if (region_allocator->allocate(region_allocator->context,
-                                       num_wqebb * sizeof(struct mlx5gda_wqebb),
-                                       &qp->wq_region) != 0) {
+        if (qp_region_allocator->allocate(
+                qp_region_allocator->context,
+                num_wqebb * sizeof(struct mlx5gda_wqebb),
+                &qp->wq_region) != 0) {
             perror("Failed to allocate WQ control region");
             goto fail;
         }
-        if (region_allocator->allocate(region_allocator->context,
-                                       sizeof(struct mlx5gda_wq_dbr),
-                                       &qp->dbr_region) != 0) {
+        if (qp_region_allocator->allocate(qp_region_allocator->context,
+                                          sizeof(struct mlx5gda_wq_dbr),
+                                          &qp->dbr_region) != 0) {
             perror("Failed to allocate QP DBR control region");
             goto fail;
         }
@@ -416,15 +422,14 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
         dbr_offset = 0;
     } else {
         wq_offset = memheap_aligned_alloc(
-            ctrl_buf_heap, num_wqebb * sizeof(struct mlx5gda_wqebb),
+            ctrl->heap, num_wqebb * sizeof(struct mlx5gda_wqebb),
             (size_t)1 << MLX5_ADAPTER_PAGE_SHIFT);
         if (wq_offset == (size_t)-1) {
             perror("Failed to allocate WQ memory");
             goto fail;
         }
 
-        dbr_offset =
-            memheap_alloc(ctrl_buf_heap, sizeof(struct mlx5gda_wq_dbr));
+        dbr_offset = memheap_alloc(ctrl->heap, sizeof(struct mlx5gda_wq_dbr));
         if (dbr_offset == (size_t)-1) {
             perror("Failed to allocate DBR memory");
             goto fail;
@@ -496,8 +501,14 @@ struct mlx5gda_qp* mlx5gda_create_rc_qp(
     qp->num_wqebb = num_wqebb;
     qp->wq_offset = wq_offset;
     qp->dbr_offset = dbr_offset;
+    qp->wq_heap = ctrl->heap;
     qp->wq = static_cast<char*>(wq) + wq_offset;
     qp->dbr = static_cast<char*>(dbr) + dbr_offset;
+    qp->dev_wq =
+        split_regions ? qp->wq : static_cast<char*>(ctrl->dev_addr) + wq_offset;
+    qp->dev_dbr = split_regions
+                      ? qp->dbr
+                      : static_cast<char*>(ctrl->dev_addr) + dbr_offset;
     return qp;
 
 fail:
@@ -506,10 +517,11 @@ fail:
         mlx5dv_devx_obj_destroy(mlx5_qp);
     }
     if (uar) {
+        if (qp) unmap_uar_for_device(qp);
         destroy_uar(uar);
     }
     if (send_cq) {
-        mlx5gda_destroy_cq(ctrl_buf_heap, send_cq);
+        mlx5gda_destroy_cq(send_cq);
     }
     if (qp) {
         release_control_region(&qp->region_allocator, &qp->dbr_region);
@@ -519,34 +531,35 @@ fail:
         free(qp);
     }
     if (!split_regions && wq_offset != (size_t)-1) {
-        memheap_free(ctrl_buf_heap, wq_offset);
+        memheap_free(ctrl->heap, wq_offset);
     }
     if (!split_regions && dbr_offset != (size_t)-1) {
-        memheap_free(ctrl_buf_heap, dbr_offset);
+        memheap_free(ctrl->heap, dbr_offset);
     }
     errno = saved_errno;
     return NULL;
 }
 
-void mlx5gda_destroy_qp(struct memheap* ctrl_buf_heap, struct mlx5gda_qp* qp) {
+void mlx5gda_destroy_qp(struct mlx5gda_qp* qp) {
     if (qp->mqp) {
         mlx5dv_devx_obj_destroy(qp->mqp);
     }
     if (qp->uar) {
+        unmap_uar_for_device(qp);
         destroy_uar(qp->uar);
     }
     if (qp->send_cq) {
-        mlx5gda_destroy_cq(ctrl_buf_heap, qp->send_cq);
+        mlx5gda_destroy_cq(qp->send_cq);
     }
     if (uses_control_regions(&qp->region_allocator)) {
         release_control_region(&qp->region_allocator, &qp->dbr_region);
         release_control_region(&qp->region_allocator, &qp->wq_region);
     } else {
         if (qp->wq_offset != (size_t)-1) {
-            memheap_free(ctrl_buf_heap, qp->wq_offset);
+            memheap_free(qp->wq_heap, qp->wq_offset);
         }
         if (qp->dbr_offset != (size_t)-1) {
-            memheap_free(ctrl_buf_heap, qp->dbr_offset);
+            memheap_free(qp->wq_heap, qp->dbr_offset);
         }
     }
     if (qp) {


### PR DESCRIPTION
## Description

The IBGDA transport currently assumes that QP WQ/DBR buffers and CQ buffers share one control allocation and one memory heap. Device-visible addresses and resource cleanup are consequently derived from the same layout.

MUSA IBGDA requires a split layout: per-QP GPU-VA WQ/DBR buffers together with a pinned host CQ/CQ-DBR buffer mapped into device VA. This layout is not expressible through the existing single-control-buffer interface.

This patch introduces an explicit control-buffer descriptor carrying host address, device address, UMEM, and heap; separates CQ and QP control-region allocators and ownership; passes explicit device-visible addresses to the IBGDA device context; adds `kPerQpGpuVaHostMappedCq` for MUSA; sizes the mapped CQ buffer from the QP count; and adds the MUSA CUDA-alike mappings and device-side IBGDA publish sequence.

CUDA's existing DMA-BUF control-region path remains available. The change is scoped to the Transfer Engine IBGDA memory layout and vendor compatibility.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] New feature
- [x] Refactor
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
clang-format-20 --dry-run --Werror \\
  mooncake-transfer-engine/include/gpu_vendor/musa.h \\
  mooncake-transfer-engine/include/transport/device/ibgda/mlx5gda.h \\
  mooncake-transfer-engine/include/transport/device/ibgda_device.cuh \\
  mooncake-transfer-engine/src/transport/device/ibgda_device_transport.cpp \\
  mooncake-transfer-engine/src/transport/device/mlx5gda.cpp
git diff --check origin/main...HEAD
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (MUSA/CUDA hardware gates to be attached after running them on this extracted branch)
- Formatting and whitespace validation passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `clang-format-20`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex assisted with branch extraction, rebase, formatting, and PR preparation)

The human submitter is responsible for understanding and defending all changes.