### PR TITLE
[Store] Remove dead DRAM/NoF metric overload declarations

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -81,10 +81,6 @@ class MasterMetricManager {
     CacheHitStatDict calculate_cache_stats();
 
     // Memory Storage Metrics
-    void inc_allocated_mem_size(int64_t val = 1);
-    void dec_allocated_mem_size(int64_t val = 1);
-    void inc_total_mem_capacity(int64_t val = 1);
-    void dec_total_mem_capacity(int64_t val = 1);
     int64_t get_allocated_mem_size();
     int64_t get_total_mem_capacity();
     double get_segment_mem_used_ratio(const std::string& segment);
@@ -99,10 +95,6 @@ class MasterMetricManager {
     void remove_segment_metrics(const std::string& segment);
 
     // NoF segment Metrics
-    void inc_allocated_nof_size(int64_t val = 1);
-    void dec_allocated_nof_size(int64_t val = 1);
-    void inc_total_nof_capacity(int64_t val = 1);
-    void dec_total_nof_capacity(int64_t val = 1);
     int64_t get_allocated_nof_size();
     int64_t get_total_nof_capacity();
     double get_segment_nof_used_ratio(const std::string& segment);


### PR DESCRIPTION
## Description

Remove unused parameterless DRAM/NoF `inc_*` / `dec_*` overloads from `MasterMetricManager`.

These declarations had no matching definitions in `master_metric_manager.cpp` and no call sites. The segment-keyed overloads remain and are the real update path.

This cleanup was originally folded into an unrelated domain-metrics refactor and is being split out so that PR stays focused.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# Header-only dead-declaration removal; no runtime behavior change.
rg 'inc_allocated_mem_size\(int64_t|inc_total_mem_capacity\(int64_t|inc_allocated_nof_size\(int64_t|inc_total_nof_capacity\(int64_t' mooncake-store
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Confirmed on `origin/main` that only the `const std::string& segment` overloads are defined, and there are no call sites for the parameterless overloads.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor assisted with identifying the dead declarations and preparing this split-out cleanup PR. The human submitter reviewed the change.


Made with [Cursor](https://cursor.com)