### PR TITLE
[Bugfix][Integration] Reject unsupported allocator protocols

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -50,11 +50,11 @@ static void (*freeMemory)(void*) = nullptr;
 static std::string g_protocol;
 
 //  Handle allocateMemory function pointer based on protocol
-void initMemoryAllocator(const char* protocol) {
+bool initMemoryAllocator(const char* protocol) {
     if (allocateMemory != nullptr) {
         LOG(WARNING) << "Memory allocator already initialized with: "
                      << g_protocol;
-        return;
+        return true;
     }
     g_protocol = protocol;
     if (strcmp(protocol, "nvlink") == 0) {
@@ -68,6 +68,7 @@ void initMemoryAllocator(const char* protocol) {
         LOG(INFO) << "Selected MNNVL (NVLink) memory allocator";
 #else
         LOG(ERROR) << "Protocol 'nvlink' requires -DUSE_MNNVL=ON";
+        return false;
 #endif
     } else if (strcmp(protocol, "hip") == 0) {
 #ifdef USE_HIP
@@ -80,6 +81,7 @@ void initMemoryAllocator(const char* protocol) {
         LOG(INFO) << "Selected HIP memory allocator";
 #else
         LOG(ERROR) << "Protocol 'hip' requires -DUSE_HIP=ON";
+        return false;
 #endif
     } else if (strcmp(protocol, "nvlink_intra") == 0) {
 #ifdef USE_INTRA_NVLINK
@@ -93,12 +95,14 @@ void initMemoryAllocator(const char* protocol) {
         LOG(INFO) << "Selected Intra-NVLink memory allocator";
 #else
         LOG(ERROR) << "Protocol 'nvlink_intra' requires -DUSE_INTRA_NVLINK=ON";
+        return false;
 #endif
     } else {
         allocateMemory = malloc;
         freeMemory = free;
         LOG(WARNING) << "Using default malloc/free for protocol: " << protocol;
     }
+    return true;
 }
 
 TransferEnginePy::TransferEnginePy() {
@@ -169,7 +173,7 @@ int TransferEnginePy::initialize(const char* local_hostname,
                                  const char* metadata_server,
                                  const char* protocol,
                                  const char* device_name) {
-    initMemoryAllocator(protocol);
+    if (!initMemoryAllocator(protocol)) return -1;
 
     auto conn_string = parseConnectionString(metadata_server);
     return initializeExt(local_hostname, conn_string.second.c_str(), protocol,

--- a/mooncake-wheel/tests/test_transfer_engine_protocol.py
+++ b/mooncake-wheel/tests/test_transfer_engine_protocol.py
@@ -1,0 +1,25 @@
+import socket
+
+import pytest
+
+from mooncake import engine
+
+
+@pytest.mark.parametrize(
+    ("protocol", "is_supported"),
+    (
+        ("nvlink", engine.SUPPORT_MNNVL),
+        ("hip", engine.SUPPORT_HIP),
+        ("nvlink_intra", engine.SUPPORT_INTRA_NVLINK),
+    ),
+)
+def test_initialize_rejects_unsupported_protocol(protocol, is_supported):
+    if is_supported:
+        pytest.skip(f"{protocol} is available in this build")
+
+    transfer_engine = engine.TransferEngine()
+
+    assert (
+        transfer_engine.initialize(socket.gethostname(), "P2PHANDSHAKE", protocol, "")
+        == -1
+    )


### PR DESCRIPTION
## Description

`TransferEngine.initialize()` previously logged an error when `nvlink`, `hip`,
or `nvlink_intra` was requested without the corresponding compile-time support,
but continued initializing the engine. On hosts with RDMA devices this could
silently install RDMA and return success even though the requested protocol was
unavailable.

This change makes memory allocator initialization report failure and propagates
`-1` before topology discovery. A parameterized wheel test covers each optional
protocol and skips only the protocols supported by the current build.

Duplicate check: searches for `unsupported protocol initialize fallback`,
`unsupported nvlink initialize`, and `USE_MNNVL initialize` found no open issue
or PR implementing this behavior.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The bug was reproduced on an 8x NVIDIA B300 host with a CUDA build configured
with `USE_MNNVL=OFF`. Before the fix, all three unsupported protocol cases
returned `0` and the NVLink case proceeded to RDMA topology discovery. After
the fix, all three return `-1` before transport discovery.

The same host was also used to start vLLM with MooncakeConnector and
`mooncake_protocol=nvlink`. The patched engine now surfaces
`Mooncake Transfer Engine initialization failed` instead of silently installing
RDMA.

**Test commands:**
```bash
cmake -S . -B build -G Ninja \
  -DUSE_CUDA=ON -DUSE_MNNVL=OFF -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF -DWITH_EP=OFF \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_EXAMPLES=OFF \
  -DCMAKE_BUILD_TYPE=Release
cmake --build build --target engine -j 16
python -m pytest -q mooncake-wheel/tests/test_transfer_engine_protocol.py
pre-commit run --files \
  mooncake-integration/transfer_engine/transfer_engine_py.cpp \
  mooncake-wheel/tests/test_transfer_engine_protocol.py
```

**Test results:**
- [x] Unit tests pass (`3 passed`)
- [x] Integration tests pass (vLLM startup fails closed for unsupported NVLink)
- [x] Manual testing done (B300 CUDA build without MNNVL)

No model evaluation is required because this change only affects initialization
failure handling and does not change model outputs.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable; documented build requirements are unchanged)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 35-line diff)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with root-cause analysis, implementation, test authoring,
and command execution. The human submitter must review every changed line and
be able to explain and defend the change before marking this PR ready for review.