### PR TITLE
[Wheel] Add DataProto catalog lifecycle management

### DIFF
--- a/mooncake-wheel/mooncake/dataproto_catalog.py
+++ b/mooncake-wheel/mooncake/dataproto_catalog.py
@@ -1,24 +1,37 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Mapping, Sequence
+import logging
+import threading
+import uuid
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any
+
+
+logger = logging.getLogger(__name__)
 
 
 class DataProtoCatalog:
     """Map logical rows and fields to immutable DataProto refs.
 
-    The catalog only tracks metadata. Data transfer and object lifetime remain
-    owned by MooncakeBundleTransfer and Mooncake Store, respectively. Calls to
-    one catalog instance must be serialized by its host. Each update publishes
-    one immutable, single-stage fragment; multi-stage append handles are not
-    catalog fragments.
+    Calls to one catalog instance must be serialized by its host. Direct
+    handles remain metadata-only. DataProtoCatalogTransfer marks only fresh,
+    independent fragments as managed so their physical lifetime can follow
+    logical references and active readers; append-derived handles are not
+    managed catalog fragments.
     """
 
     def __init__(self) -> None:
         self._partitions: dict[str, dict[str, dict[str, Any]]] = {}
         self._fragments: dict[str, dict[str, Any]] = {}
+        self._retired: dict[str, dict[str, Any]] = {}
+        self._publications: dict[str, dict[str, Any]] = {}
         self._fragment_refcounts: dict[str, int] = {}
+        self._managed_fragments: set[str] = set()
+        self._fragment_readers: dict[str, int] = {}
+        self._read_pins: dict[int, tuple[str, ...]] = {}
+        self._next_read_token = 0
+        self._drained = False
 
     def update(
         self,
@@ -28,7 +41,47 @@ class DataProtoCatalog:
         tags: Sequence[Mapping[str, Any]] | None = None,
         handle: Mapping[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Merge tags and publish every field in a single-stage ``handle``."""
+        return self._update(partition, keys, tags=tags, handle=handle, managed=False)
+
+    def publish(
+        self,
+        operation_id: str,
+        partition: str,
+        keys: Sequence[str],
+        *,
+        tags: Sequence[Mapping[str, Any]] | None = None,
+        handle: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Idempotently publish one transfer-managed fresh fragment."""
+        operation_id = _nonempty_string(operation_id, "operation_id")
+        previous = self._publications.get(operation_id)
+        if previous is not None:
+            return copy.deepcopy(previous)
+
+        result = self._update(
+            partition,
+            keys,
+            tags=tags,
+            handle=handle,
+            managed=handle is not None,
+        )
+        self._publications[operation_id] = copy.deepcopy(result)
+        return result
+
+    def ack_publication(self, operation_id: str) -> None:
+        self._publications.pop(_nonempty_string(operation_id, "operation_id"), None)
+
+    def _update(
+        self,
+        partition: str,
+        keys: Sequence[str],
+        *,
+        tags: Sequence[Mapping[str, Any]] | None,
+        handle: Mapping[str, Any] | None,
+        managed: bool,
+    ) -> dict[str, Any]:
+        if self._drained:
+            raise RuntimeError("DataProto catalog is drained")
         partition = _nonempty_string(partition, "partition")
         keys = _names(keys, "keys")
         normalized_tags = _tags(tags, len(keys))
@@ -41,6 +94,17 @@ class DataProtoCatalog:
             previous = self._fragments.get(fragment_id)
             if previous is not None and previous != stored_handle:
                 raise ValueError(f"DataProto fragment id collision: {fragment_id!r}")
+            if (
+                previous is not None
+                and (fragment_id in self._managed_fragments) != managed
+            ):
+                raise ValueError(
+                    f"DataProto fragment management mismatch: {fragment_id!r}"
+                )
+            if fragment_id in self._retired:
+                raise ValueError(
+                    f"DataProto fragment id is pending retirement: {fragment_id!r}"
+                )
 
         current_entries = self._partitions.get(partition, {})
         merged_tags = {}
@@ -56,6 +120,8 @@ class DataProtoCatalog:
         if fragment is not None:
             self._fragments.setdefault(fragment_id, stored_handle)
             self._fragment_refcounts.setdefault(fragment_id, 0)
+            if managed:
+                self._managed_fragments.add(fragment_id)
 
         for row, key in enumerate(keys):
             entry = entries.setdefault(key, {"tag": {}, "fields": {}})
@@ -79,6 +145,7 @@ class DataProtoCatalog:
             "keys": list(keys),
             "tags": response_tags,
             "fields": _field_union(entries, keys),
+            **self._retired_result(),
         }
 
     def resolve(
@@ -86,6 +153,8 @@ class DataProtoCatalog:
         partition: str,
         keys: Sequence[str],
         fields: Sequence[str] | None = None,
+        *,
+        pin: bool = False,
     ) -> dict[str, Any]:
         """Resolve an ordered logical read into immutable fragment locations."""
         partition = _nonempty_string(partition, "partition")
@@ -118,7 +187,20 @@ class DataProtoCatalog:
             grouped_fields.setdefault(locations, []).append(field)
             fragment_ids.update(location[0] for location in locations)
 
-        return {
+        handles = {
+            fragment_id: copy.deepcopy(self._fragments[fragment_id])
+            for fragment_id in fragment_ids
+        }
+        meta_info: dict[str, Any] = {}
+        for handle in handles.values():
+            for name, value in handle.get("meta_info", {}).items():
+                if name in meta_info and meta_info[name] != value:
+                    raise ValueError(
+                        f"conflicting DataProto meta_info value for {name!r}"
+                    )
+                meta_info[name] = copy.deepcopy(value)
+
+        result = {
             "keys": list(keys),
             "tags": [copy.deepcopy(entries[key]["tag"]) for key in keys],
             "fields": selected,
@@ -126,11 +208,36 @@ class DataProtoCatalog:
                 {"fields": fields, "locations": list(locations)}
                 for locations, fields in grouped_fields.items()
             ],
-            "handles": {
-                fragment_id: copy.deepcopy(self._fragments[fragment_id])
-                for fragment_id in fragment_ids
-            },
+            "handles": handles,
+            "meta_info": meta_info,
         }
+        if pin:
+            self._next_read_token += 1
+            token = self._next_read_token
+            pinned = tuple(fragment_ids)
+            self._read_pins[token] = pinned
+            for fragment_id in pinned:
+                self._fragment_readers[fragment_id] = (
+                    self._fragment_readers.get(fragment_id, 0) + 1
+                )
+            result["read_token"] = token
+        return result
+
+    def release_read(self, token: int) -> dict[str, Any]:
+        """Idempotently release a pinned resolve and return pending handles."""
+        fragment_ids = self._read_pins.pop(token, None)
+        if fragment_ids is None:
+            return self._retired_result()
+
+        for fragment_id in fragment_ids:
+            readers = self._fragment_readers[fragment_id] - 1
+            if readers:
+                self._fragment_readers[fragment_id] = readers
+                continue
+            del self._fragment_readers[fragment_id]
+            if fragment_id not in self._fragment_refcounts:
+                self._retire_fragment(fragment_id)
+        return self._retired_result()
 
     def list(self, partition: str | None = None) -> dict[str, dict[str, Any]]:
         """Return tags using the same partition/key shape as rollout KV APIs."""
@@ -147,16 +254,16 @@ class DataProtoCatalog:
             for partition_id in partitions
         }
 
-    def remove(self, partition: str, keys: Sequence[str]) -> None:
+    def remove(self, partition: str, keys: Sequence[str]) -> dict[str, Any]:
         """Remove logical keys after their writers have finished.
 
-        This only removes catalog metadata; physical lifetime stays with Store.
+        Returned managed handles can be passed to ``cleanup_dataproto``.
         """
         partition = _nonempty_string(partition, "partition")
         keys = _names(keys, "keys")
         entries = self._partitions.get(partition)
         if entries is None:
-            return
+            return self._retired_result()
 
         for key in keys:
             entry = entries.pop(key, None)
@@ -166,6 +273,38 @@ class DataProtoCatalog:
                 self._drop_fragment_reference(fragment_id)
         if not entries:
             del self._partitions[partition]
