### PR TITLE
[Bugfix][Store] Fix MasterScenario tenant quota assertions after lock-free rework

### DIFF
--- a/mooncake-store/tests/master_scenario.cpp
+++ b/mooncake-store/tests/master_scenario.cpp
@@ -411,10 +411,8 @@ MasterScenario& MasterScenario::Then(TenantQuotaSpec tenant_quota) {
     }
 
     const auto matches = [&tenant_quota](const TenantQuotaSnapshot& value) {
-        return (!tenant_quota.used_bytes.has_value() ||
-                value.used_bytes == *tenant_quota.used_bytes) &&
-               (!tenant_quota.reserved_bytes.has_value() ||
-                value.reserved_bytes == *tenant_quota.reserved_bytes);
+        return !tenant_quota.charged_bytes.has_value() ||
+               value.charged_bytes == *tenant_quota.charged_bytes;
     };
     const auto deadline =
         std::chrono::steady_clock::now() + tenant_quota.eventual_timeout;
@@ -428,17 +426,11 @@ MasterScenario& MasterScenario::Then(TenantQuotaSpec tenant_quota) {
         }
     }
 
-    if (tenant_quota.used_bytes.has_value() &&
-        snapshot->used_bytes != *tenant_quota.used_bytes) {
-        Fail("TenantQuota(" + tenant_quota.tenant + ") uses " +
-             std::to_string(snapshot->used_bytes) + "; expected " +
-             std::to_string(*tenant_quota.used_bytes));
-    }
-    if (tenant_quota.reserved_bytes.has_value() &&
-        snapshot->reserved_bytes != *tenant_quota.reserved_bytes) {
-        Fail("TenantQuota(" + tenant_quota.tenant + ") reserves " +
-             std::to_string(snapshot->reserved_bytes) + "; expected " +
-             std::to_string(*tenant_quota.reserved_bytes));
+    if (tenant_quota.charged_bytes.has_value() &&
+        snapshot->charged_bytes != *tenant_quota.charged_bytes) {
+        Fail("TenantQuota(" + tenant_quota.tenant + ") charges " +
+             std::to_string(snapshot->charged_bytes) + "; expected " +
+             std::to_string(*tenant_quota.charged_bytes));
     }
     return *this;
 }

