### PR TITLE
[Store] Remove duplicate metadata key storage in Master

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -949,15 +949,13 @@ class MasterService {
             size_t value_length, std::vector<Replica>&& reps,
             bool enable_soft_pin, bool enable_hard_pin = false,
             ObjectDataType data_type_ = ObjectDataType::UNKNOWN,
-            std::string group_id_ = "", TenantId tenant_id_ = TenantId(),
-            std::string user_key_ = {})
+            std::string group_id_ = "", TenantId tenant_id_ = TenantId())
             : client_id(client_id_),
               put_start_time(put_start_time_),
               size(value_length),
               data_type(data_type_),
               group_id(std::move(group_id_)),
               tenant_id(std::move(tenant_id_)),
-              user_key(std::move(user_key_)),
               lease_timeout(),
               soft_pin_timeout(std::nullopt),
               hard_pinned(enable_hard_pin),
@@ -984,7 +982,6 @@ class MasterService {
         const ObjectDataType data_type{ObjectDataType::UNKNOWN};
         const std::string group_id;
         const TenantId tenant_id;
-        const std::string user_key;
 
         mutable SpinLock lock;
         // Default constructor, creates a time_point representing
@@ -1561,7 +1558,8 @@ class MasterService {
     // Helper to clean up stale handles pointing to unmounted segments
     // or local_disk replicas whose owner client is no longer alive.
     bool CleanupStaleHandles(
-        TenantState& tenant_state, ObjectMetadata& metadata,
+        TenantState& tenant_state, const std::string& user_key,
+        ObjectMetadata& metadata,
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
         MetadataShardAccessorRW* shard = nullptr);
 
@@ -1663,7 +1661,8 @@ class MasterService {
         }
     }
     void CancelPromotionTaskForRemovedReplicas(
-        TenantState& tenant_state, ObjectMetadata& metadata,
+        TenantState& tenant_state, const std::string& user_key,
+        ObjectMetadata& metadata,
         const std::vector<ReplicaID>& removed_replica_ids)
         NO_THREAD_SAFETY_ANALYSIS;
 
@@ -1746,7 +1745,8 @@ class MasterService {
                     },
                     &removed_replica_ids);
                 service_->CancelPromotionTaskForRemovedReplicas(
-                    *tenant_state_, it_->second, removed_replica_ids);
+                    *tenant_state_, it_->first, it_->second,
+                    removed_replica_ids);
                 const uint64_t after_charge =
                     service_->CompletedMemoryQuotaCharge(it_->second);
                 if (before_charge > after_charge) {
@@ -1838,10 +1838,10 @@ class MasterService {
             auto result = tenant_state_->metadata.emplace(
                 std::piecewise_construct,
                 std::forward_as_tuple(object_id_.user_key),
-                std::forward_as_tuple(
-                    client_id, now, total_length, std::move(replicas),
-                    enable_soft_pin, enable_hard_pin, data_type, group_id,
-                    object_id_.tenant_id, object_id_.user_key));
+                std::forward_as_tuple(client_id, now, total_length,
+                                      std::move(replicas), enable_soft_pin,
+                                      enable_hard_pin, data_type, group_id,
+                                      object_id_.tenant_id));
             it_ = result.first;
             if (result.second) {
                 service_->IncrementTenantMetadataObjectCount(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1719,8 +1719,8 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     if (erased_local_disk) {
         shard.OnDiskReplicaRemoved(erased_local_disk, metadata);
     }
-    CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
-                                          erased_replica_ids);
+    CancelPromotionTaskForRemovedReplicas(tenant_state, metadata_it->first,
+                                          metadata, erased_replica_ids);
     if (!metadata.IsValid()) {
         EraseMetadata(tenant_state, metadata_it, tenant_id, quota_mode, &shard);
         if (tenant_state.Empty()) {
@@ -2098,7 +2098,7 @@ void MasterService::ClearInvalidHandles(
                             continue;
                         }
                     }
-                    if (CleanupStaleHandles(tenant_state, it->second,
+                    if (CleanupStaleHandles(tenant_state, it->first, it->second,
                                             alive_clients, &shard)) {
                         it = EraseMetadata(tenant_state, it, tenant_it->first,
                                            QuotaEraseMode::kFull, &shard);
@@ -2410,9 +2410,7 @@ auto MasterService::GetAllKeys(const TenantId& tenant_id)
             continue;
         }
         for (const auto& item : tenant_it->second.metadata) {
-            all_keys.push_back(item.second.user_key.empty()
-                                   ? item.first
-                                   : item.second.user_key);
+            all_keys.push_back(item.first);
         }
     }
     return all_keys;
@@ -2640,10 +2638,10 @@ void MasterService::RestoreFromStandbySnapshot(
             auto& tenant_state = shard->tenants[tenant_id];
             tenant_state.metadata.emplace(
                 std::piecewise_construct, std::forward_as_tuple(user_key),
-                std::forward_as_tuple(
-                    standby_meta.client_id, now, standby_meta.size,
-                    std::move(replicas), false, false, standby_meta.data_type,
-                    standby_meta.group_id, tenant_id, user_key));
+                std::forward_as_tuple(standby_meta.client_id, now,
+                                      standby_meta.size, std::move(replicas),
+                                      false, false, standby_meta.data_type,
+                                      standby_meta.group_id, tenant_id));
             if (!standby_meta.group_id.empty()) {
                 RegisterGroupMember(tenant_state, tenant_id, user_key,
                                     standby_meta.group_id);
@@ -3565,7 +3563,7 @@ auto MasterService::AllocateAndInsertMetadata(
         std::piecewise_construct, std::forward_as_tuple(key),
         std::forward_as_tuple(client_id, now, value_length, std::move(replicas),
                               config.with_soft_pin, config.with_hard_pin,
-                              config.data_type, group_id, tenant_id, key));
+                              config.data_type, group_id, tenant_id));
     if (!inserted) {
         LOG(INFO) << "key=" << key << ", info=object_already_exists";
         abort_reserved_quota();
@@ -3676,8 +3674,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     if (enable_oplog_) {
                         return tl::make_unexpected(
                             ErrorCode::OBJECT_ALREADY_EXISTS);
-                    } else if (CleanupStaleHandles(tenant_state, it->second,
-                                                   alive_clients, &shard)) {
+                    } else if (CleanupStaleHandles(tenant_state, it->first,
+                                                   it->second, alive_clients,
+                                                   &shard)) {
                         EraseMetadata(tenant_state, it, object_id.tenant_id,
                                       QuotaEraseMode::kFull, &shard);
                         it = tenant_state.metadata.end();
@@ -4283,8 +4282,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     if (enable_oplog_) {
                         return tl::make_unexpected(
                             ErrorCode::OBJECT_ALREADY_EXISTS);
-                    } else if (CleanupStaleHandles(tenant_state, it->second,
-                                                   alive_clients, &shard)) {
+                    } else if (CleanupStaleHandles(tenant_state, it->first,
+                                                   it->second, alive_clients,
+                                                   &shard)) {
                         // EraseMetadata handles processing_keys,
                         // replication_tasks, offloading_tasks (with
                         // dec_refcnt), and promotion task cleanup.
@@ -5832,8 +5832,9 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
                             ? ErrorCode::OBJECT_NOT_FOUND
                             : ErrorCode::OBJECT_ALREADY_EXISTS);
                     continue;
-                } else if (CleanupStaleHandles(tenant_state, it->second,
-                                               alive_clients, &shard)) {
+                } else if (CleanupStaleHandles(tenant_state, it->first,
+                                               it->second, alive_clients,
+                                               &shard)) {
                     EraseMetadata(tenant_state, it, normalized_tenant,
                                   QuotaEraseMode::kFull, &shard);
                     if (tenant_state.Empty()) {
@@ -5922,13 +5923,14 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
 }
 
 void MasterService::CancelPromotionTaskForRemovedReplicas(
-    TenantState& tenant_state, ObjectMetadata& metadata,
+    TenantState& tenant_state, const std::string& user_key,
+    ObjectMetadata& metadata,
     const std::vector<ReplicaID>& removed_replica_ids) {
     if (removed_replica_ids.empty()) {
         return;
     }
 
-    auto task_it = tenant_state.promotion_tasks.find(metadata.user_key);
+    auto task_it = tenant_state.promotion_tasks.find(user_key);
     if (task_it == tenant_state.promotion_tasks.end() ||
         task_it->second.alloc_id == 0 ||
         std::find(removed_replica_ids.begin(), removed_replica_ids.end(),
@@ -5941,8 +5943,7 @@ void MasterService::CancelPromotionTaskForRemovedReplicas(
         source->dec_refcnt();
     }
     const UUID holder_id = task_it->second.holder_id;
-    ErasePromotionTaskIfPresent(tenant_state, metadata.user_key,
-                                metadata.tenant_id);
+    ErasePromotionTaskIfPresent(tenant_state, user_key, metadata.tenant_id);
 
     // Best-effort cleanup of a task that may still be queued on the holder.
     ScopedLocalDiskSegmentAccess local_disk_segment_access =
@@ -5953,12 +5954,13 @@ void MasterService::CancelPromotionTaskForRemovedReplicas(
     if (segment_it != client_local_disk_segment.end()) {
         MutexLocker locker(&segment_it->second->offloading_mutex_);
         segment_it->second->promotion_objects.erase(
-            metadata.tenant_id.MakeScopedKey(metadata.user_key));
+            metadata.tenant_id.MakeScopedKey(user_key));
     }
 }
 
 bool MasterService::CleanupStaleHandles(
-    TenantState& tenant_state, ObjectMetadata& metadata,
+    TenantState& tenant_state, const std::string& user_key,
+    ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
     MetadataShardAccessorRW* shard) {
     bool had_completed_disk = metadata.HasReplica([](const Replica& r) {
@@ -5977,7 +5979,7 @@ bool MasterService::CleanupStaleHandles(
                    replica.is_completed();
         },
         &removed_replica_ids);
-    CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
+    CancelPromotionTaskForRemovedReplicas(tenant_state, user_key, metadata,
                                           removed_replica_ids);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
     if (before_charge > after_charge) {
@@ -9821,7 +9823,6 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
 
         auto metadata_ptr = std::move(metadata_result.value());
         auto& tenant_state = shard.tenants[tenant_id];
-        const std::string user_key = key;
         auto [it, inserted] = tenant_state.metadata.emplace(
             std::piecewise_construct, std::forward_as_tuple(std::move(key)),
             std::forward_as_tuple(
@@ -9829,7 +9830,7 @@ MasterService::MetadataSerializer::DeserializeShard(const msgpack::object& obj,
                 metadata_ptr->size, metadata_ptr->PopReplicas(),
                 metadata_ptr->soft_pin_timeout.has_value(),
                 metadata_ptr->IsHardPinned(), metadata_ptr->data_type,
-                metadata_ptr->group_id, tenant_id, user_key));
+                metadata_ptr->group_id, tenant_id));
 
         it->second.lease_timeout = metadata_ptr->lease_timeout;
         it->second.soft_pin_timeout = metadata_ptr->soft_pin_timeout;

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -18,9 +18,9 @@
 #include <random>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <utility>
 #include <vector>
-#include <unordered_set>
 
 #include <unistd.h>
 
@@ -1040,6 +1040,48 @@ TEST_F(MasterServiceTest, GetAllKeysListsOnlyRequestedTenant) {
     EXPECT_EQ(
         std::find(tenant_keys->begin(), tenant_keys->end(), default_only_key),
         tenant_keys->end());
+}
+
+TEST_F(MasterServiceTest, MetadataMapKeyRemainsCanonicalAfterRehash) {
+    std::unique_ptr<MasterService> service_(new MasterService());
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(*service_);
+    const UUID client_id = generate_uuid();
+
+    static constexpr size_t kMetadataShardCount = 1024;
+    static constexpr size_t kKeyCount = 256;
+    const size_t target_shard =
+        std::hash<std::string>{}("canonical_metadata_key") %
+        kMetadataShardCount;
+
+    std::vector<std::string> keys;
+    keys.reserve(kKeyCount);
+    for (uint64_t candidate = 0; keys.size() < kKeyCount; ++candidate) {
+        std::string key = "canonical_metadata_key_" + std::to_string(candidate);
+        if (std::hash<std::string>{}(key) % kMetadataShardCount ==
+            target_shard) {
+            keys.push_back(std::move(key));
+        }
+    }
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    for (const auto& key : keys) {
+        PutCompletedObject(*service_, client_id, key, config);
+    }
+
+    auto listed_keys = service_->GetAllKeys(TenantId::Default());
+    ASSERT_TRUE(listed_keys.has_value());
+    const std::unordered_set<std::string> listed_set(listed_keys->begin(),
+                                                     listed_keys->end());
+    ASSERT_EQ(listed_set.size(), keys.size());
+    for (const auto& key : keys) {
+        EXPECT_EQ(listed_set.count(key), 1u);
+        ASSERT_TRUE(service_->Remove(key, TenantId::Default()).has_value());
+    }
+
+    auto remaining_keys = service_->GetAllKeys(TenantId::Default());
+    ASSERT_TRUE(remaining_keys.has_value());
+    EXPECT_TRUE(remaining_keys->empty());
 }
 
 TEST_F(MasterServiceTest,


### PR DESCRIPTION
## Description

`TenantState::metadata` already owns each object key as the `std::unordered_map` key, while `ObjectMetadata::user_key` retained a second persistent copy of the same string. At large metadata cardinalities, that duplicate ownership adds one string allocation and duplicated key bytes per object.

This draft makes the map key the canonical persistent owner:

- remove `ObjectMetadata::user_key`;
- pass the current map key explicitly to stale-handle and promotion-task cleanup helpers;
- use the map key directly for listing, standby restore, and snapshot deserialization;
- add a regression test that inserts 256 keys into one metadata shard, forces map growth/rehash, then lists and removes every key.

The helper references are used synchronously while the metadata shard lock is held, before the corresponding map entry can be erased.

There is no RPC, public API, CLI/config, OpLog, or snapshot wire-format change.

### Local performance evidence

Measurements were collected on Ubuntu 24.04 / WSL2 with Release `-O3 -DNDEBUG` binaries from base commit `10f91862a75db2c7572a2e7102579f39d45bf31d`. A/B order was alternated.

| Workload | Result |
|---|---:|
| Allocation/RSS harness, 5 A/B rounds and 20 clean subruns | RSS per KV: **-10.09%** (95% CI: -10.77% to -9.42%) |
| Same harness | allocation calls per KV: **-2.59%**, approximately one allocation removed per KV |
| Same harness | requested allocation bytes per KV: **-2.47%** (95% CI: -2.91% to -2.02%) |
| Metadata-only `master_bench`, 7 A/B rounds | throughput: **+7.19%** (95% CI: +2.19% to +12.19%) |
| Full Store healthy-write path, 7 A/B rounds | throughput: **+1.10%** (95% CI: -1.21% to +3.40%) |
| Full Store mixed metadata path, 2.8M requests | throughput: **+0.83%** (95% CI: -4.84% to +6.50%) |

The full-Store results are statistically neutral, so this PR does **not** claim a general Store throughput improvement. The primary demonstrated benefit is lower Master metadata memory/allocation overhead. The branch was subsequently rebased and correctness-tested on current `main` at `9fbd622256e7a26aeea9f038e316eeb58203c102`; the four intervening upstream commits do not modify the three files in this patch.

This is intentionally a draft for maintainer feedback and pending human line-by-line review.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build /home/lorry/.cache/mooncake-store-metadata-key-release --target master_service_test -j1
cmake --build /home/lorry/.cache/mooncake-store-metadata-key-release --target master_service_ha_test -j1

/home/lorry/.cache/mooncake-store-metadata-key-release/mooncake-store/tests/master_service_test

/home/lorry/.cache/mooncake-store-metadata-key-release/mooncake-store/tests/master_service_ha_test --gtest_filter=-MasterServiceBatchRecordE2ETest.PromotionCatchesUpToDurablePrefix

./scripts/code_format.sh --staged -- mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/tests/master_service_test.cpp

pre-commit run --files mooncake-store/include/master_service.h mooncake-store/src/master_service.cpp mooncake-store/tests/master_service_test.cpp
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (upstream CI pending)
- [x] Manual testing done
- `master_service_test`: **147/147 passed**.
- HA suite with the ETCD-only case excluded: **66/66 passed**.
- Nine additional snapshot, SSD, promotion, offload, and recovery test executables passed.
- The excluded HA case requires `STORE_USE_ETCD`; this local build has `STORE_USE_ETCD=OFF`. The same case fails with the same `Batch-record OpLog requires STORE_USE_ETCD` message on the unmodified `10f9186` baseline.
- Holder `SIGKILL` recovery validation restored replacement capacity and completed 256 I/O operations with zero misses, verification errors, or I/O failures.
- ClangFormat 20 staged check, changed-file pre-commit hooks, and `git diff --check` passed.

## Checklist

- [ ] I have performed a self-review of my own code (human line-by-line review pending)
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass (changed-file hooks passed)
- [ ] I have updated the documentation (not applicable: no user-facing interface change)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable: 119 changed lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with implementation review, regression-test design, local benchmark analysis, verification, and PR preparation. The human submitter remains responsible for understanding and defending the change; this PR stays in draft pending that review.