+        return self._retired_result()
+
+    def drain(self) -> dict[str, Any]:
+        """Retire all metadata after clients quiesce and return pending handles."""
+        if self._read_pins:
+            raise RuntimeError(
+                f"cannot drain DataProto catalog with {len(self._read_pins)} active read(s)"
+            )
+        for fragment_id in self._managed_fragments:
+            self._retired[fragment_id] = self._fragments[fragment_id]
+        self._partitions.clear()
+        self._fragments.clear()
+        self._fragment_refcounts.clear()
+        self._managed_fragments.clear()
+        self._fragment_readers.clear()
+        self._publications.clear()
+        self._drained = True
+        return self._retired_result()
+
+    def ack_retired(self, handles: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+        """Forget retired handles whose Store objects were removed successfully."""
+        for handle in handles:
+            _ref, fragment_id, normalized = _normalize_handle(handle)
+            pending = self._retired.get(fragment_id)
+            if pending is None:
+                continue
+            if pending != normalized:
+                raise ValueError(
+                    f"retired DataProto fragment mismatch: {fragment_id!r}"
+                )
+            del self._retired[fragment_id]
+        return self._retired_result()
 
     def _drop_fragment_reference(self, fragment_id: str) -> None:
         remaining = self._fragment_refcounts[fragment_id] - 1
@@ -173,32 +312,260 @@ class DataProtoCatalog:
             self._fragment_refcounts[fragment_id] = remaining
             return
         del self._fragment_refcounts[fragment_id]
-        del self._fragments[fragment_id]
+        if self._fragment_readers.get(fragment_id, 0):
+            return
+        self._retire_fragment(fragment_id)
+
+    def _retire_fragment(self, fragment_id: str) -> None:
+        handle = self._fragments.pop(fragment_id)
+        if fragment_id in self._managed_fragments:
+            self._managed_fragments.remove(fragment_id)
+            self._retired[fragment_id] = handle
+
+    def _retired_result(self) -> dict[str, Any]:
+        return {
+            "retired_handles": [
+                copy.deepcopy(handle) for handle in self._retired.values()
+            ]
+        }
 
 
-def _fragment(
-    handle: Mapping[str, Any], batch_size: int
-) -> tuple[str, dict[str, Any], tuple[str, ...]]:
+class DataProtoCatalogTransfer:
+    _RESULTS_ATTR = "_mooncake_catalog_results"
+
+    def __init__(self, transfer: Any, catalog_call: Callable[..., Any]) -> None:
+        self.transfer = transfer
+        self._catalog_call = catalog_call
+        self._pending_publications: list[dict[str, Any]] = []
+        self._pending_publication_acks: list[str] = []
+        self._pending_results: list[Any] = []
+        self._cleanup_lock = threading.RLock()
+
+    def put(
+        self,
+        data: Any,
+        *,
+        partition: str,
+        keys: Sequence[str],
+        tags: Sequence[Mapping[str, Any]] | None = None,
+        **put_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Put one immutable fragment and atomically publish it in Catalog."""
+        self._retry_publication_acks()
+        self._retry_publications(strict=True)
+        partition = _nonempty_string(partition, "partition")
+        normalized_keys = _names(keys, "keys")
+        normalized_tags = _tags(tags, len(normalized_keys))
+        if data is None and normalized_tags is None:
+            raise ValueError("catalog update requires tags or DataProto data")
+
+        handle = None
+        if data is not None:
+            if len(data) != len(normalized_keys):
+                raise ValueError(
+                    f"DataProto batch size {len(data)} does not match {len(normalized_keys)} logical keys"
+                )
+            from mooncake.structured_object_store import export_dataproto_ref
+
+            handle = export_dataproto_ref(
+                self.transfer.put(
+                    data, type="dataproto", partition=partition, **put_kwargs
+                )
+            )
+        publication = {
+            "operation_id": uuid.uuid4().hex,
+            "partition": partition,
+            "keys": normalized_keys,
+            "tags": normalized_tags,
+            "handle": handle,
+        }
+        for attempt in range(2):
+            try:
+                return self._publish(publication)
+            except Exception:
+                if attempt:
+                    with self._cleanup_lock:
+                        self._pending_publications.append(publication)
+                    raise
+                logger.exception("Retrying DataProto Catalog publication")
+        raise AssertionError("unreachable")
+
+    def resolve(
+        self,
+        partition: str,
+        keys: Sequence[str],
+        fields: Sequence[str] | None = None,
+    ) -> dict[str, Any]:
+        return self._catalog_call("resolve", partition, keys, fields, pin=True)
+
+    def release_read(self, token: int) -> None:
+        self._cleanup_retired(self._catalog_call("release_read", token))
+
+    def attach_results(self, output: Any, results: Sequence[Any]) -> None:
+        setattr(output, self._RESULTS_ATTR, list(results))
+
+    def release_result(self, output: Any) -> None:
+        results = getattr(output, self._RESULTS_ATTR, ()) or ()
+        setattr(output, self._RESULTS_ATTR, [])
+        self.discard_results(results)
+
+    def discard_results(self, results: Sequence[Any], *, strict: bool = False) -> None:
+        self._retry_pending(
+            "_pending_results",
+            results,
+            self.transfer.release_result,
+            "release DataProto read buffer",
+            attempts=2,
+            strict=strict,
+        )
+
+    def list(self, partition: str | None = None) -> dict[str, dict[str, Any]]:
+        return self._catalog_call("list", partition)
+
+    def remove(self, partition: str, keys: Sequence[str]) -> None:
+        self._cleanup_retired(self._catalog_call("remove", partition, keys))
+
+    def drain(self) -> None:
+        for attempt in range(2):
+            try:
+                self._cleanup_retired(self._catalog_call("drain"), strict=True)
+                return
+            except Exception:
+                if attempt:
+                    raise
+                logger.exception("Retrying DataProto Catalog drain")
+
+    def close(self) -> None:
+        self.discard_results((), strict=True)
+        self._retry_publications(strict=True)
+        self._retry_publication_acks(strict=True)
+
+    def _cleanup_retired(
+        self, result: Mapping[str, Any], *, strict: bool = False
+    ) -> None:
+        removed = []
+        failures = 0
+        for handle in result.get("retired_handles", ()):
+            try:
+                self.transfer.cleanup_dataproto(handle)
+            except Exception:
+                failures += 1
+                logger.exception("Failed to clean up retired DataProto fragment")
+            else:
+                removed.append(handle)
+        if removed:
+            try:
+                self._catalog_call("ack_retired", removed)
+            except Exception:
+                logger.exception("Failed to acknowledge retired DataProto fragments")
+                if strict:
+                    raise
+        if strict and failures:
+            raise RuntimeError(
+                f"failed to clean up {failures} retired DataProto fragment(s)"
+            )
+
+    def _publish(self, publication: Mapping[str, Any]) -> dict[str, Any]:
+        operation_id = publication["operation_id"]
+        result = self._catalog_call(
+            "publish",
+            operation_id,
+            publication["partition"],
+            publication["keys"],
+            tags=publication["tags"],
+            handle=publication["handle"],
+        )
+        self._cleanup_retired(result)
+        self._ack_publication(operation_id)
+        return result
+
+    def _ack_publication(self, operation_id: str) -> None:
+        try:
+            self._catalog_call("ack_publication", operation_id)
+        except Exception:
+            logger.exception("Failed to acknowledge DataProto Catalog publication")
+            with self._cleanup_lock:
+                if operation_id not in self._pending_publication_acks:
+                    self._pending_publication_acks.append(operation_id)
+
+    def _retry_publication_acks(self, *, strict: bool = False) -> None:
+        self._retry_pending(
+            "_pending_publication_acks",
+            (),
+            lambda operation_id: self._catalog_call("ack_publication", operation_id),
+            "acknowledge DataProto Catalog publication",
+            strict=strict,
+        )
+
+    def _retry_publications(self, *, strict: bool = False) -> None:
+        self._retry_pending(
+            "_pending_publications",
+            (),
+            self._publish,
+            "publish pending DataProto fragment",
+            strict=strict,
+        )
+
+    def _retry_pending(
+        self,
+        pending_attr: str,
+        items: Sequence[Any],
+        action: Callable[[Any], None],
+        label: str,
+        *,
+        attempts: int = 1,
+        strict: bool = False,
+    ) -> None:
+        with self._cleanup_lock:
+            pending = [*getattr(self, pending_attr), *items]
+            setattr(self, pending_attr, [])
+        for _attempt in range(attempts):
+            failed = []
+            for item in pending:
+                try:
+                    action(item)
+                except Exception:
+                    logger.exception("Failed to %s", label)
+                    failed.append(item)
+            pending = failed
+        with self._cleanup_lock:
+            getattr(self, pending_attr).extend(pending)
+            pending_count = len(getattr(self, pending_attr))
+        if strict and pending_count:
+            raise RuntimeError(f"failed to {label} for {pending_count} item(s)")
+
+
+def _normalize_handle(
+    handle: Mapping[str, Any],
+) -> tuple[Any, str, dict[str, Any]]:
     from mooncake.structured_object_store import (
         export_dataproto_ref,
         import_dataproto_ref,
     )
 
     ref = import_dataproto_ref(handle)
+    if len(ref.stage_refs) != 1:
+        raise ValueError("catalog fragments must contain exactly one DataProto stage")
+    fragment_id = _nonempty_string(
+        next(iter(ref.stage_refs.values())).manifest_key,
+        "manifest_key",
+    )
+    return ref, fragment_id, export_dataproto_ref(ref)
+
+
+def _fragment(
+    handle: Mapping[str, Any], batch_size: int
+) -> tuple[str, dict[str, Any], tuple[str, ...]]:
+    ref, fragment_id, stored_handle = _normalize_handle(handle)
     if ref.batch_size != batch_size:
         raise ValueError(
             f"DataProto batch size {ref.batch_size!r} does not match "
             f"{batch_size} logical keys"
         )
-    if len(ref.stage_refs) != 1:
-        raise ValueError("catalog fragments must contain exactly one DataProto stage")
-    fragment_id = _nonempty_string(
-        next(iter(ref.stage_refs.values())).manifest_key, "manifest_key"
-    )
     fields = _names(ref.field_index, "field names")
     if not fields:
         raise ValueError("DataProto catalog fragments cannot be empty")
-    return fragment_id, export_dataproto_ref(ref), fields
+    return fragment_id, stored_handle, fields
 
 
 def _field_union(

--- a/mooncake-wheel/mooncake/dataproto_catalog.py
+++ b/mooncake-wheel/mooncake/dataproto_catalog.py
@@ -86,17 +86,21 @@ class DataProtoCatalog:
         if previous is not None:
             return copy.deepcopy(previous)
         if self._drained:
-            raise RuntimeError("DataProto catalog is drained")
+            return self._reject_append(operation_id, "DataProto catalog is drained")
         fragment_id = _nonempty_string(fragment_id, "fragment_id")
         partition = _nonempty_string(partition, "partition")
         keys = _names(keys, "keys")
         previous_ref, normalized_previous = _normalize_handle(previous_handle)
         ref, normalized = _normalize_handle(handle)
         current = self._fragments.get(fragment_id)
-        if current is None or fragment_id not in self._managed_fragments:
-            raise ValueError(f"DataProto fragment is not managed: {fragment_id!r}")
-        if current != normalized_previous:
-            raise ValueError(f"stale DataProto append handle: {fragment_id!r}")
+        if (
+            current is None
+            or fragment_id not in self._managed_fragments
+            or current != normalized_previous
+        ):
+            return self._reject_append(
+                operation_id, f"stale DataProto append handle: {fragment_id!r}"
+            )
         if (
             ref.batch_size != previous_ref.batch_size
             or ref.batch_size != len(keys)
@@ -104,13 +108,17 @@ class DataProtoCatalog:
             or ref.partition != partition
             or ref._storage_group_id != previous_ref._storage_group_id
         ):
-            raise ValueError("appended DataProto handle changed fragment identity")
+            return self._reject_append(
+                operation_id, "appended DataProto handle changed fragment identity"
+            )
         previous_fields = previous_ref.field_index
         if any(
             ref.field_index.get(name) != location
             for name, location in previous_fields.items()
         ):
-            raise ValueError("appended DataProto handle changed existing fields")
+            return self._reject_append(
+                operation_id, "appended DataProto handle changed existing fields"
+            )
         new_fields = [
             field for field in ref.field_index if field not in previous_fields
         ]
@@ -118,7 +126,10 @@ class DataProtoCatalog:
         entries = self._partitions.get(partition, {})
         missing = [key for key in keys if key not in entries]
         if missing:
-            raise ValueError(f"keys not found in partition {partition!r}: {missing}")
+            return self._reject_append(
+                operation_id,
+                f"keys not found in partition {partition!r}: {missing}",
+            )
         for row, key in enumerate(keys):
             for field in new_fields:
                 location = (fragment_id, row)
@@ -134,6 +145,11 @@ class DataProtoCatalog:
             "fields": _field_union(entries, keys),
             **self._retired_result(),
         }
+        self._publications[operation_id] = copy.deepcopy(result)
+        return result
+
+    def _reject_append(self, operation_id: str, message: str) -> dict[str, Any]:
+        result = {"append_rejected": message}
         self._publications[operation_id] = copy.deepcopy(result)
         return result
 
@@ -515,13 +531,18 @@ class DataProtoCatalogTransfer:
         }
         for attempt in range(2):
             try:
-                return self._publish(publication)
+                result = self._publish(publication)
             except Exception:
                 if attempt:
                     with self._cleanup_lock:
                         self._pending_publications.append(publication)
                     raise
                 logger.exception("Retrying DataProto Catalog append publication")
+            else:
+                rejection = result.get("append_rejected")
+                if rejection is not None:
+                    raise ValueError(rejection)
+                return result
         raise AssertionError("unreachable")
 
     def resolve(
@@ -608,6 +629,13 @@ class DataProtoCatalogTransfer:
             *publication["args"],
             **publication["kwargs"],
         )
+        if publication["method"] == "publish_append" and result.get(
+            "append_rejected"
+        ):
+            self.transfer.cleanup_dataproto_append(
+                publication["kwargs"]["previous_handle"],
+                publication["kwargs"]["handle"],
+            )
         self._cleanup_retired(result)
         self._ack_publication(operation_id)
         return result

--- a/mooncake-wheel/mooncake/dataproto_catalog.py
+++ b/mooncake-wheel/mooncake/dataproto_catalog.py
@@ -16,9 +16,8 @@ class DataProtoCatalog:
 
     Calls to one catalog instance must be serialized by its host. Direct
     handles remain metadata-only. DataProtoCatalogTransfer marks only fresh,
-    independent fragments as managed so their physical lifetime can follow
-    logical references and active readers; append-derived handles are not
-    managed catalog fragments.
+    independent fragments as managed so their physical lifetime, including
+    append-derived handles, can follow logical references and active readers.
     """
 
     def __init__(self) -> None:
@@ -70,6 +69,73 @@ class DataProtoCatalog:
 
     def ack_publication(self, operation_id: str) -> None:
         self._publications.pop(_nonempty_string(operation_id, "operation_id"), None)
+
+    def publish_append(
+        self,
+        operation_id: str,
+        fragment_id: str,
+        partition: str,
+        keys: Sequence[str],
+        *,
+        previous_handle: Mapping[str, Any],
+        handle: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Idempotently replace a managed fragment with its appended handle."""
+        operation_id = _nonempty_string(operation_id, "operation_id")
+        previous = self._publications.get(operation_id)
+        if previous is not None:
+            return copy.deepcopy(previous)
+        if self._drained:
+            raise RuntimeError("DataProto catalog is drained")
+        fragment_id = _nonempty_string(fragment_id, "fragment_id")
+        partition = _nonempty_string(partition, "partition")
+        keys = _names(keys, "keys")
+        previous_ref, normalized_previous = _normalize_handle(previous_handle)
+        ref, normalized = _normalize_handle(handle)
+        current = self._fragments.get(fragment_id)
+        if current is None or fragment_id not in self._managed_fragments:
+            raise ValueError(f"DataProto fragment is not managed: {fragment_id!r}")
+        if current != normalized_previous:
+            raise ValueError(f"stale DataProto append handle: {fragment_id!r}")
+        if (
+            ref.batch_size != previous_ref.batch_size
+            or ref.batch_size != len(keys)
+            or ref.partition != previous_ref.partition
+            or ref.partition != partition
+            or ref._storage_group_id != previous_ref._storage_group_id
+        ):
+            raise ValueError("appended DataProto handle changed fragment identity")
+        previous_fields = previous_ref.field_index
+        if any(
+            ref.field_index.get(name) != location
+            for name, location in previous_fields.items()
+        ):
+            raise ValueError("appended DataProto handle changed existing fields")
+        new_fields = [
+            field for field in ref.field_index if field not in previous_fields
+        ]
+
+        entries = self._partitions.get(partition, {})
+        missing = [key for key in keys if key not in entries]
+        if missing:
+            raise ValueError(f"keys not found in partition {partition!r}: {missing}")
+        for row, key in enumerate(keys):
+            for field in new_fields:
+                location = (fragment_id, row)
+                old_location = entries[key]["fields"].get(field)
+                if old_location is not None:
+                    self._drop_fragment_reference(old_location[0])
+                entries[key]["fields"][field] = location
+                self._fragment_refcounts[fragment_id] += 1
+        self._fragments[fragment_id] = normalized
+        result = {
+            "keys": list(keys),
+            "tags": [copy.deepcopy(entries[key]["tag"]) for key in keys],
+            "fields": _field_union(entries, keys),
+            **self._retired_result(),
+        }
+        self._publications[operation_id] = copy.deepcopy(result)
+        return result
 
     def _update(
         self,
@@ -295,15 +361,24 @@ class DataProtoCatalog:
     def ack_retired(self, handles: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
         """Forget retired handles whose Store objects were removed successfully."""
         for handle in handles:
-            _ref, fragment_id, normalized = _normalize_handle(handle)
-            pending = self._retired.get(fragment_id)
-            if pending is None:
+            ref, normalized = _normalize_handle(handle)
+            fragment_id = next(
+                (
+                    key
+                    for key, pending in self._retired.items()
+                    if pending == normalized
+                ),
+                None,
+            )
+            if fragment_id is not None:
+                del self._retired[fragment_id]
                 continue
-            if pending != normalized:
-                raise ValueError(
-                    f"retired DataProto fragment mismatch: {fragment_id!r}"
-                )
-            del self._retired[fragment_id]
+            if len(ref.stage_refs) == 1:
+                fragment_id = next(iter(ref.stage_refs.values())).manifest_key
+                if fragment_id in self._retired:
+                    raise ValueError(
+                        f"retired DataProto fragment mismatch: {fragment_id!r}"
+                    )
         return self._retired_result()
 
     def _drop_fragment_reference(self, fragment_id: str) -> None:
@@ -374,10 +449,9 @@ class DataProtoCatalogTransfer:
             )
         publication = {
             "operation_id": uuid.uuid4().hex,
-            "partition": partition,
-            "keys": normalized_keys,
-            "tags": normalized_tags,
-            "handle": handle,
+            "method": "publish",
+            "args": (partition, normalized_keys),
+            "kwargs": {"tags": normalized_tags, "handle": handle},
         }
         for attempt in range(2):
             try:
@@ -388,6 +462,66 @@ class DataProtoCatalogTransfer:
                         self._pending_publications.append(publication)
                     raise
                 logger.exception("Retrying DataProto Catalog publication")
+        raise AssertionError("unreachable")
+
+    def append(
+        self,
+        fragment_id: str,
+        handle: Mapping[str, Any],
+        data: Any,
+        *,
+        partition: str,
+        keys: Sequence[str],
+        stage: str,
+        **append_kwargs: Any,
+    ) -> dict[str, Any]:
+        """Append fields and transfer managed-fragment ownership to the result."""
+        self._retry_publication_acks()
+        self._retry_publications(strict=True)
+        fragment_id = _nonempty_string(fragment_id, "fragment_id")
+        partition = _nonempty_string(partition, "partition")
+        normalized_keys = _names(keys, "keys")
+        if append_kwargs.get("overwrite"):
+            raise ValueError("catalog append does not support overwrite")
+        if len(data) != len(normalized_keys):
+            raise ValueError(
+                f"DataProto batch size {len(data)} does not match {len(normalized_keys)} logical keys"
+            )
+        previous_ref, previous_handle = _normalize_handle(handle)
+        if previous_ref.partition != partition:
+            raise ValueError(
+                "DataProto handle partition does not match Catalog partition"
+            )
+        plan = self._catalog_call(
+            "resolve", partition, normalized_keys, list(previous_ref.field_index)
+        )
+        if plan["handles"].get(fragment_id) != previous_handle:
+            raise ValueError(f"stale DataProto append handle: {fragment_id!r}")
+        from mooncake.structured_object_store import export_dataproto_ref
+
+        appended_handle = export_dataproto_ref(
+            self.transfer.append_dataproto_fields(
+                previous_handle, data, stage=stage, **append_kwargs
+            )
+        )
+        publication = {
+            "operation_id": uuid.uuid4().hex,
+            "method": "publish_append",
+            "args": (fragment_id, partition, normalized_keys),
+            "kwargs": {
+                "previous_handle": previous_handle,
+                "handle": appended_handle,
+            },
+        }
+        for attempt in range(2):
+            try:
+                return self._publish(publication)
+            except Exception:
+                if attempt:
+                    with self._cleanup_lock:
+                        self._pending_publications.append(publication)
+                    raise
+                logger.exception("Retrying DataProto Catalog append publication")
         raise AssertionError("unreachable")
 
     def resolve(
@@ -469,12 +603,10 @@ class DataProtoCatalogTransfer:
     def _publish(self, publication: Mapping[str, Any]) -> dict[str, Any]:
         operation_id = publication["operation_id"]
         result = self._catalog_call(
-            "publish",
+            publication["method"],
             operation_id,
-            publication["partition"],
-            publication["keys"],
-            tags=publication["tags"],
-            handle=publication["handle"],
+            *publication["args"],
+            **publication["kwargs"],
         )
         self._cleanup_retired(result)
         self._ack_publication(operation_id)
@@ -538,26 +670,26 @@ class DataProtoCatalogTransfer:
 
 def _normalize_handle(
     handle: Mapping[str, Any],
-) -> tuple[Any, str, dict[str, Any]]:
+) -> tuple[Any, dict[str, Any]]:
     from mooncake.structured_object_store import (
         export_dataproto_ref,
         import_dataproto_ref,
     )
 
     ref = import_dataproto_ref(handle)
+    return ref, export_dataproto_ref(ref)
+
+
+def _fragment(
+    handle: Mapping[str, Any], batch_size: int
+) -> tuple[str, dict[str, Any], tuple[str, ...]]:
+    ref, stored_handle = _normalize_handle(handle)
     if len(ref.stage_refs) != 1:
         raise ValueError("catalog fragments must contain exactly one DataProto stage")
     fragment_id = _nonempty_string(
         next(iter(ref.stage_refs.values())).manifest_key,
         "manifest_key",
     )
-    return ref, fragment_id, export_dataproto_ref(ref)
-
-
-def _fragment(
-    handle: Mapping[str, Any], batch_size: int
-) -> tuple[str, dict[str, Any], tuple[str, ...]]:
-    ref, fragment_id, stored_handle = _normalize_handle(handle)
     if ref.batch_size != batch_size:
         raise ValueError(
             f"DataProto batch size {ref.batch_size!r} does not match "

--- a/mooncake-wheel/mooncake/dataproto_catalog.py
+++ b/mooncake-wheel/mooncake/dataproto_catalog.py
@@ -428,6 +428,7 @@ class DataProtoCatalogTransfer:
     def drain(self) -> None:
         for attempt in range(2):
             try:
+                self._retry_publications(strict=True)
                 self._cleanup_retired(self._catalog_call("drain"), strict=True)
                 return
             except Exception:

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -51,6 +51,8 @@ class BundleStore(Protocol):
 
     def remove(self, key: str, force: bool = False) -> int: ...
 
+    def is_exist(self, key: str) -> int: ...
+
 
 @dataclass(frozen=True)
 class BundleTransferPolicy:
@@ -658,6 +660,12 @@ class MooncakeBundleTransfer:
             items_to_visit = None
             if isinstance(value, Mapping):
                 items_to_visit = value.values()
+            elif hasattr(value, "batch") and hasattr(value, "non_tensor_batch"):
+                items_to_visit = (
+                    value.batch,
+                    value.non_tensor_batch,
+                    getattr(value, "meta_info", None),
+                )
             elif isinstance(value, (list, tuple)):
                 items_to_visit = value
             elif isinstance(value, np.ndarray) and value.dtype == object:
@@ -3690,11 +3698,39 @@ class _BundleManifestStore:
         return RemoteBundleRef(manifest_key=manifest_key, manifest=manifest)
 
     def remove_bundle(self, ref: RemoteBundleRef | Mapping[str, Any]) -> None:
-        manifest = self.resolve_manifest(ref)
+        manifest_key = (
+            ref.manifest_key
+            if isinstance(ref, RemoteBundleRef)
+            else ref.get("manifest_key")
+        )
+        embedded_manifest = (
+            ref.manifest if isinstance(ref, RemoteBundleRef) else ref.get("manifest")
+        )
+        is_exist = getattr(self._store, "is_exist", None)
+        if (
+            not embedded_manifest
+            and isinstance(manifest_key, str)
+            and callable(is_exist)
+        ):
+            status = is_exist(manifest_key)
+            if status == 0:
+                return
+            if status != 1:
+                raise RuntimeError(f"is_exist failed for {manifest_key}: {status}")
+        try:
+            manifest = self.resolve_manifest(ref)
+        except Exception:
+            if (
+                isinstance(manifest_key, str)
+                and callable(is_exist)
+                and is_exist(manifest_key) == 0
+            ):
+                return
+            raise
         keys = self._payload_keys(manifest)
         keys.extend(manifest.get("cleanup_keys", []))
-        keys.append(self._manifest_key(ref, manifest))
         _cleanup_keys(self._store, keys, strict=True)
+        _cleanup_keys(self._store, [self._manifest_key(ref, manifest)], strict=True)
 
     def manifest_key(self, ref: RemoteBundleRef | Mapping[str, Any]) -> str:
         return self._manifest_key(ref, self.resolve_manifest(ref))
@@ -6004,7 +6040,13 @@ def _deserialize_nested_tensor_payload(
 ) -> Any:
     payload_format = field_spec.get("format", "torch_save")
     if payload_format == "torch_save":
-        return _deserialize_torch_save_payload(payload)
+        value = _deserialize_torch_save_payload(payload)
+        return _nested_tensor_from_parts(
+            value.values(),
+            value.offsets(),
+            value.lengths(),
+            int(getattr(value, "_ragged_idx", 1)),
+        )
     if payload_format != "tensor_parts":
         raise ValueError(f"unsupported nested tensor payload format: {payload_format}")
 
@@ -6017,7 +6059,9 @@ def _deserialize_nested_tensor_payload(
     offset = 0
     for part_size in part_bytes:
         if (
-            not isinstance(part_size, int) or isinstance(part_size, bool) or part_size <= 0
+            not isinstance(part_size, int)
+            or isinstance(part_size, bool)
+            or part_size <= 0
         ):
             raise ValueError("nested tensor payload has invalid part size")
         end = offset + int(part_size)
@@ -6028,11 +6072,30 @@ def _deserialize_nested_tensor_payload(
     if offset != len(payload):
         raise ValueError("nested tensor payload has trailing bytes")
 
-    return _torch.nested.nested_tensor_from_jagged(
+    return _nested_tensor_from_parts(
         tensors[0],
-        offsets=tensors[1],
-        lengths=tensors[2] if expected_parts == 3 else None,
-        jagged_dim=int(field_spec.get("ragged_idx", 1)),
+        tensors[1],
+        tensors[2] if expected_parts == 3 else None,
+        int(field_spec.get("ragged_idx", 1)),
+    )
+
+
+def _nested_tensor_from_parts(
+    values: Any, offsets: Any, lengths: Any, ragged_idx: int
+) -> Any:
+    sequence_lengths = lengths if lengths is not None else offsets.diff()
+    if sequence_lengths.numel():
+        min_seqlen = int(sequence_lengths.min().item())
+        max_seqlen = int(sequence_lengths.max().item())
+    else:
+        min_seqlen = max_seqlen = 0
+    return _torch.nested.nested_tensor_from_jagged(
+        values,
+        offsets=offsets,
+        lengths=lengths,
+        jagged_dim=ragged_idx,
+        min_seqlen=min_seqlen,
+        max_seqlen=max_seqlen,
     )
 
 

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -560,6 +560,58 @@ class MooncakeBundleTransfer:
         """Remove all Mooncake objects that belong to a stored bundle."""
         self._bundle_store.remove_bundle(ref)
 
+    def cleanup_dataproto_append(
+        self, previous: DataProtoRefLike, appended: DataProtoRefLike
+    ) -> None:
+        """Remove an unpublished append without touching the previous handle."""
+        previous = _resolve_dataproto_ref(previous)
+        appended = _resolve_dataproto_ref(appended)
+        for stage, stage_ref in appended.stage_refs.items():
+            previous_stage_ref = previous.stage_refs.get(stage)
+            if previous_stage_ref is None:
+                self.remove_bundle(stage_ref)
+                continue
+            if stage_ref.manifest_key == previous_stage_ref.manifest_key:
+                continue
+
+            is_exist = getattr(self.store, "is_exist", None)
+            if callable(is_exist) and is_exist(stage_ref.manifest_key) == 0:
+                continue
+            new_manifest = self._bundle_store.resolve_manifest(stage_ref)
+            old_buffer_names = {
+                location.member
+                for location in previous.field_index.values()
+                if location.stage == stage
+            }
+            for name, encoded in previous.encoded_non_tensor.items():
+                if previous.field_index[name].stage == stage:
+                    old_buffer_names.update(encoded["payload_members"].values())
+            new_payloads = [
+                payload
+                for name, payload in new_manifest["buffers"].items()
+                if name not in old_buffer_names
+            ]
+            new_object_ids = {
+                self._bundle_store._object_id_from_bundle_key(payload["key"])
+                for payload in new_payloads
+            }
+            cleanup_keys = [
+                *self._bundle_store.payload_keys(new_manifest["meta"]),
+                *[
+                    chunk["key"]
+                    for payload in new_payloads
+                    for chunk in payload["chunks"]
+                ],
+            ]
+            cleanup_keys.extend(
+                key
+                for key in new_manifest.get("cleanup_keys", [])
+                if self._bundle_store._object_id_from_bundle_key(key)
+                in new_object_ids
+            )
+            self._bundle_store.remove_keys(cleanup_keys, strict=True)
+            self._bundle_store.remove_keys([stage_ref.manifest_key], strict=True)
+
     def put_structured_object(
         self,
         payload: StructuredObjectPayload,

--- a/mooncake-wheel/tests/test_dataproto_catalog.py
+++ b/mooncake-wheel/tests/test_dataproto_catalog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from types import SimpleNamespace
 
 import pytest
@@ -141,6 +142,10 @@ def test_catalog_only_retires_managed_fragments() -> None:
     retired = catalog.remove("train", ["a"])["retired_handles"]
     assert len(retired) == 1
     assert retired[0]["stage_refs"] == managed["stage_refs"]
+    mismatched = copy.deepcopy(retired[0])
+    mismatched["field_index"]["value"]["member"] = "batch.other"
+    with pytest.raises(ValueError, match="fragment mismatch"):
+        catalog.ack_retired([mismatched])
     assert catalog.ack_retired(retired)["retired_handles"] == []
 
 
@@ -152,6 +157,69 @@ def test_catalog_drain_is_terminal() -> None:
     retired = catalog.drain()["retired_handles"]
     with pytest.raises(RuntimeError, match="catalog is drained"):
         catalog.publish("pending-op", "train", ["a"], handle=managed)
+    assert catalog.ack_retired(retired)["retired_handles"] == []
+
+
+def test_catalog_append_replaces_managed_handle_ownership() -> None:
+    catalog = DataProtoCatalog()
+    base = handle("base", ["input", "value"], batch_size=1)
+    base["storage_group_id"] = "structured-test"
+    base["partition"] = "train"
+    catalog.publish("put-op", "train", ["a"], handle=base)
+    catalog.ack_publication("put-op")
+    catalog.update(
+        "train", ["a"], handle=handle("replacement", ["value"], batch_size=1)
+    )
+
+    appended = copy.deepcopy(base)
+    appended["stage_refs"]["value"] = {"manifest_key": "manifest/value"}
+    appended["field_index"]["score"] = {
+        "stage": "value",
+        "member": "batch.score",
+        "section": "batch",
+    }
+    with pytest.raises(ValueError, match="fragment identity"):
+        catalog.publish_append(
+            "wrong-partition",
+            "manifest/base",
+            "other",
+            ["a"],
+            previous_handle=base,
+            handle=appended,
+        )
+    catalog.publish_append(
+        "append-op",
+        "manifest/base",
+        "train",
+        ["a"],
+        previous_handle=base,
+        handle=appended,
+    )
+    assert catalog.publish_append(
+        "append-op",
+        "manifest/base",
+        "train",
+        ["a"],
+        previous_handle=base,
+        handle=appended,
+    )["fields"] == ["input", "value", "score"]
+    with pytest.raises(ValueError, match="stale"):
+        catalog.publish_append(
+            "stale-op",
+            "manifest/base",
+            "train",
+            ["a"],
+            previous_handle=base,
+            handle=appended,
+        )
+
+    plan = catalog.resolve("train", ["a"])
+    assert plan["fields"] == ["input", "value", "score"]
+    assert set(plan["handles"]) == {"manifest/base", "manifest/replacement"}
+    assert plan["handles"]["manifest/base"]["stage_refs"] == appended["stage_refs"]
+    assert plan["field_groups"][1]["locations"] == [("manifest/replacement", 0)]
+    retired = catalog.remove("train", ["a"])["retired_handles"]
+    assert retired == [plan["handles"]["manifest/base"]]
     assert catalog.ack_retired(retired)["retired_handles"] == []
 
 

--- a/mooncake-wheel/tests/test_dataproto_catalog.py
+++ b/mooncake-wheel/tests/test_dataproto_catalog.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
-from mooncake.dataproto_catalog import DataProtoCatalog
+from mooncake.dataproto_catalog import DataProtoCatalog, DataProtoCatalogTransfer
+from mooncake.structured_object_store import import_dataproto_ref
 
 
 def handle(name: str, fields: list[str], batch_size: int = 2) -> dict:
@@ -120,3 +123,177 @@ def test_catalog_rejects_missing_or_incomplete_reads_without_mutation() -> None:
 
     assert catalog.list("train") == {"train": {"a": {}, "b": {}}}
     assert "invalid" not in catalog.list()
+
+
+def test_catalog_only_retires_managed_fragments() -> None:
+    catalog = DataProtoCatalog()
+    external = handle("external", ["value"], batch_size=1)
+    catalog.update("train", ["a"], handle=external)
+    assert catalog.remove("train", ["a"])["retired_handles"] == []
+
+    managed = handle("managed", ["value"], batch_size=1)
+    catalog.publish("managed-op", "train", ["a"], handle=managed)
+    assert catalog.publish("managed-op", "other", ["x"], handle=external)["fields"] == [
+        "value"
+    ]
+    assert "other" not in catalog.list()
+    catalog.ack_publication("managed-op")
+    retired = catalog.remove("train", ["a"])["retired_handles"]
+    assert len(retired) == 1
+    assert retired[0]["stage_refs"] == managed["stage_refs"]
+    assert catalog.ack_retired(retired)["retired_handles"] == []
+
+
+def test_catalog_drain_is_terminal() -> None:
+    catalog = DataProtoCatalog()
+    managed = handle("managed", ["value"], batch_size=1)
+    catalog.publish("pending-op", "train", ["a"], handle=managed)
+
+    retired = catalog.drain()["retired_handles"]
+    with pytest.raises(RuntimeError, match="catalog is drained"):
+        catalog.publish("pending-op", "train", ["a"], handle=managed)
+    assert catalog.ack_retired(retired)["retired_handles"] == []
+
+
+class FakeTransfer:
+    def __init__(self) -> None:
+        self.count = self.release_attempts = 0
+        self.cleaned = []
+
+    def put(self, data, **_kwargs):
+        self.count += 1
+        return import_dataproto_ref(
+            handle(f"put-{self.count}", list(data.fields), len(data))
+        )
+
+    def cleanup_dataproto(self, ref) -> None:
+        self.cleaned.append(next(iter(ref["stage_refs"].values()))["manifest_key"])
+
+    def release_result(self, _result) -> None:
+        self.release_attempts += 1
+        if self.release_attempts == 1:
+            raise RuntimeError("release failed")
+
+
+def test_catalog_transfer_lifecycle_and_failure_retries() -> None:
+    catalog, transfer = DataProtoCatalog(), FakeTransfer()
+
+    def call(method, *args, **kwargs):
+        return getattr(catalog, method)(*args, **kwargs)
+
+    client = DataProtoCatalogTransfer(transfer, call)
+    data = type("FakeData", (list,), {"fields": ("value",)})([None])
+    client.put(data, partition="train", keys=["a"])
+    first_read = client.resolve("train", ["a"])
+    second_read = client.resolve("train", ["a"])
+    client.remove("train", ["a"])
+    client.release_read(first_read["read_token"])
+    assert transfer.cleaned == []
+    with pytest.raises(RuntimeError, match="active read"):
+        client.drain()
+    client.release_read(second_read["read_token"])
+    assert transfer.cleaned == ["manifest/put-1"]
+
+    output = SimpleNamespace()
+    result = SimpleNamespace(batch={}, non_tensor_batch={}, meta_info={})
+    client.attach_results(output, [result])
+    client.release_result(output)
+    assert transfer.release_attempts == 2
+
+    publication_failure = "before_commit"
+    lost_responses = 0
+
+    def fail_update(method, *args, **kwargs):
+        nonlocal publication_failure, lost_responses
+        if method != "publish":
+            return call(method, *args, **kwargs)
+        if publication_failure == "before_commit":
+            raise RuntimeError("publication failed")
+        result = call(method, *args, **kwargs)
+        if publication_failure == "after_commit" and lost_responses:
+            lost_responses -= 1
+            raise RuntimeError("response lost after commit")
+        return result
+
+    client._catalog_call = fail_update
+    with pytest.raises(RuntimeError, match="publication failed"):
+        client.put(data, partition="train", keys=["b"])
+    assert transfer.cleaned == ["manifest/put-1"]
+
+    publication_failure = None
+    client.close()
+    assert catalog.resolve("train", ["b"])["fields"] == ["value"]
+    client.remove("train", ["b"])
+    assert transfer.cleaned[-1] == "manifest/put-2"
+
+    publication_failure = "after_commit"
+    lost_responses = 2
+    with pytest.raises(RuntimeError, match="response lost"):
+        client.put(data, partition="train", keys=["c"])
+    assert catalog.resolve("train", ["c"])["fields"] == ["value"]
+    assert transfer.cleaned[-1] == "manifest/put-2"
+
+    publication_failure = None
+    client.close()
+    client.remove("train", ["c"])
+    assert transfer.cleaned[-1] == "manifest/put-3"
+
+
+def test_catalog_retry_does_not_resurrect_a_superseded_fragment() -> None:
+    catalog, transfer = DataProtoCatalog(), FakeTransfer()
+
+    def call(method, *args, **kwargs):
+        return getattr(catalog, method)(*args, **kwargs)
+
+    lost_responses = 2
+
+    def lose_publish_response(method, *args, **kwargs):
+        nonlocal lost_responses
+        result = call(method, *args, **kwargs)
+        if method == "publish" and lost_responses:
+            lost_responses -= 1
+            raise RuntimeError("response lost after commit")
+        return result
+
+    data = type("FakeData", (list,), {"fields": ("value",)})([None])
+    first = DataProtoCatalogTransfer(transfer, lose_publish_response)
+    with pytest.raises(RuntimeError, match="response lost"):
+        first.put(data, partition="train", keys=["a"])
+
+    second = DataProtoCatalogTransfer(transfer, call)
+    second.put(data, partition="train", keys=["a"])
+    assert transfer.cleaned == ["manifest/put-1"]
+
+    first.close()
+    plan = catalog.resolve("train", ["a"])
+    assert set(plan["handles"]) == {"manifest/put-2"}
+    assert transfer.cleaned == ["manifest/put-1"]
+
+
+def test_catalog_ack_retry_does_not_republish_a_superseded_fragment() -> None:
+    catalog, transfer = DataProtoCatalog(), FakeTransfer()
+
+    def call(method, *args, **kwargs):
+        return getattr(catalog, method)(*args, **kwargs)
+
+    lose_ack = True
+
+    def lose_ack_response(method, *args, **kwargs):
+        nonlocal lose_ack
+        result = call(method, *args, **kwargs)
+        if method == "ack_publication" and lose_ack:
+            lose_ack = False
+            raise RuntimeError("ack response lost")
+        return result
+
+    data = type("FakeData", (list,), {"fields": ("value",)})([None])
+    first = DataProtoCatalogTransfer(transfer, lose_ack_response)
+    first.put(data, partition="train", keys=["a"])
+
+    second = DataProtoCatalogTransfer(transfer, call)
+    second.put(data, partition="train", keys=["a"])
+    first.close()
+
+    plan = catalog.resolve("train", ["a"])
+    assert set(plan["handles"]) == {"manifest/put-2"}
+    assert transfer.cleaned == ["manifest/put-1"]

--- a/mooncake-wheel/tests/test_dataproto_catalog.py
+++ b/mooncake-wheel/tests/test_dataproto_catalog.py
@@ -239,6 +239,27 @@ def test_catalog_transfer_lifecycle_and_failure_retries() -> None:
     assert transfer.cleaned[-1] == "manifest/put-3"
 
 
+def test_catalog_transfer_drain_resolves_pending_publications() -> None:
+    catalog, transfer = DataProtoCatalog(), FakeTransfer()
+    fail_publication = True
+
+    def call(method, *args, **kwargs):
+        if method == "publish" and fail_publication:
+            raise RuntimeError("publication failed")
+        return getattr(catalog, method)(*args, **kwargs)
+
+    client = DataProtoCatalogTransfer(transfer, call)
+    data = type("FakeData", (list,), {"fields": ("value",)})([None])
+    with pytest.raises(RuntimeError, match="publication failed"):
+        client.put(data, partition="train", keys=["a"])
+    with pytest.raises(RuntimeError, match="publish pending"):
+        client.drain()
+
+    fail_publication = False
+    client.drain()
+    assert transfer.cleaned == ["manifest/put-1"]
+
+
 def test_catalog_retry_does_not_resurrect_a_superseded_fragment() -> None:
     catalog, transfer = DataProtoCatalog(), FakeTransfer()
 

--- a/mooncake-wheel/tests/test_dataproto_catalog.py
+++ b/mooncake-wheel/tests/test_dataproto_catalog.py
@@ -178,15 +178,14 @@ def test_catalog_append_replaces_managed_handle_ownership() -> None:
         "member": "batch.score",
         "section": "batch",
     }
-    with pytest.raises(ValueError, match="fragment identity"):
-        catalog.publish_append(
-            "wrong-partition",
-            "manifest/base",
-            "other",
-            ["a"],
-            previous_handle=base,
-            handle=appended,
-        )
+    assert "fragment identity" in catalog.publish_append(
+        "wrong-partition",
+        "manifest/base",
+        "other",
+        ["a"],
+        previous_handle=base,
+        handle=appended,
+    )["append_rejected"]
     catalog.publish_append(
         "append-op",
         "manifest/base",
@@ -203,15 +202,14 @@ def test_catalog_append_replaces_managed_handle_ownership() -> None:
         previous_handle=base,
         handle=appended,
     )["fields"] == ["input", "value", "score"]
-    with pytest.raises(ValueError, match="stale"):
-        catalog.publish_append(
-            "stale-op",
-            "manifest/base",
-            "train",
-            ["a"],
-            previous_handle=base,
-            handle=appended,
-        )
+    assert "stale" in catalog.publish_append(
+        "stale-op",
+        "manifest/base",
+        "train",
+        ["a"],
+        previous_handle=base,
+        handle=appended,
+    )["append_rejected"]
 
     plan = catalog.resolve("train", ["a"])
     assert plan["fields"] == ["input", "value", "score"]

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 import mooncake.structured_object_store as sos
+from mooncake.dataproto_catalog import DataProtoCatalog, DataProtoCatalogTransfer
 from mooncake.structured_object_store import (
     BundleTransferPolicy,
     FieldSchema,
@@ -1034,6 +1035,116 @@ def test_imported_handle_append_recovers_group_without_scanning_old_stage() -> N
         list(config.group_ids) == [group_id]
         for config in store.put_configs[first_append_record:]
     )
+
+
+@pytest.mark.parametrize("append_stage", ["rollout", "value"])
+@pytest.mark.parametrize("ungrouped", [False, True])
+@pytest.mark.parametrize("lose_response", [False, True])
+def test_catalog_manages_appended_handle_lifetime(
+    append_stage, ungrouped, lose_response
+) -> None:
+    class SizedDataProto(SimpleDataProto):
+        def __len__(self) -> int:
+            return len(next(iter(self.batch.values())))
+
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="catalog-append")
+    appender = MooncakeBundleTransfer(store, key_prefix="catalog-append")
+    catalog = DataProtoCatalog()
+    lost_responses = 2 if lose_response else 0
+
+    def call(method, *args, **kwargs):
+        nonlocal lost_responses
+        result = getattr(catalog, method)(*args, **kwargs)
+        if method == "publish_append" and lost_responses:
+            lost_responses -= 1
+            raise RuntimeError("response lost after commit")
+        return result
+
+    writer_client = DataProtoCatalogTransfer(writer, call)
+    appender_client = DataProtoCatalogTransfer(appender, call)
+    writer_client.put(
+        SizedDataProto(batch={"input_ids": np.arange(2)}),
+        partition="train",
+        keys=["a", "b"],
+        stage="rollout",
+        config=GroupConfig([""]) if ungrouped else None,
+    )
+    base_plan = writer_client.resolve("train", ["a", "b"])
+    fragment_id, base_handle = next(iter(base_plan["handles"].items()))
+    writer_client.put(
+        SizedDataProto(batch={"partial_score": np.arange(1)}),
+        partition="train",
+        keys=["a"],
+        stage="score",
+    )
+
+    with pytest.raises(ValueError, match="overwrite"):
+        appender_client.append(
+            fragment_id,
+            base_handle,
+            SizedDataProto(batch={"input_ids": np.arange(2) + 10}),
+            partition="train",
+            keys=["a", "b"],
+            stage="rollout",
+            overwrite=True,
+        )
+    stored_keys = (set(store.objects), set(store.tensor_objects))
+    with pytest.raises(ValueError, match="keys were not found"):
+        appender_client.append(
+            fragment_id,
+            base_handle,
+            SizedDataProto(batch={"values": np.arange(2) + 10}),
+            partition="train",
+            keys=["a", "missing"],
+            stage=append_stage,
+        )
+    assert (set(store.objects), set(store.tensor_objects)) == stored_keys
+    append_args = (
+        fragment_id,
+        base_handle,
+        SizedDataProto(batch={"values": np.arange(2) + 10}),
+    )
+    append_kwargs = {
+        "partition": "train",
+        "keys": ["a", "b"],
+        "stage": append_stage,
+    }
+    if lose_response:
+        with pytest.raises(RuntimeError, match="response lost"):
+            appender_client.append(*append_args, **append_kwargs)
+    else:
+        appender_client.append(*append_args, **append_kwargs)
+    latest_plan = appender_client.resolve(
+        "train", ["a", "b"], fields=["input_ids", "values"]
+    )
+    appended = import_dataproto_ref(latest_plan["handles"][fragment_id])
+    assert appended._storage_group_id == base_handle.get("storage_group_id")
+    assert np.array_equal(
+        appender.get_dataproto(appended)["batch"]["values"], np.arange(2) + 10
+    )
+    old_reader = writer.get_dataproto(import_dataproto_ref(base_handle))
+    assert np.array_equal(old_reader["batch"]["input_ids"], np.arange(2))
+    stored_keys = (set(store.objects), set(store.tensor_objects))
+    with pytest.raises(ValueError, match="stale"):
+        appender_client.append(
+            fragment_id,
+            base_handle,
+            SizedDataProto(batch={"rewards": np.arange(2) + 20}),
+            partition="train",
+            keys=["a", "b"],
+            stage="reward",
+        )
+    assert (set(store.objects), set(store.tensor_objects)) == stored_keys
+    appender_client.close()
+
+    appender_client.remove("train", ["a", "b"])
+    assert store.objects or store.tensor_objects
+    appender_client.release_read(latest_plan["read_token"])
+    assert store.objects or store.tensor_objects
+    writer_client.release_read(base_plan["read_token"])
+    assert store.objects == {}
+    assert store.tensor_objects == {}
 
 
 def test_legacy_v1_handle_append_get_and_cleanup_uses_caller_group() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1039,9 +1039,9 @@ def test_imported_handle_append_recovers_group_without_scanning_old_stage() -> N
 
 @pytest.mark.parametrize("append_stage", ["rollout", "value"])
 @pytest.mark.parametrize("ungrouped", [False, True])
-@pytest.mark.parametrize("lose_response", [False, True])
+@pytest.mark.parametrize("response_error", [None, RuntimeError, ValueError])
 def test_catalog_manages_appended_handle_lifetime(
-    append_stage, ungrouped, lose_response
+    append_stage, ungrouped, response_error
 ) -> None:
     class SizedDataProto(SimpleDataProto):
         def __len__(self) -> int:
@@ -1051,14 +1051,14 @@ def test_catalog_manages_appended_handle_lifetime(
     writer = MooncakeBundleTransfer(store, key_prefix="catalog-append")
     appender = MooncakeBundleTransfer(store, key_prefix="catalog-append")
     catalog = DataProtoCatalog()
-    lost_responses = 2 if lose_response else 0
+    lost_responses = 2 if response_error is not None else 0
 
     def call(method, *args, **kwargs):
         nonlocal lost_responses
         result = getattr(catalog, method)(*args, **kwargs)
         if method == "publish_append" and lost_responses:
             lost_responses -= 1
-            raise RuntimeError("response lost after commit")
+            raise response_error("response lost after commit")
         return result
 
     writer_client = DataProtoCatalogTransfer(writer, call)
@@ -1110,8 +1110,8 @@ def test_catalog_manages_appended_handle_lifetime(
         "keys": ["a", "b"],
         "stage": append_stage,
     }
-    if lose_response:
-        with pytest.raises(RuntimeError, match="response lost"):
+    if response_error is not None:
+        with pytest.raises(response_error, match="response lost"):
             appender_client.append(*append_args, **append_kwargs)
     else:
         appender_client.append(*append_args, **append_kwargs)
@@ -1253,6 +1253,224 @@ def test_concurrent_append_branches_inherit_group_without_merging_refs() -> None
         list(config.group_ids) == [group_id]
         for config in store.put_configs
     )
+
+
+@pytest.mark.parametrize("append_stage", ["rollout", "value"])
+@pytest.mark.parametrize("cleanup_failures", [0, 2])
+def test_catalog_concurrent_append_cleans_stale_loser(
+    append_stage, cleanup_failures, monkeypatch
+) -> None:
+    class SizedDataProto(SimpleDataProto):
+        def __len__(self) -> int:
+            return len(next(iter(self.batch.values())))
+
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="catalog-concurrent-append")
+    first = MooncakeBundleTransfer(store, key_prefix="catalog-concurrent-append")
+    second = MooncakeBundleTransfer(store, key_prefix="catalog-concurrent-append")
+    catalog = DataProtoCatalog()
+    publish_barrier = threading.Barrier(3)
+    catalog_lock = threading.Lock()
+    publication_lock = threading.Lock()
+    seen_publications = set()
+
+    def call(method, *args, **kwargs):
+        if method == "publish_append":
+            with publication_lock:
+                first_attempt = args[0] not in seen_publications
+                seen_publications.add(args[0])
+            if first_attempt:
+                publish_barrier.wait(timeout=5)
+        with catalog_lock:
+            return getattr(catalog, method)(*args, **kwargs)
+
+    writer_client = DataProtoCatalogTransfer(writer, call)
+    first_client = DataProtoCatalogTransfer(first, call)
+    second_client = DataProtoCatalogTransfer(second, call)
+    remaining_cleanup_failures = cleanup_failures
+
+    def fail_cleanup(transfer):
+        original = transfer.cleanup_dataproto_append
+
+        def cleanup(*args):
+            nonlocal remaining_cleanup_failures
+            if remaining_cleanup_failures:
+                remaining_cleanup_failures -= 1
+                raise RuntimeError("injected append cleanup failure")
+            original(*args)
+
+        monkeypatch.setattr(transfer, "cleanup_dataproto_append", cleanup)
+
+    fail_cleanup(first)
+    fail_cleanup(second)
+    writer_client.put(
+        SizedDataProto(batch={"input_ids": np.arange(2)}),
+        partition="train",
+        keys=["a", "b"],
+        stage="rollout",
+    )
+    base_plan = writer_client.resolve("train", ["a", "b"])
+    fragment_id, base_handle = next(iter(base_plan["handles"].items()))
+
+    results = {}
+    failures = []
+    clients = {"first": first_client, "second": second_client}
+
+    def append(name: str) -> None:
+        try:
+            results[name] = clients[name].append(
+                fragment_id,
+                base_handle,
+                SizedDataProto(batch={name: np.arange(2) + 10}),
+                partition="train",
+                keys=["a", "b"],
+                stage=append_stage,
+            )
+        except BaseException as error:
+            failures.append(error)
+
+    first_thread = threading.Thread(target=append, args=("first",))
+    second_thread = threading.Thread(target=append, args=("second",))
+    first_thread.start()
+    second_thread.start()
+    publish_barrier.wait(timeout=5)
+    first_thread.join(timeout=5)
+    second_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert len(results) == 1
+    assert len(failures) == 1
+    if cleanup_failures:
+        assert isinstance(failures[0], RuntimeError)
+        assert "cleanup failure" in str(failures[0])
+        pending_client = next(
+            client for client in clients.values() if client._pending_publications
+        )
+        pending_client.close()
+    else:
+        assert isinstance(failures[0], ValueError)
+        assert "stale" in str(failures[0])
+    assert first_client._pending_publications == []
+    assert second_client._pending_publications == []
+
+    winner_name = next(iter(results))
+    winner_client = clients[winner_name]
+    winner_plan = winner_client.resolve("train", ["a", "b"])
+    winner = import_dataproto_ref(winner_plan["handles"][fragment_id])
+    winner_data = winner_client.transfer.get_dataproto(winner)
+    assert set(winner_data["batch"]) == {"input_ids", winner_name}
+    assert np.array_equal(
+        winner_data["batch"][winner_name], np.arange(2) + 10
+    )
+    old_data = writer.get_dataproto(import_dataproto_ref(base_handle))
+    assert np.array_equal(old_data["batch"]["input_ids"], np.arange(2))
+
+    winner_client.remove("train", ["a", "b"])
+    winner_client.release_read(winner_plan["read_token"])
+    old_data = writer.get_dataproto(import_dataproto_ref(base_handle))
+    assert np.array_equal(old_data["batch"]["input_ids"], np.arange(2))
+    writer_client.release_read(base_plan["read_token"])
+    writer_client.close()
+    first_client.close()
+    second_client.close()
+    assert store.objects == {}
+    assert store.tensor_objects == {}
+
+
+@pytest.mark.parametrize("append_stage", ["rollout", "value"])
+@pytest.mark.parametrize("race", ["remove", "drain"])
+def test_catalog_cleans_append_rejected_after_remove_or_drain(
+    append_stage, race
+) -> None:
+    class SizedDataProto(SimpleDataProto):
+        def __len__(self) -> int:
+            return len(next(iter(self.batch.values())))
+
+    store = InMemoryStore()
+    writer = MooncakeBundleTransfer(store, key_prefix="catalog-append-race")
+    appender = MooncakeBundleTransfer(store, key_prefix="catalog-append-race")
+    catalog = DataProtoCatalog()
+    raced = False
+
+    def direct_call(method, *args, **kwargs):
+        return getattr(catalog, method)(*args, **kwargs)
+
+    writer_client = DataProtoCatalogTransfer(writer, direct_call)
+    drainer_client = DataProtoCatalogTransfer(writer, direct_call)
+
+    def call(method, *args, **kwargs):
+        nonlocal raced
+        if method == "publish_append" and not raced:
+            raced = True
+            if race == "remove":
+                writer_client.remove("train", ["a"])
+            else:
+                drainer_client.drain()
+        return direct_call(method, *args, **kwargs)
+
+    appender_client = DataProtoCatalogTransfer(appender, call)
+    writer_client.put(
+        SizedDataProto(batch={"input_ids": np.arange(2)}),
+        partition="train",
+        keys=["a", "b"],
+        stage="rollout",
+    )
+    plan = catalog.resolve("train", ["a", "b"])
+    fragment_id, base_handle = next(iter(plan["handles"].items()))
+
+    match = "keys not found" if race == "remove" else "catalog is drained"
+    with pytest.raises(ValueError, match=match):
+        appender_client.append(
+            fragment_id,
+            base_handle,
+            SizedDataProto(batch={"values": np.arange(2) + 10}),
+            partition="train",
+            keys=["a", "b"],
+            stage=append_stage,
+        )
+
+    appender_client.close()
+    if race == "remove":
+        writer_client.remove("train", ["b"])
+    assert store.objects == {}
+    assert store.tensor_objects == {}
+
+
+def test_same_stage_append_cleanup_tolerates_lost_manifest_remove_response(
+    monkeypatch,
+) -> None:
+    store, transfer = make_transfer(key_prefix="append-cleanup-response-loss")
+    base = transfer.put_dataproto(
+        SimpleDataProto(batch={"input_ids": np.arange(2)}), stage="rollout"
+    )
+    appended = transfer.append_dataproto_fields(
+        base,
+        SimpleDataProto(batch={"values": np.arange(2) + 10}),
+        stage="rollout",
+    )
+    appended_manifest = appended.stage_refs["rollout"].manifest_key
+    batch_remove = store.batch_remove
+    lose_response = True
+
+    def remove_then_lose_response(keys, force=False):
+        nonlocal lose_response
+        results = batch_remove(keys, force)
+        if lose_response and keys == [appended_manifest]:
+            lose_response = False
+            raise RuntimeError("manifest remove response lost")
+        return results
+
+    monkeypatch.setattr(store, "batch_remove", remove_then_lose_response)
+    with pytest.raises(RuntimeError, match="response lost"):
+        transfer.cleanup_dataproto_append(base, appended)
+    transfer.cleanup_dataproto_append(base, appended)
+
+    result = transfer.get_dataproto(base)
+    assert np.array_equal(result["batch"]["input_ids"], np.arange(2))
+    transfer.cleanup_dataproto(base)
+    assert store.objects == {}
+    assert store.tensor_objects == {}
 
 
 def test_append_rejects_conflicting_group_before_write() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -120,6 +120,10 @@ class InMemoryStore:
         finally:
             self._exit_get()
 
+    def is_exist(self, key: str) -> int:
+        with self.lock:
+            return int(key in self.objects or key in self.tensor_objects)
+
     def remove(self, key: str, force: bool = False) -> int:
         with self.lock:
             self.objects.pop(key, None)
@@ -1636,7 +1640,7 @@ def test_bundle_remove_deletes_payload_and_manifest() -> None:
     transfer.remove_bundle(ref)
 
     assert store.objects == {}
-    assert store.batch_remove_calls == 1
+    assert store.batch_remove_calls == 2
 
 
 def test_bundle_partial_put_failure_cleans_payloads() -> None:
@@ -1665,7 +1669,7 @@ def test_bundle_remove_uses_force_batch_remove_when_available() -> None:
     transfer.materialize(transfer.read_spec(ref))
     transfer.remove_bundle(ref)
 
-    assert store.batch_remove_forces == [True]
+    assert store.batch_remove_forces == [True, True]
     assert store.objects == {}
 
 
@@ -1676,7 +1680,36 @@ def test_bundle_remove_recovers_after_transient_batch_failure() -> None:
     transfer.remove_bundle(ref)
 
     assert store.objects == {}
-    assert store.batch_remove_calls == 1
+    assert store.batch_remove_calls == 2
+
+
+def test_bundle_remove_keeps_manifest_until_payload_cleanup_succeeds(
+    monkeypatch,
+) -> None:
+    store, transfer = make_transfer()
+    ref = transfer.put_bundle(b"meta", {"payload": b"abcdef"}, chunk_bytes=2)
+    failed_key = ref.manifest["buffers"]["payload"]["chunks"][0]["key"]
+    remove = store.remove
+    monkeypatch.setattr(
+        store,
+        "remove",
+        lambda key, force=False: -1 if key == failed_key else remove(key, force),
+    )
+    monkeypatch.setattr(
+        store,
+        "batch_remove",
+        lambda keys, force=False: [store.remove(key, force) for key in keys],
+    )
+
+    with pytest.raises(RuntimeError, match="failed to remove"):
+        transfer.remove_bundle(ref)
+
+    assert failed_key in store.objects
+    assert ref.manifest_key in store.objects
+    monkeypatch.setattr(store, "remove", remove)
+    transfer.remove_bundle(ref)
+    transfer.remove_bundle({"manifest_key": ref.manifest_key})
+    assert store.objects == {}
 
 
 def test_bundle_batch_get_failure_unregisters_buffer() -> None:
@@ -4069,6 +4102,26 @@ def test_dataproto_helper_jagged_nested_batch_tensor_roundtrip() -> None:
     assert matrix_result._ragged_idx == 2
     for actual, expected in zip(matrix_result.unbind(), matrix_rows):
         assert torch.equal(actual, expected)
+
+
+def test_dataproto_helper_refreshes_stale_jagged_sequence_cache(monkeypatch) -> None:
+    torch = pytest.importorskip("torch")
+    monkeypatch.setattr(sos, "_has_tensor_codec_helpers", lambda: False)
+    _store, transfer = make_transfer()
+    offsets = torch.arange(0, 513, 64)
+    nested = torch.nested.nested_tensor_from_jagged(
+        torch.arange(512, dtype=torch.float32),
+        offsets=offsets,
+        min_seqlen=512,
+        max_seqlen=512,
+    )
+
+    ref = transfer.put_dataproto(SimpleDataProto(batch={"log_probs": nested}))
+    result = transfer.get_dataproto(ref)["batch"]["log_probs"]
+
+    assert result.offsets().tolist() == offsets.tolist()
+    assert result._min_seqlen == result._max_seqlen == 64
+    assert torch.nested.to_padded_tensor(result, 0).shape == (8, 64)
 
 
 def _assert_tensor_object_equal(actual, expected) -> None:


### PR DESCRIPTION
## Description

### Motivation

PR #3345 added a DataProto catalog for fragmented rollout data, but physical fragment and read-buffer lifetimes were still left to each framework integration. Superseded fragments must stay alive while a reader is materializing them, and publication or acknowledgement response loss must not delete or resurrect Store objects.

The structured-object cleanup path also needs retry-safe manifest handling, and jagged NestedTensor deserialization must refresh sequence-length metadata instead of preserving stale cached bounds.

### Changes

- Add `DataProtoCatalogTransfer` to coordinate Store writes, Catalog publication, reader pins, BufferPool result release, retirement, and physical cleanup.
- Add operation-ID-based publish/ack semantics. An ambiguous publish retries the same operation, while an ambiguous acknowledgement retries only the acknowledgement.
- Keep direct `DataProtoCatalog.update(handle=...)` metadata-only. Only fresh, independent fragments created by the transfer helper receive physical ownership semantics; append-derived handles are outside that path.
- Make `drain()` a terminal Catalog operation. It refuses active readers, retires managed fragments, clears idempotency records, and rejects later publications.
- Remove bundle payloads before their manifest and make missing-manifest retries idempotent through Store existence checks.
- Release pool-backed arrays reachable through DataProto-like objects.
- Rebuild jagged NestedTensor values with sequence bounds recomputed from lengths or offsets.

This is a follow-up to #3345. The production diff is 496 changed LOC excluding tests (`+463/-33`), so the >500 LOC RFC requirement does not apply.

### Lifecycle Boundary

Catalog calls must be serialized by the host. A lost read token remains fail-closed: `drain()` rejects cleanup until the framework has quiesced readers and released every token. Catalog drain is terminal and should be used during host shutdown.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-wheel
PYTHONPATH=. python -m pytest tests/test_dataproto_catalog.py tests/test_structured_object_store.py -q

python -m py_compile mooncake/dataproto_catalog.py mooncake/structured_object_store.py
python -m py_compile tests/test_dataproto_catalog.py tests/test_structured_object_store.py

ruff check mooncake/dataproto_catalog.py mooncake/structured_object_store.py
ruff check tests/test_dataproto_catalog.py tests/test_structured_object_store.py

git diff --check origin/main..HEAD
```

**Test results:**
- [x] Unit tests pass: `106 passed, 16 skipped`
- [ ] Integration tests pass (not run; focused unit/regression coverage only)
- [ ] Manual testing done (not applicable)

Additional touched-file hooks passed: trailing whitespace, end-of-file fixer, merge-conflict check, large-file check, Ruff lint, and codespell.

The pinned Ruff formatter was applied to the new Catalog module and Catalog tests. Running Ruff format across the two large pre-existing structured-object files rewrites unrelated historical formatting, so that full-file churn is intentionally excluded; their changed hunks follow the pinned formatter output.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

The RFC item is not applicable because the production change is 496 LOC excluding tests.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to review and simplify the lifecycle state machine, identify publication/acknowledgement failure windows, add focused regression coverage, run validation, and prepare this PR description. The human submitter reviewed the final code and is responsible for the change.