### PR TITLE
[Doc] Update Mooncake PG design documentation

### DIFF
--- a/docs/source/api-reference/python/ep-backend.md
+++ b/docs/source/api-reference/python/ep-backend.md
@@ -1,14 +1,13 @@
-# Mooncake EP & Mooncake Backend (PG)
+# Mooncake EP & Mooncake PG
 
 ## Overview
 
 Mooncake provides two closely related components for fault-tolerant MoE
 inference:
 
-- **Mooncake Backend (PG)** is a `torch.distributed` ProcessGroup backend. It
-  registers the `mooncake` accelerator backend and the `mooncake-cpu` backend,
-  implements common collective and point-to-point APIs, tracks active ranks, and
-  exposes elastic recovery helpers.
+- **Mooncake PG** is a `torch.distributed` ProcessGroup backend. It registers
+  the `mooncake` accelerator backend and the `mooncake-cpu` backend, implements
+  collective and point-to-point APIs, and exposes dynamic-membership helpers.
 - **Mooncake EP** is an expert-parallel dispatch/combine runtime for
   latency-sensitive MoE inference. It follows the DeepEP low-latency programming
   model while adding rank activeness awareness and Mooncake transport support.
@@ -17,8 +16,9 @@ The usual integration pattern is to initialize a Mooncake process group first,
 then construct a Mooncake EP `Buffer` from that group. The process group is used
 both for regular collectives and for exchanging EP bootstrap metadata.
 
-For implementation details, see the [Mooncake Backend (PG) design guide](../../design/mooncake-backend-pg.md)
-and the [Mooncake EP design guide](../../design/mooncake-ep.md).
+For implementation details, see the
+[Mooncake PG design guide](../../design/mooncake-backend-pg.md) and the
+[Mooncake EP design guide](../../design/mooncake-ep.md).
 
 ## Installation and build notes
 
@@ -35,7 +35,7 @@ match the active `torch.__version__`. If the current PyTorch version does not
 match a built extension, import will fail with a message such as
 `Mooncake PG was not built against torch==...`.
 
-## Mooncake Backend (PG) quick start
+## Mooncake PG quick start
 
 ### CUDA backend
 
@@ -54,14 +54,10 @@ local_rank = int(os.environ.get("LOCAL_RANK", rank))
 torch.cuda.set_device(local_rank)
 device = torch.device("cuda", local_rank)
 
-# Backend-level active-rank mask. Use int32 and place it on the backend device.
-active_ranks = torch.ones(world_size, dtype=torch.int32, device=device)
-
 dist.init_process_group(
     backend="mooncake",
     rank=rank,
     world_size=world_size,
-    pg_options=pg.MooncakeBackendOptions(active_ranks),
 )
 
 x = torch.tensor([rank + 1], dtype=torch.int32, device=device)
@@ -77,17 +73,19 @@ torchrun --nproc-per-node=2 pg_quickstart.py
 
 ### CPU backend
 
-Use `backend="mooncake-cpu"` and put `active_ranks` on CPU:
+Use `backend="mooncake-cpu"`:
 
 ```python
-active_ranks = torch.ones(world_size, dtype=torch.int32)
 dist.init_process_group(
     backend="mooncake-cpu",
     rank=rank,
     world_size=world_size,
-    pg_options=pg.MooncakeBackendOptions(active_ranks),
 )
 ```
+
+`pg_options` is optional for a fixed-size group using the default failure
+handling. Pass `MooncakeBackendOptions` when reserving additional group
+capacity, joining as an extension, or selecting a non-default failure mode.
 
 ### Selecting network devices
 
@@ -103,27 +101,38 @@ pg.set_device_filter(["mlx5_1", "mlx5_2"])
 For test and benchmark commands, the same setting is commonly passed through
 `MOONCAKE_PGTEST_DEVICE_FILTERS=mlx5_1,mlx5_2`.
 
-## Mooncake Backend (PG) API reference
+## Mooncake PG Torch API reference
 
 ### `MooncakeBackendOptions`
 
 ```python
+pg.MooncakeBackendOptions(max_group_size)
+pg.MooncakeBackendOptions(max_group_size, is_extension)
+pg.MooncakeBackendOptions(
+    max_group_size,
+    is_extension,
+    auto_deactivate_on_failure,
+    auto_sync_on_failure,
+)
+
+# Explicit active-rank mirror overloads
 pg.MooncakeBackendOptions(active_ranks)
 pg.MooncakeBackendOptions(active_ranks, is_extension)
-pg.MooncakeBackendOptions(active_ranks, is_extension, max_world_size)
+pg.MooncakeBackendOptions(active_ranks, is_extension, max_group_size)
 ```
 
 Arguments:
 
-- `active_ranks`: `torch.int32` tensor used as the backend-level rank-health
-  mask. For `mooncake`, it must be on the accelerator device; for
-  `mooncake-cpu`, it must be on CPU. When `max_world_size` is set, size this
-  tensor to `max_world_size`, not the current visible world size.
+- `max_group_size`: fixed in-group slot capacity. It must be at least the
+  initially declared group size and cannot be increased later.
+- `active_ranks`: optional contiguous `torch.int32` storage used as a mirror of
+  committed PG membership. Its initial contents are ignored. Size it to
+  `max_group_size`; it may be on CPU or GPU.
 - `is_extension`: set to `True` for a replacement or joining process that will
   enter an existing group through `join_group()`.
-- `max_world_size`: optional upper bound for reserved rank slots. It lets
-  healthy ranks reserve inactive future ranks while keeping
-  `dist.get_world_size()` equal to the current active size.
+- `auto_deactivate_on_failure` and `auto_sync_on_failure`: select automatic or
+  framework-managed failure handling. Both default to `True`; auto-sync
+  requires auto-deactivation.
 
 ### Utility functions
 
@@ -133,15 +142,17 @@ Arguments:
 | `pg.set_device_filter(filters)` | Restrict NIC/HCA selection. | Call before `init_process_group()`. |
 | `pg.set_transfer_engine(engine)` | Reuse an external `TransferEngine`. | The engine must outlive all process groups. |
 | `pg.get_active_ranks(backend)` | Return the backend active-rank tensor. | Used by EP fallback and recovery paths. |
