### PR TITLE
fix(store): make P2P oplog replay idempotent

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/oplog_applier.h
@@ -92,6 +92,7 @@ class OpLogApplier {
     // sequence_ids from etcd. If an entry arrives late:
     // - REMOVE / PUT_REVOKE: delete the key
     // - PUT_END: discard
+    // - delete-like custom entries: handled by subclasses
     //
     // This is used during Standby promotion so we don't block promotion on
     // gaps, but still best-effort clean up potentially stale metadata.
@@ -108,6 +109,12 @@ class OpLogApplier {
     virtual bool ApplyCustomOpLogEntry(const OpLogEntry& entry);
 
     virtual bool IsBestEffortOpLogEntry(const OpLogEntry& entry) const;
+
+    // Late entries for skipped sequence IDs are only safe to apply when they
+    // cannot resurrect old state. The base class treats generic deletes as
+    // delete-like; subclasses can include backend-specific delete operations.
+    virtual bool IsLateSkippedDeleteLikeOpLogEntry(
+        const OpLogEntry& entry) const;
 
    private:
     bool ApplyOpLogEntryInternal(const OpLogEntry& entry);
@@ -144,6 +151,8 @@ class OpLogApplier {
      */
     bool RequestMissingOpLog(uint64_t missing_seq_id);
 
+    bool ApplyLateSkippedDeleteLikeOpLogEntry(const OpLogEntry& entry);
+
     bool HandleApplyFailure(const OpLogEntry& entry, const char* reason);
 
     MetadataStore* metadata_store_;
@@ -166,8 +175,8 @@ class OpLogApplier {
     std::set<uint64_t> confirmed_missing_sequence_ids_;
 
     // Sequence IDs we chose to skip (gap-timeout). If the late entry arrives:
-    // - REMOVE / PUT_REVOKE: delete the key (safe)
-    // - PUT_END: discard (do not resurrect potentially stale metadata)
+    // - delete-like entries: apply to avoid stale metadata
+    // - PUT_END / add-like entries: discard to avoid resurrecting stale state
     std::map<uint64_t, std::chrono::steady_clock::time_point>
         skipped_sequence_ids_;
 

--- a/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_applier.h
@@ -39,6 +39,8 @@ class P2POpLogApplier : public OpLogApplier {
    protected:
     bool ApplyCustomOpLogEntry(const OpLogEntry& entry) override;
     bool IsBestEffortOpLogEntry(const OpLogEntry& entry) const override;
+    bool IsLateSkippedDeleteLikeOpLogEntry(
+        const OpLogEntry& entry) const override;
 
    private:
     // Apply individual P2P OpTypes. Return true on success.

--- a/mooncake-store/include/ha_metric_manager.h
+++ b/mooncake-store/include/ha_metric_manager.h
@@ -68,6 +68,8 @@ class HAMetricManager {
     void set_standby_degraded(bool value);
     void set_primary_degraded(bool value);
     void set_oplog_last_successful_poll_timestamp_ms(int64_t timestamp_ms);
+    void set_p2p_snapshot_bootstrap_baseline_sequence_id(int64_t seq_id);
+    void set_p2p_bootstrap_catchup_target_sequence_id(int64_t seq_id);
 
     // ========== Error Counters ==========
 
@@ -131,6 +133,10 @@ class HAMetricManager {
     void inc_promotion_restore_failures(int64_t val = 1);
     void inc_promotion_skipped_replicas(int64_t val = 1);
     void inc_promotion_skipped_objects(int64_t val = 1);
+    void inc_p2p_snapshot_bootstrap_success(int64_t val = 1);
+    void inc_p2p_snapshot_bootstrap_failures(int64_t val = 1);
+    void inc_p2p_snapshot_resync_success(int64_t val = 1);
+    void inc_p2p_snapshot_resync_failures(int64_t val = 1);
 
     /**
      * @brief Increment counter for watch disconnections
@@ -224,6 +230,8 @@ class HAMetricManager {
     ylt::metric::gauge_t standby_degraded_;
     ylt::metric::gauge_t primary_degraded_;
     ylt::metric::gauge_t oplog_last_successful_poll_timestamp_ms_;
+    ylt::metric::gauge_t p2p_snapshot_bootstrap_baseline_sequence_id_;
+    ylt::metric::gauge_t p2p_bootstrap_catchup_target_sequence_id_;
 
     // Error Counters
     ylt::metric::counter_t oplog_skipped_entries_total_;
@@ -254,6 +262,10 @@ class HAMetricManager {
     ylt::metric::counter_t promotion_restore_failures_total_;
     ylt::metric::counter_t promotion_skipped_replicas_total_;
     ylt::metric::counter_t promotion_skipped_objects_total_;
+    ylt::metric::counter_t p2p_snapshot_bootstrap_success_total_;
+    ylt::metric::counter_t p2p_snapshot_bootstrap_failures_total_;
+    ylt::metric::counter_t p2p_snapshot_resync_success_total_;
+    ylt::metric::counter_t p2p_snapshot_resync_failures_total_;
     ylt::metric::counter_t oplog_watch_disconnections_total_;
     ylt::metric::counter_t oplog_applied_entries_total_;
     ylt::metric::counter_t oplog_dropped_put_end_total_;

--- a/mooncake-store/src/ha/oplog/oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_applier.cpp
@@ -63,8 +63,8 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
     //   pending_entries_ can grow and the applier may appear stuck.
     const uint64_t expected = expected_sequence_id_.load();
     if (IsSequenceOlder(entry.sequence_id, expected)) {
-        // Late arrival of a previously-skipped gap entry: apply only if it's a
-        // delete/revoke.
+        // Late arrival of a previously-skipped gap entry: apply only if it
+        // cannot resurrect old state.
         bool was_skipped = false;
         {
             std::lock_guard<std::mutex> lock(pending_mutex_);
@@ -75,19 +75,21 @@ bool OpLogApplier::ApplyOpLogEntry(const OpLogEntry& entry) {
             }
         }
         if (was_skipped) {
-            // TODO(P2P HA): Define type-aware handling for late P2P entries as
-            // part of the standby out-of-order/error-handling work.
-            if (entry.op_type == OpType::REMOVE ||
-                entry.op_type == OpType::PUT_REVOKE) {
-                // Safe: ensure we don't keep stale metadata.
-                if (entry.op_type == OpType::REMOVE) {
-                    ApplyRemove(entry);
-                } else {
-                    ApplyPutRevoke(entry);
+            if (IsLateSkippedDeleteLikeOpLogEntry(entry)) {
+                if (!ApplyLateSkippedDeleteLikeOpLogEntry(entry)) {
+                    LOG(ERROR)
+                        << "OpLogApplier: failed to apply late skipped "
+                           "delete-like entry"
+                        << ", op_type=" << static_cast<int>(entry.op_type)
+                        << ", sequence_id=" << entry.sequence_id
+                        << ", key=" << entry.object_key;
+                    return HandleApplyFailure(
+                        entry, "late skipped delete-like apply failed");
                 }
                 return true;
             }
-            // PUT_END (or others): discard to avoid resurrecting stale state.
+            // PUT_END / add-like entries: discard to avoid resurrecting stale
+            // state.
             if (entry.op_type == OpType::PUT_END) {
                 HAMetricManager::instance().inc_oplog_dropped_put_end();
             }
@@ -168,6 +170,12 @@ bool OpLogApplier::ApplyOpLogEntryInternal(const OpLogEntry& entry) {
 
 bool OpLogApplier::IsBestEffortOpLogEntry(const OpLogEntry&) const {
     return false;
+}
+
+bool OpLogApplier::IsLateSkippedDeleteLikeOpLogEntry(
+    const OpLogEntry& entry) const {
+    return entry.op_type == OpType::REMOVE ||
+           entry.op_type == OpType::PUT_REVOKE;
 }
 
 std::string OpLogApplier::GetFailureReason() const {
@@ -488,17 +496,22 @@ OpLogApplier::GapResolveResult OpLogApplier::TryResolveGapsOnceForPromotion(
         }
         r.fetched++;
 
-        // Apply policy: only delete/revoke; drop PUT_END.
-        if (e.op_type == OpType::REMOVE) {
-            ApplyRemove(e);
-            r.applied_deletes++;
-            successfully_processed.push_back(seq);
-        } else if (e.op_type == OpType::PUT_REVOKE) {
-            ApplyPutRevoke(e);
+        // Apply policy: only delete-like entries; drop PUT_END/add-like ops.
+        if (IsLateSkippedDeleteLikeOpLogEntry(e)) {
+            if (!ApplyLateSkippedDeleteLikeOpLogEntry(e)) {
+                LOG(ERROR) << "Promotion gap resolve: failed to apply "
+                              "delete-like seq="
+                           << seq
+                           << ", op_type=" << static_cast<int>(e.op_type);
+                (void)HandleApplyFailure(
+                    e, "promotion gap delete-like apply failed");
+                continue;
+            }
             r.applied_deletes++;
             successfully_processed.push_back(seq);
         } else {
-            // PUT_END or others: mark as processed (dropped) so we don't retry.
+            // PUT_END / add-like entries: mark as processed (dropped) so we
+            // don't retry.
             successfully_processed.push_back(seq);
         }
     }
@@ -514,6 +527,19 @@ OpLogApplier::GapResolveResult OpLogApplier::TryResolveGapsOnceForPromotion(
         }
     }
     return r;
+}
+
+bool OpLogApplier::ApplyLateSkippedDeleteLikeOpLogEntry(
+    const OpLogEntry& entry) {
+    if (entry.op_type == OpType::REMOVE) {
+        ApplyRemove(entry);
+        return true;
+    }
+    if (entry.op_type == OpType::PUT_REVOKE) {
+        ApplyPutRevoke(entry);
+        return true;
+    }
+    return ApplyCustomOpLogEntry(entry);
 }
 
 bool OpLogApplier::CheckSequenceOrder(const OpLogEntry& entry) {

--- a/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_hot_standby_service.cpp
@@ -61,6 +61,7 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         !config_.snapshot_source_endpoints.empty() ||
         !discovered_snapshot_sources.empty() ||
         baseline_sequence_id < trimmed_sequence_id;
+    bool snapshot_bootstrap_succeeded = false;
     if (bootstrap_requested) {
         ErrorCode bootstrap_err = ErrorCode::INTERNAL_ERROR;
         const bool bootstrap_required =
@@ -105,6 +106,8 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
             }
             LOG(WARNING) << "P2PHotStandbyService: optional peer bootstrap "
                             "failed; falling back to OpLog replay";
+        } else {
+            snapshot_bootstrap_succeeded = true;
         }
     }
     auto latest_err = probe_store->GetLatestSequenceId(initial_sync_target);
@@ -112,6 +115,11 @@ ErrorCode P2PHotStandbyService::Start(uint64_t baseline_sequence_id) {
         LOG(ERROR) << "P2PHotStandbyService: failed to get initial sync target";
         state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
         return latest_err;
+    }
+    if (snapshot_bootstrap_succeeded) {
+        HAMetricManager::instance()
+            .set_p2p_bootstrap_catchup_target_sequence_id(
+                static_cast<int64_t>(initial_sync_target));
     }
     LOG(INFO) << "P2PHotStandbyService: initial OpLog catch-up started"
               << ", baseline_sequence_id=" << baseline_sequence_id
@@ -546,6 +554,13 @@ ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
                                     config_.snapshot_chunk_size);
         if (err == ErrorCode::OK) {
             baseline_sequence_id = source_sequence_id;
+            // Counts only the snapshot restore RPC. The surrounding
+            // bootstrap/resync flow can still fail during trim validation or
+            // OpLog catch-up and is tracked by the resync failure counters.
+            HAMetricManager::instance().inc_p2p_snapshot_bootstrap_success();
+            HAMetricManager::instance()
+                .set_p2p_snapshot_bootstrap_baseline_sequence_id(
+                    static_cast<int64_t>(baseline_sequence_id));
             LOG(INFO) << "P2PHotStandbyService: snapshot bootstrap succeeded"
                       << ", source=" << endpoint
                       << ", baseline_sequence_id=" << baseline_sequence_id;
@@ -560,6 +575,7 @@ ErrorCode P2PHotStandbyService::BootstrapFromSnapshotSources(
     LOG(ERROR) << "P2PHotStandbyService: all snapshot sources failed"
                << ", cluster_id=" << config_.cluster_id
                << ", source_count=" << endpoints.size();
+    HAMetricManager::instance().inc_p2p_snapshot_bootstrap_failures();
     return ErrorCode::INTERNAL_ERROR;
 }
 
@@ -572,6 +588,7 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
         LOG(ERROR) << "P2PHotStandbyService: snapshot resync bootstrap failed"
                    << ", cluster_id=" << config_.cluster_id
                    << ", error=" << toString(err);
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return err;
     }
 
@@ -581,6 +598,7 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                       "while validating snapshot resync trim horizon"
                    << ", cluster_id=" << config_.cluster_id
                    << ", baseline_sequence_id=" << baseline_sequence_id;
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return ErrorCode::OPLOG_TRIMMED;
     }
     uint64_t trimmed_sequence_id = 0;
@@ -591,6 +609,7 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                    << ", cluster_id=" << config_.cluster_id
                    << ", baseline_sequence_id=" << baseline_sequence_id
                    << ", error=" << toString(err);
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return ErrorCode::OPLOG_TRIMMED;
     }
     if (baseline_sequence_id < trimmed_sequence_id) {
@@ -599,6 +618,7 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                    << ", cluster_id=" << config_.cluster_id
                    << ", baseline_sequence_id=" << baseline_sequence_id
                    << ", trimmed_sequence_id=" << trimmed_sequence_id;
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return ErrorCode::OPLOG_TRIMMED;
     }
 
@@ -614,8 +634,11 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                    << ", cluster_id=" << config_.cluster_id
                    << ", baseline_sequence_id=" << baseline_sequence_id
                    << ", error=" << toString(err);
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return err;
     }
+    HAMetricManager::instance().set_p2p_bootstrap_catchup_target_sequence_id(
+        static_cast<int64_t>(catch_up_target));
     err = StartOplogFollowingLocked(baseline_sequence_id);
     if (err != ErrorCode::OK) {
         LOG(ERROR) << "P2PHotStandbyService: failed to restart OpLog "
@@ -624,6 +647,7 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                    << ", baseline_sequence_id=" << baseline_sequence_id
                    << ", catch_up_target=" << catch_up_target
                    << ", error=" << toString(err);
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return err;
     }
     if (!WaitForAppliedSequenceLocked(catch_up_target)) {
@@ -633,8 +657,10 @@ ErrorCode P2PHotStandbyService::ResyncFromSnapshotLocked() {
                    << ", applied_sequence_id="
                    << GetLocalLastAppliedSequenceIdLocked();
         ResetOplogFollowingLocked();
+        HAMetricManager::instance().inc_p2p_snapshot_resync_failures();
         return ErrorCode::INTERNAL_ERROR;
     }
+    HAMetricManager::instance().inc_p2p_snapshot_resync_success();
     LOG(INFO) << "P2PHotStandbyService: snapshot resync completed"
               << ", baseline_sequence_id=" << baseline_sequence_id
               << ", applied_sequence_id="

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -40,6 +40,16 @@ bool P2POpLogApplier::IsBestEffortOpLogEntry(const OpLogEntry& entry) const {
     return IsBestEffortP2POpLog(entry.op_type);
 }
 
+bool P2POpLogApplier::IsLateSkippedDeleteLikeOpLogEntry(
+    const OpLogEntry& entry) const {
+    // TODO(P2P HA): Add per-replica/segment/client sequence guards so a stale
+    // late delete cannot remove newer same-target state after a re-add.
+    return OpLogApplier::IsLateSkippedDeleteLikeOpLogEntry(entry) ||
+           entry.op_type == OpType_REMOVE_REPLICA ||
+           entry.op_type == OpType_UNMOUNT_SEGMENT ||
+           entry.op_type == OpType_UNREGISTER_CLIENT;
+}
+
 bool P2POpLogApplier::ApplyAddReplica(const OpLogEntry& entry) {
     AddReplicaPayload payload;
     if (!DeserializeP2PPayload(entry.payload, payload)) {

--- a/mooncake-store/src/ha_metric_manager.cpp
+++ b/mooncake-store/src/ha_metric_manager.cpp
@@ -40,6 +40,12 @@ HAMetricManager::HAMetricManager()
       oplog_last_successful_poll_timestamp_ms_(
           "ha_oplog_last_successful_poll_timestamp_ms",
           "Unix timestamp of the latest successful Standby OpLog poll"),
+      p2p_snapshot_bootstrap_baseline_sequence_id_(
+          "ha_p2p_snapshot_bootstrap_baseline_sequence_id",
+          "Latest baseline sequence ID restored by P2P snapshot bootstrap"),
+      p2p_bootstrap_catchup_target_sequence_id_(
+          "ha_p2p_bootstrap_catchup_target_sequence_id",
+          "Latest OpLog target sequence ID used after P2P snapshot bootstrap"),
 
       // Error Counters
       oplog_skipped_entries_total_(
@@ -119,6 +125,18 @@ HAMetricManager::HAMetricManager()
       promotion_skipped_objects_total_(
           "ha_promotion_skipped_objects_total",
           "Total objects left without replicas during promotion restore"),
+      p2p_snapshot_bootstrap_success_total_(
+          "ha_p2p_snapshot_bootstrap_success_total",
+          "Total successful P2P snapshot bootstrap attempts"),
+      p2p_snapshot_bootstrap_failures_total_(
+          "ha_p2p_snapshot_bootstrap_failures_total",
+          "Total failed P2P snapshot bootstrap attempts"),
+      p2p_snapshot_resync_success_total_(
+          "ha_p2p_snapshot_resync_success_total",
+          "Total successful P2P snapshot resync attempts"),
+      p2p_snapshot_resync_failures_total_(
+          "ha_p2p_snapshot_resync_failures_total",
+          "Total failed P2P snapshot resync attempts"),
       oplog_watch_disconnections_total_(
           "ha_oplog_watch_disconnections_total",
           "Total number of OpLog watch disconnections"),
@@ -172,6 +190,8 @@ HAMetricManager::HAMetricManager()
     standby_degraded_.update(0);
     primary_degraded_.update(0);
     oplog_last_successful_poll_timestamp_ms_.update(0);
+    p2p_snapshot_bootstrap_baseline_sequence_id_.update(0);
+    p2p_bootstrap_catchup_target_sequence_id_.update(0);
     standby_state_.update(0);
 }
 
@@ -236,6 +256,16 @@ void HAMetricManager::set_primary_degraded(bool value) {
 void HAMetricManager::set_oplog_last_successful_poll_timestamp_ms(
     int64_t timestamp_ms) {
     oplog_last_successful_poll_timestamp_ms_.update(timestamp_ms);
+}
+
+void HAMetricManager::set_p2p_snapshot_bootstrap_baseline_sequence_id(
+    int64_t seq_id) {
+    p2p_snapshot_bootstrap_baseline_sequence_id_.update(seq_id);
+}
+
+void HAMetricManager::set_p2p_bootstrap_catchup_target_sequence_id(
+    int64_t seq_id) {
+    p2p_bootstrap_catchup_target_sequence_id_.update(seq_id);
 }
 
 // ========== Error Counters ==========
@@ -355,6 +385,22 @@ void HAMetricManager::inc_promotion_skipped_objects(int64_t val) {
     promotion_skipped_objects_total_.inc(val);
 }
 
+void HAMetricManager::inc_p2p_snapshot_bootstrap_success(int64_t val) {
+    p2p_snapshot_bootstrap_success_total_.inc(val);
+}
+
+void HAMetricManager::inc_p2p_snapshot_bootstrap_failures(int64_t val) {
+    p2p_snapshot_bootstrap_failures_total_.inc(val);
+}
+
+void HAMetricManager::inc_p2p_snapshot_resync_success(int64_t val) {
+    p2p_snapshot_resync_success_total_.inc(val);
+}
+
+void HAMetricManager::inc_p2p_snapshot_resync_failures(int64_t val) {
+    p2p_snapshot_resync_failures_total_.inc(val);
+}
+
 void HAMetricManager::inc_oplog_watch_disconnections(int64_t val) {
     oplog_watch_disconnections_total_.inc(val);
 }
@@ -450,6 +496,8 @@ std::string HAMetricManager::serialize_metrics() {
     serialize_metric(standby_degraded_);
     serialize_metric(primary_degraded_);
     serialize_metric(oplog_last_successful_poll_timestamp_ms_);
+    serialize_metric(p2p_snapshot_bootstrap_baseline_sequence_id_);
+    serialize_metric(p2p_bootstrap_catchup_target_sequence_id_);
     serialize_metric(standby_state_);
 
     // Counters
@@ -481,6 +529,10 @@ std::string HAMetricManager::serialize_metrics() {
     serialize_metric(promotion_restore_failures_total_);
     serialize_metric(promotion_skipped_replicas_total_);
     serialize_metric(promotion_skipped_objects_total_);
+    serialize_metric(p2p_snapshot_bootstrap_success_total_);
+    serialize_metric(p2p_snapshot_bootstrap_failures_total_);
+    serialize_metric(p2p_snapshot_resync_success_total_);
+    serialize_metric(p2p_snapshot_resync_failures_total_);
     serialize_metric(oplog_watch_disconnections_total_);
     serialize_metric(oplog_applied_entries_total_);
     serialize_metric(oplog_dropped_put_end_total_);

--- a/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ha_metric_manager_test.cpp
@@ -141,6 +141,8 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
     M().set_standby_degraded(true);
     M().set_primary_degraded(true);
     M().set_oplog_last_successful_poll_timestamp_ms(12345);
+    M().set_p2p_snapshot_bootstrap_baseline_sequence_id(101);
+    M().set_p2p_bootstrap_catchup_target_sequence_id(120);
     M().observe_election_duration_ms(10);
     M().inc_election_attempts();
     M().inc_election_failures();
@@ -165,6 +167,10 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
     M().inc_promotion_restore_failures();
     M().inc_promotion_skipped_replicas();
     M().inc_promotion_skipped_objects();
+    M().inc_p2p_snapshot_bootstrap_success();
+    M().inc_p2p_snapshot_bootstrap_failures();
+    M().inc_p2p_snapshot_resync_success();
+    M().inc_p2p_snapshot_resync_failures();
 
     const std::string text = M().serialize_metrics();
     for (const char* name : {
@@ -173,6 +179,8 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
              "ha_standby_degraded",
              "ha_primary_degraded",
              "ha_oplog_last_successful_poll_timestamp_ms",
+             "ha_p2p_snapshot_bootstrap_baseline_sequence_id",
+             "ha_p2p_bootstrap_catchup_target_sequence_id",
              "ha_election_failures_total",
              "ha_election_leadership_lost_total",
              "ha_election_reconnects_total",
@@ -196,6 +204,10 @@ TEST_F(HAMetricManagerTest, TestHaFailureMetricsAreExported) {
              "ha_promotion_restore_failures_total",
              "ha_promotion_skipped_replicas_total",
              "ha_promotion_skipped_objects_total",
+             "ha_p2p_snapshot_bootstrap_success_total",
+             "ha_p2p_snapshot_bootstrap_failures_total",
+             "ha_p2p_snapshot_resync_success_total",
+             "ha_p2p_snapshot_resync_failures_total",
          }) {
         EXPECT_NE(std::string::npos, text.find(name)) << name;
     }

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -90,6 +90,22 @@ Segment MakeSegment(const UUID& id, size_t size) {
     segment.size = size;
     return segment;
 }
+
+void SkipSequenceWithFutureAdd(P2POpLogApplier& applier,
+                               uint64_t skipped_sequence_id,
+                               const std::string& future_key) {
+    AddReplicaPayload future;
+    future.object_key = future_key;
+    future.client_id = MakeUUID(1000 + skipped_sequence_id, 0);
+    future.segment_id = MakeUUID(2000 + skipped_sequence_id, 0);
+    future.size = 1024;
+
+    ASSERT_FALSE(applier.ApplyOpLogEntry(
+        MakeAddReplicaEntry(skipped_sequence_id + 1, future_key, future)));
+    applier.ConfirmMissingSequenceIds({skipped_sequence_id});
+    EXPECT_EQ(applier.ProcessPendingEntries(), 1u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), skipped_sequence_id + 2);
+}
 }  // namespace
 
 // ============================================================================
@@ -342,6 +358,181 @@ TEST(P2POpLogApplierTest, ApplyUnregisterClient) {
 }
 
 // ============================================================================
+// P2POpLogApplier - Snapshot replay idempotency
+// ============================================================================
+
+TEST(P2POpLogApplierTest, ReplayAddReplicaAlreadyInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+    store.RegisterClient(client, "192.168.1.100", 50051,
+                         {MakeSegment(seg, 4096)});
+    store.AddReplica("snapshot-key", client, seg, 1024, 101);
+    applier.Recover(100);
+
+    AddReplicaPayload payload;
+    payload.object_key = "snapshot-key";
+    payload.client_id = client;
+    payload.segment_id = seg;
+    payload.size = 1024;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeAddReplicaEntry(101, "snapshot-key", payload)));
+
+    auto objects = store.GetObjects();
+    ASSERT_EQ(objects.size(), 1u);
+    ASSERT_EQ(objects.at("snapshot-key").replicas.size(), 1u);
+    EXPECT_EQ(objects.at("snapshot-key").last_sequence_id, 101u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest, ReplayMountSegmentAlreadyInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+    Segment segment = MakeSegment(seg, 4096);
+    store.RegisterClient(client, "192.168.1.100", 50051, {segment});
+    applier.Recover(100);
+
+    MountSegmentPayload payload;
+    payload.client_id = client;
+    payload.segment = segment;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeMountSegmentEntry(101, payload)));
+
+    auto info = store.GetClient(client);
+    ASSERT_NE(info, nullptr);
+    ASSERT_EQ(info->segments.size(), 1u);
+    EXPECT_EQ(info->segments[0].id, seg);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest, ReplayRegisterClientAlreadyInSnapshotIsStable) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto registration_seg = MakeUUID(10, 0);
+    auto later_seg = MakeUUID(20, 0);
+    Segment registration_segment = MakeSegment(registration_seg, 4096);
+    Segment later_segment = MakeSegment(later_seg, 8192);
+    store.RegisterClient(client, "192.168.1.100", 50051,
+                         {registration_segment, later_segment});
+    applier.Recover(100);
+
+    RegisterClientPayload payload;
+    payload.client_id = client;
+    payload.ip_address = "192.168.1.100";
+    payload.rpc_port = 50051;
+    payload.segments = {registration_segment};
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeRegisterClientEntry(101, payload)));
+
+    auto info = store.GetClient(client);
+    ASSERT_NE(info, nullptr);
+    EXPECT_EQ(info->ip_address, "192.168.1.100");
+    EXPECT_EQ(info->rpc_port, 50051u);
+    ASSERT_EQ(info->segments.size(), 2u);
+    EXPECT_EQ(info->segments[0].id, registration_seg);
+    EXPECT_EQ(info->segments[1].id, later_seg);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest, ReplayRemoveReplicaAlreadyReflectedInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    applier.Recover(100);
+
+    RemoveReplicaPayload payload;
+    payload.object_key = "removed-key";
+    payload.client_id = MakeUUID(1, 0);
+    payload.segment_id = MakeUUID(10, 0);
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeRemoveReplicaEntry(101, "removed-key", payload)));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest,
+     ReplayUnmountSegmentAlreadyReflectedInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    applier.Recover(100);
+
+    UnmountSegmentPayload payload;
+    payload.client_id = MakeUUID(1, 0);
+    payload.segment_id = MakeUUID(10, 0);
+    EXPECT_TRUE(applier.ApplyOpLogEntry(MakeUnmountSegmentEntry(101, payload)));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(store.GetClients().size(), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest,
+     ReplayUnregisterClientAlreadyReflectedInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    auto client = MakeUUID(1, 0);
+    applier.Recover(100);
+
+    UnregisterClientPayload payload;
+    payload.client_id = client;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeUnregisterClientEntry(101, payload)));
+
+    EXPECT_EQ(store.GetClient(client), nullptr);
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest, ReplayRemoveAllAlreadyReflectedInSnapshotIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    applier.Recover(100);
+
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeEntry(101, OpType_REMOVE_ALL, "", "")));
+
+    EXPECT_EQ(store.GetKeyCount(), 0u);
+    EXPECT_EQ(store.GetClients().size(), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 102u);
+}
+
+TEST(P2POpLogApplierTest, AlreadyAppliedP2PSequenceIsNoOp) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+
+    auto client = MakeUUID(1, 0);
+    auto seg = MakeUUID(10, 0);
+
+    AddReplicaPayload first;
+    first.object_key = "committed-key";
+    first.client_id = client;
+    first.segment_id = seg;
+    first.size = 1024;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeAddReplicaEntry(1, "committed-key", first)));
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 2u);
+
+    AddReplicaPayload stale;
+    stale.object_key = "stale-key";
+    stale.client_id = MakeUUID(2, 0);
+    stale.segment_id = MakeUUID(20, 0);
+    stale.size = 2048;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeAddReplicaEntry(1, "stale-key", stale)));
+
+    auto objects = store.GetObjects();
+    ASSERT_EQ(objects.size(), 1u);
+    EXPECT_NE(objects.find("committed-key"), objects.end());
+    EXPECT_EQ(objects.find("stale-key"), objects.end());
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 2u);
+}
+
+// ============================================================================
 // P2POpLogApplier - Ordering and gap detection
 // ============================================================================
 
@@ -438,6 +629,84 @@ TEST(P2POpLogApplierTest, MissingEntryTimeoutSkipsGapAndDrainsP2PEntry) {
     EXPECT_EQ(1u, applier.ProcessPendingEntries());
     EXPECT_EQ(1u, store.GetKeyCount());
     EXPECT_EQ(3u, applier.GetExpectedSequenceId());
+}
+
+TEST(P2POpLogApplierTest, LateSkippedP2PDeleteLikeEntriesAreApplied) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    applier.Recover(1);
+
+    auto remove_client = MakeUUID(1, 0);
+    auto remove_seg = MakeUUID(10, 0);
+    store.RegisterClient(remove_client, "192.168.1.100", 50051,
+                         {MakeSegment(remove_seg, 4096)});
+    store.AddReplica("late-remove-replica", remove_client, remove_seg, 1024, 1);
+    SkipSequenceWithFutureAdd(applier, 2, "future-after-remove-replica");
+
+    RemoveReplicaPayload remove_payload;
+    remove_payload.object_key = "late-remove-replica";
+    remove_payload.client_id = remove_client;
+    remove_payload.segment_id = remove_seg;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeRemoveReplicaEntry(2, "late-remove-replica", remove_payload)));
+    EXPECT_EQ(store.GetObjects().count("late-remove-replica"), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 4u);
+
+    auto unmount_client = MakeUUID(2, 0);
+    auto unmount_seg = MakeUUID(20, 0);
+    store.RegisterClient(unmount_client, "192.168.1.101", 50052,
+                         {MakeSegment(unmount_seg, 4096)});
+    store.AddReplica("late-unmount-segment", unmount_client, unmount_seg, 1024,
+                     3);
+    SkipSequenceWithFutureAdd(applier, 4, "future-after-unmount-segment");
+
+    UnmountSegmentPayload unmount_payload;
+    unmount_payload.client_id = unmount_client;
+    unmount_payload.segment_id = unmount_seg;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeUnmountSegmentEntry(4, unmount_payload)));
+    EXPECT_EQ(store.GetObjects().count("late-unmount-segment"), 0u);
+    auto unmount_info = store.GetClient(unmount_client);
+    ASSERT_NE(unmount_info, nullptr);
+    EXPECT_TRUE(unmount_info->segments.empty());
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 6u);
+
+    auto unregister_client = MakeUUID(3, 0);
+    auto unregister_seg = MakeUUID(30, 0);
+    store.RegisterClient(unregister_client, "192.168.1.102", 50053,
+                         {MakeSegment(unregister_seg, 4096)});
+    store.AddReplica("late-unregister-client", unregister_client,
+                     unregister_seg, 1024, 5);
+    SkipSequenceWithFutureAdd(applier, 6, "future-after-unregister-client");
+
+    UnregisterClientPayload unregister_payload;
+    unregister_payload.client_id = unregister_client;
+    EXPECT_TRUE(applier.ApplyOpLogEntry(
+        MakeUnregisterClientEntry(6, unregister_payload)));
+    EXPECT_EQ(store.GetClient(unregister_client), nullptr);
+    EXPECT_EQ(store.GetObjects().count("late-unregister-client"), 0u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 8u);
+}
+
+TEST(P2POpLogApplierTest, LateSkippedP2PAddLikeEntryIsDiscarded) {
+    P2PStandbyMetadataStore store;
+    P2POpLogApplier applier(&store, "test-cluster");
+    applier.Recover(1);
+
+    SkipSequenceWithFutureAdd(applier, 2, "future-after-add-like");
+
+    AddReplicaPayload stale;
+    stale.object_key = "late-add-replica";
+    stale.client_id = MakeUUID(1, 0);
+    stale.segment_id = MakeUUID(10, 0);
+    stale.size = 1024;
+    EXPECT_TRUE(
+        applier.ApplyOpLogEntry(MakeAddReplicaEntry(2, "late-add", stale)));
+
+    auto objects = store.GetObjects();
+    EXPECT_EQ(objects.count("late-add-replica"), 0u);
+    EXPECT_EQ(objects.count("future-after-add-like"), 1u);
+    EXPECT_EQ(applier.GetExpectedSequenceId(), 4u);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

  Make P2P OpLog replay idempotent for snapshot/bootstrap recovery paths.

  This change handles P2P-specific delete-like OpLog entries when skipped gaps arrive late or are resolved during promotion,
  while continuing to discard add-like late entries to avoid resurrecting stale state. It also adds P2P snapshot bootstrap/
  resync metrics and coverage for replay idempotency behavior.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  ./scripts/code_format.sh

  cmake -S . -B build-redis-oplog -DSTORE_USE_REDIS=ON -DCMAKE_BUILD_TYPE=Debug
  cmake --build build-redis-oplog --target mooncake_master p2p_oplog_test ha_metric_manager_test -j 8
  ctest --test-dir build-redis-oplog -R 'p2p_oplog_test|ha_metric_manager_test' --output-on-failure

  cmake -S . -B build-redis-oplog-asan -DSTORE_USE_REDIS=ON -DENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
  cmake --build build-redis-oplog-asan --target mooncake_master p2p_oplog_test ha_metric_manager_test -j 8
  ctest --test-dir build-redis-oplog-asan -R 'p2p_oplog_test|ha_metric_manager_test' --output-on-failure

  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to help review the change, update comments/commit message, and run local validation. The human submitter
  is responsible for understanding and defending all changes.