### PR TITLE
[Bugfix][TENT] Keep a never-constructed context in the NicID slot

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -278,18 +278,22 @@ size_t RdmaTransport::initializeContexts() {
     size_t context_count = 0;
     for (size_t i = 0; i < local_topology_->getNicCount(); ++i) {
         auto entry = local_topology_->getNicEntry(i);
-        auto context = std::make_shared<RdmaContext>(*this);
-        context_set_.push_back(context);
-        if (entry->type != Topology::NIC_RDMA) continue;
-        int ret = context->construct(entry->name, params_);
-        if (ret) {
+        if (entry->type == Topology::NIC_RDMA) {
+            auto context = std::make_shared<RdmaContext>(*this);
+            if (context->construct(entry->name, params_) == 0) {
+                context_name_lookup_[entry->name] = i;
+                ++context_count;
+                local_buffer_manager_.addDevice(context.get());
+                context_set_.push_back(std::move(context));
+                continue;
+            }
             LOG(WARNING) << "Disable RDMA device " << entry->name << " because "
                          << "of initialization failure";
-            continue;
         }
-        context_name_lookup_[entry->name] = i;
-        ++context_count;
-        local_buffer_manager_.addDevice(context.get());
+        // A never-constructed context, not the one whose construct() failed:
+        // the slot only has to stand in for the NicID, so it should not carry
+        // a device name or an endpoint store it will never use.
+        context_set_.push_back(std::make_shared<RdmaContext>(*this));
     }
     return context_count;
 }

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -31,7 +31,6 @@
 #include "tent/transfer_engine.h"
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/context.h"
-#include "tent/transport/rdma/ibv_loader.h"
 #include "tent/transport/rdma/params.h"
 #include "tent/transport/rdma/rdma_transport.h"
 #include "tent/transport/rdma/workers.h"
@@ -165,6 +164,13 @@ void expectInertContextPerNic(const RdmaContextSet& contexts, size_t expected) {
         // Inert contexts must stay safe for the whole-list consumers.
         EXPECT_EQ(contexts[i]->cq(0), nullptr);
         EXPECT_EQ(contexts[i]->notifyCq(), nullptr);
+        EXPECT_LT(contexts[i]->eventFd(), 0);
+        EXPECT_EQ(contexts[i]->nativeContext(), nullptr);
+        // construct() sets device_name_ before it can fail, so an empty name
+        // is what tells a fresh placeholder from a kept half-built context.
+        EXPECT_TRUE(contexts[i]->name().empty())
+            << "slot " << i << " kept a half-built context for "
+            << contexts[i]->name();
     }
 }
 
@@ -213,12 +219,9 @@ TEST(RdmaNicIndexAlignmentTest, ReclaimTickSkipsInertContexts) {
     RdmaTransportTestPeer::reclaimEndpoints(transport);
 }
 
