### PR TITLE
TENT: only deliver transfer-bound notifications after completion

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1914,10 +1914,11 @@ Status TransferEngineImpl::maybeFireSubmitHooks(Batch* batch, bool check) {
             for (size_t tid = hook.start_task_id; tid < hook.end_task_id;
                  ++tid) {
                 auto& t = batch->task_list[tid];
-                if (t.status == PENDING) {
-                    all_completed = false;
-                    break;
-                }
+                // Merged requests are carried by one owning task; the derived
+                // ones keep their initial status forever, so checking them
+                // would make this hook never fire. getBatchStatus() skips them
+                // for the same reason.
+                if (t.derived) continue;
                 if (t.status != COMPLETED) {
                     all_completed = false;
                     break;
@@ -2320,7 +2321,13 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         overall_status.s = worst_failure;
     }
     // else: some tasks still PENDING → overall_status.s stays PENDING
-    CHECK_STATUS(maybeFireSubmitHooks(batch, overall_status.s == COMPLETED));
+    // Transfer-bound notifications may only be delivered once the transfer
+    // they are attached to has actually completed. The second parameter is
+    // "verify completion before sending", so passing the batch's completion
+    // into it inverted the guard: for a batch still in flight, or one that
+    // ended in failure, check was false and every hook fired anyway.
+    if (overall_status.s == COMPLETED)
+        CHECK_STATUS(maybeFireSubmitHooks(batch, /*check=*/false));
     return Status::OK();
 }
 


### PR DESCRIPTION
A notification attached to a submit is delivered by `maybeFireSubmitHooks()`,
whose second parameter means "verify the submit's tasks completed before
sending". `getBatchStatus()` ended with

    maybeFireSubmitHooks(batch, overall_status.s == COMPLETED);

which inverts the guard: while the batch is still in flight (or after it
failed) the flag is false and every hook fires unconditionally; only an
already-completed batch gets verified.

Observed with two engines in one process (16 MB in 4 requests over TCP): the
peer received the notification while the data was still arriving and verified
stale bytes; a transfer to an unregistered remote address ended FAILED and
still delivered its notification. Consumers that treat a notification as "the
data is here" (the NIXL backend contract requires delivery only after all
descriptors complete) are silently broken by this.

Fix: fire the hooks only once the batch actually completed, using the
aggregate `getBatchStatus()` just computed. The per-task completion check is
fixed the same way for merged requests: derived tasks keep their initial
status forever (only the owning task progresses), so scanning them made the
hook never fire — skip them, as `getBatchStatus()` itself does.

After the change, a receiver-side count of notifications exactly matches the
count of completed notified transfers (verified before/after on an 8×H20 /
RoCE server), and failed transfers deliver nothing.

Marked draft: the original intent of the inverted flag is best judged by the
author — happy to adjust if early delivery was deliberate for some path.

Related: while validating this on GPU we found local (intra-agent)
connections never establish a notification QP, so `sendNotification` cannot
succeed there at all (`endpoint.cpp` "Notification QP not connected" via
`RdmaTransport::sendNotification`) — the very first intra-agent
transfer-with-notification hangs its receiver. That pre-existing gap is
orthogonal to this fix (the un-patched code walks the same doomed path, just
earlier); reported separately in ai-dynamo/nixl#2083 with repro details.