### PR TITLE
[TENT] drain control callbacks on unregister

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -19,9 +19,12 @@
 #include <netdb.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -121,13 +124,9 @@ class ControlService {
 
     SegmentManager& segmentManager() { return *manager_.get(); }
 
-    void setBootstrapRdmaCallback(const OnReceiveBootstrap& callback) {
-        bootstrap_callback_ = callback;
-    }
+    void setBootstrapRdmaCallback(const OnReceiveBootstrap& callback);
 
-    void setNotifyCallback(const OnNotify& callback) {
-        notify_callback_ = callback;
-    }
+    void setNotifyCallback(const OnNotify& callback);
 
     Status start(uint16_t& port, bool ipv6_ = false);
 
@@ -160,12 +159,27 @@ class ControlService {
     void onSegmentUpdated(const std::string_view& request,
                           std::string& response);
 
+    void finishBootstrapCallback();
+
+    void finishNotifyCallback();
+
    private:
     std::unique_ptr<SegmentManager> manager_;
     std::shared_ptr<CoroRpcAgent> rpc_server_;
 
+    std::mutex bootstrap_cb_mutex_;
+    std::condition_variable bootstrap_cb_cv_;
+    size_t bootstrap_callbacks_in_flight_ = 0;
+    std::chrono::milliseconds callback_drain_timeout_{std::chrono::seconds(5)};
     OnReceiveBootstrap bootstrap_callback_;
+    static thread_local const ControlService* active_bootstrap_service_;
+
+    std::mutex notify_cb_mutex_;
+    std::condition_variable notify_cb_cv_;
+    size_t notify_callbacks_in_flight_ = 0;
     OnNotify notify_callback_;
+    static thread_local const ControlService* active_notify_service_;
+
     TransferEngineImpl* impl_;
 };
 

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <set>
+#include <utility>
 
 #include "tent/common/status.h"
 #include "tent/common/utils/os.h"
