### PR TITLE
[Bugfix][TENT] Pace the transfer poll loops and stop leaking their batches

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -48,6 +48,18 @@ class Platform;
 class ProxyManager;
 class ProgressWorker;
 
+// How long a poll loop should pause before polling again. Zero means poll
+// immediately.
+//
+// progressBatch takes progress_mutex_ every call, so an unthrottled loop does
+// not just burn a core -- it contends with every other thread's submit and
+// poll path. Hot for the first iterations so short transfers keep their
+// latency, then exponential backoff to a cap.
+std::chrono::microseconds nextPollDelay(uint64_t poll_count);
+
+// One backoff step: yields while nextPollDelay is zero, sleeps after that.
+void waitBeforeNextPoll(uint64_t poll_count);
+
 struct TaskInfo {
     TransportType type{UNSPEC};
     int sub_task_id{-1};
@@ -189,6 +201,13 @@ class TransferEngineImpl {
         if (type >= 0 && type < (TransportType)kSupportedTransportTypes) {
             transport_list_[type] = std::move(xport);
         }
+    }
+
+    // Test-only hook: how many batches are still alive. Lets a test assert
+    // that a failed transfer released its batch rather than leaking it.
+    size_t aliveBatchCountForTest() {
+        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+        return alive_batches_.size();
     }
 
     // Wake the optional event-driven progress worker for `batch_id`. No-op if

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -321,9 +321,36 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
     for (size_t i = 0; i < chunks.size(); ++i) event_queue.push(i);
     std::vector<std::future<Status>> remote_futures(chunks.size());
 
+    // The loop below can leave through the CHECK_STATUS on progressBatch or
+    // through the FAILED branch, which only drains the queue. Either way the
+    // chunks still in flight own a batch that nobody would free.
+    struct PendingBatches {
+        TransferEngineImpl* impl;
+        std::vector<Chunk>& chunks;
+        ~PendingBatches() {
+            for (auto& chunk : chunks) {
+                if (!chunk.batch) continue;
+                auto status = impl->freeBatch(chunk.batch);
+                if (!status.ok())
+                    LOG(WARNING)
+                        << "failed to free chunk batch: " << status.ToString();
+                chunk.batch = 0;
+            }
+        }
+    } pending_batches{impl_, chunks};
+
+    // An in-flight chunk goes straight back on the queue, so this loop spins
+    // with nothing to do -- and the INFLIGHT case takes progress_mutex_ every
+    // pass. Back off only after a whole sweep advanced no chunk, so a queue
+    // that is progressing still runs at full speed.
+    size_t sweep_remaining = event_queue.size();
+    bool swept_progress = false;
+    uint64_t idle_sweeps = 0;
+
     while (!event_queue.empty()) {
         auto id = event_queue.front();
         auto& chunk = chunks[id];
+        const auto state_before = chunk.state;
         event_queue.pop();
         switch (chunk.state) {
             case StageState::PRE: {
@@ -494,6 +521,17 @@ Status ProxyManager::transferEventLoop(StagingTask& task,
                 }
                 break;
             }
+        }
+
+        if (chunk.state != state_before) swept_progress = true;
+        if (sweep_remaining > 0) --sweep_remaining;
+        if (sweep_remaining == 0) {
+            if (swept_progress)
+                idle_sweeps = 0;
+            else
+                waitBeforeNextPoll(idle_sweeps++);
+            swept_progress = false;
+            sweep_remaining = event_queue.size();
         }
     }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -16,6 +16,7 @@
 #include "tent/runtime/control_plane.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cstdlib>
 #include <fstream>
 #include <limits>
@@ -23,6 +24,7 @@
 #include <optional>
 #include <random>
 #include <stdexcept>
+#include <thread>
 
 #include "tent/common/config.h"
 #include "tent/common/status.h"
@@ -2355,37 +2357,93 @@ void TransferEngineImpl::notifyRuntimeQueueReady() {
     if (progress_worker_) progress_worker_->notifyRuntimeQueueReady();
 }
 
+std::chrono::microseconds nextPollDelay(uint64_t poll_count) {
+    // Covers a fast completion, so short transfers usually finish before the
+    // sleeping phase.
+    constexpr uint64_t kHotPolls = 128;
+    constexpr auto kMaxDelay = std::chrono::microseconds(200);
+    if (poll_count < kHotPolls) return std::chrono::microseconds(0);
+    const uint64_t shift = std::min<uint64_t>(poll_count - kHotPolls, 20);
+    const auto delay = std::chrono::microseconds(uint64_t(1) << shift);
+    return delay < kMaxDelay ? delay : kMaxDelay;
+}
+
+void waitBeforeNextPoll(uint64_t poll_count) {
+    const auto delay = nextPollDelay(poll_count);
+    if (delay.count() == 0)
+        std::this_thread::yield();
+    else
+        std::this_thread::sleep_for(delay);
+}
+
+namespace {
+// Frees the batch on every exit unless reset() already did. The wait loops
+// below leave through CHECK_STATUS early returns that used to skip freeBatch()
+// and leak the Batch slab with whatever SubBatches it held.
+class BatchGuard {
+   public:
+    BatchGuard(TransferEngineImpl& engine, BatchID batch_id)
+        : engine_(engine), batch_id_(batch_id) {}
+
+    ~BatchGuard() {
+        auto status = reset();
+        if (!status.ok())
+            LOG(WARNING) << "failed to free batch: " << status.ToString();
+    }
+
+    BatchGuard(const BatchGuard&) = delete;
+    BatchGuard& operator=(const BatchGuard&) = delete;
+
+    Status reset() {
+        if (!batch_id_) return Status::OK();
+        auto batch_id = batch_id_;
+        batch_id_ = 0;
+        return engine_.freeBatch(batch_id);
+    }
+
+   private:
+    TransferEngineImpl& engine_;
+    BatchID batch_id_;
+};
+}  // namespace
+
 Status TransferEngineImpl::waitTransferCompletion(BatchID batch_id) {
+    BatchGuard batch_guard(*this, batch_id);
     TransferStatus xfer_status;
-    while (true) {
+    for (uint64_t poll_count = 0;; ++poll_count) {
         CHECK_STATUS(progressBatch(batch_id, xfer_status));
         if (xfer_status.s != PENDING) {
-            freeBatch(batch_id);
+            // Deliberately dropping the free status, as the pre-existing code
+            // did: callers of this path get the transfer outcome, not the
+            // cleanup outcome. transferSync() propagates it instead.
+            (void)batch_guard.reset();
             return xfer_status.s == COMPLETED
                        ? Status::OK()
                        : Status::InternalError(
                              "Transfer failed: " +
                              std::to_string((int)xfer_status.s));
         }
+        waitBeforeNextPoll(poll_count);
     }
 }
 
 Status TransferEngineImpl::transferSync(
     const std::vector<Request>& request_list) {
     auto batch_id = allocateBatch(request_list.size());
+    BatchGuard batch_guard(*this, batch_id);
     CHECK_STATUS(submitTransfer(batch_id, request_list));
-    while (true) {
+    for (uint64_t poll_count = 0;; ++poll_count) {
         TransferStatus xfer_status;
         CHECK_STATUS(progressBatch(batch_id, xfer_status));
         if (xfer_status.s == COMPLETED) break;
         if (xfer_status.s != PENDING) {
-            CHECK_STATUS(freeBatch(batch_id));
+            CHECK_STATUS(batch_guard.reset());
             return Status::InternalError(
                 "Transfer via stage buffer failed" LOC_MARK);
         }
+        waitBeforeNextPoll(poll_count);
     }
-    CHECK_STATUS(freeBatch(batch_id));
-    return Status::OK();
+    return batch_guard.reset();
 }
 
 uint64_t TransferEngineImpl::lockStageBuffer(const std::string& location) {

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -354,6 +354,18 @@ target_include_directories(tent_stage_buffer_concurrency_test
 add_test(NAME tent_stage_buffer_concurrency_test
          COMMAND tent_stage_buffer_concurrency_test)
 
+# Backoff policy for the synchronous wait loops. Pure function, no engine
+# required.
+add_executable(tent_poll_backoff_test poll_backoff_test.cpp)
+target_link_libraries(tent_poll_backoff_test PRIVATE gtest gtest_main
+                                                     tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_poll_backoff_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_poll_backoff_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_poll_backoff_test COMMAND tent_poll_backoff_test)
+
 add_executable(tent_runtime_queue_dispatch_test runtime_queue_dispatch_test.cpp)
 target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE gtest gtest_main
                                                                tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -601,6 +601,37 @@ TEST(EngineFailoverE2E, TransferSyncUsesProgressBatchWhenPollDisabled) {
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
 }
 
+// transferSync() allocates a batch before submitting, so every error path out
+// of it has to release that batch. submitTransfer() rejecting an unregistered
+// buffer is the reachable one; the poll-failure path leaves through the same
+// guard.
+TEST(EngineFailoverE2E, TransferSyncFreesBatchWhenSubmitFails) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    std::string seg_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+
+    const size_t alive_before = engine.aliveBatchCountForTest();
+
+    // Never registered, so submitTransfer() fails before anything is posted.
+    std::vector<uint8_t> unregistered(4096, 0xD3);
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = unregistered.data();
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(unregistered.data());
+    req.length = unregistered.size();
+
+    EXPECT_FALSE(engine.transferSync({req}).ok());
+    EXPECT_EQ(fake_rdma->submit_calls.load(), 0);
+    EXPECT_EQ(engine.aliveBatchCountForTest(), alive_before)
+        << "the batch allocated by transferSync outlived the failed submit";
+}
+
 TEST(EngineFailoverE2E, ProgressBatchAdvancesExactlyOneStepPerCall) {
     auto cfg = makeMinimalP2PConfig();
     cfg->set("enable_auto_failover_on_poll", false);

--- a/mooncake-transfer-engine/tent/tests/poll_backoff_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/poll_backoff_test.cpp
@@ -1,0 +1,80 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Backoff policy for transferSync() / waitTransferCompletion().
+//
+// Both used to poll progressBatch() in a `while (true)` with no pause, and
+// progressBatch takes progress_mutex_ every time, so the spin contended with
+// every other thread's submit and poll path.
+//
+// The policy is a pure function so its shape can be pinned down without
+// standing up an engine or timing a sleep.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <limits>
+
+#include "tent/runtime/transfer_engine_impl.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr uint64_t kHotPolls = 128;
+constexpr auto kMaxDelay = std::chrono::microseconds(200);
+
+// Short transfers must not pay for the fix.
+TEST(PollBackoffTest, StaysHotForTheFirstPolls) {
+    for (uint64_t i = 0; i < kHotPolls; ++i) {
+        EXPECT_EQ(nextPollDelay(i).count(), 0) << "poll " << i;
+    }
+}
+
+TEST(PollBackoffTest, SleepsOnceHotPhaseEnds) {
+    EXPECT_EQ(nextPollDelay(kHotPolls), std::chrono::microseconds(1));
+    EXPECT_EQ(nextPollDelay(kHotPolls + 1), std::chrono::microseconds(2));
+    EXPECT_EQ(nextPollDelay(kHotPolls + 2), std::chrono::microseconds(4));
+}
+
+// The point of the change: a long transfer must stop hammering
+// progress_mutex_, so the delay has to grow.
+TEST(PollBackoffTest, DelayIsNonDecreasing) {
+    auto previous = nextPollDelay(0);
+    for (uint64_t i = 1; i < 4096; ++i) {
+        const auto current = nextPollDelay(i);
+        ASSERT_GE(current, previous) << "poll " << i;
+        previous = current;
+    }
+    EXPECT_GT(previous.count(), 0);
+}
+
+// A cap bounds completion latency; without one the backoff reaches seconds.
+TEST(PollBackoffTest, DelayIsCapped) {
+    for (uint64_t i = kHotPolls; i < 4096; ++i) {
+        ASSERT_LE(nextPollDelay(i), kMaxDelay) << "poll " << i;
+    }
+    EXPECT_EQ(nextPollDelay(4096), kMaxDelay);
+}
+
+// A loop that never terminates must not overflow the shift into a zero delay.
+TEST(PollBackoffTest, SaturatesInsteadOfOverflowing) {
+    EXPECT_EQ(nextPollDelay(std::numeric_limits<uint64_t>::max()), kMaxDelay);
+    EXPECT_EQ(nextPollDelay(uint64_t(1) << 62), kMaxDelay);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
Description

  Three loops poll progressBatch() with nothing between iterations: transferSync(), waitTransferCompletion(), and ProxyManager's transferEventLoop(), which pushes an in-flight chunk straight back onto its queue and picks it up again immediately.

  progressBatch() goes to getBatchStatus(), which takes the engine's progress_mutex_ on every call and runs refillDispatchWindow() inside it. So the spin does not merely burn a core — it repeatedly acquires the global progress lock that every other thread's submit, poll and reclaim path also needs, and by releasing and immediately re-acquiring it lets the spinner cut ahead of threads that are actually making progress. All three loops run on the staging worker threads, so several can spin at once.

  Add nextPollDelay(poll_count) and pause on it between polls. Zero for the first 128 polls — the caller yields instead, which also gives a thread waiting on progress_mutex_ a chance at it — so a transfer that completes quickly keeps its current latency. After that the delay grows exponentially from 1 µs, capped at 200 µs, which bounds how long a completed transfer can go unnoticed. The shift is clamped so a long-running loop cannot overflow it back to zero. On a 20 ms transfer this turns roughly ten thousand polls into a couple of hundred.

  transferEventLoop() is paced by whole sweeps rather than per iteration: it is a work queue, and delaying each pop would slow a queue that is actually draining. It backs off only after a full pass left every chunk in the state it started in. The switch itself is unchanged.

  Separately, transferSync() and waitTransferCompletion() leave through CHECK_STATUS early returns — on submitTransfer() and on progressBatch() failure — that skipped freeBatch() and leaked the Batch slab along with whatever SubBatches it had acquired. Free it from a scope guard instead. The guard mirrors the existing BatchRef but calls freeBatch() rather than releaseBatch(); the success paths keep their current behavior, including which one propagates the free error and which one ignores it.

  Module
  
  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  cmake .. -DUSE_TENT=ON -DBUILD_UNIT_TESTS=ON && cmake --build . -j3
  ctest -R "tent_poll_backoff_test|tent_engine_failover_e2e_test" --output-on-failure
  ctest --output-on-failure

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  nextPollDelay is a free function taking only the poll count, so tent_poll_backoff_test pins its shape down without standing up an engine or timing a sleep: hot phase, first sleeps, monotonicity, the cap, and saturation at
  UINT64_MAX. Replacing it with a constant zero fails four of the five cases.

  EngineFailoverE2E.TransferSyncFreesBatchWhenSubmitFails covers the leak: a request over an unregistered buffer makes submitTransfer() fail, and the alive-batch count must come back to where it started. Disabling the guard
  fails it. This exercises the submit-failure exit; the poll-failure exit leaves through the same guard but is not separately covered, as forcing it would need a new fault mode in FakeTransport.

  The loops themselves are already covered by existing tests — EngineFailoverE2E.TransferSyncUsesProgressBatchWhenPollDisabled and WaitTransferCompletionUsesProgressBatchWhenPollDisabled drive both against a real engine; both
  still pass.

  aliveBatchCountForTest() is the only production code here that exists for the test, alongside the existing swapTransportForTest() hook on the same class.

  Full TENT suite: 64 tests, 61 pass. The 3 failures (tcp_transport_test, transfer_metadata_test, memory_location_test) are pre-existing container-environment issues — no etcd metadata server, and no CAP_SYS_NICE for mbind —
  unrelated to this change.

  Checklist
  
  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)