-| `pg.get_num_synced_ranks(backend)` | Return the number of ranks synchronized by the backend. | Diagnostic helper. |
-| `pg.extend_group_size_to(backend, size)` | Reserve additional inactive ranks. | Newly extended ranks do not participate until recovered. |
-| `pg.get_peer_state(backend, ranks)` | Check whether candidate ranks have published peer metadata. | Collective among healthy ranks. |
-| `pg.recover_ranks(backend, ranks)` | Activate ready ranks and publish extension state. | Requires peer metadata to be ready. |
-| `pg.join_group(backend)` | Joiner-side blocking call for extension ranks. | Used after `is_extension=True` initialization. |
+| `pg.get_num_synced_ranks(backend)` | Return the number of locally activatable group slots. | Diagnostic helper. |
+| `pg.get_peer_state(backend, ranks)` | Read locally mirrored activation readiness. | A lightweight, communication-free query. |
+| `pg.activate_ranks(backend, ranks)` | Propose activation through the Coordinator. | A single call from any online rank is sufficient. |
+| `pg.recover_ranks(backend, ranks)` | Propose activation through the Coordinator. | Compatibility alias to `activate_ranks`. |
+| `pg.deactivate_ranks(backend, ranks)` | Propose deactivation through the Coordinator. | A single call from any online rank is sufficient. |
+| `pg.join_group(backend)` | Confirm readiness for activation and remain blocked until activation actually occurs. | Used for scale-up, replacement, and in-place rejoin. |
+| `pg.sync_after_failure(backend)` | Report current link observations, wait for reconciliation, and apply the latest group view. | Called automatically when `auto_sync_on_failure=True`; it may also be called manually. |
 
 ### Supported distributed operations
 
-Mooncake Backend implements the following `torch.distributed` APIs. Support may
+Mooncake PG implements the following `torch.distributed` APIs. Support may
 depend on device type, dtype, PyTorch version, and whether the current backend is
 `mooncake` or `mooncake-cpu`; run the PG tests on the target environment before
 production use.
@@ -150,29 +161,27 @@ production use.
 | --- | --- | --- |
 | Collectives | `all_reduce`, `broadcast`, `all_gather`, `all_gather_into_tensor`, `reduce_scatter_tensor`, `all_to_all`, `barrier`, `reduce`, `gather`, `scatter` | Active ranks participate; inactive ranks are skipped by backend internals. |
 | Async work | `dist.all_reduce(..., async_op=True)` | Wait on the returned work object, then synchronize the device stream as needed. |
-| P2P | `isend`, `irecv`, `batch_isend_irecv` | Single-tensor P2P is routed through the Mooncake P2P shim. |
+| P2P | `isend`, `irecv`, `batch_isend_irecv` | Single-tensor P2P is routed through the Mooncake backend shim. |
 
 ## Elastic recovery protocol
 
-Mooncake PG supports a two-sided recovery protocol. Existing healthy ranks poll
-for replacement rank readiness, then activate those ranks. Replacement ranks
-start in extension mode, publish metadata, and wait until healthy ranks recover
-them.
+Mooncake PG separates join preparation from membership activation. A joining or
+recovering rank completes local warmup, calls `join_group()`, and waits. An
+existing rank may poll local readiness and then issue the activation proposal.
+The Coordinator validates and distributes the resulting membership.
 
 ### Healthy-rank side
 
 ```python
 from mooncake import pg
 
-active_ranks = torch.tensor([1, 1, 0], dtype=torch.int32, device=device)
 dist.init_process_group(
     backend="mooncake",
     rank=rank,
     world_size=2,
     pg_options=pg.MooncakeBackendOptions(
-        active_ranks,
+        3,                 # max_group_size
         False,             # is_extension
-        3,                 # max_world_size
     ),
 )
 
@@ -191,31 +200,35 @@ pg.recover_ranks(backend, join_ranks)
 ```python
 from mooncake import pg
 
-active_ranks = torch.tensor([1, 1, 1], dtype=torch.int32, device=device)
 dist.init_process_group(
     backend="mooncake",
     rank=2,
     world_size=3,
     pg_options=pg.MooncakeBackendOptions(
-        active_ranks,
+        3,                 # max_group_size
         True,              # is_extension
-        3,                 # max_world_size
     ),
 )
 
 backend = dist.group.WORLD
