### PR TITLE
[Store] Fence batch oplog writers by producer view

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_storage.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_storage.h
@@ -14,15 +14,24 @@ class OpLogBatchStorage {
     OpLogBatchStorage(std::string cluster_id, HaKvBackend& backend);
 
     ErrorCode InitDurablePrefix(DurablePrefix& prefix);
+    ErrorCode ClaimProducerView(ViewVersionId producer_view_version);
+    ErrorCode ValidateProducerView(ViewVersionId producer_view_version) const;
     ErrorCode ReadDurablePrefix(DurablePrefix& prefix);
     ErrorCode WriteBatchAndAdvancePrefix(const OpLogBatchRecord& batch,
                                          const DurablePrefix& expected_prefix);
+    ErrorCode WriteBatchAndAdvancePrefix(const OpLogBatchRecord& batch,
+                                         const DurablePrefix& expected_prefix,
+                                         ViewVersionId producer_view_version);
     ErrorCode ReadBatch(uint64_t batch_id, OpLogBatchRecord& batch);
     ErrorCode ReadBatchesAfter(uint64_t after_batch_id, size_t limit,
                                std::vector<OpLogBatchRecord>& batches);
 
    private:
     bool IsValidClusterId() const;
+    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
+    ErrorCode WriteBatchAndAdvancePrefixImpl(
+        const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix,
+        const ViewVersionId* producer_view_version);
     ErrorCode RejectLegacyLayout() const;
     ErrorCode ValidateDurablePrefixAtStartup(const DurablePrefix& prefix);
 

--- a/mooncake-store/include/ha/oplog/oplog_batch_types.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_types.h
@@ -15,9 +15,6 @@ static constexpr int kOpLogBatchIdWidth = 20;
 struct DurablePrefix {
     uint64_t batch_id{0};
     uint64_t last_seq{0};
-    // Leadership view that produced this durable boundary. Zero means that
-    // the prefix has no producer-view metadata (legacy or not yet assigned).
-    ViewVersionId producer_view_version{0};
 
     friend bool operator==(const DurablePrefix&,
                            const DurablePrefix&) = default;
@@ -50,6 +47,7 @@ std::string FormatOpLogBatchId(uint64_t batch_id);
 std::string BuildBatchRecordKey(const std::string& cluster_id,
                                 uint64_t batch_id);
 std::string BuildDurablePrefixKey(const std::string& cluster_id);
+std::string BuildProducerViewKey(const std::string& cluster_id);
 BatchRecordRange BuildBatchRecordRange(const std::string& cluster_id,
                                        uint64_t after_batch_id);
 

--- a/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_codec.cpp
@@ -153,10 +153,6 @@ std::string EncodeDurablePrefix(const DurablePrefix& prefix) {
         static_cast<Json::UInt>(kDurablePrefixSchemaVersion);
     root["batch_id"] = static_cast<Json::UInt64>(prefix.batch_id);
     root["last_seq"] = static_cast<Json::UInt64>(prefix.last_seq);
-    if (prefix.producer_view_version != 0) {
-        root["producer_view_version"] =
-            static_cast<Json::Int64>(prefix.producer_view_version);
-    }
     return WriteJson(root);
 }
 
@@ -187,16 +183,6 @@ bool DecodeDurablePrefix(const std::string& value, DurablePrefix* prefix,
         return false;
     }
     DurablePrefix decoded;
-    if (root.isMember("producer_view_version")) {
-        const auto& producer_view = root["producer_view_version"];
-        if (!producer_view.isInt64() || producer_view.asInt64() < 0) {
-            SetReason(reason,
-                      "field must be a non-negative ViewVersionId: "
-                      "producer_view_version");
-            return false;
-        }
-        decoded.producer_view_version = producer_view.asInt64();
-    }
     if (!GetUInt64Field(root, "batch_id", &decoded.batch_id, reason)) {
         return false;
     }

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -50,6 +50,23 @@ bool TryParseBatchIdFromKey(const std::string& key, uint64_t& batch_id) {
            result.ptr == suffix.data() + suffix.size();
 }
 
+bool TryParseProducerView(std::string_view value,
+                          ViewVersionId& producer_view_version) {
+    ViewVersionId parsed = 0;
+    const auto result =
+        std::from_chars(value.data(), value.data() + value.size(), parsed);
+    if (result.ec != std::errc() || result.ptr != value.data() + value.size() ||
+        parsed <= 0 || std::to_string(parsed) != value) {
+        return false;
+    }
+    producer_view_version = parsed;
+    return true;
+}
+
+bool IsAmbiguousTxnError(ErrorCode error) {
+    return error == ErrorCode::ETCD_OPERATION_ERROR;
+}
+
 }  // namespace
 
 OpLogBatchStorage::OpLogBatchStorage(std::string cluster_id,
@@ -98,18 +115,24 @@ ErrorCode OpLogBatchStorage::InitDurablePrefix(DurablePrefix& prefix) {
                             .expected_value = ""});
     txn.puts.push_back(
         {.key = durable_key, .value = EncodeDurablePrefix(initial)});
-    err = backend_.Txn(txn);
-    if (err == ErrorCode::OK) {
+    const ErrorCode txn_err = backend_.Txn(txn);
+    if (txn_err == ErrorCode::OK) {
         prefix = initial;
         return ErrorCode::OK;
     }
-    if (err == ErrorCode::ETCD_TRANSACTION_FAIL) {
-        if ((err = ReadDurablePrefix(prefix)) != ErrorCode::OK) {
-            return err;
-        }
-        return ValidateDurablePrefixAtStartup(prefix);
+    if (txn_err != ErrorCode::ETCD_TRANSACTION_FAIL &&
+        !IsAmbiguousTxnError(txn_err)) {
+        return txn_err;
     }
-    return err;
+
+    err = ReadDurablePrefix(prefix);
+    if (err != ErrorCode::OK) {
+        return IsAmbiguousTxnError(txn_err) &&
+                       err == ErrorCode::ETCD_KEY_NOT_EXIST
+                   ? txn_err
+                   : err;
+    }
+    return ValidateDurablePrefixAtStartup(prefix);
 }
 
 ErrorCode OpLogBatchStorage::ReadDurablePrefix(DurablePrefix& prefix) {
@@ -126,6 +149,108 @@ ErrorCode OpLogBatchStorage::ReadDurablePrefix(DurablePrefix& prefix) {
     if (!DecodeDurablePrefix(value, &prefix, &reason)) {
         LOG(ERROR) << "Failed to decode durable prefix: " << reason;
         return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode OpLogBatchStorage::ReadProducerView(
+    ViewVersionId& producer_view_version) const {
+    std::string value;
+    ErrorCode err = backend_.Get(BuildProducerViewKey(cluster_id_), value);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (!TryParseProducerView(value, producer_view_version)) {
+        LOG(ERROR) << "Invalid producer view value: cluster=" << cluster_id_;
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+ErrorCode OpLogBatchStorage::ClaimProducerView(
+    ViewVersionId producer_view_version) {
+    if (!IsValidClusterId() || producer_view_version <= 0 ||
+        !backend_.SupportsTxn()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    const std::string key = BuildProducerViewKey(cluster_id_);
+    const std::string requested_value = std::to_string(producer_view_version);
+    while (true) {
+        std::string current_value;
+        ErrorCode err = backend_.Get(key, current_value);
+        if (err != ErrorCode::OK && err != ErrorCode::ETCD_KEY_NOT_EXIST) {
+            return err;
+        }
+
+        const bool key_missing = err == ErrorCode::ETCD_KEY_NOT_EXIST;
+        if (!key_missing) {
+            ViewVersionId current_view = 0;
+            if (!TryParseProducerView(current_value, current_view)) {
+                LOG(ERROR) << "Invalid producer view value while claiming: "
+                           << "cluster=" << cluster_id_;
+                return ErrorCode::INTERNAL_ERROR;
+            }
+            if (current_view > producer_view_version) {
+                LOG(WARNING)
+                    << "Producer view claim fenced: cluster=" << cluster_id_
+                    << ", requested=" << producer_view_version
+                    << ", current=" << current_view;
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+            if (current_view == producer_view_version) {
+                return ErrorCode::OK;
+            }
+        }
+
+        KvTxn txn;
+        txn.compares.push_back(
+            {.key = key,
+             .kind = key_missing ? KvCompareKind::kKeyNotExists
+                                 : KvCompareKind::kValueEquals,
+             .expected_value = key_missing ? "" : current_value});
+        txn.puts.push_back({.key = key, .value = requested_value});
+        err = backend_.Txn(txn);
+        if (err == ErrorCode::OK) {
+            return ErrorCode::OK;
+        }
+        if (IsAmbiguousTxnError(err)) {
+            ViewVersionId current_view = 0;
+            ErrorCode read_err = ReadProducerView(current_view);
+            if (read_err == ErrorCode::OK) {
+                if (current_view == producer_view_version) {
+                    return ErrorCode::OK;
+                }
+                if (current_view > producer_view_version) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
+            } else if (read_err != ErrorCode::ETCD_KEY_NOT_EXIST &&
+                       !IsAmbiguousTxnError(read_err)) {
+                return read_err;
+            }
+            return err;
+        }
+        if (err != ErrorCode::ETCD_TRANSACTION_FAIL) {
+            return err;
+        }
+    }
+}
+
+ErrorCode OpLogBatchStorage::ValidateProducerView(
+    ViewVersionId producer_view_version) const {
+    if (!IsValidClusterId() || producer_view_version <= 0) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    ViewVersionId current_view = 0;
+    ErrorCode err = ReadProducerView(current_view);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (current_view != producer_view_version) {
+        LOG(WARNING) << "Producer view validation failed: cluster="
+                     << cluster_id_ << ", expected=" << producer_view_version
+                     << ", current=" << current_view;
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
     }
     return ErrorCode::OK;
 }
@@ -177,6 +302,22 @@ ErrorCode OpLogBatchStorage::ValidateDurablePrefixAtStartup(
 
 ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
     const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix) {
+    return WriteBatchAndAdvancePrefixImpl(batch, expected_prefix, nullptr);
+}
+
+ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
+    const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix,
+    ViewVersionId producer_view_version) {
+    if (producer_view_version <= 0) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    return WriteBatchAndAdvancePrefixImpl(batch, expected_prefix,
+                                          &producer_view_version);
+}
+
+ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefixImpl(
+    const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix,
+    const ViewVersionId* producer_view_version) {
     if (!IsValidClusterId()) {
         return ErrorCode::INVALID_PARAMS;
     }
@@ -212,6 +353,13 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
         encoded_batch.size());
 #endif
     KvTxn txn;
+    if (producer_view_version != nullptr) {
+        txn.compares.push_back(
+            {.key = BuildProducerViewKey(cluster_id_),
+             .kind = KvCompareKind::kValueEquals,
+             .expected_value = std::to_string(*producer_view_version)});
+    }
+    const size_t durable_compare_index = txn.compares.size();
     txn.compares.push_back(
         {.key = durable_key,
          .kind = KvCompareKind::kValueEquals,
@@ -219,34 +367,43 @@ ErrorCode OpLogBatchStorage::WriteBatchAndAdvancePrefix(
     txn.puts.push_back({.key = BuildBatchRecordKey(cluster_id_, batch.batch_id),
                         .value = encoded_batch});
     txn.puts.push_back({.key = durable_key,
-                        .value = EncodeDurablePrefix(
-                            {.batch_id = batch.batch_id,
-                             .last_seq = batch.last_seq,
-                             .producer_view_version =
-                                 expected_prefix.producer_view_version})});
+                        .value = EncodeDurablePrefix({
+                            .batch_id = batch.batch_id,
+                            .last_seq = batch.last_seq,
+                        })});
     ErrorCode err = backend_.Txn(txn);
     if (err == ErrorCode::ETCD_TRANSACTION_FAIL) {
         std::string raw_prefix;
         DurablePrefix decoded_prefix;
         if (backend_.Get(durable_key, raw_prefix) == ErrorCode::OK &&
-            raw_prefix != txn.compares[0].expected_value &&
+            raw_prefix != txn.compares[durable_compare_index].expected_value &&
             DecodeDurablePrefix(raw_prefix, &decoded_prefix) &&
             decoded_prefix == expected_prefix) {
-            txn.compares[0].expected_value = raw_prefix;
+            txn.compares[durable_compare_index].expected_value = raw_prefix;
             err = backend_.Txn(txn);
         }
     }
-    if (err != ErrorCode::ETCD_TRANSACTION_FAIL) {
+    if (err != ErrorCode::ETCD_TRANSACTION_FAIL && !IsAmbiguousTxnError(err)) {
         return err;
+    }
+
+    if (producer_view_version != nullptr) {
+        ViewVersionId current_view = 0;
+        ErrorCode view_err = ReadProducerView(current_view);
+        if (view_err == ErrorCode::ETCD_KEY_NOT_EXIST ||
+            (view_err == ErrorCode::OK &&
+             current_view != *producer_view_version)) {
+            return ErrorCode::ETCD_TRANSACTION_FAIL;
+        }
+        if (view_err != ErrorCode::OK) {
+            return view_err;
+        }
     }
 
     DurablePrefix current_prefix;
     if (ReadDurablePrefix(current_prefix) != ErrorCode::OK ||
-        current_prefix !=
-            DurablePrefix{.batch_id = batch.batch_id,
-                          .last_seq = batch.last_seq,
-                          .producer_view_version =
-                              expected_prefix.producer_view_version}) {
+        current_prefix != DurablePrefix{.batch_id = batch.batch_id,
+                                        .last_seq = batch.last_seq}) {
         return err;
     }
     OpLogBatchRecord current_batch;

--- a/mooncake-store/src/ha/oplog/oplog_batch_types.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_types.cpp
@@ -130,6 +130,14 @@ std::string BuildDurablePrefixKey(const std::string& cluster_id) {
     return "/oplog/" + normalized + "/durable_prefix";
 }
 
+std::string BuildProducerViewKey(const std::string& cluster_id) {
+    std::string normalized = cluster_id;
+    if (!NormalizeAndValidateClusterId(normalized) || normalized.empty()) {
+        return {};
+    }
+    return "/oplog/" + normalized + "/producer_view";
+}
+
 BatchRecordRange BuildBatchRecordRange(const std::string& cluster_id,
                                        uint64_t after_batch_id) {
     std::string normalized = cluster_id;

--- a/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
+++ b/mooncake-store/src/ha/oplog/ordered_oplog_writer.cpp
@@ -397,11 +397,8 @@ void OrderedOpLogWriter::Start() {
 #endif
                     {
                         std::lock_guard<std::mutex> lock(impl_->mutex);
-                        impl_->durable_prefix = {
-                            .batch_id = batch.batch_id,
-                            .last_seq = batch.last_seq,
-                            .producer_view_version =
-                                expected_prefix.producer_view_version};
+                        impl_->durable_prefix = {.batch_id = batch.batch_id,
+                                                 .last_seq = batch.last_seq};
                         impl_->last_error = ErrorCode::OK;
                         impl_->accepting = !impl_->stop_requested;
                         for (size_t i = 0; i < entries.size(); ++i) {

--- a/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_codec_test.cpp
@@ -4,7 +4,6 @@
 #include <gtest/gtest.h>
 #include <xxhash.h>
 
-#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -128,6 +127,11 @@ TEST(OpLogBatchKeyLayoutTest, BuildsDurablePrefixKey) {
               BuildDurablePrefixKey("clusterA"));
 }
 
+TEST(OpLogBatchKeyLayoutTest, BuildsProducerViewKey) {
+    EXPECT_EQ("/oplog/clusterA/producer_view",
+              BuildProducerViewKey("clusterA"));
+}
+
 TEST(OpLogBatchKeyLayoutTest, BuildsBatchRangeBounds) {
     auto bounds = BuildBatchRecordRange("clusterA", 7);
     EXPECT_EQ("/oplog/clusterA/batches/00000000000000000008", bounds.begin_key);
@@ -145,6 +149,7 @@ TEST(OpLogBatchKeyLayoutTest, RejectsInvalidClusterId) {
     EXPECT_FALSE(reason.empty());
     EXPECT_TRUE(BuildBatchRecordKey("bad/cluster", 1).empty());
     EXPECT_TRUE(BuildDurablePrefixKey("bad/cluster").empty());
+    EXPECT_TRUE(BuildProducerViewKey("bad/cluster").empty());
     auto bounds = BuildBatchRecordRange("bad/cluster", 1);
     EXPECT_TRUE(bounds.begin_key.empty());
     EXPECT_TRUE(bounds.end_key.empty());
@@ -179,42 +184,27 @@ TEST(OpLogDurablePrefixCodecTest, RoundTripsNonZeroPrefix) {
     EXPECT_TRUE(reason.empty());
 }
 
-TEST(OpLogDurablePrefixCodecTest, PreservesLegacyEncodingWithoutProducerView) {
-    const std::string legacy =
+TEST(OpLogDurablePrefixCodecTest, PreservesCanonicalEncoding) {
+    const std::string encoded =
         R"({"batch_id":9,"last_seq":1024,"schema_version":1})";
 
     DurablePrefix prefix;
     std::string reason;
-    ASSERT_TRUE(DecodeDurablePrefix(legacy, &prefix, &reason));
-    EXPECT_EQ(0u, prefix.producer_view_version);
-    EXPECT_EQ(legacy, EncodeDurablePrefix(prefix));
+    ASSERT_TRUE(DecodeDurablePrefix(encoded, &prefix, &reason));
+    EXPECT_EQ(encoded, EncodeDurablePrefix(prefix));
     EXPECT_TRUE(reason.empty());
 }
 
-TEST(OpLogDurablePrefixCodecTest, RoundTripsMaxProducerView) {
-    DurablePrefix in{
-        .batch_id = 9,
-        .last_seq = 1024,
-        .producer_view_version = std::numeric_limits<ViewVersionId>::max()};
-
-    DurablePrefix out;
-    std::string reason;
-    ASSERT_TRUE(DecodeDurablePrefix(EncodeDurablePrefix(in), &out, &reason));
-    EXPECT_EQ(in.producer_view_version, out.producer_view_version);
-    EXPECT_TRUE(reason.empty());
-}
-
-TEST(OpLogDurablePrefixCodecTest, OmitsExplicitZeroProducerViewOnReencode) {
-    const std::string with_explicit_zero =
-        R"({"batch_id":9,"last_seq":1024,"producer_view_version":0,"schema_version":1})";
-    const std::string without_view =
+TEST(OpLogDurablePrefixCodecTest, IgnoresDetachedProducerViewField) {
+    const std::string with_view =
+        R"({"batch_id":9,"last_seq":1024,"producer_view_version":7,"schema_version":1})";
+    const std::string canonical =
         R"({"batch_id":9,"last_seq":1024,"schema_version":1})";
 
     DurablePrefix prefix;
     std::string reason;
-    ASSERT_TRUE(DecodeDurablePrefix(with_explicit_zero, &prefix, &reason));
-    EXPECT_EQ(0u, prefix.producer_view_version);
-    EXPECT_EQ(without_view, EncodeDurablePrefix(prefix));
+    ASSERT_TRUE(DecodeDurablePrefix(with_view, &prefix, &reason));
+    EXPECT_EQ(canonical, EncodeDurablePrefix(prefix));
     EXPECT_TRUE(reason.empty());
 }
 
@@ -226,49 +216,17 @@ TEST(OpLogDurablePrefixCodecTest, IgnoresUnknownFields) {
         &prefix, &reason));
     EXPECT_EQ(9u, prefix.batch_id);
     EXPECT_EQ(1024u, prefix.last_seq);
-    EXPECT_EQ(7u, prefix.producer_view_version);
     EXPECT_TRUE(reason.empty());
 }
 
-TEST(OpLogDurablePrefixCodecTest, RejectsInvalidProducerViews) {
-    const std::vector<std::string> invalid_values = {
-        R"("1")", "-1", "1.5", "9223372036854775808", "18446744073709551616"};
-
-    for (const auto& invalid_value : invalid_values) {
-        DurablePrefix prefix;
-        std::string reason;
-        const std::string encoded =
-            R"({"batch_id":9,"last_seq":1024,"producer_view_version":)" +
-            invalid_value + R"(,"schema_version":1})";
-        EXPECT_FALSE(DecodeDurablePrefix(encoded, &prefix, &reason))
-            << invalid_value;
-        EXPECT_FALSE(reason.empty()) << invalid_value;
-    }
-}
-
-TEST(OpLogDurablePrefixCodecTest, InvalidProducerViewLeavesOutputUnchanged) {
-    DurablePrefix prefix{
-        .batch_id = 11, .last_seq = 22, .producer_view_version = 33};
-    std::string reason;
-    EXPECT_FALSE(DecodeDurablePrefix(
-        R"({"batch_id":9,"last_seq":1024,"producer_view_version":"invalid","schema_version":1})",
-        &prefix, &reason));
-    EXPECT_EQ(11u, prefix.batch_id);
-    EXPECT_EQ(22u, prefix.last_seq);
-    EXPECT_EQ(33u, prefix.producer_view_version);
-    EXPECT_FALSE(reason.empty());
-}
-
 TEST(OpLogDurablePrefixCodecTest, InvalidLastSeqLeavesOutputUnchanged) {
-    DurablePrefix prefix{
-        .batch_id = 11, .last_seq = 22, .producer_view_version = 33};
+    DurablePrefix prefix{.batch_id = 11, .last_seq = 22};
     std::string reason;
     EXPECT_FALSE(DecodeDurablePrefix(
         R"({"batch_id":9,"last_seq":"invalid","schema_version":1})", &prefix,
         &reason));
     EXPECT_EQ(11u, prefix.batch_id);
     EXPECT_EQ(22u, prefix.last_seq);
-    EXPECT_EQ(33u, prefix.producer_view_version);
     EXPECT_FALSE(reason.empty());
 }
 

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <xxhash.h>
 
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -90,6 +91,11 @@ class FakeHaKvBackend : public HaKvBackend {
         for (const auto& put : txn.puts) {
             kvs_[put.key] = put.value;
         }
+        if (next_committed_txn_error_ != ErrorCode::OK) {
+            ErrorCode err = next_committed_txn_error_;
+            next_committed_txn_error_ = ErrorCode::OK;
+            return err;
+        }
         return ErrorCode::OK;
     }
 
@@ -106,6 +112,9 @@ class FakeHaKvBackend : public HaKvBackend {
     }
     void FailNextRange(ErrorCode err) { next_range_error_ = err; }
     void FailNextTxn(ErrorCode err) { next_txn_error_ = err; }
+    void FailNextCommittedTxn(ErrorCode err) {
+        next_committed_txn_error_ = err;
+    }
     const std::vector<size_t>& range_limits() const { return range_limits_; }
 
    private:
@@ -119,6 +128,7 @@ class FakeHaKvBackend : public HaKvBackend {
     ErrorCode next_get_key_error_{ErrorCode::OK};
     ErrorCode next_range_error_{ErrorCode::OK};
     ErrorCode next_txn_error_{ErrorCode::OK};
+    ErrorCode next_committed_txn_error_{ErrorCode::OK};
     std::vector<size_t> range_limits_;
 };
 
@@ -169,18 +179,131 @@ TEST(OpLogBatchStorageTest, InitializesEmptyNamespaceAtZero) {
     EXPECT_EQ(prefix.last_seq, stored.last_seq);
 }
 
-TEST(OpLogBatchStorageTest, AcceptsNonzeroViewAtEmptyBoundary) {
+TEST(OpLogBatchStorageTest, ResolvesCommittedInitTxnError) {
     FakeHaKvBackend backend;
-    ASSERT_EQ(ErrorCode::OK,
-              backend.Put("/oplog/clusterA/durable_prefix",
-                          EncodeDurablePrefix({.batch_id = 0,
-                                               .last_seq = 0,
-                                               .producer_view_version = 7})));
+    backend.FailNextCommittedTxn(ErrorCode::ETCD_OPERATION_ERROR);
     OpLogBatchStorage storage("clusterA", backend);
 
     DurablePrefix prefix;
     EXPECT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
-    EXPECT_EQ(7u, prefix.producer_view_version);
+    EXPECT_EQ((DurablePrefix{.batch_id = 0, .last_seq = 0}), prefix);
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewCreatesIndependentKey) {
+    FakeHaKvBackend backend;
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::ETCD_KEY_NOT_EXIST, storage.ValidateProducerView(7));
+    ASSERT_EQ(ErrorCode::OK, storage.ClaimProducerView(7));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(7));
+
+    std::string stored;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Get("/oplog/clusterA/producer_view", stored));
+    EXPECT_EQ("7", stored);
+    EXPECT_EQ(ErrorCode::ETCD_KEY_NOT_EXIST,
+              backend.Get("/oplog/clusterA/durable_prefix", stored));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewIsIdempotent) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::OK, storage.ClaimProducerView(7));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(7));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewAcceptsMaxView) {
+    FakeHaKvBackend backend;
+    OpLogBatchStorage storage("clusterA", backend);
+    const auto max_view = std::numeric_limits<ViewVersionId>::max();
+
+    EXPECT_EQ(ErrorCode::OK, storage.ClaimProducerView(max_view));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(max_view));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewRejectsStaleView) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "8"));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, storage.ClaimProducerView(7));
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              storage.ValidateProducerView(7));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(8));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewIgnoresDurablePrefixRace) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 1, .last_seq = 3})));
+    backend.CreateBeforeNextTxn(
+        "/oplog/clusterA/durable_prefix",
+        EncodeDurablePrefix({.batch_id = 2, .last_seq = 6}));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    ASSERT_EQ(ErrorCode::OK, storage.ClaimProducerView(8));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(8));
+    DurablePrefix prefix;
+    ASSERT_EQ(ErrorCode::OK, storage.ReadDurablePrefix(prefix));
+    EXPECT_EQ((DurablePrefix{.batch_id = 2, .last_seq = 6}), prefix);
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewLosesRaceToNewerView) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    backend.CreateBeforeNextTxn("/oplog/clusterA/producer_view", "9");
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, storage.ClaimProducerView(8));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(9));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewPropagatesBackendTxnError) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    backend.FailNextTxn(ErrorCode::ETCD_OPERATION_ERROR);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR, storage.ClaimProducerView(8));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(7));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewResolvesCommittedTxnError) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    backend.FailNextCommittedTxn(ErrorCode::ETCD_OPERATION_ERROR);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::OK, storage.ClaimProducerView(8));
+    EXPECT_EQ(ErrorCode::OK, storage.ValidateProducerView(8));
+}
+
+TEST(OpLogBatchStorageTest, ClaimProducerViewRejectsZeroAndNonTxnBackend) {
+    FakeHaKvBackend backend;
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, storage.ClaimProducerView(0));
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, storage.ValidateProducerView(0));
+    backend.SetSupportsTxn(false);
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, storage.ClaimProducerView(1));
+}
+
+TEST(OpLogBatchStorageTest, RejectsMalformedProducerView) {
+    for (const std::string value :
+         {"", "0", "-1", "07", "7x", " 7", "8.0", "9223372036854775808"}) {
+        SCOPED_TRACE(value);
+        FakeHaKvBackend backend;
+        ASSERT_EQ(ErrorCode::OK,
+                  backend.Put("/oplog/clusterA/producer_view", value));
+        OpLogBatchStorage storage("clusterA", backend);
+
+        EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.ClaimProducerView(8));
+        EXPECT_EQ(ErrorCode::INTERNAL_ERROR, storage.ValidateProducerView(8));
+    }
 }
 
 TEST(OpLogBatchStorageTest, RejectsLegacyLatest) {
@@ -393,17 +516,17 @@ TEST(OpLogBatchStorageTest, WriteBatchAndAdvancePrefixCommitsAtomically) {
     EXPECT_EQ(5u, prefix.last_seq);
 }
 
-TEST(OpLogBatchStorageTest, PreservesProducerViewWhenAdvancingPrefix) {
+TEST(OpLogBatchStorageTest, FencedAdvanceDoesNotModifyProducerView) {
     FakeHaKvBackend backend;
-    const DurablePrefix expected_prefix{
-        .batch_id = 1, .last_seq = 3, .producer_view_version = 7};
+    const DurablePrefix expected_prefix{.batch_id = 1, .last_seq = 3};
     ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/durable_prefix",
                                          EncodeDurablePrefix(expected_prefix)));
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
     OpLogBatchStorage storage("clusterA", backend);
 
     auto batch = MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2);
     ASSERT_EQ(ErrorCode::OK,
-              storage.WriteBatchAndAdvancePrefix(batch, expected_prefix));
+              storage.WriteBatchAndAdvancePrefix(batch, expected_prefix, 7));
 
     std::string encoded_prefix;
     ASSERT_EQ(ErrorCode::OK,
@@ -412,37 +535,71 @@ TEST(OpLogBatchStorageTest, PreservesProducerViewWhenAdvancingPrefix) {
     ASSERT_TRUE(DecodeDurablePrefix(encoded_prefix, &prefix));
     EXPECT_EQ(2u, prefix.batch_id);
     EXPECT_EQ(5u, prefix.last_seq);
-    EXPECT_EQ(7u, prefix.producer_view_version);
+    std::string producer_view;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Get("/oplog/clusterA/producer_view", producer_view));
+    EXPECT_EQ("7", producer_view);
 }
 
