### PR TITLE
[Bug]: RDMA reconnect storm after mlx5 local length errors

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -72,6 +72,7 @@ class WorkerPool {
     struct RailState {
         int error_count = 0;
         uint64_t pause_until_ns = 0;  // Timestamp (ns) when pause expires
+        uint64_t last_error_ns = 0;   // Timestamp (ns) of the last error
     };
 
     void markRailFailed(const std::string &peer_nic_path,
@@ -166,6 +167,10 @@ class WorkerPool {
 
     // Rail monitor configuration
     const static int kRailErrorThreshold = 5;  // Errors before pause
+    // Errors further apart than this are not consecutive, so error_count is
+    // restarted. Without it a long-lived process accumulates isolated failures
+    // until an otherwise healthy rail is paused.
+    const static uint64_t kRailErrorWindowNs = 5000000000ull;  // 5 seconds
     const static uint64_t kContextRecoveryDelayNs =
         30000000000ull;  // 30 seconds before a recovered local RNIC is reused
 

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -587,6 +587,10 @@ void WorkerPool::performPollCq(int thread_id) {
     const static size_t kPollCount = 64;
     std::unordered_map<std::atomic<int> *, int> qp_depth_set;
     std::unordered_set<RdmaEndPoint *> local_failed_endpoints;
+    // Peer NIC paths already charged a local-fault error this pass. A QP that
+    // takes a local fault completes every WR it still holds, so one burst must
+    // count as one error against the path, not one per slice.
+    std::unordered_set<std::string> local_failed_peer_paths;
     bool recorded_local_context_failure = false;
     SliceList failed_slice_list;
     SliceList local_failed_slice_list;
@@ -659,7 +663,24 @@ void WorkerPool::performPollCq(int thread_id) {
                            << ", max_retry_cnt: " << slice->rdma.max_retry_cnt
                            << "): " << ibv_wc_status_str(wc[i].status);
                 auto *retry_list = &failed_slice_list;
-                if (!context_.active() || isLocalWcFailure(wc[i])) {
+                const bool local_wc_failure = isLocalWcFailure(wc[i]);
+                if (!context_.active() || local_wc_failure) {
+                    // A local completion fault retires the endpoint, and the
+                    // slice is handed to another local RNIC that rebuilds its
+                    // own endpoint to the same peer NIC. If the fault keeps
+                    // recurring nothing throttles that cycle: the rail is
+                    // deliberately not paused on the local path, and the
+                    // context failure counter is cleared by any concurrent
+                    // success, so both RNICs re-handshake the same peer as fast
+                    // as the workers spin. Charge the path an error instead --
+                    // without an immediate pause, so a one-off fault still
+                    // costs nothing -- and let kRailErrorThreshold stop the
+                    // rebuild loop from this context. See issue #3299.
+                    if (local_wc_failure &&
+                        local_failed_peer_paths.insert(slice->peer_nic_path)
+                            .second) {
+                        markRailFailed(slice->peer_nic_path);
+                    }
                     if (!recorded_local_context_failure) {
                         handleLocalFailure(slice->peer_nic_path,
                                            slice->rdma.endpoint);
@@ -1357,6 +1378,12 @@ void WorkerPool::markRailFailed(const std::string &peer_nic_path,
     std::lock_guard<std::mutex> lock(rail_state_lock_);
     auto &state = rail_states_[peer_nic_path];
     uint64_t now = getCurrentTimeInNano();
+    // Only errors close together are consecutive. error_count is otherwise
+    // never cleared until a pause expires, so isolated failures spread over
+    // hours would eventually pause a rail that is working fine.
+    if (state.last_error_ns && now - state.last_error_ns > kRailErrorWindowNs)
+        state.error_count = 0;
+    state.last_error_ns = now;
     state.error_count++;
     if (immediate_pause && state.error_count < kRailErrorThreshold) {
         state.error_count = kRailErrorThreshold;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -30,6 +30,16 @@ target_link_libraries(rdma_endpoint_state_test PUBLIC transfer_engine gtest
                                                       gtest_main)
 add_test(NAME rdma_endpoint_state_test COMMAND rdma_endpoint_state_test)
 
+# Regression test for the reconnect storm of issue #3299: repeated local
+# completion faults toward one peer RNIC must pause that path instead of
+# re-handshaking it forever. The rail monitor is plain per-worker-pool state,
+# so this runs on every CI runner without an RDMA device.
+add_executable(worker_pool_rail_state_test
+               ${WORKSPACE}/worker_pool_rail_state_test.cpp)
+target_link_libraries(worker_pool_rail_state_test PUBLIC transfer_engine gtest
+                                                         gtest_main)
+add_test(NAME worker_pool_rail_state_test COMMAND worker_pool_rail_state_test)
+
 # Integration test for the monitorWorker reclaim tick (issue #1845). Self-skips
 # when no RDMA device is present, so safe to register with ctest.
 add_executable(endpoint_store_integration_test

--- a/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
+++ b/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
@@ -1,0 +1,192 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Rail-state regression tests for issue #3299. A local completion fault
+// (mlx5 "local length error" and friends) retires the endpoint and hands the
+// slice to another local RNIC, which rebuilds its own endpoint to the same
+// peer NIC. Nothing used to bound that teardown/rebuild cycle, so a recurring
+// fault turned into a reconnect storm. markRailFailed() now counts those
+// faults, and kRailErrorThreshold consecutive ones pause the path.
+//
+// The rail monitor is plain per-worker-pool state, so these tests need no RDMA
+// device: the pool is built over a context whose device never opens.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include <glog/logging.h>
+
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_transport/worker_pool.h"
+
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer) || \
+    MC_HAS_FEATURE(leak_sanitizer)
+#include <sanitizer/lsan_interface.h>
+#define MC_LSAN_IGNORE_OBJECT(p) __lsan_ignore_object(p)
+
+// Suppress false positives from libnuma.so's process-wide static cache
+// allocated in numa_node_to_cpus() which is intentionally retained until exit.
+extern "C" __attribute__((weak, visibility("default"))) const char *
+__lsan_default_suppressions() {
+    return "leak:libnuma.so\n";
+}
+#else
+#define MC_LSAN_IGNORE_OBJECT(p) ((void)(p))
+#endif
+
+using namespace mooncake;
+
+namespace mooncake {
+
+class WorkerPoolTestPeer {
+   public:
+    static void markRailFailed(WorkerPool &pool, const std::string &path,
+                               bool immediate_pause) {
+        pool.markRailFailed(path, immediate_pause);
+    }
+
+    static bool isRailAvailable(WorkerPool &pool, const std::string &path) {
+        return pool.isRailAvailable(path);
+    }
+
+    // Moves the recorded error timestamp back so the decay window can be
+    // exercised without sleeping through it.
+    static void ageLastError(WorkerPool &pool, const std::string &path,
+                             uint64_t age_ns) {
+        std::lock_guard<std::mutex> lock(pool.rail_state_lock_);
+        pool.rail_states_[path].last_error_ns -= age_ns;
+    }
+
+    static int errorThreshold() { return WorkerPool::kRailErrorThreshold; }
+
+    static uint64_t errorWindowNs() { return WorkerPool::kRailErrorWindowNs; }
+};
+
+}  // namespace mooncake
+
+namespace {
+
+constexpr const char *kPeerA = "10.0.0.1@mlx5_bond_0";
+constexpr const char *kPeerB = "10.0.0.1@mlx5_bond_1";
+
+class WorkerPoolRailStateTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        // monitorWorker busy-polls epoll_wait() on an invalid fd for the whole
+        // lifetime of this pool because the context was never opened. Silence
+        // it so gtest failures stay readable.
+        previous_min_log_level_ = FLAGS_minloglevel;
+        FLAGS_minloglevel = google::GLOG_FATAL;
+
+        // Intentional leak: ~RdmaTransport dereferences metadata_, which is
+        // null until install(). We only need it as RdmaContext's owner, same
+        // as rdma_endpoint_state_test.
+        transport_ = new RdmaTransport();
+        MC_LSAN_IGNORE_OBJECT(transport_);
+        context_ = std::make_unique<RdmaContext>(*transport_, "unused");
+        // Always fails, on any host, because no device is named "unused". It
+        // still creates the endpoint store, which monitorWorker's reclaim tick
+        // needs to exist.
+        context_->construct();
+        worker_pool_ = std::make_unique<WorkerPool>(*context_);
+    }
+
+    void TearDown() override {
+        worker_pool_.reset();
+        context_.reset();
+        FLAGS_minloglevel = previous_min_log_level_;
+    }
+
+    void failRail(const std::string &path, bool immediate_pause = false) {
+        WorkerPoolTestPeer::markRailFailed(*worker_pool_, path,
+                                           immediate_pause);
+    }
+
+    bool railAvailable(const std::string &path) {
+        return WorkerPoolTestPeer::isRailAvailable(*worker_pool_, path);
+    }
+
+    int previous_min_log_level_ = 0;
+    RdmaTransport *transport_ = nullptr;
+    std::unique_ptr<RdmaContext> context_;
+    std::unique_ptr<WorkerPool> worker_pool_;
+};
+
+TEST_F(WorkerPoolRailStateTest, UnknownRailIsAvailable) {
+    EXPECT_TRUE(railAvailable(kPeerA));
+}
+
+// A single local fault must stay free: the endpoint is rebuilt and the slice
+// retried, exactly as before.
+TEST_F(WorkerPoolRailStateTest, FailuresBelowThresholdDoNotPauseRail) {
+    for (int i = 0; i < WorkerPoolTestPeer::errorThreshold() - 1; ++i) {
+        failRail(kPeerA);
+        EXPECT_TRUE(railAvailable(kPeerA))
+            << "paused after " << (i + 1) << " error(s)";
+    }
+}
+
+// The regression: without this, a recurring local fault re-handshakes the same
+// peer NIC forever because nothing on the local path ever pauses it.
+TEST_F(WorkerPoolRailStateTest, RepeatedFailuresPauseRail) {
+    for (int i = 0; i < WorkerPoolTestPeer::errorThreshold(); ++i)
+        failRail(kPeerA);
+
+    EXPECT_FALSE(railAvailable(kPeerA));
+}
+
+// Remote-path handling is unchanged: one error with immediate_pause set still
+// pauses the rail right away.
+TEST_F(WorkerPoolRailStateTest, ImmediatePauseStillPausesOnFirstError) {
+    failRail(kPeerA, /*immediate_pause=*/true);
+
+    EXPECT_FALSE(railAvailable(kPeerA));
+}
+
+// Errors spread further apart than the window are not consecutive, so a
+// healthy rail cannot accumulate its way to a pause over a long process life.
+TEST_F(WorkerPoolRailStateTest, StaleErrorsDoNotAccumulate) {
+    const int threshold = WorkerPoolTestPeer::errorThreshold();
+    for (int round = 0; round < 3; ++round) {
+        for (int i = 0; i < threshold - 1; ++i) failRail(kPeerA);
+        ASSERT_TRUE(railAvailable(kPeerA));
+        WorkerPoolTestPeer::ageLastError(
+            *worker_pool_, kPeerA, WorkerPoolTestPeer::errorWindowNs() + 1);
+    }
+
+    for (int i = 0; i < threshold - 1; ++i) failRail(kPeerA);
+    EXPECT_TRUE(railAvailable(kPeerA));
+}
+
+// Pausing one peer RNIC must not take the peer's other RNIC with it, otherwise
+// a single bad path would strand every transfer to that server.
+TEST_F(WorkerPoolRailStateTest, RailsArePausedIndependently) {
+    for (int i = 0; i < WorkerPoolTestPeer::errorThreshold(); ++i)
+        failRail(kPeerA);
+
+    EXPECT_FALSE(railAvailable(kPeerA));
+    EXPECT_TRUE(railAvailable(kPeerB));
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
+++ b/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
@@ -78,6 +78,19 @@ class WorkerPoolTestPeer {
         pool.rail_states_[path].last_error_ns -= age_ns;
     }
 
+    // These tests only read and write rail state, so the pool's threads have
+    // nothing to do. Left running they busy-poll: the context never opened, so
+    // monitorWorker spins on a failing epoll_wait() for the whole suite. Same
+    // shutdown as ~WorkerPool, ordered so a worker cannot miss the wakeup and
+    // park for its full 1s timeout; the destructor then sees workers_running_
+    // already false and does not join twice.
+    static void stopWorkers(WorkerPool &pool) {
+        if (!pool.workers_running_) return;
+        pool.workers_running_.store(false);
+        pool.cond_var_.notify_all();
+        for (auto &entry : pool.worker_thread_) entry.join();
+    }
+
     static int errorThreshold() { return WorkerPool::kRailErrorThreshold; }
 
     static uint64_t errorWindowNs() { return WorkerPool::kRailErrorWindowNs; }
@@ -93,9 +106,8 @@ constexpr const char *kPeerB = "10.0.0.1@mlx5_bond_1";
 class WorkerPoolRailStateTest : public ::testing::Test {
    protected:
     void SetUp() override {
-        // monitorWorker busy-polls epoll_wait() on an invalid fd for the whole
-        // lifetime of this pool because the context was never opened. Silence
-        // it so gtest failures stay readable.
+        // The context below is expected to fail to open, and that path is
+        // noisy. Silence it so gtest failures stay readable.
         previous_min_log_level_ = FLAGS_minloglevel;
         FLAGS_minloglevel = google::GLOG_FATAL;
 
@@ -106,10 +118,11 @@ class WorkerPoolRailStateTest : public ::testing::Test {
         MC_LSAN_IGNORE_OBJECT(transport_);
         context_ = std::make_unique<RdmaContext>(*transport_, "unused");
         // Always fails, on any host, because no device is named "unused". It
-        // still creates the endpoint store, which monitorWorker's reclaim tick
-        // needs to exist.
+        // still creates the endpoint store, which the monitor tick can touch
+        // in the window before it is stopped below.
         context_->construct();
         worker_pool_ = std::make_unique<WorkerPool>(*context_);
+        WorkerPoolTestPeer::stopWorkers(*worker_pool_);
     }
 
     void TearDown() override {


### PR DESCRIPTION
# Issue #3299 — RDMA reconnect storm after mlx5 local length errors

## 1. Root cause

The reported symptom is a self-sustaining endpoint teardown/rebuild loop that
starts when QPs begin reporting local completion faults
(`local length error` / `local access violation work queue error`, i.e.
`IBV_WC_LOC_LEN_ERR`, `IBV_WC_LOC_PROT_ERR`, `IBV_WC_LOC_ACCESS_ERR`).

`WorkerPool::performPollCq()` classifies those statuses as local faults via
`isLocalWcFailure()` and takes the local-failure branch
(`mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp`):

1. `handleLocalFailure()` retires the endpoint through
   `RdmaContext::deleteEndpointByPtr()`. This is correct on its own — an RC QP
   that completes a WR in error is in `ERR` state and cannot be reused.
2. The slice goes to `local_failed_slice_list` and is redispatched with
   `handoff_to_local_worker = true`, so `tryHandoffToAnotherLocalWorker()` moves
   it to a *different local RNIC*, deliberately keeping the same
   `peer_nic_path`.
3. That other RNIC's worker has no endpoint for the peer NIC, so
   `performPostSend()` calls `RdmaContext::endpoint()` (which constructs one)
   followed by `setupConnectionsByActive()` — a full handshake RPC with a fresh
   set of QP numbers.
4. If the underlying fault recurs, step 1 happens again on that RNIC, and
   `tryHandoffToAnotherLocalWorker()` hands the slice back (the starting index
   is `slice->rdma.retry_cnt % contexts.size()`, and `retry_cnt` is bumped on
   every failure, so it alternates).

Nothing bounds the rate of that cycle:

* The rail monitor is **deliberately not** consulted on this path — the local
  branch never calls `markRailFailed()`, because "the remote rail is not the
  problem". Only the remote/default branch pauses rails.
* The context health valve needs `kContextFailureThreshold` (32) failures, but
  `markContextSuccess()` clears `context_failure_count_` whenever a poll pass
  contains any successful completion. Under concurrent healthy traffic the
  counter never climbs, so the RNIC is never retired (which is the right call
  for a partial fault, but it means there is no brake here either).
* `RdmaContext::pauseConnect()` / `ConnectPauseTracker` is the one mechanism
  designed to stop re-handshaking a failing peer, but it is gated on
  `globalConfig().conn_pause_ttl_ms`, which defaults to `0` (disabled) — see
  `mooncake-transfer-engine/include/config.h`. It is also keyed by peer *server*
  name, so it cannot express "back off from this one peer NIC".

Result: two bonded RNICs ping-pong the same slices at worker-loop speed, each
bounce destroying and re-handshaking an endpoint with brand-new QP numbers. That
matches the report exactly — `mlx5_bond_0/1: QP <n> error: local length error`
repeated dozens of times across both bonded devices within seconds, repeated
"Received RDMA ready ACK" with different peer QPNs, and reconnects that never
restore data movement.

Note on scope: the *first* local length error itself (a WR whose local address /
length / lkey does not match a registered MR) is not diagnosed here. The
slice-preparation paths (`RdmaTransport::selectDevice()`,
`selectPeerDevice()`, `tryHandoffToAnotherLocalWorker()`) all bounds-check the
buffer range and the `lkey`/`rkey` index before use, so I could not reproduce a
metadata-side origin from the code. What this change fixes is the amplification:
a handful of local faults must not become an unbounded reconnect storm.

## 2. The fix and why

Charge the failing `(this local RNIC → that peer RNIC)` path an error in the
existing rail monitor when a local completion fault is seen, and let the
existing `kRailErrorThreshold` stop the rebuild loop.

* `performPollCq()` now calls `markRailFailed(slice->peer_nic_path)` for local
  completion faults, **without** `immediate_pause`. A one-off fault therefore
  still costs nothing: the endpoint is rebuilt and the slice retried exactly as
  before. Only after `kRailErrorThreshold` (5) faults does the path get paused
  for `globalConfig().rdma_rail_pause_seconds` (default 30 s), after which
  `isRailAvailable()` auto-recovers it and clears the counter — the same
  lifecycle the remote-failure path already uses.
* Deduplicated per peer NIC path per poll pass. A QP that takes a local fault
  completes every WR it still holds, so one burst must count as one error, not
  one per slice.
* `rail_states_` is per-`WorkerPool`, i.e. per local RNIC, so pausing is scoped
  to the local NIC that is actually failing. The other local RNIC keeps serving
  that peer until it, too, accumulates its own failures. Once both have, slices
  redispatch to another peer RNIC or fail fast instead of storming.

Why the non-immediate variant: `markRailFailed(path, /*immediate_pause=*/false)`
was already declared (it is the default argument) but had no caller — every
existing call site passes `true`. The threshold mechanism was built for exactly
this "count, then pause" case and was simply not wired up.

One supporting change was needed to make counting safe: `RailState::error_count`
was only ever cleared when a pause expired, so accumulating non-immediate errors
would let isolated faults spread over hours eventually pause a healthy rail.
`markRailFailed()` now restarts the count when the previous error is older than
`kRailErrorWindowNs` (5 s), making it a true consecutive-failure counter. This
cannot change existing behaviour, because `immediate_pause = true` forces
`error_count` to the threshold regardless.

Deliberately not changed:

* `conn_pause_ttl_ms` default stays `0`. Turning the peer-level circuit breaker
  on by default is a policy decision for the maintainers, and it is coarser
  (whole peer server) than the problem.
* The remote/handshake-failure branch in `performPostSend()` has the same shape
  of gap (`markRailFailed()` is skipped when no alternate peer rail exists, so a
  sole-rail peer can churn handshakes unthrottled). It is a different trigger
  from this issue, so it is left alone rather than widening the change.

## 3. Files changed

| File | Change |
| --- | --- |
| `mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h` | `RailState::last_error_ns`; `kRailErrorWindowNs` constant |
| `mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp` | `markRailFailed()` restarts a stale error count; `performPollCq()` charges local completion faults to the peer rail, once per path per poll pass |
| `mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp` | New hardware-free regression test |
| `mooncake-transfer-engine/tests/CMakeLists.txt` | Register `worker_pool_rail_state_test` |

Net: 5 added lines in the header, 29 in the worker pool, plus the test.

## 4. Risk / uncertainty

* **Behaviour change.** After 5 local completion faults toward one peer RNIC
  within 5 s, that path is unavailable *from this local RNIC* for 30 s. Slices
  are then redispatched to another peer RNIC, or fail fast if the peer exposes
  no alternative. Previously they kept retrying through the reconnect loop.
  Failing fast is what the multi-rail case already does when the alternatives
  are paused, and both thresholds are the existing tunables
  (`kRailErrorThreshold`, `MC_RDMA_RAIL_PAUSE_SECONDS`).
* **Semantics of "rail".** Marking a *peer* rail failed for a *local* fault
  reads oddly against the existing comment ("the remote rail is not the
  problem"). It is defensible because `rail_states_` is per local context, so
  the state really describes the local→peer path, not the peer NIC. If
  maintainers prefer, the same throttle could live in a separate per-path map
  instead; the accounting would be identical.
* **The originating fault is untouched.** If a workload really does post a WR
  outside its registered MR, transfers will still fail — they will just fail
  quickly and locally instead of taking every RNIC's connection state with them.
* **Not reproduced on hardware.** The diagnosis is from code reading plus the
  reporter's logs; I have no mlx5 bonded setup to reproduce the original storm.
* The reporter's second hypothesis (slices carrying stale MR metadata across a
  reconnect) is *not* addressed, because I could not substantiate it: `rkey` is
  refreshed from a force-reloaded peer segment descriptor in `redispatch()`,
  `lkey` is refreshed in `tryHandoffToAnotherLocalWorker()`, and every
  buffer/key index is bounds-checked before use.

## 5. How I verified it

* **Formatting/lint gate that CI runs:** `clang-format --dry-run -Werror` is
  clean on all three changed C++ files (the repo `.clang-format`, Google style,
  4-space indent, is what `scripts/code_format.sh` applies). The CMake edit
  matches the surrounding `cmake-format` output byte-for-byte in indentation and
  stays under 80 columns.
* **Logic verified by execution.** The build toolchain for this repo is not
  installable in this environment (no `infiniband/verbs.h`, `glog`, `gflags`, or
  `gtest` headers present), so **I could not compile the project or run ctest.**
  To avoid asserting untested arithmetic, I extracted `RailState`,
  `markRailFailed()` and `isRailAvailable()` verbatim into a standalone program
  with an injected clock, compiled it with `g++ -std=c++17 -Wall -Wextra`, and
  ran the same scenarios the new gtest asserts. All passed:
  * unknown rail is available;
  * 4 consecutive local faults do not pause;
  * the 5th pauses, and only that rail (the peer's other NIC stays available);
  * the pause auto-expires after `rdma_rail_pause_seconds` and clears the count;
  * `immediate_pause` still pauses on the first error (remote path unchanged);
  * 20 rounds of 4 faults, each round separated by more than
    `kRailErrorWindowNs`, never pause the rail (decay works).
* **New gtest:** `worker_pool_rail_state_test.cpp` covers those same six cases
  against the real `WorkerPool`. It follows the existing hardware-free pattern
  from `rdma_async_event_drain_test.cpp` — an `RdmaContext` for a device named
  `"unused"` (whose open always fails, on any host, while still creating the
  endpoint store `monitorWorker` needs) plus a `WorkerPoolTestPeer` friend for
  the private rail-monitor members. It needs no RDMA device and no linker
  wrapping, so it is registered unconditionally with ctest. **This test has not
  been executed**, for the build reason above.
* Read-through verification of the call graph the change sits in:
  `performPollCq` → `handleLocalFailure`/`redispatch` →
  `tryHandoffToAnotherLocalWorker` → `submitPreparedPostSend` →
  `performPostSend` → `RdmaContext::endpoint` → `setupConnectionsByActive`, plus
  `isRailAvailable`'s consumers (`performPostSend`, `redispatch`,
  `hasAvailablePeerRailAlternative`) to confirm a paused path degrades into peer
  rail reselection rather than a hang.