--- a/mooncake-store/tests/master_scenario.h
+++ b/mooncake-store/tests/master_scenario.h
@@ -599,17 +599,14 @@ KeyCountSpec KeyCount(size_t value);
 
 struct TenantQuotaSpec {
     std::string tenant;
-    std::optional<uint64_t> used_bytes{};
-    std::optional<uint64_t> reserved_bytes{};
+    // Quota accounting is a single charge taken at PutStart and held until the
+    // object is released, so reserved and committed bytes are indistinguishable
+    // in a snapshot; assert on the combined charge.
+    std::optional<uint64_t> charged_bytes{};
     std::chrono::milliseconds eventual_timeout{};
 
-    TenantQuotaSpec& Uses(uint64_t value) {
-        used_bytes = value;
-        return *this;
-    }
-
-    TenantQuotaSpec& Reserves(uint64_t value) {
-        reserved_bytes = value;
+    TenantQuotaSpec& Charges(uint64_t value) {
+        charged_bytes = value;
         return *this;
     }
 

--- a/mooncake-store/tests/master_service_evict_scenario_test.cpp
+++ b/mooncake-store/tests/master_service_evict_scenario_test.cpp
@@ -491,18 +491,18 @@ TEST_F(MasterServiceEvictScenarioTest,
     backend->BlockTxn();
     scenario.When(EvictMemory(1.0))
         .Then(Object("cold").DoesNotExist())
-        .Then(TenantQuota(tenant).Uses(kObjectSize).Reserves(0))
+        .Then(TenantQuota(tenant).Charges(kObjectSize))
         .When(PutStart("before-durable", kObjectSize)
                   .ForTenant(tenant)
                   .ExpectError(ErrorCode::TENANT_QUOTA_EXCEEDED));
 
     backend->AllowTxn();
     ReadBatchEventually(storage, 3, batch);
-    scenario.Then(TenantQuota(tenant).Uses(0).Reserves(0).Eventually())
+    scenario.Then(TenantQuota(tenant).Charges(0).Eventually())
         .When(PutStart("after-durable", kObjectSize)
                   .ForTenant(tenant)
                   .ExpectReplicas(1))
-        .Then(TenantQuota(tenant).Uses(0).Reserves(kObjectSize));
+        .Then(TenantQuota(tenant).Charges(kObjectSize));
 }
 
 TEST_F(MasterServiceEvictScenarioTest,
@@ -558,8 +558,8 @@ TEST_F(MasterServiceEvictScenarioTest,
         .When(EvictMemory(0.5))
         .Then(Object("same-key").ForTenant("tenant-a").DoesNotExist())
         .Then(Object("same-key").ForTenant("tenant-b").IsReadable())
-        .Then(TenantQuota("tenant-a").Uses(0).Reserves(0))
-        .Then(TenantQuota("tenant-b").Uses(kObjectSize).Reserves(0));
+        .Then(TenantQuota("tenant-a").Charges(0))
+        .Then(TenantQuota("tenant-b").Charges(kObjectSize));
 }
 
 TEST_F(MasterServiceEvictScenarioTest,
@@ -582,10 +582,11 @@ TEST_F(MasterServiceEvictScenarioTest,
                   .ExpectReplicas(1))
         .Then(Object("tenant-a-old").ForTenant("tenant-a").DoesNotExist())
         .Then(Object("tenant-b-object").ForTenant("tenant-b").IsReadable())
-        .Then(TenantQuota("tenant-a").Uses(0).Reserves(kObjectSize))
+        .Then(TenantQuota("tenant-a").Charges(kObjectSize))
+        // PutEnd completes the object without taking a second charge.
         .When(PutEnd("tenant-a-new").ForTenant("tenant-a"))
-        .Then(TenantQuota("tenant-a").Uses(kObjectSize).Reserves(0))
-        .Then(TenantQuota("tenant-b").Uses(kObjectSize).Reserves(0));
+        .Then(TenantQuota("tenant-a").Charges(kObjectSize))
+        .Then(TenantQuota("tenant-b").Charges(kObjectSize));
 }
 
 }  // namespace


### PR DESCRIPTION
Description

  main currently does not compile. #3327 added the MasterScenario tenant quota DSL against TenantQuotaSnapshot::used_bytes / reserved_bytes; #3162 landed afterwards and collapsed both fields into a single charged_bytes when it made charge/release lock-free. Neither PR's CI observed the other.

  master_scenario.cpp:415: error: 'const struct mooncake::TenantQuotaSnapshot' has no member named 'used_bytes'; did you mean 'charged_bytes'?

  Quota is now charged once at PutStart and held until release, so a snapshot cannot distinguish reserved from committed bytes. This collapses the DSL's Uses()/Reserves() into a single Charges(). Every call site previously set exactly one of the two to a non-zero value, so the assertions keep their original strength; the pre/post PutEnd pair now verifies that completing an object takes no second charge.

  Tests only — no production code changed.

  Module

  - [x] Mooncake Store (mooncake-store)

  Type of Change

  - [x] Bug fix

  How Has This Been Tested?

  Test commands:
  cmake --build build --target master_service_evict_scenario_test
  ctest --test-dir build -R master_service_evict_scenario_test

  Test results:
  - [ ] Unit tests pass — not run locally; mooncake-store requires Linux headers and the local Docker daemon was unresponsive. Relying on CI, which is exactly what this PR unblocks.
  - [x] clang-format --dry-run -Werror clean on all three files
  - [x] pre-commit run --files <the 3 files> — all hooks pass

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (not applicable)
  - [x] I have added tests to prove my changes are effective (repairs existing tests)
  - [ ] For changes >500 LOC (not applicable, ~30 LOC)

  AI Assistance Disclosure

  - [x] AI tools were used (specify below)