-TEST(OpLogBatchStorageTest, ExplicitZeroProducerViewCanAdvancePrefix) {
+TEST(OpLogBatchStorageTest, FencedAdvanceResolvesCommittedTxnError) {
     FakeHaKvBackend backend;
-    ASSERT_EQ(ErrorCode::OK,
-              backend.Put("/oplog/clusterA/batches/00000000000000000001",
-                          EncodeOpLogBatchRecord(MakeBatch(
-                              /*batch_id=*/1, /*first_seq=*/1, /*count=*/3))));
-    ASSERT_EQ(
-        ErrorCode::OK,
-        backend.Put(
-            "/oplog/clusterA/durable_prefix",
-            R"({"schema_version":1,"batch_id":1,"last_seq":3,"producer_view_version":0})"));
+    const DurablePrefix expected_prefix{.batch_id = 1, .last_seq = 3};
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/durable_prefix",
+                                         EncodeDurablePrefix(expected_prefix)));
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "7"));
+    backend.FailNextCommittedTxn(ErrorCode::ETCD_OPERATION_ERROR);
+    OpLogBatchStorage storage("clusterA", backend);
+
+    auto batch = MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2);
+    EXPECT_EQ(ErrorCode::OK,
+              storage.WriteBatchAndAdvancePrefix(batch, expected_prefix, 7));
+
+    OpLogBatchRecord stored_batch;
+    EXPECT_EQ(ErrorCode::OK, storage.ReadBatch(2, stored_batch));
+    EXPECT_EQ(EncodeOpLogBatchRecord(batch),
+              EncodeOpLogBatchRecord(stored_batch));
+}
+
+TEST(OpLogBatchStorageTest, HigherProducerViewFencesStaleWriter) {
+    FakeHaKvBackend backend;
     OpLogBatchStorage storage("clusterA", backend);
 
     DurablePrefix prefix;
     ASSERT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
-    ASSERT_EQ(0u, prefix.producer_view_version);
-    ASSERT_EQ(
-        ErrorCode::OK,
-        storage.WriteBatchAndAdvancePrefix(
-            MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2), prefix));
+    ASSERT_EQ(ErrorCode::OK, storage.ClaimProducerView(7));
+    ASSERT_EQ(ErrorCode::OK, storage.ClaimProducerView(8));
 
