### PR TITLE
[Bugfix][TE] Reject MC_IB_PORT=0 instead of disabling every RNIC

### DIFF
--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -128,7 +128,9 @@ void loadGlobalConfig(GlobalConfig& config) {
     const char* port_env = std::getenv("MC_IB_PORT");
     if (port_env) {
         int val = atoi(port_env);
-        if (val >= 0 && val < 256)
+        // IB port numbers are 1-based. Accepting 0 made ibv_query_port fail on
+        // every device, disabling the whole topology.
+        if (val > 0 && val < 256)
             config.port = uint8_t(val);
         else
             LOG(WARNING) << "Ignore value from environment variable MC_IB_PORT";

--- a/mooncake-transfer-engine/tests/config_test.cpp
+++ b/mooncake-transfer-engine/tests/config_test.cpp
@@ -277,6 +277,56 @@ TEST_F(ConnPauseTtlEnvTest, EmptyStringKeepsDefault) {
     EXPECT_EQ(config.conn_pause_ttl_ms, 17);
 }
 
+// MC_IB_PORT names the RDMA port opened on every device. Port numbers are
+// 1-based, so 0 is not a "disable" value: it makes ibv_query_port fail on
+// every device and takes the whole topology down.
+class IbPortEnvTest : public ::testing::Test {
+   protected:
+    void TearDown() override { ::unsetenv("MC_IB_PORT"); }
+};
+
+TEST_F(IbPortEnvTest, DefaultIsPortOneWhenUnset) {
+    ::unsetenv("MC_IB_PORT");
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 1);
+}
+
+TEST_F(IbPortEnvTest, ValidOverrideIsApplied) {
+    ASSERT_EQ(::setenv("MC_IB_PORT", "2", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 2);
+}
+
+TEST_F(IbPortEnvTest, ZeroIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_PORT", "0", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 1);
+}
+
+TEST_F(IbPortEnvTest, OutOfRangeIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_PORT", "256", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 1);
+}
+
+TEST_F(IbPortEnvTest, NegativeIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_PORT", "-1", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 1);
+}
+
+TEST_F(IbPortEnvTest, NonNumericIsRejected) {
+    ASSERT_EQ(::setenv("MC_IB_PORT", "abc", 1), 0);
+    GlobalConfig config;
+    loadGlobalConfig(config);
+    EXPECT_EQ(config.port, 1);
+}
+
 // MC_MAX_CONCURRENT_REG_MR caps how many buffers registerLocalMemoryBatch()
 // registers at once; 0 (the default) means unbounded. 0 is therefore also what
 // a silent atol() fallback would produce on a typo, which would read as "the


### PR DESCRIPTION
Description

  loadGlobalConfig validated MC_IB_PORT with val >= 0, so 0 passed and became globalConfig().port. IB port numbers are 1-based: RdmaContext::openRdmaDevice then calls ibv_query_port(ctx, 0, ...) on every device, which fails, so
  construct() returns ERR_CONTEXT and each RNIC is disableDeviced. With the topology empty, TransferEngine::init() fails with ERR_DEVICE_NOT_FOUND — one mistyped environment variable takes down all RDMA on the node, and no log
  line names the value as the cause.

  atoi() returning 0 for unparseable input made this reachable by typo as well: MC_IB_PORT=abc selected port 0 instead of being ignored.

  Fix: require val > 0, matching the other bounded knobs in the same function. Out-of-range and unparseable values now keep the default port 1 and log the existing warning.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?
  
  Test commands:
  cmake .. -DBUILD_UNIT_TESTS=ON && cmake --build . -j$(nproc)
  ctest -R config_test --output-on-failure

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  config_test gains 6 IbPortEnvTest cases: unset default, valid override, and rejection of 0 / 256 / -1 / non-numeric. All pass.

  Verified the tests are not inert: with val >= 0 restored, ZeroIsRejected and NonNumericIsRejected fail; with the fix they pass.

  Full ctest: 28/31 pass. The 3 failures (tcp_transport_test, transfer_metadata_test, memory_location_test) are pre-existing environment issues in the build container — no etcd metadata server, and no CAP_SYS_NICE for mbind —
  and are unrelated to this change.

  Checklist
  
  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit run --all-files and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue
  
  pre-commit was run on the two touched files only (all hooks pass); --all-files was not run because cmake-format rewrites unrelated CMakeLists.txt files. Docs need no change — MC_IB_PORT is documented as "default value 1" and
  never advertised 0 as valid.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)