### PR TITLE
[Store][Test] Run P2P client RPC tests across processes

### DIFF
--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -14,6 +14,23 @@ function(add_store_test name)
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
+# Tests that spawn another copy of their own executable need to provide a
+# custom main() so command-line child modes can be handled before GTest starts.
+function(add_store_test_with_custom_main name)
+    add_executable(${name} ${ARGN})
+    target_link_libraries(${name} PUBLIC
+        mooncake_store
+        transfer_engine
+        cachelib_memory_allocator
+        ${ETCD_WRAPPER_LIB}
+        glog
+        ibverbs
+        gtest
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+endfunction()
+
 add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
 add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)
@@ -50,11 +67,12 @@ endif()
 add_store_test(data_manager_test data_manager_test.cpp)
 add_store_test(inflight_tracker_test inflight_tracker_test.cpp)
 add_store_test(client_rpc_service_test client_rpc_service_test.cpp)
-add_store_test(peer_client_test peer_client_test.cpp)
+add_store_test_with_custom_main(peer_client_test peer_client_test.cpp)
 add_store_test(centralized_client_meta_test centralized_client_meta_test.cpp)
 add_store_test(p2p_master_service_test p2p_master_service_test.cpp)
 add_store_test(p2p_client_ha_test p2p_client_ha_test.cpp)
-add_store_test(p2p_client_integration_test p2p_client_integration_test.cpp)
+add_store_test_with_custom_main(p2p_client_integration_test
+    p2p_client_integration_test.cpp)
 add_store_test(p2p_client_http_endpoints_test p2p_client_http_endpoints_test.cpp)
 add_store_test(p2p_register_concurrency_test p2p_register_concurrency_test.cpp)
 add_store_test(peer_client_perf_test peer_client_perf_test.cpp)

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -21,12 +21,100 @@
 #include <vector>
 
 #include "p2p_client_metric.h"
+#include "p2p_client_process_test_helper.h"
 #include "p2p_client_service.h"
 #include "test_p2p_server_helpers.h"
 #include "types.h"
 
 namespace mooncake {
 namespace testing {
+
+namespace {
+
+std::shared_ptr<P2PClientService> CreateClientForMaster(
+    const std::string& master_address, const std::string& host_name,
+    uint32_t rpc_port = 0, const std::string& local_transfer_mode = "te",
+    TransferDirectionMode transfer_direction_mode =
+        TransferDirectionMode::REVERSE) {
+    if (rpc_port == 0) {
+        rpc_port = getFreeTcpPort();
+    }
+
+    auto config = ClientConfigBuilder::build_p2p_real_client(
+        host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_address,
+        R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})",
+        /*local_buffer_size=*/0, nullptr, "", rpc_port);
+    config.local_transfer_mode = local_transfer_mode == "te"
+                                     ? LocalTransferMode::TE
+                                     : LocalTransferMode::MEMCPY;
+    config.transfer_direction_mode = transfer_direction_mode;
+    config.async_sender_thread_count = 0;
+    config.enable_http_server = false;
+    config.http_port = 0;
+
+    auto client = std::make_shared<P2PClientService>(
+        config.metadata_connstring, config.http_port, config.enable_http_server,
+        config.labels);
+    if (const auto err = client->Init(config); err != ErrorCode::OK) {
+        LOG(ERROR) << "P2P client Init failed: " << static_cast<int>(err);
+        return nullptr;
+    }
+    return client;
+}
+
+// Owns a real cross-process cluster used only by the cross-process cases:
+//   parent process: local_client_
+//   child process:  master_process_
+//   child process:  remote_peer_process_
+// It is started from main() before any P2PClientService::Init() can create
+// background threads in the test runner.
+class P2PCrossProcessEnvironment {
+   public:
+    bool Start() {
+        Stop();
+        if (!master_process_.Start()) {
+            LOG(ERROR) << "Failed to start cross-process P2P master";
+            return false;
+        }
+        if (!remote_peer_process_.Start(master_process_.master_address())) {
+            LOG(ERROR) << "Failed to start cross-process remote peer";
+            Stop();
+            return false;
+        }
+
+        local_client_ = CreateClientForMaster(
+            master_process_.master_address(),
+            "localhost:" + std::to_string(getFreeTcpPort()));
+        if (!local_client_) {
+            Stop();
+            return false;
+        }
+        return true;
+    }
+
+    void Stop() {
+        local_client_.reset();
+        remote_peer_process_.Stop();
+        master_process_.Stop();
+    }
+
+    P2PClientService& local_client() { return *local_client_; }
+    const ScopedP2PRemotePeerProcess& remote_peer() const {
+        return remote_peer_process_;
+    }
+
+   private:
+    ScopedP2PMasterProcess master_process_;
+    ScopedP2PRemotePeerProcess remote_peer_process_;
+    std::shared_ptr<P2PClientService> local_client_;
+};
+
+P2PCrossProcessEnvironment& CrossProcessEnvironment() {
+    static P2PCrossProcessEnvironment environment;
+    return environment;
+}
+
+}  // namespace
 
 // ============================================================================
 // Test fixture
