### PR TITLE
[CI/Build] Isolate nightly Python tests in venv

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -306,10 +306,13 @@ jobs:
 
       - name: Build and install Python wheel for integration tests
         run: |
+          python -m venv "${RUNNER_TEMP}/mooncake-nightly-venv"
+          echo "${RUNNER_TEMP}/mooncake-nightly-venv/bin" >> "$GITHUB_PATH"
+          source "${RUNNER_TEMP}/mooncake-nightly-venv/bin/activate"
           export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
           export CUDA_HOME=/usr/local/cuda
           PYTHON_VERSION=3.12 OUTPUT_DIR=dist ./scripts/build_wheel.sh
-          pip install mooncake-wheel/dist/*.whl
+          python -m pip install mooncake-wheel/dist/*.whl
 
       - name: Run Python integration tests (full suite)
         env:


### PR DESCRIPTION
## Description

Fixes #3372.

The nightly job installed CMake artifacts with `sudo -E cmake --install .`, which created a root-owned `mooncake` package in the Python toolcache. The later wheel installation ran as the runner user and failed when it tried to replace `mooncake/__init__.py`.

Create a dedicated virtual environment before building the integration-test wheel, activate it for the current step, and add its `bin` directory to `GITHUB_PATH` so the full Python integration suite uses the same isolated environment in the next step.

This changes CI isolation only; user-facing behavior is unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
pre-commit run --files .github/workflows/nightly.yml
python -c 'import yaml; yaml.safe_load(open(".github/workflows/nightly.yml"))'
# Local venv activation and next-step PATH inheritance simulations
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (requires the nightly GitHub Actions environment)
- [x] Manual testing done: YAML parsing, venv activation, and next-step PATH resolution passed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (no C/C++ files changed; hook skipped)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (not applicable; no user-facing change)
- [ ] I have added tests to prove my changes are effective (workflow-only fix)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 5-line diff)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex inspected the failing Actions log, identified the root-owned Python package conflict, implemented the venv-based workflow fix, and ran the listed validation. The human submitter is responsible for reviewing and defending the change.