### PR TITLE
[TENT] Support custom NIC priority matrix and native topology dump

### DIFF
--- a/docs/source/api-reference/cpp/tent.md
+++ b/docs/source/api-reference/cpp/tent.md
@@ -106,6 +106,57 @@ export MC_USE_TENT=1
 
 When this variable is set, the `mooncake::TransferEngine` class internally delegates to `mooncake::tent::TransferEngine`. Most TE APIs are translated automatically. APIs that have no TENT equivalent (e.g., `installTransport`, `getMetadata`) become no-ops or return placeholder values.
 
+Passing a NIC priority matrix through `installTransport(..., args)` is **not** supported under TENT. Configure custom topology via `MC_TENT_CONF` or `MC_CUSTOM_TOPO_JSON` instead (see below).
+
+### Custom NIC Priority Matrix
+
+TENT accepts the same classic Transfer Engine priority-matrix JSON format:
+
+```json
+{
+  "cpu:0": [["mlx5_0"], ["mlx5_1"]],
+  "cpu:1": [["mlx5_1"], ["mlx5_0"]],
+  "cuda:0": [["mlx5_0"], ["mlx5_1"]]
+}
+```
+
+Preferred HCAs map to topology rank 0; available/fallback HCAs map to rank 1.
+
+Configuration priority (highest first):
+
+1. Inline matrix in `MC_TENT_CONF` / `Config`: `topology/priority_matrix`
+2. File path: `topology/custom_json_path` (also set by `MC_CUSTOM_TOPO_JSON`)
+3. Automatic topology discovery
+
+**Inline example (`MC_TENT_CONF`):**
+
+```json
+{
+  "topology": {
+    "priority_matrix": {
+      "cpu:0": [["mlx5_0"], ["mlx5_1"]],
+      "cuda:0": [["mlx5_0"], ["mlx5_1"]]
+    }
+  }
+}
+```
+
+**Path example:**
+
+```json
+{
+  "topology": {
+    "custom_json_path": "/etc/mooncake/nic_priority_matrix.json"
+  }
+}
+```
+
+```bash
+export MC_CUSTOM_TOPO_JSON=/etc/mooncake/nic_priority_matrix.json
+```
+
+A topology file may also use TENT's native `{"nics":[...],"mems":[...]}` format when loaded via `custom_json_path` / `MC_CUSTOM_TOPO_JSON`. If loading or parsing fails, TENT falls back to auto-discovery.
+
 ## Core APIs
 
 ### Core Usage Path (C++)

--- a/docs/source/api-reference/cpp/tent.md
+++ b/docs/source/api-reference/cpp/tent.md
@@ -108,6 +108,7 @@ When this variable is set, the `mooncake::TransferEngine` class internally deleg
 
 Passing a NIC priority matrix through `installTransport(..., args)` is **not** supported under TENT. Configure custom topology via `MC_TENT_CONF` or `MC_CUSTOM_TOPO_JSON` instead (see below).
 
+(custom-nic-priority-matrix)=
 ### Custom NIC Priority Matrix
 
 TENT accepts the same classic Transfer Engine priority-matrix JSON format:

--- a/docs/source/api-reference/python/transfer-engine.md
+++ b/docs/source/api-reference/python/transfer-engine.md
@@ -636,7 +636,7 @@ The Transfer Engine respects the following environment variables:
 - `MC_LEGACY_RPC_PORT_BINDING`: Enables legacy RPC port binding behavior
 - `MC_TCP_BIND_ADDRESS`: Specifies the TCP bind address
 - `MC_RDMA_BIND_ADDRESS`: Specifies the RDMA bind address for NIC path construction in dual-NIC environments. When set, RDMA NIC paths use this address while TCP handshake uses the address from `local_hostname`. This is useful when TCP and RDMA traffic use separate network interfaces (e.g., `eth0` for TCP and `rdma-net1` for RDMA).
-- `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file (classic NIC priority matrix, or under TENT also native `nics`/`mems` JSON). Honored by classic Transfer Engine and by TENT when `MC_USE_TENT=1` (maps to `topology/custom_json_path`). For TENT, prefer inlining `topology/priority_matrix` in `MC_TENT_CONF` when possible; see [TENT C++ API](../cpp/tent.md#custom-nic-priority-matrix).
+- `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file (classic NIC priority matrix, or under TENT also native `nics`/`mems` JSON). Honored by classic Transfer Engine and by TENT when `MC_USE_TENT=1` (maps to `topology/custom_json_path`). For TENT, prefer inlining `topology/priority_matrix` in `MC_TENT_CONF` when possible; see the {ref}`TENT C++ API <custom-nic-priority-matrix>`.
 - `MC_TE_FILTERS`: Optional comma-separated whitelist of IB device names (e.g. `mlx5_0,mlx5_2`) for legacy Transfer Engine topology discovery. When unset, all available devices are discovered.
 - `MC_TE_METRIC`: Enables metrics reporting (set to "1", "true", "yes", or "on"). **Note:** Not supported when using Transfer Engine TENT.
 - `MC_TE_METRIC_INTERVAL_SECONDS`: Sets metrics reporting interval in seconds

--- a/docs/source/api-reference/python/transfer-engine.md
+++ b/docs/source/api-reference/python/transfer-engine.md
@@ -636,7 +636,7 @@ The Transfer Engine respects the following environment variables:
 - `MC_LEGACY_RPC_PORT_BINDING`: Enables legacy RPC port binding behavior
 - `MC_TCP_BIND_ADDRESS`: Specifies the TCP bind address
 - `MC_RDMA_BIND_ADDRESS`: Specifies the RDMA bind address for NIC path construction in dual-NIC environments. When set, RDMA NIC paths use this address while TCP handshake uses the address from `local_hostname`. This is useful when TCP and RDMA traffic use separate network interfaces (e.g., `eth0` for TCP and `rdma-net1` for RDMA).
