### PR TITLE
[Bugfix][TENT] Lock ProxyManager's stage buffer map

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -15,6 +15,8 @@
 #ifndef PROXY_MANAGER_H_
 #define PROXY_MANAGER_H_
 
+#include <shared_mutex>
+
 #include "tent/common/types.h"
 #include "tent/common/status.h"
 #include "tent/common/concurrent/thread_pool.h"
@@ -100,6 +102,11 @@ class ProxyManager {
     const size_t chunk_size_;
     const size_t chunk_count_;
     TransferEngineImpl* impl_;
+    // Guards the map, not the chunk bitmaps in it: those are atomic_flags and
+    // stay lock-free under a shared lock. Exclusive only to insert or erase an
+    // entry, at most once per location. Reached by the kShards staging workers
+    // via StageBufferCache and by the RPC thread via Pin/Unpin.
+    mutable std::shared_mutex stage_buffers_mutex_;
     std::unordered_map<std::string, StageBuffers> stage_buffers_;
     std::atomic<bool> running_;
     struct WorkerShard {

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -38,6 +38,8 @@ Status ProxyManager::deconstruct() {
         shards_[i].cv.notify_all();
         shards_[i].thread.join();
     }
+    // The workers are joined above, but Pin/Unpin arrive on the RPC thread.
+    std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     for (auto entry : stage_buffers_) {
         impl_->unregisterLocalMemory(entry.second.chunks);
         impl_->freeLocalMemory(entry.second.chunks);
@@ -561,6 +563,10 @@ Status ProxyManager::transferSync(StagingTask& task, StageBufferCache* cache) {
 }
 
 Status ProxyManager::allocateStageBuffers(const std::string& location) {
+    // Held across the slow allocate + register, which run once per location.
+    // Racing instead would register the same hundreds of MB twice, then throw
+    // one away.
+    std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     if (stage_buffers_.count(location)) return Status::OK();
     StageBuffers buf;
     auto total_size = chunk_size_ * chunk_count_;
@@ -575,6 +581,7 @@ Status ProxyManager::allocateStageBuffers(const std::string& location) {
 }
 
 Status ProxyManager::freeStageBuffers(const std::string& location) {
+    std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     auto it = stage_buffers_.find(location);
     if (it == stage_buffers_.end())
         return Status::InvalidArgument("Stage buffer not allocated" LOC_MARK);
@@ -587,10 +594,17 @@ Status ProxyManager::freeStageBuffers(const std::string& location) {
 
 Status ProxyManager::pinStageBuffer(const std::string& location,
                                     uint64_t& addr) {
+    std::shared_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     auto it = stage_buffers_.find(location);
     if (it == stage_buffers_.end()) {
+        // allocateStageBuffers needs the lock exclusively, so drop ours. It
+        // re-checks under its own lock, so losing the race here is harmless.
+        guard.unlock();
         CHECK_STATUS(allocateStageBuffers(location));
+        guard.lock();
         it = stage_buffers_.find(location);
+        if (it == stage_buffers_.end())
+            return Status::InternalError("Stage buffer disappeared" LOC_MARK);
     }
 
     auto& buf = it->second;
@@ -605,6 +619,7 @@ Status ProxyManager::pinStageBuffer(const std::string& location,
 }
 
 Status ProxyManager::unpinStageBuffer(uint64_t addr) {
+    std::shared_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     for (auto& [location, buf] : stage_buffers_) {
         auto base = reinterpret_cast<uint64_t>(buf.chunks);
         auto end = base + chunk_size_ * chunk_count_;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -315,6 +315,20 @@ target_include_directories(tent_progress_worker_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_progress_worker_test COMMAND tent_progress_worker_test)
 
+# stage_buffers_ is reached from the staging workers and the RPC thread. Drives
+# a real ProxyManager concurrently; no RDMA device required.
+add_executable(tent_stage_buffer_concurrency_test
+               stage_buffer_concurrency_test.cpp)
+target_link_libraries(tent_stage_buffer_concurrency_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_stage_buffer_concurrency_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_stage_buffer_concurrency_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_stage_buffer_concurrency_test
+         COMMAND tent_stage_buffer_concurrency_test)
+
 add_executable(tent_runtime_queue_dispatch_test runtime_queue_dispatch_test.cpp)
 target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE gtest gtest_main
                                                                tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/stage_buffer_concurrency_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/stage_buffer_concurrency_test.cpp
@@ -1,0 +1,228 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// ProxyManager::stage_buffers_ is reached from the kShards staging workers via
+// StageBufferCache::allocateLocal and from the RPC thread via Pin/Unpin. The
+// chunk bitmaps are atomic_flags, but the map holding them was unsynchronised,
+// so a first-time pin could rehash under another thread's find.
+//
+// These drive the map concurrently. The unlocked failure is a rehash race,
+// which a plain run may not reproduce -- run under -fsanitize=thread for that.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <memory>
+#include <set>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/proxy_manager.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class FakeSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return 0; }
+};
+
+// Only the memory hooks matter here: ProxyManager allocates and registers a
+// stage buffer through the engine, which forwards to the transport.
+class FakeTransport : public Transport {
+   public:
+    FakeTransport() { caps.dram_to_dram = true; }
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config> = nullptr) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t) override {
+        batch = new FakeSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete batch;
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(SubBatchRef,
+                               const std::vector<Request>&) override {
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef, int,
+                             TransferStatus& status) override {
+        status = {TransferStatusEnum::COMPLETED, 0};
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc, const MemoryOptions&) override {
+        desc.transports.push_back(RDMA);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& d : desc_list) {
+            auto s = addMemoryBuffer(d, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc&) override { return Status::OK(); }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        if (!*addr) return Status::InternalError("malloc failed" LOC_MARK);
+        return Status::OK();
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void*, size_t) override { return false; }
+
+    const char* getName() const override { return "<fake>"; }
+};
+
+std::shared_ptr<Config> makeLoopbackP2PConfig() {
+    auto cfg = std::make_shared<Config>();
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+    return cfg;
+}
+
+// Small enough to keep the test cheap; ProxyManager's real default would
+// allocate 4 MiB x 64 per location.
+constexpr size_t kChunkSize = 4096;
+constexpr size_t kChunkCount = 8;
+
+class StageBufferConcurrencyTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        engine_ = std::make_unique<TransferEngineImpl>(makeLoopbackP2PConfig());
+        ASSERT_TRUE(engine_->available());
+        auto fake = std::make_shared<FakeTransport>();
+        std::string seg_name = engine_->getSegmentName();
+        ASSERT_TRUE(fake->install(seg_name, nullptr, nullptr).ok());
+        engine_->swapTransportForTest(RDMA, fake);
+        proxy_ = std::make_unique<ProxyManager>(engine_.get(), kChunkSize,
+                                                kChunkCount);
+    }
+
+    // Destruction only: ProxyManager::deconstruct() joins its workers and is
+    // not idempotent, so calling it here as well would join twice.
+    void TearDown() override { proxy_.reset(); }
+
+    std::unique_ptr<TransferEngineImpl> engine_;
+    std::unique_ptr<ProxyManager> proxy_;
+};
+
+// The dangerous shape: every thread inserts a different entry at the same
+// time, so inserts and lookups overlap.
+TEST_F(StageBufferConcurrencyTest, ConcurrentFirstPinOfDistinctLocations) {
+    constexpr int kThreads = 8;
+    std::vector<std::thread> threads;
+    std::atomic<int> succeeded{0};
+    std::vector<uint64_t> addrs(kThreads, 0);
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i] {
+            uint64_t addr = 0;
+            if (proxy_->pinStageBuffer("cpu:" + std::to_string(i), addr).ok()) {
+                addrs[i] = addr;
+                succeeded.fetch_add(1);
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_EQ(succeeded.load(), kThreads);
+    std::set<uint64_t> unique(addrs.begin(), addrs.end());
+    EXPECT_EQ(unique.size(), static_cast<size_t>(kThreads))
+        << "two locations handed out the same chunk";
+}
+
+// Same entry from every thread: the bitmap must hand each caller its own
+// chunk, and the entry must be created exactly once.
+TEST_F(StageBufferConcurrencyTest,
+       ConcurrentPinOfOneLocationHandsOutDistinctChunks) {
+    std::vector<std::thread> threads;
+    std::vector<uint64_t> addrs(kChunkCount, 0);
+
+    for (size_t i = 0; i < kChunkCount; ++i) {
+        threads.emplace_back([&, i] {
+            uint64_t addr = 0;
+            if (proxy_->pinStageBuffer("cpu:0", addr).ok()) addrs[i] = addr;
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    std::set<uint64_t> unique(addrs.begin(), addrs.end());
+    EXPECT_EQ(unique.size(), kChunkCount) << "a chunk was pinned twice";
+    EXPECT_EQ(unique.count(0), 0u) << "a pin failed";
+}
+
+// Unpin walks the whole map, so it reads entries other threads are inserting.
+TEST_F(StageBufferConcurrencyTest, PinAndUnpinOverlap) {
+    constexpr int kThreads = 8;
+    std::vector<std::thread> threads;
+    std::atomic<int> failures{0};
+
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&, i] {
+            const std::string location = "cpu:" + std::to_string(i % 4);
+            for (int round = 0; round < 32; ++round) {
+                uint64_t addr = 0;
+                if (!proxy_->pinStageBuffer(location, addr).ok()) continue;
+                if (!proxy_->unpinStageBuffer(addr).ok()) failures.fetch_add(1);
+            }
+        });
+    }
+    for (auto& t : threads) t.join();
+
+    EXPECT_EQ(failures.load(), 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
Description
  
  ProxyManager::stage_buffers_ is a plain unordered_map with no synchronisation, reached from the kShards staging worker threads via StageBufferCache::allocateLocal → pinStageBuffer, and from the RPC thread via the Pin/Unpin handlers.

  The chunk bitmaps inside each entry are atomic_flags and are fine. The map holding them is not: allocateStageBuffers inserts with operator[] while pinStageBuffer and unpinStageBuffer call find() or walk the whole map. An insert that rehashes under another thread's traversal is undefined behaviour, not a benign stale read. Triggering it needs two different locations pinned for the first time concurrently — the steady state only reads existing entries — which is presumably why it has not surfaced.

  This predates the recent RPC threading work: each shard's runner() builds its own StageBufferCache and calls pinStageBuffer directly, so the single RPC thread never serialised it.

  Guard the map with a shared_mutex. Reads dominate and only touch atomics inside an entry, so pinStageBuffer holds it shared across both the lookup and the bitmap scan, and unpinStageBuffer across its walk — workers still scan concurrently and the bitmap stays lock-free. Exclusive is taken only to insert or erase, at most once per location.

  allocateStageBuffers holds the exclusive lock across the allocation and registration. Those are slow but run once per location, and racing there instead would mean registering the same hundreds of megabytes twice and discarding one. shared_mutex cannot upgrade in place, so pinStageBuffer drops its shared lock before calling it and re-acquires afterwards; allocateStageBuffers re-checks under its own exclusive lock, which makes losing that race harmless.

  Lock ordering is one-way: callers hold no engine lock on entry (lockStageBuffer/unlockStageBuffer forward directly), and the registration path never calls back into ProxyManager.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  cmake .. -DUSE_TENT=ON -DBUILD_UNIT_TESTS=ON && cmake --build . -j3
  ctest -R tent_stage_buffer_concurrency_test --output-on-failure
  ctest --output-on-failure

  Test results:
  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  Adds tent_stage_buffer_concurrency_test, which drives a real ProxyManager from several threads: concurrent first pins of distinct locations (the insert-versus-find shape), concurrent pins of one location (each caller must get its own chunk), and pins overlapping unpins (which walks the map). It uses 4 KiB × 8 buffers rather than the 4 MiB × 64 default to stay cheap, and needs no RDMA device.

  A data race is not proven by a passing run, and this was not verified under ThreadSanitizer. The build container's seccomp profile blocks the personality(ADDR_NO_RANDOMIZE) call libtsan requires at startup, so the TSan run could not be completed. The tests establish functional correctness; the race argument rests on review of the five access sites (deconstruct, allocateStageBuffers, freeStageBuffers, pinStageBuffer, unpinStageBuffer). A TSan job in CI would close this properly.

  Other TENT tests are unaffected; the usual 3 container-environment failures (tcp_transport_test, transfer_metadata_test, memory_location_test — no etcd metadata server, no CAP_SYS_NICE for mbind) are unrelated to this change.

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)