@@ -41,38 +129,16 @@ class P2PClientIntegrationTest : public ::testing::Test {
         const std::string& local_transfer_mode = "te",
         TransferDirectionMode transfer_direction_mode =
             TransferDirectionMode::REVERSE) {
-        if (rpc_port == 0) rpc_port = getFreeTcpPort();
-
-        auto config = ClientConfigBuilder::build_p2p_real_client(
-            host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_address_,
-            R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})",
-            /*local_buffer_size=*/0, nullptr, "", rpc_port);
-        if (local_transfer_mode == "te") {
-            config.local_transfer_mode = LocalTransferMode::TE;
-        } else {
-            config.local_transfer_mode = LocalTransferMode::MEMCPY;
-        }
-        config.transfer_direction_mode = transfer_direction_mode;
-
-        config.async_sender_thread_count = 0;
-
-        auto client = std::make_shared<P2PClientService>(
-            config.metadata_connstring, config.http_port,
-            config.enable_http_server, config.labels);
-
-        auto err = client->Init(config);
-        EXPECT_EQ(err, ErrorCode::OK)
-            << "Init failed: " << static_cast<int>(err);
-
+        auto client = CreateClientForMaster(master_address_, host_name, rpc_port,
+                                            local_transfer_mode,
+                                            transfer_direction_mode);
+        EXPECT_NE(client, nullptr) << "Failed to initialize P2P client";
         return client;
     }
 
     // --- Suite-level setup / teardown ---
 
     static void SetUpTestSuite() {
-        google::InitGoogleLogging("P2PClientIntegrationTest");
-        FLAGS_logtostderr = 1;
-
         // 1. Start in-process P2P master
         ASSERT_TRUE(master_.Start()) << "Failed to start P2P master";
         master_address_ = master_.master_address();
@@ -90,7 +156,6 @@ class P2PClientIntegrationTest : public ::testing::Test {
         client2_.reset();
         client_.reset();
         master_.Stop();
-        google::ShutdownGoogleLogging();
     }
 
     // Shared across all tests in this suite
@@ -105,6 +170,109 @@ InProcP2PMaster P2PClientIntegrationTest::master_;
 std::string P2PClientIntegrationTest::master_address_;
 std::shared_ptr<P2PClientService> P2PClientIntegrationTest::client_ = nullptr;
 std::shared_ptr<P2PClientService> P2PClientIntegrationTest::client2_ = nullptr;
+
+// ============================================================================
+// Cross-process P2P data path
+// ============================================================================
+
+class P2PCrossProcessIntegrationTest : public ::testing::Test {
+   protected:
+    P2PClientService& client() {
+        return CrossProcessEnvironment().local_client();
+    }
+
+    const ScopedP2PRemotePeerProcess& remote_peer() const {
+        return CrossProcessEnvironment().remote_peer();
+    }
+
+    WriteRouteRequestConfig ForceRemoteWrite() const {
+        WriteRouteRequestConfig config;
+        config.remote_weight = 1.0;
+        config.local_write_waterline = 0.0;
+        config.max_candidates = 1;
+        return config;
+    }
+
+    void ExpectReplicaOwnedByRemoteChild(const std::string& key) {
+        auto replicas = client().GetMasterClient().GetReplicaList(key);
+        ASSERT_TRUE(replicas.has_value());
+        ASSERT_EQ(replicas->replicas.size(), 1u);
+        const auto& descriptor = replicas->replicas.front();
+        ASSERT_TRUE(std::holds_alternative<P2PProxyDescriptor>(
+            descriptor.descriptor_variant));
+        const auto& proxy =
+            std::get<P2PProxyDescriptor>(descriptor.descriptor_variant);
+        EXPECT_EQ(proxy.rpc_port, remote_peer().rpc_port());
+    }
+};
+
+TEST_F(P2PCrossProcessIntegrationTest, RemotePutAndGet) {
+    const std::string key = "cross_process_remote_put_get";
+    const std::string payload = "payload_owned_by_remote_child";
+    std::vector<Slice> slices{
+        {const_cast<char*>(payload.data()), payload.size()}};
+
+    auto put = client().Put(key, slices, ForceRemoteWrite());
+    ASSERT_TRUE(put.has_value())
+        << "Cross-process remote Put failed: "
+        << static_cast<int>(put.error());
+    ExpectReplicaOwnedByRemoteChild(key);
+
+    std::vector<char> output(payload.size(), 0);
+    auto get = client().Get(key, {output.data()}, {output.size()});
+    ASSERT_TRUE(get.has_value())
+        << "Cross-process remote Get failed: "
+        << static_cast<int>(get.error());
+    EXPECT_EQ(std::string(output.data(), output.size()), payload);
+}
+
+TEST_F(P2PCrossProcessIntegrationTest, RemoteBatchPutAndBatchGet) {
+    constexpr size_t kBatchSize = 4;
+    std::vector<std::string> keys;
+    std::vector<std::string> payloads;
+    std::vector<std::vector<Slice>> put_slices;
+    keys.reserve(kBatchSize);
+    payloads.reserve(kBatchSize);
+    put_slices.reserve(kBatchSize);
+
+    for (size_t i = 0; i < kBatchSize; ++i) {
+        keys.push_back("cross_process_batch_key_" + std::to_string(i));
+        payloads.push_back("cross_process_batch_payload_" +
+                           std::to_string(i));
+    }
+    for (auto& payload : payloads) {
+        put_slices.push_back({Slice{payload.data(), payload.size()}});
+    }
+
+    auto put_results = client().BatchPut(keys, put_slices, ForceRemoteWrite());
+    ASSERT_EQ(put_results.size(), kBatchSize);
+    for (size_t i = 0; i < kBatchSize; ++i) {
+        ASSERT_TRUE(put_results[i].has_value())
+            << "Cross-process BatchPut failed for " << keys[i] << ": "
+            << static_cast<int>(put_results[i].error());
+        ExpectReplicaOwnedByRemoteChild(keys[i]);
+    }
+
+    std::vector<std::vector<char>> outputs(kBatchSize);
+    std::vector<std::vector<void*>> buffers(kBatchSize);
+    std::vector<std::vector<size_t>> sizes(kBatchSize);
+    for (size_t i = 0; i < kBatchSize; ++i) {
+        outputs[i].resize(payloads[i].size());
+        buffers[i].push_back(outputs[i].data());
+        sizes[i].push_back(outputs[i].size());
+    }
+
+    auto get_results = client().BatchGet(keys, buffers, sizes,
+                                         ReadRouteConfig{});
+    ASSERT_EQ(get_results.size(), kBatchSize);
+    for (size_t i = 0; i < kBatchSize; ++i) {
+        ASSERT_TRUE(get_results[i].has_value())
+            << "Cross-process BatchGet failed for " << keys[i] << ": "
+            << static_cast<int>(get_results[i].error());
+        EXPECT_EQ(std::string(outputs[i].data(), outputs[i].size()),
+                  payloads[i]);
+    }
+}
 
 // ============================================================================
 // Put / Get (local WRITE_LOCAL mode)
@@ -1445,3 +1613,29 @@ TEST_F(P2PClientIntegrationTest, MetricPutFailure) {
 
 }  // namespace testing
 }  // namespace mooncake
+
+int main(int argc, char** argv) {
+    mooncake::testing::SetP2PClientIntegrationTestBinaryPath(argv[0]);
+    if (auto child_exit =
+            mooncake::testing::MaybeRunP2PClientIntegrationTestChildProcess(
+                argc, argv);
+        child_exit.has_value()) {
+        return *child_exit;
+    }
+
+    ::testing::InitGoogleTest(&argc, argv);
+    google::InitGoogleLogging("P2PClientIntegrationTest");
+    FLAGS_logtostderr = 1;
+
+    auto& environment = mooncake::testing::CrossProcessEnvironment();
+    if (!environment.Start()) {
+        LOG(ERROR) << "Failed to initialize cross-process test environment";
+        google::ShutdownGoogleLogging();
+        return 2;
+    }
+
+    const int result = RUN_ALL_TESTS();
+    environment.Stop();
+    google::ShutdownGoogleLogging();
+    return result;
+}

