### PR TITLE
[Wheel] Support jagged NestedTensor transfer

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -871,6 +871,12 @@ class MooncakeBundleTransfer:
                 member, payload_spec, field_spec, indices, destination
             )
         if encoding == "torch_tensor":
+            if field_spec.get("nested"):
+                result = self.materialize_into(
+                    self.read_spec(stage_ref).select_members([member]),
+                    None if destination is None else {member: destination},
+                )
+                return _select_nested_tensor_rows(result.objects[member], indices)
             return self._read_torch_tensor_member_indices(
                 member, payload_spec, field_spec, indices, destination
             )
@@ -3178,6 +3184,22 @@ class _StructuredObjectLayer:
         member_slice: StructuredMemberSlice | None,
         destination: Any,
     ) -> Any:
+        if field_spec.get("nested"):
+            if destination is not None:
+                raise ValueError(
+                    f"structured nested tensor member {name} does not support destinations"
+                )
+            value = _deserialize_torch_save_payload(
+                self._bundle_store.read_payload(payload_spec)
+            )
+            if member_slice is None:
+                return value
+            if member_slice.axis != 0:
+                raise ValueError(
+                    "structured nested tensor slicing currently supports axis=0 only"
+                )
+            start, end, step = _normalized_member_slice(member_slice, len(value))
+            return _select_nested_tensor_rows(value, range(start, end, step))
         if member_slice is not None:
             return self._read_sliced_torch_tensor_member(
                 name, payload_spec, field_spec, member_slice, destination
@@ -4896,6 +4918,25 @@ def _normalized_member_slice(
     )
 
 
+def _select_nested_tensor_rows(value: Any, indices: Sequence[int]) -> Any:
+    rows = value.unbind()
+    selected = [rows[int(index)] for index in indices]
+    if selected:
+        result = _torch.nested.as_nested_tensor(selected, layout=value.layout)
+    else:
+        offsets = _torch.zeros(
+            1,
+            dtype=value.offsets().dtype,
+            device=value.offsets().device,
+        )
+        result = _torch.nested.nested_tensor_from_jagged(
+            value.values()[:0], offsets=offsets
+        )
+    if hasattr(value, "_ragged_idx"):
+        result._ragged_idx = value._ragged_idx
+    return result
+
+
 def _bytes_view(value: Any, name: str) -> memoryview:
     try:
         view = memoryview(value)
@@ -5128,6 +5169,14 @@ def _encode_structured_field(value: Any) -> tuple[dict[str, Any], Any]:
 
 
 def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
+    if value.is_nested:
+        if value.layout != _torch.jagged:
+            raise ValueError("structured nested tensor fields require torch.jagged layout")
+        return {
+            "encoding": "torch_tensor",
+            "dtype": str(value.dtype),
+            "nested": True,
+        }, memoryview(_torch_save_payload_bytes(value))
     return {
         "encoding": "torch_tensor",
         "dtype": str(value.dtype),

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3189,8 +3189,8 @@ class _StructuredObjectLayer:
                 raise ValueError(
                     f"structured nested tensor member {name} does not support destinations"
                 )
-            value = _deserialize_torch_save_payload(
-                self._bundle_store.read_payload(payload_spec)
+            value = _deserialize_nested_tensor_payload(
+                self._bundle_store.read_payload(payload_spec), field_spec
             )
             if member_slice is None:
                 return value
@@ -5172,11 +5172,7 @@ def _encode_torch_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
     if value.is_nested:
         if value.layout != _torch.jagged:
             raise ValueError("structured nested tensor fields require torch.jagged layout")
-        return {
-            "encoding": "torch_tensor",
-            "dtype": str(value.dtype),
-            "nested": True,
-        }, memoryview(_torch_save_payload_bytes(value))
+        return _encode_nested_tensor_field(value)
     return {
         "encoding": "torch_tensor",
         "dtype": str(value.dtype),
@@ -5460,6 +5456,79 @@ def _torch_save_payload_bytes(value: Any) -> bytes:
 
 def _deserialize_torch_save_payload(payload: bytes) -> Any:
     return _torch.load(io.BytesIO(payload), weights_only=True)
+
+
+def _encode_nested_tensor_field(value: Any) -> tuple[dict[str, Any], Any]:
+    field_spec = {
+        "encoding": "torch_tensor",
+        "dtype": str(value.dtype),
+        "nested": True,
+        "format": "torch_save",
+    }
+    values = value.values()
+    offsets = value.offsets()
+    lengths = value.lengths()
+    tensors = [values, offsets]
+    if lengths is not None:
+        tensors.append(lengths)
+
+    if _has_tensor_codec_helpers() and all(
+        tensor.device.type == "cpu" for tensor in tensors
+    ):
+        parts = [
+            _tensor_payload_bytes(_TensorPayload(tensor=tensor))[0]
+            for tensor in tensors
+        ]
+        field_spec.update(
+            {
+                "format": "tensor_parts",
+                "part_bytes": [len(part) for part in parts],
+                "has_lengths": lengths is not None,
+                "ragged_idx": int(getattr(value, "_ragged_idx", 1)),
+            }
+        )
+        return field_spec, _MultiBufferPayload(
+            buffers=tuple(memoryview(part) for part in parts)
+        )
+
+    return field_spec, memoryview(_torch_save_payload_bytes(value))
+
+
+def _deserialize_nested_tensor_payload(
+    payload: bytes, field_spec: Mapping[str, Any]
+) -> Any:
+    payload_format = field_spec.get("format", "torch_save")
+    if payload_format == "torch_save":
+        return _deserialize_torch_save_payload(payload)
+    if payload_format != "tensor_parts":
+        raise ValueError(f"unsupported nested tensor payload format: {payload_format}")
+
+    part_bytes = field_spec.get("part_bytes")
+    expected_parts = 3 if field_spec.get("has_lengths") else 2
+    if not isinstance(part_bytes, list) or len(part_bytes) != expected_parts:
+        raise ValueError("nested tensor payload has invalid part metadata")
+
+    tensors = []
+    offset = 0
+    for part_size in part_bytes:
+        if (
+            not isinstance(part_size, int) or isinstance(part_size, bool) or part_size <= 0
+        ):
+            raise ValueError("nested tensor payload has invalid part size")
+        end = offset + int(part_size)
+        if end > len(payload):
+            raise ValueError("nested tensor payload is truncated")
+        tensors.append(_deserialize_tensor_payload(payload[offset:end]))
+        offset = end
+    if offset != len(payload):
+        raise ValueError("nested tensor payload has trailing bytes")
+
+    return _torch.nested.nested_tensor_from_jagged(
+        tensors[0],
+        offsets=tensors[1],
+        lengths=tensors[2] if expected_parts == 3 else None,
+        jagged_dim=int(field_spec.get("ragged_idx", 1)),
+    )
 
 
 def _slice_tensor_metadata(

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -3041,6 +3041,40 @@ def test_dataproto_helper_ragged_tensor_non_tensor_roundtrip() -> None:
         transfer.put_dataproto(SimpleDataProto(non_tensor_batch={"ragged": mixed}))
 
 
+def test_dataproto_helper_jagged_nested_batch_tensor_roundtrip() -> None:
+    torch = pytest.importorskip("torch")
+    _store, transfer = make_transfer()
+    rows = [
+        torch.arange(2, dtype=torch.int64),
+        torch.arange(10, 14, dtype=torch.int64),
+        torch.arange(20, 21, dtype=torch.int64),
+    ]
+    nested = torch.nested.as_nested_tensor(rows, layout=torch.jagged)
+
+    ref = transfer.put_dataproto(SimpleDataProto(batch={"tokens": nested}))
+    view = transfer.dataproto_manifest_view(ref)
+
+    field_spec = view["batch_fields"]["tokens"]["spec"]
+    assert field_spec == {
+        "encoding": "torch_tensor",
+        "dtype": "torch.int64",
+        "nested": True,
+    }
+
+    for selection, expected_rows in (
+        (None, rows),
+        (slice(1, 3), rows[1:3]),
+        ([2, 0], [rows[2], rows[0]]),
+        ([], []),
+    ):
+        result = transfer.get_dataproto(ref, rows=selection)["batch"]["tokens"]
+        assert result.is_nested
+        assert result.layout == torch.jagged
+        assert len(result) == len(expected_rows)
+        for actual, expected in zip(result.unbind(), expected_rows):
+            assert torch.equal(actual, expected)
+
+
 def _assert_tensor_object_equal(actual, expected) -> None:
     torch = pytest.importorskip("torch")
     if expected is None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -3055,11 +3055,12 @@ def test_dataproto_helper_jagged_nested_batch_tensor_roundtrip() -> None:
     view = transfer.dataproto_manifest_view(ref)
 
     field_spec = view["batch_fields"]["tokens"]["spec"]
-    assert field_spec == {
-        "encoding": "torch_tensor",
-        "dtype": "torch.int64",
-        "nested": True,
-    }
+    assert field_spec["encoding"] == "torch_tensor"
+    assert field_spec["dtype"] == "torch.int64"
+    assert field_spec["nested"] is True
+    assert field_spec["format"] in {"tensor_parts", "torch_save"}
+    if field_spec["format"] == "tensor_parts":
+        assert len(field_spec["part_bytes"]) == 2
 
     for selection, expected_rows in (
         (None, rows),
@@ -3073,6 +3074,20 @@ def test_dataproto_helper_jagged_nested_batch_tensor_roundtrip() -> None:
         assert len(result) == len(expected_rows)
         for actual, expected in zip(result.unbind(), expected_rows):
             assert torch.equal(actual, expected)
+
+    matrix_rows = [
+        torch.arange(6, dtype=torch.int64).reshape(2, 3),
+        torch.arange(10, dtype=torch.int64).reshape(2, 5),
+    ]
+    matrix = torch.nested.as_nested_tensor(matrix_rows, layout=torch.jagged)
+    matrix_ref = transfer.put_dataproto(SimpleDataProto(batch={"position_ids": matrix}))
+    matrix_result = transfer.get_dataproto(matrix_ref)["batch"]["position_ids"]
+
+    assert matrix_result.is_nested
+    assert matrix_result.layout == torch.jagged
+    assert matrix_result._ragged_idx == 2
+    for actual, expected in zip(matrix_result.unbind(), matrix_rows):
+        assert torch.equal(actual, expected)
 
 
 def _assert_tensor_object_equal(actual, expected) -> None:


### PR DESCRIPTION
## Description

Add native structured-object transfer support for PyTorch jagged `NestedTensor` fields.

RL rollout data may contain variable-length sequence fields represented as jagged tensors. On `main`, their symbolic shapes are written into structured metadata and the PUT fails because `SymInt` is not JSON-serializable. Callers therefore cannot transfer the original object without changing its representation.

This PR keeps the original tensor semantics:

- mark jagged tensors explicitly without serializing symbolic shapes;
- encode CPU tensors as values, offsets, and optional lengths using Mooncake's existing tensor codec;
- retain a safe `torch.save` fallback when the tensor codec is unavailable or the values are not on CPU;
- restore `torch.jagged` tensors for full reads, slices, reordered indices, empty selections, and ragged dimension 2.

Dense tensors and the existing typed-ragged and fast-copy paths are unchanged. This change is based on the latest `main` and does not depend on #3113.

### Comparison with main

The benchmark uses a real verl rollout payload with 27 fields, including 10 jagged tensor fields. Each timing is the average of three measured rounds after warmup.

`main` fails on the first 8-sample PUT with `TypeError: Object of type SymInt is not JSON serializable`, so it has no native jagged PUT/GET timing. The current branch completes all payload sizes:

| Samples | Logical size | `main` | This PR PUT/GET (ms) |
| ---: | ---: | --- | ---: |
| 8 | 101 KiB | PUT unsupported | 11.223 / 22.193 |
| 64 | 798 KiB | PUT unsupported | 17.323 / 34.150 |
| 256 | 3.11 MiB | PUT unsupported | 38.898 / 74.812 |
| 1024 | 12.44 MiB | PUT unsupported | 123.910 / 237.775 |

To check existing-path regressions, the same rollout capture was materialized through the dense tensor path supported by `main`:

| Samples | `main` PUT/GET (ms) | This PR PUT/GET (ms) |
| ---: | ---: | ---: |
| 8 | 8.768 / 17.035 | 8.650 / 17.116 |
| 64 | 14.481 / 28.908 | 14.514 / 28.731 |
| 256 | 35.308 / 69.741 | 35.453 / 69.156 |
| 1024 | 116.887 / 230.007 | 116.497 / 227.559 |

The existing path remains within normal run-to-run noise. Profiling the initial native implementation found 10 safe `torch.load` calls per GET, one for each jagged field. Reusing the existing tensor codec removes those calls and reduces native GET from `29.018` to `22.193 ms` at 8 samples and from `40.729` to `34.150 ms` at 64 samples.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python -m pytest mooncake-wheel/tests/test_structured_object_store.py -q
python /tmp/test_verl_native_nested_real.py
python /tmp/bench_verl_real_rollout_backends_nested.py
bash /tmp/run_verl_mooncake_e2e_3steps.sh
```

**Test results:**
- [x] Unit test passes for full, sliced, reordered, empty, and ragged-dimension-2 reads
- [x] Integration test passes with a real Mooncake Store
- [x] Manual testing completes three consecutive two-GPU verl RL steps with `RC=0`
- [x] Existing dense rollout path shows no measurable regression against `main`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Focused checks pass for Ruff, `py_compile`, whitespace, and merge markers. The patch is 167 additions across two Python files.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to extract the focused patch, profile the small-payload GET path, run compatibility and performance validation, review the diff, and prepare this PR description. The submitter reviewed the resulting code and test evidence.