+
+# Collectives are local-only before join_group. Use this
+# window for framework-specific preparation, for example:
+# capture_cuda_graphs()
+# warm_up_model()
+
 pg.join_group(backend)
 ```
 
 Important semantics:
 
-- `get_peer_state()` is collective among the current healthy ranks. Call it in a
-  consistent order across those ranks.
-- New ranks are inactive after `extend_group_size_to()` and become collective
-  participants only after `recover_ranks()`.
-- A joining rank initialized with `is_extension=True` starts with local-only
-  behavior and blocks in `join_group()` until the corresponding healthy ranks
-  publish recovery state.
+- `get_peer_state()` is a local best-effort readiness query, not a collective.
+- Capacity must be reserved with `max_group_size` when founding members create
+  the group. A joining registration appends inactive slots within that capacity.
+- A joining rank starts with local-only collective behavior until `join_group`.
+  The join call then blocks until a Coordinator-approved activation commits.
+- A single `activate_ranks()` call, or its `recover_ranks()` alias, from any
+  online rank is sufficient; redundant equivalent calls are safe.
 - Subgroups must be created in the same order on healthy and joining processes,
   following PyTorch `new_group()` ordering rules.
 
@@ -403,15 +416,16 @@ updates rank activeness so EP transport metadata and QPs can be refreshed.
 
 There are two active-rank tensors in the API surface:
 
-- **PG active-rank mask**: passed to `pg.MooncakeBackendOptions`. This is the
-  backend-level health mask used by collective and recovery logic.
+- **PG active-rank mask**: passed to `pg.MooncakeBackendOptions`. This mirrors
+  the Coordinator's committed membership.
 - **EP active-rank tensor**: passed to `Buffer.dispatch()` and `Buffer.combine()`.
   It is also rank-level (`[num_ranks]`, `torch.int32`) and may be updated by EP
   kernels when timeout detection marks a peer as failed.
 
-In simple integrations these tensors often carry the same health information,
-but they are passed through different API layers. Keep their dtype, device, and
-shape consistent with the process group world size or reserved `max_world_size`.
+Their values may coincide in a simple integration, but their semantics are not
+interchangeable: PG membership is configuration, while EP may update its mask
+from kernel-level timeout observations. Keep the mapping, dtype, device, and
+capacity consistent when propagating committed PG membership into EP.
 
 ## Tests and examples
 

--- a/docs/source/design/index.md
+++ b/docs/source/design/index.md
@@ -30,7 +30,7 @@ distributed execution components.
 
 | Document | Description |
 |----------|-------------|
-| [Mooncake Backend (PG)](mooncake-backend-pg) | Fault-tolerant PyTorch process-group backend. |
+| [Mooncake PG](mooncake-backend-pg) | Elastic PyTorch process group. |
 | [Mooncake EP](mooncake-ep) | Expert-parallel communication and recovery. |
 | [TENT](tent/overview) | Next-generation transfer engine design. |
 | [TENT Benchmark](tent/tebench) | TENT benchmark framework and methodology. |

--- a/docs/source/design/mooncake-backend-pg.md
+++ b/docs/source/design/mooncake-backend-pg.md
@@ -1,210 +1,521 @@
-# Mooncake Backend (PG) Design
+# Mooncake PG Design
 
-Mooncake Backend is a `torch.distributed` ProcessGroup backend for Mooncake. It
-provides collective and point-to-point communication primitives, rank-health
-tracking, and elastic recovery hooks for inference systems that need to keep
-serving after partial rank failures.
+Mooncake PG is a communication library built on Mooncake Transfer Engine. It
+provides collective and P2P operations together with dynamic membership, fault
+tolerance, and recovery.
 
-This document is intended for developers who maintain Mooncake PG itself or
-integrate it into higher-level serving systems.
+## Dynamic Membership at a Glance
 
-## Goals
+If you are used to a fixed-membership process group, a natural mental model is
+that a group is simply _the set of ranks that were there when the group was
+created_. If the set changes, you create another group.
 
-Mooncake Backend is designed to:
+Mooncake PG uses a slightly different model. Think of a group as a **dinner
+table with numbered seats**.
 
-- integrate with PyTorch through the standard ProcessGroup extension mechanism;
-- expose `mooncake` for accelerator tensors and `mooncake-cpu` for CPU tensors;
-- support common collective APIs used by inference engines;
-- track active and inactive ranks so collectives can continue after failures;
-- allow replacement ranks to publish metadata, join an existing group, and be
-  activated by healthy ranks;
-- reuse Mooncake Transfer Engine and topology information for data movement.
+The table has a fixed number of seats, decided before dinner starts. During the
+meal, however, not every seat has to be occupied.
 
-Non-goals:
+A diner may leave, but the seat does not disappear. The other diners do not
+shuffle around to fill the gap; nobody gets a new seat number just because
+someone stepped away. Later, that diner may return to the same seat, or someone
+else may occupy it. New diners may also occupy seats that were reserved but
+never used.
 
-- It is not a drop-in replacement for every NCCL/Gloo behavior. Validate each
-  collective, dtype, and topology required by the application.
-- Elastic recovery is an explicit protocol. The backend does not silently add a
-  new process to all collectives without application coordination.
+So there are really two separate questions:
 
-## Relationship with `torch.distributed`
+- **How many seats does the table have?**
+- **Which seats are currently occupied and participating in the dinner?**
 
-Mooncake registers two PyTorch backends when the PG extension module is imported:
+The first stays fixed. The second may change over time.
 
-- `mooncake-cpu`, registered for CPU devices;
-- `mooncake`, registered for accelerator devices such as CUDA or MUSA depending
-  on the build.
+That is the basic intuition behind Mooncake PG's dynamic membership.
 
-The backend class itself derives from `c10d::ProcessGroup`. Applications use
-regular PyTorch APIs such as `dist.init_process_group()`, `dist.all_reduce()`,
-`dist.new_group()`, and `dist.batch_isend_irecv()`.
+### From the dinner table to Mooncake PG
 
-Point-to-point dispatch in PyTorch expects a `c10d::Backend` object. Mooncake PG
-therefore includes a lightweight P2P shim that delegates `send` and `recv` calls
-back to the owning `MooncakeBackend` instance.
+In Mooncake PG, the numbered seats correspond to **rank slots**. A group
+reserves a fixed number of rank slots when it is created, bounded by
+`max_group_size`. Which of those ranks currently participate in group
+operations is tracked separately by `active_ranks`.
 
-## Main runtime objects
+For example, a group can reserve eight rank slots while initially activating
+only four -- four diners at an eight-seat table:
 
-### `MooncakeBackendOptions`
-
-`MooncakeBackendOptions` carries Mooncake-specific process-group configuration:
-
-| Field | Meaning |
-| --- | --- |
-| `activeRanks_` | Rank-health tensor exposed to collectives and user code. |
-| `isExtension_` | Whether this process is a joining/replacement rank. |
-| `maxWorldSize_` | Optional reserved capacity for future ranks. |
-
-The `activeRanks_` tensor must be `torch.int32`. It must be on CPU for
-`mooncake-cpu` and on the accelerator device for `mooncake`. When
-`maxWorldSize_` is set, `activeRanks_` must be sized to `maxWorldSize_` so the
-backend can reserve inactive rank slots.
-
-### Transfer group metadata
-
-Each backend owns shared metadata for:
-
-- the current rank and backend index;
-- current capacity (`size`) and visible active size (`activeSize`);
-- host and device active-rank masks;
-- peer connection state;
-- rank-local and rank-global mapping;
-- store handles and extension state used by recovery;
-- P2P proxy and connection poller state.
-
-`size` is the reserved capacity. `activeSize` is the visible group size returned
-by `dist.get_world_size()`. With `max_world_size`, `size` may be larger than
-`activeSize`; inactive slots are masked out by the active-rank state.
-
-### Transfer Engine ownership
-
-By default, Mooncake Backend initializes its own Transfer Engine. Advanced
-integrations may call `pg.set_transfer_engine(engine)` before
-`init_process_group()` to inject an external Transfer Engine. In that mode, the
-caller owns the engine and must keep it alive until all Mooncake process groups
-using it are destroyed.
-
-## Initialization lifecycle
-
-The initialization flow is:
-
-1. Python imports `mooncake.pg`, which loads a PyTorch-version-specific native
-   extension.
-2. The extension registers `mooncake` / `mooncake-cpu` with PyTorch.
-3. `dist.init_process_group()` invokes the backend factory with PyTorch
-   distributed options and optional `MooncakeBackendOptions`.
-4. The backend initializes active-rank masks and reserved rank slots.
-5. Non-extension ranks publish local peer metadata and wait until current peers
-   are connected.
-6. Extension ranks enter local-only mode and wait for the explicit join protocol.
-
-The important distinction is that reserving capacity does not automatically make
-future ranks active. New ranks are masked until `recover_ranks()` activates them.
-
-## Active ranks and dynamic world size
-
-Mooncake PG tracks two related concepts:
-
-- **Reserved capacity** (`size`): how many rank slots the backend knows about.
-- **Visible active size** (`activeSize`): the current group size visible through
-  PyTorch APIs.
-
-When `max_world_size` is larger than the initial `world_size`, Mooncake reserves
-extra slots but marks them inactive. This lets healthy ranks poll for joiner
-metadata and activate the joiners later without reconstructing the process group.
-
-`extend_group_size_to(size)` can also increase capacity. Newly extended ranks
-start inactive; the application must call `get_peer_state()` and
-`recover_ranks()` before they participate in collectives.
-
-## Elastic recovery protocol
-
-Mooncake PG uses a two-phase protocol for recovery and scale-up:
-
-```mermaid
-sequenceDiagram
-    participant H as Healthy ranks
-    participant J as Joining rank
-    participant S as Store / metadata
-
-    H->>S: init_process_group(world_size=M, max_world_size=N)
-    J->>S: init_process_group(world_size=N, is_extension=True)
-    J->>S: publish local peer metadata
-    H->>S: get_peer_state(join_ranks)
-    H->>S: recover_ranks(join_ranks)
-    S-->>J: extension state
-    J->>J: join_group() returns
-    H->>J: collectives include recovered ranks
+```
+max_group_size = 8
+active_ranks = [1, 1, 1, 1, 0, 0, 0, 0]
 ```
 