-    std::string encoded_prefix;
+    auto batch = MakeBatch(/*batch_id=*/1, /*first_seq=*/1, /*count=*/1);
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              storage.WriteBatchAndAdvancePrefix(batch, prefix, 7));
+    EXPECT_EQ(ErrorCode::ETCD_KEY_NOT_EXIST, storage.ReadBatch(1, batch));
+    EXPECT_EQ(ErrorCode::OK,
+              storage.WriteBatchAndAdvancePrefix(
+                  MakeBatch(/*batch_id=*/1, /*first_seq=*/1, /*count=*/1),
+                  prefix, 8));
+}
+
+TEST(OpLogBatchStorageTest, FencedAdvanceRequiresClaimedViewKey) {
+    FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
-              backend.Get("/oplog/clusterA/durable_prefix", encoded_prefix));
-    ASSERT_TRUE(DecodeDurablePrefix(encoded_prefix, &prefix));
-    EXPECT_EQ(2u, prefix.batch_id);
-    EXPECT_EQ(5u, prefix.last_seq);
-    EXPECT_EQ(0u, prefix.producer_view_version);
+              backend.Put("/oplog/clusterA/durable_prefix",
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    OpLogBatchStorage storage("clusterA", backend);
+
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              storage.WriteBatchAndAdvancePrefix(
+                  MakeBatch(/*batch_id=*/1, /*first_seq=*/1, /*count=*/1),
+                  {.batch_id = 0, .last_seq = 0}, 7));
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              storage.WriteBatchAndAdvancePrefix(
+                  MakeBatch(/*batch_id=*/1, /*first_seq=*/1, /*count=*/1),
+                  {.batch_id = 0, .last_seq = 0}, 0));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put("/oplog/clusterA/producer_view", "invalid"));
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR,
+              storage.WriteBatchAndAdvancePrefix(
+                  MakeBatch(/*batch_id=*/1, /*first_seq=*/1, /*count=*/1),
+                  {.batch_id = 0, .last_seq = 0}, 7));
 }
 
 TEST(OpLogBatchStorageTest, CompareFailureDoesNotWriteBatchOrAdvancePrefix) {
@@ -484,14 +641,12 @@ TEST(OpLogBatchStorageTest, CompareFailureIsOkWhenTargetBatchAlreadyDurable) {
                                  batch, {.batch_id = 1, .last_seq = 3}));
 }
 