-// The construct()-failure branch. IbvLoader dlcloses libibverbs when no device
-// is present, so construct() cannot be driven safely in that state.
+// The construct()-failure branch. Runs on any host: this binary links
+// libibverbs directly, so IbvLoader's dlclose does not unmap it.
 TEST(RdmaNicIndexAlignmentTest, ContextSetKeepsOneSlotWhenConstructFails) {
-    if (!IbvLoader::Instance().available())
-        GTEST_SKIP() << "no usable libibverbs; construct() cannot be driven";
-
     // Device names that resolve to no real RNIC, so construct() fails on any
     // host, with a non-RDMA entry in the middle to offset the indexes.
     auto topology = std::make_shared<Topology>();


### PR DESCRIPTION
Description

  Two coupled defects around a failed RdmaContext::construct().

  1. initializeContexts() kept the half-built context. #3264 introduced this when it gave every NicID a slot — it pushed the context before constructing it, so a failed construct() left that object in context_set_. Before #3264 the failed context was dropped and became unreachable.

  2. disable() never releases anything on that path. construct() sets DEVICE_DISABLED before calling enable(), and enable() does not touch status_ until it succeeds — so every disable() on its failure paths, and the one in ~RdmaContext, hits the status_ == DEVICE_DISABLED guard and returns immediately. A context failing after openDevice() keeps its device handle, PD, epoll fd, comp channels and CQs for the life of the process.

  Together they are worse than either alone. The retained context has event_fd_ >= 0 and a non-null native_context_, so monitorThread() no longer skips the slot: it burns a 100ms epoll_wait on it every iteration, and on the ibv_query_port failure path — which closes the device by hand without clearing native_context_ — it dereferences a freed ibv_context.

  Fix. Store a never-constructed context instead; it holds no resources, so monitorThread()'s eventFd() < 0 check skips it, and the half-built one is released at end of iteration as before.

  Then make disable() do its job. Its body is already idempotent — every release is individually guarded, and endpoint_store_ exists whenever status_ has left DEVICE_UNINIT — so the guard drops to DEVICE_UNINIT alone. Two call sites must change with it or the fix would make things worse:

  - The ibv_query_port path closed the device itself and returned without disable(). Once disable() stops short-circuiting, ~RdmaContext would close that handle again. It now releases through disable() like every other failure path.
  - The CQ loop pushed to cq_list_ only after a successful construct, so a failed RdmaCQ was owned by nobody. It is registered first; ~RdmaCQ guards on cq_, so destroying a half-built one is safe.

  Follow-up to #3264. Independent of #3265.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  The existing regression test could not have caught this. It was gated on IbvLoader::available(), which is false without an RNIC because IbvLoader treats "zero devices" as unavailable — so it skipped on every CI runner. Reverting the placeholder change kept it green.

  The gate is removed. The test needs libibverbs to be callable, not a device present, and this binary links libibverbs directly (hasRdmaDevice), so IbvLoader's dlclose does not unmap it. Device names matching no real RNIC make construct() fail identically with or without hardware. A name() assertion discriminates: construct() assigns device_name_ before it can fail, so a kept half-built context has a name and a fresh placeholder does not.

  Test commands:
  Linux container; GitHub runners have libibverbs installed but no /dev/infiniband,
  which is the same shape this reproduces.
  cmake -S . -B build-tent -DBUILD_UNIT_TESTS=ON -DWITH_TE=ON \
        -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DUSE_TENT=ON
  cmake --build build-tent -j2
  ./build-tent/mooncake-transfer-engine/tent/tests/tent_rdma_transport_test \
        --gtest_filter='RdmaNicIndexAlignmentTest.*'
  cd build-tent && ctest ./scripts/code_format.sh --check

  Test results:

  All three alignment tests now run for real instead of skipping. Verified by reverting the placeholder change:

  rdma_transport_test.cpp:176: Failure
  slot 0 kept a half-built context for mc-absent-rnic-0
  slot 2 kept a half-built context for mc-absent-rnic-2

  ctest: 60/63. tcp_transport_test and transfer_metadata_test abort on a missing etcd metadata plugin; memory_location_test on mbind EPERM. All three fail identically without this change. pre-commit on the touched files: all hooks pass.

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable) — not run; needs RDMA hardware
  - [x] Manual testing done (describe below)

  Manual verification = the revert experiment above.

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable) — n/a, no user-facing behavior change
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue — n/a, 33 lines

  Unchecked on purpose: self-review is the submitter's own attestation; --all-files was not run (only pre-commit run --files on the 3 touched files, all passing) per AGENTS.md's warning about unrelated rewrites.
  
  Two things reviewers should weigh:

  1. The disable() half has no test. Reaching a leak needs enable() to fail after openDevice() succeeds, impossible without an RNIC, and RdmaContext::verbs_ is a const IbvSymbols& to the loader singleton
  — no per-context injection point. Opening that seam is a separate change. Only the placeholder half is covered by evidence.
  2. Removing the gate rests on a linkage property, not on an IbvLoader contract: its failure paths dlclose the handle but leave symbols_ populated, and the pointers stay valid only because this binary has its own NEEDED reference. Documented in a comment at the test. Hardening IbvLoader to zero symbols_ would spill into RdmaContext's constructor, so it is left out here.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)