### PR TITLE
[TENT] reclaim rdma endpoints outside store lock

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -122,6 +122,9 @@ void FIFOEndpointStore::evictOne() {
 void FIFOEndpointStore::reclaim() {
     std::vector<std::shared_ptr<RdmaEndPoint>> candidates;
     {
+        // Only protect the waiting_list_ iteration. finishDestroy() may wait
+        // for CQ drain and take the endpoint lock, so it must run after this
+        // store lock has been released.
         RWSpinlock::ReadGuard guard(endpoint_map_lock_);
         candidates.reserve(waiting_list_.size());
         for (auto& endpoint : waiting_list_) candidates.push_back(endpoint);
@@ -302,6 +305,9 @@ void SIEVEEndpointStore::reclaim() {
 
     std::vector<std::shared_ptr<RdmaEndPoint>> candidates;
     {
+        // Only protect the waiting_list_ iteration. finishDestroy() may wait
+        // for CQ drain and take the endpoint lock, so it must run after this
+        // store lock has been released.
         RWSpinlock::ReadGuard guard(endpoint_map_lock_);
         candidates.reserve(waiting_list_.size());
         for (auto& endpoint : waiting_list_) candidates.push_back(endpoint);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -120,11 +120,20 @@ void FIFOEndpointStore::evictOne() {
 }
 
 void FIFOEndpointStore::reclaim() {
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    std::vector<std::shared_ptr<RdmaEndPoint>> candidates;
+    {
+        RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+        candidates.reserve(waiting_list_.size());
+        for (auto& endpoint : waiting_list_) candidates.push_back(endpoint);
+    }
+
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto& endpoint : waiting_list_) {
+    for (auto& endpoint : candidates) {
         if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
     }
+    if (to_delete.empty()) return;
+
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
     for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
 }
 
@@ -290,13 +299,24 @@ void SIEVEEndpointStore::evictOne() {
 
 void SIEVEEndpointStore::reclaim() {
     if (waiting_list_len_.load(std::memory_order_relaxed) == 0) return;
-    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+
+    std::vector<std::shared_ptr<RdmaEndPoint>> candidates;
+    {
+        RWSpinlock::ReadGuard guard(endpoint_map_lock_);
+        candidates.reserve(waiting_list_.size());
+        for (auto& endpoint : waiting_list_) candidates.push_back(endpoint);
+    }
+
     std::vector<std::shared_ptr<RdmaEndPoint>> to_delete;
-    for (auto& endpoint : waiting_list_) {
+    for (auto& endpoint : candidates) {
         if (endpoint->finishDestroy()) to_delete.push_back(endpoint);
     }
-    for (auto& endpoint : to_delete) waiting_list_.erase(endpoint);
-    waiting_list_len_ -= to_delete.size();
+    if (to_delete.empty()) return;
+
+    size_t erased = 0;
+    RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+    for (auto& endpoint : to_delete) erased += waiting_list_.erase(endpoint);
+    waiting_list_len_.fetch_sub(erased, std::memory_order_relaxed);
 }
 
 size_t SIEVEEndpointStore::size() { return endpoint_map_.size(); }


### PR DESCRIPTION
## Description

This PR fixes a RDMA endpoint teardown deadlock risk in the TENT endpoint store.

`FIFOEndpointStore::reclaim()` and `SIEVEEndpointStore::reclaim()` previously called `RdmaEndPoint::finishDestroy()` while holding `endpoint_map_lock_`. `finishDestroy()` may enter blocking verbs teardown paths, while async event handling may need to look up endpoint ownership through the same store lock. Holding the store lock across endpoint destruction can therefore block teardown progress.

The fix changes reclaim to:

1. Take a strong-reference snapshot of `waiting_list_` under the store lock.
2. Release the store lock before calling `finishDestroy()`.
3. Re-acquire the store lock only to erase successfully destroyed endpoints.

This keeps retiring endpoints discoverable in `waiting_list_` while avoiding a Store lock / Endpoint teardown lock cycle.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`git diff --check` passed.

Full unit test execution was not completed in the current environment because the local Mooncake checkout is missing required build dependencies/submodules (`pybind11`, Python development headers, and TENT standalone CMake dependency wiring for `yalantinglibs`).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the downstream TENT fix, compare it with upstream Mooncake, and prepare this minimal upstream patch. The submitter reviewed the final diff.