-TEST(OpLogBatchStorageTest,
-     CompareFailureWithDifferentProducerViewIsNotIdempotentSuccess) {
+TEST(OpLogBatchStorageTest, FencedBatchIsNotIdempotentSuccess) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put("/oplog/clusterA/durable_prefix",
-                          EncodeDurablePrefix({.batch_id = 2,
-                                               .last_seq = 5,
-                                               .producer_view_version = 8})));
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 5})));
+    ASSERT_EQ(ErrorCode::OK, backend.Put("/oplog/clusterA/producer_view", "8"));
     auto batch = MakeBatch(/*batch_id=*/2, /*first_seq=*/4, /*count=*/2);
     ASSERT_EQ(ErrorCode::OK,
               backend.Put("/oplog/clusterA/batches/00000000000000000002",
@@ -499,10 +654,9 @@ TEST(OpLogBatchStorageTest,
     backend.FailNextTxn(ErrorCode::ETCD_TRANSACTION_FAIL);
     OpLogBatchStorage storage("clusterA", backend);
 
-    EXPECT_EQ(
-        ErrorCode::ETCD_TRANSACTION_FAIL,
-        storage.WriteBatchAndAdvancePrefix(
-            batch, {.batch_id = 1, .last_seq = 3, .producer_view_version = 7}));
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              storage.WriteBatchAndAdvancePrefix(
+                  batch, {.batch_id = 1, .last_seq = 3}, 7));
 }
 
 TEST(OpLogBatchStorageTest, RejectsSkippedBatchId) {

--- a/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
+++ b/mooncake-store/tests/ha/oplog/ordered_oplog_writer_test.cpp
@@ -599,39 +599,6 @@ TEST(OrderedOpLogWriterLoopTest, ContinuesFromInitialDurablePrefix) {
     writer.Stop();
 }
 
-TEST(OrderedOpLogWriterLoopTest, PreservesProducerViewAcrossBatches) {
-    FakeBatchWriter storage;
-    OrderedOpLogWriter writer(
-        OrderedOpLogWriterConfig{
-            .max_entries_per_batch = 1,
-            .initial_durable_prefix = {.producer_view_version = 7}},
-        [&](const OpLogBatchRecord& batch,
-            const DurablePrefix& expected_prefix) {
-            return storage.Write(batch, expected_prefix);
-        });
-    writer.Start();
-
-    auto first = writer.Reserve();
-    ASSERT_TRUE(first.has_value());
-    ASSERT_TRUE(
-        writer.Commit(std::move(*first), MakeEntry("k1"), [](const auto&) {})
-            .has_value());
-    ASSERT_TRUE(storage.WaitForWrites(1));
-
-    auto second = writer.Reserve();
-    ASSERT_TRUE(second.has_value());
-    ASSERT_TRUE(
-        writer.Commit(std::move(*second), MakeEntry("k2"), [](const auto&) {})
-            .has_value());
-    ASSERT_TRUE(storage.WaitForWrites(2));
-
-    const auto prefixes = storage.ExpectedPrefixes();
-    ASSERT_EQ(2u, prefixes.size());
-    EXPECT_EQ(7u, prefixes[0].producer_view_version);
-    EXPECT_EQ(7u, prefixes[1].producer_view_version);
-    writer.Stop();
-}
-
 TEST(OrderedOpLogWriterLoopTest, CommitWhileReadyBatchExistsFormsNextBatch) {
     FakeBatchWriter storage;
     OrderedOpLogWriter writer(


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is stacked on #3204 and must not be merged before #3204.
> After #3204 is merged, this branch will be rebased onto the updated `main`.

## Description

Depends on #3204. This branch currently includes its `OrderedOpLogWriter` terminal-state changes.

This PR adds the storage-level producer-view fencing contract for batch OpLog:

- Stores the current producer view in an independent `/oplog/<cluster>/producer_view` key, separate from the durable batch/sequence prefix.
- Adds `OpLogBatchStorage::ClaimProducerView()` to create or atomically advance that key with compare-and-swap.
- Treats claiming the current view as an idempotent success and rejects lower views with `ETCD_TRANSACTION_FAIL`.
- Makes claims independent of concurrent durable-prefix advancement, so batch and sequence progress cannot interfere with leadership claims.
- Adds `ValidateProducerView()` for the final pre-serving leadership check used by the follow-up integration.
- Adds a fenced `WriteBatchAndAdvancePrefix()` overload that compares the producer-view key in the same transaction that writes the batch record and advances the durable prefix.
- Resolves ambiguous transaction errors by rereading the affected state after a possible commit, covering initialization, view claims, and batch writes without weakening fencing.
- Keeps the existing unfenced overload as the S03 staging path; F01 will bind the claimed view into the production writer lifecycle.
- Uses a strict canonical positive decimal encoding for producer views and fails closed on malformed persisted values.
- Removes producer-view metadata from `DurablePrefix`; batch records and snapshot metadata retain their existing producer-view fields.

Production leadership wiring remains follow-up work in F01. The future supervisor will claim the ACQUIRED session view before promotion and validate leadership again immediately before serving.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target \
  oplog_batch_storage_test \
  oplog_batch_codec_test \
  ordered_oplog_writer_test \
  oplog_batch_standby_reader_test -j32

LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_storage_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_codec_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/ordered_oplog_writer_test
LSAN_OPTIONS=detect_leaks=0 ./build/mooncake-store/tests/oplog_batch_standby_reader_test

pre-commit run --files <all changed files>
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done

Results:

- `oplog_batch_storage_test`: 50/50 passed
- `oplog_batch_codec_test`: 32/32 passed
- `ordered_oplog_writer_test`: 35/35 passed
- `oplog_batch_standby_reader_test`: 20/20 passed
- Pre-commit: all hooks passed

Coverage includes claim creation, same-view idempotency, stale and concurrent claim rejection, durable-prefix independence, ambiguous committed-transaction recovery, strict value parsing, backend-error propagation, atomic fenced writes, missing/corrupt view handling, and stale-writer fencing.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted the changed C++ files
- [x] I have run pre-commit on all changed files and all hooks pass
- [x] Documentation is not required for this staged internal storage contract
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required because this change is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI tools assisted with design review, implementation, test development, and code review. The submitter remains responsible for reviewing and defending the final changes.
