### PR TITLE
[TransferEngine] Fix graceful shutdown test hangs in USE_ETCD builds

### DIFF
--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -359,8 +359,7 @@ if(ENABLE_MULTI_PROTOCOL)
 endif()
 
 add_executable(graceful_shutdown_test ${WORKSPACE}/graceful_shutdown_test.cpp)
-target_link_libraries(graceful_shutdown_test PUBLIC transfer_engine gtest
-                                                    gtest_main)
+target_link_libraries(graceful_shutdown_test PUBLIC transfer_engine gtest)
 add_test(NAME graceful_shutdown_test COMMAND graceful_shutdown_test)
 
 add_executable(show_links_test ${WORKSPACE}/show_links_test.cpp)

--- a/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
+++ b/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
@@ -13,72 +13,212 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <poll.h>
 #include <signal.h>
+#include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <chrono>
+#include <climits>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 
 #include "transfer_engine.h"
+
+extern char** environ;
 
 using namespace mooncake;
 
 namespace {
 
-void waitChildWithTimeout(pid_t pid, int* status) {
-    for (int i = 0; i < 50; ++i) {
+constexpr char kChildFlag[] = "--graceful-shutdown-child";
+constexpr int kChildTimeoutMs = 5000;
+
+enum class ChildMode { kSingle, kDestroyed, kMultiple };
+
+const char* childModeName(ChildMode mode) {
+    switch (mode) {
+        case ChildMode::kSingle:
+            return "single";
+        case ChildMode::kDestroyed:
+            return "destroyed";
+        case ChildMode::kMultiple:
+            return "multiple";
+    }
+    return "unknown";
+}
+
+bool parseChildMode(const char* value, ChildMode* mode) {
+    if (strcmp(value, "single") == 0) {
+        *mode = ChildMode::kSingle;
+    } else if (strcmp(value, "destroyed") == 0) {
+        *mode = ChildMode::kDestroyed;
+    } else if (strcmp(value, "multiple") == 0) {
+        *mode = ChildMode::kMultiple;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+int runShutdownChild(ChildMode mode, int ready_fd) {
+    std::unique_ptr<TransferEngine> engine1;
+    std::unique_ptr<TransferEngine> engine2;
+
+    if (mode == ChildMode::kDestroyed) {
+        auto engine = std::make_unique<TransferEngine>(false);
+        engine->enableGracefulShutdown();
+    } else {
+        engine1 = std::make_unique<TransferEngine>(false);
+        engine1->enableGracefulShutdown();
+        if (mode == ChildMode::kMultiple) {
+            engine2 = std::make_unique<TransferEngine>(false);
+            engine2->enableGracefulShutdown();
+        }
+    }
+
+    const char ready = '1';
+    ssize_t bytes_written;
+    do {
+        bytes_written = write(ready_fd, &ready, sizeof(ready));
+    } while (bytes_written < 0 && errno == EINTR);
+    if (bytes_written != static_cast<ssize_t>(sizeof(ready))) return 111;
+    close(ready_fd);
+    for (;;) pause();
+}
+
+void killAndReap(pid_t pid) {
+    if (kill(pid, SIGKILL) != 0 && errno != ESRCH) {
+        ADD_FAILURE() << "kill(SIGKILL) failed: " << strerror(errno);
+    }
+
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    }
+}
+
+bool waitChildWithTimeout(pid_t pid, int* status) {
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(kChildTimeoutMs);
+    for (;;) {
         pid_t ret = waitpid(pid, status, WNOHANG);
-        ASSERT_NE(ret, -1) << "waitpid() failed";
-        if (ret == pid) return;
+        if (ret == pid) return true;
+        if (ret < 0) {
+            if (errno == EINTR) continue;
+            int error = errno;
+            if (error != ECHILD) killAndReap(pid);
+            ADD_FAILURE() << "waitpid() failed: " << strerror(error);
+            return false;
+        }
+        if (std::chrono::steady_clock::now() >= deadline) break;
         usleep(100000);
     }
-    kill(pid, SIGKILL);
-    waitpid(pid, status, 0);
-    FAIL() << "child did not exit before timeout";
+
+    killAndReap(pid);
+    ADD_FAILURE() << "child did not exit before timeout";
+    return false;
+}
+
+bool waitForChildReady(int fd) {
+    pollfd pfd{fd, POLLIN, 0};
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(kChildTimeoutMs);
+    int ret;
+    for (;;) {
+        auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             deadline - std::chrono::steady_clock::now())
+                             .count();
+        if (remaining <= 0) {
+            ret = 0;
+            break;
+        }
+        ret = poll(&pfd, 1, static_cast<int>(remaining));
+        if (ret >= 0 || errno != EINTR) break;
+    }
+
+    if (ret == 0) {
+        ADD_FAILURE() << "child did not report readiness before timeout";
+        return false;
+    }
+    if (ret < 0) {
+        ADD_FAILURE() << "poll() failed: " << strerror(errno);
+        return false;
+    }
+
+    char ready = 0;
+    ssize_t bytes_read;
+    do {
+        bytes_read = read(fd, &ready, sizeof(ready));
+    } while (bytes_read < 0 && errno == EINTR);
+    if (bytes_read != static_cast<ssize_t>(sizeof(ready)) || ready != '1') {
+        ADD_FAILURE() << "child exited before reporting readiness";
+        return false;
+    }
+    return true;
+}
+
+pid_t spawnReadyChild(ChildMode mode) {
+    int ready_pipe[2];
+    if (pipe(ready_pipe) != 0) {
+        ADD_FAILURE() << "pipe() failed: " << strerror(errno);
+        return -1;
+    }
+
+    char ready_fd[32];
+    snprintf(ready_fd, sizeof(ready_fd), "%d", ready_pipe[1]);
+    char* child_argv[] = {
+        const_cast<char*>("/proc/self/exe"), const_cast<char*>(kChildFlag),
+        const_cast<char*>(childModeName(mode)), ready_fd, nullptr};
+
+    pid_t pid = -1;
+    int spawn_error = posix_spawn(&pid, "/proc/self/exe", nullptr, nullptr,
+                                  child_argv, environ);
+    close(ready_pipe[1]);
+    if (spawn_error != 0) {
+        close(ready_pipe[0]);
+        ADD_FAILURE() << "posix_spawn() failed: " << strerror(spawn_error);
+        return -1;
+    }
+
+    bool ready = waitForChildReady(ready_pipe[0]);
+    close(ready_pipe[0]);
+    if (!ready) {
+        killAndReap(pid);
+        return -1;
+    }
+    return pid;
+}
+
+void expectGracefulExit(ChildMode mode, int signo) {
+    pid_t pid = spawnReadyChild(mode);
+    ASSERT_GT(pid, 0);
+
+    if (kill(pid, signo) != 0) {
+        int error = errno;
+        killAndReap(pid);
+        FAIL() << "kill(" << signo << ") failed: " << strerror(error);
+    }
+
+    int status = 0;
+    ASSERT_TRUE(waitChildWithTimeout(pid, &status));
+    ASSERT_TRUE(WIFEXITED(status))
+        << "Child did not exit normally (signaled: " << WIFSIGNALED(status)
+        << ")";
+    EXPECT_EQ(WEXITSTATUS(status), 128 + signo);
 }
 
 }  // namespace
 
 TEST(GracefulShutdownTest, SigtermTriggersCleanExit) {
-    pid_t pid = fork();
-    ASSERT_NE(pid, -1) << "fork() failed";
-
-    if (pid == 0) {
-        auto engine = std::make_unique<TransferEngine>(false);
-        engine->enableGracefulShutdown();
-        pause();
-        _exit(99);
-    }
-
-    usleep(100000);
-    kill(pid, SIGTERM);
-
-    int status;
-    waitChildWithTimeout(pid, &status);
-    ASSERT_TRUE(WIFEXITED(status))
-        << "Child did not exit normally (signaled: " << WIFSIGNALED(status)
-        << ")";
-    EXPECT_EQ(WEXITSTATUS(status), 128 + SIGTERM);
+    expectGracefulExit(ChildMode::kSingle, SIGTERM);
 }
 
 TEST(GracefulShutdownTest, SigintTriggersCleanExit) {
-    pid_t pid = fork();
-    ASSERT_NE(pid, -1) << "fork() failed";
-
-    if (pid == 0) {
-        auto engine = std::make_unique<TransferEngine>(false);
-        engine->enableGracefulShutdown();
-        pause();
-        _exit(99);
-    }
-
-    usleep(100000);
-    kill(pid, SIGINT);
-
-    int status;
-    waitChildWithTimeout(pid, &status);
-    ASSERT_TRUE(WIFEXITED(status)) << "Child did not exit normally";
-    EXPECT_EQ(WEXITSTATUS(status), 128 + SIGINT);
+    expectGracefulExit(ChildMode::kSingle, SIGINT);
 }
 
 TEST(GracefulShutdownTest, IdempotentEnable) {
@@ -89,25 +229,7 @@ TEST(GracefulShutdownTest, IdempotentEnable) {
 }
 
 TEST(GracefulShutdownTest, EngineDestroyedBeforeSignal) {
-    pid_t pid = fork();
-    ASSERT_NE(pid, -1) << "fork() failed";
-
-    if (pid == 0) {
-        {
-            auto engine = std::make_unique<TransferEngine>(false);
-            engine->enableGracefulShutdown();
-        }
-        pause();
-        _exit(99);
-    }
-
-    usleep(100000);
-    kill(pid, SIGTERM);
-
-    int status;
-    waitChildWithTimeout(pid, &status);
-    ASSERT_TRUE(WIFEXITED(status));
-    EXPECT_EQ(WEXITSTATUS(status), 128 + SIGTERM);
+    expectGracefulExit(ChildMode::kDestroyed, SIGTERM);
 }
 
 TEST(GracefulShutdownTest, ForkAfterInstallDoesNotHangChildSignal) {
@@ -118,15 +240,17 @@ TEST(GracefulShutdownTest, ForkAfterInstallDoesNotHangChildSignal) {
     ASSERT_NE(pid, -1) << "fork() failed";
 
     if (pid == 0) {
-        pause();
-        _exit(99);
+        for (;;) pause();
     }
 
-    usleep(100000);
-    kill(pid, SIGTERM);
+    if (kill(pid, SIGTERM) != 0) {
+        int error = errno;
+        killAndReap(pid);
+        FAIL() << "kill(SIGTERM) failed: " << strerror(error);
+    }
 
-    int status;
-    waitChildWithTimeout(pid, &status);
+    int status = 0;
+    ASSERT_TRUE(waitChildWithTimeout(pid, &status));
     ASSERT_TRUE(WIFEXITED(status))
         << "Child did not exit normally (signaled: " << WIFSIGNALED(status)
         << ")";
@@ -134,23 +258,22 @@ TEST(GracefulShutdownTest, ForkAfterInstallDoesNotHangChildSignal) {
 }
 
 TEST(GracefulShutdownTest, MultipleEngines) {
-    pid_t pid = fork();
-    ASSERT_NE(pid, -1) << "fork() failed";
+    expectGracefulExit(ChildMode::kMultiple, SIGTERM);
+}
 
-    if (pid == 0) {
-        auto engine1 = std::make_unique<TransferEngine>(false);
-        auto engine2 = std::make_unique<TransferEngine>(false);
-        engine1->enableGracefulShutdown();
-        engine2->enableGracefulShutdown();
-        pause();
-        _exit(99);
+int main(int argc, char** argv) {
+    if (argc == 4 && strcmp(argv[1], kChildFlag) == 0) {
+        ChildMode mode;
+        char* end = nullptr;
+        errno = 0;
+        long ready_fd = strtol(argv[3], &end, 10);
+        if (!parseChildMode(argv[2], &mode) || errno != 0 || *end != '\0' ||
+            ready_fd < 0 || ready_fd > INT_MAX) {
+            return 2;
+        }
+        return runShutdownChild(mode, static_cast<int>(ready_fd));
     }
 
-    usleep(100000);
-    kill(pid, SIGTERM);
-
-    int status;
-    waitChildWithTimeout(pid, &status);
-    ASSERT_TRUE(WIFEXITED(status));
-    EXPECT_EQ(WEXITSTATUS(status), 128 + SIGTERM);
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
+++ b/mooncake-transfer-engine/tests/graceful_shutdown_test.cpp
@@ -97,7 +97,13 @@ void killAndReap(pid_t pid) {
     }
 
     int status = 0;
-    while (waitpid(pid, &status, 0) < 0 && errno == EINTR) {
+    pid_t ret;
+    do {
+        ret = waitpid(pid, &status, 0);
+    } while (ret < 0 && errno == EINTR);
+    if (ret < 0) {
+        ADD_FAILURE() << "waitpid() failed while reaping child: "
+                      << strerror(errno);
     }
 }
 
@@ -154,8 +160,18 @@ bool waitForChildReady(int fd) {
     do {
         bytes_read = read(fd, &ready, sizeof(ready));
     } while (bytes_read < 0 && errno == EINTR);
-    if (bytes_read != static_cast<ssize_t>(sizeof(ready)) || ready != '1') {
+    if (bytes_read == 0) {
         ADD_FAILURE() << "child exited before reporting readiness";
+        return false;
+    }
+    if (bytes_read < 0) {
+        ADD_FAILURE() << "read() failed while waiting for readiness: "
+                      << strerror(errno);
+        return false;
+    }
+    if (ready != '1') {
+        ADD_FAILURE() << "unexpected readiness marker: "
+                      << static_cast<int>(static_cast<unsigned char>(ready));
         return false;
     }
     return true;


### PR DESCRIPTION
## Description

Fixes #3349.

`graceful_shutdown_test` could intermittently hang in CI when built with `USE_ETCD=ON`.

The test binary loads the Go c-shared etcd runtime, which starts background threads before GTest runs. The affected tests then called `fork()` and constructed `TransferEngine` in the child process. This performed memory allocation, mutex operations, logging initialization, and `std::thread` creation between `fork()` and `exec()`, which is unsafe when the parent process is already multithreaded.

The parent also used a fixed 100 ms sleep before sending SIGTERM or SIGINT. This did not guarantee that the child had installed its graceful shutdown handlers.

This change:

- starts the signal target with `posix_spawn()` and self-executes the test binary in an internal child mode;
- constructs `TransferEngine` only after the child has entered a fresh process image;
- replaces the fixed sleep with a readiness pipe;
- applies bounded timeouts to both readiness and child exit;
- kills and reaps the child on every relevant failure path;
- handles `EINTR` while waiting, reading, and writing;
- shares the helper across the single-engine, destroyed-engine, multiple-engine, SIGTERM, and SIGINT cases;
- keeps `ForkAfterInstallDoesNotHangChildSignal` as a direct `fork()` test because it specifically validates inherited handler behavior, while ensuring its child only calls async-signal-safe operations.

No production graceful shutdown code is changed. This is separate from the shutdown watcher signal-mask issue fixed by #3278.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The test was built and run with both the CI-equivalent `USE_ETCD=ON + ENABLE_ASAN=ON` configuration and a minimal `USE_ETCD=OFF` configuration.

**Test commands:**

```bash
cmake --build build --target graceful_shutdown_test -j32

LSAN_OPTIONS=detect_leaks=0 \
ctest --test-dir build \
  -R '^graceful_shutdown_test$' \
  --output-on-failure
```

The previously failing SIGTERM case was also stress-tested with 32 concurrent workers:

```bash
seq 1 2000 | xargs -P32 -n1 sh -c \
  'LSAN_OPTIONS=detect_leaks=0 \
   ./build/mooncake-transfer-engine/tests/graceful_shutdown_test \
   --gtest_filter=GracefulShutdownTest.SigtermTriggersCleanExit \
   >/dev/null 2>&1'
```

The complete test binary was stress-tested 500 times with 32 concurrent workers.

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [x] Manual testing done
- CI-equivalent `USE_ETCD=ON + ASan`: passed
- `USE_ETCD=OFF`: passed
- SIGTERM stress test, 2,000 runs at 32-way concurrency: 0 failures
- Complete suite stress test, 500 runs at 32-way concurrency: 0 failures
- No orphaned `graceful_shutdown_test` processes remained

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable; test-only change)
- [x] I have added or updated tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

Targeted pre-commit hooks passed. The full-file `cmake-format` hook was skipped because it rewrites unrelated pre-existing sections of `mooncake-transfer-engine/tests/CMakeLists.txt`; those unrelated changes were not included.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex was used to investigate the CI failure pattern, implement the test process-isolation change, run local validation, and prepare this PR description. The human submitter is responsible for reviewing and defending the final change.