### PR TITLE
[Bugfix][Wheel] Preserve PIL image state in structured transfer

### DIFF
--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -40,6 +40,20 @@ _ENCODING_FALLBACK_ERRORS = (
     RuntimeError,
     RecursionError,
 )
+_PIL_MEDIA_STATE_MAX_BYTES = 8 * 1024**2
+_PIL_MEDIA_TUPLE_EXT = 1
+_PIL_MEDIA_FRAMING = "pil_v2"
+_MEDIA_KIND_BYTES = 0
+_MEDIA_KIND_PIL = 1
+_PIL_MEDIA_FORMAT_MODES = {
+    None: frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "CMYK", "I", "I;16"}),
+    "PNG": frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "I", "I;16"}),
+    "JPEG": frozenset({"L", "RGB", "CMYK"}),
+}
+_PIL_MEDIA_BYTES_PER_PIXEL = {
+    "L": 1, "P": 1, "LA": 2, "I;16": 2, "RGB": 3,
+    "RGBA": 4, "CMYK": 4, "I": 4,
+}
 
 
 class BundleStore(Protocol):
@@ -589,8 +603,10 @@ class MooncakeBundleTransfer:
         """Release pool-backed buffers in a GET result.
 
         After get_dataproto / get_dict, ndarray payloads may be backed by
-        the BufferPool. Call this to release those leases deterministically
-        instead of waiting for GC ``__del__``.
+        the BufferPool. PIL images decoded from selected raw modes may retain
+        the same backing memory. Call this after the result is no longer in use
+        to release those leases deterministically instead of waiting for GC
+        ``__del__``. Access after release is invalid.
 
         Works for both flat dicts and nested envelope dicts
         (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
@@ -1230,10 +1246,6 @@ class MooncakeBundleTransfer:
                 if count:
                     ranges.append((int(begin), destination_offset, count))
                 destination_offset += count
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = [
-                    metadata["media_encodings"][index] for index in indices
-                ]
             return {
                 "data": read_data_ranges("data", ranges),
                 "offsets": gathered_offsets,
@@ -1267,7 +1279,6 @@ class MooncakeBundleTransfer:
             destination_offset = 0
             source_index = 0
             destination_boundary = 1
-            media_encodings = []
             for begin, count in zip(item_begins, item_counts):
                 for item in range(count):
                     byte_begin = int(byte_offsets[source_index + item])
@@ -1278,13 +1289,7 @@ class MooncakeBundleTransfer:
                     destination_offset += byte_count
                     gathered_byte_offsets[destination_boundary] = destination_offset
                     destination_boundary += 1
-                if "media_encodings" in metadata:
-                    media_encodings.extend(
-                        metadata["media_encodings"][int(begin) : int(begin) + count]
-                    )
                 source_index += count + 1
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = media_encodings
             return {
                 "data": read_data_ranges("data", ranges),
                 "row_offsets": gathered_row_offsets,
@@ -1394,8 +1399,6 @@ class MooncakeBundleTransfer:
             base = int(offsets[0])
             limit = int(offsets[-1])
             offsets = offsets - base
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = metadata["media_encodings"][start:end]
             return {
                 "data": read_bytes("data", base, limit),
                 "offsets": offsets,
@@ -1411,10 +1414,6 @@ class MooncakeBundleTransfer:
             byte_start = int(byte_offsets[0])
             byte_end = int(byte_offsets[-1])
             byte_offsets = byte_offsets - byte_start
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = metadata["media_encodings"][
-                    item_start:item_end
-                ]
             return {
                 "data": read_bytes("data", byte_start, byte_end),
                 "row_offsets": row_offsets,
@@ -1907,7 +1906,8 @@ def _coerce_flat_dict_non_tensor_field(
                 f"flat dict non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
         array = np.empty(row_count, dtype=object)
-        array[:] = list(value)
+        for index, item in enumerate(value):
+            array[index] = item
         return array
     raise TypeError(
         f"flat dict non_tensor_batch field {name!r} must be an ndarray or non-string sequence"
@@ -3013,44 +3013,167 @@ def _decode_numeric_scalar_values(payload: dict[str, Any]) -> list[Any]:
     return values.tolist()
 
 
-def _value_to_media_bytes(value: Any) -> tuple[bytes, str | None, dict[str, Any]]:
+def _encode_pil_state_default(value: Any) -> Any:
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, tuple):
+        return _msgpack.ExtType(
+            _PIL_MEDIA_TUPLE_EXT,
+            _msgpack.packb(
+                list(value),
+                use_bin_type=True,
+                strict_types=True,
+                default=_encode_pil_state_default,
+            ),
+        )
+    raise TypeError(
+        f"PIL image info contains unsupported {type(value).__name__}; "
+        "pass encoded PNG or JPEG bytes to preserve custom image state"
+    )
+
+
+def _decode_pil_state_ext(code: int, data: bytes) -> Any:
+    if code != _PIL_MEDIA_TUPLE_EXT:
+        raise ValueError(f"unsupported PIL image state extension: {code}")
+    values = _msgpack.unpackb(
+        data,
+        raw=False,
+        ext_hook=_decode_pil_state_ext,
+        max_str_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        max_bin_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        max_array_len=1024,
+        max_map_len=1024,
+        max_ext_len=_PIL_MEDIA_STATE_MAX_BYTES,
+    )
+    if not isinstance(values, list):
+        raise ValueError("invalid PIL image tuple state")
+    return tuple(values)
+
+
+def _validate_pil_state_tree(value: Any) -> None:
+    stack = [(value, 0)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 4096 or depth > 16:
+            raise ValueError("PIL image state is too complex")
+        if isinstance(item, dict):
+            if len(item) > 1024 or any(not isinstance(key, str) for key in item):
+                raise ValueError("PIL image state keys must be strings")
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, (list, tuple)):
+            if len(item) > 1024:
+                raise ValueError("PIL image state collection is too large")
+            stack.extend((child, depth + 1) for child in item)
+        elif not isinstance(item, (str, bool, int, float, bytes, type(None))):
+            raise ValueError(
+                f"PIL image state contains unsupported {type(item).__name__}"
+            )
+
+
+def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
+    frame_count = int(getattr(value, "n_frames", 1))
+    if frame_count != 1:
+        raise ValueError(
+            "multi-frame PIL images are not supported; pass the encoded image bytes"
+        )
+    value.load()
+    image_format = getattr(value, "format", None)
+    if image_format is not None:
+        image_format = str(image_format).upper()
+        if image_format == "JPG":
+            image_format = "JPEG"
+    supported_modes = _PIL_MEDIA_FORMAT_MODES.get(image_format)
+    width, height = value.size
+    if (
+        supported_modes is None
+        or value.mode not in supported_modes
+        or width <= 0
+        or height <= 0
+    ):
+        raise ValueError(
+            f"unsupported PIL image format/mode: {image_format!r}/{value.mode!r}; "
+            "pass the encoded image bytes"
+        )
+    palette = None
+    if value.palette is not None:
+        palette_mode, palette_data = value.palette.getdata()
+        if palette_mode not in {"RGB", "RGBA"}:
+            raise ValueError(f"unsupported PIL palette mode: {palette_mode!r}")
+        palette_data = bytes(palette_data)
+        palette = [palette_mode, palette_data] if palette_data else None
+        if (
+            palette is not None
+            and (
+                value.mode != "P"
+                or len(palette_data) > 256 * len(palette_mode)
+                or len(palette_data) % len(palette_mode)
+            )
+        ):
+            raise ValueError("invalid PIL image palette")
+    state = [
+        1,
+        value.mode,
+        int(width),
+        int(height),
+        image_format,
+        palette,
+        dict(value.info),
+    ]
+    _validate_pil_state_tree(state)
+    state_bytes = _msgpack.packb(
+        state,
+        use_bin_type=True,
+        strict_types=True,
+        default=_encode_pil_state_default,
+    )
+    if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
+        raise ValueError(f"PIL image state is too large: {len(state_bytes)} bytes")
+    return value.tobytes(), state_bytes
+
+
+def _value_to_media_parts(
+    value: Any,
+) -> tuple[bytes | bytearray | memoryview, bytes, str | None, int]:
     if value is None:
-        return b"", None, {"kind": "null"}
+        return b"", b"", None, _MEDIA_KIND_BYTES
     if _is_bytes_like(value):
-        return bytes(value), None, {"kind": "bytes"}
+        encoded = value if isinstance(value, bytes) else bytes(value)
+        return encoded, b"", None, _MEDIA_KIND_BYTES
     if _is_pil_image(value):
-        image = (
-            value.convert(value.mode) if getattr(value, "readonly", False) else value
-        )
-        return (
-            image.tobytes(),
-            "image/raw",
-            {
-                "kind": "pil_raw",
-                "mode": image.mode,
-                "size": list(image.size),
-                "format": getattr(value, "format", None),
-            },
-        )
-    return bytes(value), None, {"kind": "bytes"}
+        pixels, state = _encode_pil_image(value)
+        return pixels, state, "image/raw", _MEDIA_KIND_PIL
+    return bytes(value), b"", None, _MEDIA_KIND_BYTES
+
+
+def _pil_pixel_bytes(mode: str, width: int, height: int) -> int:
+    if mode == "1":
+        return ((width + 7) // 8) * height
+    return width * height * _PIL_MEDIA_BYTES_PER_PIXEL[mode]
+
 
 def _encode_bytes_like_values(
     values: list[Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     offsets = [0]
-    parts = []
+    items = []
     media_types = []
-    encodings = []
     for value in values:
-        data, media_type, encoding = _value_to_media_bytes(value)
-        parts.append(data)
+        data, state, media_type, kind = _value_to_media_parts(value)
+        items.append((data, state, kind))
         media_types.append(media_type)
-        encodings.append(encoding)
-        offsets.append(offsets[-1] + len(data))
-    payload_bytes = _multi_buffer_bytes_payload(parts)
+    framed = any(kind == _MEDIA_KIND_PIL for _data, _state, kind in items)
+    parts = []
+    for data, state, kind in items:
+        item_parts = _framed_media_parts(data, state, kind) if framed else (data,)
+        parts.extend(item_parts)
+        offsets.append(offsets[-1] + sum(len(part) for part in item_parts))
     metadata: dict[str, Any] = {}
-    if any(encoding.get("kind") == "pil_raw" for encoding in encodings):
-        metadata["media_encodings"] = encodings
+    if framed:
+        metadata["media_framing"] = _PIL_MEDIA_FRAMING
     non_null_media_types = sorted(
         {media_type for media_type in media_types if media_type}
     )
@@ -3059,7 +3182,7 @@ def _encode_bytes_like_values(
         metadata["encode_source"] = "raw_pixels_from_object"
     return (
         {
-            "data": payload_bytes,
+            "data": _multi_buffer_bytes_payload(parts),
             "offsets": np.asarray(offsets, dtype=np.int64),
             "nulls": np.asarray([value is None for value in values], dtype=np.bool_),
         },
@@ -3067,25 +3190,133 @@ def _encode_bytes_like_values(
     )
 
 
+def _framed_media_parts(
+    data: bytes | bytearray | memoryview, state: bytes, kind: int
+) -> tuple[bytes | bytearray | memoryview, ...]:
+    if kind == _MEDIA_KIND_BYTES:
+        return (bytes((_MEDIA_KIND_BYTES,)), data)
+    header = bytes((_MEDIA_KIND_PIL,)) + len(state).to_bytes(4, "little")
+    return header, state, data
+
+
 def _multi_buffer_bytes_payload(
-    parts: Sequence[bytes | memoryview],
+    parts: Sequence[bytes | bytearray | memoryview],
 ) -> _MultiBufferPayload:
     buffers = tuple(_bytes_view(part, "payload part") for part in parts if part)
     return _MultiBufferPayload(buffers, tuple(parts))
 
 
-def _decode_media_bytes(data: Any, encoding: Optional[Mapping[str, Any]]) -> Any:
-    if not encoding or encoding.get("kind") != "pil_raw":
-        return bytes(data)
+def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
+    try:
+        if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
+            raise ValueError("PIL image state is too large")
+        state = _msgpack.unpackb(
+            state_bytes,
+            raw=False,
+            ext_hook=_decode_pil_state_ext,
+            max_str_len=_PIL_MEDIA_STATE_MAX_BYTES,
+            max_bin_len=_PIL_MEDIA_STATE_MAX_BYTES,
+            max_array_len=1024,
+            max_map_len=1024,
+            max_ext_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        )
+        _validate_pil_state_tree(state)
+    except (
+        TypeError,
+        ValueError,
+        OverflowError,
+        RecursionError,
+        _msgpack.UnpackException,
+    ) as exc:
+        raise ValueError("invalid PIL image state") from exc
+    if not isinstance(state, list) or len(state) != 7 or type(state[0]) is not int:
+        raise ValueError("unsupported PIL image state")
+    if state[0] != 1:
+        raise ValueError("unsupported PIL image state")
+    _, mode, width, height, image_format, palette, info = state
+    if not isinstance(mode, str) or (
+        image_format is not None and not isinstance(image_format, str)
+    ):
+        raise ValueError("invalid PIL image mode or format")
+    supported_modes = _PIL_MEDIA_FORMAT_MODES.get(image_format)
+    if (
+        supported_modes is None
+        or mode not in supported_modes
+        or isinstance(width, bool)
+        or not isinstance(width, int)
+        or width <= 0
+        or isinstance(height, bool)
+        or not isinstance(height, int)
+        or height <= 0
+    ):
+        raise ValueError("invalid PIL image mode, format, or dimensions")
+    pixels = data
+    expected_pixel_bytes = _pil_pixel_bytes(mode, width, height)
+    if len(pixels) != expected_pixel_bytes:
+        raise ValueError(
+            f"invalid PIL image pixel length: {len(pixels)}, "
+            f"expected {expected_pixel_bytes}"
+        )
     try:
         from PIL import Image
-    except ImportError:
-        return bytes(data)
-    image = Image.frombuffer(
-        encoding["mode"], tuple(encoding["size"]), data, "raw", encoding["mode"], 0, 1
-    )
-    image.format = encoding.get("format")
+    except ImportError as exc:
+        raise ImportError("Pillow is required to decode PIL image payloads") from exc
+    image = Image.frombuffer(mode, (width, height), pixels, "raw", mode, 0, 1)
+    if palette is not None:
+        valid_palette = isinstance(palette, list) and len(palette) == 2
+        palette_mode = palette[0] if valid_palette else None
+        palette_data = palette[1] if valid_palette else None
+        if (
+            mode != "P"
+            or palette_mode not in {"RGB", "RGBA"}
+            or not isinstance(palette_data, bytes)
+            or not 0 < len(palette_data) <= 256 * len(palette_mode)
+            or len(palette_data) % len(palette_mode)
+        ):
+            raise ValueError("invalid PIL image palette")
+        image.putpalette(palette_data, palette_mode)
+    if not isinstance(info, dict):
+        raise ValueError("invalid PIL image info")
+    image.info = info
+    image.format = image_format
     return image
+
+
+def _decode_media_bytes(
+    data: Any,
+    framed: bool = False,
+    owner: Any = None,
+) -> Any:
+    if not framed:
+        return bytes(data)
+    if not data:
+        raise ValueError("invalid framed media payload")
+    kind = int(data[0])
+    if kind == _MEDIA_KIND_BYTES:
+        return bytes(data[1:])
+    if kind != _MEDIA_KIND_PIL:
+        raise ValueError(f"unsupported media encoding: {kind!r}")
+    if len(data) < 5:
+        raise ValueError("invalid framed PIL payload")
+    state_size = int.from_bytes(data[1:5], "little")
+    state_end = 5 + state_size
+    if state_size > _PIL_MEDIA_STATE_MAX_BYTES or state_end > len(data):
+        raise ValueError("invalid framed PIL state")
+    pixels = data[state_end:]
+    try:
+        image = _decode_pil_image(pixels, data[5:state_end])
+    except ImportError:
+        return bytes(pixels)
+    if owner is not None and bool(getattr(image, "readonly", False)):
+        image._mooncake_pool_owner = owner
+    return image
+
+
+def _media_framed(metadata: Optional[Mapping[str, Any]]) -> bool:
+    framing = (metadata or {}).get("media_framing")
+    if framing not in {None, _PIL_MEDIA_FRAMING}:
+        raise ValueError(f"unsupported media framing: {framing!r}")
+    return framing == _PIL_MEDIA_FRAMING
 
 
 def _decode_bytes_like_values(
@@ -3094,16 +3325,23 @@ def _decode_bytes_like_values(
     data = payload["data"]
     offsets = payload["offsets"]
     nulls = payload["nulls"]
-    encodings = (metadata or {}).get("media_encodings", [])
+    framed = _media_framed(metadata)
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    has_owner = False
     values = []
     for row in range(rows):
         if bool(nulls[row]):
             values.append(None)
             continue
         item = memoryview(data)[int(offsets[row]) : int(offsets[row + 1])]
-        encoding = encodings[row] if row < len(encodings) else None
-        values.append(_decode_media_bytes(item, encoding))
-    return values
+        value = _decode_media_bytes(item, framed, owner)
+        has_owner = (
+            has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
+        )
+        values.append(value)
+    return (
+        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
+    )
 
 
 def _encode_media_list_values(
@@ -3111,30 +3349,34 @@ def _encode_media_list_values(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     row_offsets = [0]
     byte_offsets = [0]
-    parts = []
+    encoded_items = []
     media_types = []
-    encodings = []
     for value in values:
-        items = [] if value is None else list(value)
-        for item in items:
-            data, media_type, encoding = _value_to_media_bytes(item)
-            parts.append(data)
+        row_items = [] if value is None else list(value)
+        for item in row_items:
+            data, state, media_type, kind = _value_to_media_parts(item)
+            encoded_items.append((data, state, kind))
             media_types.append(media_type)
-            encodings.append(encoding)
-            byte_offsets.append(byte_offsets[-1] + len(data))
-        row_offsets.append(row_offsets[-1] + len(items))
-    metadata: dict[str, Any] = {
-        "encode_source": "raw_pixels_from_object",
-        "media_encodings": encodings,
-    }
+        row_offsets.append(len(encoded_items))
+    framed = any(
+        kind == _MEDIA_KIND_PIL for _data, _state, kind in encoded_items
+    )
+    parts = []
+    for data, state, kind in encoded_items:
+        item_parts = _framed_media_parts(data, state, kind) if framed else (data,)
+        parts.extend(item_parts)
+        byte_offsets.append(byte_offsets[-1] + sum(len(part) for part in item_parts))
+    metadata: dict[str, Any] = {"encode_source": "raw_pixels_from_object"}
     non_null_media_types = sorted(
         {media_type for media_type in media_types if media_type}
     )
     if non_null_media_types:
         metadata["media_types"] = non_null_media_types
+    if framed:
+        metadata["media_framing"] = _PIL_MEDIA_FRAMING
     return (
         {
-            "data": b"".join(parts),
+            "data": _multi_buffer_bytes_payload(parts),
             "row_offsets": np.asarray(row_offsets, dtype=np.int64),
             "byte_offsets": np.asarray(byte_offsets, dtype=np.int64),
             "nulls": np.asarray([value is None for value in values], dtype=np.bool_),
@@ -3150,7 +3392,9 @@ def _decode_media_list_values(
     row_offsets = payload["row_offsets"]
     byte_offsets = payload["byte_offsets"]
     nulls = payload["nulls"]
-    encodings = (metadata or {}).get("media_encodings", [])
+    framed = _media_framed(metadata)
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    has_owner = False
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -3161,10 +3405,15 @@ def _decode_media_list_values(
             item = memoryview(data)[
                 int(byte_offsets[item_index]) : int(byte_offsets[item_index + 1])
             ]
-            encoding = encodings[item_index] if item_index < len(encodings) else None
-            items.append(_decode_media_bytes(item, encoding))
+            value = _decode_media_bytes(item, framed, owner)
+            has_owner = (
+                has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
+            )
+            items.append(value)
         values.append(items)
-    return values
+    return (
+        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
+    )
 
 
 class _StructuredObjectLayer:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ctypes
+import gc
+import io
 import json
 import os
 import threading
@@ -1979,6 +1981,175 @@ def test_unified_dict_put_accepts_field_schemas() -> None:
     assert result["global_batch_sizes"] == [2]
     assert result["num_microbatches"] == 1
     assert result["step"] == 7
+
+
+def _pil_fixture(image_format: str):
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.new("RGB", (12, 9), (1, 2, 3))
+    output = io.BytesIO()
+    options = {"icc_profile": b"test-icc-profile"}
+    if image_format == "PNG":
+        PngImagePlugin = pytest.importorskip("PIL.PngImagePlugin")
+        png_info = PngImagePlugin.PngInfo()
+        png_info.add_text("source", "mooncake-test")
+        options.update(pnginfo=png_info, dpi=(96, 96))
+    else:
+        exif = Image.Exif()
+        exif[0x010E] = "mooncake-test"
+        options.update(quality=95, dpi=(144, 144), exif=exif)
+    image.save(output, format=image_format, **options)
+    encoded = output.getvalue()
+    decoded = Image.open(io.BytesIO(encoded))
+    return decoded, encoded
+
+
+def _assert_pil_roundtrip(actual, expected) -> None:
+    assert actual.mode == expected.mode
+    assert actual.size == expected.size
+    assert actual.format == expected.format
+    assert actual.tobytes() == expected.tobytes()
+    assert actual.info == expected.info
+    expected_palette = expected.palette.getdata() if expected.palette else None
+    actual_palette = actual.palette.getdata() if actual.palette else None
+    assert actual_palette == expected_palette
+
+
+def _palette_image():
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.fromarray(np.arange(20, dtype=np.uint8).reshape(4, 5), mode="P")
+    image.putpalette(bytes([0, 255, 0, 255, 0, 127]))
+    image.info = {
+        "transparency": 0,
+        "dpi": (72, 72),
+        "nested": (("source", 1), 2),
+    }
+    image.format = "PNG"
+    return image
+
+
+@pytest.mark.parametrize("image_format", ["PNG", "JPEG"])
+def test_unified_dict_pil_codec_preserves_common_image_state(image_format) -> None:
+    _store, transfer = make_transfer()
+    image, _encoded = _pil_fixture(image_format)
+
+    ref = transfer.put(
+        {"image": [image]},
+        type="dict",
+        field_schemas={
+            "image": FieldSchema(
+                codec="media_bytes", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+    actual = transfer.get(ref, type="dict")["image"][0]
+
+    _assert_pil_roundtrip(actual, image)
+
+
+def test_unified_dict_pil_codec_preserves_palette_and_partial_reads() -> None:
+    png, png_bytes = _pil_fixture("PNG")
+    jpeg, jpeg_bytes = _pil_fixture("JPEG")
+    palette = _palette_image()
+    rows = [[png, png_bytes], None, [], [jpeg, jpeg_bytes, palette]]
+    _store, transfer = make_transfer()
+    ref = transfer.put(
+        {"media": rows},
+        type="dict",
+        field_schemas={
+            "media": FieldSchema(
+                codec="media_list_ragged",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    sliced = transfer.get(ref, type="dict", rows=slice(2, 4))["media"]
+    gathered = transfer.get(ref, type="dict", rows=[3, 0])["media"]
+
+    assert sliced[0] == []
+    _assert_pil_roundtrip(sliced[1][0], jpeg)
+    assert sliced[1][1] == jpeg_bytes
+    _assert_pil_roundtrip(sliced[1][2], palette)
+    assert [
+        item.tobytes() if hasattr(item, "tobytes") else item for item in gathered[0]
+    ] == [
+        jpeg.tobytes(),
+        jpeg_bytes,
+        palette.tobytes(),
+    ]
+    _assert_pil_roundtrip(gathered[1][0], png)
+    assert gathered[1][1] == png_bytes
+
+
+@pytest.mark.parametrize("mode", ["1", "L", "LA", "RGB", "RGBA", "CMYK", "I", "I;16"])
+def test_pil_codec_roundtrips_supported_raw_modes(mode) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.new(mode, (5, 3))
+
+    pixels, state = sos._encode_pil_image(image)
+    actual = sos._decode_pil_image(memoryview(pixels), memoryview(state))
+
+    _assert_pil_roundtrip(actual, image)
+
+
+def test_unified_dict_pil_codec_releases_buffer_pool_once() -> None:
+    image = _palette_image()
+    pool = FakeBufferPool()
+    _store, transfer = make_transfer(buffer_pool=pool)
+    ref = transfer.put(
+        {"image": [image]},
+        type="dict",
+        field_schemas={
+            "image": FieldSchema(
+                codec="media_bytes", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+    result = transfer.get(ref, type="dict")
+    actual = result["image"][0]
+    _assert_pil_roundtrip(actual, image)
+    assert hasattr(actual, "_mooncake_pool_owner")
+    del result
+    gc.collect()
+    assert pool.release_count < pool.acquire_count
+    MooncakeBundleTransfer.release_result(actual)
+    assert pool.release_count == pool.acquire_count
+    after_release = pool.release_count
+    MooncakeBundleTransfer.release_result(actual)
+    assert pool.release_count == after_release
+
+
+def test_pil_codec_rejects_multiframe_images() -> None:
+    Image = pytest.importorskip("PIL.Image")
+    encoded = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(
+        encoded,
+        format="PNG",
+        save_all=True,
+        append_images=[Image.new("RGB", (2, 2), "blue")],
+    )
+    image = Image.open(io.BytesIO(encoded.getvalue()))
+
+    with pytest.raises(ValueError, match="multi-frame PIL images"):
+        sos._encode_pil_image(image)
+
+
+@pytest.mark.parametrize(
+    "payload", [b"\x07pixels", b"\x01\x0b\x00\x00\x00not-msgpackpixels"]
+)
+def test_pil_codec_rejects_invalid_encodings(payload) -> None:
+    with pytest.raises(ValueError, match="media encoding|PIL image state"):
+        sos._decode_media_bytes(memoryview(payload), framed=True)
+
+
+def test_pil_codec_rejects_unsupported_state_and_framing() -> None:
+    image = _palette_image()
+    image.info = {1: "non-string key"}
+    with pytest.raises(ValueError, match="keys must be strings"):
+        sos._encode_pil_image(image)
+
+    with pytest.raises(ValueError, match="unsupported media framing"):
+        sos._media_framed({"media_framing": "pil_v3"})
 
 
 def test_release_result_recurses_into_ragged_row_views() -> None:


### PR DESCRIPTION
## Description

The structured media codec previously serialized a PIL image as raw pixels only. GET could reconstruct the pixels, but it lost image state such as the original format, palette, EXIF, ICC profile, and other entries from `Image.info`. Encoded PNG and JPEG byte payloads also need to remain byte-exact rather than being decoded and re-encoded.

This PR adds a framed binary representation for PIL entries in structured non-tensor fields. It stores raw pixels and validated msgpack state as payload members, while the existing offsets continue to provide row-level partial reads. PNG/JPEG byte entries remain unchanged and byte-exact. The decoder restores the PIL mode, size, format, palette, and supported `Image.info` state, and preserves the existing raw-byte fallback when Pillow is unavailable.

The implementation keeps image state out of the bundle manifest/catalog, reuses the existing structured codec and chunk planning paths, and retains BufferPool owners for zero-copy-compatible decoded images until `release_result()` is called.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python3.12 -m pytest -q mooncake-wheel/tests/test_structured_object_store.py
python3.12 -m py_compile mooncake-wheel/mooncake/structured_object_store.py mooncake-wheel/tests/test_structured_object_store.py
git diff --check origin/main...HEAD
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Result: `99 passed, 29 skipped`. The skipped tests require a working Torch/CUDA runtime; the test host has a pre-existing Torch/CUDA shared-library mismatch. Manual coverage included PNG/JPEG encoded-byte preservation, common PIL modes, palette images, EXIF/ICC state, partial row reads, malformed state rejection, missing-Pillow fallback, and BufferPool owner release.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Python formatting was intentionally not run to avoid unrelated formatting churn in the existing Python files. `py_compile` and `git diff --check` pass.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the existing structured codec, implement the focused fix, review failure and lifecycle paths, and run the validation matrix. The submitter reviewed the final diff and test results.
