### PR TITLE
[Bugfix][TE] Install shutdown handlers before unblocking signals

### DIFF
--- a/mooncake-transfer-engine/src/graceful_shutdown.cpp
+++ b/mooncake-transfer-engine/src/graceful_shutdown.cpp
@@ -95,7 +95,10 @@ void signalWatcher() {
     _Exit(1);
 }
 
-bool startSignalWatcherLocked(pid_t current_pid) {
+bool startSignalWatcherLocked(pid_t current_pid, sigset_t* saved_mask,
+                              bool* mask_blocked) {
+    *mask_blocked = false;
+
     if (g_signal_pipe[0] >= 0) close(g_signal_pipe[0]);
     if (g_signal_pipe[1] >= 0) close(g_signal_pipe[1]);
     g_signal_pipe[0] = -1;
@@ -107,16 +110,16 @@ bool startSignalWatcherLocked(pid_t current_pid) {
     // The watcher must never take SIGTERM/SIGINT itself: the handler writes
     // to the pipe and then pauses forever, so if it ran on the watcher
     // thread no reader would be left and cleanup would never run. Block both
-    // signals around thread creation so the watcher inherits the mask, and
-    // restore the caller's original mask on every path (it may have had its
-    // own reasons to block these signals).
+    // signals before creating the watcher so it inherits the mask; the caller
+    // restores the original mask once sigaction() has installed the handlers,
+    // so a signal arriving mid-install is not delivered while the disposition
+    // is still SIG_DFL.
     sigset_t watcher_block_set;
-    sigset_t saved_mask;
     sigemptyset(&watcher_block_set);
     sigaddset(&watcher_block_set, SIGTERM);
     sigaddset(&watcher_block_set, SIGINT);
-    const bool mask_blocked =
-        pthread_sigmask(SIG_BLOCK, &watcher_block_set, &saved_mask) == 0;
+    *mask_blocked =
+        pthread_sigmask(SIG_BLOCK, &watcher_block_set, saved_mask) == 0;
 
     bool watcher_started = false;
     try {
@@ -127,8 +130,6 @@ bool startSignalWatcherLocked(pid_t current_pid) {
                      << e.what();
     } catch (...) {
     }
-
-    if (mask_blocked) pthread_sigmask(SIG_SETMASK, &saved_mask, nullptr);
 
     if (!watcher_started) {
         close(g_signal_pipe[0]);
@@ -189,18 +190,24 @@ void installGracefulShutdownHandlers() {
         g_atexit_registered = true;
     }
 
-    if (!startSignalWatcherLocked(current_pid)) return;
+    sigset_t saved_mask;
+    bool mask_blocked = false;
+    if (startSignalWatcherLocked(current_pid, &saved_mask, &mask_blocked)) {
+        struct sigaction sa{};
+        sa.sa_handler = shutdownSignalHandler;
+        sigemptyset(&sa.sa_mask);
+        sigaddset(&sa.sa_mask, SIGTERM);
+        sigaddset(&sa.sa_mask, SIGINT);
+        sa.sa_flags = 0;
+        sigaction(SIGTERM, &sa, nullptr);
+        sigaction(SIGINT, &sa, nullptr);
 
-    struct sigaction sa{};
-    sa.sa_handler = shutdownSignalHandler;
-    sigemptyset(&sa.sa_mask);
-    sigaddset(&sa.sa_mask, SIGTERM);
-    sigaddset(&sa.sa_mask, SIGINT);
-    sa.sa_flags = 0;
-    sigaction(SIGTERM, &sa, nullptr);
-    sigaction(SIGINT, &sa, nullptr);
+        g_handlers_installed = true;
+    }
 
-    g_handlers_installed = true;
+    // Restore last: a signal that arrived mid-install stays pending until the
+    // handlers above are in place.
+    if (mask_blocked) pthread_sigmask(SIG_SETMASK, &saved_mask, nullptr);
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
Description
  startSignalWatcherLocked() restored the caller's signal mask before installGracefulShutdownHandlers() had called sigaction(), leaving a window where SIGTERM/SIGINT was deliverable while the disposition was still SIG_DFL. A signal arriving in that window kills the process outright and the graceful shutdown never runs — the containerized-startup case the feature exists for. Creating the watcher thread is the slowest step on that path, so the exposure is widest on a cold process.

   pthread_sigmask(SIG_BLOCK, {TERM,INT})
   std::thread(signalWatcher).detach()     <-- slowest step
   pthread_sigmask(SIG_SETMASK, saved)     <-- unblocked here; a signal that arrived above is delivered NOW
   sigaction(SIGTERM/SIGINT)               <-- ...but the handler lands here

  This hands the saved mask back to the caller and restores it only after sigaction() has installed the handlers, on every path including the thread-creation failure path. A signal arriving mid-install now stays pending and reaches the real handler. The exposed window shrinks to the pipe() call preceding the mask block.

  The mask itself was introduced by #3278; this only widens its scope to cover the whole install. Independent of the test-side fork() hangs fixed in #3351.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  graceful_shutdown_test passes (6/6) and 25 rounds x 8 concurrent workers ran without a failure. The suite is unaffected by this change: it signals only after the child reports readiness, so it never enters the install window.

  To measure the window itself, the install sequence was extracted into a standalone harness mirroring graceful_shutdown.cpp, with a knob to widen each phase. Counting runs where the child died by the default disposition instead of exiting 128 + signo, before vs. after this change:

  - masked window widened to 150 ms, 200 runs: 200 killed, then 0
  - post-unblock window widened to 150 ms, 200 runs: 200 killed, then 0
  - natural timing, kill delay swept 50 us - 2 ms, 576 runs: 52 killed, then 18

  The residual 18 are signals delivered before enableGracefulShutdown() is entered at all, which no ordering inside the function can affect.

  Test commands:
  cmake --build build --target graceful_shutdown_test -j"$(nproc)"
  ASAN_OPTIONS=detect_leaks=0 ctest --test-dir build \
    -R '^graceful_shutdown_test$' --output-on-failure

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Checklist

  - [ ] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [ ] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  No test is added: the race needs the signal to land inside a window that is microseconds wide and not externally observable, which cannot be pinned deterministically without a test-only seam in the install path. The numbers
  above come from the standalone harness; happy to add it under tests/ as a stress target if reviewers want it in-tree.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)