### PR TITLE
[TENT]Add bounded timeout for TENT TCP data RPC

### DIFF
--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -81,7 +81,7 @@
             "retry_base_delay_ms": 100,
             "retry_max_delay_ms": 2000,
             "max_concurrent_tasks": 16,
-            "data_rpc_timeout_ms": 5000
+            "data_rpc_timeout_ms": 30000
         },
         "gds": {
             "enable" : true

--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -80,7 +80,8 @@
             "max_retry_count": 3,
             "retry_base_delay_ms": 100,
             "retry_max_delay_ms": 2000,
-            "max_concurrent_tasks": 16
+            "max_concurrent_tasks": 16,
+            "data_rpc_timeout_ms": 5000
         },
         "gds": {
             "enable" : true

--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -16,10 +16,12 @@
 #define TENT_YLT_RPC_H
 
 #include <atomic>
+#include <chrono>
 #include <csignal>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -69,15 +71,18 @@ class CoroRpcAgent {
 
     Status stop();
 
-    Status call(const std::string &server_addr, int func_id,
-                const std::string_view &request, std::string &response);
+    Status call(
+        const std::string &server_addr, int func_id,
+        const std::string_view &request, std::string &response,
+        std::optional<std::chrono::milliseconds> call_timeout = std::nullopt);
 
     using AsyncCallback = std::function<void(Status, std::string)>;
     void callAsync(const std::string &server_addr, int func_id,
                    const std::string &request, AsyncCallback callback);
 
     async_simple::coro::Lazy<std::pair<Status, std::string>> callCoroutine(
-        std::string server_addr, int func_id, std::string request);
+        std::string server_addr, int func_id, std::string request,
+        std::optional<std::chrono::milliseconds> call_timeout = std::nullopt);
 
    private:
     void process(int func_id);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -25,6 +25,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -81,13 +82,15 @@ class ControlClient {
                             const BootstrapDesc& request,
                             BootstrapDesc& response);
 
-    static Status sendData(const std::string& server_addr,
-                           uint64_t peer_mem_addr, void* local_mem_addr,
-                           size_t length);
+    static Status sendData(
+        const std::string& server_addr, uint64_t peer_mem_addr,
+        void* local_mem_addr, size_t length,
+        std::optional<std::chrono::milliseconds> call_timeout = std::nullopt);
 
