### PR TITLE
[TransferEngine] Support multi-target tebench runs

### DIFF
--- a/docs/source/performance/mooncake/tebench.md
+++ b/docs/source/performance/mooncake/tebench.md
@@ -32,8 +32,8 @@ cmake --build . -j
 
 ### Role Selection
 
-* If both `--target_seg_name` and `--target_seg_names` are **empty** → Target mode
-* If either `--target_seg_name` or `--target_seg_names` is **set** → Initiator mode
+* If `--target_seg_name` is **empty** → Target mode
+* If `--target_seg_name` is **set** → Initiator mode
 
 ### Backend Selection
 
@@ -260,9 +260,9 @@ Example:
   thus multiple transports — SHM for DRAM, NVLink for VRAM) concurrently.
   Empty falls back to `--seg_type` (single type, existing behavior). See
   Section 5.8 for usage and the multi-transport configuration it requires.
-* `--target_seg_name` : target segment name (empty → Target mode)
-* `--target_seg_names` : comma-separated target segment names. When set,
-  worker threads are distributed across all listed target segments.
+* `--target_seg_name` : target segment name (empty → Target mode).
+  A comma-separated list enables multi-target initiator mode, and worker
+  threads are distributed across all listed target segments.
 
 **Scan ranges**
 
@@ -280,14 +280,14 @@ block_size × batch_size × num_threads > total_buffer_size
 
 **Multi-target initiator**
 