--- a/mooncake-store/tests/p2p_client_process_test_helper.h
+++ b/mooncake-store/tests/p2p_client_process_test_helper.h
@@ -1,0 +1,459 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "client_config_builder.h"
+#include "p2p_client_service.h"
+#include "test_p2p_server_helpers.h"
+#include "types.h"
+#include "utils.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace mooncake::testing {
+
+inline std::string& P2PClientIntegrationTestBinaryPath() {
+    static std::string path;
+    return path;
+}
+
+inline void SetP2PClientIntegrationTestBinaryPath(const char* argv0) {
+    if (!P2PClientIntegrationTestBinaryPath().empty()) {
+        return;
+    }
+    std::error_code ec;
+    auto absolute = std::filesystem::absolute(argv0, ec);
+    P2PClientIntegrationTestBinaryPath() =
+        ec ? std::string(argv0) : absolute.string();
+}
+
+inline std::optional<std::string> FindP2PArgValue(int argc, char** argv,
+                                                  std::string_view prefix) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        if (arg.rfind(prefix, 0) == 0) {
+            return std::string(arg.substr(prefix.size()));
+        }
+    }
+    return std::nullopt;
+}
+
+inline std::string MakeP2PTempStateFilePath(std::string_view prefix) {
+#ifdef _WIN32
+    const auto pid = static_cast<unsigned long>(GetCurrentProcessId());
+#else
+    const auto pid = static_cast<unsigned long>(getpid());
+#endif
+    return (std::filesystem::temp_directory_path() /
+            (std::string(prefix) + "_" + std::to_string(pid) + "_" +
+             std::to_string(getFreeTcpPort()) + ".txt"))
+        .string();
+}
+
+inline bool WriteReadyStateFile(const std::string& path) {
+    std::ofstream out(path, std::ios::trunc);
+    if (!out) {
+        return false;
+    }
+    out << "ready";
+    return true;
+}
+
+inline bool WaitForReadyStateFile(
+    const std::string& path,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(3000)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::ifstream in(path);
+        if (in) {
+            std::string line;
+            std::getline(in, line);
+            if (line == "ready") {
+                return true;
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+// Spawns a test child via fork()/execv() (POSIX). Call only before any
+// P2PClientService::Init() in the parent test process.
+class P2PClientChildProcess {
+   public:
+    P2PClientChildProcess() = default;
+    P2PClientChildProcess(const P2PClientChildProcess&) = delete;
+    P2PClientChildProcess& operator=(const P2PClientChildProcess&) = delete;
+    ~P2PClientChildProcess() { Stop(); }
+
+    bool Start(const std::vector<std::string>& args) {
+        Stop();
+
+        if (P2PClientIntegrationTestBinaryPath().empty()) {
+            LOG(ERROR) << "P2P integration test binary path is empty";
+            return false;
+        }
+
+#ifdef _WIN32
+        std::string command_line =
+            QuoteArg(P2PClientIntegrationTestBinaryPath());
+        for (const auto& arg : args) {
+            command_line += " ";
+            command_line += QuoteArg(arg);
+        }
+
+        STARTUPINFOA si;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+        ZeroMemory(&process_info_, sizeof(process_info_));
+
+        std::vector<char> command_buffer(command_line.begin(),
+                                         command_line.end());
+        command_buffer.push_back('\0');
+        if (!CreateProcessA(P2PClientIntegrationTestBinaryPath().c_str(),
+                            command_buffer.data(), nullptr, nullptr, FALSE, 0,
+                            nullptr, nullptr, &si, &process_info_)) {
+            LOG(ERROR) << "CreateProcess failed, err=" << GetLastError();
+            ZeroMemory(&process_info_, sizeof(process_info_));
+            return false;
+        }
+        owns_process_ = true;
+        return true;
+#else
+        std::vector<char*> argv_ptrs;
+        argv_ptrs.reserve(args.size() + 2);
+        argv_ptrs.push_back(
+            const_cast<char*>(P2PClientIntegrationTestBinaryPath().c_str()));
+        for (const auto& arg : args) {
+            argv_ptrs.push_back(const_cast<char*>(arg.c_str()));
+        }
+        argv_ptrs.push_back(nullptr);
+
+        pid_ = fork();
+        if (pid_ < 0) {
+            pid_ = -1;
+            return false;
+        }
+        if (pid_ == 0) {
+            execv(P2PClientIntegrationTestBinaryPath().c_str(),
+                  argv_ptrs.data());
+            std::_Exit(127);
+        }
+        owns_process_ = true;
+        return true;
+#endif
+    }
+
+    void Stop() {
+        if (!owns_process_) {
+            return;
+        }
+#ifdef _WIN32
+        if (process_info_.hProcess != nullptr) {
+            TerminateProcess(process_info_.hProcess, 0);
+            WaitForSingleObject(process_info_.hProcess, 5000);
+            CloseHandle(process_info_.hThread);
+            CloseHandle(process_info_.hProcess);
+            ZeroMemory(&process_info_, sizeof(process_info_));
+        }
+#else
+        if (pid_ > 0) {
+            kill(pid_, SIGKILL);
+            int status = 0;
+            waitpid(pid_, &status, 0);
+            pid_ = -1;
+        }
+#endif
+        owns_process_ = false;
+    }
+
+   private:
+#ifdef _WIN32
+    static std::string QuoteArg(const std::string& arg) {
+        if (arg.find(' ') == std::string::npos &&
+            arg.find('"') == std::string::npos) {
+            return arg;
+        }
+        std::string out = "\"";
+        for (char ch : arg) {
+            if (ch == '"') {
+                out += '\\';
+            }
+            out += ch;
+        }
+        out += "\"";
+        return out;
+    }
+
+    PROCESS_INFORMATION process_info_{};
+#else
+    pid_t pid_ = -1;
+#endif
+    bool owns_process_ = false;
+};
+
+inline int RunP2PMasterChildProcess(int argc, char** argv) {
+    google::InitGoogleLogging("P2PMasterChild");
+    FLAGS_logtostderr = 1;
+
+    const int rpc_port =
+        std::stoi(FindP2PArgValue(argc, argv, "--mooncake-master-rpc-port=")
+                      .value_or("0"));
+    if (rpc_port <= 0) {
+        google::ShutdownGoogleLogging();
+        return 2;
+    }
+
+    InProcP2PMaster master;
+    InProcMasterConfig config;
+    config.rpc_port = rpc_port;
+    if (!master.Start(config)) {
+        google::ShutdownGoogleLogging();
+        return 3;
+    }
+
+    if (auto state_file =
+            FindP2PArgValue(argc, argv, "--mooncake-state-file=")) {
+        if (!WriteReadyStateFile(*state_file)) {
+            master.Stop();
+            google::ShutdownGoogleLogging();
+            return 4;
+        }
+    }
+
+    for (;;) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+}
+
+class P2PPeerProcessStack {
+   public:
+    bool Start(const std::string& master_address, const std::string& host_name,
+               uint16_t rpc_port, const std::string& local_transfer_mode,
+               TransferDirectionMode transfer_direction_mode) {
+        auto config = ClientConfigBuilder::build_p2p_real_client(
+            host_name, "P2PHANDSHAKE", "tcp", std::nullopt, master_address,
+            R"({"tiers": [{"type": "DRAM", "capacity": 67108864, "priority": 100}]})",
+            /*local_buffer_size=*/0, nullptr, "", rpc_port);
+
+        config.enable_http_server = false;
+        config.http_port = 0;
+        config.async_sender_thread_count = 0;
+        config.local_transfer_mode = local_transfer_mode == "te"
+                                         ? LocalTransferMode::TE
+                                         : LocalTransferMode::MEMCPY;
+        config.transfer_direction_mode = transfer_direction_mode;
+
+        client_ = std::make_shared<P2PClientService>(
+            config.metadata_connstring, config.http_port,
+            config.enable_http_server, config.labels);
+        return client_->Init(config) == ErrorCode::OK;
+    }
+
+    void Stop() { client_.reset(); }
+
+   private:
+    std::shared_ptr<P2PClientService> client_;
+};
+
+inline int RunP2PPeerChildProcess(int argc, char** argv) {
+    google::InitGoogleLogging("P2PPeerChild");
+    FLAGS_logtostderr = 1;
+
+    auto master_address =
+        FindP2PArgValue(argc, argv, "--mooncake-master-address=");
+    auto host_name = FindP2PArgValue(argc, argv, "--mooncake-host-name=");
+    const int rpc_port =
+        std::stoi(FindP2PArgValue(argc, argv, "--mooncake-client-rpc-port=")
+                      .value_or("0"));
+    const std::string local_transfer_mode =
+        FindP2PArgValue(argc, argv, "--mooncake-local-transfer-mode=")
+            .value_or("te");
+    const std::string transfer_direction =
+        FindP2PArgValue(argc, argv, "--mooncake-transfer-direction-mode=")
+            .value_or("reverse");
+
+    if (!master_address.has_value() || !host_name.has_value() ||
+        rpc_port <= 0) {
+        google::ShutdownGoogleLogging();
+        return 2;
+    }
+
+    P2PPeerProcessStack peer;
+    const auto direction = transfer_direction == "forward"
+                               ? TransferDirectionMode::FORWARD
+                               : TransferDirectionMode::REVERSE;
+    if (!peer.Start(*master_address, *host_name,
+                    static_cast<uint16_t>(rpc_port), local_transfer_mode,
+                    direction)) {
+        google::ShutdownGoogleLogging();
+        return 3;
+    }
+
+    if (auto state_file =
+            FindP2PArgValue(argc, argv, "--mooncake-state-file=")) {
+        if (!WriteReadyStateFile(*state_file)) {
+            peer.Stop();
+            google::ShutdownGoogleLogging();
+            return 4;
+        }
+    }
+
+    for (;;) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+}
+
+inline std::optional<int> MaybeRunP2PClientIntegrationTestChildProcess(
+    int argc, char** argv) {
+    auto child_mode = FindP2PArgValue(argc, argv, "--mooncake-child-mode=");
+    if (!child_mode.has_value()) {
+        return std::nullopt;
+    }
+    if (*child_mode == "p2p-master") {
+        return RunP2PMasterChildProcess(argc, argv);
+    }
+    if (*child_mode == "p2p-peer") {
+        return RunP2PPeerChildProcess(argc, argv);
+    }
+    LOG(ERROR) << "Unknown child mode: " << *child_mode;
+    return 5;
+}
+
+class ScopedP2PMasterProcess {
+   public:
+    ~ScopedP2PMasterProcess() { Stop(); }
+
+    bool Start() {
+        Stop();
+        CleanupStateFile();
+
+        rpc_port_ = static_cast<uint16_t>(getFreeTcpPort());
+        state_file_path_ = MakeP2PTempStateFilePath("p2p_master_ready");
+        std::vector<std::string> args = {
+            "--mooncake-child-mode=p2p-master",
+            "--mooncake-master-rpc-port=" + std::to_string(rpc_port_),
+            "--mooncake-state-file=" + *state_file_path_};
+        if (!process_.Start(args)) {
+            CleanupStateFile();
+            return false;
+        }
+        if (!WaitForReadyStateFile(*state_file_path_)) {
+            process_.Stop();
+            CleanupStateFile();
+            return false;
+        }
+        return true;
+    }
+
+    void Stop() {
+        process_.Stop();
+        CleanupStateFile();
+    }
+
+    std::string master_address() const {
+        return "127.0.0.1:" + std::to_string(rpc_port_);
+    }
+
+   private:
+    void CleanupStateFile() {
+        if (!state_file_path_.has_value()) {
+            return;
+        }
+        std::error_code ec;
+        std::filesystem::remove(*state_file_path_, ec);
+        state_file_path_.reset();
+    }
+
+    P2PClientChildProcess process_;
+    uint16_t rpc_port_ = 0;
+    std::optional<std::string> state_file_path_;
+};
+
+// Remote peer child process. Must be started in SetUpTestSuite() (or
+// otherwise before the first CreateP2PClient()), never mid-test after Init().
+class ScopedP2PRemotePeerProcess {
+   public:
+    ~ScopedP2PRemotePeerProcess() { Stop(); }
+
+    bool Start(const std::string& master_address,
+               const std::string& local_transfer_mode = "te",
+               TransferDirectionMode transfer_direction_mode =
+                   TransferDirectionMode::REVERSE) {
+        Stop();
+        CleanupStateFile();
+
+        host_name_ = "localhost:" + std::to_string(getFreeTcpPort());
+        rpc_port_ = static_cast<uint16_t>(getFreeTcpPort());
+        state_file_path_ = MakeP2PTempStateFilePath("p2p_peer_ready");
+        std::vector<std::string> args = {
+            "--mooncake-child-mode=p2p-peer",
+            "--mooncake-master-address=" + master_address,
+            "--mooncake-host-name=" + host_name_,
+            "--mooncake-client-rpc-port=" + std::to_string(rpc_port_),
+            "--mooncake-local-transfer-mode=" + local_transfer_mode,
+            "--mooncake-transfer-direction-mode=" +
+                std::string(transfer_direction_mode ==
+                                    TransferDirectionMode::FORWARD
+                                ? "forward"
+                                : "reverse"),
+            "--mooncake-state-file=" + *state_file_path_};
+        if (!process_.Start(args)) {
+            CleanupStateFile();
+            return false;
+        }
+        if (!WaitForReadyStateFile(*state_file_path_)) {
+            process_.Stop();
+            CleanupStateFile();
+            return false;
+        }
+        return true;
+    }
+
+    void Stop() {
+        process_.Stop();
+        CleanupStateFile();
+    }
+
+    const std::string& host_name() const { return host_name_; }
+    uint16_t rpc_port() const { return rpc_port_; }
+    std::string rpc_endpoint() const {
+        return "127.0.0.1:" + std::to_string(rpc_port_);
+    }
+
+   private:
+    void CleanupStateFile() {
+        if (!state_file_path_.has_value()) {
+            return;
+        }
+        std::error_code ec;
+        std::filesystem::remove(*state_file_path_, ec);
+        state_file_path_.reset();
+    }
+
+    P2PClientChildProcess process_;
+    std::string host_name_;
+    uint16_t rpc_port_ = 0;
+    std::optional<std::string> state_file_path_;
+};
+
+}  // namespace mooncake::testing

--- a/mooncake-store/tests/peer_client_process_test_helper.h
+++ b/mooncake-store/tests/peer_client_process_test_helper.h
@@ -1,0 +1,618 @@
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+#include <async_simple/coro/SyncAwait.h>
+#include <glog/logging.h>
+#include <json/json.h>
+#include <ylt/coro_io/client_pool.hpp>
+#include <ylt/coro_rpc/coro_rpc_client.hpp>
+#include <ylt/coro_rpc/coro_rpc_server.hpp>
+
+#include "client_rpc_service.h"
+#include "data_manager.h"
+#include "tiered_cache/tiered_backend.h"
+#include "transfer_engine.h"
+#include "types.h"
+#include "utils.h"
+#include "utils/common.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace mooncake::testing {
+
+inline std::string& PeerClientTestBinaryPath() {
+    static std::string path;
+    return path;
+}
+
+inline void SetPeerClientTestBinaryPath(const char* argv0) {
+    if (!PeerClientTestBinaryPath().empty()) {
+        return;
+    }
+    std::error_code ec;
+    auto absolute = std::filesystem::absolute(argv0, ec);
+    PeerClientTestBinaryPath() = ec ? std::string(argv0) : absolute.string();
+}
+
+inline std::optional<std::string> FindArgValue(int argc, char** argv,
+                                               std::string_view prefix) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view arg(argv[i]);
+        if (arg.rfind(prefix, 0) == 0) {
+            return std::string(arg.substr(prefix.size()));
+        }
+    }
+    return std::nullopt;
+}
+
+inline bool ParseJsonString(const std::string& json_str, Json::Value& value) {
+    Json::CharReaderBuilder builder;
+    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
+    std::string errs;
+    return reader->parse(json_str.data(), json_str.data() + json_str.size(),
+                         &value, &errs);
+}
+
+class PeerClientTestControlRpcService {
+   public:
+    explicit PeerClientTestControlRpcService(DataManager& data_manager)
+        : data_manager_(data_manager) {}
+
+    tl::expected<void, ErrorCode> PutKey(const std::string& key,
+                                         const std::string& data) {
+        std::vector<Slice> slices{
+            {const_cast<char*>(data.data()), data.size()}};
+        auto put_result = data_manager_.Put(key, slices);
+        if (!put_result.has_value()) {
+            return tl::make_unexpected(put_result.error());
+        }
+        return put_result.value()->Wait();
+    }
+
+    tl::expected<void, ErrorCode> DeleteKey(const std::string& key) {
+        auto delete_result = data_manager_.Delete(key, /*tier_id=*/std::nullopt,
+                                                  /*notify_master=*/false);
+        if (!delete_result.has_value() &&
+            delete_result.error() != ErrorCode::OBJECT_NOT_FOUND) {
+            return tl::make_unexpected(delete_result.error());
+        }
+        return {};
+    }
+
+    tl::expected<bool, ErrorCode> KeyExists(const std::string& key) {
+        return data_manager_.Exist(key);
+    }
+
+   private:
+    DataManager& data_manager_;
+};
+
+inline void RegisterPeerClientTestControlRpcService(
+    coro_rpc::coro_rpc_server& server,
+    PeerClientTestControlRpcService& service) {
+    server.register_handler<&PeerClientTestControlRpcService::PutKey>(&service);
+    server.register_handler<&PeerClientTestControlRpcService::DeleteKey>(
+        &service);
+    server.register_handler<&PeerClientTestControlRpcService::KeyExists>(
+        &service);
+}
+
+class PeerClientTestControlClient {
+   public:
+    tl::expected<void, ErrorCode> Connect(const std::string& endpoint) {
+        endpoint_ = endpoint;
+        coro_io::client_pool<coro_rpc::coro_rpc_client>::pool_config
+            pool_conf{};
+        const char* value = std::getenv("MC_RPC_PROTOCOL");
+        if (value && std::string_view(value) == "rdma") {
+            pool_conf.client_config.socket_config =
+                coro_io::ib_socket_t::config_t{};
+        }
+
+        client_pools_ =
+            std::make_shared<coro_io::client_pools<coro_rpc::coro_rpc_client>>(
+                pool_conf);
+        client_pool_ = client_pools_->at(endpoint);
+        return {};
+    }
+
+    void Reset() {
+        client_pool_.reset();
+        client_pools_.reset();
+        endpoint_.clear();
+    }
+
+    async_simple::coro::Lazy<tl::expected<void, ErrorCode>> PutKey(
+        const std::string& key, const std::string& data) {
+        if (!client_pool_) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto ret = co_await client_pool_->send_request(
+            [&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client& client) {
+                return client
+                    .send_request<&PeerClientTestControlRpcService::PutKey>(
+                        key, data);
+            });
+        if (!ret.has_value()) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto rpc_result = co_await ret.value();
+        if (!rpc_result) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+        co_return rpc_result->result();
+    }
+
+    async_simple::coro::Lazy<tl::expected<void, ErrorCode>> DeleteKey(
+        const std::string& key) {
+        if (!client_pool_) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto ret = co_await client_pool_->send_request(
+            [&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client& client) {
+                return client
+                    .send_request<&PeerClientTestControlRpcService::DeleteKey>(
+                        key);
+            });
+        if (!ret.has_value()) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto rpc_result = co_await ret.value();
+        if (!rpc_result) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+        co_return rpc_result->result();
+    }
+
+    async_simple::coro::Lazy<tl::expected<bool, ErrorCode>> KeyExists(
+        const std::string& key) {
+        if (!client_pool_) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto ret = co_await client_pool_->send_request(
+            [&](coro_io::client_reuse_hint, coro_rpc::coro_rpc_client& client) {
+                return client.send_request<
+                    &PeerClientTestControlRpcService::KeyExists>(key);
+            });
+        if (!ret.has_value()) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+
+        auto rpc_result = co_await ret.value();
+        if (!rpc_result) {
+            co_return tl::make_unexpected(ErrorCode::RPC_FAIL);
+        }
+        co_return rpc_result->result();
+    }
+
+   private:
+    std::shared_ptr<coro_io::client_pools<coro_rpc::coro_rpc_client>>
+        client_pools_;
+    std::shared_ptr<coro_io::client_pool<coro_rpc::coro_rpc_client>>
+        client_pool_;
+    std::string endpoint_;
+};
+
+class PeerClientRpcServerStack {
+   public:
+    ~PeerClientRpcServerStack() { Stop(); }
+
+    bool Start(uint16_t port) {
+        port_ = port;
+        transfer_engine_ = std::make_shared<TransferEngine>(false);
+
+        const std::string json_config_str = R"({
+            "tiers": [
+                {
+                    "type": "DRAM",
+                    "capacity": 1073741824,
+                    "priority": 10,
+                    "tags": ["fast", "local"],
+                    "allocator_type": "OFFSET"
+                }
+            ]
+        })";
+        Json::Value config;
+        if (!ParseJsonString(json_config_str, config)) {
+            return false;
+        }
+
+        auto tiered_backend = std::make_unique<TieredBackend>();
+        auto init_result = InitTieredBackendForTest(*tiered_backend, config);
+        if (!init_result.has_value()) {
+            return false;
+        }
+
+        LocalTransferConfig local_transfer_config;
+        local_transfer_config.mode = LocalTransferMode::MEMCPY;
+        local_transfer_config.local_memcpy_async_worker_num = 32;
+        data_manager_ = std::make_unique<DataManager>(
+            std::move(tiered_backend), transfer_engine_,
+            /*lock_shard_count=*/1024, local_transfer_config);
+        rpc_service_ = std::make_unique<ClientRpcService>(*data_manager_);
+        control_service_ =
+            std::make_unique<PeerClientTestControlRpcService>(*data_manager_);
+
+        server_ = std::make_unique<coro_rpc::coro_rpc_server>(
+            /*thread_num=*/1, port_);
+        RegisterClientRpcService(*server_, *rpc_service_);
+        RegisterPeerClientTestControlRpcService(*server_, *control_service_);
+
+        server_thread_ = std::thread([this]() {
+            auto ec = server_->start();
+            if (ec) {
+                LOG(ERROR) << "RPC server start failed: " << ec.message();
+            }
+        });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        return true;
+    }
+
+    bool Put(std::string_view key, std::string_view data) {
+        if (!data_manager_) {
+            return false;
+        }
+        std::vector<Slice> slices{
+            {const_cast<char*>(data.data()), data.size()}};
+        auto put_result = data_manager_->Put(key, slices);
+        if (!put_result.has_value()) {
+            return false;
+        }
+        return put_result.value()->Wait().has_value();
+    }
+
+    std::optional<UUID> GetFirstTierId() const {
+        if (!data_manager_) {
+            return std::nullopt;
+        }
+        auto tier_views = data_manager_->GetTierViews();
+        if (tier_views.empty()) {
+            return std::nullopt;
+        }
+        return tier_views[0].id;
+    }
+
+    bool WriteStateFile(const std::string& path) const {
+        auto tier_id = GetFirstTierId();
+        if (!tier_id.has_value()) {
+            return false;
+        }
+        std::ofstream out(path, std::ios::trunc);
+        if (!out) {
+            return false;
+        }
+        out << tier_id->first << "," << tier_id->second;
+        return true;
+    }
+
+    void Stop() {
+        if (server_) {
+            server_->stop();
+        }
+        if (server_thread_.joinable()) {
+            server_thread_.join();
+        }
+        server_.reset();
+        control_service_.reset();
+        rpc_service_.reset();
+        data_manager_.reset();
+        transfer_engine_.reset();
+    }
+
+   private:
+    uint16_t port_ = 0;
+    std::shared_ptr<TransferEngine> transfer_engine_;
+    std::unique_ptr<DataManager> data_manager_;
+    std::unique_ptr<ClientRpcService> rpc_service_;
+    std::unique_ptr<PeerClientTestControlRpcService> control_service_;
+    std::unique_ptr<coro_rpc::coro_rpc_server> server_;
+    std::thread server_thread_;
+};
+
+inline std::optional<UUID> ReadTierIdFromStateFile(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) {
+        return std::nullopt;
+    }
+    std::string line;
+    std::getline(in, line);
+    const auto comma = line.find(',');
+    if (comma == std::string::npos) {
+        return std::nullopt;
+    }
+    try {
+        UUID tier_id;
+        tier_id.first = std::stoull(line.substr(0, comma));
+        tier_id.second = std::stoull(line.substr(comma + 1));
+        return tier_id;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+inline bool WaitForStateFile(
+    const std::string& path,
+    std::chrono::milliseconds timeout = std::chrono::milliseconds(3000)) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (ReadTierIdFromStateFile(path).has_value()) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    return false;
+}
+
+inline std::string MakeTempStateFilePath() {
+#ifdef _WIN32
+    const auto pid = static_cast<unsigned long>(GetCurrentProcessId());
+#else
+    const auto pid = static_cast<unsigned long>(getpid());
+#endif
+    return (std::filesystem::temp_directory_path() /
+            ("peer_client_test_state_" + std::to_string(pid) + "_" +
+             std::to_string(getFreeTcpPort()) + ".txt"))
+        .string();
+}
+
+inline int RunRpcServerChildProcess(int argc, char** argv) {
+    google::InitGoogleLogging("PeerClientRpcServerChild");
+    FLAGS_logtostderr = 1;
+
+    const int rpc_port = std::stoi(
+        FindArgValue(argc, argv, "--mooncake-rpc-port=").value_or("0"));
+    if (rpc_port <= 0) {
+        google::ShutdownGoogleLogging();
+        return 2;
+    }
+
+    PeerClientRpcServerStack stack;
+    if (!stack.Start(static_cast<uint16_t>(rpc_port))) {
+        google::ShutdownGoogleLogging();
+        return 3;
+    }
+
+    if (auto pre_put_key =
+            FindArgValue(argc, argv, "--mooncake-pre-put-key=")) {
+        const std::string pre_put_data =
+            FindArgValue(argc, argv, "--mooncake-pre-put-data=").value_or("");
+        if (!stack.Put(*pre_put_key, pre_put_data)) {
+            stack.Stop();
+            google::ShutdownGoogleLogging();
+            return 4;
+        }
+    }
+
+    if (auto state_file = FindArgValue(argc, argv, "--mooncake-state-file=")) {
+        if (!stack.WriteStateFile(*state_file)) {
+            stack.Stop();
+            google::ShutdownGoogleLogging();
+            return 5;
+        }
+    }
+
+    LOG(INFO) << "PeerClient RPC server child ready on port " << rpc_port;
+    for (;;) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    }
+}
+
+inline std::optional<int> MaybeRunPeerClientTestChildProcess(int argc,
+                                                             char** argv) {
+    auto child_mode = FindArgValue(argc, argv, "--mooncake-child-mode=");
+    if (!child_mode.has_value()) {
+        return std::nullopt;
+    }
+    if (*child_mode == "rpc-server") {
+        return RunRpcServerChildProcess(argc, argv);
+    }
+    LOG(ERROR) << "Unknown child mode: " << *child_mode;
+    return 5;
+}
+
+class PeerClientTestChildProcess {
+   public:
+    PeerClientTestChildProcess() = default;
+    PeerClientTestChildProcess(const PeerClientTestChildProcess&) = delete;
+    PeerClientTestChildProcess& operator=(const PeerClientTestChildProcess&) =
+        delete;
+    ~PeerClientTestChildProcess() { Stop(); }
+
+    bool Start(const std::vector<std::string>& args) {
+        Stop();
+
+        if (PeerClientTestBinaryPath().empty()) {
+            LOG(ERROR) << "Peer client test binary path is empty";
+            return false;
+        }
+
+#ifdef _WIN32
+        std::string command_line = QuoteArg(PeerClientTestBinaryPath());
+        for (const auto& arg : args) {
+            command_line += " ";
+            command_line += QuoteArg(arg);
+        }
+
+        STARTUPINFOA si;
+        ZeroMemory(&si, sizeof(si));
+        si.cb = sizeof(si);
+        ZeroMemory(&process_info_, sizeof(process_info_));
+
+        std::vector<char> command_buffer(command_line.begin(),
+                                         command_line.end());
+        command_buffer.push_back('\0');
+        if (!CreateProcessA(PeerClientTestBinaryPath().c_str(),
+                            command_buffer.data(), nullptr, nullptr, FALSE, 0,
+                            nullptr, nullptr, &si, &process_info_)) {
+            LOG(ERROR) << "CreateProcess failed, err=" << GetLastError();
+            ZeroMemory(&process_info_, sizeof(process_info_));
+            return false;
+        }
+        owns_process_ = true;
+        return true;
+#else
+        std::vector<char*> argv_ptrs;
+        argv_ptrs.reserve(args.size() + 2);
+        argv_ptrs.push_back(
+            const_cast<char*>(PeerClientTestBinaryPath().c_str()));
+        for (const auto& arg : args) {
+            argv_ptrs.push_back(const_cast<char*>(arg.c_str()));
+        }
+        argv_ptrs.push_back(nullptr);
+
+        pid_ = fork();
+        if (pid_ < 0) {
+            pid_ = -1;
+            return false;
+        }
+        if (pid_ == 0) {
+            execv(PeerClientTestBinaryPath().c_str(), argv_ptrs.data());
+            std::_Exit(127);
+        }
+        owns_process_ = true;
+        return true;
+#endif
+    }
+
+    void Stop() {
+        if (!owns_process_) {
+            return;
+        }
+#ifdef _WIN32
+        if (process_info_.hProcess != nullptr) {
+            TerminateProcess(process_info_.hProcess, 0);
+            WaitForSingleObject(process_info_.hProcess, 5000);
+            CloseHandle(process_info_.hThread);
+            CloseHandle(process_info_.hProcess);
+            ZeroMemory(&process_info_, sizeof(process_info_));
+        }
+#else
+        if (pid_ > 0) {
+            kill(pid_, SIGKILL);
+            int status = 0;
+            waitpid(pid_, &status, 0);
+            pid_ = -1;
+        }
+#endif
+        owns_process_ = false;
+    }
+
+   private:
+#ifdef _WIN32
+    static std::string QuoteArg(const std::string& arg) {
+        if (arg.find(' ') == std::string::npos &&
+            arg.find('"') == std::string::npos) {
+            return arg;
+        }
+        std::string out = "\"";
+        for (char ch : arg) {
+            if (ch == '"') {
+                out += '\\';
+            }
+            out += ch;
+        }
+        out += "\"";
+        return out;
+    }
+
+    PROCESS_INFORMATION process_info_{};
+#else
+    pid_t pid_ = -1;
+#endif
+    bool owns_process_ = false;
+};
+
+class ScopedPeerClientRpcServerProcess {
+   public:
+    bool Start(const std::optional<std::string>& pre_put_key = std::nullopt,
+               const std::optional<std::string>& pre_put_data = std::nullopt,
+               const std::optional<std::string>& state_file = std::nullopt) {
+        control_client_.Reset();
+        port_ = static_cast<uint16_t>(getFreeTcpPort());
+        std::vector<std::string> args = {
+            "--mooncake-child-mode=rpc-server",
+            "--mooncake-rpc-port=" + std::to_string(port_)};
+        if (pre_put_key.has_value()) {
+            args.push_back("--mooncake-pre-put-key=" + *pre_put_key);
+            args.push_back("--mooncake-pre-put-data=" +
+                           pre_put_data.value_or(""));
+        }
+        if (state_file.has_value()) {
+            args.push_back("--mooncake-state-file=" + *state_file);
+        }
+        if (!process_.Start(args)) {
+            return false;
+        }
+        if (state_file.has_value()) {
+            if (!WaitForStateFile(*state_file)) {
+                process_.Stop();
+                return false;
+            }
+        } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        }
+        auto connect_result = control_client_.Connect(endpoint());
+        if (!connect_result.has_value()) {
+            process_.Stop();
+            control_client_.Reset();
+            return false;
+        }
+        return true;
+    }
+
+    void Stop() {
+        control_client_.Reset();
+        process_.Stop();
+    }
+
+    async_simple::coro::Lazy<tl::expected<void, ErrorCode>> PutKey(
+        const std::string& key, const std::string& data) {
+        co_return co_await control_client_.PutKey(key, data);
+    }
+
+    async_simple::coro::Lazy<tl::expected<void, ErrorCode>> DeleteKey(
+        const std::string& key) {
+        co_return co_await control_client_.DeleteKey(key);
+    }
+
+    async_simple::coro::Lazy<tl::expected<bool, ErrorCode>> KeyExists(
+        const std::string& key) {
+        co_return co_await control_client_.KeyExists(key);
+    }
+
+    uint16_t port() const { return port_; }
+    std::string endpoint() const {
+        return "127.0.0.1:" + std::to_string(port_);
+    }
+
+   private:
+    PeerClientTestChildProcess process_;
+    PeerClientTestControlClient control_client_;
+    uint16_t port_ = 0;
+};
+
+}  // namespace mooncake::testing

