### PR TITLE
[Wheel] Add DataProto catalog for fragmented rollout data

### DIFF
--- a/mooncake-wheel/mooncake/dataproto_catalog.py
+++ b/mooncake-wheel/mooncake/dataproto_catalog.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+class DataProtoCatalog:
+    """Map logical rows and fields to immutable DataProto refs.
+
+    The catalog only tracks metadata. Data transfer and object lifetime remain
+    owned by MooncakeBundleTransfer and Mooncake Store, respectively. Calls to
+    one catalog instance must be serialized by its host. Each update publishes
+    one immutable, single-stage fragment; multi-stage append handles are not
+    catalog fragments.
+    """
+
+    def __init__(self) -> None:
+        self._partitions: dict[str, dict[str, dict[str, Any]]] = {}
+        self._fragments: dict[str, dict[str, Any]] = {}
+        self._fragment_refcounts: dict[str, int] = {}
+
+    def update(
+        self,
+        partition: str,
+        keys: Sequence[str],
+        *,
+        tags: Sequence[Mapping[str, Any]] | None = None,
+        handle: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Merge tags and publish every field in a single-stage ``handle``."""
+        partition = _nonempty_string(partition, "partition")
+        keys = _names(keys, "keys")
+        normalized_tags = _tags(tags, len(keys))
+        fragment = _fragment(handle, len(keys)) if handle is not None else None
+        if normalized_tags is None and fragment is None:
+            raise ValueError("catalog update requires tags or a DataProto handle")
+
+        if fragment is not None:
+            fragment_id, stored_handle, fields = fragment
+            previous = self._fragments.get(fragment_id)
+            if previous is not None and previous != stored_handle:
+                raise ValueError(f"DataProto fragment id collision: {fragment_id!r}")
+
+        current_entries = self._partitions.get(partition, {})
+        merged_tags = {}
+        response_tags = []
+        for row, key in enumerate(keys):
+            tag = copy.deepcopy(current_entries.get(key, {"tag": {}})["tag"])
+            if normalized_tags is not None:
+                tag.update(normalized_tags[row])
+            merged_tags[key] = tag
+            response_tags.append(copy.deepcopy(tag))
+
+        entries = self._partitions.setdefault(partition, {})
+        if fragment is not None:
+            self._fragments.setdefault(fragment_id, stored_handle)
+            self._fragment_refcounts.setdefault(fragment_id, 0)
+
+        for row, key in enumerate(keys):
+            entry = entries.setdefault(key, {"tag": {}, "fields": {}})
+            entry["tag"] = merged_tags[key]
+            if fragment is None:
+                continue
+            for field in fields:
+                location = (fragment_id, row)
+                old_location = entry["fields"].get(field)
+                if old_location == location:
+                    continue
+                if old_location is not None and old_location[0] == fragment_id:
+                    entry["fields"][field] = location
+                    continue
+                if old_location is not None:
+                    self._drop_fragment_reference(old_location[0])
+                entry["fields"][field] = location
+                self._fragment_refcounts[fragment_id] += 1
+
+        return {
+            "keys": list(keys),
+            "tags": response_tags,
+            "fields": _field_union(entries, keys),
+        }
+
+    def resolve(
+        self,
+        partition: str,
+        keys: Sequence[str],
+        fields: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        """Resolve an ordered logical read into immutable fragment locations."""
+        partition = _nonempty_string(partition, "partition")
+        keys = _names(keys, "keys")
+        entries = self._partitions.get(partition, {})
+        missing = [key for key in keys if key not in entries]
+        if missing:
+            raise ValueError(
+                f"keys were not found in partition {partition!r}: {missing}"
+            )
+
+        selected = (
+            list(_names(fields, "field names"))
+            if fields is not None
+            else _field_union(entries, keys)
+        )
+        if not selected:
+            raise ValueError("requested keys do not contain any fields")
+
+        for key in keys:
+            entry_fields = entries[key]["fields"]
+            unavailable = [field for field in selected if field not in entry_fields]
+            if unavailable:
+                raise ValueError(f"fields are not ready for key {key!r}: {unavailable}")
+
+        grouped_fields: dict[tuple[tuple[str, int], ...], list[str]] = {}
+        fragment_ids: set[str] = set()
+        for field in selected:
+            locations = tuple(entries[key]["fields"][field] for key in keys)
+            grouped_fields.setdefault(locations, []).append(field)
+            fragment_ids.update(location[0] for location in locations)
+
+        return {
+            "keys": list(keys),
+            "tags": [copy.deepcopy(entries[key]["tag"]) for key in keys],
+            "fields": selected,
+            "field_groups": [
+                {"fields": fields, "locations": list(locations)}
+                for locations, fields in grouped_fields.items()
+            ],
+            "handles": {
+                fragment_id: copy.deepcopy(self._fragments[fragment_id])
+                for fragment_id in fragment_ids
+            },
+        }
+
+    def list(self, partition: str | None = None) -> dict[str, dict[str, Any]]:
+        """Return tags using the same partition/key shape as rollout KV APIs."""
+        if partition is not None:
+            partition = _nonempty_string(partition, "partition")
+            partitions = [partition] if partition in self._partitions else []
+        else:
+            partitions = list(self._partitions)
+        return {
+            partition_id: {
+                key: copy.deepcopy(entry["tag"])
+                for key, entry in self._partitions[partition_id].items()
+            }
+            for partition_id in partitions
+        }
+
+    def remove(self, partition: str, keys: Sequence[str]) -> None:
+        """Remove logical keys after their writers have finished.
+
+        This only removes catalog metadata; physical lifetime stays with Store.
+        """
+        partition = _nonempty_string(partition, "partition")
+        keys = _names(keys, "keys")
+        entries = self._partitions.get(partition)
+        if entries is None:
+            return
+
+        for key in keys:
+            entry = entries.pop(key, None)
+            if entry is None:
+                continue
+            for fragment_id, _row in entry["fields"].values():
+                self._drop_fragment_reference(fragment_id)
+        if not entries:
+            del self._partitions[partition]
+
+    def _drop_fragment_reference(self, fragment_id: str) -> None:
+        remaining = self._fragment_refcounts[fragment_id] - 1
+        if remaining:
+            self._fragment_refcounts[fragment_id] = remaining
+            return
+        del self._fragment_refcounts[fragment_id]
+        del self._fragments[fragment_id]
+
+
+def _fragment(
+    handle: Mapping[str, Any], batch_size: int
+) -> tuple[str, dict[str, Any], tuple[str, ...]]:
+    from mooncake.structured_object_store import (
+        export_dataproto_ref,
+        import_dataproto_ref,
+    )
+
+    ref = import_dataproto_ref(handle)
+    if ref.batch_size != batch_size:
+        raise ValueError(
+            f"DataProto batch size {ref.batch_size!r} does not match "
+            f"{batch_size} logical keys"
+        )
+    if len(ref.stage_refs) != 1:
+        raise ValueError("catalog fragments must contain exactly one DataProto stage")
+    fragment_id = _nonempty_string(
+        next(iter(ref.stage_refs.values())).manifest_key, "manifest_key"
+    )
+    fields = _names(ref.field_index, "field names")
+    if not fields:
+        raise ValueError("DataProto catalog fragments cannot be empty")
+    return fragment_id, export_dataproto_ref(ref), fields
+
+
+def _field_union(
+    entries: Mapping[str, Mapping[str, Any]], keys: Sequence[str]
+) -> list[str]:
+    return list(
+        dict.fromkeys(field for key in keys for field in entries[key]["fields"])
+    )
+
+
+def _names(values: Sequence[str] | Mapping[str, Any], label: str) -> tuple[str, ...]:
+    if isinstance(values, str):
+        raise ValueError(f"{label} must be a sequence of non-empty strings")
+    result = tuple(values)
+    if not result or any(not isinstance(value, str) or not value for value in result):
+        raise ValueError(f"{label} must be non-empty strings")
+    if len(result) != len(set(result)):
+        raise ValueError(f"{label} must be unique")
+    return result
+
+
+def _tags(
+    tags: Sequence[Mapping[str, Any]] | None, count: int
+) -> list[dict[str, Any]] | None:
+    if tags is None:
+        return None
+    if len(tags) != count:
+        raise ValueError("tags must have the same length as keys")
+    if any(not isinstance(tag, Mapping) for tag in tags):
+        raise TypeError("tags must be mappings")
+    return [copy.deepcopy(dict(tag)) for tag in tags]
+
+
+def _nonempty_string(value: Any, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -363,9 +363,14 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
         manifest_key = _require_mapping(stage_ref, f"stage_refs[{stage!r}]").get(
             "manifest_key"
         )
-        if not isinstance(stage, str) or not isinstance(manifest_key, str):
+        if (
+            not isinstance(stage, str)
+            or not stage
+            or not isinstance(manifest_key, str)
+            or not manifest_key
+        ):
             raise ValueError(
-                "DataProto ref handle stage refs must contain string manifest_key values"
+                "DataProto ref handle stage refs must contain non-empty string names and manifest_key values"
             )
         stage_refs[stage] = RemoteBundleRef(manifest_key=manifest_key, manifest={})
     field_index: dict[str, StructuredFieldLocation] = {}
@@ -380,10 +385,15 @@ def import_dataproto_ref(handle: Mapping[str, Any]) -> MooncakeDataProtoRef:
         member = location.get("member")
         if (
             not isinstance(name, str)
+            or not name
             or not isinstance(stage, str)
+            or not stage
             or not isinstance(member, str)
+            or not member
         ):
-            raise ValueError("DataProto ref handle field locations must be strings")
+            raise ValueError(
+                "DataProto ref handle field locations must be non-empty strings"
+            )
         if stage not in stage_refs:
             raise ValueError(
                 f"DataProto ref handle field {name!r} references unknown stage {stage!r}"
@@ -999,6 +1009,15 @@ class MooncakeBundleTransfer:
         indices: Sequence[int],
         destination: Any,
     ) -> Any:
+        if payload_spec.get("format") == "torch_save":
+            if destination is not None:
+                raise ValueError(
+                    f"structured torch_save tensor member {name} does not support destinations"
+                )
+            value = _deserialize_torch_save_payload(
+                self._bundle_store.read_payload(payload_spec)
+            )
+            return value[list(indices)]
         metadata_bytes = int(payload_spec.get("metadata_bytes", -1))
         shape = field_spec.get("shape")
         element_size = int(field_spec.get("element_size", 0))
@@ -3301,6 +3320,20 @@ class _StructuredObjectLayer:
         member_slice: StructuredMemberSlice,
         destination: Any,
     ) -> Any:
+        if payload_spec.get("format") == "torch_save":
+            if destination is not None:
+                raise ValueError(
+                    f"structured torch_save tensor member {name} does not support destinations"
+                )
+            if member_slice.axis != 0:
+                raise ValueError(
+                    "structured tensor slicing currently supports axis=0 only"
+                )
+            value = _deserialize_torch_save_payload(
+                self._bundle_store.read_payload(payload_spec)
+            )
+            start, end, step = _normalized_member_slice(member_slice, len(value))
+            return value[start:end:step]
         metadata_bytes = int(payload_spec.get("metadata_bytes", -1))
         shape = field_spec.get("shape")
         element_size = int(field_spec.get("element_size", 0))

--- a/mooncake-wheel/tests/test_dataproto_catalog.py
+++ b/mooncake-wheel/tests/test_dataproto_catalog.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.dataproto_catalog import DataProtoCatalog
+
+
+def handle(name: str, fields: list[str], batch_size: int = 2) -> dict:
+    return {
+        "type": "mooncake_dataproto_ref",
+        "version": 1,
+        "kind": "bundle_stages",
+        "batch_size": batch_size,
+        "stage_refs": {"rollout": {"manifest_key": f"manifest/{name}"}},
+        "field_index": {
+            field: {
+                "stage": "rollout",
+                "member": f"batch.{field}",
+                "section": "batch",
+            }
+            for field in fields
+        },
+    }
+
+
+def test_catalog_merges_tags_and_resolves_fragmented_fields_in_key_order() -> None:
+    catalog = DataProtoCatalog()
+    catalog.update(
+        "train",
+        ["a", "b"],
+        tags=[{"status": "running"}, {"status": "running"}],
+        handle=handle("base", ["input_ids", "attention_mask"]),
+    )
+    result = catalog.update(
+        "train",
+        ["b", "a"],
+        tags=[{"status": "done"}, {"status": "done"}],
+        handle=handle("scores", ["score"]),
+    )
+
+    assert result["fields"] == ["input_ids", "attention_mask", "score"]
+    assert catalog.list("train") == {
+        "train": {
+            "a": {"status": "done"},
+            "b": {"status": "done"},
+        }
+    }
+    plan = catalog.resolve("train", ["a", "b"], ["score", "input_ids"])
+    assert plan["fields"] == ["score", "input_ids"]
+    assert plan["field_groups"] == [
+        {
+            "fields": ["score"],
+            "locations": [("manifest/scores", 1), ("manifest/scores", 0)],
+        },
+        {
+            "fields": ["input_ids"],
+            "locations": [("manifest/base", 0), ("manifest/base", 1)],
+        },
+    ]
+    assert set(plan["handles"]) == {"manifest/base", "manifest/scores"}
+    grouped = catalog.resolve("train", ["b", "a"], ["input_ids", "attention_mask"])
+    assert catalog.resolve("train", ["a", "b"])["fields"] == [
+        "input_ids",
+        "attention_mask",
+        "score",
+    ]
+    assert grouped["field_groups"] == [
+        {
+            "fields": ["input_ids", "attention_mask"],
+            "locations": [("manifest/base", 1), ("manifest/base", 0)],
+        }
+    ]
+
+
+def test_catalog_drops_replaced_and_removed_locations() -> None:
+    catalog = DataProtoCatalog()
+    base = handle("base", ["value"])
+    replacement = handle("replacement", ["value"])
+    catalog.update("train", ["a", "b"], handle=base)
+
+    catalog.update("train", ["a"], handle={**replacement, "batch_size": 1})
+    catalog.update("train", ["b", "a"], handle=base)
+    plan = catalog.resolve("train", ["a", "b"], ["value"])
+    assert plan["field_groups"] == [
+        {
+            "fields": ["value"],
+            "locations": [("manifest/base", 1), ("manifest/base", 0)],
+        }
+    ]
+    catalog.remove("train", ["b"])
+    catalog.remove("train", ["a"])
+    assert catalog.list() == {}
+
+
+def test_catalog_rejects_missing_or_incomplete_reads_without_mutation() -> None:
+    catalog = DataProtoCatalog()
+    catalog.update("train", ["a", "b"], tags=[{}, {}])
+    catalog.update("train", ["a"], handle=handle("one", ["value"], batch_size=1))
+
+    with pytest.raises(ValueError, match="were not found"):
+        catalog.resolve("train", ["missing"])
+    with pytest.raises(ValueError, match="not ready"):
+        catalog.resolve("train", ["a", "b"], ["value"])
+    with pytest.raises(ValueError, match="do not contain any fields"):
+        catalog.resolve("train", ["b"])
+    with pytest.raises(ValueError, match="same length"):
+        catalog.update("train", ["a", "b"], tags=[{}])
+    with pytest.raises(ValueError, match="sequence"):
+        catalog.resolve("train", "a")
+    with pytest.raises(ValueError, match="sequence"):
+        catalog.resolve("train", ["a"], "value")
+    invalid_handle = handle("invalid", ["value"], batch_size=1)
+    invalid_handle["version"] = 999
+    with pytest.raises(ValueError, match="unsupported.*version"):
+        catalog.update("invalid", ["a"], handle=invalid_handle)
+    multi_stage = handle("multi", ["value"], batch_size=1)
+    multi_stage["stage_refs"]["extra"] = {"manifest_key": "manifest/extra"}
+    with pytest.raises(ValueError, match="exactly one.*stage"):
+        catalog.update("invalid", ["a"], handle=multi_stage)
+
+    assert catalog.list("train") == {"train": {"a": {}, "b": {}}}
+    assert "invalid" not in catalog.list()

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -526,6 +526,27 @@ def test_put_object_torch_tensor_raw_fallback_roundtrip() -> None:
     assert store.batch_get_into_calls > 0
 
 
+def test_dataproto_torch_save_fallback_supports_row_selection(monkeypatch) -> None:
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(sos, "_has_tensor_codec_helpers", lambda: False)
+    _store, transfer = make_transfer(NoTensorFastPathStore())
+    tensor = torch.arange(24, dtype=torch.float32).reshape(6, 4)
+
+    ref = transfer.put_dataproto(SimpleDataProto(batch={"tensor": tensor}))
+    payload = ref.stage_refs["default"].manifest["buffers"]["batch.tensor"]
+
+    assert payload["format"] == "torch_save"
+    for rows in (slice(1, 6, 2), [4, 1, 4], [], [-1, 0]):
+        assert torch.equal(
+            transfer.get_dataproto(ref, rows=rows)["batch"]["tensor"],
+            tensor[rows],
+        )
+    with pytest.raises(ValueError, match="does not support destinations"):
+        transfer.get_dataproto(
+            ref, rows=[1], destinations={"tensor": object()}
+        )
+
+
 def test_bundle_read_spec_full_read_is_partial_special_case() -> None:
     store, transfer = make_transfer()
     array = np.arange(16, dtype=np.int32).reshape(4, 4)
@@ -2107,6 +2128,26 @@ def test_dataproto_ref_handle_rejects_unknown_field_stage() -> None:
     handle["field_index"]["input_ids"]["stage"] = "missing"
 
     with pytest.raises(ValueError, match="unknown stage"):
+        import_dataproto_ref(handle)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("stage_refs", "default", "manifest_key"), ""),
+        (("field_index", "input_ids", "member"), ""),
+    ],
+)
+def test_dataproto_ref_handle_rejects_empty_locations(path, value) -> None:
+    _store, transfer = make_transfer()
+    ref = transfer.put_dataproto(SimpleDataProto(batch={"input_ids": np.arange(4)}))
+    handle = export_dataproto_ref(ref)
+    target = handle
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+    with pytest.raises(ValueError, match="non-empty"):
         import_dataproto_ref(handle)
 
 


### PR DESCRIPTION
## Motivation

Asynchronous RL pipelines address rollout samples by logical key while fields become available at different stages. A Mooncake DataProto handle describes one immutable transfer fragment, but it does not provide the logical key/field index needed to resolve a rollout assembled from multiple fragments. Keeping this mapping in each framework would duplicate validation and reconstruction logic.

## Description

This PR adds a metadata-only `DataProtoCatalog` to the Python wheel. It:

- maps `(partition, key, field)` to immutable single-stage DataProto fragments;
- merges per-key tags and supports ordered `update`, `resolve`, `list`, and `remove` operations;
- validates handles through the existing canonical DataProto import/export helpers;
- returns compact `field_groups` for fields sharing the same ordered fragment locations;
- keeps physical object ownership and lifetime in Mooncake Store rather than the catalog.

The PR also fixes DataProto row selection when tensors use the `torch_save` fallback because native tensor codec helpers are unavailable. These payloads are fully decoded before applying slice or index selection; native tensor payloads continue to use the existing range-read path.

The catalog intentionally accepts one immutable single-stage fragment per update. Multi-stage handles produced by append operations are rejected explicitly, so each published fragment has one stable manifest identity.

This branch is based directly on the latest `kvcache-ai/Mooncake` `main`. It does not contain or duplicate the grouped lifecycle implementation from #3133; that PR remains responsible for Store-side group lease semantics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PYTHONPATH=mooncake-wheel python -m pytest \
  mooncake-wheel/tests/test_dataproto_catalog.py \
  mooncake-wheel/tests/test_structured_object_store.py -q

ruff check mooncake-wheel/mooncake/dataproto_catalog.py \
  mooncake-wheel/mooncake/structured_object_store.py \
  mooncake-wheel/tests/test_dataproto_catalog.py \
  mooncake-wheel/tests/test_structured_object_store.py

SKIP=ruff-format pre-commit run --files \
  mooncake-wheel/mooncake/dataproto_catalog.py \
  mooncake-wheel/mooncake/structured_object_store.py \
  mooncake-wheel/tests/test_dataproto_catalog.py \
  mooncake-wheel/tests/test_structured_object_store.py

pre-commit run ruff-format --files \
  mooncake-wheel/mooncake/dataproto_catalog.py \
  mooncake-wheel/tests/test_dataproto_catalog.py

./scripts/code_format.sh --changed-lines --check
git diff --check
```

**Test results:**
- [x] Unit tests pass: 99 passed, 16 skipped
- [x] Integration tests pass: real Store + catalog + grouped-write compatibility smoke passed
- [x] Manual testing done: a prototype consumer resolved reordered, fragmented fields from captured 27-field Verl rollout data

`pre-commit run --all-files` was also run in an isolated worktree. It is not used as the validation signal because the current `main` branch has repository-wide pre-existing trailing-whitespace, EOF, Ruff, codespell, cmake-format, and missing-`cargo` failures outside this PR. All applicable hooks pass on the four files changed here; full-file `ruff-format` was limited to the two new files to avoid unrelated formatting churn in existing files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable: 274 implementation additions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to implement the focused patch, run multi-axis review and validation, and prepare this PR description. The submitter reviewed every changed line and validated the behavior end to end.