-Use `--target_seg_names` when one initiator process should send traffic to
-multiple target segments:
+Use a comma-separated `--target_seg_name` value when one initiator process
+should send traffic to multiple target segments:
 
 ```bash
 ./tebench \
   --backend=tent \
   --metadata_type=p2p \
-  --target_seg_names=<SEG_A>,<SEG_B>,<SEG_C> \
+  --target_seg_name=<SEG_A>,<SEG_B>,<SEG_C> \
   --op_type=read \
   --start_num_threads=3 \
   --max_num_threads=3
@@ -303,7 +303,7 @@ For multi-node benchmarks, tebench intentionally stays at the endpoint level:
 each process publishes its own segment, and an external launcher decides which
 target segment list each initiator receives. This keeps M-to-N, fan-out,
 incast, and all-to-all topologies as different launch configurations over the
-same `--target_seg_names` primitive.
+same comma-separated `--target_seg_name` primitive.
 
 For multiple initiator processes sharing the same target segment, use
 `--target_offset` and `--target_range_size` to partition the remote address

--- a/docs/source/performance/mooncake/tebench.md
+++ b/docs/source/performance/mooncake/tebench.md
@@ -32,8 +32,8 @@ cmake --build . -j
 
 ### Role Selection
 
-* If `--target_seg_name` is **empty** → Target mode
-* If `--target_seg_name` is **set** → Initiator mode
+* If both `--target_seg_name` and `--target_seg_names` are **empty** → Target mode
+* If either `--target_seg_name` or `--target_seg_names` is **set** → Initiator mode
 
 ### Backend Selection
 
@@ -261,6 +261,8 @@ Example:
   Empty falls back to `--seg_type` (single type, existing behavior). See
   Section 5.8 for usage and the multi-transport configuration it requires.
 * `--target_seg_name` : target segment name (empty → Target mode)
+* `--target_seg_names` : comma-separated target segment names. When set,
+  worker threads are distributed across all listed target segments.
 
 **Scan ranges**
 
@@ -275,6 +277,54 @@ A test case is skipped when:
 ```
 block_size × batch_size × num_threads > total_buffer_size
 ```
+
+**Multi-target initiator**
+
+Use `--target_seg_names` when one initiator process should send traffic to
+multiple target segments:
+
+```bash
+./tebench \
+  --backend=tent \
+  --metadata_type=p2p \
+  --target_seg_names=<SEG_A>,<SEG_B>,<SEG_C> \
+  --op_type=read \
+  --start_num_threads=3 \
+  --max_num_threads=3
+```
+
+Thread `i` selects target `i % target_count`. Within the selected target, the
+local target-thread index is `i / target_count`, so increasing the thread count
+spreads traffic across targets before advancing to the next buffer slot inside
+each target. `--target_gpu_id` shifts the per-target buffer slot and does not
+change the target selection order.
+
+For multi-node benchmarks, tebench intentionally stays at the endpoint level:
+each process publishes its own segment, and an external launcher decides which
+target segment list each initiator receives. This keeps M-to-N, fan-out,
+incast, and all-to-all topologies as different launch configurations over the
+same `--target_seg_names` primitive.
+
+For multiple initiator processes sharing the same target segment, use
+`--target_offset` and `--target_range_size` to partition the remote address
+space. The range size is relative to each initiator; tebench also validates that
+`target_offset + relative_offset + transfer_size` stays inside the actual target
+buffer.
+
+```bash
+# Initiator 0 uses [0, 512MiB)
+./tebench --target_seg_name=<SEG> --target_offset=0 --target_range_size=536870912
+
+# Initiator 1 uses [512MiB, 1GiB)
+./tebench --target_seg_name=<SEG> --target_offset=536870912 --target_range_size=536870912
+```
+
+For read-only verification with multiple readers, first write deterministic data
+using `--op_type=write_seed`, then run readers with `--op_type=read_verify`
+against the same target range. `read_verify` performs pure READs and validates
+the local buffer without modifying the remote data. Do not combine these modes
+with `--check_consistency`; `--check_consistency` remains the existing
+WRITE→READ self-check mode.
 
 ---
 

--- a/mooncake-store/tests/mmap_arena_fallback_test.cpp
+++ b/mooncake-store/tests/mmap_arena_fallback_test.cpp
@@ -15,6 +15,21 @@
 
 #include "utils.h"
 
+#if defined(__has_feature)
+#define MC_HAS_FEATURE(x) __has_feature(x)
+#else
+#define MC_HAS_FEATURE(x) 0
+#endif
+#if defined(__SANITIZE_ADDRESS__) || MC_HAS_FEATURE(address_sanitizer) || \
+    MC_HAS_FEATURE(leak_sanitizer)
+// Suppress false positives from libnuma.so process-wide caches that are
+// intentionally retained until process exit.
+extern "C" __attribute__((weak, visibility("default"))) const char*
+__lsan_default_suppressions() {
+    return "leak:libnuma.so\n";
+}
+#endif
+
 namespace mooncake {
 
 namespace {
@@ -77,7 +92,6 @@ TEST_F(MmapArenaFallbackTest, PopulateNumaHugetlbMappingTouchesEveryRegion) {
     if (numa_available() < 0) {
         GTEST_SKIP() << "NUMA is unavailable";
     }
-
     setenv("MC_STORE_USE_HUGEPAGE", "1", 1);
     setenv("MC_STORE_HUGEPAGE_SIZE", "2MB", 1);
 

--- a/mooncake-transfer-engine/benchmark/bench_runner.h
+++ b/mooncake-transfer-engine/benchmark/bench_runner.h
@@ -54,12 +54,17 @@ class BenchRunner {
     virtual uint64_t getLocalBufferBase(int thread_id, uint64_t block_size,
                                         uint64_t batch_size) const = 0;
 
+    virtual size_t getTargetCount() const = 0;
+
+    virtual uint64_t getTargetSegmentId(int thread_id) const = 0;
+
     virtual uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,
                                          uint64_t batch_size) const = 0;
 
-    virtual double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
-                                     uint64_t block_size, uint64_t batch_size,
-                                     OpCode opcode, uint64_t deadline_ns,
+    virtual double runSingleTransfer(uint64_t local_addr, uint64_t target_id,
+                                     uint64_t target_addr, uint64_t block_size,
+                                     uint64_t batch_size, OpCode opcode,
+                                     uint64_t deadline_ns,
                                      IntentType intent_type) = 0;
 };
 

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -109,7 +109,7 @@ int processBatchSizes(
             local_gpu_offset + thread_id, address_stride_bytes, 1);
         uint64_t target_addr = runner.getTargetBufferBase(
             target_thread_id, address_stride_bytes, 1);
-        uint64_t target_id = runner.getTargetSegmentId(thread_id);
+        uint64_t target_id = runner.getTargetSegmentId(target_thread_id);
         const bool qos_enabled = !qos_classes.empty();
         const size_t qos_class =
             qos_enabled ? qosClassForThread(qos_classes, thread_id) : 0;
@@ -263,13 +263,6 @@ int main(int argc, char* argv[]) {
         "Usage: ./tebench [options]");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     XferBenchConfig::loadFromFlags();
-    if (!XferBenchConfig::target_seg_name.empty() &&
-        !XferBenchConfig::target_seg_names.empty()) {
-        LOG(ERROR) << "Use only one of --target_seg_name or "
-                      "--target_seg_names";
-        return EXIT_FAILURE;
-    }
-
     std::vector<WorkloadClassConfig> workload_classes;
     std::vector<QosClassConfig> qos_classes;
     if (!XferBenchConfig::workload_classes_json.empty() &&
@@ -380,8 +373,7 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
 #endif
     }
-    if (XferBenchConfig::target_seg_name.empty() &&
-        XferBenchConfig::target_seg_names.empty()) {
+    if (XferBenchConfig::target_seg_name.empty()) {
         std::cout << "\033[33mTo start initiators, run " << std::endl
                   << "  ./tebench --target_seg_name="
                   << runner->getSegmentName()

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -191,8 +191,8 @@ int processBatchSizes(
                                "operation payload size");
                 const uint64_t batch_bytes = bytes;
                 if (write_seed) {
-                    memset((void*)local_addr, stableDataSeed(target_addr),
-                           bytes);
+                    fillData((void*)local_addr, bytes,
+                             stableDataSeed(target_addr));
                 }
                 paceRequest();
                 auto val = runner.runSingleTransfer(

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -43,15 +43,31 @@ int processBatchSizes(
     const std::vector<QosClassConfig>& qos_classes,
     const std::vector<WorkloadClassConfig>& workload_classes = {}) {
     bool mixed_opcode = false;
+    bool write_seed = false;
+    bool read_verify = false;
     OpCode opcode = READ;
+    if (XferBenchConfig::check_consistency &&
+        (XferBenchConfig::op_type == "write_seed" ||
+         XferBenchConfig::op_type == "read_verify")) {
+        LOG(ERROR) << "--check_consistency cannot be combined with "
+                      "write_seed/read_verify";
+        exit(EXIT_FAILURE);
+    }
     if (XferBenchConfig::check_consistency || XferBenchConfig::op_type == "mix")
         mixed_opcode = true;
     else if (XferBenchConfig::op_type == "read")
         opcode = READ;
     else if (XferBenchConfig::op_type == "write")
         opcode = WRITE;
-    else {
-        LOG(ERROR) << "Invalid args: workload only support read|write|mix";
+    else if (XferBenchConfig::op_type == "write_seed") {
+        opcode = WRITE;
+        write_seed = true;
+    } else if (XferBenchConfig::op_type == "read_verify") {
+        opcode = READ;
+        read_verify = true;
+    } else {
+        LOG(ERROR) << "Invalid args: workload only support "
+                      "read|write|mix|write_seed|read_verify";
         exit(EXIT_FAILURE);
     }
 
@@ -76,18 +92,24 @@ int processBatchSizes(
     if (!workload_classes.empty()) {
         address_stride_bytes = 0;
         for (const auto& config : workload_classes) {
-            address_stride_bytes = std::max(
-                address_stride_bytes, config.block_size * config.batch_size);
+            address_stride_bytes =
+                std::max(address_stride_bytes,
+                         checkedMul(config.block_size, config.batch_size,
+                                    "workload address stride"));
         }
     }
     int rc = runner.runInitiatorTasks([&](int thread_id) -> int {
         runner.pinThread(thread_id);
         auto local_gpu_offset = std::max(0, XferBenchConfig::local_gpu_id);
         auto target_gpu_offset = std::max(0, XferBenchConfig::target_gpu_id);
+        const int target_thread_id =
+            static_cast<int>(target_gpu_offset * runner.getTargetCount()) +
+            thread_id;
         uint64_t local_addr = runner.getLocalBufferBase(
             local_gpu_offset + thread_id, address_stride_bytes, 1);
         uint64_t target_addr = runner.getTargetBufferBase(
-            target_gpu_offset + thread_id, address_stride_bytes, 1);
+            target_thread_id, address_stride_bytes, 1);
+        uint64_t target_id = runner.getTargetSegmentId(thread_id);
         const bool qos_enabled = !qos_classes.empty();
         const size_t qos_class =
             qos_enabled ? qosClassForThread(qos_classes, thread_id) : 0;
@@ -115,9 +137,9 @@ int processBatchSizes(
 
         XferBenchTimer timer;
         while (timer.lap_us(false) < 1000000ull) {
-            runner.runSingleTransfer(local_addr, target_addr, thread_block_size,
-                                     thread_batch_size, opcode, deadlineNs(),
-                                     intent_type);
+            runner.runSingleTransfer(local_addr, target_id, target_addr,
+                                     thread_block_size, thread_batch_size,
+                                     opcode, deadlineNs(), intent_type);
         }
         if (measurement_ready.fetch_add(1, std::memory_order_acq_rel) + 1 ==
             num_threads) {
@@ -133,43 +155,55 @@ int processBatchSizes(
         if (mixed_opcode) {
             while (timer.lap_us(false) <
                    XferBenchConfig::duration * 1000000ull) {
-                const uint64_t batch_bytes =
-                    thread_block_size * thread_batch_size;
+                const size_t bytes =
+                    checkedMul(thread_block_size, thread_batch_size,
+                               "consistency payload size");
+                const uint64_t batch_bytes = bytes;
                 uint8_t pattern = 0;
                 if (XferBenchConfig::check_consistency)
-                    pattern = fillData((void*)local_addr,
-                                       thread_block_size * thread_batch_size);
+                    pattern = fillData((void*)local_addr, bytes);
                 paceRequest();
                 auto val = runner.runSingleTransfer(
-                    local_addr, target_addr, thread_block_size,
+                    local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, WRITE, deadlineNs(), intent_type);
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
                 transfer_duration.push_back(val);
-                fillData((void*)local_addr,
-                         thread_block_size * thread_batch_size);
+                fillData((void*)local_addr, bytes);
                 paceRequest();
                 val = runner.runSingleTransfer(
-                    local_addr, target_addr, thread_block_size,
+                    local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, READ, deadlineNs(), intent_type);
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
                 if (XferBenchConfig::check_consistency)
                     verifyData((void*)local_addr,
-                               thread_block_size * thread_batch_size, pattern);
+                               checkedMul(thread_block_size, thread_batch_size,
+                                          "consistency payload size"),
+                               pattern);
                 transfer_duration.push_back(val);
             }
         } else {
             while (timer.lap_us(false) <
                    XferBenchConfig::duration * 1000000ull) {
-                const uint64_t batch_bytes =
-                    thread_block_size * thread_batch_size;
+                const size_t bytes =
+                    checkedMul(thread_block_size, thread_batch_size,
+                               "operation payload size");
+                const uint64_t batch_bytes = bytes;
+                if (write_seed) {
+                    memset((void*)local_addr, stableDataSeed(target_addr),
+                           bytes);
+                }
                 paceRequest();
                 auto val = runner.runSingleTransfer(
-                    local_addr, target_addr, thread_block_size,
+                    local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, opcode, deadlineNs(), intent_type);
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
+                if (read_verify) {
+                    verifyData((void*)local_addr, bytes,
+                               stableDataSeed(target_addr));
+                }
                 transfer_duration.push_back(val);
             }
         }
@@ -229,6 +263,13 @@ int main(int argc, char* argv[]) {
         "Usage: ./tebench [options]");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     XferBenchConfig::loadFromFlags();
+    if (!XferBenchConfig::target_seg_name.empty() &&
+        !XferBenchConfig::target_seg_names.empty()) {
+        LOG(ERROR) << "Use only one of --target_seg_name or "
+                      "--target_seg_names";
+        return EXIT_FAILURE;
+    }
+
     std::vector<WorkloadClassConfig> workload_classes;
     std::vector<QosClassConfig> qos_classes;
     if (!XferBenchConfig::workload_classes_json.empty() &&
@@ -339,7 +380,8 @@ int main(int argc, char* argv[]) {
         return EXIT_FAILURE;
 #endif
     }
-    if (XferBenchConfig::target_seg_name.empty()) {
+    if (XferBenchConfig::target_seg_name.empty() &&
+        XferBenchConfig::target_seg_names.empty()) {
         std::cout << "\033[33mTo start initiators, run " << std::endl
                   << "  ./tebench --target_seg_name="
                   << runner->getSegmentName()
@@ -371,8 +413,16 @@ int main(int argc, char* argv[]) {
             for (size_t batch_size = XferBenchConfig::start_batch_size;
                  !interrupted && batch_size <= XferBenchConfig::max_batch_size;
                  batch_size *= 2) {
-                if (block_size * batch_size * num_threads >
-                    XferBenchConfig::total_buffer_size) {
+                const size_t bytes_per_thread = checkedMul(
+                    block_size, batch_size, "benchmark operation size");
+                if (XferBenchConfig::target_range_size != 0 &&
+                    bytes_per_thread > XferBenchConfig::target_range_size) {
+                    LOG(ERROR) << "target range is smaller than one operation";
+                    interrupted = true;
+                } else if (num_threads != 0 &&
+                           bytes_per_thread >
+                               XferBenchConfig::total_buffer_size /
+                                   num_threads) {
                     LOG(INFO) << "Skipped for block_size " << block_size
                               << " batch_size " << batch_size;
                 } else {

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -265,10 +265,7 @@ int TEBenchRunner::startInitiator(int num_threads) {
         LOG(ERROR) << "Initiator cannot start: initialization failed";
         return -1;
     }
-    std::string target_names = XferBenchConfig::target_seg_names.empty()
-                                   ? XferBenchConfig::target_seg_name
-                                   : XferBenchConfig::target_seg_names;
-    auto names = splitCommaSeparated(target_names);
+    auto names = splitCommaSeparated(XferBenchConfig::target_seg_name);
     if (names.empty()) {
         LOG(ERROR) << "No target segment name specified";
         return -1;

--- a/mooncake-transfer-engine/benchmark/te_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/te_backend.cpp
@@ -242,17 +242,50 @@ int TEBenchRunner::runTarget() {
     return 0;
 }
 
+size_t TEBenchRunner::targetIndex(int thread_id) const {
+    LOG_ASSERT(!target_handles_.empty());
+    return static_cast<size_t>(thread_id) % target_handles_.size();
+}
+
+int TEBenchRunner::localTargetThreadId(int thread_id) const {
+    LOG_ASSERT(!target_handles_.empty());
+    return thread_id / static_cast<int>(target_handles_.size());
+}
+
+uint64_t TEBenchRunner::getTargetSegmentId(int thread_id) const {
+    return target_handles_[targetIndex(thread_id)];
+}
+
+size_t TEBenchRunner::getTargetCount() const {
+    return std::max<size_t>(target_handles_.size(), 1);
+}
+
 int TEBenchRunner::startInitiator(int num_threads) {
     if (!init_ok_) {
         LOG(ERROR) << "Initiator cannot start: initialization failed";
         return -1;
     }
-    handle_ = engine_->openSegment(XferBenchConfig::target_seg_name);
-    info_ = engine_->getMetadata()->getSegmentDescByID(handle_);
-    std::sort(
-        info_->buffers.begin(), info_->buffers.end(),
-        [](const TransferMetadata::BufferDesc& a,
-           const TransferMetadata::BufferDesc& b) { return a.name < b.name; });
+    std::string target_names = XferBenchConfig::target_seg_names.empty()
+                                   ? XferBenchConfig::target_seg_name
+                                   : XferBenchConfig::target_seg_names;
+    auto names = splitCommaSeparated(target_names);
+    if (names.empty()) {
+        LOG(ERROR) << "No target segment name specified";
+        return -1;
+    }
+    target_handles_.clear();
+    target_infos_.clear();
+    for (const auto& name : names) {
+        SegmentID handle = engine_->openSegment(name);
+        auto info = engine_->getMetadata()->getSegmentDescByID(handle);
+        std::sort(info->buffers.begin(), info->buffers.end(),
+                  [](const TransferMetadata::BufferDesc& a,
+                     const TransferMetadata::BufferDesc& b) {
+                      return a.name < b.name;
+                  });
+        target_handles_.push_back(handle);
+        target_infos_.push_back(std::move(info));
+    }
     threads_.resize(num_threads);
     g_te_running = true;
     current_task_.resize(threads_.size());
@@ -346,7 +379,7 @@ int TEBenchRunner::runInitiatorTasks(
     return g_te_running ? 0 : -1;
 }
 
-double TEBenchRunner::runSingleTransfer(uint64_t local_addr,
+double TEBenchRunner::runSingleTransfer(uint64_t local_addr, uint64_t target_id,
                                         uint64_t target_addr,
                                         uint64_t block_size,
                                         uint64_t batch_size, OpCode opcode,
@@ -362,7 +395,7 @@ double TEBenchRunner::runSingleTransfer(uint64_t local_addr,
             opcode == READ ? TransferRequest::READ : TransferRequest::WRITE;
         entry.length = block_size;
         entry.source = (void*)(local_addr + block_size * i);
-        entry.target_id = handle_;
+        entry.target_id = target_id;
         entry.target_offset = target_addr + block_size * i;
         requests.emplace_back(entry);
     }

--- a/mooncake-transfer-engine/benchmark/te_backend.h
+++ b/mooncake-transfer-engine/benchmark/te_backend.h
@@ -61,16 +61,42 @@ class TEBenchRunner : public BenchRunner {
                block_size * batch_size * (thread_id / num_buffers);
     }
 
+    size_t getTargetCount() const;
+
+    uint64_t getTargetSegmentId(int thread_id) const;
+
     uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,
                                  uint64_t batch_size) const {
-        return info_->buffers[thread_id % info_->buffers.size()].addr +
-               block_size * batch_size * (thread_id / info_->buffers.size());
+        const size_t target_idx = targetIndex(thread_id);
+        const int local_thread_id = localTargetThreadId(thread_id);
+        const auto& info = target_infos_[target_idx];
+        const size_t buffer_idx = local_thread_id % info->buffers.size();
+        const uint64_t bytes =
+            checkedMul(block_size, batch_size, "target operation size");
+        const uint64_t relative_offset =
+            checkedMul(bytes, local_thread_id / info->buffers.size(),
+                       "target relative offset");
+        const auto& buffer = info->buffers[buffer_idx];
+        if (XferBenchConfig::target_range_size != 0 &&
+            !rangeContains(relative_offset, bytes,
+                           XferBenchConfig::target_range_size)) {
+            LOG(FATAL) << "Target range too small for thread " << thread_id;
+        }
+        if (XferBenchConfig::target_offset > buffer.length ||
+            !rangeContains(relative_offset, bytes,
+                           buffer.length - XferBenchConfig::target_offset)) {
+            LOG(FATAL) << "Target buffer too small for thread " << thread_id;
+        }
+        return checkedAdd(buffer.addr,
+                          checkedAdd(XferBenchConfig::target_offset,
+                                     relative_offset, "target address offset"),
+                          "target address");
     }
 
-    double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
-                             uint64_t block_size, uint64_t batch_size,
-                             OpCode opcode, uint64_t deadline_ns,
-                             IntentType intent_type);
+    double runSingleTransfer(uint64_t local_addr, uint64_t target_id,
+                             uint64_t target_addr, uint64_t block_size,
+                             uint64_t batch_size, OpCode opcode,
+                             uint64_t deadline_ns, IntentType intent_type);
 
    private:
     int allocateBuffers();
@@ -79,11 +105,15 @@ class TEBenchRunner : public BenchRunner {
 
     int runner(int thread_id);
 
+    size_t targetIndex(int thread_id) const;
+
+    int localTargetThreadId(int thread_id) const;
+
    private:
     std::unique_ptr<mooncake::TransferEngine> engine_;
     std::vector<void*> pinned_buffer_list_;
-    SegmentID handle_;
-    std::shared_ptr<TransferMetadata::SegmentDesc> info_;
+    std::vector<SegmentID> target_handles_;
+    std::vector<std::shared_ptr<TransferMetadata::SegmentDesc>> target_infos_;
 
     std::vector<std::function<int(int)>> current_task_;
     std::vector<std::thread> threads_;

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -325,10 +325,7 @@ size_t TENTBenchRunner::getTargetCount() const {
 }
 
 int TENTBenchRunner::startInitiator(int num_threads) {
-    std::string target_names = XferBenchConfig::target_seg_names.empty()
-                                   ? XferBenchConfig::target_seg_name
-                                   : XferBenchConfig::target_seg_names;
-    auto names = splitCommaSeparated(target_names);
+    auto names = splitCommaSeparated(XferBenchConfig::target_seg_name);
     if (names.empty()) {
         LOG(ERROR) << "No target segment name specified";
         return -1;

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -306,14 +306,51 @@ int TENTBenchRunner::runTarget() {
     return 0;
 }
 
+size_t TENTBenchRunner::targetIndex(int thread_id) const {
+    LOG_ASSERT(!target_handles_.empty());
+    return static_cast<size_t>(thread_id) % target_handles_.size();
+}
+
+int TENTBenchRunner::localTargetThreadId(int thread_id) const {
+    LOG_ASSERT(!target_handles_.empty());
+    return thread_id / static_cast<int>(target_handles_.size());
+}
+
+uint64_t TENTBenchRunner::getTargetSegmentId(int thread_id) const {
+    return target_handles_[targetIndex(thread_id)];
+}
+
+size_t TENTBenchRunner::getTargetCount() const {
+    return std::max<size_t>(target_handles_.size(), 1);
+}
+
 int TENTBenchRunner::startInitiator(int num_threads) {
-    CHECK_FAIL(engine_->openSegment(handle_, XferBenchConfig::target_seg_name));
-    info_.buffers.clear();
-    CHECK_FAIL(engine_->getSegmentInfo(handle_, info_));
-    std::sort(info_.buffers.begin(), info_.buffers.end(),
-              [](const SegmentInfo::Buffer& a, const SegmentInfo::Buffer& b) {
-                  return a.location < b.location;
-              });
+    std::string target_names = XferBenchConfig::target_seg_names.empty()
+                                   ? XferBenchConfig::target_seg_name
+                                   : XferBenchConfig::target_seg_names;
+    auto names = splitCommaSeparated(target_names);
+    if (names.empty()) {
+        LOG(ERROR) << "No target segment name specified";
+        return -1;
+    }
+    target_handles_.clear();
+    target_infos_.clear();
+    target_handles_.reserve(names.size());
+    target_infos_.reserve(names.size());
+    for (const auto& name : names) {
+        SegmentID handle = 0;
+        CHECK_FAIL(engine_->openSegment(handle, name));
+        SegmentInfo info;
+        CHECK_FAIL(engine_->getSegmentInfo(handle, info));
+        std::sort(
+            info.buffers.begin(), info.buffers.end(),
+            [](const SegmentInfo::Buffer& a, const SegmentInfo::Buffer& b) {
+                return a.location < b.location;
+            });
+        target_handles_.push_back(handle);
+        target_infos_.push_back(std::move(info));
+    }
+    LOG(INFO) << "Opened " << target_handles_.size() << " target segments";
     threads_.resize(num_threads);
     current_task_.resize(threads_.size());
     g_tent_running = true;
@@ -429,12 +466,10 @@ int TENTBenchRunner::runInitiatorTasks(
     return g_tent_running ? 0 : -1;
 }
 
-double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
-                                          uint64_t target_addr,
-                                          uint64_t block_size,
-                                          uint64_t batch_size, OpCode opcode,
-                                          uint64_t deadline_ns,
-                                          IntentType intent_type) {
+double TENTBenchRunner::runSingleTransfer(
+    uint64_t local_addr, uint64_t target_id, uint64_t target_addr,
+    uint64_t block_size, uint64_t batch_size, OpCode opcode,
+    uint64_t deadline_ns, IntentType intent_type) {
     auto batch_id = engine_->allocateBatch(batch_size);
     std::vector<Request> requests;
     for (uint64_t i = 0; i < batch_size; ++i) {
@@ -442,7 +477,7 @@ double TENTBenchRunner::runSingleTransfer(uint64_t local_addr,
         entry.opcode = opcode == READ ? Request::READ : Request::WRITE;
         entry.length = block_size;
         entry.source = (void*)(local_addr + block_size * i);
-        entry.target_id = handle_;
+        entry.target_id = target_id;
         entry.target_offset = target_addr + block_size * i;
         entry.transport_hint = transport_hint_;
         entry.deadline_ns = deadline_ns;

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -87,23 +87,52 @@ class TENTBenchRunner : public BenchRunner {
                    ((thread_id / seg_type_mix_.size()) / count);
     }
 
+    size_t getTargetCount() const;
+
+    uint64_t getTargetSegmentId(int thread_id) const;
+
     uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,
                                  uint64_t batch_size) const {
+        const size_t target_idx = targetIndex(thread_id);
+        const int local_thread_id = localTargetThreadId(thread_id);
+        const auto& info = target_infos_[target_idx];
         if (seg_type_mix_.empty()) {
             // Single seg_type mode: original behavior.
-            return info_.buffers[thread_id % info_.buffers.size()].base +
-                   block_size * batch_size * (thread_id / info_.buffers.size());
+            const size_t buffer_idx = local_thread_id % info.buffers.size();
+            const uint64_t bytes =
+                checkedMul(block_size, batch_size, "target operation size");
+            const uint64_t relative_offset =
+                checkedMul(bytes, local_thread_id / info.buffers.size(),
+                           "target relative offset");
+            const auto& buffer = info.buffers[buffer_idx];
+            if (XferBenchConfig::target_range_size != 0 &&
+                !rangeContains(relative_offset, bytes,
+                               XferBenchConfig::target_range_size)) {
+                LOG(FATAL) << "Target range too small for thread " << thread_id;
+            }
+            if (XferBenchConfig::target_offset > buffer.length ||
+                !rangeContains(
+                    relative_offset, bytes,
+                    buffer.length - XferBenchConfig::target_offset)) {
+                LOG(FATAL) << "Target buffer too small for thread "
+                           << thread_id;
+            }
+            return checkedAdd(
+                buffer.base,
+                checkedAdd(XferBenchConfig::target_offset, relative_offset,
+                           "target address offset"),
+                "target address");
         }
         // Mixed mode: pick this thread's seg_type, then index into the
         // subset of target segment buffers matching that seg_type. Use
         // LocationParser to classify each buffer as host (cpu) vs device
         // (cuda/rocm/supa/...) rather than hard-coding a vendor prefix.
         const std::string& seg_type =
-            seg_type_mix_[thread_id % seg_type_mix_.size()];
+            seg_type_mix_[local_thread_id % seg_type_mix_.size()];
         bool want_device = (seg_type == "vram");
         std::vector<size_t> matches;
-        for (size_t i = 0; i < info_.buffers.size(); ++i) {
-            const auto& loc = info_.buffers[i].location;
+        for (size_t i = 0; i < info.buffers.size(); ++i) {
+            const auto& loc = info.buffers[i].location;
             bool is_device =
                 LocationParser(loc).type() != "cpu" && loc != kWildcardLocation;
             if (is_device == want_device) {
@@ -114,16 +143,33 @@ class TENTBenchRunner : public BenchRunner {
             LOG(FATAL) << "No target buffer of seg_type " << seg_type
                        << " for thread " << thread_id;
         }
-        size_t slot = (thread_id / seg_type_mix_.size()) % matches.size();
-        return info_.buffers[matches[slot]].base +
-               block_size * batch_size *
-                   ((thread_id / seg_type_mix_.size()) / matches.size());
+        size_t slot = (local_thread_id / seg_type_mix_.size()) % matches.size();
+        const uint64_t bytes =
+            checkedMul(block_size, batch_size, "target operation size");
+        const uint64_t relative_offset = checkedMul(
+            bytes, (local_thread_id / seg_type_mix_.size()) / matches.size(),
+            "target relative offset");
+        const auto& buffer = info.buffers[matches[slot]];
+        if (XferBenchConfig::target_range_size != 0 &&
+            !rangeContains(relative_offset, bytes,
+                           XferBenchConfig::target_range_size)) {
+            LOG(FATAL) << "Target range too small for thread " << thread_id;
+        }
+        if (XferBenchConfig::target_offset > buffer.length ||
+            !rangeContains(relative_offset, bytes,
+                           buffer.length - XferBenchConfig::target_offset)) {
+            LOG(FATAL) << "Target buffer too small for thread " << thread_id;
+        }
+        return checkedAdd(buffer.base,
+                          checkedAdd(XferBenchConfig::target_offset,
+                                     relative_offset, "target address offset"),
+                          "target address");
     }
 
-    double runSingleTransfer(uint64_t local_addr, uint64_t target_addr,
-                             uint64_t block_size, uint64_t batch_size,
-                             OpCode opcode, uint64_t deadline_ns,
-                             IntentType intent_type);
+    double runSingleTransfer(uint64_t local_addr, uint64_t target_id,
+                             uint64_t target_addr, uint64_t block_size,
+                             uint64_t batch_size, OpCode opcode,
+                             uint64_t deadline_ns, IntentType intent_type);
 
    private:
     int allocateBuffers();
@@ -131,6 +177,10 @@ class TENTBenchRunner : public BenchRunner {
     int freeBuffers();
 
     int runner(int thread_id);
+
+    size_t targetIndex(int thread_id) const;
+
+    int localTargetThreadId(int thread_id) const;
 
    private:
     std::unique_ptr<TransferEngine> engine_;
@@ -142,8 +192,8 @@ class TENTBenchRunner : public BenchRunner {
     // Parsed --seg_type_mix (e.g. ["dram", "vram"]). Empty when --seg_type_mix
     // is not set → single-seg_type mode (existing behavior).
     std::vector<std::string> seg_type_mix_;
-    SegmentID handle_;
-    SegmentInfo info_;
+    std::vector<SegmentID> target_handles_;
+    std::vector<SegmentInfo> target_infos_;
     TransportType transport_hint_{UNSPEC};
     IntentType intent_type_{IntentType::INTENT_UNSPEC};
 

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -30,7 +30,12 @@ DEFINE_string(
     "concurrently. Empty falls back to --seg_type (single type, existing "
     "behavior). Requires transports to be enabled via MC_TENT_CONF.");
 DEFINE_string(target_seg_name, "", "Memory segment name for the target side");
-DEFINE_string(op_type, "read", "Operation type to benchmark: read|write|mix");
+DEFINE_string(target_seg_names, "",
+              "Comma-separated target segment names. When set, initiator "
+              "threads are distributed across all listed target segments.");
+DEFINE_string(
+    op_type, "read",
+    "Operation type to benchmark: read|write|mix|write_seed|read_verify");
 DEFINE_bool(check_consistency, false,
             "Enable data consistency check after transfer.");
 DEFINE_uint64(total_buffer_size, 1UL << 30,
@@ -44,6 +49,13 @@ DEFINE_int32(start_num_threads, 1,
              "Start number of concurrent worker threads.");
 DEFINE_int32(max_num_threads, 1,
              "Maximum number of concurrent worker threads.");
+DEFINE_uint64(target_offset, 0,
+              "Base offset added to every target buffer address. Useful when "
+              "multiple initiator processes share one target segment.");
+DEFINE_uint64(
+    target_range_size, 0,
+    "Per-initiator target range size. 0 disables range validation; "
+    "non-zero requires every target address to stay inside the range.");
 DEFINE_string(
     qos_classes, "",
     "QoS classes as name:threads:slo_us:weight[:isolated_gbps],...; "
@@ -102,6 +114,7 @@ std::string XferBenchConfig::seg_name;
 std::string XferBenchConfig::seg_type;
 std::string XferBenchConfig::seg_type_mix;
 std::string XferBenchConfig::target_seg_name;
+std::string XferBenchConfig::target_seg_names;
 std::string XferBenchConfig::op_type;
 bool XferBenchConfig::check_consistency = false;
 
@@ -113,6 +126,8 @@ size_t XferBenchConfig::max_batch_size = 0;
 int XferBenchConfig::duration = 0;
 int XferBenchConfig::max_num_threads = 0;
 int XferBenchConfig::start_num_threads = 0;
+size_t XferBenchConfig::target_offset = 0;
+size_t XferBenchConfig::target_range_size = 0;
 std::string XferBenchConfig::qos_classes;
 std::string XferBenchConfig::qos_classes_json;
 std::string XferBenchConfig::workload_classes_json;
@@ -140,6 +155,7 @@ void XferBenchConfig::loadFromFlags() {
     seg_type_mix = FLAGS_seg_type_mix;
     seg_name = FLAGS_seg_name;
     target_seg_name = FLAGS_target_seg_name;
+    target_seg_names = FLAGS_target_seg_names;
     op_type = FLAGS_op_type;
     check_consistency = FLAGS_check_consistency;
 
@@ -150,6 +166,8 @@ void XferBenchConfig::loadFromFlags() {
     max_batch_size = FLAGS_max_batch_size;
     start_num_threads = FLAGS_start_num_threads;
     max_num_threads = FLAGS_max_num_threads;
+    target_offset = FLAGS_target_offset;
+    target_range_size = FLAGS_target_range_size;
     qos_classes = FLAGS_qos_classes;
     qos_classes_json = FLAGS_qos_classes_json;
     workload_classes_json = FLAGS_workload_classes_json;
@@ -248,6 +266,28 @@ void printDeadlineGroupStats(const char* group, size_t block_size,
     std::cout << " operations=" << stats.transfer_duration.count()
               << " throughput=" << std::fixed << std::setprecision(6)
               << throughput_gbs << " GB/s" << std::endl;
+}
+
+std::vector<std::string> splitCommaSeparated(const std::string& value) {
+    std::vector<std::string> result;
+    std::stringstream ss(value);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+        const size_t begin = token.find_first_not_of(" \t\r\n");
+        if (begin == std::string::npos) continue;
+        const size_t end = token.find_last_not_of(" \t\r\n");
+        result.push_back(token.substr(begin, end - begin + 1));
+    }
+    return result;
+}
+
+uint8_t stableDataSeed(uint64_t target_addr) {
+    uint64_t value = target_addr;
+    value ^= value >> 33;
+    value *= 0xff51afd7ed558ccdULL;
+    value ^= value >> 33;
+    uint8_t seed = static_cast<uint8_t>(value);
+    return seed == 0 ? 1 : seed;
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -29,10 +29,9 @@ DEFINE_string(
     "thus multiple transports — SHM for DRAM, NVLink for VRAM) "
     "concurrently. Empty falls back to --seg_type (single type, existing "
     "behavior). Requires transports to be enabled via MC_TENT_CONF.");
-DEFINE_string(target_seg_name, "", "Memory segment name for the target side");
-DEFINE_string(target_seg_names, "",
-              "Comma-separated target segment names. When set, initiator "
-              "threads are distributed across all listed target segments.");
+DEFINE_string(target_seg_name, "",
+              "Target segment name for the initiator side. A comma-separated "
+              "list enables multi-target initiator mode.");
 DEFINE_string(
     op_type, "read",
     "Operation type to benchmark: read|write|mix|write_seed|read_verify");
@@ -114,7 +113,6 @@ std::string XferBenchConfig::seg_name;
 std::string XferBenchConfig::seg_type;
 std::string XferBenchConfig::seg_type_mix;
 std::string XferBenchConfig::target_seg_name;
-std::string XferBenchConfig::target_seg_names;
 std::string XferBenchConfig::op_type;
 bool XferBenchConfig::check_consistency = false;
 
@@ -155,7 +153,6 @@ void XferBenchConfig::loadFromFlags() {
     seg_type_mix = FLAGS_seg_type_mix;
     seg_name = FLAGS_seg_name;
     target_seg_name = FLAGS_target_seg_name;
-    target_seg_names = FLAGS_target_seg_names;
     op_type = FLAGS_op_type;
     check_consistency = FLAGS_check_consistency;
 

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -237,32 +237,36 @@ static inline bool isGpuMemory(void* ptr) {
     return false;
 }
 
-static inline uint8_t fillData(void* addr, size_t length) {
-    uint8_t seed = (uint8_t)SimpleRandom::Get().next(256);
+static inline void fillData(void* addr, size_t length, uint8_t seed) {
 #if defined(USE_CUDA)
     if (isCudaMemory(addr)) {
-        std::vector<uint8_t> ref_data(length, seed);
-        cudaMemcpy(addr, ref_data.data(), length, cudaMemcpyDefault);
-        return seed;
+        auto err = cudaMemset(addr, seed, length);
+        LOG_ASSERT(err == cudaSuccess)
+            << "cudaMemset failed: " << cudaGetErrorString(err);
+        return;
     }
 #elif defined(USE_SUNRISE)
     if (isCudaMemory(addr)) {
-        std::vector<uint8_t> ref_data(length, seed);
-        auto err =
-            cudaMemcpy(addr, ref_data.data(), length, cudaMemcpyHostToDevice);
+        auto err = cudaMemset(addr, seed, length);
         LOG_ASSERT(err == cudaSuccess)
-            << "cudaMemcpy failed: " << cudaGetErrorString(err);
-        return seed;
+            << "cudaMemset failed: " << cudaGetErrorString(err);
+        return;
     }
 #endif
 #ifdef USE_HIP
     if (isHipMemory(addr)) {
-        std::vector<uint8_t> ref_data(length, seed);
-        hipMemcpy(addr, ref_data.data(), length, hipMemcpyDefault);
-        return seed;
+        auto err = hipMemset(addr, seed, length);
+        LOG_ASSERT(err == hipSuccess)
+            << "hipMemset failed: " << hipGetErrorString(err);
+        return;
     }
 #endif
     memset(addr, seed, length);
+}
+
+static inline uint8_t fillData(void* addr, size_t length) {
+    uint8_t seed = (uint8_t)SimpleRandom::Get().next(256);
+    fillData(addr, length, seed);
     return seed;
 }
 

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -61,7 +61,6 @@ struct XferBenchConfig {
     // "dram,vram". Empty falls back to --seg_type (single type).
     static std::string seg_type_mix;
     static std::string target_seg_name;
-    static std::string target_seg_names;
     static std::string op_type;
     static bool check_consistency;
 

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -26,6 +26,7 @@
 #include <numeric>
 #include <stdexcept>
 #include <chrono>
+#include <limits>
 
 #include "tent/common/utils/os.h"
 #include "tent/common/utils/random.h"
@@ -60,6 +61,7 @@ struct XferBenchConfig {
     // "dram,vram". Empty falls back to --seg_type (single type).
     static std::string seg_type_mix;
     static std::string target_seg_name;
+    static std::string target_seg_names;
     static std::string op_type;
     static bool check_consistency;
 
@@ -71,6 +73,8 @@ struct XferBenchConfig {
     static int duration;
     static int max_num_threads;
     static int start_num_threads;
+    static size_t target_offset;
+    static size_t target_range_size;
     static std::string qos_classes;
     static std::string qos_classes_json;
     static std::string workload_classes_json;
@@ -182,6 +186,31 @@ void printStats(size_t block_size, size_t batch_size, XferBenchStats& stats,
 void printDeadlineGroupStats(const char* group, size_t block_size,
                              size_t batch_size, XferBenchStats& stats,
                              int num_threads, uint64_t deadline_us);
+
+std::vector<std::string> splitCommaSeparated(const std::string& value);
+
+uint8_t stableDataSeed(uint64_t target_addr);
+
+static inline uint64_t checkedMul(uint64_t lhs, uint64_t rhs,
+                                  const char* label) {
+    if (rhs != 0 && lhs > std::numeric_limits<uint64_t>::max() / rhs) {
+        LOG(FATAL) << label << " overflows uint64_t: " << lhs << " * " << rhs;
+    }
+    return lhs * rhs;
+}
+
+static inline uint64_t checkedAdd(uint64_t lhs, uint64_t rhs,
+                                  const char* label) {
+    if (lhs > std::numeric_limits<uint64_t>::max() - rhs) {
+        LOG(FATAL) << label << " overflows uint64_t: " << lhs << " + " << rhs;
+    }
+    return lhs + rhs;
+}
+
+static inline bool rangeContains(uint64_t offset, uint64_t bytes,
+                                 uint64_t limit) {
+    return offset <= limit && bytes <= limit - offset;
+}
 
 #if defined(USE_CUDA) || defined(USE_SUNRISE)
 static inline bool isCudaMemory(void* ptr) {


### PR DESCRIPTION
## Description

This PR implements the first code step from RFC #3371: generalizing `tebench` from a single-target benchmark driver to an endpoint-level multi-target benchmark driver.

The change keeps topology orchestration outside `tebench`. `tebench` only provides the primitive to open multiple target segments and route requests to a selected target id. Launchers can then express 1-to-N fan-out, M-to-1 incast, M-to-N, and all-to-all by starting peers with different comma-separated `--target_seg_name` values.

Related RFC: https://github.com/kvcache-ai/Mooncake/issues/3371

Main changes:

- Extend the existing `--target_seg_name` option to accept comma-separated target segment names while preserving single-target behavior.
- Carry `target_id` through `BenchRunner::runSingleTransfer()` and backend implementations so each transfer is submitted to the selected remote segment.
- Support multi-target execution for both classic TransferEngine and TENT backends.
- Add `write_seed` and `read_verify` operations for multi-process shared-target verification flows.
- Add overflow-safe range helpers for address layout validation.
- Document the boundary: `tebench` provides benchmark knobs and metrics; external launchers own node orchestration and topology construction.

Example usage:

1. 1-to-N fan-out: one initiator sends traffic to two targets.

```bash
# Target A
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41081 \
  --seg_name=target_a \
  --total_buffer_size=33554432 \
  --xport_type=rdma --tent_transport_hint=rdma