-    static Status recvData(const std::string& server_addr,
-                           uint64_t peer_mem_addr, void* local_mem_addr,
-                           size_t length);
+    static Status recvData(
+        const std::string& server_addr, uint64_t peer_mem_addr,
+        void* local_mem_addr, size_t length,
+        std::optional<std::chrono::milliseconds> call_timeout = std::nullopt);
 
     static Status notify(const std::string& server_addr,
                          const Notification& message);

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -32,10 +32,10 @@ namespace tent {
 
 struct TcpParams {
     size_t max_retry_count = 3;
-    uint64_t retry_base_delay_ms = 100;   // 100ms initial backoff
-    uint64_t retry_max_delay_ms = 2'000;  // 2s max backoff
-    size_t max_concurrent_tasks = 16;     // worker thread pool size
-    int64_t data_rpc_timeout_ms = 5'000;  // per-attempt data RPC timeout
+    uint64_t retry_base_delay_ms = 100;    // 100ms initial backoff
+    uint64_t retry_max_delay_ms = 2'000;   // 2s max backoff
+    size_t max_concurrent_tasks = 16;      // worker thread pool size
+    int64_t data_rpc_timeout_ms = 30'000;  // per-attempt data RPC timeout
 };
 
 struct TcpTask {

--- a/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/tcp/tcp_transport.h
@@ -16,6 +16,7 @@
 #define TCP_TRANSPORT_H_
 
 #include <atomic>
+#include <cstdint>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -34,6 +35,7 @@ struct TcpParams {
     uint64_t retry_base_delay_ms = 100;   // 100ms initial backoff
     uint64_t retry_max_delay_ms = 2'000;  // 2s max backoff
     size_t max_concurrent_tasks = 16;     // worker thread pool size
+    int64_t data_rpc_timeout_ms = 5'000;  // per-attempt data RPC timeout
 };
 
 struct TcpTask {

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -183,6 +183,7 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
     const auto started_at = std::chrono::steady_clock::now();
     auto remainingTimeout = [&]() -> std::optional<std::chrono::milliseconds> {
         if (!call_timeout.has_value()) return std::nullopt;
+        if (call_timeout->count() < 0) return call_timeout;
         const auto elapsed =
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now() - started_at);
@@ -197,7 +198,7 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
         lease.client = std::make_unique<coro_rpc_client>(
             GetTransferEngineRpcClientIoContextPool().get_executor());
         const auto connect_timeout = remainingTimeout();
-        if (connect_timeout.has_value() && connect_timeout->count() <= 0) {
+        if (connect_timeout.has_value() && connect_timeout->count() == 0) {
             lease.broken = true;
             auto msg =
                 "RPC timed out before connecting. server: " + server_addr +
@@ -222,7 +223,7 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
     auto request_config = coro_rpc::request_config_t{};
     request_config.request_timeout_duration = remainingTimeout();
     if (request_config.request_timeout_duration.has_value() &&
-        request_config.request_timeout_duration->count() <= 0) {
+        request_config.request_timeout_duration->count() == 0) {
         lease.broken = true;
         auto msg =
             "RPC timed out before sending request. server: " + server_addr +

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -16,6 +16,9 @@
 #include <glog/logging.h>
 #include <async_simple/executors/SimpleExecutor.h>
 
+#include <chrono>
+#include <optional>
+
 #include "transfer_engine_rpc_client_io_context.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/random.h"
@@ -168,7 +171,8 @@ std::shared_ptr<ClientPool> CoroRpcAgent::getOrCreatePool(
 }
 
 Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
-    std::string server_addr, int func_id, std::string request) {
+    std::string server_addr, int func_id, std::string request,
+    std::optional<std::chrono::milliseconds> call_timeout) {
     if (tl_inside_rpc_handler) {
         co_return std::make_pair(
             Status::InvalidArgument(
@@ -176,13 +180,35 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
             "");
     }
 
+    const auto started_at = std::chrono::steady_clock::now();
+    auto remainingTimeout = [&]() -> std::optional<std::chrono::milliseconds> {
+        if (!call_timeout.has_value()) return std::nullopt;
+        const auto elapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started_at);
+        if (elapsed >= *call_timeout) return std::chrono::milliseconds(0);
+        return *call_timeout - elapsed;
+    };
+
     auto pool = getOrCreatePool(server_addr);
     ClientLease lease{pool->acquire(), pool, false};
 
     if (!lease.client) {
         lease.client = std::make_unique<coro_rpc_client>(
             GetTransferEngineRpcClientIoContextPool().get_executor());
-        auto conn_result = co_await lease.client->connect(server_addr);
+        const auto connect_timeout = remainingTimeout();
+        if (connect_timeout.has_value() && connect_timeout->count() <= 0) {
+            lease.broken = true;
+            auto msg =
+                "RPC timed out before connecting. server: " + server_addr +
+                ", func_id: " + std::to_string(func_id);
+            co_return std::make_pair(Status::RpcServiceError(msg + LOC_MARK),
+                                     "");
+        }
+        auto conn_result =
+            connect_timeout.has_value()
+                ? co_await lease.client->connect(server_addr, *connect_timeout)
+                : co_await lease.client->connect(server_addr);
         if (conn_result.val() != 0) {
             lease.broken = true;
             auto msg = "Failed to connect RPC server. server: " + server_addr +
@@ -193,9 +219,20 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
         }
     }
 
-    lease->set_req_attachment(request);
+    auto request_config = coro_rpc::request_config_t{};
+    request_config.request_timeout_duration = remainingTimeout();
+    if (request_config.request_timeout_duration.has_value() &&
+        request_config.request_timeout_duration->count() <= 0) {
+        lease.broken = true;
+        auto msg =
+            "RPC timed out before sending request. server: " + server_addr +
+            ", func_id: " + std::to_string(func_id);
+        co_return std::make_pair(Status::RpcServiceError(msg + LOC_MARK), "");
+    }
+    request_config.request_attachment = request;
 
-    auto call_result = co_await lease->call<&CoroRpcAgent::process>(func_id);
+    auto call_result = co_await lease->call<&CoroRpcAgent::process>(
+        std::move(request_config), func_id);
 
     if (!call_result.has_value()) {
         lease.broken = true;
@@ -211,11 +248,12 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
     co_return std::make_pair(Status::OK(), std::move(response));
 }
 
-Status CoroRpcAgent::call(const std::string& server_addr, int func_id,
-                          const std::string_view& request,
-                          std::string& response) {
-    auto [status, resp] = async_simple::coro::syncAwait(
-        callCoroutine(server_addr, func_id, std::string(request)));
+Status CoroRpcAgent::call(
+    const std::string& server_addr, int func_id,
+    const std::string_view& request, std::string& response,
+    std::optional<std::chrono::milliseconds> call_timeout) {
+    auto [status, resp] = async_simple::coro::syncAwait(callCoroutine(
+        server_addr, func_id, std::string(request), call_timeout));
 
     if (status.ok()) {
         response = std::move(resp);

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -69,28 +69,32 @@ Status ControlClient::bootstrap(const std::string& server_addr,
     return Status::OK();
 }
 
-Status ControlClient::sendData(const std::string& server_addr,
-                               uint64_t peer_mem_addr, void* local_mem_addr,
-                               size_t length) {
+Status ControlClient::sendData(
+    const std::string& server_addr, uint64_t peer_mem_addr,
+    void* local_mem_addr, size_t length,
+    std::optional<std::chrono::milliseconds> call_timeout) {
     std::string request, response;
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
     request.resize(sizeof(XferDataDesc) + length);
     memcpy(&request[0], &desc, sizeof(desc));
     Platform::getLoader().copy(&request[sizeof(desc)], local_mem_addr, length);
-    auto status = tl_rpc_agent.call(server_addr, SendData, request, response);
+    auto status = tl_rpc_agent.call(server_addr, SendData, request, response,
+                                    call_timeout);
     if (!status.ok()) return status;
     if (!response.empty()) return Status::RpcServiceError(response);
     return Status::OK();
 }
 
-Status ControlClient::recvData(const std::string& server_addr,
-                               uint64_t peer_mem_addr, void* local_mem_addr,
-                               size_t length) {
+Status ControlClient::recvData(
+    const std::string& server_addr, uint64_t peer_mem_addr,
+    void* local_mem_addr, size_t length,
+    std::optional<std::chrono::milliseconds> call_timeout) {
     std::string request, response;
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
     request.resize(sizeof(XferDataDesc));
     memcpy(&request[0], &desc, sizeof(desc));
-    auto status = tl_rpc_agent.call(server_addr, RecvData, request, response);
+    auto status = tl_rpc_agent.call(server_addr, RecvData, request, response,
+                                    call_timeout);
     if (!status.ok()) return status;
     if (response.size() != length)
         return Status::RpcServiceError(

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -77,7 +77,10 @@ Status ControlClient::sendData(
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
     request.resize(sizeof(XferDataDesc) + length);
     memcpy(&request[0], &desc, sizeof(desc));
-    Platform::getLoader().copy(&request[sizeof(desc)], local_mem_addr, length);
+    if (length > 0) {
+        Platform::getLoader().copy(&request[sizeof(desc)], local_mem_addr,
+                                   length);
+    }
     auto status = tl_rpc_agent.call(server_addr, SendData, request, response,
                                     call_timeout);
     if (!status.ok()) return status;
@@ -96,10 +99,19 @@ Status ControlClient::recvData(
     auto status = tl_rpc_agent.call(server_addr, RecvData, request, response,
                                     call_timeout);
     if (!status.ok()) return status;
-    if (response.size() != length)
+    if (response.empty()) {
+        return Status::RpcServiceError("RecvData returned an empty response");
+    }
+    if (response[0] != '\0') {
+        return Status::RpcServiceError(response.substr(1));
+    }
+    if (response.size() != length + 1) {
         return Status::RpcServiceError(
-            "RecvData failed: target address not in registered buffer");
-    Platform::getLoader().copy(local_mem_addr, response.data(), length);
+            "RecvData returned an invalid payload size");
+    }
+    if (length > 0) {
+        Platform::getLoader().copy(local_mem_addr, response.data() + 1, length);
+    }
     return Status::OK();
 }
 
@@ -379,7 +391,12 @@ void ControlService::onSendData(const std::string_view& request,
     }
 
     if (local_desc->findBuffer(peer_mem_addr, length)) {
-        Platform::getLoader().copy((void*)peer_mem_addr, &desc[1], length);
+        if (length > 0) {
+            Platform::getLoader().copy(
+                (void*)peer_mem_addr,
+                const_cast<char*>(request.data() + sizeof(XferDataDesc)),
+                length);
+        }
     } else {
         response = "SendData failed: target address not in registered buffer";
     }
@@ -387,8 +404,12 @@ void ControlService::onSendData(const std::string_view& request,
 
 void ControlService::onRecvData(const std::string_view& request,
                                 std::string& response) {
+    auto set_error = [&](const std::string& message) {
+        response.assign(1, '\1');
+        response.append(message);
+    };
     if (request.size() < sizeof(XferDataDesc)) {
-        response = "RecvData failed: request too short";
+        set_error("RecvData failed: request too short");
         return;
     }
     XferDataDesc* desc = (XferDataDesc*)request.data();
@@ -396,19 +417,22 @@ void ControlService::onRecvData(const std::string_view& request,
     auto peer_mem_addr = le64toh(desc->peer_mem_addr);
     auto length = le64toh(desc->length);
 
-    // Validate length to prevent DoS via excessive memory allocation
+    // Validate length to prevent DoS via excessive memory allocation.
     constexpr size_t kMaxTransferSize = 1ULL << 30;  // 1GB max per RPC
     if (length > kMaxTransferSize) {
-        response = "RecvData failed: length exceeds maximum allowed";
+        set_error("RecvData failed: length exceeds maximum allowed");
         return;
     }
 
     if (local_desc->findBuffer(peer_mem_addr, length)) {
-        response.resize(length);
-        Platform::getLoader().copy(response.data(), (void*)peer_mem_addr,
-                                   length);
+        response.resize(length + 1);
+        response[0] = '\0';
+        if (length > 0) {
+            Platform::getLoader().copy(response.data() + 1,
+                                       (void*)peer_mem_addr, length);
+        }
     } else {
-        response = "RecvData failed: target address not in registered buffer";
+        set_error("RecvData failed: target address not in registered buffer");
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -24,6 +24,7 @@
 #include <cstdint>
 #include <iomanip>
 #include <memory>
+#include <optional>
 #include <thread>
 
 #include "tent/common/status.h"
@@ -84,6 +85,14 @@ Status TcpTransport::install(std::string &local_segment_name,
         params_.max_concurrent_tasks =
             conf->get("transports/tcp/max_concurrent_tasks",
                       params_.max_concurrent_tasks);
+        params_.data_rpc_timeout_ms = conf->get(
+            "transports/tcp/data_rpc_timeout_ms", params_.data_rpc_timeout_ms);
+    }
+
+    if (params_.data_rpc_timeout_ms == 0 || params_.data_rpc_timeout_ms < -1) {
+        return Status::InvalidArgument(
+            "transports/tcp/data_rpc_timeout_ms must be positive, or -1 to "
+            "disable the per-attempt timeout" LOC_MARK);
     }
 
     thread_pool_ = std::make_unique<ThreadPool>(params_.max_concurrent_tasks);
@@ -103,7 +112,8 @@ Status TcpTransport::install(std::string &local_segment_name,
 
     LOG(INFO) << "TCP transport installed: max_retry_count="
               << params_.max_retry_count
-              << " max_concurrent_tasks=" << params_.max_concurrent_tasks;
+              << " max_concurrent_tasks=" << params_.max_concurrent_tasks
+              << " data_rpc_timeout_ms=" << params_.data_rpc_timeout_ms;
     return Status::OK();
 }
 
@@ -223,6 +233,12 @@ Status TcpTransport::doTransferWithRetry(TcpTask *task) {
                           task->request.target_id, rpc_server_addr);
     if (!status.ok()) return status;
 
+    std::optional<std::chrono::milliseconds> data_rpc_timeout;
+    if (params_.data_rpc_timeout_ms > 0) {
+        data_rpc_timeout =
+            std::chrono::milliseconds(params_.data_rpc_timeout_ms);
+    }
+
     Status last_error;
     uint64_t delay_ms = params_.retry_base_delay_ms;
 
@@ -247,11 +263,11 @@ Status TcpTransport::doTransferWithRetry(TcpTask *task) {
         if (task->request.opcode == Request::WRITE) {
             status = ControlClient::sendData(
                 rpc_server_addr, task->request.target_offset,
-                task->request.source, task->request.length);
+                task->request.source, task->request.length, data_rpc_timeout);
         } else {
             status = ControlClient::recvData(
                 rpc_server_addr, task->request.target_offset,
-                task->request.source, task->request.length);
+                task->request.source, task->request.length, data_rpc_timeout);
         }
 
         if (status.ok()) return Status::OK();

--- a/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/tcp/tcp_transport.cpp
@@ -233,11 +233,8 @@ Status TcpTransport::doTransferWithRetry(TcpTask *task) {
                           task->request.target_id, rpc_server_addr);
     if (!status.ok()) return status;
 
-    std::optional<std::chrono::milliseconds> data_rpc_timeout;
-    if (params_.data_rpc_timeout_ms > 0) {
-        data_rpc_timeout =
-            std::chrono::milliseconds(params_.data_rpc_timeout_ms);
-    }
+    std::optional<std::chrono::milliseconds> data_rpc_timeout{
+        std::chrono::milliseconds(params_.data_rpc_timeout_ms)};
 
     Status last_error;
     uint64_t delay_ms = params_.retry_base_delay_ms;

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -39,7 +39,7 @@ TEST(TcpParamsTest, DefaultValues) {
     EXPECT_EQ(params.retry_base_delay_ms, 100ULL);
     EXPECT_EQ(params.retry_max_delay_ms, 2'000ULL);
     EXPECT_EQ(params.max_concurrent_tasks, 16);
-    EXPECT_EQ(params.data_rpc_timeout_ms, 5'000);
+    EXPECT_EQ(params.data_rpc_timeout_ms, 30'000);
 }
 
 // ---------------------------------------------------------------------------
@@ -162,7 +162,7 @@ TEST(TcpTransportConfigTest, MissingConfigUsesDefaults) {
               16);
     EXPECT_EQ(conf->get("transports/tcp/data_rpc_timeout_ms",
                         defaults.data_rpc_timeout_ms),
-              5'000);
+              30'000);
 }
 
 TEST(TcpTransportConfigTest, RejectsInvalidDataRpcTimeout) {
@@ -218,6 +218,31 @@ TEST(TcpTransportConfigTest, DataRpcTimeoutBoundsSlowSendData) {
     EXPECT_LT(elapsed.count(), 400);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_TRUE(server.stop().ok());
+}
+
+TEST(TcpTransportConfigTest, DisabledDataRpcTimeoutAllowsSlowSendData) {
+    CoroRpcAgent server;
+    server.registerFunction(
+        SendData, [](const std::string_view&, std::string&) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        });
+
+    uint16_t port = 0;
+    ASSERT_TRUE(server.start(port).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    std::array<char, 4> payload{};
+    const auto started_at = std::chrono::steady_clock::now();
+    auto status = ControlClient::sendData("127.0.0.1:" + std::to_string(port),
+                                          0, payload.data(), payload.size(),
+                                          std::chrono::milliseconds(-1));
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started_at);
+
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_GE(elapsed.count(), 200);
+
     EXPECT_TRUE(server.stop().ok());
 }
 

--- a/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_transport_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -38,6 +39,7 @@ TEST(TcpParamsTest, DefaultValues) {
     EXPECT_EQ(params.retry_base_delay_ms, 100ULL);
     EXPECT_EQ(params.retry_max_delay_ms, 2'000ULL);
     EXPECT_EQ(params.max_concurrent_tasks, 16);
+    EXPECT_EQ(params.data_rpc_timeout_ms, 5'000);
 }
 
 // ---------------------------------------------------------------------------
@@ -139,11 +141,13 @@ TEST(TcpTransportConfigTest, ConfigOverridesDefaults) {
     conf->set("transports/tcp/retry_base_delay_ms", 200ULL);
     conf->set("transports/tcp/retry_max_delay_ms", 4000ULL);
     conf->set("transports/tcp/max_concurrent_tasks", 32);
+    conf->set("transports/tcp/data_rpc_timeout_ms", 1500LL);
 
     EXPECT_EQ(conf->get("transports/tcp/max_retry_count", 0), 5);
     EXPECT_EQ(conf->get("transports/tcp/retry_base_delay_ms", 0ULL), 200ULL);
     EXPECT_EQ(conf->get("transports/tcp/retry_max_delay_ms", 0ULL), 4000ULL);
     EXPECT_EQ(conf->get("transports/tcp/max_concurrent_tasks", 0), 32);
+    EXPECT_EQ(conf->get("transports/tcp/data_rpc_timeout_ms", 0LL), 1500LL);
 }
 
 TEST(TcpTransportConfigTest, MissingConfigUsesDefaults) {
@@ -156,6 +160,65 @@ TEST(TcpTransportConfigTest, MissingConfigUsesDefaults) {
     EXPECT_EQ(conf->get("transports/tcp/max_concurrent_tasks",
                         defaults.max_concurrent_tasks),
               16);
+    EXPECT_EQ(conf->get("transports/tcp/data_rpc_timeout_ms",
+                        defaults.data_rpc_timeout_ms),
+              5'000);
+}
+
+TEST(TcpTransportConfigTest, RejectsInvalidDataRpcTimeout) {
+    for (int64_t timeout_ms : {0LL, -2LL}) {
+        auto conf = std::make_shared<Config>();
+        conf->set("transports/tcp/data_rpc_timeout_ms", timeout_ms);
+
+        TcpTransport transport;
+        std::string local_segment_name = "127.0.0.1:16001";
+        auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+        auto topology = std::make_shared<Topology>();
+        auto status =
+            transport.install(local_segment_name, metadata, topology, conf);
+
+        EXPECT_TRUE(status.IsInvalidArgument()) << status.ToString();
+    }
+}
+
+TEST(TcpTransportConfigTest, AllowsDisabledDataRpcTimeout) {
+    auto conf = std::make_shared<Config>();
+    conf->set("transports/tcp/data_rpc_timeout_ms", -1LL);
+
+    TcpTransport transport;
+    std::string local_segment_name = "127.0.0.1:16002";
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    auto topology = std::make_shared<Topology>();
+    auto status =
+        transport.install(local_segment_name, metadata, topology, conf);
+
+    EXPECT_TRUE(status.ok()) << status.ToString();
+}
+
+TEST(TcpTransportConfigTest, DataRpcTimeoutBoundsSlowSendData) {
+    CoroRpcAgent server;
+    server.registerFunction(
+        SendData, [](const std::string_view&, std::string&) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        });
+
+    uint16_t port = 0;
+    ASSERT_TRUE(server.start(port).ok());
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    std::array<char, 4> payload{};
+    const auto started_at = std::chrono::steady_clock::now();
+    auto status = ControlClient::sendData("127.0.0.1:" + std::to_string(port),
+                                          0, payload.data(), payload.size(),
+                                          std::chrono::milliseconds(100));
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - started_at);
+
+    EXPECT_TRUE(status.IsRpcServiceError()) << status.ToString();
+    EXPECT_LT(elapsed.count(), 400);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT_TRUE(server.stop().ok());
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

TENT TCP transport currently uses the generic RPC path for data-plane `SendData` / `RecvData` requests. When the remote peer accepts the connection but does not respond, a single data RPC attempt can wait for the generic RPC timeout before retrying, which makes TCP transport failure recovery much slower than the configured retry policy suggests.

This PR adds a bounded per-attempt timeout for TENT TCP data RPCs:

- Adds `transports/tcp/data_rpc_timeout_ms`, defaulting to `5000` ms.
- Allows `-1` to explicitly disable the per-attempt data RPC timeout.
- Rejects `0` and values below `-1`, because `0` would create ambiguous immediate-timeout behavior instead of a useful configuration.
- Threads the optional timeout through `ControlClient::sendData()` / `recvData()` into `CoroRpcAgent`.
- Applies the timeout only to TCP data RPCs; existing metadata/bootstrap/notification calls keep their existing behavior.
- Adds unit coverage for default/override/invalid/disabled config and a slow `SendData` RPC that verifies the timeout is actually honored.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-tent-tcp-timeout \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DBUILD_UNIT_TESTS=ON \
  -DUSE_TENT=ON

cmake --build build-tent-tcp-timeout --target tent_tcp_transport_test -j8

./build-tent-tcp-timeout/mooncake-transfer-engine/tent/tests/tent_tcp_transport_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: `tent_tcp_transport_test` passed 15/15 tests, including the slow `SendData` timeout regression.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped inspect the relevant TENT TCP/RPC paths and draft the patch. The submitted changes were reviewed and verified with the test commands above.