-Healthy rank responsibilities:
+If rank 2 is later deactivated -- one diner leaves the table:
 
-1. Reserve capacity with `max_world_size` or `extend_group_size_to()`.
-2. Poll `get_peer_state(backend, ranks)` from all healthy ranks in a consistent
-   order.
-3. Call `recover_ranks(backend, ranks)` once candidate ranks are connected.
-4. Refresh higher-level components, such as Mooncake EP buffers, if they cache
-   transport metadata.
+```
+active_ranks = [1, 1, 0, 1, 0, 0, 0, 0]
+```
 
-Joining rank responsibilities:
+its rank slot remains reserved, and the other ranks are not renumbered -- the
+empty seat simply remains empty.
 
-1. Initialize the process group with `is_extension=True`.
-2. Publish local peer metadata through the backend initialization path.
-3. Call `join_group(backend)` and block until healthy ranks publish extension
-   state.
-4. Re-enter normal collectives after `join_group()` returns.
+Rank 4 may also subsequently become active without filling that hole:
 
-## Subgroup semantics
+```
+active_ranks = [1, 1, 0, 1, 1, 0, 0, 0]
+```
 
-Mooncake PG follows PyTorch process-group ordering requirements. All processes
-that participate in a parent group should call `dist.new_group()` in a consistent
-order. This is especially important for elastic subgroups because healthy ranks
-and joining ranks must agree on store prefixes and backend indices.
+The group keeps the same rank structure throughout these changes; only the set
+of active participants changes.
 
-For split-rank elastic patterns, create subgroups using the current membership
-on healthy ranks and the eventual membership on joining ranks, while preserving
-the same creation order. The PG elastic tests contain executable examples of this
-pattern.
+This design also extends naturally to fault tolerance and recovery. A failed
+rank can be removed from the active membership without reshaping the group,
+while a recovered rank can later rejoin through the same membership mechanism.
 
-## Collective behavior
+## Core Concepts
 
-Collectives use the backend active-rank state to skip inactive ranks. The exact
-implementation varies by operation and device type, but the high-level contract
-is:
+### Capacity and size
 
-- active ranks participate in the collective;
-- inactive ranks are not waited on;
-- if communication detects a rank failure, active-rank state can be updated;
-- user code can read the current mask with `pg.get_active_ranks(backend)`.
+Mooncake PG has capacity at two scopes:
 
-The backend currently implements common collective APIs including all-reduce,
-broadcast, all-gather, reduce-scatter, all-to-all, barrier, reduce, gather,
-scatter, and single-tensor P2P send/recv.
+- Process-level `max_world_size` bounds the number of ranks in the whole world.
+- Group-level `max_group_size` bounds the number of ranks in a group.
 
-## Failure and recovery boundaries
+Despite the name, a group's `size` is not the number of active members. It is
+one past the highest active in-group rank and therefore acts as a rank-index
+upper bound. For example:
 
-Mooncake PG exposes low-level recovery primitives; higher-level systems are
-responsible for policy decisions such as:
+```text
+active_ranks   = [1, 0, 1, 0]
+size           = 3
+max_group_size = 4
+```
 
-- which ranks are safe to replace;
-- when to stop routing traffic to a failed rank;
-- how to recreate model state on a replacement process;
-- when to refresh EP, scheduler, or application-level metadata;
-- how to coordinate subgroup recovery.
+User code that allocates rank-indexed buffers must cover at least `size`
+entries, including inactive holes below that bound. Per-group masks such as
+`active_ranks` and `failed_ranks_hint` span `max_group_size`.
 
