### PR TITLE
[CI/Build] Fix nightly CUDA stub runtime

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,10 +248,26 @@ jobs:
             -DSTORE_USE_ETCD=ON -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_UNIT_TESTS=ON -DENABLE_SCCACHE=ON
 
+      - name: Configure CUDA driver runtime
+        run: |
+          cuda_driver_library=$(sed -n \
+            's/^CUDA_cuda_driver_LIBRARY:FILEPATH=//p' build/CMakeCache.txt)
+          if [ -z "$cuda_driver_library" ] || [ ! -f "$cuda_driver_library" ]; then
+            echo "::error::CMake did not resolve the CUDA driver library"
+            exit 1
+          fi
+
+          cuda_driver_dir=$(dirname "$cuda_driver_library")
+          if [ ! -e "$cuda_driver_dir/libcuda.so.1" ]; then
+            sudo ln -s "$(basename "$cuda_driver_library")" \
+              "$cuda_driver_dir/libcuda.so.1"
+          fi
+          echo "LIBRARY_PATH=$cuda_driver_dir:${LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$cuda_driver_dir:${LD_LIBRARY_PATH:-}" >> "$GITHUB_ENV"
+
       - name: Build project
         run: |
           cd build
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LIBRARY_PATH:-}
           cmake --build . -j$(nproc)
           sudo -E cmake --install .
 
@@ -259,7 +275,6 @@ jobs:
         run: |
           mkdir -p build/mooncake-transfer-engine/nvlink-allocator
           cd mooncake-transfer-engine/nvlink-allocator
-          export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
           bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
 
       - name: Start Metadata Server
@@ -271,14 +286,8 @@ jobs:
 
       - name: Run CTest unit tests
         run: |
-          # libcuda.so.1 (SONAME of the CUDA stub) must be findable at runtime.
-          # The toolkit stubs dir only ships libcuda.so; create the versioned symlink.
-          if [ -f /usr/local/cuda/lib64/stubs/libcuda.so ] && \
-             [ ! -e /usr/local/cuda/lib64/stubs/libcuda.so.1 ]; then
-            sudo ln -s libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
-          fi
           cd build
-          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}:/usr/local/lib
+          export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
           MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
           DEFAULT_KV_LEASE_TTL=500 \
             ctest --parallel $(nproc) --output-on-failure
@@ -292,7 +301,6 @@ jobs:
       - name: Run Go store binding integration tests
         env:
           MOONCAKE_STORE_CLUSTER_ID: nightly_go_cluster
-          MOONCAKE_STORE_GO_LINK_COMMON: "0"
           MOONCAKE_STORE_GO_SANITIZED: "0"
         run: ./scripts/ci/run_store_go_integration.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -271,8 +271,14 @@ jobs:
 
       - name: Run CTest unit tests
         run: |
+          # libcuda.so.1 (SONAME of the CUDA stub) must be findable at runtime.
+          # The toolkit stubs dir only ships libcuda.so; create the versioned symlink.
+          if [ -f /usr/local/cuda/lib64/stubs/libcuda.so ] && \
+             [ ! -e /usr/local/cuda/lib64/stubs/libcuda.so.1 ]; then
+            sudo ln -s libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+          fi
           cd build
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}:/usr/local/lib
           MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
           DEFAULT_KV_LEASE_TTL=500 \
             ctest --parallel $(nproc) --output-on-failure

--- a/scripts/ci/run_store_go_integration.sh
+++ b/scripts/ci/run_store_go_integration.sh
@@ -14,15 +14,6 @@ case "${MOONCAKE_STORE_GO_SANITIZED:-0}" in
         ;;
 esac
 
-case "${MOONCAKE_STORE_GO_LINK_COMMON:-0}" in
-    0) link_common=false ;;
-    1) link_common=true ;;
-    *)
-        echo "MOONCAKE_STORE_GO_LINK_COMMON must be 0 or 1" >&2
-        exit 2
-        ;;
-esac
-
 "$GITHUB_WORKSPACE/build/mooncake-store/src/mooncake_master" \
     --eviction_high_watermark_ratio=0.95 \
     --cluster_id="$MOONCAKE_STORE_CLUSTER_ID" \
@@ -31,7 +22,7 @@ master_pid=$!
 sleep 3
 
 cd "$GITHUB_WORKSPACE/mooncake-store/go"
-export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd"
+export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-common:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:${LD_LIBRARY_PATH:-}"
 export CGO_ENABLED=1
 export CGO_CFLAGS="-I$GITHUB_WORKSPACE/mooncake-store/include -I$GITHUB_WORKSPACE/mooncake-transfer-engine/include"
 
