### PR TITLE
[Bugfix][TENT] Keep a delegated transfer off the RPC event loop

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -63,7 +63,18 @@ class CoroRpcAgent {
    public:
     using Function = std::function<void(const std::string_view & /* request */,
                                         std::string & /* response */)>;
-    Status registerFunction(int func_id, const Function &func);
+
+    // Handlers run on the single io_context (kRpcThreads), so a blocking one
+    // stalls every connection, not just its own.
+    //
+    // offload=false (default): inline, no thread hop. Right for anything that
+    // returns promptly.
+    // offload=true: runs on ylt's blocking executor while the connection
+    // coroutine suspends, keeping the io_context free. Callers see the same
+    // request/response, but ordering within a connection is no longer
+    // guaranteed.
+    Status registerFunction(int func_id, const Function &func,
+                            bool offload = false);
 
     Status start(uint16_t &port, bool ipv6 = false);
 
@@ -80,18 +91,23 @@ class CoroRpcAgent {
         std::string server_addr, int func_id, std::string request);
 
    private:
-    void process(int func_id);
+    async_simple::coro::Lazy<void> process(int func_id);
 
     std::shared_ptr<ClientPool> getOrCreatePool(const std::string &server_addr);
 
    private:
+    struct Handler {
+        Function func;
+        bool offload = false;
+    };
+
     coro_rpc::coro_rpc_server *server_ = nullptr;
 
     std::mutex pools_mutex_;
     std::unordered_map<std::string, std::shared_ptr<ClientPool>> pools_;
 
     std::mutex func_map_mutex_;
-    std::unordered_map<int, Function> func_map_;
+    std::unordered_map<int, Handler> func_map_;
 
     std::atomic<bool> running_{false};
     constexpr static size_t kRpcThreads = 1;

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -87,9 +87,10 @@ CoroRpcAgent::CoroRpcAgent() = default;
 
 CoroRpcAgent::~CoroRpcAgent() { stop(); }
 
-Status CoroRpcAgent::registerFunction(int func_id, const Function& func) {
+Status CoroRpcAgent::registerFunction(int func_id, const Function& func,
+                                      bool offload) {
     func_map_mutex_.lock();
-    func_map_[func_id] = func;
+    func_map_[func_id] = Handler{func, offload};
     func_map_mutex_.unlock();
     return Status::OK();
 }
@@ -145,16 +146,33 @@ Status CoroRpcAgent::stop() {
     return Status::OK();
 }
 
-void CoroRpcAgent::process(int func_id) {
-    RpcHandlerScope handler_scope(tl_inside_rpc_handler);
-    auto ctx = coro_rpc::get_context();
-    if (func_map_.count(func_id)) {
-        auto request = ctx->get_request_attachment();
-        std::string response;
-        auto func = func_map_.at(func_id);
-        func(request, response);
-        ctx->set_response_attachment(response);
+Lazy<void> CoroRpcAgent::process(int func_id) {
+    auto* ctx = co_await coro_rpc::get_context_in_coro();
+    auto it = func_map_.find(func_id);
+    if (it == func_map_.end()) co_return;
+    const auto handler = it->second;
+
+    auto request = ctx->get_request_attachment();
+    std::string response;
+    if (handler.offload) {
+        // Suspends this coroutine, freeing the io_context thread. The request
+        // buffer belongs to the context_info this coroutine keeps alive, so
+        // the view survives the hop. tl_inside_rpc_handler is deliberately
+        // not set: it guards against deadlocking the RPC thread, which an
+        // offloaded handler no longer occupies.
+        //
+        // post() reports a throwing handler through the Try instead of
+        // unwinding, so rethrow here: the router turns that into the same
+        // rpc_throw_exception an inline handler would produce. Dropping it
+        // would answer a malformed request with an empty success.
+        auto result =
+            co_await coro_io::post([&] { handler.func(request, response); });
+        result.value();
+    } else {
+        RpcHandlerScope handler_scope(tl_inside_rpc_handler);
+        handler.func(request, response);
     }
+    ctx->set_response_attachment(std::move(response));
 }
 
 std::shared_ptr<ClientPool> CoroRpcAgent::getOrCreatePool(

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -217,11 +217,14 @@ ControlService::ControlService(const std::string& type,
         Probe, [this](const std::string_view& request, std::string& response) {
             onProbe(request, response);
         });
+    // onDelegate runs a whole transfer to completion; holding the io_context
+    // thread for that long blocked every other RPC on this node.
     rpc_server_->registerFunction(
         Delegate,
         [this](const std::string_view& request, std::string& response) {
             onDelegate(request, response);
-        });
+        },
+        /*offload=*/true);
     rpc_server_->registerFunction(
         Pin, [this](const std::string_view& request, std::string& response) {
             onPinStageBuffer(request, response);
@@ -305,7 +308,7 @@ Status ControlService::start(uint16_t& port, bool ipv6_) {
 
 void ControlService::onGetSegmentDesc(const std::string_view& request,
                                       std::string& response) {
-    // Re-use the cached dump shared across concurrent peer fetches.
+    // Reuse the cached dump shared across concurrent peer fetches.
     auto cached = manager_->getLocalDumpedJson();
     response = *cached;
 }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -376,6 +376,31 @@ target_include_directories(tent_poll_backoff_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_poll_backoff_test COMMAND tent_poll_backoff_test)
 
+# Delegate RPC end to end: ControlClient::delegate -> onDelegate ->
+# transferSync, against a real engine on loopback with a FakeTransport.
+add_executable(tent_delegate_rpc_test delegate_rpc_test.cpp)
+target_link_libraries(tent_delegate_rpc_test PRIVATE gtest gtest_main
+                                                     tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_delegate_rpc_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_delegate_rpc_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_delegate_rpc_test COMMAND tent_delegate_rpc_test)
+
+# A slow handler must not stall the single-io_context RPC server. Starts a real
+# CoroRpcAgent on loopback; no RDMA device required.
+add_executable(tent_rpc_handler_isolation_test rpc_handler_isolation_test.cpp)
+target_link_libraries(tent_rpc_handler_isolation_test PRIVATE gtest gtest_main
+                                                              tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_rpc_handler_isolation_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_rpc_handler_isolation_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_rpc_handler_isolation_test
+         COMMAND tent_rpc_handler_isolation_test)
+
 add_executable(tent_runtime_queue_dispatch_test runtime_queue_dispatch_test.cpp)
 target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE gtest gtest_main
                                                                tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/delegate_rpc_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/delegate_rpc_test.cpp
@@ -1,0 +1,231 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end coverage for the Delegate RPC, which had none:
+// ControlClient::delegate -> onDelegate -> TransferEngineImpl::transferSync.
+//
+// The engine runs in p2p mode on loopback, so getSegmentName() is the address
+// to delegate to, and a FakeTransport stands in for real hardware.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+    size_t task_count = 0;
+    std::vector<TransferStatus> statuses;
+};
+
+// Minimal always-succeeding transport: enough for checkAvailability() and
+// resolveTransport() to pick it, and it records how many submits it saw.
+class FakeTransport : public Transport {
+   public:
+    explicit FakeTransport(TransportType self_type) : self_type_(self_type) {
+        caps.dram_to_dram = true;
+    }
+
+    std::atomic<int> submit_calls{0};
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config> = nullptr) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete batch;
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request>& request_list) override {
+        ++submit_calls;
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        for (const auto& req : request_list) {
+            fb->statuses.push_back({TransferStatusEnum::COMPLETED, req.length});
+            fb->task_count++;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fb->statuses.size())
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        status = fb->statuses[task_id];
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(self_type_);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& d : desc_list) {
+            auto s = addMemoryBuffer(d, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        if (!*addr) return Status::InternalError("malloc failed" LOC_MARK);
+        return Status::OK();
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void*, size_t) override { return false; }
+
+    const char* getName() const override { return "<fake>"; }
+
+   private:
+    TransportType self_type_;
+};
+
+std::shared_ptr<Config> makeLoopbackP2PConfig() {
+    auto cfg = std::make_shared<Config>();
+    // p2p metadata keeps this self-contained: no redis/etcd/http server, and
+    // the segment name becomes 127.0.0.1:<bound port>, which is exactly the
+    // address Delegate is sent to.
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+    return cfg;
+}
+
+constexpr size_t kBufLen = 4096;
+
+class DelegateRpcTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        engine_ = std::make_unique<TransferEngineImpl>(makeLoopbackP2PConfig());
+        ASSERT_TRUE(engine_->available());
+
+        fake_ = std::make_shared<FakeTransport>(RDMA);
+        std::string seg_name = engine_->getSegmentName();
+        ASSERT_TRUE(fake_->install(seg_name, nullptr, nullptr).ok());
+        engine_->swapTransportForTest(RDMA, fake_);
+
+        buffer_.assign(kBufLen, 0xC1);
+        ASSERT_TRUE(engine_->registerLocalMemory(buffer_.data(), kBufLen).ok());
+        addr_ = engine_->getSegmentName();
+    }
+
+    void TearDown() override {
+        if (engine_)
+            (void)engine_->unregisterLocalMemory(buffer_.data(), kBufLen);
+    }
+
+    // A self-targeted WRITE: the serving node is this same engine, so the
+    // pointers carried in the request are valid there.
+    Request makeRequest() const {
+        Request req;
+        req.opcode = Request::WRITE;
+        req.source = const_cast<uint8_t*>(buffer_.data());
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = reinterpret_cast<uint64_t>(buffer_.data());
+        req.length = kBufLen;
+        return req;
+    }
+
+    std::unique_ptr<TransferEngineImpl> engine_;
+    std::shared_ptr<FakeTransport> fake_;
+    std::vector<uint8_t> buffer_;
+    std::string addr_;
+};
+
+TEST_F(DelegateRpcTest, DelegatedTransferRunsOnTheServingNode) {
+    ASSERT_TRUE(ControlClient::delegate(addr_, makeRequest()).ok());
+    EXPECT_EQ(fake_->submit_calls.load(), 1)
+        << "the delegated transfer never reached the transport";
+}
+
+TEST_F(DelegateRpcTest, DelegateReportsFailureBackToTheCaller) {
+    // Nothing is registered at this address, so submitTransfer must reject it
+    // and the error has to travel back over the RPC rather than being
+    // swallowed into an OK response.
+    Request req = makeRequest();
+    req.target_offset = 0;
+    req.source = nullptr;
+    EXPECT_FALSE(ControlClient::delegate(addr_, req).ok());
+}
+
+// onDelegate is registered with offload=true, so N delegates now run on N
+// executor threads instead of being serialized by the single RPC thread. Each
+// must still get its own batch and its own correct answer.
+TEST_F(DelegateRpcTest, ConcurrentDelegatesAllSucceed) {
+    constexpr int kConcurrency = 8;
+    std::vector<std::thread> threads;
+    std::atomic<int> succeeded{0};
+    for (int i = 0; i < kConcurrency; ++i) {
+        threads.emplace_back([&] {
+            if (ControlClient::delegate(addr_, makeRequest()).ok())
+                succeeded.fetch_add(1);
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_EQ(succeeded.load(), kConcurrency);
+    EXPECT_EQ(fake_->submit_calls.load(), kConcurrency);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/rpc_handler_isolation_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rpc_handler_isolation_test.cpp
@@ -1,0 +1,163 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A slow RPC handler must not stall the rest of the control plane.
+//
+// The server runs one io_context (kRpcThreads == 1) and every connection's
+// coroutine is scheduled on it, so an inline handler pins that thread for its
+// whole duration -- for every peer, not just its own. onDelegate does exactly
+// that: it runs a full transfer to completion. offload=true moves the handler
+// off the io_context so the event loop keeps serving.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "tent/rpc/rpc.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using namespace std::chrono_literals;
+
+constexpr int kSlowFunc = 4001;
+constexpr int kFastFunc = 4002;
+constexpr int kThrowingFunc = 4003;
+
+// Long enough that a serialized fast call is unambiguously distinguishable
+// from a concurrent one, short enough to keep the test quick.
+constexpr auto kSlowHandlerDuration = 800ms;
+// A concurrent fast call only pays connect + round trip. Generous enough to
+// survive a loaded CI box, still far below kSlowHandlerDuration.
+constexpr auto kFastCallBudget = 400ms;
+
+class RpcHandlerIsolationTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        server_ = std::make_unique<CoroRpcAgent>();
+        ASSERT_TRUE(
+            server_
+                ->registerFunction(
+                    kSlowFunc,
+                    [this](const std::string_view&, std::string& response) {
+                        slow_running_.store(true);
+                        std::this_thread::sleep_for(kSlowHandlerDuration);
+                        slow_running_.store(false);
+                        response = "slow";
+                    },
+                    /*offload=*/true)
+                .ok());
+        ASSERT_TRUE(
+            server_
+                ->registerFunction(
+                    kFastFunc, [](const std::string_view&,
+                                  std::string& response) { response = "fast"; })
+                .ok());
+        ASSERT_TRUE(server_
+                        ->registerFunction(
+                            kThrowingFunc,
+                            [](const std::string_view&, std::string&) {
+                                throw std::runtime_error("handler blew up");
+                            },
+                            /*offload=*/true)
+                        .ok());
+        uint16_t port = 0;
+        ASSERT_TRUE(server_->start(port).ok());
+        addr_ = "127.0.0.1:" + std::to_string(port);
+    }
+
+    void TearDown() override {
+        if (server_) server_->stop();
+    }
+
+    std::unique_ptr<CoroRpcAgent> server_;
+    std::string addr_;
+    std::atomic<bool> slow_running_{false};
+};
+
+TEST_F(RpcHandlerIsolationTest, SlowOffloadedHandlerDoesNotStallOtherRpcs) {
+    CoroRpcAgent slow_client;
+    CoroRpcAgent fast_client;
+
+    std::atomic<bool> slow_done{false};
+    std::thread slow_thread([&] {
+        std::string response;
+        auto status = slow_client.call(addr_, kSlowFunc, "", response);
+        EXPECT_TRUE(status.ok()) << status.ToString();
+        EXPECT_EQ(response, "slow");
+        slow_done.store(true);
+    });
+
+    // Wait until the slow handler is actually executing, so the fast call
+    // below genuinely overlaps it.
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (!slow_running_.load() &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    ASSERT_TRUE(slow_running_.load()) << "slow handler never started";
+
+    const auto started = std::chrono::steady_clock::now();
+    std::string response;
+    auto status = fast_client.call(addr_, kFastFunc, "", response);
+    const auto elapsed = std::chrono::steady_clock::now() - started;
+
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(response, "fast");
+    EXPECT_TRUE(slow_done.load() == false || slow_running_.load() == false);
+    EXPECT_LT(elapsed, kFastCallBudget)
+        << "fast RPC took "
+        << std::chrono::duration_cast<std::chrono::milliseconds>(elapsed)
+               .count()
+        << "ms: it waited for the slow handler instead of being served "
+           "concurrently";
+
+    slow_thread.join();
+    EXPECT_TRUE(slow_done.load());
+}
+
+// Handlers left at the default offload=false keep running inline on the
+// io_context thread, which is what every non-blocking handler wants: no thread
+// hop, no extra latency.
+TEST_F(RpcHandlerIsolationTest, InlineHandlerStillWorks) {
+    CoroRpcAgent client;
+    std::string response;
+    ASSERT_TRUE(client.call(addr_, kFastFunc, "", response).ok());
+    EXPECT_EQ(response, "fast");
+}
+
+TEST_F(RpcHandlerIsolationTest, OffloadedHandlerReturnsItsResponse) {
+    CoroRpcAgent client;
+    std::string response;
+    ASSERT_TRUE(client.call(addr_, kSlowFunc, "", response).ok());
+    EXPECT_EQ(response, "slow");
+}
+
+// Handlers do throw -- onDelegate starts with json::parse. The executor
+// reports that through a Try rather than by unwinding, so it has to be
+// rethrown or the caller would see an empty success.
+TEST_F(RpcHandlerIsolationTest, OffloadedHandlerExceptionReachesTheCaller) {
+    CoroRpcAgent client;
+    std::string response;
+    EXPECT_FALSE(client.call(addr_, kThrowingFunc, "", response).ok());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
Description

  CoroRpcAgent runs the server with a single io_context (kRpcThreads == 1), and every connection's coroutine is scheduled on it. A non-coroutine handler is invoked inline from that coroutine, so it never suspends and pins the thread for its whole duration — for every peer's connection, not just its own.

  ControlService::onDelegate does exactly that: it runs an entire transfer to completion via transferSync(). While a delegated transfer is in flight this node answers no RPC at all, BootstrapRdma included.

  Fix: make process() a coroutine and add a per-handler offload flag to registerFunction(). An offloaded handler runs via co_await coro_io::post() on ylt's blocking executor, which suspends the connection coroutine and returns the io_context thread to the event loop. The response is still delivered on the same RPC, so callers are unaffected. Only Delegate is marked; the other ten handlers stay inline.

  Two things for reviewers to weigh:
  - Requests within a connection are no longer ordered against an offloaded handler. Synchronous callers are unaffected; pipelining ones would see it.
  - coro_io::post uses the global blocking executor, whose queue is unbounded, so concurrent Delegates consume executor threads. The single-thread model had implicit backpressure; an explicit bound is left to a follow-up.

  Raising kRpcThreads was rejected as the alternative: it would make all eleven handlers concurrent at once, turning the unlocked func_map_ read into a real data race and exposing every other single-RPC-thread assumption.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other
  
  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?
  
  Test commands:
  cmake .. -DUSE_TENT=ON -DBUILD_UNIT_TESTS=ON && cmake --build . -j3
  ctest -R "tent_delegate_rpc_test|tent_rpc_handler_isolation_test" --output-on-failure
  ctest --output-on-failure

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Two new tests, neither needing an RDMA device:

  - tent_rpc_handler_isolation_test (3 cases) — with an 800 ms handler in flight, an unrelated RPC on another connection must return within 400 ms. Switching that handler back to inline makes it fail, so it tests what it claims to.
  - tent_delegate_rpc_test (3 cases) — Delegate had no coverage at all. Drives ControlClient::delegate → onDelegate → transferSync against a real engine on loopback with a FakeTransport: happy path, error propagation back over the RPC, and 8 concurrent delegates (only reachable with this change). Stubbing onDelegate to a no-op fails all three.

  Full TENT suite: 66 tests, 63 pass. The 3 failures (tcp_transport_test, transfer_metadata_test, memory_location_test) are pre-existing container-environment issues — no etcd metadata server, and no CAP_SYS_NICE for mbind —
  unrelated to this change.

  Checklist
  
  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  codespell flagged a pre-existing Re-use typo in a comment in control_plane.cpp (from 94ac60df) because this PR touches that file; corrected so the hook passes.

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)