-Avoid assuming that `recover_ranks()` alone reconstructs all higher-level state.
-It activates the process-group communication path; the application still owns
-model weights, KV-cache state, routing policy, and request scheduling.
+An extension rank before `joinGroup` (`Isolated` or `Quiescing`) is the
+exception: `getSize()` continues to report the group's declared size for
+PyTorch rank validation, even though its effective membership is temporarily
+`{self}`.
 
-## Testing checklist for PG changes
+Holes preserve rank numbers. So user code that needs the number of participants
+must count `active_ranks` rather than use `getSize()` or
+`dist.get_world_size()`.
 
-When modifying PG internals, run at least:
+### Rank namespaces
+
+A process has one `GlobalRank` in the world and may have a different
+`InGroupRank` in each group:
+
+- `GlobalRank` indexes the world-capacity namespace `[0, max_world_size)`.
+- `InGroupRank` indexes the group-capacity namespace `[0, max_group_size)`.
+
+The distinction matters whenever a group contains only part of the world or
+orders its ranks differently. Group-level operations, including
+`activate_ranks` and `deactivate_ranks`, use in-group ranks unless stated
+otherwise.
+
+### Rank state
+
+The Coordinator tracks a process-level `RankState`:
+
+| State     | Meaning                                                                                         |
+| --------- | ----------------------------------------------------------------------------------------------- |
+| `Offline` | No usable Agent session exists for this global rank.                                            |
+| `Synced`  | The Agent session is synchronized, but the rank is not in the current healthy set.              |
+| `Healthy` | The Agent session is synchronized and current link evidence places the rank in the healthy set. |
+
+A new Agent session moves a rank from `Offline` to `Synced`. Link evidence can
+promote it to `Healthy` or demote it back to `Synced`; losing the Agent session
+makes it `Offline`.
+
+The Coordinator combines link reports from all ranks to determine which ranks
+are `Healthy`. The healthy ranks must be connected to one another in both
+directions. A registered rank that does not meet these conditions remains
+`Synced`.
+
+`RankState` is independent of any group. It describes whether a process is
+ready for data-plane communication; participation in a particular group is
+described separately by group membership.
+
+### Group membership
+
+`rank_order` connects the two namespaces: it records the `GlobalRank` assigned
+to each `InGroupRank`. This is a stable slot assignment, not a list of current
+participants. Whether an assigned rank participates is recorded separately by
+its `GroupMemberState` and reflected in `active_ranks`.
+
+For example, suppose global ranks 2, 5, and 7 form a group with
+`max_group_size = 5`. Inside that group they are in-group ranks 0, 1, and 2, so
+`rank_order = [2, 5, 7]`. Calling `deactivate_ranks([1])` targets global rank 5:
+its member state becomes `Inactive`, `active_ranks` becomes
+`[1, 0, 1, 0, 0]`, and the rank order does not change.
+
+If global rank 9 is later added, it is assigned in-group rank 3 and the rank
+order becomes `[2, 5, 7, 9]`. Existing in-group ranks are never renumbered;
+new ranks extend the order, while unused group capacity remains unassigned.
+
+`GroupMemberState` has the following values:
+
+| State                | Meaning                                                                  |
+| -------------------- | ------------------------------------------------------------------------ |
+| `None`               | The rank has not registered with this group.                             |
+| `Inactive`           | The rank is registered but has not declared itself ready for activation. |
+| `AwaitingActivation` | The rank calls `join_group` and declares itself ready for activation.    |
+| `Active`             | The rank participates in collective operations.                          |
+| `Left`               | The rank unregistered from this group.                                   |
+
+Founding members become `Active` directly during group bootstrap. A joining
+member's activation follows `Inactive` → `AwaitingActivation` → `Active`.
+Deactivation returns an active member to `Inactive`.
+
+A `Healthy` rank is ready for data-plane communication, but it participates in
+a group only when its group member state is `Active`.
+
+Membership changes are checked against both kinds of state. To activate ranks,
+the group must be ready, every newly activated target must be
+`AwaitingActivation`, `Healthy`, and have a published endpoint, and every rank
+in the resulting active set must be mutually connected with every other rank in
+that set. An early activation request remains pending until these conditions
+hold or its admission timeout expires.
+
+## Architecture
+
+The data plane executes transfers directly through Mooncake Transfer Engine,
+while the control plane tracks processes, connectivity, endpoints, and
+committed membership.
+
+```mermaid
+flowchart LR
+    Framework[Framework] --> Torch[torch.distributed]
+
+    subgraph PG[Mooncake PG]
+        Comm[Communicator]
+        Agent[Agent]
+        Coordinator[Coordinator on rank 0]
+        Workers[Collective worker and P2P proxy]
+        Comm <--> Agent
+        Agent <--> Coordinator
+        Comm --> Workers
+    end
+
+    Torch --> Comm
+    Workers --> TE[Transfer Engine]
+```
+
+### Process context and communicators
+
+Each process has one Mooncake PG context. It owns or references the Transfer
+Engine and hosts an Agent and the process-wide worker managers; global rank 0
+also hosts the Coordinator.
+
+### Coordinator and Agents
+
+The Coordinator owns process `RankState` and each group's member states.
+It serializes membership changes and publishes them as `GroupView`s. Agents
+mirror those views and apply them to local communicators. Collective and P2P
+workers report link evidence; the Coordinator derives the mutually connected
+healthy set and decides the resulting state changes.
+
+The Coordinator currently runs on global rank 0 and is not highly available.
+
+### Collectives
+
+Collectives use a direct-write design over Transfer Engine. Each communicator
+registers their send, receive, and synchronization buffers.
+The worker records transfer failures in `failed_ranks_hint` and reports to the
+Agent; membership is not changed on the collective worker side.
+
+### P2P
+
+P2P send and receive use a receiver-driven, credit-based protocol. A receive
+operation reserves chunks from a receive pool and writes `CreditSlot`s to the
+sender. Each credit identifies the destination chunk and length. The sender
+then stages the corresponding data in a send-pool chunk, performs a TE write to
+that destination, and writes an `AckSlot` back. The receiver copies the
+acknowledged chunk into the user buffer and returns the chunk to the pool.
+
+Each communicator has per-peer operation queues and separate credit and
+acknowledgement rings. The control slots carry a group epoch and sequence
+number, and a matching header/footer token prevents a partially written slot
+from being consumed. Epoch checks discard control traffic left over from an
+older group view.
+
+The send and receive polling threads and their fixed-size chunk pools are
+shared by all communicators on the same device. Chunk allocation never blocks
+a polling thread. When a pool has no free chunk, the operation remains pending
+and the poller retries it later.
+A transfer error or timeout resets the affected peer lane and reports failure
+evidence through the same control-plane path as a collective failure.
+
+## Planned scaling
+
+This section describes planned scaling through Mooncake PG dynamic membership.
+
+### Scale-up
+
+The group must have enough unused `max_group_size` capacity. A joining process
+declares an extended rank order (also `is_extension=True` in the PyTorch
+integration). The existing group adopts the appended slots as inactive; this
+step alone never activates them.
+
+The later join and activation steps are:
+
+1. The joining rank starts in `Isolated` with an effective `{self}`
+   membership. This gives the upper layer framework a local-only window for
+   initialization and warmup before the rank can affect existing members.
+   Collectives in this state must not be interpreted as results from the
+   eventual group.
+2. When local preparation is complete, the joining rank calls `join_group`.
+   The call enters `Quiescing`, drains previously issued collective and P2P
+   work, marks the member `AwaitingActivation`, and waits.
+3. Any online rank calls `activate_ranks`. The Coordinator admits the request
+   only after the activation conditions described above hold for the complete
+   future active set. It distributes the new membership and waits for the
+   required ranks to apply it; both `join_group` and `activate_ranks` then
+   return.
+
+An activation request may arrive before `join_group`; it waits for the joining
+rank to become ready rather than bypassing the checks.
+
+### Scale-down
+
+After the upper layer framework stops issuing operations that use the old
+membership, any online rank can call `deactivate_ranks` for one or more in-group
+ranks. The Coordinator changes those members from `Active` to `Inactive`,
+distributes the new membership, and waits for acknowledgements from online
+ranks in the old or new active set before returning.
+
+Deactivation does not renumber slots or mark the target process
+unhealthy. Its Agent session and data-plane links remain available; to
+participate again, that process calls `join_group` and follows the normal
+activation path.
+
+## Fault tolerance
+
+### Failure handling
+
+A failed operation reports the caller's data-plane observations to the
+Coordinator; the worker itself does not make a membership decision. The two
+caller-visible results are:
+
+- `local_success`: whether all transfers required by this operation completed
+  at the caller. A successful local result is valid for that caller, but says
+  nothing about whether the operation completed at every other rank.
+- `failed_ranks_hint`: a per-operation bitmap of length `max_group_size`,
+  indexed by in-group rank. It records the ranks for which the caller observed
+  a transfer failure; a set bit is evidence, not a global conclusion that the
+  peer is faulty.
+
+Failure hints can differ across ranks. Workers submit such observations to the
+Coordinator instead of changing membership locally.
+
+#### Reconciliation and `sync_after_failure`
+
+Negative evidence opens a reconciliation window in the Coordinator, allowing
+reports from different ranks to arrive before a single decision is made. The
+window is 30 seconds by default and must be configured to exceed the default
+collective timeout. When the window closes, the Coordinator derives the
+mutually connected healthy set, updates `RankState`, and distributes the
+result. For groups with auto-deactivation enabled, it also changes unhealthy
+active members to `Inactive`.
+
+`sync_after_failure` is both a reporting path and a synchronization point. Its
+request piggybacks the Agent's current, unacknowledged link observations. If the
+caller has just observed `local_success=false`, those observations can open or
+join the Coordinator's reconciliation window. The call then waits for any
+pending reconciliation and applies the group view returned by
+the Coordinator.
+
+With `auto_deactivate_on_failure=true`, a successful return means that the
+caller has applied the membership produced by reconciliation. Its local
+`active_ranks` therefore reflects the Coordinator's deactivation decision, and
+locally cached readiness queries such as `get_peer_state` are based on the
+reconciled state.
+
+With auto-deactivation disabled, reconciliation does not remove members, so
+the membership in the returned view may be unchanged.
+
+#### Failure-handling modes
+
+The two options control different parts of the failure path:
+
+- `auto_deactivate_on_failure` selects who owns failure-driven membership
+  changes: Mooncake PG or the upper layer framework.
+- `auto_sync_on_failure` selects whether a failed collective or P2P operation
+  calls `sync_after_failure` automatically before it completes. It does not
+  control whether the Coordinator reconciles observations or automatically
+  changes membership.
+
+With auto-deactivation disabled, an unhealthy rank may remain active. An
+`Offline` rank rejects new operations locally, whereas a `Synced` but unhealthy
+rank may still issue them. Successful transfers provide positive link evidence
+and can return a `Synced` rank to `Healthy`.
+
+There are three valid configurations.
+
+##### PG-managed, synchronized (default)
+
+```text
+auto_deactivate_on_failure = true
+auto_sync_on_failure       = true
+```
+
+After a local transfer failure, the operation reports its observations and
+automatically enters `sync_after_failure`. The Coordinator reconciles rank
+state, deactivates unhealthy members, and returns the resulting view; the
+caller applies that view before the failed operation completes. The framework
+does not need a separate synchronization or deactivation step.
+
+This is the safest and simplest mode, but it deliberately puts control-plane
+latency on the failure-completion path. A negative observation opens a
+reconciliation window, so the failed operation may remain pending for tens of
+seconds while the Coordinator reconciles reports from different ranks.
+
+##### PG-managed, deferred synchronization
+
+```text
+auto_deactivate_on_failure = true
+auto_sync_on_failure       = false
+```
+
+Mooncake PG still reconciles observations and owns the failure-driven
+deactivation decision. The difference is that the operation returns after its
+data-plane work finishes and exposes `local_success` and `failed_ranks_hint`
+without waiting for the reconciliation window. The framework may perform
+other work first and call `sync_after_failure` later, before relying on the new
+membership or resuming communication on the group.
+
+This mode is useful because `local_success` and `failed_ranks_hint` are
+data-plane results, whereas reconciliation is a much slower control-plane
+operation. It separates failure notification from membership synchronization
+without transferring the membership decision back to the framework.
+
+##### Framework-managed
+
+```text
+auto_deactivate_on_failure = false
+auto_sync_on_failure       = false
+```
+
+The failed operation returns its local evidence without changing membership.
+The framework observes failures through `local_success` and
+`failed_ranks_hint`, chooses the ranks to remove, and then calls
+`deactivate_ranks`.
+
+##### Invalid combination
+
+```text
+auto_deactivate_on_failure = false
+auto_sync_on_failure       = true
+```
+
+This combination is rejected at construction. Automatic synchronization is
+meaningful only when Mooncake PG also owns failure-driven deactivation;
+otherwise synchronization cannot produce an automatically updated membership
+for the failed operation.
+
+This restriction applies only to automatic synchronization.
+`sync_after_failure` may still be called manually in any mode, including when
+`auto_deactivate_on_failure=false`. The call also acts as an explicit pull of
+the Coordinator's latest group view, rather than relying only on pushed view
+updates. The framework can therefore obtain a current view while retaining its
+own deactivation policy.
+
+### Recovery
+
+A replacement process and a same-process in-place rejoin are separate ways to
+bring an inactive slot back. Both reuse the scale-up flow: restored
+connectivity can make a rank `Healthy`, but rejoining membership still requires
+`join_group` and activation.
+
+#### Replacement process
+
+A replacement registers a new Agent session for the same global rank. The
+Coordinator increments the rank epoch and invalidates the old process's link
+evidence and endpoints. The replacement recreates its local communicators in
+extension mode, starts at `Synced`, may perform local warmup while isolated,
+and then follows the normal join and activation flow.
+
+#### In-place rejoin
+
+In-place rejoin applies when the process and its control-plane session remain
+alive but the rank has become inactive, commonly after a transient data-plane
+failure. Once connectivity recovers, the Coordinator can mark the rank
+`Healthy` again. The same process calls `join_group`, drains old
+work, republishes the endpoint under a fresh epoch, and
+waits for activation. No process restart is required.
+
+## Integration
+
+### Choosing an integration model
+
+An integration combines two independent choices: how planned scaling changes
+the communication group, and who owns failure-driven deactivation.
+
+For planned scaling, framework-level group replacement creates another group
+and switches to it, so it works with a fixed-membership CCL. Mooncake PG dynamic
+membership instead keeps the same group and changes its active ranks.
+
+For failure handling, `auto_deactivate_on_failure` determines ownership. When
+it is `true`, Mooncake PG owns deactivation; when it is `false`, the framework
+does. `auto_sync_on_failure` is separate from ownership: it only controls
+whether a failed operation invokes `sync_after_failure` automatically and waits
+for any pending reconciliation before completing.
+
+The table below summarizes the four supported combinations:
+
+| Scaling × Failure mode                                                                   | **PG-managed membership**<br><span style="font-weight: normal;">PG reconciles and deactivates</span>                                                                                                                                                                                 | **Framework-managed membership**<br><span style="font-weight: normal;">Framework synchronizes and decides </span>                                                                                                                                                                              |
+| ---------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Mooncake PG dynamic membership**<br>Keep the current group and change its active ranks | Mooncake PG commits requested scaling changes and handles failure-driven deactivation in the existing group. This fits a lean integration with minimal membership orchestration and no group rebuilds.  | The group stays in place, while the framework synchronizes after failures and submits its own deactivation decisions. This fits applications that need direct control over group membership; it uses dynamic membership without group rebuilds, but requires an explicit failure-control path. |
+| **Framework-level group replacement**<br>Create a standby/new group and switch to it     | The framework switches groups for planned scaling, while Mooncake PG handles failure-driven deactivation in the current group. This fits an existing standby-group design with minimal failure orchestration; planned scaling still incurs the cost of group creation and switching. | The framework's control plane manages both replacement groups and failure policy. This fits frameworks that already manage group lifecycle and failure policy centrally; it offers the most flexibility but requires the most orchestration.                                                      |
+
+### Interfaces
+
+Mooncake PG exposes a PyTorch integration and an experimental C API.
+
+Importing `mooncake.pg` registers two `torch.distributed` backends:
+
+- `mooncake-cpu` for CPU devices;
+- `mooncake` for the accelerator supported by the build.
+
+`MooncakeBackend` derives from `c10d::ProcessGroup`, so applications use the
+usual PyTorch entry points, including `dist.init_process_group()`,
+`dist.new_group()`, `dist.all_reduce()`, and `dist.batch_isend_irecv()`.
+Mooncake-specific capacity, extension, and failure-handling options are passed
+through `MooncakeBackendOptions`.
+
+PyTorch dispatches P2P operations and some collective entry points through a
+`c10d::Backend` object. Each `MooncakeBackend` therefore registers a lightweight
+`MooncakeBackendShim` that forwards supported operations back to its owning
+`MooncakeBackend`.
+See the [Python API](../api-reference/python/ep-backend.md) for
+initialization examples and API details.
+
+Non-PyTorch integrations can use the experimental C API declared in
+[`mooncake_pg.h`](https://github.com/kvcache-ai/Mooncake/blob/main/mooncake-pg/include/mooncake_pg.h).
+
+## Contributing
+
+The PG tests are the executable contracts for current behavior:
+
+| Test file                          | Contract covered                                                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `test_pg_init_functional.py`       | Initialization, single rank, subgroup creation, destruction, and reinitialization                                                    |
+| `test_pg_collectives.py`           | Collective coverage                                                                                                                  |
+| `test_pg_p2p.py`                   | Direct and batched P2P, ordering, multiple senders, and failure detection                                                            |
+| `test_pg_elastic.py`               | Automatic and manual failure handling, scale-up, process replacement, graceful leave, subgroup extension, holes, and in-place rejoin |
+| `test_pg_inference_topologies.py`  | TP, PP, DP, EP, and prefill/decode group layouts                                                                                     |
+| `test_pg_inference_collectives.py` | Traffic across inference-style groups                                                                                                |
+
+Run tests from the repository root:
 
 ```bash
-# CPU functional tests
+# Run all PG tests
+python -m unittest discover -s mooncake-pg/tests -v
+
+# Run CPU-only PG tests
 python -m unittest discover -s mooncake-pg/tests -k CPU -v
 
-# CUDA functional tests, when GPUs are available
+# Run CUDA PG tests
 python -m unittest discover -s mooncake-pg/tests -k CUDA -v
 
 # Collective benchmark smoke test
@@ -213,9 +524,8 @@ python mooncake-pg/benchmark/pgbench.py \
   --collective all_reduce --backend mooncake --device cuda -g 2 -b 8 -e 1M -f 2
 ```
 
-Also run elastic tests for changes that touch active ranks, metadata polling,
-subgroups, `extend_group_size_to()`, `get_peer_state()`, `recover_ranks()`, or
-`join_group()`.
+Set `MOONCAKE_PGTEST_DEVICE_FILTERS` to a comma-separated NIC/HCA list when the
+test environment needs explicit device selection.
 
 ## Related documentation
 

--- a/docs/source/design/mooncake-ep.md
+++ b/docs/source/design/mooncake-ep.md
@@ -16,7 +16,7 @@ Mooncake EP is designed to:
 - keep the Python programming model close to DeepEP low-latency mode;
 - use Mooncake device transports for fast intra-node and inter-node movement;
 - detect failed source ranks through timeout-aware kernels;
-- interoperate with Mooncake Backend (PG) for bootstrap metadata exchange and
+- interoperate with Mooncake PG for bootstrap metadata exchange and
   rank-health state.
 
 ## High-level data flow
@@ -242,6 +242,6 @@ Adapt launch commands to the target environment and number of GPUs.
 
 ## Related documentation
 
-- [Mooncake Backend (PG) design](mooncake-backend-pg.md)
+- [Mooncake PG design](mooncake-backend-pg.md)
 - [Python API reference](../api-reference/python/ep-backend.md)
 - [PG/EP troubleshooting](../troubleshooting/pg-ep-troubleshooting.md)

--- a/docs/source/troubleshooting/pg-ep-troubleshooting.md
+++ b/docs/source/troubleshooting/pg-ep-troubleshooting.md
@@ -1,7 +1,7 @@
 # Mooncake PG/EP Troubleshooting
 
 This page covers common setup, import, runtime, and recovery issues for
-Mooncake Backend (PG) and Mooncake EP.
+Mooncake PG and Mooncake EP.
 
 ## Import fails with a PyTorch version error
 
@@ -41,80 +41,25 @@ Fixes:
 3. Make sure the Python environment used at runtime is the same one used for the
    build.
 
-## `activeRanks must be int` or device mismatch
+## `dist.get_world_size()` differs from the number of active ranks
 
-Symptoms:
+Mooncake PG preserves stable in-group rank slots. Consequently:
 
-```text
-activeRanks must be int.
-activeRanks must be on CPU.
-activeRanks must be on GPU.
-activeRanks must be sized to max_world_size when max_world_size is set
-```
-
-Causes and fixes:
-
-- Use `torch.int32`, not `bool`, `int64`, or floating-point types.
-- For `backend="mooncake"`, put `active_ranks` on the accelerator device.
-- For `backend="mooncake-cpu"`, put `active_ranks` on CPU.
-- If `max_world_size` is set, allocate `active_ranks` with length
-  `max_world_size`, even if the initial visible `world_size` is smaller.
-
-Examples:
-
-```python
-# CUDA / accelerator backend
-active_ranks = torch.ones(max_world_size, dtype=torch.int32, device="cuda")
-
-# CPU backend
-active_ranks = torch.ones(max_world_size, dtype=torch.int32)
-```
-
-## `dist.get_world_size()` is smaller than `max_world_size`
-
-This is expected. Mooncake PG distinguishes reserved capacity from visible active
-membership:
-
-- `max_world_size` reserves future rank slots.
-- `dist.get_world_size()` returns the visible active size.
-- Reserved ranks are inactive until `recover_ranks()` activates them.
+- `max_group_size` is the fixed slot capacity;
+- `dist.get_world_size()` is the highest active in-group rank plus one;
+- holes below that extent remain visible in the rank space but are skipped by
+  the active mask.
 
 Use `pg.get_active_ranks(backend)` to inspect the current backend mask.
 
-## `get_peer_state()` or `join_group()` hangs
+## `join_group()` hangs or activation times out
 
 Common causes:
 
-- Healthy ranks are not all calling `get_peer_state()` in the same order.
-- The joining rank did not initialize with `is_extension=True`.
-- `max_world_size` / rank numbering differs between healthy and joining ranks.
-- Subgroups were created in different orders on healthy and joining processes.
-- The joining process has not published peer metadata yet.
-- Network device filters differ across ranks.
-
-Debug checklist:
-
-1. Confirm all ranks use the same rendezvous address and store.
-2. Print rank, visible `world_size`, and `max_world_size` at initialization.
-3. Confirm `active_ranks` length and values on every rank.
-4. Verify healthy ranks poll the same `join_ranks` list.
-5. For subgroup recovery, confirm every rank calls `dist.new_group()` in the same
-   order.
-6. If using RDMA, set the same HCA whitelist on every rank.
-
-## Newly extended ranks participate too early
-
-After `pg.extend_group_size_to(backend, new_size)`, new ranks are reserved but
-inactive. They should not participate in collectives until healthy ranks call
-`pg.recover_ranks(backend, ranks)`.
-
-If a new rank appears to participate early, check whether:
-
-- `active_ranks` was initialized with `1` for future ranks without masking them
-  through the backend protocol;
-- the application called collectives on the joining process before
-  `pg.join_group()` returned;
-- different ranks used inconsistent `max_world_size` or rank IDs.
+- No existing rank submitted `activate_ranks()` / `recover_ranks()` after the
+  joining process entered `join_group()`.
+- The future active set is not mutually connected, so the activation proposal
+  remains pending until timeout.
 
 ## EP dispatch/combine timeout marks a rank inactive
 


### PR DESCRIPTION
## Description

Recent changes to Mooncake PG have made parts of the existing documentation outdated. This PR rewrites the PG design documentation to reflect the current architecture and behavior, and updates the related API reference and troubleshooting documentation.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The documentation was built and previewed locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)



Codex helped draft and refine the documentation.