### PR TITLE
TENT: link tent_runtime against mooncake_common

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/runtime/CMakeLists.txt
@@ -17,3 +17,13 @@ if (TARGET metastore_etcd)
 endif()
 
 target_link_libraries(tent_runtime PUBLIC tent_common tent_rpc tent_platform_all tent_transport_all tent_metrics)
+# The runtime references the Transfer Engine client I/O pool accessor
+# (mooncake::CreateRpcClientIoContextPool / mooncake::Environ) from the common
+# library. Declaring the dependency here keeps the shared library link ordered
+# correctly; otherwise libtent_shared.so is emitted with dangling undefined
+# symbols (Ubuntu's default --as-needed drops libmooncake_common.so because it
+# is placed before the archives that reference it), and consumers linking only
+# against libtent_shared.so (e.g. the NIXL Mooncake plugin) fail at load time.
+if(TARGET mooncake_common)
+  target_link_libraries(tent_runtime PUBLIC mooncake_common)
+endif()


### PR DESCRIPTION
`libtent_shared.so` uses symbols from `mooncake_common` (e.g.
`mooncake::Environ::Get`) but does not declare the dependency, so with the
default `--as-needed` link policy the DT_NEEDED entry is absent and consumers
that link only `-ltent_shared` fail at load time with undefined symbols.

One-line CMake fix: link `tent_runtime` PUBLIC against `mooncake_common`.

Verified on Ubuntu 22.04 / gcc 11.4: `readelf -d libtent_shared.so` now lists
`libmooncake_common.so` in DT_NEEDED and `ldd -r` reports zero unresolved
symbols; an external consumer (the NIXL Mooncake plugin) links and loads
cleanly against `-ltent_shared` alone.