### PR TITLE
[TENT] Make ProxyManager staging cleanup safe and asynchronous

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -97,6 +97,11 @@ class ControlClient {
     static Status delegate(const std::string& server_addr,
                            const Request& request);
 
+    using DelegateCallback = std::function<void(Status)>;
+    static void delegateAsync(const std::string& server_addr,
+                              const Request& request,
+                              DelegateCallback callback);
+
     static Status pinStageBuffer(const std::string& server_addr,
                                  const std::string& location, uint64_t& addr);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -15,11 +15,11 @@
 #ifndef PROXY_MANAGER_H_
 #define PROXY_MANAGER_H_
 
+#include <memory>
 #include <shared_mutex>
 
 #include "tent/common/types.h"
 #include "tent/common/status.h"
-#include "tent/common/concurrent/thread_pool.h"
 
 #include "tent/runtime/transport.h"
 
@@ -30,6 +30,9 @@ namespace tent {
 class TransferEngineImpl;
 class TaskInfo;
 struct StageBufferCache;
+namespace internal {
+class RemoteStageOperation;
+}
 
 struct StagingTask {
     TaskInfo* native{nullptr};
@@ -66,7 +69,11 @@ class ProxyManager {
    private:
     void runner(size_t id);
 
-    Status transferEventLoop(StagingTask& task, StageBufferCache* cache);
+    Status transferEventLoop(
+        StagingTask& task, StageBufferCache* cache,
+        bool& buffers_safe_to_release, std::vector<BatchID>& undrained_batches,
+        std::vector<std::shared_ptr<internal::RemoteStageOperation>>&
+            undrained_remote_operations);
 
     Status transferSync(StagingTask& task, StageBufferCache* cache);
 
@@ -93,12 +100,22 @@ class ProxyManager {
                            const Request& request, uint64_t remote_stage_buffer,
                            uint64_t chunk_length, uint64_t offset);
 
-    void submitRemoteStage(const std::string& server_addr,
-                           const Request& request, uint64_t remote_stage_buffer,
-                           uint64_t chunk_length, uint64_t offset,
-                           std::future<Status>& handle);
+    void submitRemoteStage(
+        const std::string& server_addr, const Request& request,
+        uint64_t remote_stage_buffer, uint64_t chunk_length, uint64_t offset,
+        std::shared_ptr<internal::RemoteStageOperation>& operation);
+
+    void flushPendingCleanups(bool unpin_remote_buffers = true);
 
    private:
+    struct PendingBufferCleanup {
+        std::vector<uint64_t> local_addrs;
+        std::vector<std::pair<std::string, uint64_t>> remote_addrs;
+        std::vector<BatchID> batches;
+        std::vector<std::shared_ptr<internal::RemoteStageOperation>>
+            remote_operations;
+    };
+
     const size_t chunk_size_;
     const size_t chunk_count_;
     TransferEngineImpl* impl_;
@@ -108,6 +125,10 @@ class ProxyManager {
     // via StageBufferCache and by the RPC thread via Pin/Unpin.
     mutable std::shared_mutex stage_buffers_mutex_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
+    std::recursive_mutex stage_buffers_mu_;
+    std::vector<PendingBufferCleanup> pending_cleanups_;
+    std::mutex pending_cleanups_mu_;
+    std::atomic<bool> has_pending_cleanups_{false};
     std::atomic<bool> running_;
     struct WorkerShard {
         std::thread thread;
@@ -117,7 +138,6 @@ class ProxyManager {
     };
     const static size_t kShards = 8;
     WorkerShard shards_[kShards];
-    ThreadPool delegate_pool_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -72,7 +72,7 @@ struct TaskInfo {
     bool staging{false};
     bool cancel_requested{false};
     TransferStatusEnum status{TransferStatusEnum::PENDING};
-    volatile TransferStatusEnum staging_status{TransferStatusEnum::PENDING};
+    std::atomic<TransferStatusEnum> staging_status{TransferStatusEnum::PENDING};
     std::chrono::steady_clock::time_point start_time{};     // Request submit
     std::chrono::steady_clock::time_point dispatch_time{};  // Initial dispatch
     std::chrono::steady_clock::time_point post_time{};      // Initial post
@@ -84,6 +84,100 @@ struct TaskInfo {
     std::chrono::steady_clock::time_point attempt_post_time{};
     TransportType attempt_type{UNSPEC};
     bool attempt_active{false};
+
+    TaskInfo() = default;
+
+    TaskInfo(const TaskInfo& other)
+        : type(other.type),
+          sub_task_id(other.sub_task_id),
+          derived(other.derived),
+          xport_priority(other.xport_priority),
+          failover_count(other.failover_count),
+          device_mask(other.device_mask),
+          qp_pool(other.qp_pool),
+          request(other.request),
+          staging(other.staging),
+          cancel_requested(other.cancel_requested),
+          status(other.status),
+          staging_status(other.staging_status.load(std::memory_order_relaxed)),
+          start_time(other.start_time),
+          dispatch_time(other.dispatch_time),
+          post_time(other.post_time),
+          attempt_post_time(other.attempt_post_time),
+          attempt_type(other.attempt_type),
+          attempt_active(other.attempt_active) {}
+
+    TaskInfo(TaskInfo&& other) noexcept
+        : type(other.type),
+          sub_task_id(other.sub_task_id),
+          derived(other.derived),
+          xport_priority(other.xport_priority),
+          failover_count(other.failover_count),
+          device_mask(other.device_mask),
+          qp_pool(std::move(other.qp_pool)),
+          request(std::move(other.request)),
+          staging(other.staging),
+          cancel_requested(other.cancel_requested),
+          status(other.status),
+          staging_status(other.staging_status.load(std::memory_order_relaxed)),
+          start_time(other.start_time),
+          dispatch_time(other.dispatch_time),
+          post_time(other.post_time),
+          attempt_post_time(other.attempt_post_time),
+          attempt_type(other.attempt_type),
+          attempt_active(other.attempt_active) {}
+
+    TaskInfo& operator=(const TaskInfo& other) {
+        if (this != &other) {
+            type = other.type;
+            sub_task_id = other.sub_task_id;
+            derived = other.derived;
+            xport_priority = other.xport_priority;
+            failover_count = other.failover_count;
+            device_mask = other.device_mask;
+            qp_pool = other.qp_pool;
+            request = other.request;
+            staging = other.staging;
+            cancel_requested = other.cancel_requested;
+            status = other.status;
+            staging_status.store(
+                other.staging_status.load(std::memory_order_relaxed),
+                std::memory_order_relaxed);
+            start_time = other.start_time;
+            dispatch_time = other.dispatch_time;
+            post_time = other.post_time;
+            attempt_post_time = other.attempt_post_time;
+            attempt_type = other.attempt_type;
+            attempt_active = other.attempt_active;
+        }
+        return *this;
+    }
+
+    TaskInfo& operator=(TaskInfo&& other) noexcept {
+        if (this != &other) {
+            type = other.type;
+            sub_task_id = other.sub_task_id;
+            derived = other.derived;
+            xport_priority = other.xport_priority;
+            failover_count = other.failover_count;
+            device_mask = other.device_mask;
+            qp_pool = std::move(other.qp_pool);
+            request = std::move(other.request);
+            staging = other.staging;
+            cancel_requested = other.cancel_requested;
+            status = other.status;
+            staging_status.store(
+                other.staging_status.load(std::memory_order_relaxed),
+                std::memory_order_relaxed);
+            start_time = other.start_time;
+            dispatch_time = other.dispatch_time;
+            post_time = other.post_time;
+            attempt_post_time = other.attempt_post_time;
+            attempt_type = other.attempt_type;
+            attempt_active = other.attempt_active;
+        }
+        return *this;
+    }
 };
 
 class TransferEngineImpl {

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -155,6 +155,25 @@ Status ControlClient::delegate(const std::string& server_addr,
                                 : Status::RpcServiceError(response_raw);
 }
 
+void ControlClient::delegateAsync(const std::string& server_addr,
+                                  const Request& request,
+                                  DelegateCallback callback) {
+    json j = request;
+    std::string request_raw = j.dump();
+    tl_rpc_agent.callAsync(
+        server_addr, Delegate, request_raw,
+        [callback = std::move(callback)](Status status,
+                                         std::string response_raw) mutable {
+            if (!status.ok()) {
+                callback(std::move(status));
+                return;
+            }
+            callback(response_raw.empty()
+                         ? Status::OK()
+                         : Status::RpcServiceError(response_raw));
+        });
+}
+
 Status ControlClient::pinStageBuffer(const std::string& server_addr,
                                      const std::string& location,
                                      uint64_t& addr) {

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "tent/runtime/proxy_manager.h"
 #include "tent/runtime/transfer_engine_impl.h"
+#include "remote_stage_operation.h"
 #include <algorithm>
 #include <cstring>
 #include <sstream>
@@ -32,13 +33,115 @@ ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
 
 ProxyManager::~ProxyManager() { deconstruct(); }
 
+void ProxyManager::flushPendingCleanups(bool unpin_remote_buffers) {
+    if (!has_pending_cleanups_.load(std::memory_order_relaxed)) return;
+    std::vector<Batch*> batches_to_release;
+    std::vector<uint64_t> local_addrs_to_unpin;
+    std::vector<std::pair<std::string, uint64_t>> remote_addrs_to_unpin;
+    {
+        std::lock_guard<std::mutex> lk(pending_cleanups_mu_);
+        if (pending_cleanups_.empty()) {
+            has_pending_cleanups_.store(false, std::memory_order_relaxed);
+            return;
+        }
+        for (auto it = pending_cleanups_.begin();
+             it != pending_cleanups_.end();) {
+            for (auto batch_it = it->batches.begin();
+                 batch_it != it->batches.end();) {
+                TransferStatus status;
+                auto poll_status = impl_->progressBatch(*batch_it, status);
+                if (!poll_status.ok()) {
+                    LOG_EVERY_N(WARNING, 100)
+                        << "Failed to poll deferred staging batch: "
+                        << poll_status;
+                    ++batch_it;
+                    continue;
+                }
+                if (status.s == PENDING) {
+                    ++batch_it;
+                    continue;
+                }
+                batches_to_release.push_back((Batch*)*batch_it);
+                batch_it = it->batches.erase(batch_it);
+            }
+
+            internal::pollRemoteOperations(it->remote_operations);
+            if (it->batches.empty()) {
+                local_addrs_to_unpin.insert(local_addrs_to_unpin.end(),
+                                            it->local_addrs.begin(),
+                                            it->local_addrs.end());
+                it->local_addrs.clear();
+                if (it->remote_operations.empty() && unpin_remote_buffers) {
+                    remote_addrs_to_unpin.insert(remote_addrs_to_unpin.end(),
+                                                 it->remote_addrs.begin(),
+                                                 it->remote_addrs.end());
+                    it->remote_addrs.clear();
+                }
+            }
+
+            if (it->local_addrs.empty() && it->remote_addrs.empty() &&
+                it->batches.empty() && it->remote_operations.empty()) {
+                it = pending_cleanups_.erase(it);
+                continue;
+            }
+            ++it;
+        }
+        if (pending_cleanups_.empty()) {
+            has_pending_cleanups_.store(false, std::memory_order_relaxed);
+        }
+    }
+
+    for (auto batch : batches_to_release) impl_->releaseBatch(batch);
+    for (auto addr : local_addrs_to_unpin) unpinStageBuffer(addr);
+    for (auto& [server, addr] : remote_addrs_to_unpin) {
+        ControlClient::unpinStageBuffer(server, addr);
+    }
+}
+
 Status ProxyManager::deconstruct() {
-    running_ = false;
+    if (!running_.exchange(false, std::memory_order_acq_rel)) {
+        return Status::OK();
+    }
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].cv.notify_all();
-        shards_[i].thread.join();
+        if (shards_[i].thread.joinable()) shards_[i].thread.join();
     }
-    // The workers are joined above, but Pin/Unpin arrive on the RPC thread.
+
+    auto has_pending_batches = [this]() {
+        std::lock_guard<std::mutex> lk(pending_cleanups_mu_);
+        return std::any_of(
+            pending_cleanups_.begin(), pending_cleanups_.end(),
+            [](const PendingBufferCleanup& p) { return !p.batches.empty(); });
+    };
+
+    flushPendingCleanups(false);
+    while (has_pending_batches()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        flushPendingCleanups(false);
+    }
+
+    flushPendingCleanups(false);
+    std::vector<PendingBufferCleanup> remaining;
+    {
+        std::lock_guard<std::mutex> lk(pending_cleanups_mu_);
+        remaining = std::move(pending_cleanups_);
+        pending_cleanups_.clear();
+        has_pending_cleanups_.store(false, std::memory_order_relaxed);
+    }
+    for (auto& pending : remaining) {
+        if (!pending.remote_operations.empty()) {
+            LOG(WARNING)
+                << "Leaving " << pending.remote_addrs.size()
+                << " remote stage buffers pinned because "
+                << pending.remote_operations.size()
+                << " remote staging requests have not reached a confirmed "
+                   "terminal state";
+            continue;
+        }
+        for (auto& [server, addr] : pending.remote_addrs) {
+            ControlClient::unpinStageBuffer(server, addr);
+        }
+    }
     std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     for (auto entry : stage_buffers_) {
         impl_->unregisterLocalMemory(entry.second.chunks);
@@ -112,20 +215,20 @@ Status ProxyManager::waitRemoteStage(const std::string& server_addr,
     return ControlClient::delegate(server_addr, remote_stage);
 }
 
-void ProxyManager::submitRemoteStage(const std::string& server_addr,
-                                     const Request& request,
-                                     uint64_t remote_stage_buffer,
-                                     uint64_t chunk_length, uint64_t offset,
-                                     std::future<Status>& handle) {
+void ProxyManager::submitRemoteStage(
+    const std::string& server_addr, const Request& request,
+    uint64_t remote_stage_buffer, uint64_t chunk_length, uint64_t offset,
+    std::shared_ptr<internal::RemoteStageOperation>& operation) {
     Request remote_stage;
     remote_stage.opcode = request.opcode;
     remote_stage.source = (void*)remote_stage_buffer;
     remote_stage.length = chunk_length;
     remote_stage.target_id = LOCAL_SEGMENT_ID;
     remote_stage.target_offset = request.target_offset + offset;
-    handle = delegate_pool_.enqueue([server_addr, remote_stage]() {
-        return ControlClient::delegate(server_addr, remote_stage);
-    });
+    operation = std::make_shared<internal::RemoteStageOperation>();
+    ControlClient::delegateAsync(
+        server_addr, remote_stage,
+        [operation](Status status) { operation->complete(std::move(status)); });
 }
 
 Status ProxyManager::waitCrossStage(const Request& request,
@@ -144,7 +247,7 @@ Status ProxyManager::submit(TaskInfo* task, BatchID batch,
     staging_task.native = task;
     staging_task.batch = batch;
     staging_task.params = params;
-    task->staging_status = PENDING;
+    task->staging_status.store(PENDING, std::memory_order_relaxed);
     static std::atomic<size_t> next_queue_index(0);
     thread_local size_t id = next_queue_index.fetch_add(1) % kShards;
     {
@@ -157,7 +260,7 @@ Status ProxyManager::submit(TaskInfo* task, BatchID batch,
 
 Status ProxyManager::getStatus(TaskInfo* task, TransferStatus& task_status) {
     if (!task || !task->staging) return Status::InvalidArgument("Invalid task");
-    task_status.s = task->staging_status;
+    task_status.s = task->staging_status.load(std::memory_order_acquire);
     if (task_status.s == COMPLETED) {
         task_status.transferred_bytes = task->request.length;
     }
@@ -175,7 +278,7 @@ struct StageBufferCache {
         uint64_t addr = 0;
         auto status = mgr.pinStageBuffer(location, addr);
         if (!status.ok()) {
-            LOG(FATAL) << "Failed to pin local stage buffer: " << status
+            LOG(ERROR) << "Failed to pin local stage buffer: " << status
                        << ", location " << location;
             return 0;
         }
@@ -193,7 +296,7 @@ struct StageBufferCache {
         auto status =
             ControlClient::pinStageBuffer(server_addr, location, addr);
         if (!status.ok()) {
-            LOG(FATAL) << "Failed to pin remote stage buffer: " << status
+            LOG(ERROR) << "Failed to pin remote stage buffer: " << status
                        << ", location " << location;
             return 0;
         }
@@ -222,9 +325,8 @@ struct StageBufferCache {
 };
 
 void ProxyManager::runner(size_t id) {
-    StageBufferCache cache(*this);
     auto& shard = shards_[id];
-    while (running_) {
+    while (running_.load(std::memory_order_acquire)) {
         StagingTask task;
         {
             std::unique_lock<std::mutex> lk(shard.mu);
@@ -241,17 +343,50 @@ void ProxyManager::runner(size_t id) {
         }
 
         if (!task.native) continue;
-        auto status = transferEventLoop(task, &cache);
-        auto staging_status = status.ok() ? COMPLETED : FAILED;
-        __atomic_store(&task.native->staging_status, &staging_status,
-                       __ATOMIC_RELEASE);
+        flushPendingCleanups();
+        StageBufferCache cache(*this);
+        bool buffers_safe_to_release = true;
+        std::vector<BatchID> undrained_batches;
+        std::vector<std::shared_ptr<internal::RemoteStageOperation>>
+            undrained_remote_operations;
+        auto status =
+            transferEventLoop(task, &cache, buffers_safe_to_release,
+                              undrained_batches, undrained_remote_operations);
+        if (buffers_safe_to_release) {
+            cache.reset();
+        } else {
+            LOG(WARNING) << "Staging cleanup could not drain all in-flight "
+                            "operations; deferring stage buffer cleanup";
+            PendingBufferCleanup pending;
+            for (auto& entry : cache.local_stage_buffers) {
+                pending.local_addrs.push_back(entry.second);
+            }
+            for (auto& server_entry : cache.remote_stage_buffers) {
+                for (auto& entry : server_entry.second) {
+                    pending.remote_addrs.push_back(
+                        {server_entry.first, entry.second});
+                }
+            }
+            pending.batches = std::move(undrained_batches);
+            pending.remote_operations = std::move(undrained_remote_operations);
+            {
+                std::lock_guard<std::mutex> lk(pending_cleanups_mu_);
+                pending_cleanups_.push_back(std::move(pending));
+                has_pending_cleanups_.store(true, std::memory_order_relaxed);
+            }
+        }
+        task.native->staging_status.store(status.ok() ? COMPLETED : FAILED,
+                                          std::memory_order_release);
         impl_->notifyBatchMaybeReady(task.batch);
     }
-    cache.reset();
 }
 
-Status ProxyManager::transferEventLoop(StagingTask& task,
-                                       StageBufferCache* cache) {
+Status ProxyManager::transferEventLoop(
+    StagingTask& task, StageBufferCache* cache, bool& buffers_safe_to_release,
+    std::vector<BatchID>& undrained_batches,
+    std::vector<std::shared_ptr<internal::RemoteStageOperation>>&
+        undrained_remote_operations) {
+    buffers_safe_to_release = true;
     auto& request = task.native->request;
     auto server_addr = task.params[0];
     bool local_staging = !task.params[1].empty();
@@ -319,7 +454,52 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     }
 
     for (size_t i = 0; i < chunks.size(); ++i) event_queue.push(i);
-    std::vector<std::future<Status>> remote_futures(chunks.size());
+    std::vector<std::shared_ptr<internal::RemoteStageOperation>>
+        remote_operations(chunks.size());
+    auto drain_batch = [&](BatchID batch) {
+        TransferStatus xfer_status;
+        auto status = impl_->progressBatch(batch, xfer_status);
+        if (!status.ok()) {
+            LOG(ERROR) << "Failed to poll in-flight staging batch: " << status;
+            impl_->freeBatch(batch);
+            return false;
+        }
+        auto free_status = impl_->freeBatch(batch);
+        if (!free_status.ok()) {
+            LOG(WARNING) << "Failed to free drained staging batch: "
+                         << free_status;
+        }
+        return xfer_status.s != PENDING;
+    };
+    auto cleanup_inflight = [&]() {
+        bool all_drained = true;
+        for (auto& chunk : chunks) {
+            if (!chunk.batch) continue;
+            Batch* bptr = nullptr;
+            auto retain_status = impl_->retainBatch(chunk.batch, bptr);
+            if (drain_batch(chunk.batch)) {
+                if (retain_status.ok() && bptr) {
+                    impl_->releaseBatch(bptr);
+                }
+                chunk.batch = 0;
+            } else {
+                all_drained = false;
+                if (retain_status.ok() && bptr) {
+                    undrained_batches.push_back(chunk.batch);
+                }
+            }
+        }
+        if (!internal::pollRemoteOperations(remote_operations)) {
+            all_drained = false;
+            for (auto& operation : remote_operations) {
+                if (operation) {
+                    undrained_remote_operations.push_back(std::move(operation));
+                }
+            }
+            remote_operations.clear();
+        }
+        return all_drained;
+    };
 
     // The loop below can leave through the CHECK_STATUS on progressBatch or
     // through the FAILED branch, which only drains the queue. Either way the
@@ -348,6 +528,10 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     uint64_t idle_sweeps = 0;
 
     while (!event_queue.empty()) {
+        if (!running_.load(std::memory_order_acquire)) {
+            buffers_safe_to_release = cleanup_inflight();
+            return Status::InternalError("Proxy manager is shutting down");
+        }
         auto id = event_queue.front();
         auto& chunk = chunks[id];
         const auto state_before = chunk.state;
@@ -378,7 +562,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                     remote_locked.insert(chunk.remote_buf);
                     submitRemoteStage(server_addr, request, chunk.remote_buf,
                                       chunk.length, chunk.offset,
-                                      remote_futures[id]);
+                                      remote_operations[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
                     event_queue.push(id);
@@ -421,7 +605,7 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 if (request.opcode == Request::WRITE && remote_staging) {
                     submitRemoteStage(server_addr, request, chunk.remote_buf,
                                       chunk.length, chunk.offset,
-                                      remote_futures[id]);
+                                      remote_operations[id]);
                     chunk.prev_state = chunk.state;
                     chunk.state = StageState::INFLIGHT_REMOTE;
                     event_queue.push(id);
@@ -445,7 +629,11 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
 
             case StageState::INFLIGHT: {
                 TransferStatus xfer_status;
-                CHECK_STATUS(impl_->progressBatch(chunk.batch, xfer_status));
+                auto status = impl_->progressBatch(chunk.batch, xfer_status);
+                if (!status.ok()) {
+                    buffers_safe_to_release = cleanup_inflight();
+                    return status;
+                }
                 if (xfer_status.s == PENDING) {
                     event_queue.push(id);
                     break;
@@ -482,25 +670,22 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
             }
 
             case StageState::FAILED: {
-                // Drain the queue to avoid losing chunks
-                while (!event_queue.empty()) {
-                    event_queue.pop();
-                }
+                buffers_safe_to_release = cleanup_inflight();
                 return Status::InternalError(
                     "Proxy event loop in failed state");
             }
 
             case StageState::INFLIGHT_REMOTE: {
-                auto& fut = remote_futures[id];
-                if (!fut.valid()) {
+                auto& operation = remote_operations[id];
+                if (!operation) {
                     chunk.state = StageState::FAILED;
                     event_queue.push(id);
                     break;
                 }
-                if (fut.wait_for(std::chrono::seconds(0)) ==
-                    std::future_status::ready) {
-                    Status rs = fut.get();
-                    if (!rs.ok()) {
+                auto result = operation->tryTakeResult();
+                if (result) {
+                    operation.reset();
+                    if (!result->ok()) {
                         chunk.state = StageState::FAILED;
                         event_queue.push(id);
                         break;
@@ -632,27 +817,45 @@ Status ProxyManager::freeStageBuffers(const std::string& location) {
 
 Status ProxyManager::pinStageBuffer(const std::string& location,
                                     uint64_t& addr) {
-    std::shared_lock<std::shared_mutex> guard(stage_buffers_mutex_);
-    auto it = stage_buffers_.find(location);
-    if (it == stage_buffers_.end()) {
-        // allocateStageBuffers needs the lock exclusively, so drop ours. It
-        // re-checks under its own lock, so losing the race here is harmless.
-        guard.unlock();
-        CHECK_STATUS(allocateStageBuffers(location));
-        guard.lock();
-        it = stage_buffers_.find(location);
-        if (it == stage_buffers_.end())
-            return Status::InternalError("Stage buffer disappeared" LOC_MARK);
-    }
+    {
+        std::shared_lock<std::shared_mutex> guard(stage_buffers_mutex_);
+        auto it = stage_buffers_.find(location);
+        if (it == stage_buffers_.end()) {
+            guard.unlock();
+            CHECK_STATUS(allocateStageBuffers(location));
+            guard.lock();
+            it = stage_buffers_.find(location);
+            if (it == stage_buffers_.end())
+                return Status::InternalError(
+                    "Stage buffer disappeared" LOC_MARK);
+        }
 
-    auto& buf = it->second;
-    for (size_t i = 0; i < chunk_count_; ++i) {
-        if (!buf.bitmap[i].test_and_set(std::memory_order_acquire)) {
-            addr = reinterpret_cast<uint64_t>(static_cast<char*>(buf.chunks) +
-                                              i * chunk_size_);
-            return Status::OK();
+        auto& buf = it->second;
+        for (size_t i = 0; i < chunk_count_; ++i) {
+            if (!buf.bitmap[i].test_and_set(std::memory_order_acquire)) {
+                addr = reinterpret_cast<uint64_t>(
+                    static_cast<char*>(buf.chunks) + i * chunk_size_);
+                return Status::OK();
+            }
         }
     }
+
+    if (has_pending_cleanups_.load(std::memory_order_relaxed)) {
+        flushPendingCleanups();
+        std::shared_lock<std::shared_mutex> guard(stage_buffers_mutex_);
+        auto it = stage_buffers_.find(location);
+        if (it != stage_buffers_.end()) {
+            auto& buf = it->second;
+            for (size_t i = 0; i < chunk_count_; ++i) {
+                if (!buf.bitmap[i].test_and_set(std::memory_order_acquire)) {
+                    addr = reinterpret_cast<uint64_t>(
+                        static_cast<char*>(buf.chunks) + i * chunk_size_);
+                    return Status::OK();
+                }
+            }
+        }
+    }
+
     return Status::TooManyRequests("No available stage buffer in " + location);
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
@@ -1,0 +1,47 @@
+#include "remote_stage_operation.h"
+
+#include <utility>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace tent {
+namespace internal {
+
+void RemoteStageOperation::complete(Status status) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    result_ = std::move(status);
+}
+
+std::optional<Status> RemoteStageOperation::tryTakeResult() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!result_) return std::nullopt;
+    auto result = std::move(result_);
+    result_.reset();
+    return result;
+}
+
+bool pollRemoteOperations(
+    std::vector<RemoteStageOperationPtr>& remote_operations) {
+    for (auto it = remote_operations.begin(); it != remote_operations.end();) {
+        if (!*it) {
+            it = remote_operations.erase(it);
+            continue;
+        }
+        auto result = (*it)->tryTakeResult();
+        if (!result) {
+            ++it;
+            continue;
+        }
+        if (!result->ok()) {
+            LOG(WARNING) << "Failed to drain remote staging request: "
+                         << *result;
+        }
+        it = remote_operations.erase(it);
+    }
+    return remote_operations.empty();
+}
+
+}  // namespace internal
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
@@ -1,0 +1,35 @@
+#ifndef REMOTE_STAGE_OPERATION_H_
+#define REMOTE_STAGE_OPERATION_H_
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include "tent/common/status.h"
+
+namespace mooncake {
+namespace tent {
+namespace internal {
+
+class RemoteStageOperation {
+   public:
+    void complete(Status status);
+
+    std::optional<Status> tryTakeResult();
+
+   private:
+    std::mutex mutex_;
+    std::optional<Status> result_;
+};
+
+using RemoteStageOperationPtr = std::shared_ptr<RemoteStageOperation>;
+
+bool pollRemoteOperations(
+    std::vector<RemoteStageOperationPtr>& remote_operations);
+
+}  // namespace internal
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // REMOTE_STAGE_OPERATION_H_

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -802,6 +802,7 @@ BatchID TransferEngineImpl::allocateBatch(size_t batch_size) {
     Batch* batch = Slab<Batch>::Get().allocate();
     if (!batch) return (BatchID)0;
     batch->max_size = batch_size;
+    batch->task_list.reserve(batch_size);
     BatchID batch_id = (BatchID)batch;
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     batch_set_.active.insert(batch);
@@ -1464,6 +1465,11 @@ void TransferEngineImpl::attachProgressNotifier(
 Status TransferEngineImpl::commitPreparedSubmit(
     Batch* batch, const PreparedSubmit& prepared) {
     if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
+    if (batch->task_list.size() > batch->max_size ||
+        prepared.tasks.size() > batch->max_size - batch->task_list.size()) {
+        return Status::TooManyRequests(
+            "batch public task capacity exceeded" LOC_MARK);
+    }
 
     std::vector<Request> classified_request_list[kSupportedTransportTypes];
     std::vector<size_t> task_id_list[kSupportedTransportTypes];

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -347,7 +347,8 @@ if(TARGET asio_shared)
   target_link_libraries(tent_progress_worker_test PRIVATE asio_shared)
 endif()
 target_include_directories(tent_progress_worker_test
-                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                                   ${CMAKE_CURRENT_SOURCE_DIR}/../src/runtime)
 add_test(NAME tent_progress_worker_test COMMAND tent_progress_worker_test)
 
 # stage_buffers_ is reached from the staging workers and the RPC thread. Drives

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -39,12 +39,15 @@
 #include "tent/common/config.h"
 #include "tent/common/types.h"
 #include "tent/runtime/segment.h"
+#include "tent/runtime/proxy_manager.h"
 #include "tent/runtime/transfer_engine_impl.h"
 #include "tent/runtime/transport.h"
 #include "tent/transport/fault_proxy/fault_proxy_transport.h"
+#include "remote_stage_operation.h"
 
 namespace mooncake {
 namespace tent {
+
 namespace {
 
 // ---------------------------------------------------------------------------
@@ -181,6 +184,77 @@ class FakeTransport : public Transport {
     StatusFactory status_factory_;
     PollStatusFactory poll_status_factory_;
 };
+
+class DeferredCleanupProbeTransport : public FakeTransport {
+   public:
+    DeferredCleanupProbeTransport() : FakeTransport(TCP) {}
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request>& request_list) override {
+        const int attempt =
+            submit_attempts.fetch_add(1, std::memory_order_relaxed) + 1;
+        if (attempt == 2) {
+            return Status::InternalError(
+                "injected second staging submission failure" LOC_MARK);
+        }
+        return FakeTransport::submitTransferTasks(batch, request_list);
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        poll_attempts.fetch_add(1, std::memory_order_relaxed);
+        if (fail_polling.load(std::memory_order_acquire)) {
+            return Status::InternalError(
+                "injected deferred cleanup poll failure" LOC_MARK);
+        }
+
+        auto* fake_batch = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fake_batch->requests.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        if (stay_pending.load(std::memory_order_acquire)) {
+            status.s = TransferStatusEnum::PENDING;
+            status.transferred_bytes = 0;
+        } else {
+            status.s = TransferStatusEnum::COMPLETED;
+            status.transferred_bytes = fake_batch->requests[task_id].length;
+        }
+        return Status::OK();
+    }
+
+    Status freeLocalMemory(void* addr, size_t size) override {
+        free_local_memory_calls.fetch_add(1, std::memory_order_relaxed);
+        if (stay_pending.load(std::memory_order_acquire)) {
+            free_local_memory_while_pending.fetch_add(
+                1, std::memory_order_relaxed);
+        }
+        return FakeTransport::freeLocalMemory(addr, size);
+    }
+
+    std::atomic<int> submit_attempts{0};
+    std::atomic<int> poll_attempts{0};
+    std::atomic<int> free_local_memory_calls{0};
+    std::atomic<int> free_local_memory_while_pending{0};
+    std::atomic<bool> stay_pending{true};
+    std::atomic<bool> fail_polling{false};
+};
+
+TransferStatus waitForStagingTerminal(ProxyManager& manager, TaskInfo& task) {
+    TransferStatus status;
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto poll_status = manager.getStatus(&task, status);
+        if (!poll_status.ok()) {
+            ADD_FAILURE() << "getStatus failed: " << poll_status.ToString();
+            status.s = INVALID;
+            return status;
+        }
+        if (status.s != PENDING) return status;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return status;
+}
 
 std::shared_ptr<Config> makeMinimalP2PConfig() {
     auto cfg = std::make_shared<Config>();
@@ -520,6 +594,570 @@ TEST(ProgressWorker, EngineDestructorJoinsWorker) {
     // If teardown hangs or crashes here, gtest fails this test on timeout
     // / signal — no further assert needed.
     SUCCEED();
+}
+
+TEST(ProxyManager, ConcurrentFirstAllocationIsBounded) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    ProxyManager manager(&engine, 4096, 4);
+    constexpr int kCallers = 8;
+    std::atomic<int> ready{0};
+    std::atomic<int> attempted{0};
+    std::atomic<int> successful{0};
+    std::atomic<int> exhausted{0};
+    std::atomic<int> unpin_failures{0};
+    std::atomic<bool> start{false};
+    std::vector<std::thread> callers;
+    callers.reserve(kCallers);
+
+    for (int i = 0; i < kCallers; ++i) {
+        callers.emplace_back([&] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire))
+                std::this_thread::yield();
+
+            uint64_t addr = 0;
+            auto status = manager.pinStageBuffer(kWildcardLocation, addr);
+            if (status.ok()) {
+                successful.fetch_add(1, std::memory_order_relaxed);
+            } else if (status.IsTooManyRequests()) {
+                exhausted.fetch_add(1, std::memory_order_relaxed);
+            }
+            attempted.fetch_add(1, std::memory_order_release);
+            while (attempted.load(std::memory_order_acquire) != kCallers)
+                std::this_thread::yield();
+            if (status.ok() && !manager.unpinStageBuffer(addr).ok())
+                unpin_failures.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+
+    while (ready.load(std::memory_order_acquire) != kCallers)
+        std::this_thread::yield();
+    start.store(true, std::memory_order_release);
+    for (auto& caller : callers) caller.join();
+
+    EXPECT_EQ(successful.load(), 4);
+    EXPECT_EQ(exhausted.load(), 4);
+    EXPECT_EQ(unpin_failures.load(), 0);
+}
+
+TEST(ProxyManager, ReclaimsStageBuffersBetweenWorkerTasks) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x21);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    {
+        ProxyManager manager(&engine, 64, 2);
+        Request request;
+        request.opcode = Request::WRITE;
+        request.source = source.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(target.data());
+        request.length = kBufferLength;
+        const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+        for (int i = 0; i < 8; ++i) {
+            TaskInfo task;
+            task.request = request;
+            task.staging = true;
+            Status submit_status;
+            std::thread submitter(
+                [&] { submit_status = manager.submit(&task, 0, params); });
+            submitter.join();
+            ASSERT_TRUE(submit_status.ok());
+
+            TransferStatus status;
+            const auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::seconds(2);
+            while (std::chrono::steady_clock::now() < deadline) {
+                ASSERT_TRUE(manager.getStatus(&task, status).ok());
+                if (status.s != PENDING) break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
+            ASSERT_TRUE(manager.getStatus(&task, status).ok());
+            EXPECT_EQ(status.s, COMPLETED);
+        }
+    }
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
+}
+
+TEST(ProxyManager, DrainsInflightBatchesAfterProgressError) {
+    class FailOncePollTransport : public FakeTransport {
+       public:
+        explicit FailOncePollTransport(TransportType type)
+            : FakeTransport(type) {}
+
+        Status getTransferStatus(SubBatchRef batch, int task_id,
+                                 TransferStatus& status) override {
+            const int attempt =
+                poll_attempts.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (attempt == 1) {
+                return Status::InternalError("injected poll failure" LOC_MARK);
+            }
+            return FakeTransport::getTransferStatus(batch, task_id, status);
+        }
+
+        std::atomic<int> poll_attempts{0};
+    };
+
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<FailOncePollTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x31);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    {
+        ProxyManager manager(&engine, 64, 2);
+        Request request;
+        request.opcode = Request::WRITE;
+        request.source = source.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(target.data());
+        request.length = kBufferLength;
+        const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+        TaskInfo task;
+        task.request = request;
+        task.staging = true;
+        ASSERT_TRUE(manager.submit(&task, 0, params).ok());
+
+        TransferStatus status;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+            ASSERT_TRUE(manager.getStatus(&task, status).ok());
+            if (status.s != PENDING) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_TRUE(manager.getStatus(&task, status).ok());
+        EXPECT_EQ(status.s, FAILED);
+        EXPECT_GE(fake_tcp->poll_attempts.load(), 3);
+
+        uint64_t first = 0;
+        uint64_t second = 0;
+        uint64_t exhausted = 0;
+        ASSERT_TRUE(manager.pinStageBuffer(kWildcardLocation, first).ok());
+        ASSERT_TRUE(manager.pinStageBuffer(kWildcardLocation, second).ok());
+        EXPECT_TRUE(manager.pinStageBuffer(kWildcardLocation, exhausted)
+                        .IsTooManyRequests());
+        EXPECT_TRUE(manager.unpinStageBuffer(first).ok());
+        EXPECT_TRUE(manager.unpinStageBuffer(second).ok());
+    }
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
+}
+
+TEST(TransferEngineImpl, DirectSubmitRejectsBatchCapacityOverflow) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> buffer(kBufferLength, 0x41);
+    ASSERT_TRUE(engine.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    BatchID batch = engine.allocateBatch(1);
+    ASSERT_NE(batch, (BatchID)0);
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = buffer.data();
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(buffer.data());
+    request.length = buffer.size();
+
+    ASSERT_TRUE(engine.submitTransfer(batch, {request}).ok());
+    EXPECT_TRUE(engine.submitTransfer(batch, {request}).IsTooManyRequests());
+
+    EXPECT_TRUE(engine.waitTransferCompletion(batch).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+}
+
+TEST(ProxyManager, CleansUpDeferredStageBuffersWhenPendingBatchCompletes) {
+    class ControlledTransport : public FakeTransport {
+       public:
+        explicit ControlledTransport(TransportType type)
+            : FakeTransport(type) {}
+
+        Status submitTransferTasks(
+            SubBatchRef batch,
+            const std::vector<Request>& request_list) override {
+            int count =
+                submit_count.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (count == 2) {
+                return Status::InternalError(
+                    "injected submit failure" LOC_MARK);
+            }
+            return FakeTransport::submitTransferTasks(batch, request_list);
+        }
+
+        Status getTransferStatus(SubBatchRef batch, int task_id,
+                                 TransferStatus& status) override {
+            if (stay_pending.load(std::memory_order_relaxed)) {
+                status.s = TransferStatusEnum::PENDING;
+                return Status::OK();
+            }
+            status.s = TransferStatusEnum::COMPLETED;
+            return Status::OK();
+        }
+
+        std::atomic<int> submit_count{0};
+        std::atomic<bool> stay_pending{true};
+    };
+
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<ControlledTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x51);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    {
+        ProxyManager manager(&engine, 64, 2);
+        Request request;
+        request.opcode = Request::WRITE;
+        request.source = source.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(target.data());
+        request.length = kBufferLength;
+        const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+        TaskInfo task1;
+        task1.request = request;
+        task1.staging = true;
+        ASSERT_TRUE(manager.submit(&task1, 0, params).ok());
+
+        TransferStatus status;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+            ASSERT_TRUE(manager.getStatus(&task1, status).ok());
+            if (status.s != PENDING) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_TRUE(manager.getStatus(&task1, status).ok());
+        EXPECT_EQ(status.s, FAILED);
+
+        // While task1's batch is still PENDING, its stage buffer remains
+        // deferred and pinned.
+        uint64_t addr = 0;
+        EXPECT_TRUE(manager.pinStageBuffer(kWildcardLocation, addr)
+                        .IsTooManyRequests());
+
+        // Allow in-flight batches to complete.
+        fake_tcp->stay_pending.store(false, std::memory_order_relaxed);
+
+        // Submit task2 to trigger flushPendingCleanups() in worker thread.
+        TaskInfo task2;
+        task2.request = request;
+        task2.request.length =
+            64;  // 1 chunk so submitSubBatch count 3 succeeds
+        task2.staging = true;
+        ASSERT_TRUE(manager.submit(&task2, 0, params).ok());
+
+        const auto deadline2 =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline2) {
+            ASSERT_TRUE(manager.getStatus(&task2, status).ok());
+            if (status.s != PENDING) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_TRUE(manager.getStatus(&task2, status).ok());
+
+        // Now deferred stage buffers from task1 have been reclaimed!
+        ASSERT_TRUE(manager.pinStageBuffer(kWildcardLocation, addr).ok());
+        EXPECT_TRUE(manager.unpinStageBuffer(addr).ok());
+    }
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
+}
+
+TEST(ProxyManager, RetainsBatchToPreventSlabReuseLeak) {
+    class ControlledTransport : public FakeTransport {
+       public:
+        explicit ControlledTransport(TransportType type)
+            : FakeTransport(type) {}
+
+        Status submitTransferTasks(
+            SubBatchRef batch,
+            const std::vector<Request>& request_list) override {
+            int count =
+                submit_count.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (count == 2) {
+                return Status::InternalError(
+                    "injected submit failure" LOC_MARK);
+            }
+            return FakeTransport::submitTransferTasks(batch, request_list);
+        }
+
+        Status getTransferStatus(SubBatchRef batch, int task_id,
+                                 TransferStatus& status) override {
+            if (stay_pending.load(std::memory_order_relaxed)) {
+                status.s = TransferStatusEnum::PENDING;
+                return Status::OK();
+            }
+            status.s = TransferStatusEnum::COMPLETED;
+            return Status::OK();
+        }
+
+        std::atomic<int> submit_count{0};
+        std::atomic<bool> stay_pending{true};
+    };
+
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<ControlledTransport>(TCP);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x61);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    {
+        ProxyManager manager(&engine, 64, 2);
+        Request request;
+        request.opcode = Request::WRITE;
+        request.source = source.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(target.data());
+        request.length = kBufferLength;
+        const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+        TaskInfo task1;
+        task1.request = request;
+        task1.staging = true;
+        ASSERT_TRUE(manager.submit(&task1, 0, params).ok());
+
+        TransferStatus status;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+            ASSERT_TRUE(manager.getStatus(&task1, status).ok());
+            if (status.s != PENDING) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        ASSERT_TRUE(manager.getStatus(&task1, status).ok());
+        EXPECT_EQ(status.s, FAILED);
+
+        // Allow task1 in-flight batch to finish on transport
+        fake_tcp->stay_pending.store(false, std::memory_order_relaxed);
+
+        // Attempting to allocate a new batch should not collide with retained
+        // batch
+        BatchID new_batch = engine.allocateBatch(1);
+        ASSERT_NE(new_batch, (BatchID)0);
+
+        // Submit task2 to trigger flushPendingCleanups()
+        TaskInfo task2;
+        task2.request = request;
+        task2.request.length = 64;
+        task2.staging = true;
+        ASSERT_TRUE(manager.submit(&task2, 0, params).ok());
+
+        const auto deadline2 =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline2) {
+            ASSERT_TRUE(manager.getStatus(&task2, status).ok());
+            if (status.s != PENDING) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        // Verify task1 stage buffers were successfully reclaimed after retained
+        // batch completed
+        uint64_t addr = 0;
+        ASSERT_TRUE(manager.pinStageBuffer(kWildcardLocation, addr).ok());
+        EXPECT_TRUE(manager.unpinStageBuffer(addr).ok());
+
+        engine.freeBatch(new_batch);
+    }
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
+}
+
+TEST(ProxyManager, DeferredCleanupPollErrorKeepsStageBuffersPinned) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<DeferredCleanupProbeTransport>();
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x71);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    {
+        ProxyManager manager(&engine, 64, 2);
+        Request request;
+        request.opcode = Request::WRITE;
+        request.source = source.data();
+        request.target_id = LOCAL_SEGMENT_ID;
+        request.target_offset = reinterpret_cast<uint64_t>(target.data());
+        request.length = kBufferLength;
+        const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+        TaskInfo task;
+        task.request = request;
+        task.staging = true;
+        ASSERT_TRUE(manager.submit(&task, 0, params).ok());
+        ASSERT_EQ(waitForStagingTerminal(manager, task).s, FAILED);
+
+        fake_tcp->fail_polling.store(true, std::memory_order_release);
+        uint64_t addr = 0;
+        auto pin_status = manager.pinStageBuffer(kWildcardLocation, addr);
+        EXPECT_TRUE(pin_status.IsTooManyRequests())
+            << "a polling error must not release an in-flight stage buffer: "
+            << pin_status.ToString();
+        if (pin_status.ok()) {
+            EXPECT_TRUE(manager.unpinStageBuffer(addr).ok());
+        }
+
+        fake_tcp->fail_polling.store(false, std::memory_order_release);
+        fake_tcp->stay_pending.store(false, std::memory_order_release);
+        ASSERT_TRUE(manager.pinStageBuffer(kWildcardLocation, addr).ok());
+        EXPECT_TRUE(manager.unpinStageBuffer(addr).ok());
+    }
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
+}
+
+TEST(ProxyManager, RemoteCleanupProbeDoesNotBlockOnPendingOperation) {
+    auto operation = std::make_shared<internal::RemoteStageOperation>();
+    std::vector<internal::RemoteStageOperationPtr> remote_operations = {
+        operation};
+
+    EXPECT_FALSE(internal::pollRemoteOperations(remote_operations));
+    ASSERT_EQ(remote_operations.size(), 1);
+
+    operation->complete(Status::OK());
+    EXPECT_TRUE(internal::pollRemoteOperations(remote_operations));
+    EXPECT_TRUE(remote_operations.empty());
+}
+
+TEST(ProxyManager, DestructorWaitsForDeferredBatchBeforeFreeingStageMemory) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<DeferredCleanupProbeTransport>();
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x81);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(target.data(), target.size()).ok());
+
+    auto manager = std::make_unique<ProxyManager>(&engine, 64, 2);
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = source.data();
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(target.data());
+    request.length = kBufferLength;
+    const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+    TaskInfo task;
+    task.request = request;
+    task.staging = true;
+    ASSERT_TRUE(manager->submit(&task, 0, params).ok());
+    ASSERT_EQ(waitForStagingTerminal(*manager, task).s, FAILED);
+
+    std::atomic<bool> destroyed{false};
+    std::thread destroyer([&] {
+        manager.reset();
+        destroyed.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(destroyed.load(std::memory_order_acquire));
+    EXPECT_EQ(fake_tcp->free_local_memory_calls.load(std::memory_order_acquire),
+              0);
+    EXPECT_EQ(fake_tcp->free_local_memory_while_pending.load(
+                  std::memory_order_acquire),
+              0);
+
+    fake_tcp->stay_pending.store(false, std::memory_order_release);
+    destroyer.join();
+    EXPECT_TRUE(destroyed.load(std::memory_order_acquire));
+    EXPECT_GT(fake_tcp->free_local_memory_calls.load(std::memory_order_acquire),
+              0);
+    EXPECT_EQ(fake_tcp->free_local_memory_while_pending.load(
+                  std::memory_order_acquire),
+              0);
+
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(target.data(), target.size()).ok());
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

Fixes concurrency, resource-lifetime, and shutdown-safety issues in the TENT `ProxyManager` staging path by stabilizing `TaskInfo` storage, using atomic staging status, enforcing batch capacity limits, scoping staging buffer caches to individual tasks, and returning recoverable allocation errors.
Deferred cleanup retains internal batch references and keeps staging buffers pinned when `progressBatch()` fails or remains `PENDING`, preventing premature slab reuse and use-after-free.
Additionally, remote staging has been refactored from thread-blocking "fake async" to true event-driven asynchronous execution. By introducing `ControlClient::delegateAsync()` built on top of `CoroRpcAgent::callAsync()`, remote completion is now tracked non-blockingly via `RemoteStageOperation` handles, removing the need for `ThreadPool` thread dispatching, `std::future` polling, or test-specific friend declarations (`ProxyManagerTestPeer`).
Shutdown stops staging workers and drains retained local/cross-stage batches to a confirmed terminal state before releasing staging memory, while unresolved remote stage buffers remain pinned for DMA safety.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other


## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added comprehensive unit test coverage in `mooncake-transfer-engine/tent/tests/progress_worker_test.cpp`:
- `ProxyManager.ConcurrentFirstAllocationIsBounded`
- `ProxyManager.ReclaimsStageBuffersBetweenWorkerTasks`
- `ProxyManager.DrainsInflightBatchesAfterProgressError`
- `ProxyManager.CleansUpDeferredStageBuffersWhenPendingBatchCompletes`
- `ProxyManager.RetainsBatchToPreventSlabReuseLeak`
- `ProxyManager.DeferredCleanupPollErrorKeepsStageBuffersPinned`
- `ProxyManager.RemoteCleanupProbeDoesNotBlockOnPendingOperation`
- `ProxyManager.DestructorWaitsForDeferredBatchBeforeFreeingStageMemory`
- `TransferEngineImpl.DirectSubmitRejectsBatchCapacityOverflow`

**Test commands:**
```bash
cmake -S . -B build-tent \
  -DUSE_TENT=ON \
  -DUSE_CUDA=OFF \
  -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=ON

cmake --build build-tent --target tent_progress_worker_test -j

./build-tent/mooncake-transfer-engine/tent/tests/tent_progress_worker_test
```

**End-to-End Data Integrity Verification:**
```bash
./build-tent/mooncake-transfer-engine/benchmark/tebench --backend=tent --xport_type=shm --check_consistency=true --op_type=mix --duration=2
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Ran all unit tests in `tent_progress_worker_test` and verified end-to-end data integrity via `tebench --check_consistency=true`; all tests passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)