@@ -25,6 +26,25 @@
 
 namespace mooncake {
 namespace tent {
+namespace {
+
+template <typename Fn>
+class CallbackInvocationGuard {
+   public:
+    explicit CallbackInvocationGuard(Fn on_exit)
+        : on_exit_(std::move(on_exit)) {}
+
+    ~CallbackInvocationGuard() { on_exit_(); }
+
+    CallbackInvocationGuard(const CallbackInvocationGuard&) = delete;
+    CallbackInvocationGuard& operator=(const CallbackInvocationGuard&) =
+        delete;
+
+   private:
+    Fn on_exit_;
+};
+
+}  // namespace
 
 thread_local const ControlService* ControlService::active_bootstrap_service_ =
     nullptr;
@@ -309,25 +329,30 @@ void ControlService::onBootstrapRdma(const std::string_view& request,
     }
 
     BootstrapDesc response_desc;
-    const ControlService* previous_service = active_bootstrap_service_;
-    active_bootstrap_service_ = this;
-    try {
-        BootstrapDesc request_desc =
-            json::parse(mutable_request).get<BootstrapDesc>();
-        int rc = callback(request_desc, response_desc);
-        if (rc != 0 && response_desc.reply_msg.empty()) {
+    {
+        const ControlService* previous_service = active_bootstrap_service_;
+        active_bootstrap_service_ = this;
+        CallbackInvocationGuard invocation_guard([this, previous_service] {
+            active_bootstrap_service_ = previous_service;
+            finishBootstrapCallback();
+        });
+
+        try {
+            BootstrapDesc request_desc =
+                json::parse(mutable_request).get<BootstrapDesc>();
+            int rc = callback(request_desc, response_desc);
+            if (rc != 0 && response_desc.reply_msg.empty()) {
+                response_desc.reply_msg = "BootstrapRdma callback failed";
+            }
+        } catch (const std::exception& e) {
+            LOG(ERROR) << "onBootstrapRdma failed: " << e.what();
+            response_desc.reply_msg =
+                std::string("BootstrapRdma callback failed: ") + e.what();
+        } catch (...) {
+            LOG(ERROR) << "onBootstrapRdma failed with unknown exception";
             response_desc.reply_msg = "BootstrapRdma callback failed";
         }
-    } catch (const std::exception& e) {
-        LOG(ERROR) << "onBootstrapRdma failed: " << e.what();
-        response_desc.reply_msg =
-            std::string("BootstrapRdma callback failed: ") + e.what();
-    } catch (...) {
-        LOG(ERROR) << "onBootstrapRdma failed with unknown exception";
-        response_desc.reply_msg = "BootstrapRdma callback failed";
     }
-    active_bootstrap_service_ = previous_service;
-    finishBootstrapCallback();
 
     json j = response_desc;
     response = j.dump();
@@ -397,6 +422,11 @@ void ControlService::onNotify(const std::string_view& request,
 
     const ControlService* previous_service = active_notify_service_;
     active_notify_service_ = this;
+    CallbackInvocationGuard invocation_guard([this, previous_service] {
+        active_notify_service_ = previous_service;
+        finishNotifyCallback();
+    });
+
     try {
         Notification message = json::parse(request).get<Notification>();
         callback(message);
@@ -405,8 +435,6 @@ void ControlService::onNotify(const std::string_view& request,
     } catch (...) {
         LOG(ERROR) << "onNotify failed with unknown exception";
     }
-    active_notify_service_ = previous_service;
-    finishNotifyCallback();
 }
 
 void ControlService::onProbe(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -25,6 +25,11 @@
 
 namespace mooncake {
 namespace tent {
+
+thread_local const ControlService* ControlService::active_bootstrap_service_ =
+    nullptr;
+thread_local const ControlService* ControlService::active_notify_service_ =
+    nullptr;
 thread_local CoroRpcAgent tl_rpc_agent;
 
 Status ControlClient::getSegmentDesc(const std::string& server_addr,
@@ -218,7 +223,62 @@ ControlService::ControlService(const std::string& type,
         });
 }
 
-ControlService::~ControlService() {}
+ControlService::~ControlService() {
+    // Stop RPC workers while callback state and synchronization primitives are
+    // still alive. Member destruction would otherwise tear them down first.
+    rpc_server_.reset();
+}
+
+void ControlService::setBootstrapRdmaCallback(
+    const OnReceiveBootstrap& callback) {
+    std::unique_lock<std::mutex> guard(bootstrap_cb_mutex_);
+    if (active_bootstrap_service_ == this) {
+        bootstrap_callback_ = callback;
+        return;
+    }
+    bootstrap_callback_ = nullptr;
+    if (!bootstrap_cb_cv_.wait_for(
+            guard, callback_drain_timeout_,
+            [this] { return bootstrap_callbacks_in_flight_ == 0; })) {
+        LOG(ERROR)
+            << "Timed out waiting for BootstrapRdma callbacks to drain, "
+            << "in_flight=" << bootstrap_callbacks_in_flight_
+            << ", timeout_ms=" << callback_drain_timeout_.count()
+            << ". Continue replacing the callback to keep shutdown bounded.";
+    }
+    bootstrap_callback_ = callback;
+}
+
+void ControlService::setNotifyCallback(const OnNotify& callback) {
+    std::unique_lock<std::mutex> guard(notify_cb_mutex_);
+    if (active_notify_service_ == this) {
+        notify_callback_ = callback;
+        return;
+    }
+    notify_callback_ = nullptr;
+    if (!notify_cb_cv_.wait_for(
+            guard, callback_drain_timeout_,
+            [this] { return notify_callbacks_in_flight_ == 0; })) {
+        LOG(ERROR) << "Timed out waiting for Notify callbacks to drain, "
+                   << "in_flight=" << notify_callbacks_in_flight_
+                   << ", timeout_ms=" << callback_drain_timeout_.count()
+                   << ". Continue replacing the callback to keep shutdown "
+                   << "bounded.";
+    }
+    notify_callback_ = callback;
+}
+
+void ControlService::finishBootstrapCallback() {
+    std::lock_guard<std::mutex> guard(bootstrap_cb_mutex_);
+    --bootstrap_callbacks_in_flight_;
+    bootstrap_cb_cv_.notify_all();
+}
+
+void ControlService::finishNotifyCallback() {
+    std::lock_guard<std::mutex> guard(notify_cb_mutex_);
+    --notify_callbacks_in_flight_;
+    notify_cb_cv_.notify_all();
+}
 
 Status ControlService::start(uint16_t& port, bool ipv6_) {
     return rpc_server_->start(port, ipv6_);
@@ -234,10 +294,41 @@ void ControlService::onGetSegmentDesc(const std::string_view& request,
 void ControlService::onBootstrapRdma(const std::string_view& request,
                                      std::string& response) {
     std::string mutable_request(request);
-    BootstrapDesc request_desc =
-        json::parse(std::string(request)).get<BootstrapDesc>();
+    OnReceiveBootstrap callback;
+    {
+        std::lock_guard<std::mutex> guard(bootstrap_cb_mutex_);
+        if (!bootstrap_callback_) {
+            BootstrapDesc response_desc;
+            response_desc.reply_msg = "NOT_READY: transport not initialized";
+            json j = response_desc;
+            response = j.dump();
+            return;
+        }
+        callback = bootstrap_callback_;
+        ++bootstrap_callbacks_in_flight_;
+    }
+
     BootstrapDesc response_desc;
-    if (bootstrap_callback_) bootstrap_callback_(request_desc, response_desc);
+    const ControlService* previous_service = active_bootstrap_service_;
+    active_bootstrap_service_ = this;
+    try {
+        BootstrapDesc request_desc =
+            json::parse(mutable_request).get<BootstrapDesc>();
+        int rc = callback(request_desc, response_desc);
+        if (rc != 0 && response_desc.reply_msg.empty()) {
+            response_desc.reply_msg = "BootstrapRdma callback failed";
+        }
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "onBootstrapRdma failed: " << e.what();
+        response_desc.reply_msg =
+            std::string("BootstrapRdma callback failed: ") + e.what();
+    } catch (...) {
+        LOG(ERROR) << "onBootstrapRdma failed with unknown exception";
+        response_desc.reply_msg = "BootstrapRdma callback failed";
+    }
+    active_bootstrap_service_ = previous_service;
+    finishBootstrapCallback();
+
     json j = response_desc;
     response = j.dump();
 }
@@ -295,8 +386,27 @@ void ControlService::onRecvData(const std::string_view& request,
 
 void ControlService::onNotify(const std::string_view& request,
                               std::string& response) {
-    Notification message = json::parse(request).get<Notification>();
-    if (notify_callback_) notify_callback_(message);
+    (void)response;
+    OnNotify callback;
+    {
+        std::lock_guard<std::mutex> guard(notify_cb_mutex_);
+        if (!notify_callback_) return;
+        callback = notify_callback_;
+        ++notify_callbacks_in_flight_;
+    }
+
+    const ControlService* previous_service = active_notify_service_;
+    active_notify_service_ = this;
+    try {
+        Notification message = json::parse(request).get<Notification>();
+        callback(message);
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "onNotify failed: " << e.what();
+    } catch (...) {
+        LOG(ERROR) << "onNotify failed with unknown exception";
+    }
+    active_notify_service_ = previous_service;
+    finishNotifyCallback();
 }
 
 void ControlService::onProbe(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -237,9 +237,9 @@ void ControlService::setBootstrapRdmaCallback(
         return;
     }
     bootstrap_callback_ = nullptr;
-    if (!bootstrap_cb_cv_.wait_for(
-            guard, callback_drain_timeout_,
-            [this] { return bootstrap_callbacks_in_flight_ == 0; })) {
+    if (!bootstrap_cb_cv_.wait_for(guard, callback_drain_timeout_, [this] {
+            return bootstrap_callbacks_in_flight_ == 0;
+        })) {
         LOG(ERROR)
             << "Timed out waiting for BootstrapRdma callbacks to drain, "
             << "in_flight=" << bootstrap_callbacks_in_flight_
@@ -256,9 +256,9 @@ void ControlService::setNotifyCallback(const OnNotify& callback) {
         return;
     }
     notify_callback_ = nullptr;
-    if (!notify_cb_cv_.wait_for(
-            guard, callback_drain_timeout_,
-            [this] { return notify_callbacks_in_flight_ == 0; })) {
+    if (!notify_cb_cv_.wait_for(guard, callback_drain_timeout_, [this] {
+            return notify_callbacks_in_flight_ == 0;
+        })) {
         LOG(ERROR) << "Timed out waiting for Notify callbacks to drain, "
                    << "in_flight=" << notify_callbacks_in_flight_
                    << ", timeout_ms=" << callback_drain_timeout_.count()

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -37,8 +37,7 @@ class CallbackInvocationGuard {
     ~CallbackInvocationGuard() { on_exit_(); }
 
     CallbackInvocationGuard(const CallbackInvocationGuard&) = delete;
-    CallbackInvocationGuard& operator=(const CallbackInvocationGuard&) =
-        delete;
+    CallbackInvocationGuard& operator=(const CallbackInvocationGuard&) = delete;
 
    private:
     Fn on_exit_;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -378,6 +378,12 @@ Status RdmaTransport::install(std::string& local_segment_name,
 }
 
 Status RdmaTransport::uninstall() {
+    // ControlService may still receive BootstrapRdma RPCs while uninstall is
+    // running. Unregister and drain the callback before destroying workers,
+    // contexts, and other state used by onSetupRdmaConnections(). Keep this
+    // outside installed_ so partially-installed transports are covered too.
+    if (metadata_) metadata_->setBootstrapRdmaCallback(nullptr);
+
     if (installed_) {
         // Stop notification worker thread
         notify_worker_running_ = false;


### PR DESCRIPTION
## Description

This PR makes TENT `ControlService` callback unregister/replacement bounded and lifetime-safe.

Before this change, `setBootstrapRdmaCallback()` and `setNotifyCallback()` directly replaced the callback function. If a transport unregisters a callback while an RPC worker is still executing the old callback, shutdown may proceed and destroy transport-owned state while the in-flight callback still references it.

The fix adds:

1. Per-callback mutex and condition variable.
2. In-flight counters for BootstrapRdma and Notify callbacks.
3. Bounded drain when replacing/unregistering callbacks.
4. Self-unregister protection to avoid callback-triggered deadlock.
5. Local callback copies in RPC handlers so the callback remains valid during invocation.
6. Explicit `rpc_server_.reset()` in `ControlService::~ControlService()` while callback synchronization state is still alive.

If callback drain times out, the service logs an error and continues replacing the callback to keep shutdown bounded.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`git diff --check` passed.

Full build/unit test execution was not completed in the current environment because the local Mooncake checkout is missing required build dependencies/submodules (`pybind11`, Python development headers, `numa.h`, and TENT standalone CMake dependency wiring for `yalantinglibs`).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the downstream TENT fix, compare it with upstream Mooncake, and prepare this minimal upstream patch. The submitter reviewed the final diff.