# Target B
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41082 \
  --seg_name=target_b \
  --total_buffer_size=33554432 \
  --xport_type=rdma --tent_transport_hint=rdma

# Initiator
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41083 \
  --seg_name=initiator_0 \
  --target_seg_name=10.0.0.11:41081,10.0.0.12:41082 \
  --total_buffer_size=33554432 \
  --xport_type=rdma --tent_transport_hint=rdma \
  --start_block_size=4096 --max_block_size=4096 \
  --start_batch_size=1 --max_batch_size=1 \
  --start_num_threads=4 --max_num_threads=4 \
  --duration=10 --check_consistency=true
```

2. M-to-1 incast: start one target, then start multiple initiators with the same target list.

```bash
# Target
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41081 \
  --seg_name=shared_target \
  --total_buffer_size=67108864 \
  --xport_type=rdma --tent_transport_hint=rdma

# Initiator on host 0
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41100 \
  --seg_name=initiator_0 \
  --target_seg_name=10.0.0.11:41081 \
  --total_buffer_size=67108864 \
  --xport_type=rdma --tent_transport_hint=rdma \
  --target_offset=0 --target_range_size=33554432 \
  --duration=10

# Initiator on host 1, using a disjoint remote range.
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41101 \
  --seg_name=initiator_1 \
  --target_seg_name=10.0.0.11:41081 \
  --total_buffer_size=67108864 \
  --xport_type=rdma --tent_transport_hint=rdma \
  --target_offset=33554432 --target_range_size=33554432 \
  --duration=10
