### PR TITLE
[TENT] Add RDMA direct path for latency-sensitive transfers [WIP]

### DIFF
--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -28,8 +28,6 @@
 
 using namespace mooncake::tent;
 
-namespace {
-
 uint64_t steadyClockNs() {
     const auto now = std::chrono::steady_clock::now().time_since_epoch();
     return std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
@@ -39,8 +37,6 @@ double gbPerSecond(uint64_t bytes, double duration_us) {
     if (duration_us <= 0.0) return 0.0;
     return static_cast<double>(bytes) / (1000.0 * duration_us);
 }
-
-}  // namespace
 
 int processBatchSizes(
     BenchRunner& runner, size_t block_size, size_t batch_size, int num_threads,

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -22,7 +22,25 @@
 #include "tent_backend.h"
 #endif
 
+#include <atomic>
+#include <mutex>
+#include <thread>
+
 using namespace mooncake::tent;
+
+namespace {
+
+uint64_t steadyClockNs() {
+    const auto now = std::chrono::steady_clock::now().time_since_epoch();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now).count();
+}
+
+double gbPerSecond(uint64_t bytes, double duration_us) {
+    if (duration_us <= 0.0) return 0.0;
+    return static_cast<double>(bytes) / (1000.0 * duration_us);
+}
+
+}  // namespace
 
 int processBatchSizes(
     BenchRunner& runner, size_t block_size, size_t batch_size, int num_threads,
@@ -46,6 +64,17 @@ int processBatchSizes(
     XferBenchStats tight_stats;
     XferBenchStats loose_stats;
     std::mutex mutex;
+    std::atomic<int> measurement_ready{0};
+    std::atomic<bool> measurement_started{false};
+    auto paceRequest = [&]() {
+        if (XferBenchConfig::request_interval_us == 0) return;
+        const uint64_t interval_ns =
+            XferBenchConfig::request_interval_us * 1000ull;
+        const uint64_t target_ns = steadyClockNs() + interval_ns;
+        while (steadyClockNs() < target_ns) {
+            std::this_thread::yield();
+        }
+    };
     size_t address_stride_bytes =
         XferBenchConfig::max_block_size * XferBenchConfig::max_batch_size;
     if (!workload_classes.empty()) {
@@ -94,24 +123,41 @@ int processBatchSizes(
                                      thread_batch_size, opcode, deadlineNs(),
                                      intent_type);
         }
+        if (measurement_ready.fetch_add(1, std::memory_order_acq_rel) + 1 ==
+            num_threads) {
+            measurement_started.store(true, std::memory_order_release);
+        } else {
+            while (!measurement_started.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+        }
         timer.reset();
         std::vector<double> transfer_duration;
+        std::vector<double> thread_instant_bandwidth;
         if (mixed_opcode) {
             while (timer.lap_us(false) <
                    XferBenchConfig::duration * 1000000ull) {
+                const uint64_t batch_bytes =
+                    thread_block_size * thread_batch_size;
                 uint8_t pattern = 0;
                 if (XferBenchConfig::check_consistency)
                     pattern = fillData((void*)local_addr,
                                        thread_block_size * thread_batch_size);
+                paceRequest();
                 auto val = runner.runSingleTransfer(
                     local_addr, target_addr, thread_block_size,
                     thread_batch_size, WRITE, deadlineNs(), intent_type);
+                thread_instant_bandwidth.push_back(
+                    gbPerSecond(batch_bytes, val));
                 transfer_duration.push_back(val);
                 fillData((void*)local_addr,
                          thread_block_size * thread_batch_size);
+                paceRequest();
                 val = runner.runSingleTransfer(
                     local_addr, target_addr, thread_block_size,
                     thread_batch_size, READ, deadlineNs(), intent_type);
+                thread_instant_bandwidth.push_back(
+                    gbPerSecond(batch_bytes, val));
                 if (XferBenchConfig::check_consistency)
                     verifyData((void*)local_addr,
                                thread_block_size * thread_batch_size, pattern);
@@ -120,9 +166,14 @@ int processBatchSizes(
         } else {
             while (timer.lap_us(false) <
                    XferBenchConfig::duration * 1000000ull) {
+                const uint64_t batch_bytes =
+                    thread_block_size * thread_batch_size;
+                paceRequest();
                 auto val = runner.runSingleTransfer(
                     local_addr, target_addr, thread_block_size,
                     thread_batch_size, opcode, deadlineNs(), intent_type);
+                thread_instant_bandwidth.push_back(
+                    gbPerSecond(batch_bytes, val));
                 transfer_duration.push_back(val);
             }
         }
@@ -130,9 +181,12 @@ int processBatchSizes(
         std::lock_guard<std::mutex> lock(mutex);
         stats.total_duration.add(total_duration);
         stats.transfer_duration.add(transfer_duration);
+        stats.instant_bandwidth.add(thread_instant_bandwidth);
         if (qos_enabled) {
             qos_stats[qos_class].total_duration.add(total_duration);
             qos_stats[qos_class].transfer_duration.add(transfer_duration);
+            qos_stats[qos_class].instant_bandwidth.add(
+                thread_instant_bandwidth);
         }
         auto& group_stats = tight ? tight_stats : loose_stats;
         group_stats.total_duration.add(total_duration);

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -55,6 +55,15 @@ int processBatchSizes(
         exit(EXIT_FAILURE);
     }
 
+    IntentType sweep_intent_type = IntentType::INTENT_UNSPEC;
+    if (workload_classes.empty() &&
+        !parseBenchIntentType(XferBenchConfig::tent_intent_type,
+                              &sweep_intent_type)) {
+        LOG(ERROR) << "Invalid --tent_intent_type="
+                   << XferBenchConfig::tent_intent_type;
+        return -1;
+    }
+
     XferBenchStats stats;
     std::vector<XferBenchStats> qos_stats(qos_classes.size());
     XferBenchStats tight_stats;
@@ -98,7 +107,7 @@ int processBatchSizes(
         const size_t thread_batch_size =
             workload ? workload->batch_size : batch_size;
         const IntentType intent_type =
-            workload ? workload->intent_type : IntentType::INTENT_UNSPEC;
+            workload ? workload->intent_type : sweep_intent_type;
         const bool tight = XferBenchConfig::deadline_us > 0 &&
                            thread_id < XferBenchConfig::deadline_tight_threads;
         auto deadlineNs = [&]() -> uint64_t {
@@ -301,6 +310,11 @@ int main(int argc, char* argv[]) {
     if (XferBenchConfig::deadline_us > 0 &&
         XferBenchConfig::backend != "tent") {
         LOG(ERROR) << "deadline tagging is supported only by the tent backend";
+        return EXIT_FAILURE;
+    }
+    if (XferBenchConfig::tent_intent_type != "unspec" &&
+        XferBenchConfig::backend != "tent") {
+        LOG(ERROR) << "--tent_intent_type is supported only by the tent backend";
         return EXIT_FAILURE;
     }
     if (!workload_classes.empty() &&

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -14,6 +14,7 @@
 
 #include "tent_backend.h"
 #include "utils.h"
+#include "workload_config.h"
 #include "char_util.h"
 #include "tent/common/types.h"
 #include "tent/runtime/platform.h"
@@ -92,26 +93,6 @@ static TransportType getTransportType(const std::string& xport_type) {
     if (xport_type == "iouring") return IOURING;
     if (xport_type == "sunrise_link") return SUNRISE_LINK;
     return UNSPEC;
-}
-
-static IntentType getIntentType(const std::string& intent_type) {
-    std::string normalized_intent = intent_type;
-    for (auto& c : normalized_intent) c = to_lower(c);
-
-    static const std::unordered_map<std::string, IntentType> kIntentTypes = {
-        {"unspec", IntentType::INTENT_UNSPEC},
-        {"intent_unspec", IntentType::INTENT_UNSPEC},
-        {"foreground_get", IntentType::FOREGROUND_GET},
-        {"background_prefetch", IntentType::BACKGROUND_PREFETCH},
-        {"migration", IntentType::MIGRATION},
-        {"checkpoint", IntentType::CHECKPOINT},
-        {"weight_loading", IntentType::WEIGHT_LOADING},
-        {"staging_internal", IntentType::STAGING_INTERNAL},
-    };
-    auto it = kIntentTypes.find(normalized_intent);
-    LOG_ASSERT(it != kIntentTypes.end())
-        << "Invalid --tent_intent_type=" << intent_type;
-    return it->second;
 }
 
 // Resolve device prefix, start index, and buffer count for a single seg_type.
@@ -293,7 +274,9 @@ TENTBenchRunner::TENTBenchRunner() {
     signal(SIGTERM, signalHandlerV1);
     engine_ = std::make_unique<TransferEngine>(loadConfig());
     transport_hint_ = parseTransportType(XferBenchConfig::tent_transport_hint);
-    intent_type_ = getIntentType(XferBenchConfig::tent_intent_type);
+    LOG_ASSERT(parseBenchIntentType(XferBenchConfig::tent_intent_type,
+                                    &intent_type_))
+        << "Invalid --tent_intent_type=" << XferBenchConfig::tent_intent_type;
     allocateBuffers();
 }
 

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -214,7 +214,6 @@ void printStats(size_t block_size, size_t batch_size, XferBenchStats& stats,
     auto num_ops = stats.transfer_duration.count();
     double total_duration = stats.total_duration.avg();
     total_data_transferred = ((block_size * batch_size) * num_ops);
-    avg_latency = (total_duration * num_threads / num_ops);
     throughput_gb = (((double)total_data_transferred / (1000 * 1000 * 1000)) /
                      (total_duration / 1e6));  // In GB/Sec
     const double avg_instant_gbps = stats.instant_bandwidth.avg();

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -60,6 +60,9 @@ DEFINE_double(qos_link_capacity_gbps, 0.0,
               "Link capacity in GB/s for total utilization (0 reports N/A).");
 DEFINE_string(qos_output_jsonl, "",
               "Append versioned QoS metric records to this JSONL file.");
+DEFINE_uint64(request_interval_us, 0,
+              "Per-thread delay before issuing each transfer batch, in "
+              "microseconds. 0 disables pacing.");
 DEFINE_uint64(deadline_us, 0,
               "tent only: relative per-transfer deadline in microseconds for "
               "tight worker threads (0 disables deadline tagging); cannot be "
@@ -115,6 +118,7 @@ std::string XferBenchConfig::qos_classes_json;
 std::string XferBenchConfig::workload_classes_json;
 double XferBenchConfig::qos_link_capacity_gbps = 0.0;
 std::string XferBenchConfig::qos_output_jsonl;
+uint64_t XferBenchConfig::request_interval_us = 0;
 uint64_t XferBenchConfig::deadline_us = 0;
 int XferBenchConfig::deadline_tight_threads = 0;
 bool XferBenchConfig::deadline_bw_arbitration = false;
@@ -151,6 +155,7 @@ void XferBenchConfig::loadFromFlags() {
     workload_classes_json = FLAGS_workload_classes_json;
     qos_link_capacity_gbps = FLAGS_qos_link_capacity_gbps;
     qos_output_jsonl = FLAGS_qos_output_jsonl;
+    request_interval_us = FLAGS_request_interval_us;
     deadline_us = FLAGS_deadline_us;
     deadline_tight_threads = FLAGS_deadline_tight_threads;
     deadline_bw_arbitration = FLAGS_deadline_bw_arbitration;
@@ -191,7 +196,8 @@ void printStatsHeader() {
     std::cout << std::left
               << std::setw(14) << "BlkSize (B)"
               << std::setw(8) << "Batch"
-              << std::setw(14) << "BW (GB/S)"
+              << std::setw(14) << "BW (GB/s)"
+              << std::setw(18) << "Avg Inst GB/s"
               << std::setw(14) << "Avg Lat (us)"
               << std::setw(14) << "Avg Tx (us)"
               << std::setw(14) << "P99 Tx (us)"
@@ -211,6 +217,11 @@ void printStats(size_t block_size, size_t batch_size, XferBenchStats& stats,
     avg_latency = (total_duration * num_threads / num_ops);
     throughput_gb = (((double)total_data_transferred / (1000 * 1000 * 1000)) /
                      (total_duration / 1e6));  // In GB/Sec
+    const double avg_instant_gbps = stats.instant_bandwidth.avg();
+    if (avg_instant_gbps > 0.0) {
+        avg_latency = static_cast<double>(block_size * batch_size) /
+                      (avg_instant_gbps * 1000.0);
+    }
 
     // Tabulate print with fixed width for each string
     // clang-format off
@@ -218,6 +229,7 @@ void printStats(size_t block_size, size_t batch_size, XferBenchStats& stats,
               << std::setw(14) << block_size
               << std::setw(8)  << batch_size
               << std::setw(14) << throughput_gb
+              << std::setw(18) << avg_instant_gbps
               << std::setprecision(1)
               << std::setw(14) << avg_latency
               << std::setw(14) << stats.transfer_duration.avg()

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -76,6 +76,7 @@ struct XferBenchConfig {
     static std::string workload_classes_json;
     static double qos_link_capacity_gbps;
     static std::string qos_output_jsonl;
+    static uint64_t request_interval_us;
     static uint64_t deadline_us;
     static int deadline_tight_threads;
     static bool deadline_bw_arbitration;
@@ -147,6 +148,7 @@ struct XferMetricStats {
 struct XferBenchStats {
     XferMetricStats total_duration;
     XferMetricStats transfer_duration;
+    XferMetricStats instant_bandwidth;
 };
 
 class XferBenchTimer {

--- a/mooncake-transfer-engine/benchmark/workload_config.cpp
+++ b/mooncake-transfer-engine/benchmark/workload_config.cpp
@@ -15,6 +15,7 @@
 #include "workload_config.h"
 
 #include <algorithm>
+#include <cctype>
 #include <limits>
 #include <unordered_map>
 
@@ -22,9 +23,15 @@
 
 namespace mooncake {
 namespace tent {
-namespace {
 
-bool parseIntentType(const std::string& value, IntentType* intent_type) {
+static std::string normalizeIntentTypeName(std::string value) {
+    for (auto& c : value) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return value;
+}
+
+bool parseBenchIntentType(const std::string& value, IntentType* intent_type) {
     static const std::unordered_map<std::string, IntentType> kIntentTypes = {
         {"unspec", IntentType::INTENT_UNSPEC},
         {"intent_unspec", IntentType::INTENT_UNSPEC},
@@ -35,15 +42,15 @@ bool parseIntentType(const std::string& value, IntentType* intent_type) {
         {"weight_loading", IntentType::WEIGHT_LOADING},
         {"staging_internal", IntentType::STAGING_INTERNAL},
     };
-    const auto it = kIntentTypes.find(value);
+    const auto it = kIntentTypes.find(normalizeIntentTypeName(value));
     if (it == kIntentTypes.end()) return false;
     *intent_type = it->second;
     return true;
 }
 
-bool parsePositiveSize(const nlohmann::json& node, const char* field,
-                       const std::string& path, size_t* result,
-                       std::string* error) {
+static bool parsePositiveSize(const nlohmann::json& node, const char* field,
+                              const std::string& path, size_t* result,
+                              std::string* error) {
     if (!node.contains(field) || !node[field].is_number_unsigned()) {
         *error = path + "." + field + " must be an unsigned integer";
         return false;
@@ -56,8 +63,6 @@ bool parsePositiveSize(const nlohmann::json& node, const char* field,
     *result = static_cast<size_t>(value);
     return true;
 }
-
-}  // namespace
 
 bool parseWorkloadClassesJson(const std::string& spec,
                               std::vector<WorkloadClassConfig>* classes,
@@ -100,8 +105,8 @@ bool parseWorkloadClassesJson(const std::string& spec,
             }
             if (!node.contains("intent_type") ||
                 !node["intent_type"].is_string() ||
-                !parseIntentType(node["intent_type"].get<std::string>(),
-                                 &config.intent_type)) {
+                !parseBenchIntentType(node["intent_type"].get<std::string>(),
+                                      &config.intent_type)) {
                 *error = path + ".intent_type is invalid";
                 return false;
             }

--- a/mooncake-transfer-engine/benchmark/workload_config.h
+++ b/mooncake-transfer-engine/benchmark/workload_config.h
@@ -34,6 +34,8 @@ struct WorkloadClassConfig {
     IntentType intent_type = IntentType::INTENT_UNSPEC;
 };
 
+bool parseBenchIntentType(const std::string& value, IntentType* intent_type);
+
 bool parseWorkloadClassesJson(const std::string& spec,
                               std::vector<WorkloadClassConfig>* classes,
                               std::string* error);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -47,11 +47,12 @@ struct BootstrapDesc {
     std::string local_gid;
     std::string reply_msg;       // on error
     uint32_t notify_qp_num = 0;  // Notification QP number (0 = not supported)
+    uint32_t direct_qp_num = 0;  // Foreground direct QP number (0 = unsupported)
 
    public:
     NLOHMANN_DEFINE_TYPE_INTRUSIVE(BootstrapDesc, local_nic_path, peer_nic_path,
                                    qp_num, local_lid, local_gid, reply_msg,
-                                   notify_qp_num);
+                                   notify_qp_num, direct_qp_num);
 };
 
 struct XferDataDesc {

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/buffers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/buffers.h
@@ -15,10 +15,13 @@
 #ifndef TENT_BUFFERS_H
 #define TENT_BUFFERS_H
 
+#include <algorithm>
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <shared_mutex>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -78,6 +81,32 @@ struct BufferQueryResult {
     uint32_t rkey;
     int device_id;
 };
+
+static inline std::string bufferLocationForRange(const BufferDesc &buffer,
+                                                 uint64_t addr,
+                                                 uint64_t length) {
+    std::string location = buffer.location;
+    if (!buffer.regions.empty()) {
+        uint64_t offset = buffer.addr;
+        uint64_t best_overlap = 0;
+        uint64_t target_start = addr;
+        uint64_t target_end = addr + length;
+        for (const auto &entry : buffer.regions) {
+            uint64_t region_start = offset;
+            uint64_t region_end = offset + entry.size;
+            uint64_t overlap_start = std::max(region_start, target_start);
+            uint64_t overlap_end = std::min(region_end, target_end);
+            uint64_t overlap =
+                (overlap_end > overlap_start) ? overlap_end - overlap_start : 0;
+            if (overlap > best_overlap) {
+                best_overlap = overlap;
+                location = entry.location;
+            }
+            offset += entry.size;
+        }
+    }
+    return location;
+}
 
 class LocalBufferManager {
    public:

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -42,6 +42,7 @@ class RdmaCQ;
 class RdmaEndPoint;
 class EndpointStore;
 class RdmaTransport;
+struct RdmaTask;
 
 class RdmaContext {
     friend class RdmaCQ;
@@ -121,6 +122,14 @@ class RdmaContext {
     // Notification CQ (dedicated for notification QPs)
     RdmaCQ *notifyCq() { return notify_cq_; }
 
+    // Dedicated foreground CQ. Worker threads do not poll this CQ; callers
+    // drive it through getTransferStatus().
+    RdmaCQ *directCq() { return direct_cq_; }
+
+    bool tryAcquireDirectLane(RdmaTask *task);
+
+    void releaseDirectLane(RdmaTask *task);
+
    private:
     int openDevice(const std::string &device_name, uint8_t port);
 
@@ -157,6 +166,8 @@ class RdmaContext {
 
     // Dedicated CQ for notification QPs (one per device)
     RdmaCQ *notify_cq_ = nullptr;
+    RdmaCQ *direct_cq_ = nullptr;
+    std::atomic<RdmaTask *> direct_lane_owner_{nullptr};
 
     // PCIe Relaxed Ordering support
     bool relaxed_ordering_enabled_ = false;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -129,6 +129,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     // Notification QP operations
     uint32_t notifyQpNum() const { return notify_qp_ ? notify_qp_->qp_num : 0; }
+    uint32_t directQpNum() const { return direct_qp_ ? direct_qp_->qp_num : 0; }
 
     bool sendNotification(const std::string& name, const std::string& msg);
 
@@ -157,6 +158,10 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
     int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index);
 
+    Status submitDirectSlice(RdmaSlice* slice);
+
+    void completeDirectSlice(RdmaSlice* slice);
+
     int submitRecvImmDataRequest(int qp_index, uint64_t id);
 
     size_t acknowledge(RdmaSlice* slice, TransferStatusEnum status);
@@ -180,6 +185,10 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     bool reserveQuota(int qp_index, int num_entries);
 
     void cancelQuota(int qp_index, int num_entries);
+
+    bool reserveDirectQuota();
+
+    void cancelDirectQuota();
 
    private:
     // Caller must hold lock_ in write mode.
@@ -218,8 +227,11 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     std::string peer_server_name_;
     std::string peer_nic_name_;
     std::vector<uint32_t> peer_qp_num_list_;
+    uint32_t peer_direct_qp_num_ = 0;
     // Notification QP (one per endpoint for control plane operations)
     ibv_qp* notify_qp_ = nullptr;
+    ibv_qp* direct_qp_ = nullptr;
+    std::atomic<int> direct_wr_depth_{0};
 
     // Notification buffers
     static constexpr size_t kNotifyBufferSize = 65536;  // 64 KB

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -162,6 +162,11 @@ class RdmaTransport : public Transport {
     void unregisterNotifyQp(uint32_t qp_num);
     std::shared_ptr<RdmaEndPoint> getEndpoint(SegmentID target_id,
                                               int device_id);
+    std::shared_ptr<RdmaEndPoint> getEndpointForContextIndex(
+        int context_index, SegmentID target_id, int remote_device_id);
+    int contextIndexForDevice(int device_id) const;
+    bool trySubmitDirect(RdmaSubBatch* rdma_batch, const Request& request);
+    void pollDirectCompletions(int context_index);
 
     // Notification worker thread
     void notifyWorkerThread();

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -60,6 +60,9 @@ struct RdmaTask {
     std::atomic<int> success_slices{0};
     std::atomic<int> resolved_slices{0};
     volatile TransferStatusEnum first_error = PENDING;
+    bool direct = false;
+    int direct_context_index = -1;
+    RdmaSlice* direct_slice = nullptr;
 
     // Set by the control thread. Workers observe this flag before posting or
     // retrying a slice. Already-posted WRs are allowed to drain normally.
@@ -109,6 +112,7 @@ struct RdmaSlice {
     // rotate through all combinations with wraparound instead of hammering one.
     int last_fallback_idx = -1;
     bool failed = false;
+    bool direct_posted = false;
     // True while DeviceSelector accounts this slice against source_dev_id.
     // The worker clears it exactly once on completion, failure, or cancel.
     bool quota_charged = false;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -391,6 +391,15 @@ int RdmaContext::enable() {
         return notify_ret;
     }
 
+    direct_cq_ = new RdmaCQ();
+    int direct_ret = direct_cq_->construct(this, params_->device.max_cqe,
+                                          params_->device.num_cq_list + 1);
+    if (direct_ret) {
+        LOG(ERROR) << "Failed to create direct CQ for " << device_name_;
+        disable();
+        return direct_ret;
+    }
+
     // Check PCIe Relaxed Ordering support from config
     // Mode: 0 = disabled, 1 = enabled if supported, 2 = auto (default)
     auto mode =
@@ -475,6 +484,11 @@ void RdmaContext::cleanupResources() {
         delete notify_cq_;
         notify_cq_ = nullptr;
     }
+    if (direct_cq_) {
+        delete direct_cq_;
+        direct_cq_ = nullptr;
+    }
+    direct_lane_owner_.store(nullptr, std::memory_order_release);
 
     if (event_fd_ >= 0) {
         if (close(event_fd_)) PLOG(ERROR) << "close";
@@ -497,6 +511,18 @@ void RdmaContext::cleanupResources() {
             PLOG(ERROR) << "ibv_close_device";
         native_context_ = nullptr;
     }
+}
+
+bool RdmaContext::tryAcquireDirectLane(RdmaTask* task) {
+    RdmaTask* expected = nullptr;
+    return direct_lane_owner_.compare_exchange_strong(
+        expected, task, std::memory_order_acq_rel, std::memory_order_acquire);
+}
+
+void RdmaContext::releaseDirectLane(RdmaTask* task) {
+    RdmaTask* expected = task;
+    direct_lane_owner_.compare_exchange_strong(
+        expected, nullptr, std::memory_order_acq_rel, std::memory_order_acquire);
 }
 
 int RdmaContext::pause() {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -147,13 +147,37 @@ int RdmaEndPoint::construct(RdmaContext* context, EndPointParams* params,
         return -1;
     }
 
+    auto direct_cq = context_->directCq()->cq();
+    ibv_qp_init_attr direct_attr;
+    memset(&direct_attr, 0, sizeof(direct_attr));
+    direct_attr.send_cq = direct_cq;
+    direct_attr.recv_cq = direct_cq;
+    direct_attr.sq_sig_all = false;
+    direct_attr.qp_type = IBV_QPT_RC;
+    direct_attr.qp_context = this;
+    direct_attr.cap.max_send_wr = 1;
+    direct_attr.cap.max_recv_wr = 1;
+    direct_attr.cap.max_send_sge = 1;
+    direct_attr.cap.max_recv_sge = 1;
+    direct_attr.cap.max_inline_data = params_->max_inline_bytes;
+    direct_qp_ =
+        context_->verbs_.ibv_create_qp(context_->nativePD(), &direct_attr);
+    if (!direct_qp_) {
+        PLOG(ERROR) << "Failed to create direct QP";
+        deconstruct();
+        return -1;
+    }
+    direct_wr_depth_.store(0, std::memory_order_relaxed);
+
     // Modify notification QP to INIT
     ibv_qp_attr qp_attr;
     memset(&qp_attr, 0, sizeof(qp_attr));
     qp_attr.qp_state = IBV_QPS_INIT;
     qp_attr.pkey_index = params_->pkey_index;
     qp_attr.port_num = context_->portNum();
-    qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
+    qp_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                              IBV_ACCESS_REMOTE_WRITE |
+                              IBV_ACCESS_REMOTE_ATOMIC;
 
     if (context_->verbs_.ibv_modify_qp(notify_qp_, &qp_attr,
                                        IBV_QP_STATE | IBV_QP_PKEY_INDEX |
@@ -222,6 +246,16 @@ int RdmaEndPoint::deconstructUnlocked() {
     }
 
     int result = 0;
+    if (direct_qp_) {
+        int outstanding = direct_wr_depth_.load(std::memory_order_relaxed);
+        if (outstanding != 0) cancelDirectQuota();
+        if (context_->verbs_.ibv_destroy_qp(direct_qp_)) {
+            PLOG(ERROR) << "Failed to destroy direct QP";
+            result = -1;
+        } else {
+            direct_qp_ = nullptr;
+        }
+    }
 
     {
         std::lock_guard<std::mutex> notify_guard(notify_resource_mutex_);
@@ -292,10 +326,11 @@ int RdmaEndPoint::deconstructUnlocked() {
         wr_depth_list_ = nullptr;
     }
 
-    if (result == 0 && !notify_qp_ && notify_recv_mrs_.empty() &&
-        !notify_send_mr_ && qp_list_.empty()) {
+    if (result == 0 && !direct_qp_ && !notify_qp_ &&
+        notify_recv_mrs_.empty() && !notify_send_mr_ && qp_list_.empty()) {
         peer_server_name_.clear();
         peer_nic_name_.clear();
+        peer_direct_qp_num_ = 0;
         status_.store(EP_DESTROYED, std::memory_order_release);
         return 0;
     }
@@ -349,6 +384,10 @@ void RdmaEndPoint::beginDestroyNoLock() {
         PLOG(ERROR) << "Failed to modify notification QP to ERR in "
                        "beginDestroy";
     }
+    if (direct_qp_ &&
+        context_->verbs_.ibv_modify_qp(direct_qp_, &attr, IBV_QP_STATE)) {
+        PLOG(ERROR) << "Failed to modify direct QP to ERR in beginDestroy";
+    }
 }
 
 bool RdmaEndPoint::finishDestroy() {
@@ -372,6 +411,9 @@ bool RdmaEndPoint::finishDestroy() {
             has_outstanding = true;
             break;
         }
+    }
+    if (direct_wr_depth_.load(std::memory_order_relaxed) != 0) {
+        has_outstanding = true;
     }
     if (has_outstanding) {
         double elapsed = (getCurrentTimeInNano() - destroy_start_time_) / 1e9;
@@ -427,6 +469,7 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         qp_num = qpNum();
         local_desc.qp_num = qp_num;
         local_desc.notify_qp_num = notifyQpNum();
+        local_desc.direct_qp_num = directQpNum();
         local_desc.local_lid = context_->lid();
         local_desc.local_gid = context_->gid();
 
@@ -523,6 +566,18 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
                 "Failed to configure RDMA endpoint" LOC_MARK);
         }
         peer_qp_num_list_ = qp_num;
+        peer_direct_qp_num_ = peer_desc.direct_qp_num;
+        if (direct_qp_ && peer_desc.direct_qp_num != 0) {
+            rc = setupNotifyQpConnection(
+                direct_qp_, context_, peer_gid, peer_lid,
+                peer_desc.direct_qp_num, params_->pkey_index,
+                params_->service_level, params_->traffic_class);
+            if (rc) {
+                beginDestroyNoLock();
+                return mooncake::tent::Status::InternalError(
+                    "Failed to configure direct RDMA QP" LOC_MARK);
+            }
+        }
 
         // Setup notification QP connection if peer supports it
         if (peer_desc.notify_qp_num != 0 && notify_qp_) {
@@ -562,7 +617,8 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             getNicNameFromNicPath(peer_desc.local_nic_path);
         if (incoming_peer_server == peer_server_name_ &&
             incoming_peer_nic == peer_nic_name_ &&
-            peer_desc.qp_num == peer_qp_num_list_) {
+            peer_desc.qp_num == peer_qp_num_list_ &&
+            peer_desc.direct_qp_num == peer_direct_qp_num_) {
             LOG(INFO) << "Endpoint already established with " << peer_nic_name_
                       << " of " << peer_server_name_
                       << " (duplicate bootstrap, reusing connection)";
@@ -574,6 +630,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             local_desc.local_lid = context_->lid();
             local_desc.local_gid = context_->gid();
             local_desc.notify_qp_num = notifyQpNum();
+            local_desc.direct_qp_num = directQpNum();
             return mooncake::tent::Status::OK();
         }
         // The bootstrap does not match the established connection: the peer
@@ -610,6 +667,7 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
     local_desc.local_lid = context_->lid();
     local_desc.local_gid = context_->gid();
     local_desc.notify_qp_num = notifyQpNum();  // Pass notification QP number
+    local_desc.direct_qp_num = directQpNum();
     if (peer_desc.local_gid.empty()) {
         return mooncake::tent::Status::InvalidArgument(
             "Missing peer GID in bootstrap" LOC_MARK);
@@ -624,6 +682,18 @@ Status RdmaEndPoint::accept(const BootstrapDesc& peer_desc,
             "Failed to configure RDMA endpoint" LOC_MARK);
     }
     peer_qp_num_list_ = peer_desc.qp_num;
+    peer_direct_qp_num_ = peer_desc.direct_qp_num;
+    if (direct_qp_ && peer_desc.direct_qp_num != 0) {
+        rc = setupNotifyQpConnection(
+            direct_qp_, context_, peer_desc.local_gid, peer_desc.local_lid,
+            peer_desc.direct_qp_num, params_->pkey_index, params_->service_level,
+            params_->traffic_class);
+        if (rc) {
+            beginDestroyNoLock();
+            return mooncake::tent::Status::InternalError(
+                "Failed to configure direct RDMA QP" LOC_MARK);
+        }
+    }
 
     // Setup notification QP connection if peer supports it
     if (peer_desc.notify_qp_num != 0 && notify_qp_) {
@@ -715,6 +785,54 @@ static ibv_wr_opcode getOpCode(RdmaSlice* slice) {
         default:
             return IBV_WR_RDMA_READ;
     }
+}
+
+Status RdmaEndPoint::submitDirectSlice(RdmaSlice* slice) {
+    if (!slice) return Status::InvalidArgument("Invalid direct slice" LOC_MARK);
+    RWSpinlock::ReadGuard guard(lock_);
+    if (!direct_qp_ ||
+        status_.load(std::memory_order_relaxed) != EP_READY) {
+        return Status::InvalidArgument("Direct QP is not ready" LOC_MARK);
+    }
+    if (!reserveDirectQuota()) {
+        return Status::TooManyRequests("Direct QP is busy" LOC_MARK);
+    }
+
+    auto self = shared_from_this();
+    slice->ep_weak_ptr = self;
+    slice->qp_index = -1;
+    slice->failed = false;
+
+    ibv_sge sge;
+    memset(&sge, 0, sizeof(sge));
+    sge.addr = reinterpret_cast<uint64_t>(slice->source_addr);
+    sge.length = slice->length;
+    sge.lkey = slice->source_lkey;
+
+    ibv_send_wr wr;
+    memset(&wr, 0, sizeof(wr));
+    wr.wr_id = reinterpret_cast<uint64_t>(slice);
+    wr.opcode = getOpCode(slice);
+    wr.num_sge = 1;
+    wr.sg_list = &sge;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    wr.wr.rdma.remote_addr = slice->target_addr;
+    wr.wr.rdma.rkey = slice->target_rkey;
+
+    ibv_send_wr* bad_wr = nullptr;
+    int rc = ibv_post_send(direct_qp_, &wr, &bad_wr);
+    if (rc) {
+        cancelDirectQuota();
+        return Status::RdmaError(
+            std::string("direct ibv_post_send: ") + strerror(abs(rc)) +
+            LOC_MARK);
+    }
+    return Status::OK();
+}
+
+void RdmaEndPoint::completeDirectSlice(RdmaSlice* slice) {
+    (void)slice;
+    cancelDirectQuota();
 }
 
 int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
@@ -884,6 +1002,27 @@ void RdmaEndPoint::cancelQuota(int qp_index, int num_entries) {
     cq->cancelQuota(num_entries);
 }
 
+bool RdmaEndPoint::reserveDirectQuota() {
+    auto cq = context_->directCq();
+    if (!cq || !cq->reserveQuota(1)) return false;
+    int prev = direct_wr_depth_.fetch_add(1, std::memory_order_acq_rel);
+    if (prev >= 1) {
+        cancelDirectQuota();
+        return false;
+    }
+    return true;
+}
+
+void RdmaEndPoint::cancelDirectQuota() {
+    int prev = direct_wr_depth_.fetch_sub(1, std::memory_order_acq_rel);
+    if (prev <= 0) {
+        direct_wr_depth_.fetch_add(1, std::memory_order_acq_rel);
+        return;
+    }
+    auto cq = context_->directCq();
+    if (cq) cq->cancelQuota(1);
+}
+
 int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
                              uint16_t peer_lid, uint32_t peer_qp_num,
                              std::string* reply_msg) {
@@ -1041,7 +1180,9 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
     qp_attr.qp_state = IBV_QPS_INIT;
     qp_attr.pkey_index = pkey_index;
     qp_attr.port_num = ctx->portNum();
-    qp_attr.qp_access_flags = IBV_ACCESS_REMOTE_WRITE;
+    qp_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ |
+                              IBV_ACCESS_REMOTE_WRITE |
+                              IBV_ACCESS_REMOTE_ATOMIC;
     ret = ibv_modify_qp(
         qp, &qp_attr,
         IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -20,6 +20,7 @@
 #include <sys/mman.h>
 #include <sys/time.h>
 
+#include <algorithm>
 #include <cassert>
 #include <cerrno>
 #include <cstddef>
@@ -51,9 +52,7 @@
 namespace mooncake {
 namespace tent {
 
-namespace {
-
-uint16_t getRdmaBindDefaultPort(const Config& config) {
+static uint16_t getRdmaBindDefaultPort(const Config& config) {
     constexpr const char* kKey = "rpc_server_port";
     if (!config.contains(kKey)) return 0;
 
@@ -80,8 +79,6 @@ uint16_t getRdmaBindDefaultPort(const Config& config) {
 
     return 0;
 }
-
-}  // namespace
 
 static Status configureLaneCount(std::shared_ptr<Config> conf,
                                  std::shared_ptr<RdmaParams> params) {
@@ -430,6 +427,273 @@ static inline uint64_t roundup(uint64_t a, uint64_t b) {
     return (a % b == 0) ? a : (a / b + 1) * b;
 }
 
+static inline bool prefersLatencyPosting(const Request& request) {
+    return request.deadline_ns != 0 ||
+           request.intent_type == IntentType::FOREGROUND_GET;
+}
+
+static bool memEntryContainsDevice(const Topology::MemEntry* entry,
+                                   int device_id) {
+    if (!entry) return false;
+    for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
+        const auto& list = entry->device_list[rank];
+        if (std::find(list.begin(), list.end(), device_id) != list.end())
+            return true;
+    }
+    return false;
+}
+
+static std::vector<int> rank0DevicesForMemEntry(
+    const Topology::MemEntry* entry) {
+    if (!entry) return {};
+    return entry->device_list[0];
+}
+
+int RdmaTransport::contextIndexForDevice(int device_id) const {
+    if (!local_topology_) return -1;
+    auto* nic = local_topology_->getNicEntry(device_id);
+    if (!nic) return -1;
+    auto it = context_name_lookup_.find(nic->name);
+    if (it == context_name_lookup_.end()) return -1;
+    return it->second;
+}
+
+void RdmaTransport::pollDirectCompletions(int context_index) {
+    if (context_index < 0 || context_index >= (int)context_set_.size()) return;
+    auto& context = context_set_[context_index];
+    if (!context || !context->directCq()) return;
+    ibv_wc wc[8];
+    int nr_poll = context->directCq()->poll(8, wc);
+    if (nr_poll <= 0) return;
+    for (int i = 0; i < nr_poll; ++i) {
+        auto* slice = reinterpret_cast<RdmaSlice*>(wc[i].wr_id);
+        if (!slice || !slice->task) continue;
+        if (auto ep = slice->ep_weak_ptr.lock()) {
+            ep->completeDirectSlice(slice);
+            if (wc[i].status != IBV_WC_SUCCESS) {
+                ep->resetConnection("Direct QP completion error");
+            }
+        }
+        if (slice->task->direct) {
+            context->releaseDirectLane(slice->task);
+        }
+        updateSliceStatus(slice,
+                          wc[i].status == IBV_WC_SUCCESS ? COMPLETED : FAILED);
+    }
+}
+
+bool RdmaTransport::trySubmitDirect(RdmaSubBatch* rdma_batch,
+                                    const Request& request) {
+    if (!rdma_batch || request.length == 0) return false;
+
+    SegmentDescRef source_pin, target_pin;
+    BufferDesc* source_buffer = nullptr;
+    BufferDesc* target_buffer = nullptr;
+    const Topology* source_topo = nullptr;
+    const Topology::MemEntry* source_mem_entry = nullptr;
+    const Topology* target_topo = nullptr;
+    const Topology::MemEntry* target_mem_entry = nullptr;
+    std::string source_location;
+    auto& segment_manager = metadata_->segmentManager();
+    auto source_status = segment_manager.withCachedSegment(
+        LOCAL_SEGMENT_ID, source_pin, [&](SegmentDesc* segment) {
+            if (segment->type != SegmentType::Memory)
+                return Status::NeedsRefreshCache(
+                    "Local segment type is not Memory" LOC_MARK);
+            source_buffer = segment->findBuffer(
+                reinterpret_cast<uint64_t>(request.source), request.length);
+            if (!source_buffer)
+                return Status::NeedsRefreshCache(
+                    "No matched local buffer for direct RDMA" LOC_MARK);
+            source_topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
+            source_location = bufferLocationForRange(
+                *source_buffer, reinterpret_cast<uint64_t>(request.source),
+                request.length);
+            return Status::OK();
+        });
+    if (!source_status.ok()) return false;
+    auto source_mem_id = source_topo->getMemId(source_location);
+    if (source_mem_id < 0)
+        source_mem_id = source_topo->getMemId(kWildcardLocation);
+    source_mem_entry = source_topo->getMemEntry(source_mem_id);
+    if (!source_mem_entry) return false;
+
+    std::string target_location;
+    auto target_status = segment_manager.withCachedSegment(
+        request.target_id, target_pin, [&](SegmentDesc* segment) {
+            if (segment->type != SegmentType::Memory)
+                return Status::NeedsRefreshCache(
+                    "Target segment type is not Memory" LOC_MARK);
+            target_buffer =
+                segment->findBuffer(request.target_offset, request.length);
+            if (!target_buffer)
+                return Status::NeedsRefreshCache(
+                    "No matched target buffer for direct RDMA" LOC_MARK);
+            target_topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
+            target_location = bufferLocationForRange(
+                *target_buffer, request.target_offset, request.length);
+            return Status::OK();
+        });
+    if (!target_status.ok()) return false;
+    auto target_mem_id = target_topo->getMemId(target_location);
+    if (target_mem_id < 0)
+        target_mem_id = target_topo->getMemId(kWildcardLocation);
+    target_mem_entry = target_topo->getMemEntry(target_mem_id);
+    if (!target_mem_entry) return false;
+
+    std::vector<int> source_devs;
+    for (int dev_id : rank0DevicesForMemEntry(source_mem_entry)) {
+        if (dev_id < 0 || dev_id >= 64) continue;
+        if ((rdma_batch->device_mask & (1ULL << dev_id)) == 0) continue;
+        if (static_cast<size_t>(dev_id) >= source_buffer->lkey.size())
+            continue;
+        int context_index = contextIndexForDevice(dev_id);
+        if (context_index < 0 || context_index >= (int)context_set_.size())
+            continue;
+        auto& context = context_set_[context_index];
+        if (!context || context->status() != RdmaContext::DEVICE_ENABLED)
+            continue;
+        source_devs.push_back(dev_id);
+    }
+    if (source_devs.empty()) return false;
+
+    const size_t slice_size = params_->workers.block_size;
+    if (slice_size == 0) return false;
+    size_t num_slices = 1;
+    if (request.length > slice_size) {
+        num_slices = std::min<size_t>(
+            source_devs.size(), (request.length + slice_size - 1) / slice_size);
+    }
+    source_devs.resize(num_slices);
+
+    const auto target_rank0 = rank0DevicesForMemEntry(target_mem_entry);
+    std::vector<int> target_devs;
+    std::vector<int> context_indices;
+    target_devs.reserve(num_slices);
+    context_indices.reserve(num_slices);
+    for (size_t i = 0; i < num_slices; ++i) {
+        const int source_dev_id = source_devs[i];
+        int target_dev_id = memEntryContainsDevice(target_mem_entry,
+                                                   source_dev_id)
+                                ? source_dev_id
+                                : (target_rank0.empty()
+                                       ? -1
+                                       : target_rank0[i % target_rank0.size()]);
+        if (target_dev_id < 0 ||
+            static_cast<size_t>(target_dev_id) >= target_buffer->rkey.size()) {
+            return false;
+        }
+        int context_index = contextIndexForDevice(source_dev_id);
+        if (context_index < 0 || context_index >= (int)context_set_.size())
+            return false;
+        target_devs.push_back(target_dev_id);
+        context_indices.push_back(context_index);
+    }
+
+    auto* task = RdmaTaskStorage::Get().allocate();
+    if (!task) return false;
+    std::vector<int> acquired_contexts;
+    for (int context_index : context_indices) {
+        auto& context = context_set_[context_index];
+        if (!context->tryAcquireDirectLane(task)) {
+            for (int acquired : acquired_contexts) {
+                context_set_[acquired]->releaseDirectLane(task);
+            }
+            RdmaTaskStorage::Get().deallocate(task);
+            return false;
+        }
+        acquired_contexts.push_back(context_index);
+    }
+
+    std::vector<RdmaSlice*> slices;
+    slices.reserve(num_slices);
+    const size_t base_len = request.length / num_slices;
+    const size_t extra = request.length % num_slices;
+    uint64_t offset = 0;
+    for (size_t i = 0; i < num_slices; ++i) {
+        auto* slice = RdmaSliceStorage::Get().allocate();
+        if (!slice) {
+            for (auto* entry : slices) RdmaSliceStorage::Get().deallocate(entry);
+            for (int acquired : acquired_contexts) {
+                context_set_[acquired]->releaseDirectLane(task);
+            }
+            RdmaTaskStorage::Get().deallocate(task);
+            return false;
+        }
+        const size_t length = base_len + (i < extra ? 1 : 0);
+        slice->source_addr = static_cast<char*>(request.source) + offset;
+        slice->target_addr = request.target_offset + offset;
+        slice->length = length;
+        slice->task = task;
+        slice->next = nullptr;
+        slice->source_lkey = source_buffer->lkey[source_devs[i]];
+        slice->target_rkey = target_buffer->rkey[target_devs[i]];
+        slice->source_dev_id = source_devs[i];
+        slice->target_dev_id = target_devs[i];
+        slice->ep_weak_ptr.reset();
+        slice->word = PENDING;
+        slice->qp_index = -1;
+        slice->retry_count = 0;
+        slice->failed = false;
+        slice->direct_posted = true;
+        slice->priority = request.priority;
+        slice->quota_charged = false;
+        slice->rail_monitor = nullptr;
+        slice->enqueue_ts = getCurrentTimeInNano();
+        slice->submit_ts = 0;
+        if (!slices.empty()) slices.back()->next = slice;
+        slices.push_back(slice);
+        offset += length;
+    }
+
+    std::vector<std::shared_ptr<RdmaEndPoint>> endpoints;
+    endpoints.reserve(num_slices);
+    for (size_t i = 0; i < num_slices; ++i) {
+        auto endpoint = getEndpointForContextIndex(
+            context_indices[i], request.target_id, target_devs[i]);
+        if (!endpoint) {
+            for (auto* slice : slices) RdmaSliceStorage::Get().deallocate(slice);
+            for (int acquired : acquired_contexts) {
+                context_set_[acquired]->releaseDirectLane(task);
+            }
+            RdmaTaskStorage::Get().deallocate(task);
+            return false;
+        }
+        endpoints.push_back(std::move(endpoint));
+    }
+
+    task->num_slices = static_cast<int>(num_slices);
+    task->request = request;
+    task->qp_pool = rdma_batch->qp_pool;
+    task->status_word = PENDING;
+    task->transferred_bytes = 0;
+    task->success_slices.store(0, std::memory_order_relaxed);
+    task->resolved_slices.store(0, std::memory_order_relaxed);
+    task->first_error = PENDING;
+    task->direct = true;
+    task->direct_context_index =
+        (num_slices == 1) ? context_indices.front() : -1;
+    task->direct_slice = slices.front();
+    task->cancel_requested.store(false, std::memory_order_relaxed);
+    task->ref();  // Batch holds a reference to the task
+    for (size_t i = 0; i < num_slices; ++i) {
+        task->ref();  // Each direct slice holds a reference until completion
+    }
+
+    rdma_batch->task_list.push_back(task);
+    rdma_batch->slice_chain.push_back(slices.front());
+
+    for (size_t i = 0; i < num_slices; ++i) {
+        auto post_status = endpoints[i]->submitDirectSlice(slices[i]);
+        slices[i]->submit_ts = getCurrentTimeInNano();
+        if (!post_status.ok()) {
+            context_set_[context_indices[i]]->releaseDirectLane(task);
+            updateSliceStatus(slices[i], FAILED);
+        }
+    }
+    return true;
+}
+
 Status RdmaTransport::submitTransferTasks(
     SubBatchRef batch, const std::vector<Request>& request_list) {
     auto rdma_batch = dynamic_cast<RdmaSubBatch*>(batch);
@@ -443,13 +707,25 @@ Status RdmaTransport::submitTransferTasks(
     const int num_workers = params_->workers.num_workers;
     std::vector<RdmaSliceList> slice_lists(num_workers);
     std::vector<RdmaSlice*> slice_tails(num_workers, nullptr);
+    auto append_slice = [](RdmaSliceList& list, RdmaSlice*& tail,
+                           RdmaSlice* slice) {
+        list.num_slices++;
+        if (list.first) {
+            tail->next = slice;
+            tail = slice;
+        } else {
+            list.first = tail = slice;
+        }
+    };
     auto enqueue_ts = getCurrentTimeInNano();
 
     // Distribute starting worker across threads to avoid contention
     static std::atomic<int> g_caller_threads(0);
     thread_local int tl_caller_id = g_caller_threads.fetch_add(1);
     int next_worker_idx = tl_caller_id;
-    for (auto& request : request_list) {
+    for (const auto& request : request_list) {
+        const bool latency_request = prefersLatencyPosting(request);
+        if (latency_request && trySubmitDirect(rdma_batch, request)) continue;
         auto opcode = request.opcode;
         auto type = Platform::getLoader().getMemoryType(request.source);
         size_t max_slice_count = 64;
@@ -465,6 +741,9 @@ Status RdmaTransport::submitTransferTasks(
         task->success_slices.store(0, std::memory_order_relaxed);
         task->resolved_slices.store(0, std::memory_order_relaxed);
         task->first_error = PENDING;
+        task->direct = false;
+        task->direct_context_index = -1;
+        task->direct_slice = nullptr;
         task->cancel_requested.store(false, std::memory_order_relaxed);
         task->ref();  // Batch holds a reference to the task
 
@@ -521,6 +800,7 @@ Status RdmaTransport::submitTransferTasks(
             slice->quota_charged = false;
             slice->ep_weak_ptr.reset();
             slice->word = PENDING;
+            slice->direct_posted = false;
             slice->next = nullptr;
             slice->enqueue_ts = enqueue_ts;
             slice->priority = request.priority;  // Copy priority from request
@@ -534,22 +814,15 @@ Status RdmaTransport::submitTransferTasks(
             int part_id = next_worker_idx % num_workers;
             auto& list = slice_lists[part_id];
             auto& tail = slice_tails[part_id];
-            list.num_slices++;
             next_worker_idx++;
-            if (list.first) {
-                tail->next = slice;
-                tail = slice;
-            } else {
-                list.first = tail = slice;
-            }
+            append_slice(list, tail, slice);
         }
     }
 
     for (int i = 0; i < num_workers; ++i) {
-        if (slice_lists[i].first) {
-            rdma_batch->slice_chain.push_back(slice_lists[i].first);
-            workers_->submit(slice_lists[i], i);
-        }
+        if (!slice_lists[i].first) continue;
+        rdma_batch->slice_chain.push_back(slice_lists[i].first);
+        workers_->submit(slice_lists[i], i);
     }
     return Status::OK();
 }
@@ -561,6 +834,15 @@ Status RdmaTransport::getTransferStatus(SubBatchRef batch, int task_id,
         return Status::InvalidArgument("Invalid task ID" LOC_MARK);
     }
     auto* task = rdma_batch->task_list[task_id];
+    if (task->direct && task->status_word == PENDING) {
+        if (task->direct_context_index >= 0) {
+            pollDirectCompletions(task->direct_context_index);
+        } else {
+            for (size_t i = 0; i < context_set_.size(); ++i) {
+                pollDirectCompletions(static_cast<int>(i));
+            }
+        }
+    }
     status = TransferStatus{task->status_word, task->transferred_bytes};
     return Status::OK();
 }
@@ -575,6 +857,17 @@ Status RdmaTransport::cancelTransferTask(SubBatchRef batch, int task_id) {
     }
     auto* task = rdma_batch->task_list[task_id];
     if (task->status_word != PENDING) return Status::OK();
+    if (task->direct) {
+        task->cancel_requested.store(true, std::memory_order_release);
+        if (task->direct_context_index >= 0) {
+            pollDirectCompletions(task->direct_context_index);
+        } else {
+            for (size_t i = 0; i < context_set_.size(); ++i) {
+                pollDirectCompletions(static_cast<int>(i));
+            }
+        }
+        return Status::OK();
+    }
     return workers_->cancel(task);
 }
 
@@ -692,6 +985,11 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
 
 std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
                                                          int device_id) {
+    return getEndpointForContextIndex(0, target_id, device_id);
+}
+
+std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpointForContextIndex(
+    int context_index, SegmentID target_id, int remote_device_id) {
     std::string rpc_server_addr, target_seg_name, target_dev_name,
         target_nic_path_name;
 
@@ -709,7 +1007,7 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
             auto topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
             target_seg_name = segment->name;
             target_nic_path_name = segment->nicPathServerName();
-            target_dev_name = topo->getNicName(device_id);
+            target_dev_name = topo->getNicName(remote_device_id);
             if (target_seg_name.empty() || target_dev_name.empty()) {
                 return Status::NeedsRefreshCache(
                     "Empty target segment or device name" LOC_MARK);
@@ -722,35 +1020,28 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
         return nullptr;
     }
 
-    // context_set_ is NicID-indexed, so slot 0 may be inert; take the first
-    // enabled context instead.
-    RdmaContext* context = nullptr;
-    for (auto& ctx : context_set_) {
-        if (ctx->status() == RdmaContext::DEVICE_ENABLED) {
-            context = ctx.get();
-            break;
-        }
-    }
-    if (!context) {
+    if (context_index < 0 || context_index >= (int)context_set_.size()) {
         return nullptr;
     }
-    std::shared_ptr<RdmaEndPoint> endpoint;
+    auto context = context_set_[context_index].get();
+    if (context->status() != RdmaContext::DEVICE_ENABLED) return nullptr;
+
     std::string peer_name = MakeNicPath(target_nic_path_name, target_dev_name);
-    endpoint = context->endpointStore()->getOrInsert(peer_name);
+    auto endpoint = context->endpointStore()->getOrInsert(peer_name);
     if (!endpoint) {
         LOG(ERROR) << "Cannot allocate endpoint " << peer_name;
         return nullptr;
     }
     if (endpoint->status() != RdmaEndPoint::EP_READY) {
-        auto status = endpoint->connect(target_seg_name, target_dev_name,
-                                        rpc_server_addr);
-        if (!status.ok()) {
+        auto connect_status =
+            endpoint->connect(target_seg_name, target_dev_name, rpc_server_addr);
+        if (!connect_status.ok()) {
             thread_local uint64_t tl_last_output_ts = 0;
             uint64_t current_ts = getCurrentTimeInNano();
             if (current_ts - tl_last_output_ts > 10000000000ull) {
                 tl_last_output_ts = current_ts;
                 LOG(ERROR) << "Unable to connect endpoint " << peer_name << ": "
-                           << status.ToString();
+                           << connect_status.ToString();
             }
             return nullptr;
         }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -36,7 +36,6 @@ namespace mooncake {
 namespace tent {
 thread_local int tl_wid = -1;
 
-namespace {
 struct ArbitrationEntry {
     RdmaSlice* slice;
     double mlu;
@@ -46,7 +45,7 @@ struct ArbitrationEntry {
 // Look up (or create) the RailMonitor for `machine_id` on this worker's
 // map. Returning a stable reference is safe because the map stores values
 // via unique_ptr -- rehashes move the pointer slot, not the RailMonitor.
-RailMonitor& getOrCreateRail(
+static RailMonitor& getOrCreateRail(
     std::unordered_map<std::string, std::unique_ptr<RailMonitor>>& rails,
     const std::string& machine_id) {
     auto it = rails.find(machine_id);
@@ -54,7 +53,6 @@ RailMonitor& getOrCreateRail(
     auto [ins, _] = rails.emplace(machine_id, std::make_unique<RailMonitor>());
     return *ins->second;
 }
-}  // namespace
 
 Workers::Workers(RdmaTransport* transport)
     : transport_(transport),
@@ -312,67 +310,8 @@ void Workers::releaseSliceQuota(RdmaSlice* slice, double latency) {
 }
 
 std::shared_ptr<RdmaEndPoint> Workers::getEndpoint(Workers::PostPath path) {
-    std::string rpc_server_addr, target_seg_name, target_dev_name,
-        target_nic_path_name;
-    RouteHint hint;
-    auto& segment_manager = transport_->metadata_->segmentManager();
-    auto target_id = path.remote_segment_id;
-    auto device_id = path.remote_device_id;
-
-    auto status = segment_manager.withCachedSegment(
-        target_id, hint.pin, [&](SegmentDesc* segment) {
-            hint.segment = segment;
-            if (segment->type != SegmentType::Memory) {
-                return Status::NeedsRefreshCache(
-                    "Segment type is not Memory" LOC_MARK);
-            }
-            hint.topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
-            if (target_id != LOCAL_SEGMENT_ID) {
-                rpc_server_addr = segment->rpc_server_addr;
-            }
-            target_seg_name = segment->name;
-            target_nic_path_name = segment->nicPathServerName();
-            target_dev_name = hint.topo->getNicName(device_id);
-            if (target_seg_name.empty() || target_dev_name.empty()) {
-                return Status::NeedsRefreshCache(
-                    "Empty target segment or device name" LOC_MARK);
-            }
-            return Status::OK();
-        });
-
-    if (!status.ok()) {
-        LOG(ERROR) << status.ToString();
-        return nullptr;
-    }
-
-    auto context = transport_->context_set_[path.local_device_id].get();
-    if (context->status() != RdmaContext::DEVICE_ENABLED) {
-        // LOG(WARNING) << "Context " << context->name() << " is not serving";
-        return nullptr;  // experimental: force to fail this slice and mark this
-                         // connection unavailable
-    }
-    std::shared_ptr<RdmaEndPoint> endpoint;
-    auto peer_name = MakeNicPath(target_nic_path_name, target_dev_name);
-    endpoint = context->endpointStore()->getOrInsert(peer_name);
-    if (!endpoint) {
-        LOG(ERROR) << "Cannot allocate endpoint " << peer_name;
-        return nullptr;
-    }
-    if (endpoint->status() != RdmaEndPoint::EP_READY) {
-        auto status = endpoint->connect(target_seg_name, target_dev_name,
-                                        rpc_server_addr);
-        if (!status.ok()) {
-            thread_local uint64_t tl_last_output_ts = 0;
-            uint64_t current_ts = getCurrentTimeInNano();
-            if (current_ts - tl_last_output_ts > 10000000000ull) {
-                tl_last_output_ts = current_ts;
-                LOG(ERROR) << "Unable to connect endpoint " << peer_name << ": "
-                           << status.ToString();
-            }
-            return nullptr;
-        }
-    }
-    return endpoint;
+    return transport_->getEndpointForContextIndex(
+        path.local_device_id, path.remote_segment_id, path.remote_device_id);
 }
 
 void Workers::disableEndpoint(RdmaSlice* slice) {
@@ -882,27 +821,7 @@ Status Workers::getRouteHint(RouteHint& hint, SegmentID segment_id,
         }));
 
     hint.topo = &std::get<MemorySegmentDesc>(hint.segment->detail).topology;
-    std::string location = hint.buffer->location;
-    if (!hint.buffer->regions.empty()) {
-        size_t offset = hint.buffer->addr;
-        size_t best_overlap = 0;
-        size_t target_start = addr;
-        size_t target_end = addr + length;
-        for (auto& entry : hint.buffer->regions) {
-            size_t region_start = offset;
-            size_t region_end = offset + entry.size;
-            size_t overlap_start = std::max(region_start, target_start);
-            size_t overlap_end = std::min(region_end, target_end);
-            size_t overlap = (overlap_end > overlap_start)
-                                 ? (overlap_end - overlap_start)
-                                 : 0;
-            if (overlap > best_overlap) {
-                best_overlap = overlap;
-                location = entry.location;
-            }
-            offset += entry.size;
-        }
-    }
+    std::string location = bufferLocationForRange(*hint.buffer, addr, length);
     auto mem_id = hint.topo->getMemId(location);
     if (mem_id < 0) mem_id = hint.topo->getMemId(kWildcardLocation);
     hint.topo_entry = hint.topo->getMemEntry(mem_id);
@@ -910,21 +829,12 @@ Status Workers::getRouteHint(RouteHint& hint, SegmentID segment_id,
     return Status::OK();
 }
 
-int Workers::getDeviceRank(const RouteHint& hint, int device_id) {
-    for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
-        auto& list = hint.topo_entry->device_list[rank];
-        for (auto& entry : list)
-            if (entry == device_id) return rank;
-    }
-    return -1;
-}
-
 Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
                                     RdmaSlice* slice) {
     auto& worker = worker_context_[tl_wid];
     if (slice->source_dev_id < 0) {
         CHECK_STATUS(device_selector_->allocate(
-            slice->length, source.buffer->location, slice->source_dev_id));
+            slice->length, source.location, slice->source_dev_id));
         slice->quota_charged = true;
     }
 


### PR DESCRIPTION
## Description

This PR adds an opportunistic RDMA direct fast path in TENT for latency-sensitive transfers. （#3366）

Requests with either a non-zero `deadline_ns` or `IntentType::FOREGROUND_GET` first try to bypass the normal RDMA worker queue and post directly to a dedicated per-endpoint direct QP. If the direct lane is unavailable or setup cannot be resolved safely, the request falls back to the existing worker-based RDMA path.

Main changes:
- Add dedicated direct CQ per `RdmaContext`.
- Add dedicated shallow direct QP per `RdmaEndPoint`.
- Add per-context direct lane ownership to bound direct-path concurrency.
- Exchange `direct_qp_num` during RDMA bootstrap.
- Poll direct completions from `getTransferStatus()`.
- Support multi-rail direct transfer when multiple eligible rank-0 RDMA devices are available.
- Refactor endpoint lookup so worker and direct paths share `getEndpointForContextIndex()`.
- Extend `tebench` with intent passing, request pacing, synchronized measurement start, workload-class support, and instantaneous bandwidth reporting.

The intent is to improve burst latency for foreground/deadline-sensitive traffic while keeping the normal worker path as the throughput-oriented fallback.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to help draft this PR description. The submitter is responsible for reviewing and validating all changed code.