@@ -41,23 +32,13 @@ linker_flags=(
     "-L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src"
     "-L$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base"
     "-L$GITHUB_WORKSPACE/build/mooncake-common"
+    "-L$GITHUB_WORKSPACE/build/mooncake-common/src"
+    "-L$GITHUB_WORKSPACE/build/mooncake-common/etcd"
+    -Wl,--start-group
+    -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase
+    -lmooncake_common
+    -Wl,--end-group
 )
-if $link_common; then
-    linker_flags+=("-L$GITHUB_WORKSPACE/build/mooncake-common/src")
-fi
-linker_flags+=("-L$GITHUB_WORKSPACE/build/mooncake-common/etcd")
-if $link_common; then
-    linker_flags+=(
-        -Wl,--start-group
-        -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase
-        -lmooncake_common
-        -Wl,--end-group
-    )
-else
-    linker_flags+=(
-        -lmooncake_store -lcachelib_memory_allocator -ltransfer_engine -lbase
-    )
-fi
 linker_flags+=(
     -lasio -letcd_wrapper -lstdc++ -lnuma -lglog -lgflags -libverbs -lmlx5
     -ljsoncpp -lzstd -lcurl -luring
@@ -75,6 +56,18 @@ export CGO_LDFLAGS="${linker_flags[*]}"
 # Link cudart if CUDA is available (needed for D2H staging in mooncake_store).
 if [ -d /usr/local/cuda/lib64 ]; then
     export CGO_LDFLAGS="$CGO_LDFLAGS -L/usr/local/cuda/lib64 -lcudart"
+fi
+# USE_CUDA links transfer_engine against the CUDA Driver API in addition to the
+# runtime API. Reuse the exact driver library that CMake selected.
+if grep -q '^USE_CUDA:BOOL=ON$' "$GITHUB_WORKSPACE/build/CMakeCache.txt"; then
+    cuda_driver_library=$(sed -n \
+        's/^CUDA_cuda_driver_LIBRARY:FILEPATH=//p' \
+        "$GITHUB_WORKSPACE/build/CMakeCache.txt")
+    if [ -z "$cuda_driver_library" ] || [ ! -f "$cuda_driver_library" ]; then
+        echo "CMake did not resolve the CUDA driver library" >&2
+        exit 1
+    fi
+    export CGO_LDFLAGS="$CGO_LDFLAGS -L$(dirname "$cuda_driver_library") -lcuda"
 fi
 # The KV events publisher is optional and linked when libzmq is installed.
 if ldconfig -p 2>/dev/null | grep -q libzmq; then


### PR DESCRIPTION
## Description

Fixes #3343.

The CUDA-enabled nightly job built successfully against the CUDA driver stub, but the runtime setup was incomplete:

1. CTest could not load CUDA-linked binaries because the toolkit stub lacked the `libcuda.so.1` SONAME symlink and its directory was absent from the runtime search path.
2. The later Go integration test omitted `mooncake_common` in the release profile and linked only `cudart`, even though `USE_CUDA=ON` also leaves CUDA Driver API references in the static Store and Transfer Engine libraries.

This change:

- reads the CUDA driver library selected by CMake instead of assuming a toolkit layout;
- creates the `libcuda.so.1` symlink when needed;
- persists the driver directory through `LIBRARY_PATH` and `LD_LIBRARY_PATH` for the build, CTest, Rust, Go, wheel, and Python steps;
- always links the Go integration binary with `mooncake_common`;
- adds `-lcuda` from the CMake-selected driver directory for CUDA-enabled builds; and
- preserves the inherited runtime library path in the Go integration script.

User/developer impact: the CUDA-enabled nightly test pipeline can proceed through all native and language-binding test stages on the CPU-only GitHub-hosted runner instead of failing in the dynamic loader or Go linker.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
bash -n scripts/ci/run_store_go_integration.sh
pre-commit run --files .github/workflows/nightly.yml scripts/ci/run_store_go_integration.sh
```

A focused linker probe used the same CUDA-enabled static Store and Transfer Engine archives and the updated Go linker flags. The resulting executable declares both `libcudart` and `libcuda.so.1` and exits successfully with the CUDA driver stub runtime.

CTest was also run against the CUDA-enabled local build with a `libcuda.so.1` stub alias. All 120 tests loaded; 70 passed in the constrained local sandbox, while the remaining failures were attributable to the local etcd test stub and blocked network operations rather than CUDA library loading.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (full suite requires the GitHub-hosted Nightly environment)
- [x] Manual testing done as described above

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable; no C/C++ changes)
- [ ] I have run `pre-commit run --all-files` and all hooks pass (all hooks passed on the touched files)
- [ ] I have updated the documentation (not applicable)
- [ ] I have added tests to prove my changes are effective (validated with focused runtime and linker probes)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex analyzed the failed Nightly logs, traced the masked CTest and Go linkage failures, prepared the workflow and integration-script changes, and ran the listed validation. The human submitter remains responsible for reviewing and understanding the change.