-- `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file
+- `MC_CUSTOM_TOPO_JSON`: Path to custom topology JSON file (classic NIC priority matrix, or under TENT also native `nics`/`mems` JSON). Honored by classic Transfer Engine and by TENT when `MC_USE_TENT=1` (maps to `topology/custom_json_path`). For TENT, prefer inlining `topology/priority_matrix` in `MC_TENT_CONF` when possible; see [TENT C++ API](../cpp/tent.md#custom-nic-priority-matrix).
 - `MC_TE_FILTERS`: Optional comma-separated whitelist of IB device names (e.g. `mlx5_0,mlx5_2`) for legacy Transfer Engine topology discovery. When unset, all available devices are discovered.
 - `MC_TE_METRIC`: Enables metrics reporting (set to "1", "true", "yes", or "on"). **Note:** Not supported when using Transfer Engine TENT.
 - `MC_TE_METRIC_INTERVAL_SECONDS`: Sets metrics reporting interval in seconds

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -15,6 +15,7 @@
 #include "transfer_engine_py.h"
 
 #include <cassert>
+#include <cstdlib>
 #include <numeric>
 #include <fstream>
 
@@ -1068,13 +1069,38 @@ std::string TransferEnginePy::getLocalTopology(const char* device_name) {
     pybind11::gil_scoped_release release;
     auto device_name_safe = device_name ? std::string(device_name) : "";
     auto device_filter = buildDeviceFilter(device_name_safe);
+
+    // Under TENT, classic constructor filters are ignored; map device_name to
+    // MC_TE_FILTERS so topology discovery respects the whitelist.
+    std::string saved_filters;
+    bool restore_filters = false;
+    const bool use_tent =
+        getenv("MC_USE_TENT") != nullptr || getenv("MC_USE_TEV1") != nullptr;
+    if (use_tent && !device_name_safe.empty()) {
+        const char* old = getenv("MC_TE_FILTERS");
+        if (old) saved_filters = old;
+        setenv("MC_TE_FILTERS", device_name_safe.c_str(), 1);
+        restore_filters = true;
+    }
+
     std::shared_ptr<TransferEngine> tmp_engine =
         std::make_shared<TransferEngine>(true, device_filter);
 
     std::string metadata_conn_string{"P2PHANDSHAKE"}, local_server_name{};
     tmp_engine->init(metadata_conn_string, local_server_name);
 
-    return tmp_engine->getLocalTopology()->toString();
+    // Under TENT this returns native {"nics","mems"} with rank0/1/2; under
+    // classic TE it returns the priority-matrix JSON.
+    std::string result = tmp_engine->getLocalTopologyString();
+
+    if (restore_filters) {
+        if (saved_filters.empty()) {
+            unsetenv("MC_TE_FILTERS");
+        } else {
+            setenv("MC_TE_FILTERS", saved_filters.c_str(), 1);
+        }
+    }
+    return result;
 }
 
 std::vector<TransferEnginePy::TransferNotify> TransferEnginePy::getNotifies() {

--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -23,7 +23,9 @@
 #include "transport/rpc_communicator/rpc_interface.h"
 
 #ifdef USE_TENT
+#include "tent/common/config.h"
 #include "tent/common/types.h"
+#include "tent/transfer_engine.h"
 #endif
 
 #ifdef USE_EFA
@@ -1068,39 +1070,39 @@ uintptr_t TransferEnginePy::getFirstBufferAddress(
 std::string TransferEnginePy::getLocalTopology(const char* device_name) {
     pybind11::gil_scoped_release release;
     auto device_name_safe = device_name ? std::string(device_name) : "";
-    auto device_filter = buildDeviceFilter(device_name_safe);
 
-    // Under TENT, classic constructor filters are ignored; map device_name to
-    // MC_TE_FILTERS so topology discovery respects the whitelist.
-    std::string saved_filters;
-    bool restore_filters = false;
     const bool use_tent =
         getenv("MC_USE_TENT") != nullptr || getenv("MC_USE_TEV1") != nullptr;
-    if (use_tent && !device_name_safe.empty()) {
-        const char* old = getenv("MC_TE_FILTERS");
-        if (old) saved_filters = old;
-        setenv("MC_TE_FILTERS", device_name_safe.c_str(), 1);
-        restore_filters = true;
+#ifdef USE_TENT
+    if (use_tent) {
+        // The classic shim (TransferEngine(true, filter)) silently drops the
+        // filter on the TENT path and builds its own Config in init(), so
+        // inject the whitelist via the per-instance Config that TENT's public
+        // constructor already accepts. Avoids touching the process-global
+        // MC_TE_FILTERS env var (racey under concurrent callers, leaked on
+        // throw). Note: if MC_TE_FILTERS is also set in env, loadFromEnv()
+        // inside TransferEngineImpl will override this — env takes priority.
+        auto conf = std::make_shared<mooncake::tent::Config>();
+        conf->set("metadata_type", "p2p");
+        if (!device_name_safe.empty()) {
+            conf->set("topology/rdma_whitelist",
+                      std::vector<std::string>{device_name_safe});
+        }
+        mooncake::tent::TransferEngine tent_engine(conf);
+        return tent_engine.available() ? tent_engine.getLocalTopologyString()
+                                       : "{}";
     }
+#else
+    (void)use_tent;
+#endif
 
+    // Classic path: device_filter is honored by classic TransferEngineImpl.
+    auto device_filter = buildDeviceFilter(device_name_safe);
     std::shared_ptr<TransferEngine> tmp_engine =
         std::make_shared<TransferEngine>(true, device_filter);
-
     std::string metadata_conn_string{"P2PHANDSHAKE"}, local_server_name{};
     tmp_engine->init(metadata_conn_string, local_server_name);
-
-    // Under TENT this returns native {"nics","mems"} with rank0/1/2; under
-    // classic TE it returns the priority-matrix JSON.
-    std::string result = tmp_engine->getLocalTopologyString();
-
-    if (restore_filters) {
-        if (saved_filters.empty()) {
-            unsetenv("MC_TE_FILTERS");
-        } else {
-            setenv("MC_TE_FILTERS", saved_filters.c_str(), 1);
-        }
-    }
-    return result;
+    return tmp_engine->getLocalTopologyString();
 }
 
 std::vector<TransferEnginePy::TransferNotify> TransferEnginePy::getNotifies() {

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -269,6 +269,11 @@ class TransferEngine {
 
     std::shared_ptr<Topology> getLocalTopology();
 
+    // String dump of the live local topology. Under TENT this is the native
+    // {"nics","mems"} JSON (with rank0/1/2). Under classic TE it is the
+    // priority-matrix JSON.
+    std::string getLocalTopologyString();
+
     void enableGracefulShutdown();
     std::string showLinks(bool json = false) const;
 

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -313,6 +313,11 @@ std::shared_ptr<Topology> TransferEngine::getLocalTopology() {
     return impl_->getLocalTopology();
 }
 
+std::string TransferEngine::getLocalTopologyString() {
+    auto topo = impl_->getLocalTopology();
+    return topo ? topo->toString() : "{}";
+}
+
 void TransferEngine::enableGracefulShutdown() {
     if (!shutdown_token_) {
         shutdown_token_ = registerTransferEngineShutdownToken(this);
@@ -332,6 +337,9 @@ std::string TransferEngine::showLinks(bool json) const {
 #include "transfer_engine_impl.h"
 #include "tent/transfer_engine.h"
 #include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/topology.h"
+#include "topology.h"
 
 #include <mutex>
 #include <utility>
@@ -865,10 +873,61 @@ int TransferEngine::numContexts() const {
 
 std::shared_ptr<Topology> TransferEngine::getLocalTopology() {
     if (use_tent_) {
-        LOG(WARNING) << "API deprecated in Mooncake TENT";
-        return std::make_shared<Topology>();
-    } else
+        // Classic Topology only supports a 2-tier priority matrix. Prefer
+        // getLocalTopologyString() for the full TENT nics/mems (rank0/1/2)
+        // representation. This method still projects into the classic format
+        // for existing C++ callers.
+        auto classic = std::make_shared<Topology>();
+        if (!impl_tent_ || !impl_tent_->available()) return classic;
+        auto tent_topo = impl_tent_->getLocalTopology();
+        if (!tent_topo) return classic;
+
+        Json::Value root(Json::objectValue);
+        for (size_t mi = 0; mi < tent_topo->getMemCount(); ++mi) {
+            const auto* mem =
+                tent_topo->getMemEntry(static_cast<tent::Topology::MemID>(mi));
+            if (!mem) continue;
+            if (mem->name.empty() || mem->name == tent::kWildcardLocation) {
+                continue;
+            }
+            Json::Value preferred(Json::arrayValue);
+            Json::Value avail(Json::arrayValue);
+            for (auto id : mem->device_list[0]) {
+                preferred.append(tent_topo->getNicName(id));
+            }
+            for (size_t rank = 1; rank < tent::Topology::DevicePriorityRanks;
+                 ++rank) {
+                for (auto id : mem->device_list[rank]) {
+                    avail.append(tent_topo->getNicName(id));
+                }
+            }
+            Json::Value entry(Json::arrayValue);
+            entry.append(preferred);
+            entry.append(avail);
+            root[mem->name] = entry;
+        }
+
+        Json::StreamWriterBuilder builder;
+        builder["indentation"] = "";
+        const std::string json = Json::writeString(builder, root);
+        if (classic->parse(json)) {
+            LOG(WARNING) << "Failed to translate TENT topology to classic "
+                            "priority matrix";
+            classic->clear();
+        }
+        return classic;
+    } else {
         return impl_->getLocalTopology();
+    }
+}
+
+std::string TransferEngine::getLocalTopologyString() {
+    if (use_tent_) {
+        if (!impl_tent_ || !impl_tent_->available()) return "{}";
+        return impl_tent_->getLocalTopologyString();
+    }
+    auto topo = impl_ ? impl_->getLocalTopology() : nullptr;
+    return topo ? topo->toString() : "{}";
 }
 
 void* TransferEngine::getBaseAddr() {

--- a/mooncake-transfer-engine/tent/include/tent/common/config.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config.h
@@ -165,6 +165,9 @@ class Config {
 
     std::string dump(int indent = 2) const;
 
+    // If key_path resolves to a JSON value, dump it into *out and return true.
+    bool dumpSubtree(const std::string& key_path, std::string* out) const;
+
    private:
     json config_data_;
     mutable std::mutex mutex_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
@@ -87,6 +87,18 @@ class Topology {
 
     Status parse(const std::string& json_content);
 
+    // Parse classic TE NIC priority matrix:
+    // {"cpu:0": [["mlx5_0"], ["mlx5_1"]], ...}
+    // preferred → device_list[rank0], avail → device_list[rank1].
+    Status parsePriorityMatrix(const std::string& json_content);
+
+    // Auto-detect native {"nics","mems"} JSON vs classic priority matrix.
+    Status parseCustomTopology(const std::string& json_content);
+
+    // Load topology from Config (inline matrix / file path) or discover.
+    Status loadFromConfig(const Config& conf,
+                          const std::vector<Platform*>& platforms);
+
     std::string toString() const;
 
     void print() const;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -97,6 +97,9 @@ class TransferEngineImpl {
 
     uint16_t getRpcServerPort() const;
 
+    // Local topology discovered (or loaded from custom matrix) at construct.
+    std::shared_ptr<Topology> getLocalTopology() const;
+
    public:
     Status exportLocalSegment(std::string& shared_handle);
 

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -239,6 +239,7 @@ namespace mooncake {
 namespace tent {
 class TransferEngineImpl;
 class Config;
+class Topology;
 class TransferEngine {
    public:
     TransferEngine();
@@ -261,6 +262,12 @@ class TransferEngine {
     const std::string getRpcServerAddress() const;
 
     uint16_t getRpcServerPort() const;
+
+    // Returns the live local topology (nics/mems). Empty if engine unavailable.
+    std::shared_ptr<Topology> getLocalTopology() const;
+
+    // Native {"nics","mems"} JSON dump (includes rank0/1/2). "{}" if empty.
+    std::string getLocalTopologyString() const;
 
    public:
     Status exportLocalSegment(std::string& shared_handle);

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -49,6 +49,36 @@ std::string Config::dump(int indent) const {
     return config_data_.dump(indent);
 }
 
+bool Config::dumpSubtree(const std::string& key_path, std::string* out) const {
+    if (!out || key_path.empty()) return false;
+    std::lock_guard<std::mutex> lock(mutex_);
+    const json* node = &config_data_;
+    std::string::size_type start = 0;
+    bool nested_found = true;
+    while (start < key_path.size()) {
+        auto pos = key_path.find(kDelimiter, start);
+        auto segment = key_path.substr(start, pos - start);
+        start = (pos == std::string::npos) ? key_path.size() : pos + 1;
+        if (segment.empty()) continue;
+        auto it = node->find(segment);
+        if (it == node->end()) {
+            nested_found = false;
+            break;
+        }
+        node = &(*it);
+    }
+    if (nested_found && !node->is_null()) {
+        *out = node->dump();
+        return true;
+    }
+    auto flat_it = config_data_.find(key_path);
+    if (flat_it != config_data_.end() && !flat_it->is_null()) {
+        *out = flat_it->dump();
+        return true;
+    }
+    return false;
+}
+
 static inline void setConfig(Config& config, const std::string& env_key,
                              const std::string& config_key) {
     const char* val = std::getenv(env_key.c_str());
@@ -145,6 +175,10 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     // Consumed by filterInfiniBandDevices() in the platform probes.
     setArrayConfig(config, "MC_TE_FILTERS", "topology/rdma_whitelist");
     setArrayConfig(config, "MC_TE_FILTERS_EXCLUDE", "topology/rdma_blacklist");
+    // Classic TE custom topology file path. Maps into TENT config so the same
+    // MC_CUSTOM_TOPO_JSON works under MC_USE_TENT. Inline
+    // topology/priority_matrix in MC_TENT_CONF still takes precedence.
+    setConfig(config, "MC_CUSTOM_TOPO_JSON", "topology/custom_json_path");
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -436,6 +436,9 @@ PYBIND11_MODULE(tent, m) {
         .def("get_segment_name", &TransferEngine::getSegmentName)
         .def("get_rpc_server_address", &TransferEngine::getRpcServerAddress)
         .def("get_rpc_server_port", &TransferEngine::getRpcServerPort)
+        .def("get_local_topology", &TransferEngine::getLocalTopologyString,
+             "Dump local topology as native TENT JSON (nics/mems with "
+             "rank0/1/2)")
 
         // ---------------------------------------------------------------------
         // export/import: out param -> return

--- a/mooncake-transfer-engine/tent/src/runtime/topology.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/topology.cpp
@@ -19,6 +19,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -232,6 +233,166 @@ Status Topology::parse(const std::string& json_content) {
         return Status::MalformedJson(std::string(e.what()) + LOC_MARK);
     }
     return Status::OK();
+}
+
+namespace {
+
+Topology::MemType memTypeFromLocation(const std::string& location) {
+    LocationParser parser(location);
+    const auto type = parser.type();
+    if (type == "cpu") return Topology::MEM_HOST;
+    if (type == "cuda" || type == "gpu") return Topology::MEM_CUDA;
+    if (type == "rocm") return Topology::MEM_ROCM;
+    if (type == "ascend") return Topology::MEM_ASCEND;
+    return Topology::MEM_UNKNOWN;
+}
+
+Topology::NicID ensureNic(
+    Topology& topo, const std::string& name,
+    std::unordered_map<std::string, Topology::NicID>* ids) {
+    auto it = ids->find(name);
+    if (it != ids->end()) return it->second;
+    Topology::NicID id = static_cast<Topology::NicID>(topo.nic_list_.size());
+    Topology::NicEntry nic;
+    nic.name = name;
+    nic.type = Topology::NIC_RDMA;
+    nic.numa_node = -1;
+    topo.nic_list_.push_back(std::move(nic));
+    (*ids)[name] = id;
+    return id;
+}
+
+}  // namespace
+
+Status Topology::parsePriorityMatrix(const std::string& json_content) {
+    try {
+        clear();
+        if (json_content.empty()) {
+            return Status::MalformedJson("empty priority matrix" LOC_MARK);
+        }
+        nlohmann::json root = nlohmann::json::parse(json_content);
+        if (!root.is_object()) {
+            return Status::MalformedJson(
+                "priority matrix must be a JSON object" LOC_MARK);
+        }
+
+        std::unordered_map<std::string, NicID> nic_ids;
+        std::vector<NicID> all_preferred;
+        std::vector<NicID> all_avail;
+        std::unordered_set<NicID> seen_preferred;
+        std::unordered_set<NicID> seen_avail;
+
+        for (auto it = root.begin(); it != root.end(); ++it) {
+            const auto& value = it.value();
+            if (!value.is_array() || value.size() != 2 ||
+                !value[0].is_array() || !value[1].is_array()) {
+                return Status::MalformedJson(
+                    "each priority matrix entry must be "
+                    "[[preferred...],[avail...]]" LOC_MARK);
+            }
+
+            MemEntry mem;
+            mem.name = it.key();
+            mem.pci_bus_id = "";
+            mem.type = memTypeFromLocation(mem.name);
+            mem.numa_node = -1;
+
+            for (const auto& hca : value[0]) {
+                if (!hca.is_string()) {
+                    return Status::MalformedJson(
+                        "HCA names must be strings" LOC_MARK);
+                }
+                NicID id = ensureNic(*this, hca.get<std::string>(), &nic_ids);
+                mem.device_list[0].push_back(id);
+                if (seen_preferred.insert(id).second) {
+                    all_preferred.push_back(id);
+                }
+            }
+            for (const auto& hca : value[1]) {
+                if (!hca.is_string()) {
+                    return Status::MalformedJson(
+                        "HCA names must be strings" LOC_MARK);
+                }
+                NicID id = ensureNic(*this, hca.get<std::string>(), &nic_ids);
+                mem.device_list[1].push_back(id);
+                if (seen_avail.insert(id).second) {
+                    all_avail.push_back(id);
+                }
+            }
+            mem_list_.push_back(std::move(mem));
+        }
+
+        // Wildcard entry used when memory location is unknown.
+        MemEntry wildcard;
+        wildcard.name = kWildcardLocation;
+        wildcard.pci_bus_id = "";
+        wildcard.type = MEM_UNKNOWN;
+        wildcard.numa_node = -1;
+        wildcard.device_list[0] = all_preferred;
+        wildcard.device_list[1] = all_avail;
+        mem_list_.push_back(std::move(wildcard));
+    } catch (std::exception& e) {
+        clear();
+        return Status::MalformedJson(std::string(e.what()) + LOC_MARK);
+    }
+    return Status::OK();
+}
+
+Status Topology::parseCustomTopology(const std::string& json_content) {
+    nlohmann::json j;
+    try {
+        j = nlohmann::json::parse(json_content);
+    } catch (std::exception& e) {
+        return Status::MalformedJson(std::string(e.what()) + LOC_MARK);
+    }
+    if (j.is_object() && (j.contains("nics") || j.contains("mems"))) {
+        return parse(json_content);
+    }
+    return parsePriorityMatrix(json_content);
+}
+
+Status Topology::loadFromConfig(const Config& conf,
+                                const std::vector<Platform*>& platforms) {
+    if (conf.contains("topology/priority_matrix")) {
+        std::string matrix_json;
+        if (conf.dumpSubtree("topology/priority_matrix", &matrix_json)) {
+            auto status = parsePriorityMatrix(matrix_json);
+            if (status.ok()) {
+                LOG(INFO) << "Using custom NIC priority matrix from config";
+                return Status::OK();
+            }
+            LOG(WARNING) << "Failed to parse topology/priority_matrix: "
+                         << status.ToString()
+                         << ", falling back to auto-discover";
+            return discover(platforms);
+        }
+    }
+
+    auto path = conf.get("topology/custom_json_path", std::string());
+    if (!path.empty()) {
+        LOG(INFO) << "Using custom topology from: " << path;
+        std::ifstream file(path);
+        if (!file.is_open()) {
+            LOG(WARNING) << "Failed to load custom topology from " << path
+                         << ", falling back to auto-detect.";
+            return discover(platforms);
+        }
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        std::string content = buffer.str();
+        if (content.empty()) {
+            LOG(WARNING) << "Failed to load custom topology from " << path
+                         << ", falling back to auto-detect.";
+            return discover(platforms);
+        }
+        auto status = parseCustomTopology(content);
+        if (status.ok()) return Status::OK();
+        LOG(WARNING) << "Failed to parse custom topology from " << path << ": "
+                     << status.ToString() << ", falling back to auto-detect.";
+        return discover(platforms);
+    }
+
+    return discover(platforms);
 }
 
 size_t Topology::getNicCount(NicType type) const {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -329,7 +329,7 @@ Status TransferEngineImpl::construct() {
 
     topology_ = std::make_shared<Topology>();
     auto loader = &Platform::getLoader(conf_);
-    CHECK_STATUS(topology_->discover({loader}));
+    CHECK_STATUS(topology_->loadFromConfig(*conf_, {loader}));
 
     metadata_ =
         std::make_shared<ControlService>(metadata_type, metadata_servers, this);
@@ -522,6 +522,10 @@ const std::string TransferEngineImpl::getRpcServerAddress() const {
 }
 
 uint16_t TransferEngineImpl::getRpcServerPort() const { return port_; }
+
+std::shared_ptr<Topology> TransferEngineImpl::getLocalTopology() const {
+    return topology_;
+}
 
 Status TransferEngineImpl::exportLocalSegment(std::string& shared_handle) {
     return Status::NotImplemented(

--- a/mooncake-transfer-engine/tent/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine.cpp
@@ -15,6 +15,7 @@
 #include "tent/transfer_engine.h"
 #include "tent/common/config.h"
 #include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/topology.h"
 #include <glog/logging.h>
 
 namespace mooncake {
@@ -49,6 +50,15 @@ const std::string TransferEngine::getRpcServerAddress() const {
 
 uint16_t TransferEngine::getRpcServerPort() const {
     return impl_->getRpcServerPort();
+}
+
+std::shared_ptr<Topology> TransferEngine::getLocalTopology() const {
+    return impl_->getLocalTopology();
+}
+
+std::string TransferEngine::getLocalTopologyString() const {
+    auto topo = impl_->getLocalTopology();
+    return topo ? topo->toString() : "{}";
 }
 
 Status TransferEngine::exportLocalSegment(std::string& shared_handle) {

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -259,6 +259,16 @@ target_include_directories(tent_transport_selector_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_transport_selector_test COMMAND tent_transport_selector_test)
 
+add_executable(tent_topology_priority_matrix_test
+               topology_priority_matrix_test.cpp)
+target_link_libraries(tent_topology_priority_matrix_test PRIVATE gtest
+                                                                 gtest_main
+                                                                 tent_link_group)
+target_include_directories(tent_topology_priority_matrix_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_topology_priority_matrix_test
+         COMMAND tent_topology_priority_matrix_test)
+
 if(USE_UB)
   add_executable(
     tent_ub_teardown_test

--- a/mooncake-transfer-engine/tent/tests/topology_priority_matrix_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/topology_priority_matrix_test.cpp
@@ -1,0 +1,246 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/topology.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class TempTopologyFile {
+   public:
+    explicit TempTopologyFile(const std::string& content) {
+        auto unique_name =
+            "tent-topo-" +
+            std::to_string(
+                std::chrono::steady_clock::now().time_since_epoch().count()) +
+            ".json";
+        path_ = std::filesystem::temp_directory_path() / unique_name;
+        std::ofstream ofs(path_);
+        ofs << content;
+    }
+
+    ~TempTopologyFile() {
+        std::error_code ec;
+        std::filesystem::remove(path_, ec);
+    }
+
+    std::string path() const { return path_.string(); }
+
+   private:
+    std::filesystem::path path_;
+};
+
+TEST(TopologyPriorityMatrixTest, ParsesClassicMatrixRanksAndWildcard) {
+    constexpr const char* kMatrix = R"json(
+        {
+          "cpu:0": [["mlx5_0"], ["mlx5_1"]],
+          "cpu:1": [["mlx5_1"], ["mlx5_0"]],
+          "cuda:0": [["mlx5_0"], ["mlx5_1"]]
+        }
+    )json";
+
+    Topology topology;
+    ASSERT_TRUE(topology.parsePriorityMatrix(kMatrix).ok());
+
+    ASSERT_EQ(topology.getNicCount(), 2u);
+    EXPECT_EQ(topology.getNicName(0), "mlx5_0");
+    EXPECT_EQ(topology.getNicName(1), "mlx5_1");
+    EXPECT_EQ(topology.getNicType(0), Topology::NIC_RDMA);
+
+    const auto* cpu0 = topology.getMemEntry("cpu:0");
+    ASSERT_NE(cpu0, nullptr);
+    EXPECT_EQ(cpu0->type, Topology::MEM_HOST);
+    ASSERT_EQ(cpu0->device_list[0].size(), 1u);
+    EXPECT_EQ(cpu0->device_list[0][0], 0);
+    ASSERT_EQ(cpu0->device_list[1].size(), 1u);
+    EXPECT_EQ(cpu0->device_list[1][0], 1);
+    EXPECT_TRUE(cpu0->device_list[2].empty());
+
+    const auto* cpu1 = topology.getMemEntry("cpu:1");
+    ASSERT_NE(cpu1, nullptr);
+    ASSERT_EQ(cpu1->device_list[0].size(), 1u);
+    EXPECT_EQ(cpu1->device_list[0][0], 1);
+    ASSERT_EQ(cpu1->device_list[1].size(), 1u);
+    EXPECT_EQ(cpu1->device_list[1][0], 0);
+
+    const auto* cuda0 = topology.getMemEntry("cuda:0");
+    ASSERT_NE(cuda0, nullptr);
+    EXPECT_EQ(cuda0->type, Topology::MEM_CUDA);
+
+    const auto* wildcard = topology.getMemEntry(kWildcardLocation);
+    ASSERT_NE(wildcard, nullptr);
+    ASSERT_EQ(wildcard->device_list[0].size(), 2u);
+    EXPECT_EQ(wildcard->device_list[0][0], 0);
+    EXPECT_EQ(wildcard->device_list[0][1], 1);
+    ASSERT_EQ(wildcard->device_list[1].size(), 2u);
+    EXPECT_EQ(wildcard->device_list[1][0], 1);
+    EXPECT_EQ(wildcard->device_list[1][1], 0);
+}
+
+TEST(TopologyPriorityMatrixTest, RejectsMalformedMatrixEntries) {
+    Topology topology;
+    EXPECT_FALSE(topology.parsePriorityMatrix("").ok());
+    EXPECT_FALSE(
+        topology.parsePriorityMatrix(R"({"cpu:0": [["mlx5_0"]]})").ok());
+    EXPECT_FALSE(topology.parsePriorityMatrix(R"({"cpu:0": "mlx5_0"})").ok());
+    EXPECT_FALSE(
+        topology.parsePriorityMatrix(R"({"cpu:0": [[1], ["mlx5_1"]]})").ok());
+}
+
+TEST(TopologyPriorityMatrixTest, ParseCustomRoutesNativeFormat) {
+    constexpr const char* kNative = R"json(
+        {
+          "nics": [{"name": "mlx5_0", "type": 0, "numa_node": 0}],
+          "mems": [{
+            "name": "cpu:0",
+            "type": 0,
+            "numa_node": 0,
+            "device_list": {"rank0": [0]}
+          }]
+        }
+    )json";
+
+    Topology topology;
+    ASSERT_TRUE(topology.parseCustomTopology(kNative).ok());
+    ASSERT_EQ(topology.getNicCount(), 1u);
+    EXPECT_EQ(topology.getNicName(0), "mlx5_0");
+    EXPECT_NE(topology.getMemEntry("cpu:0"), nullptr);
+    // Native path does not synthesize wildcard.
+    EXPECT_EQ(topology.getMemEntry(kWildcardLocation), nullptr);
+}
+
+TEST(TopologyPriorityMatrixTest, ParseCustomRoutesClassicMatrix) {
+    Topology topology;
+    ASSERT_TRUE(
+        topology.parseCustomTopology(R"({"cpu:0": [["erdma_0"],["erdma_1"]]})")
+            .ok());
+    EXPECT_EQ(topology.getNicCount(), 2u);
+    EXPECT_NE(topology.getMemEntry(kWildcardLocation), nullptr);
+}
+
+TEST(TopologyPriorityMatrixTest, LoadFromConfigInlineMatrix) {
+    Config conf;
+    ASSERT_TRUE(conf.load(R"json({
+      "topology": {
+        "priority_matrix": {
+          "cpu:0": [["mlx5_0"], ["mlx5_1"]]
+        },
+        "custom_json_path": "/nonexistent/should_be_ignored.json"
+      }
+    })json")
+                    .ok());
+
+    Topology topology;
+    ASSERT_TRUE(topology.loadFromConfig(conf, {}).ok());
+    EXPECT_EQ(topology.getNicName(0), "mlx5_0");
+    EXPECT_EQ(topology.getNicName(1), "mlx5_1");
+    EXPECT_NE(topology.getMemEntry("cpu:0"), nullptr);
+}
+
+TEST(TopologyPriorityMatrixTest, LoadFromConfigPathFile) {
+    TempTopologyFile file(R"({"cpu:0": [["mlx5_2"], ["mlx5_3"]]})");
+    Config conf;
+    conf.set("topology/custom_json_path", file.path());
+
+    Topology topology;
+    ASSERT_TRUE(topology.loadFromConfig(conf, {}).ok());
+    EXPECT_EQ(topology.getNicName(0), "mlx5_2");
+    EXPECT_EQ(topology.getNicName(1), "mlx5_3");
+}
+
+TEST(TopologyPriorityMatrixTest, LoadFromConfigInlinePreferredOverPath) {
+    TempTopologyFile file(R"({"cpu:0": [["from_file"], []]})");
+    Config conf;
+    ASSERT_TRUE(conf.load(R"json({
+      "topology": {
+        "priority_matrix": {
+          "cpu:0": [["from_inline"], []]
+        }
+      }
+    })json")
+                    .ok());
+    conf.set("topology/custom_json_path", file.path());
+
+    Topology topology;
+    ASSERT_TRUE(topology.loadFromConfig(conf, {}).ok());
+    EXPECT_EQ(topology.getNicName(0), "from_inline");
+}
+
+TEST(TopologyPriorityMatrixTest, LoadFromConfigInvalidInlineFallsBack) {
+    Config conf;
+    ASSERT_TRUE(conf.load(R"json({
+      "topology": {
+        "priority_matrix": {
+          "cpu:0": ["bad"]
+        }
+      }
+    })json")
+                    .ok());
+
+    Topology topology;
+    // Empty platform list → discover yields empty topology.
+    ASSERT_TRUE(topology.loadFromConfig(conf, {}).ok());
+    EXPECT_TRUE(topology.empty());
+}
+
+TEST(ConfigDumpSubtreeTest, DumpsNestedPriorityMatrix) {
+    Config conf;
+    ASSERT_TRUE(conf.load(R"json({
+      "topology": {
+        "priority_matrix": {
+          "cpu:0": [["mlx5_0"], []]
+        }
+      }
+    })json")
+                    .ok());
+
+    std::string dumped;
+    ASSERT_TRUE(conf.dumpSubtree("topology/priority_matrix", &dumped));
+    Topology topology;
+    ASSERT_TRUE(topology.parsePriorityMatrix(dumped).ok());
+    EXPECT_EQ(topology.getNicName(0), "mlx5_0");
+}
+
+TEST(ConfigEnvMappingTest, CustomTopoJsonEnvLoadsPath) {
+    const char* name = "MC_CUSTOM_TOPO_JSON";
+    const char* old = std::getenv(name);
+    std::string old_value = old ? old : "";
+    setenv(name, "/tmp/mooncake-nic-priority-matrix.json", 1);
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+    EXPECT_EQ(config.get("topology/custom_json_path", ""),
+              "/tmp/mooncake-nic-priority-matrix.json");
+
+    if (old) {
+        setenv(name, old_value.c_str(), 1);
+    } else {
+        unsetenv(name);
+    }
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -336,6 +336,17 @@ TEST(TransferEngineConfigOverrideTest, FilterNicUnsetLeavesWhitelistEmpty) {
         config.getArray<std::string>("topology/rdma_whitelist").empty());
 }
 
+TEST(TransferEngineConfigOverrideTest, CustomTopoJsonEnvLoadsPath) {
+    EnvVarGuard guard("MC_CUSTOM_TOPO_JSON",
+                      "/tmp/mooncake-nic-priority-matrix.json");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_EQ(config.get("topology/custom_json_path", ""),
+              "/tmp/mooncake-nic-priority-matrix.json");
+}
+
 TEST(TransferEngineConfigOverrideTest,
      ExplicitMetadataOverridesDriveSuccessfulHttpInitialization) {
 #ifdef _WIN32

--- a/mooncake-wheel/mooncake/transfer_engine_topology_dump.py
+++ b/mooncake-wheel/mooncake/transfer_engine_topology_dump.py
@@ -1,28 +1,203 @@
 import argparse
-import sys
+import json
 import os
+import sys
+import tempfile
+
 
 def parse_args():
     """Parse command line arguments."""
     parser = argparse.ArgumentParser(
-        description="Dump device topology",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        description=(
+            "Dump device topology for classic Transfer Engine or TENT. "
+            "By default clears custom topology overrides so the output "
+            "reflects auto-discovery. Use --use-custom-topo or "
+            "--custom-topo-json to load a custom NIC priority matrix instead. "
+            "TENT backend prints native {nics,mems} JSON with rank0/1/2."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
-        "--device-name", 
-        type=str, 
-        default="", 
-        help="Filter topology by given device name"
+        "--device-name",
+        type=str,
+        default="",
+        help=(
+            "Filter topology by IB device name(s), comma-separated. "
+            "Under TENT this maps to MC_TE_FILTERS."
+        ),
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "te", "tent"),
+        default="auto",
+        help=(
+            "Topology backend: te=classic Transfer Engine, tent=Mooncake TENT, "
+            "auto=follow MC_USE_TENT/MC_USE_TEV1"
+        ),
+    )
+    parser.add_argument(
+        "--use-custom-topo",
+        action="store_true",
+        help=(
+            "Keep existing MC_CUSTOM_TOPO_JSON / TENT topology overrides "
+            "(compare discover vs custom by running with and without this flag)"
+        ),
+    )
+    parser.add_argument(
+        "--custom-topo-json",
+        type=str,
+        default=None,
+        help=(
+            "Path to custom topology JSON; sets MC_CUSTOM_TOPO_JSON "
+            "(also honored by TENT as topology/custom_json_path)"
+        ),
     )
     return parser.parse_args()
-    
+
+
+def resolve_backend(backend: str) -> str:
+    if backend == "auto":
+        if os.environ.get("MC_USE_TENT") or os.environ.get("MC_USE_TEV1"):
+            return "tent"
+        return "te"
+    return backend
+
+
+def apply_backend(backend: str) -> None:
+    if backend == "tent":
+        os.environ.setdefault("MC_USE_TENT", "1")
+    else:
+        os.environ.pop("MC_USE_TENT", None)
+        os.environ.pop("MC_USE_TEV1", None)
+
+
+def _load_tent_conf_object(conf: str):
+    if not conf:
+        return None, False
+    if os.path.isfile(conf):
+        with open(conf, "r", encoding="utf-8") as f:
+            return json.load(f), True
+    try:
+        return json.loads(conf), False
+    except json.JSONDecodeError:
+        return None, False
+
+
+def sanitize_tent_conf_for_discover():
+    """
+    Remove topology/priority_matrix and topology/custom_json_path from
+    MC_TENT_CONF so discover mode is not overridden by an existing conf.
+    Returns a temp file path that the caller should delete, or None.
+    """
+    conf = os.environ.get("MC_TENT_CONF", "")
+    data, _ = _load_tent_conf_object(conf)
+    if not isinstance(data, dict):
+        return None
+    topo = data.get("topology")
+    if not isinstance(topo, dict):
+        return None
+    if "priority_matrix" not in topo and "custom_json_path" not in topo:
+        return None
+
+    sanitized = dict(data)
+    new_topo = dict(topo)
+    new_topo.pop("priority_matrix", None)
+    new_topo.pop("custom_json_path", None)
+    sanitized["topology"] = new_topo
+
+    fd, path = tempfile.mkstemp(prefix="tent-topo-dump-", suffix=".json")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        json.dump(sanitized, f)
+    os.environ["MC_TENT_CONF"] = path
+    return path
+
+
+def dump_te_topology(device_name: str) -> str:
+    from mooncake.engine import TransferEngine
+
+    engine = TransferEngine()
+    return engine.get_local_topology(device_name=device_name or None)
+
+
+def dump_tent_topology(device_name: str) -> str:
+    """
+    Prefer the native tent Python module (same engine path as tebench).
+    Fall back to mooncake.engine under MC_USE_TENT, which returns native
+    {"nics","mems"} via get_local_topology / getLocalTopologyString.
+    """
+    if device_name:
+        os.environ["MC_TE_FILTERS"] = device_name
+
+    try:
+        import tent
+
+        engine = tent.TransferEngine()
+        if not engine.available():
+            raise RuntimeError("tent.TransferEngine is not available")
+        return engine.get_local_topology()
+    except ImportError:
+        return dump_te_topology(device_name)
+
+
 def main():
     args = parse_args()
-    os.environ['MC_LOG_LEVEL'] = 'ERROR'
-    os.environ['MC_CUSTOM_TOPO_JSON'] = ''
-    from mooncake.engine import TransferEngine
-    engine = TransferEngine()
-    print('Local topology: ', engine.get_local_topology(device_name=args.device_name))
+    os.environ["MC_LOG_LEVEL"] = "ERROR"
+
+    backend = resolve_backend(args.backend)
+    apply_backend(backend)
+
+    temp_conf = None
+    if args.custom_topo_json is not None:
+        os.environ["MC_CUSTOM_TOPO_JSON"] = args.custom_topo_json
+        mode = f"custom ({args.custom_topo_json})"
+    elif args.use_custom_topo:
+        custom_path = os.environ.get("MC_CUSTOM_TOPO_JSON", "")
+        has_inline = False
+        if backend == "tent":
+            data, _ = _load_tent_conf_object(os.environ.get("MC_TENT_CONF", ""))
+            topo = data.get("topology") if isinstance(data, dict) else None
+            has_inline = isinstance(topo, dict) and (
+                "priority_matrix" in topo or "custom_json_path" in topo
+            )
+        if not custom_path and not has_inline:
+            print(
+                "error: --use-custom-topo requires MC_CUSTOM_TOPO_JSON "
+                "or TENT topology/priority_matrix|custom_json_path in "
+                "MC_TENT_CONF",
+                file=sys.stderr,
+            )
+            return 1
+        mode = (
+            f"custom ({custom_path})"
+            if custom_path
+            else "custom (MC_TENT_CONF topology)"
+        )
+    else:
+        # Force discover path. Empty string still makes getenv non-null in C++,
+        # which falls back to auto-detect when the path cannot be loaded.
+        os.environ["MC_CUSTOM_TOPO_JSON"] = ""
+        if backend == "tent":
+            temp_conf = sanitize_tent_conf_for_discover()
+        mode = "discover"
+
+    try:
+        if backend == "tent":
+            topo = dump_tent_topology(args.device_name)
+        else:
+            topo = dump_te_topology(args.device_name)
+        print(f"Local topology [{backend}/{mode}]: ", end="")
+        print(topo)
+        return 0
+    except Exception as exc:
+        print(f"error: failed to dump topology: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        if temp_conf and os.path.exists(temp_conf):
+            try:
+                os.unlink(temp_conf)
+            except OSError:
+                pass
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
## Description

Enable TENT to use the same custom NIC priority matrix as classic Transfer Engine, and dump TENT-native topology (`nics`/`mems` with `rank0`/`rank1`/`rank2`) instead of collapsing to the classic 2-tier matrix.

**Custom topology loading (priority high → low):**

1. Inline `topology/priority_matrix` in `MC_TENT_CONF`
2. `topology/custom_json_path` / `MC_CUSTOM_TOPO_JSON` (classic matrix or native `nics`/`mems` JSON)
3. Auto-discover (fallback on load/parse failure)

Classic matrix mapping: preferred → `device_list[rank0]`, avail → `device_list[rank1]`, `rank2` empty; synthesizes `*` wildcard. Successful custom load skips `MC_TE_FILTERS` (aligned with TE).

**Topology dump / API:**

- Add `getLocalTopologyString()` (TENT native JSON); Python `get_local_topology` / `tent.TransferEngine.get_local_topology` use it under TENT
- `transfer_engine_topology_dump.py`: `--backend {auto,te,tent}`, `--use-custom-topo` / `--custom-topo-json`

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
# Unit tests (topology matrix + MC_CUSTOM_TOPO_JSON env mapping)
# Built/run in local HIP+TENT tree when googletest available:
#   topology_priority_matrix_test
#   transfer_engine_config_override_test (CustomTopoJsonEnvLoadsPath)

# Manual dump (discover vs custom)
python3 -m mooncake.transfer_engine_topology_dump --backend tent
python3 -m mooncake.transfer_engine_topology_dump --backend tent \
  --custom-topo-json /path/to/nic_priority_matrix.json
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual: on a ROCm host with `USE_HIP=ON`/`USE_TENT=ON` build, `--backend tent` printed native `nics`/`mems` with `rocm:*` and rank0/1/2; `--custom-topo-json` loaded classic matrix and produced rank0/rank1-only topology with synthesized `*`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit run --all-files` and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok) assisted with implementation, tests, docs, and dump-tool wiring. Human submitter reviewed all changed lines.