```

3. M-to-N / all-to-all: each peer starts a target segment, then each peer starts an initiator with the other peers in `--target_seg_name`.

```bash
# Peer 0 initiator targets peer 1 and peer 2.
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41200 \
  --seg_name=peer0_initiator \
  --target_seg_name=10.0.0.12:41082,10.0.0.13:41083 \
  --total_buffer_size=67108864 \
  --xport_type=rdma --tent_transport_hint=rdma \
  --duration=10

# Peer 1 initiator targets peer 0 and peer 2.
./tebench --backend=tent --metadata_type=p2p \
  --rpc_server_port=41201 \
  --seg_name=peer1_initiator \
  --target_seg_name=10.0.0.11:41081,10.0.0.13:41083 \
  --total_buffer_size=67108864 \
  --xport_type=rdma --tent_transport_hint=rdma \
  --duration=10
```

For the classic TransferEngine backend, use `--backend=classic` and pass the actual P2P target segment names printed by target processes. Existing single-target usage via `--target_seg_name` remains unchanged.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-tebench-multinode \
  -DBUILD_UNIT_TESTS=ON -DBUILD_BENCHMARK=ON \
  -DUSE_CUDA=OFF -DUSE_TENT=ON \
  -DUSE_ETCD=OFF -DUSE_REDIS=OFF -DUSE_HTTP=OFF \
  -DWITH_STORE=OFF -DWITH_P2P_STORE=OFF -DWITH_EP=OFF

cmake --build build-tebench-multinode --target tebench -j$(nproc)
cmake --build build-tebench-multinode --target tebench_qos_metrics_test -j$(nproc)
./build-tebench-multinode/mooncake-transfer-engine/benchmark/tebench_qos_metrics_test
```

Manual smoke coverage:

- TENT backend, one initiator opening two target segments with `--target_seg_name`: passed.
- Classic TransferEngine backend, one initiator opening two target segments with `--target_seg_name`: passed.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`tebench_qos_metrics_test` passed: 9/9 tests.

Local two-target TENT smoke passed with `Opened 2 target segments` and exit code 0.

Local two-target classic backend smoke passed with exit code 0.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `clang-format` on changed C++ files
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to draft and iterate on the implementation and validation plan. The submitted code and test results were reviewed by the human author.