--- a/mooncake-store/tests/peer_client_test.cpp
+++ b/mooncake-store/tests/peer_client_test.cpp
@@ -1,7 +1,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
-#include <json/json.h>
 #include <csignal>
+#include <filesystem>
 #include <future>
 #include <memory>
 #include <mutex>
@@ -12,37 +12,16 @@
 
 #include <async_simple/coro/Lazy.h>
 #include <async_simple/coro/SyncAwait.h>
-#include <ylt/coro_rpc/coro_rpc_server.hpp>
-
-#include "client_rpc_service.h"
 #include "client_rpc_types.h"
-#include "data_manager.h"
 #include "peer_client.h"
-#include "tiered_cache/tiered_backend.h"
-#include "utils/common.h"
-#include "transfer_engine.h"
+#include "peer_client_process_test_helper.h"
 #include "types.h"
 
 namespace mooncake {
 
-// Helper function to parse JSON string
-static bool parseJsonString(const std::string& json_str, Json::Value& value,
-                            std::string* error_msg = nullptr) {
-    Json::CharReaderBuilder builder;
-    std::unique_ptr<Json::CharReader> reader(builder.newCharReader());
-    std::string errs;
-
-    bool success = reader->parse(
-        json_str.data(), json_str.data() + json_str.size(), &value, &errs);
-    if (!success && error_msg) {
-        *error_msg = errs;
-    }
-    return success;
-}
-
 // Test fixture for PeerClient tests.
-// Sets up a coro_rpc_server with ClientRpcService registered,
-// and a PeerClient connected to the server.
+// The PeerClient lives in the GTest parent process. ClientRpcService,
+// DataManager, TieredBackend and the RPC server live in a child process.
 //
 // Error propagation: PeerClient forwards server-side error codes
 // (INVALID_PARAMS, INTERNAL_ERROR, INVALID_KEY) transparently.
@@ -50,105 +29,53 @@ static bool parseJsonString(const std::string& json_str, Json::Value& value,
 // (e.g., client not connected).
 class PeerClientTest : public ::testing::Test {
    protected:
-    static constexpr uint16_t kTestPort = 50051;
-
-    void SetUp() override {
+    static void SetUpTestSuite() {
         google::InitGoogleLogging("PeerClientTest");
         FLAGS_logtostderr = 1;
 
-        // Create a minimal TransferEngine
-        transfer_engine_ = std::make_shared<TransferEngine>(false);
-
-        // Create TieredBackend with DRAM tier configuration
-        std::string json_config_str = R"({
-            "tiers": [
-                {
-                    "type": "DRAM",
-                    "capacity": 1073741824,
-                    "priority": 10,
-                    "tags": ["fast", "local"],
-                    "allocator_type": "OFFSET"
-                }
-            ]
-        })";
-        Json::Value config;
-        ASSERT_TRUE(parseJsonString(json_config_str, config));
-
-        tiered_backend_ = std::make_unique<TieredBackend>();
-        auto init_result = InitTieredBackendForTest(*tiered_backend_, config);
-        ASSERT_TRUE(init_result.has_value())
-            << "Failed to initialize TieredBackend: " << init_result.error();
-
-        // Verify tier was created successfully
-        auto tier_views = tiered_backend_->GetTierViews();
-        ASSERT_EQ(tier_views.size(), 1)
-            << "Expected 1 tier, got " << tier_views.size();
-        saved_tier_id_ = tier_views[0].id;
-
-        // Create DataManager (MEMCPY mode: no TE endpoint available in unit
-        // tests)
-        LocalTransferConfig local_transfer_config;
-        local_transfer_config.mode = LocalTransferMode::MEMCPY;
-        local_transfer_config.local_memcpy_async_worker_num = 32;
-        data_manager_ = std::make_unique<DataManager>(
-            std::move(tiered_backend_), transfer_engine_,
-            /*lock_shard_count=*/1024, local_transfer_config);
-
-        // Create ClientRpcService
-        rpc_service_ = std::make_unique<ClientRpcService>(*data_manager_);
-
-        // Start coro_rpc_server
-        server_ = std::make_unique<coro_rpc::coro_rpc_server>(
-            /*thread_num=*/1, kTestPort);
-        RegisterClientRpcService(*server_, *rpc_service_);
-
-        server_thread_ = std::thread([this]() {
-            auto ec = server_->start();
-            if (ec) {
-                LOG(ERROR) << "Server start failed: " << ec.message();
-            }
-        });
-
-        // Wait for server to be ready
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-        // Create and connect PeerClient
-        peer_client_ = std::make_unique<PeerClient>();
-        std::string endpoint = "127.0.0.1:" + std::to_string(kTestPort);
-        auto connect_result = peer_client_->Connect(endpoint);
-        ASSERT_TRUE(connect_result.has_value()) << "PeerClient::Connect failed";
+        state_file_path_ = testing::MakeTempStateFilePath();
+        ASSERT_TRUE(
+            server_process_.Start(std::nullopt, std::nullopt, state_file_path_))
+            << "Failed to start PeerClient RPC server child process";
+        tier_id_ = testing::ReadTierIdFromStateFile(*state_file_path_);
+        ASSERT_TRUE(tier_id_.has_value())
+            << "Failed to read the child process tier id";
     }
 
-    void TearDown() override {
-        peer_client_.reset();
-        if (server_) {
-            server_->stop();
+    static void TearDownTestSuite() {
+        server_process_.Stop();
+        if (state_file_path_) {
+            std::error_code ec;
+            std::filesystem::remove(*state_file_path_, ec);
+            state_file_path_.reset();
         }
-        if (server_thread_.joinable()) {
-            server_thread_.join();
-        }
-        server_.reset();
-        rpc_service_.reset();
-        data_manager_.reset();
-        tiered_backend_.reset();
-        transfer_engine_.reset();
         google::ShutdownGoogleLogging();
     }
 
-    // Helper: Get tier ID from backend
-    std::optional<UUID> GetTierId() {
-        if (saved_tier_id_.has_value()) {
-            return saved_tier_id_;
-        }
-        return std::nullopt;
+    void SetUp() override {
+        peer_client_ = std::make_unique<PeerClient>();
+        auto connect_result = peer_client_->Connect(server_process_.endpoint());
+        ASSERT_TRUE(connect_result.has_value()) << "PeerClient::Connect failed";
     }
 
-    // Helper: Create test data buffer
-    std::unique_ptr<char[]> StringToBuffer(const std::string& str) {
-        auto buffer = std::make_unique<char[]>(str.size());
-        std::memcpy(buffer.get(), str.data(), str.size());
-        return buffer;
+    void TearDown() override { peer_client_.reset(); }
+
+    void PutRemoteKey(const std::string& key, const std::string& data) {
+        auto result =
+            async_simple::coro::syncAwait(server_process_.PutKey(key, data));
+        ASSERT_TRUE(result.has_value())
+            << "Failed to seed key in child process: " << key;
     }
+
+    bool RemoteKeyExists(const std::string& key) {
+        auto result =
+            async_simple::coro::syncAwait(server_process_.KeyExists(key));
+        EXPECT_TRUE(result.has_value())
+            << "Failed to query key in child process: " << key;
+        return result.has_value() && result.value();
+    }
+
+    std::optional<UUID> GetTierId() const { return tier_id_; }
 
     // Helper: Create a valid RemoteBufferDesc
     RemoteBufferDesc CreateBufferDesc(const std::string& segment_endpoint,
@@ -160,15 +87,15 @@ class PeerClientTest : public ::testing::Test {
         return desc;
     }
 
-    std::unique_ptr<DataManager> data_manager_;
-    std::unique_ptr<TieredBackend> tiered_backend_;
-    std::shared_ptr<TransferEngine> transfer_engine_;
-    std::unique_ptr<ClientRpcService> rpc_service_;
-    std::unique_ptr<coro_rpc::coro_rpc_server> server_;
-    std::thread server_thread_;
     std::unique_ptr<PeerClient> peer_client_;
-    std::optional<UUID> saved_tier_id_;
+    static testing::ScopedPeerClientRpcServerProcess server_process_;
+    static std::optional<std::string> state_file_path_;
+    static std::optional<UUID> tier_id_;
 };
+
+testing::ScopedPeerClientRpcServerProcess PeerClientTest::server_process_;
+std::optional<std::string> PeerClientTest::state_file_path_;
+std::optional<UUID> PeerClientTest::tier_id_;
 
 // ============================================================================
 // Connect Tests
@@ -253,14 +180,10 @@ TEST_F(PeerClientTest, AsyncReadRemoteDataInvalidBufferNullAddr) {
 }
 
 TEST_F(PeerClientTest, AsyncReadRemoteDataWithExistingKey) {
-    // First, put some data via DataManager
+    // Seed the DataManager owned by the RPC-server child through test-only RPC.
     const std::string key = "async_read_key";
     const std::string test_data = "Hello, Async!";
-    auto buffer = StringToBuffer(test_data);
-    std::vector<Slice> put_slices{{buffer.get(), test_data.size()}};
-    auto put_result = data_manager_->Put(key, put_slices);
-    ASSERT_TRUE(put_result.has_value()) << "Put failed";
-    put_result.value()->Wait();
+    PutRemoteKey(key, test_data);
 
     // Create read request
     RemoteReadRequest request;
@@ -303,11 +226,7 @@ TEST_F(PeerClientTest, AsyncPinKeyKeyNotFound) {
 TEST_F(PeerClientTest, AsyncPinKeyAfterPut) {
     const std::string key = "peer_async_pin_after_put";
     const std::string blob = "payload";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value()) << "Put failed";
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest req;
     req.key = key;
@@ -335,11 +254,7 @@ TEST_F(PeerClientTest, AsyncPinKeyAfterPut) {
 TEST_F(PeerClientTest, AsyncPinKeyTwiceSameTokenThenUnpinTwice) {
     const std::string key = "peer_async_pin_twice_ref";
     const std::string blob = "ref";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -375,11 +290,7 @@ TEST_F(PeerClientTest, AsyncPinKeyTwiceSameTokenThenUnpinTwice) {
 TEST_F(PeerClientTest, ConcurrentAsyncPinKeySameKey) {
     const std::string key = "peer_concurrent_async_pin";
     const std::string blob = "concurrent_pin_data";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -426,11 +337,7 @@ TEST_F(PeerClientTest, ConcurrentAsyncPinKeySameKey) {
 TEST_F(PeerClientTest, AsyncPinKeyAfterUnpinNewToken) {
     const std::string key = "peer_async_pin_new_token_after_unpin";
     const std::string blob = "tok";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -492,11 +399,7 @@ TEST_F(PeerClientTest, AsyncUnPinKeyZeroToken) {
 TEST_F(PeerClientTest, AsyncUnPinKeyWrongTokenAfterPin) {
     const std::string key = "peer_async_unpin_wrong_token";
     const std::string blob = "x";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -664,11 +567,7 @@ TEST_F(PeerClientTest, AsyncPreWriteValidRequest) {
 TEST_F(PeerClientTest, AsyncPreWriteWhenObjectAlreadyExists) {
     const std::string key = "peer_async_pre_key_exists";
     const std::string blob = "existing";
-    auto buffer = StringToBuffer(blob);
-    std::vector<Slice> put_slices{{buffer.get(), blob.size()}};
-    auto put_result = data_manager_->Put(key, put_slices);
-    ASSERT_TRUE(put_result.has_value()) << "Put failed";
-    put_result.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PreWriteRequest pre;
     pre.key = key;
@@ -764,7 +663,7 @@ TEST_F(PeerClientTest, AsyncWriteCommitAfterPreWrite) {
     ASSERT_TRUE(commit_res.has_value())
         << "AsyncWriteCommit failed: " << static_cast<int>(commit_res.error());
 
-    EXPECT_TRUE(data_manager_->Exist(key))
+    EXPECT_TRUE(RemoteKeyExists(key))
         << "Key should exist on owner after WriteCommit";
 }
 
@@ -927,14 +826,10 @@ TEST_F(PeerClientTest, SyncReadRemoteDataEmptyBuffers) {
 }
 
 TEST_F(PeerClientTest, SyncReadRemoteDataWithExistingKey) {
-    // Put data first
+    // Put data in the server child first.
     const std::string key = "sync_read_key";
     const std::string test_data = "Hello, Sync Read!";
-    auto buffer = StringToBuffer(test_data);
-    std::vector<Slice> put_slices{{buffer.get(), test_data.size()}};
-    auto put_result = data_manager_->Put(key, put_slices);
-    ASSERT_TRUE(put_result.has_value()) << "Put failed";
-    put_result.value()->Wait();
+    PutRemoteKey(key, test_data);
 
     RemoteReadRequest request;
     request.key = key;
@@ -965,11 +860,7 @@ TEST_F(PeerClientTest, SyncPinKeyEmptyKey) {
 TEST_F(PeerClientTest, SyncPinKeyAfterPut) {
     const std::string key = "peer_sync_pin_after_put";
     const std::string blob = "sync-payload";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest req;
     req.key = key;
@@ -993,11 +884,7 @@ TEST_F(PeerClientTest, SyncPinKeyAfterPut) {
 TEST_F(PeerClientTest, SyncPinKeyTwiceSameTokenThenUnpinTwice) {
     const std::string key = "peer_sync_pin_twice_ref";
     const std::string blob = "ref";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -1029,11 +916,7 @@ TEST_F(PeerClientTest, SyncPinKeyTwiceSameTokenThenUnpinTwice) {
 TEST_F(PeerClientTest, SyncPinKeyAfterUnpinNewToken) {
     const std::string key = "peer_sync_pin_new_token_after_unpin";
     const std::string blob = "tok";
-    auto buf = StringToBuffer(blob);
-    std::vector<Slice> slices{{buf.get(), blob.size()}};
-    auto put = data_manager_->Put(key, slices);
-    ASSERT_TRUE(put.has_value());
-    put.value()->Wait();
+    PutRemoteKey(key, blob);
 
     PinKeyRequest pin_req;
     pin_req.key = key;
@@ -1160,7 +1043,7 @@ TEST_F(PeerClientTest, SyncWriteCommitAfterPreWrite) {
     ASSERT_TRUE(commit_res.has_value())
         << "WriteCommit failed: " << static_cast<int>(commit_res.error());
 
-    EXPECT_TRUE(data_manager_->Exist(key))
+    EXPECT_TRUE(RemoteKeyExists(key))
         << "Key should exist on owner after WriteCommit";
 }
 
@@ -1401,3 +1284,15 @@ TEST_F(PeerClientTest, SyncWriteRevokeWithoutConnect) {
 }
 
 }  // namespace mooncake
+
+int main(int argc, char** argv) {
+    mooncake::testing::SetPeerClientTestBinaryPath(argv[0]);
+    if (auto child_exit =
+            mooncake::testing::MaybeRunPeerClientTestChildProcess(argc, argv);
+        child_exit.has_value()) {
+        return *child_exit;
+    }
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- run `peer_client_test` with `PeerClient` and the RPC server in separate processes
- add cross-process remote Put/Get and BatchPut/BatchGet coverage for `P2PClientService`
- add child-process lifecycle and readiness helpers
- provide custom test mains for process child modes

## Motivation

The existing tests exercised local and remote clients inside a single process. This change adds process-level isolation so peer RPC and cross-node data paths are tested more closely to the actual deployment model.

## Testing

- `git diff --check` passed
- Build and runtime tests were not executed locally because the current environment does not provide CMake or a C++ toolchain