### PR TITLE
[Store] Structure OffsetAllocatorBackendConfig environment settings

### DIFF
--- a/mooncake-common/include/environ.h
+++ b/mooncake-common/include/environ.h
@@ -2,7 +2,12 @@
 
 #include <cstdint>
 #include <cstdlib>
+#include <iostream>
+#include <optional>
 #include <string>
+
+#include "environment_variable.h"
+#include "environment_value_parser.h"
 
 namespace mooncake {
 
@@ -91,7 +96,7 @@ class Environ {
         return transfer_engine_rpc_client_io_threads_;
     }
 
-    // Helper method to get int from env
+    // Helper methods to get numeric values from env
     static int GetInt(const char* name, int default_value);
     static int64_t GetInt64(const char* name, int64_t default_value);
     static uint32_t GetUInt32(const char* name, uint32_t default_value);
@@ -105,6 +110,35 @@ class Environ {
     // Helper method to get string from env
     static std::string GetString(const char* name,
                                  const std::string& default_value);
+
+    // Read a typed variable definition from the process environment. Missing
+    // or invalid typed values return nullopt; string variables preserve an
+    // explicitly empty value.
+    template <typename T>
+    static std::optional<T> Read(const EnvironmentVariable<T>& variable) {
+        const char* value = std::getenv(variable.name);
+        if (value == nullptr) {
+            return std::nullopt;
+        }
+        return TryParseEnvironmentValue<T>(value);
+    }
+
+    template <typename T>
+    static T ReadOr(const EnvironmentVariable<T>& variable, T default_value) {
+        const char* value = std::getenv(variable.name);
+        if (value == nullptr) {
+            return default_value;
+        }
+
+        const auto parsed = TryParseEnvironmentValue<T>(value);
+        if (parsed.has_value()) {
+            return *parsed;
+        }
+        std::cerr << "[Mooncake] Warning: invalid value '" << value
+                  << "' for env " << variable.name << ", using default "
+                  << default_value << std::endl;
+        return default_value;
+    }
 
    private:
     // Member variables

--- a/mooncake-common/include/environment_value_parser.h
+++ b/mooncake-common/include/environment_value_parser.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <cerrno>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <type_traits>
+
+#include "bool_parser.h"
+#include "integer_parser.h"
+
+namespace mooncake {
+
+struct EnvironmentDoubleParseOptions {
+    bool allow_trailing_characters{false};
+    bool allow_non_finite{false};
+};
+
+inline std::optional<double> TryParseEnvironmentDouble(
+    std::string_view value, EnvironmentDoubleParseOptions options = {}) {
+    if (value.empty()) {
+        return std::nullopt;
+    }
+
+    const std::string text(value);
+    char* end = nullptr;
+    const int saved_errno = errno;
+    errno = 0;
+    const double parsed = std::strtod(text.c_str(), &end);
+    const int parse_errno = errno;
+    errno = saved_errno;
+    const bool consumed_value = end != text.c_str() && end != nullptr;
+    while (end != nullptr && std::isspace(static_cast<unsigned char>(*end))) {
+        ++end;
+    }
+    const bool consumed_required_input =
+        options.allow_trailing_characters || (consumed_value && *end == '\0');
+    const bool accepted_finiteness =
+        options.allow_non_finite || std::isfinite(parsed);
+    if (consumed_value && consumed_required_input && parse_errno != ERANGE &&
+        accepted_finiteness) {
+        return parsed;
+    }
+    return std::nullopt;
+}
+
+template <typename>
+inline constexpr bool kUnsupportedEnvironmentValueType = false;
+
+template <typename T>
+std::optional<T> TryParseEnvironmentValue(std::string_view value) {
+    if constexpr (std::is_same_v<T, std::string>) {
+        return std::string(value);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        return TryParseBool(value);
+    } else if constexpr (std::is_integral_v<T>) {
+        return TryParseInteger<T>(
+            value, {.trim_ascii_whitespace = true, .allow_leading_plus = true});
+    } else if constexpr (std::is_same_v<T, double>) {
+        return TryParseEnvironmentDouble(value);
+    } else {
+        static_assert(kUnsupportedEnvironmentValueType<T>,
+                      "unsupported environment value type");
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-common/include/environment_variable.h
+++ b/mooncake-common/include/environment_variable.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace mooncake {
+
+template <typename T>
+struct EnvironmentVariable {
+    const char* name;
+};
+
+}  // namespace mooncake

--- a/mooncake-common/src/environ.cpp
+++ b/mooncake-common/src/environ.cpp
@@ -1,15 +1,8 @@
 #include "environ.h"
 
 #include <algorithm>
-#include <cerrno>
-#include <cctype>
-#include <cmath>
 #include <iostream>
-#include <string_view>
 #include <thread>
-
-#include "bool_parser.h"
-#include "integer_parser.h"
 
 namespace mooncake {
 
@@ -41,9 +34,7 @@ Integer ReadInteger(const EnvironSource& source, const char* name,
         return default_value;
     }
 
-    const auto parsed = TryParseInteger<Integer>(
-        std::string_view(value),
-        {.trim_ascii_whitespace = true, .allow_leading_plus = true});
+    const auto parsed = TryParseEnvironmentValue<Integer>(value);
     if (parsed.has_value()) {
         return *parsed;
     }
@@ -74,15 +65,9 @@ double ReadDouble(const EnvironSource& source, const char* name,
         return default_value;
     }
 
-    char* end = nullptr;
-    errno = 0;
-    const double parsed = std::strtod(value, &end);
-    while (end != nullptr && std::isspace(static_cast<unsigned char>(*end))) {
-        ++end;
-    }
-    if (end != value && end != nullptr && *end == '\0' && errno != ERANGE &&
-        std::isfinite(parsed)) {
-        return parsed;
+    const auto parsed = TryParseEnvironmentValue<double>(value);
+    if (parsed.has_value()) {
+        return *parsed;
     }
 
     std::cerr << "[Mooncake] Warning: invalid value '" << value << "' for env "
@@ -97,7 +82,7 @@ bool ReadBool(const EnvironSource& source, const char* name,
         return default_value;
     }
 
-    const auto parsed = TryParseBool(value);
+    const auto parsed = TryParseEnvironmentValue<bool>(value);
     if (parsed.has_value()) {
         return *parsed;
     }

--- a/mooncake-common/tests/CMakeLists.txt
+++ b/mooncake-common/tests/CMakeLists.txt
@@ -21,7 +21,8 @@ target_link_libraries(rpc_client_io_context_test PUBLIC mooncake_common gtest
                                                         ibverbs pthread)
 add_test(NAME rpc_client_io_context_test COMMAND rpc_client_io_context_test)
 
-foreach(parser_test ascii_string bool_parser integer_parser)
+foreach(parser_test ascii_string bool_parser environment_value_parser
+                    integer_parser)
   add_executable(${parser_test}_test ${parser_test}_test.cpp)
   target_link_libraries(${parser_test}_test PUBLIC mooncake_common gtest
                                                    gtest_main pthread)

--- a/mooncake-common/tests/environ_test.cpp
+++ b/mooncake-common/tests/environ_test.cpp
@@ -13,11 +13,13 @@
 // limitations under the License.
 
 #include "environ.h"
+#include "environment_variable.h"
 
 #include <gtest/gtest.h>
 
 #include <climits>
 #include <cstdlib>
+#include <optional>
 
 using mooncake::Environ;
 
@@ -295,6 +297,36 @@ TEST_F(EnvironTest, GetStringEmpty) {
 TEST_F(EnvironTest, GetStringWithSpaces) {
     setenv("MC_TEST_STRING", "hello world", 1);
     EXPECT_EQ(Environ::GetString("MC_TEST_STRING", ""), "hello world");
+}
+
+TEST_F(EnvironTest, ReadsTypedEnvironmentVariableDefinitions) {
+    constexpr mooncake::EnvironmentVariable<int64_t> number{"MC_TEST_INT64"};
+    constexpr mooncake::EnvironmentVariable<bool> enabled{"MC_TEST_BOOL"};
+    constexpr mooncake::EnvironmentVariable<std::string> text{"MC_TEST_STRING"};
+
+    EXPECT_FALSE(Environ::Read(number).has_value());
+    EXPECT_EQ(Environ::ReadOr(number, int64_t{17}), 17);
+
+    setenv(number.name, "42", 1);
+    setenv(enabled.name, "off", 1);
+    setenv(text.name, "", 1);
+
+    EXPECT_EQ(Environ::Read(number), 42);
+    EXPECT_EQ(Environ::Read(enabled), false);
+    ASSERT_TRUE(Environ::Read(text).has_value());
+    EXPECT_TRUE(Environ::Read(text)->empty());
+}
+
+TEST_F(EnvironTest, TypedReadOrWarnsAndUsesDefaultForInvalidValues) {
+    constexpr mooncake::EnvironmentVariable<int64_t> number{"MC_TEST_INT64"};
+    setenv(number.name, "invalid", 1);
+
+    testing::internal::CaptureStderr();
+    EXPECT_EQ(Environ::ReadOr(number, int64_t{17}), 17);
+    const std::string logs = testing::internal::GetCapturedStderr();
+
+    EXPECT_NE(logs.find("MC_TEST_INT64"), std::string::npos);
+    EXPECT_NE(logs.find("using default 17"), std::string::npos);
 }
 
 int main(int argc, char** argv) {

--- a/mooncake-common/tests/environment_value_parser_test.cpp
+++ b/mooncake-common/tests/environment_value_parser_test.cpp
@@ -1,0 +1,72 @@
+#include "environment_value_parser.h"
+
+#include <gtest/gtest.h>
+
+#include <cerrno>
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+namespace mooncake::test {
+
+TEST(EnvironmentValueParserTest, ParsesSupportedTypes) {
+    EXPECT_EQ(TryParseEnvironmentValue<int64_t>(" \t+42\r\n"), 42);
+    EXPECT_EQ(TryParseEnvironmentValue<bool>("ON"), true);
+    EXPECT_EQ(TryParseEnvironmentValue<std::string>("value"), "value");
+
+    const auto ratio = TryParseEnvironmentValue<double>("0.75");
+    ASSERT_TRUE(ratio.has_value());
+    EXPECT_DOUBLE_EQ(*ratio, 0.75);
+}
+
+TEST(EnvironmentValueParserTest, RejectsInvalidTypedValues) {
+    EXPECT_FALSE(TryParseEnvironmentValue<int64_t>("").has_value());
+    EXPECT_FALSE(
+        TryParseEnvironmentValue<int64_t>("not-an-integer").has_value());
+    EXPECT_FALSE(TryParseEnvironmentValue<bool>("").has_value());
+    EXPECT_FALSE(TryParseEnvironmentValue<bool>("unknown").has_value());
+    EXPECT_FALSE(TryParseEnvironmentValue<double>("").has_value());
+    EXPECT_FALSE(TryParseEnvironmentValue<double>("not-a-ratio").has_value());
+}
+
+TEST(EnvironmentValueParserTest, RequiresFiniteCompleteDoubleValues) {
+    EXPECT_FALSE(TryParseEnvironmentValue<double>("0.75suffix").has_value());
+    EXPECT_FALSE(TryParseEnvironmentValue<double>("nan").has_value());
+
+    const auto ratio = TryParseEnvironmentValue<double>(" 0.75 ");
+    ASSERT_TRUE(ratio.has_value());
+    EXPECT_DOUBLE_EQ(*ratio, 0.75);
+}
+
+TEST(EnvironmentValueParserTest, SupportsExplicitLenientDoubleParsing) {
+    const EnvironmentDoubleParseOptions options{
+        .allow_trailing_characters = true,
+        .allow_non_finite = true,
+    };
+
+    const auto suffixed = TryParseEnvironmentDouble("0.75suffix", options);
+    ASSERT_TRUE(suffixed.has_value());
+    EXPECT_DOUBLE_EQ(*suffixed, 0.75);
+
+    const auto nan = TryParseEnvironmentDouble("nan", options);
+    ASSERT_TRUE(nan.has_value());
+    EXPECT_TRUE(std::isnan(*nan));
+
+    EXPECT_FALSE(TryParseEnvironmentDouble(" invalid", options).has_value());
+}
+
+TEST(EnvironmentValueParserTest, PreservesEmptyStrings) {
+    const auto empty = TryParseEnvironmentValue<std::string>("");
+    ASSERT_TRUE(empty.has_value());
+    EXPECT_TRUE(empty->empty());
+}
+
+TEST(EnvironmentValueParserTest, PreservesErrno) {
+    for (const char* value : {"0.75", "not-a-ratio", "1e9999"}) {
+        errno = EDOM;
+        static_cast<void>(TryParseEnvironmentValue<double>(value));
+        EXPECT_EQ(errno, EDOM);
+    }
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -27,7 +27,6 @@
 #include "utils.h"
 #include "crc32c.h"
 #include "ascii_string.h"
-#include "bool_parser.h"
 #include "environ.h"
 
 #include <ylt/util/tl/expected.hpp>
@@ -57,6 +56,31 @@ struct FdGuard {
 #endif
 
 namespace mooncake {
+
+namespace {
+
+struct OffsetAllocatorBackendEnvironmentVariables {
+    inline static constexpr EnvironmentVariable<std::string>
+        kMooncakeOffsetEvictionPolicy{"MOONCAKE_OFFSET_EVICTION_POLICY"};
+    inline static constexpr EnvironmentVariable<std::string>
+        kMooncakeOffsetHighRatio{"MOONCAKE_OFFSET_HIGH_RATIO"};
+    inline static constexpr EnvironmentVariable<std::string>
+        kMooncakeOffsetLowRatio{"MOONCAKE_OFFSET_LOW_RATIO"};
+    inline static constexpr EnvironmentVariable<int64_t>
+        kMooncakeOffsetMaxCapacityNodes{"MOONCAKE_OFFSET_MAX_CAPACITY_NODES"};
+    inline static constexpr EnvironmentVariable<int64_t>
+        kMooncakeOffsetMaxEvictPerOffload{
+            "MOONCAKE_OFFSET_MAX_EVICT_PER_OFFLOAD"};
+    inline static constexpr EnvironmentVariable<std::string>
+        kMooncakeOffsetPersistMode{"MOONCAKE_OFFSET_PERSIST_MODE"};
+    inline static constexpr EnvironmentVariable<int64_t>
+        kMooncakeOffsetPersistIntervalSeconds{
+            "MOONCAKE_OFFSET_PERSIST_INTERVAL_SECONDS"};
+    inline static constexpr EnvironmentVariable<bool> kMooncakeOffsetRecordCrc{
+        "MOONCAKE_OFFSET_RECORD_CRC"};
+};
+
+}  // namespace
 
 bool FilePerKeyConfig::Validate() const {
     if (fsdir.empty()) {
@@ -165,42 +189,42 @@ bool OffsetAllocatorBackendConfig::Validate() const {
     return true;
 }
 
-static std::optional<double> GetEnvDouble(const char* name) {
-    const char* env = std::getenv(name);
-    if (!env || env[0] == '\0') return std::nullopt;
-    try {
-        return std::stod(env);
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
 OffsetAllocatorBackendConfig OffsetAllocatorBackendConfig::FromEnvironment() {
     OffsetAllocatorBackendConfig cfg;
+    using Variables = OffsetAllocatorBackendEnvironmentVariables;
 
-    const char* pol = std::getenv("MOONCAKE_OFFSET_EVICTION_POLICY");
-    if (pol) {
-        if (AsciiCaseInsensitiveEquals(pol, "fifo")) {
+    const auto policy = Environ::Read(Variables::kMooncakeOffsetEvictionPolicy);
+    if (policy.has_value()) {
+        if (AsciiCaseInsensitiveEquals(*policy, "fifo")) {
             cfg.eviction_policy = OffsetEvictionPolicy::FIFO;
         }
         // NONE is default; LRU reserved for phase 2
     }
 
-    if (auto v = GetEnvDouble("MOONCAKE_OFFSET_HIGH_RATIO"))
-        cfg.high_ratio = *v;
-    if (auto v = GetEnvDouble("MOONCAKE_OFFSET_LOW_RATIO")) cfg.low_ratio = *v;
+    constexpr EnvironmentDoubleParseOptions kLegacyRatioParsing{
+        .allow_trailing_characters = true,
+        .allow_non_finite = true,
+    };
+    if (const auto value = Environ::Read(Variables::kMooncakeOffsetHighRatio)) {
+        cfg.high_ratio = TryParseEnvironmentDouble(*value, kLegacyRatioParsing)
+                             .value_or(cfg.high_ratio);
+    }
+    if (const auto value = Environ::Read(Variables::kMooncakeOffsetLowRatio)) {
+        cfg.low_ratio = TryParseEnvironmentDouble(*value, kLegacyRatioParsing)
+                            .value_or(cfg.low_ratio);
+    }
     // Both byte and key watermarks derive from the same ratio pair.
     cfg.keys_high_ratio = cfg.high_ratio;
     cfg.keys_low_ratio = cfg.low_ratio;
 
-    cfg.max_capacity_nodes = Environ::GetInt64(
-        "MOONCAKE_OFFSET_MAX_CAPACITY_NODES", cfg.max_capacity_nodes);
+    cfg.max_capacity_nodes = Environ::ReadOr(
+        Variables::kMooncakeOffsetMaxCapacityNodes, cfg.max_capacity_nodes);
 
     // Read eviction cap as int64_t to guard against negative env values
     // which would wrap to SIZE_MAX with an unsigned parser.
     auto max_evict_raw =
-        Environ::GetInt64("MOONCAKE_OFFSET_MAX_EVICT_PER_OFFLOAD",
-                          static_cast<int64_t>(cfg.max_evict_per_offload));
+        Environ::ReadOr(Variables::kMooncakeOffsetMaxEvictPerOffload,
+                        static_cast<int64_t>(cfg.max_evict_per_offload));
     if (max_evict_raw > 0) {
         cfg.max_evict_per_offload = static_cast<size_t>(max_evict_raw);
     } else if (max_evict_raw <= 0) {
@@ -210,9 +234,9 @@ OffsetAllocatorBackendConfig OffsetAllocatorBackendConfig::FromEnvironment() {
     }
 
     // Persistence mode
-    const char* persist = std::getenv("MOONCAKE_OFFSET_PERSIST_MODE");
-    if (persist) {
-        std::string s(persist);
+    const auto persist = Environ::Read(Variables::kMooncakeOffsetPersistMode);
+    if (persist.has_value()) {
+        const std::string& s = *persist;
         if (AsciiCaseInsensitiveEquals(s, "disabled")) {
             cfg.persist_mode = OffsetPersistMode::kDisabled;
         } else if (AsciiCaseInsensitiveEquals(s, "relaxed")) {
@@ -226,16 +250,14 @@ OffsetAllocatorBackendConfig OffsetAllocatorBackendConfig::FromEnvironment() {
     }
 
     cfg.persist_interval_seconds =
-        Environ::GetInt64("MOONCAKE_OFFSET_PERSIST_INTERVAL_SECONDS",
-                          cfg.persist_interval_seconds);
+        Environ::ReadOr(Variables::kMooncakeOffsetPersistIntervalSeconds,
+                        cfg.persist_interval_seconds);
 
     // Record CRC-32C: "0"/"false"/"off" disables per-record checksums.
-    const char* crc_env = std::getenv("MOONCAKE_OFFSET_RECORD_CRC");
-    if (crc_env) {
-        const auto parsed = TryParseBool(crc_env);
-        if (parsed.has_value() && !*parsed) {
-            cfg.enable_record_crc = false;
-        }
+    if (const auto record_crc =
+            Environ::Read(Variables::kMooncakeOffsetRecordCrc);
+        record_crc.has_value() && !*record_crc) {
+        cfg.enable_record_crc = false;
     }
 
     return cfg;

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -7,11 +7,15 @@
 #include <fstream>
 #include <iostream>
 #include <limits>
+#include <cmath>
+#include <optional>
 #include <ranges>
+#include <string>
 #include <thread>
 #include <atomic>
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
 #include <mutex>
 #include <fcntl.h>
 #include <unistd.h>
@@ -23,6 +27,72 @@
 
 namespace fs = std::filesystem;
 namespace mooncake::test {
+
+class ScopedEnvVar {
+   public:
+    explicit ScopedEnvVar(const char* name) : name_(name) {
+        const char* value = std::getenv(name);
+        if (value != nullptr) {
+            original_ = value;
+        }
+        unsetenv(name);
+    }
+
+    ~ScopedEnvVar() {
+        if (original_.has_value()) {
+            setenv(name_.c_str(), original_->c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+    void Set(const char* value) { setenv(name_.c_str(), value, 1); }
+
+   private:
+    std::string name_;
+    std::optional<std::string> original_;
+};
+
+struct OffsetAllocatorEnvironment {
+    ScopedEnvVar policy{"MOONCAKE_OFFSET_EVICTION_POLICY"};
+    ScopedEnvVar high_ratio{"MOONCAKE_OFFSET_HIGH_RATIO"};
+    ScopedEnvVar low_ratio{"MOONCAKE_OFFSET_LOW_RATIO"};
+    ScopedEnvVar max_nodes{"MOONCAKE_OFFSET_MAX_CAPACITY_NODES"};
+    ScopedEnvVar max_evict{"MOONCAKE_OFFSET_MAX_EVICT_PER_OFFLOAD"};
+    ScopedEnvVar persist_mode{"MOONCAKE_OFFSET_PERSIST_MODE"};
+    ScopedEnvVar persist_interval{"MOONCAKE_OFFSET_PERSIST_INTERVAL_SECONDS"};
+    ScopedEnvVar record_crc{"MOONCAKE_OFFSET_RECORD_CRC"};
+
+    void SetAll(const char* value) {
+        policy.Set(value);
+        high_ratio.Set(value);
+        low_ratio.Set(value);
+        max_nodes.Set(value);
+        max_evict.Set(value);
+        persist_mode.Set(value);
+        persist_interval.Set(value);
+        record_crc.Set(value);
+    }
+};
+
+void ExpectDefaultOffsetAllocatorConfig(
+    const OffsetAllocatorBackendConfig& config) {
+    EXPECT_EQ(config.eviction_policy, OffsetEvictionPolicy::NONE);
+    EXPECT_EQ(config.high_watermark_bytes, 0);
+    EXPECT_EQ(config.low_watermark_bytes, 0);
+    EXPECT_DOUBLE_EQ(config.high_ratio, 0.90);
+    EXPECT_DOUBLE_EQ(config.low_ratio, 0.80);
+    EXPECT_EQ(config.high_watermark_keys, 0);
+    EXPECT_EQ(config.low_watermark_keys, 0);
+    EXPECT_DOUBLE_EQ(config.keys_high_ratio, 0.90);
+    EXPECT_DOUBLE_EQ(config.keys_low_ratio, 0.80);
+    EXPECT_EQ(config.max_capacity_nodes, 0);
+    EXPECT_EQ(config.max_evict_per_offload, 4096);
+    EXPECT_EQ(config.fallback_evict_batch, 16);
+    EXPECT_EQ(config.persist_mode, OffsetPersistMode::kDisabled);
+    EXPECT_EQ(config.persist_interval_seconds, 60);
+    EXPECT_TRUE(config.enable_record_crc);
+}
 
 class StorageBackendTest : public ::testing::Test {
    protected:
@@ -187,6 +257,119 @@ TEST_F(StorageBackendTest, CreateAcceptsValidConfig) {
     auto result = StorageBackend::Create(data_path, "fsdir", true);
     ASSERT_TRUE(result.has_value());
     EXPECT_NE(result.value(), nullptr);
+}
+
+class OffsetAllocatorEnvironmentTest : public StorageBackendTest {
+   protected:
+    OffsetAllocatorEnvironment env;
+};
+
+TEST_F(OffsetAllocatorEnvironmentTest, KeepsDefaultsWhenVariablesAreUnset) {
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    ExpectDefaultOffsetAllocatorConfig(config);
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest, ReadsValidValues) {
+    env.policy.Set("FIFO");
+    env.high_ratio.Set("0.75");
+    env.low_ratio.Set("0.50");
+    env.max_nodes.Set("123");
+    env.max_evict.Set("17");
+    env.persist_mode.Set("RELAXED");
+    env.persist_interval.Set("10");
+    env.record_crc.Set("false");
+
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    EXPECT_EQ(config.eviction_policy, OffsetEvictionPolicy::FIFO);
+    EXPECT_DOUBLE_EQ(config.high_ratio, 0.75);
+    EXPECT_DOUBLE_EQ(config.low_ratio, 0.50);
+    EXPECT_DOUBLE_EQ(config.keys_high_ratio, 0.75);
+    EXPECT_DOUBLE_EQ(config.keys_low_ratio, 0.50);
+    EXPECT_EQ(config.max_capacity_nodes, 123);
+    EXPECT_EQ(config.max_evict_per_offload, 17);
+    EXPECT_EQ(config.persist_mode, OffsetPersistMode::kRelaxed);
+    EXPECT_EQ(config.persist_interval_seconds, 10);
+    EXPECT_FALSE(config.enable_record_crc);
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest, PreservesLegacyRatioParsing) {
+    env.high_ratio.Set("0.75suffix");
+
+    const auto suffixed = OffsetAllocatorBackendConfig::FromEnvironment();
+    EXPECT_DOUBLE_EQ(suffixed.high_ratio, 0.75);
+    EXPECT_DOUBLE_EQ(suffixed.keys_high_ratio, 0.75);
+
+    env.high_ratio.Set("nan");
+    const auto nan = OffsetAllocatorBackendConfig::FromEnvironment();
+    EXPECT_TRUE(std::isnan(nan.high_ratio));
+    EXPECT_TRUE(std::isnan(nan.keys_high_ratio));
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest, KeepsDefaultsForInvalidValues) {
+    env.policy.Set("unknown");
+    env.high_ratio.Set("not-a-ratio");
+    env.low_ratio.Set("not-a-ratio");
+    env.max_nodes.Set("not-an-integer");
+    env.max_evict.Set("-1");
+    env.persist_mode.Set("unknown");
+    env.persist_interval.Set("not-an-integer");
+    env.record_crc.Set("unknown");
+
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    ExpectDefaultOffsetAllocatorConfig(config);
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest,
+       KeepsDefaultRatioForWhitespacePrefixedInvalidValue) {
+    env.high_ratio.Set(" invalid");
+
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    EXPECT_DOUBLE_EQ(config.high_ratio, 0.90);
+    EXPECT_DOUBLE_EQ(config.keys_high_ratio, 0.90);
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest, KeepsDefaultsForEmptyValues) {
+    env.SetAll("");
+
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    ExpectDefaultOffsetAllocatorConfig(config);
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest,
+       PreservesDiagnosticsForUnparsableAndEmptyValues) {
+    for (const char* value : {"invalid", ""}) {
+        env.SetAll(value);
+        testing::internal::CaptureStderr();
+        const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+        const std::string logs = testing::internal::GetCapturedStderr();
+
+        ExpectDefaultOffsetAllocatorConfig(config);
+        EXPECT_NE(logs.find("MOONCAKE_OFFSET_MAX_CAPACITY_NODES"),
+                  std::string::npos);
+        EXPECT_NE(logs.find("MOONCAKE_OFFSET_MAX_EVICT_PER_OFFLOAD"),
+                  std::string::npos);
+        EXPECT_NE(logs.find("MOONCAKE_OFFSET_PERSIST_MODE"), std::string::npos);
+        EXPECT_NE(logs.find("MOONCAKE_OFFSET_PERSIST_INTERVAL_SECONDS"),
+                  std::string::npos);
+        EXPECT_EQ(logs.find("MOONCAKE_OFFSET_EVICTION_POLICY"),
+                  std::string::npos);
+        EXPECT_EQ(logs.find("MOONCAKE_OFFSET_HIGH_RATIO"), std::string::npos);
+        EXPECT_EQ(logs.find("MOONCAKE_OFFSET_LOW_RATIO"), std::string::npos);
+        EXPECT_EQ(logs.find("MOONCAKE_OFFSET_RECORD_CRC"), std::string::npos);
+    }
+}
+
+TEST_F(OffsetAllocatorEnvironmentTest,
+       PreservesWarningForNonPositiveEvictionCap) {
+    env.max_evict.Set("-1");
+    testing::internal::CaptureStderr();
+    const auto config = OffsetAllocatorBackendConfig::FromEnvironment();
+    const std::string logs = testing::internal::GetCapturedStderr();
+
+    ExpectDefaultOffsetAllocatorConfig(config);
+    EXPECT_NE(logs.find("MOONCAKE_OFFSET_MAX_EVICT_PER_OFFLOAD=-1 is "
+                        "non-positive"),
+              std::string::npos);
 }
 
 // Regression tests for StorageBackendAdaptor::Init validation (issue #3134


### PR DESCRIPTION
## Description

This PR uses `OffsetAllocatorBackendConfig::FromEnvironment()` as a focused pilot for consolidating environment configuration. These existing settings configure the offset allocator storage backend's eviction, capacity, persistence, and record-integrity behavior.

- Add a typed parser for converting strings to supported value types, independent of environment lookup.
- Add typed environment-variable definitions, group the offset allocator backend's existing variables together, and keep its legacy ratio parsing explicit in that group.
- Route the group through `Environ` while keeping policy and persistence-mode mapping in the Store layer.
- Preserve existing defaults, parsing and validation behavior, diagnostics, configuration precedence, and read timing.
- Cover unset, valid, invalid, and explicitly empty values.

This PR does not change config-file or CLI handling, add dynamic configuration reloads, or change user-facing configuration semantics.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build-verify -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build-verify \
  --target environ_test environment_value_parser_test storage_backend_test \
           default_config_test ascii_string_test bool_parser_test \
           integer_parser_test master_service_evict_scenario_test -j 8
ctest --test-dir build-verify \
  -R '^(environ_test|environment_value_parser_test|ascii_string_test|bool_parser_test|integer_parser_test|default_config_test|storage_backend_test|master_service_evict_scenario_test)$' \
  --output-on-failure
pre-commit run --files \
  mooncake-common/include/environ.h \
  mooncake-common/include/environment_value_parser.h \
  mooncake-common/include/environment_variable.h \
  mooncake-common/src/environ.cpp \
  mooncake-common/tests/CMakeLists.txt \
  mooncake-common/tests/environ_test.cpp \
  mooncake-common/tests/environment_value_parser_test.cpp \
  mooncake-store/src/storage_backend.cpp \
  mooncake-store/tests/storage_backend_test.cpp
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used for repository exploration, implementation, test additions, and verification. The human submitter reviewed every changed line and is responsible for understanding and defending the complete change.
