### PR TITLE
[Performance][Wheel] Avoid PIL RGB pixel copies

### DIFF
--- a/mooncake-wheel/mooncake/_fast_copy.c
+++ b/mooncake-wheel/mooncake/_fast_copy.c
@@ -8,6 +8,233 @@
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+struct ArrowArray {
+    int64_t length, null_count, offset, n_buffers, n_children;
+    const void **buffers;
+    struct ArrowArray **children;
+    struct ArrowArray *dictionary;
+    void (*release)(struct ArrowArray *);
+    void *private_data;
+};
+struct ArrowSchema {
+    const char *format, *name, *metadata;
+    int64_t flags, n_children;
+    struct ArrowSchema **children;
+    struct ArrowSchema *dictionary;
+    void (*release)(struct ArrowSchema *);
+    void *private_data;
+};
+#endif
+
+typedef struct {
+    struct ArrowArray array;
+    const void *data;
+} PillowArrowOwner;
+
+typedef struct {
+    const void *buffers[2];
+    Py_buffer view;
+} BufferArrowOwner;
+
+static void release_moved_pillow_array(PyObject *capsule) {
+    PillowArrowOwner *owner =
+        PyCapsule_GetPointer(capsule, "mooncake_pillow_arrow");
+    if (!owner) {
+        PyErr_Clear();
+        return;
+    }
+    if (owner->array.release) owner->array.release(&owner->array);
+    free(owner);
+}
+
+static int parse_pillow_arrow(PyObject *image, PillowArrowOwner **out,
+                              unsigned long long *data_size) {
+    PyObject *capsules = PyObject_CallMethod(image, "__arrow_c_array__", NULL);
+    if (!capsules) return -1;
+    if (!PyTuple_Check(capsules) || PyTuple_GET_SIZE(capsules) != 2) {
+        Py_DECREF(capsules);
+        PyErr_SetString(PyExc_ValueError,
+                        "Pillow returned invalid Arrow capsules");
+        return -1;
+    }
+    struct ArrowSchema *schema =
+        PyCapsule_GetPointer(PyTuple_GET_ITEM(capsules, 0), "arrow_schema");
+    struct ArrowArray *array =
+        PyCapsule_GetPointer(PyTuple_GET_ITEM(capsules, 1), "arrow_array");
+    if (!schema || !array) {
+        Py_DECREF(capsules);
+        return -1;
+    }
+    if (!schema->release || !array->release) goto invalid;
+    if (!schema->format || strcmp(schema->format, "+w:4") != 0 ||
+        schema->n_children != 1 || array->n_children != 1 ||
+        array->n_buffers != 1 || !array->buffers || array->buffers[0] ||
+        schema->dictionary || !schema->children || !array->children)
+        goto invalid;
+    const struct ArrowSchema *data_schema = schema->children[0];
+    const struct ArrowArray *data_array = array->children[0];
+    if (!data_schema || !data_array || !data_schema->release ||
+        !data_array->release || !data_schema->format ||
+        strcmp(data_schema->format, "C") != 0 || data_schema->n_children != 0 ||
+        data_schema->dictionary || data_schema->children ||
+        data_array->offset != 0 || data_array->null_count != 0 ||
+        data_array->n_buffers != 2 || data_array->n_children != 0 ||
+        data_array->dictionary || data_array->children ||
+        !data_array->buffers || data_array->buffers[0] ||
+        !data_array->buffers[1] || array->offset != 0 ||
+        array->null_count != 0 || array->dictionary || array->length < 0 ||
+        array->length > INT64_MAX / 4 ||
+        data_array->length != array->length * 4)
+        goto invalid;
+    PillowArrowOwner *owner = calloc(1, sizeof(*owner));
+    if (!owner) {
+        Py_DECREF(capsules);
+        PyErr_NoMemory();
+        return -1;
+    }
+    owner->array = *array;
+    array->release = NULL;
+    *data_size = (unsigned long long)data_array->length;
+    owner->data = data_array->buffers[1];
+    Py_DECREF(capsules);
+    *out = owner;
+    return 0;
+invalid:
+    Py_DECREF(capsules);
+    PyErr_SetString(PyExc_ValueError, "unsupported Pillow Arrow layout");
+    return -1;
+}
+
+static PyObject *pillow_arrow_view(PyObject *self, PyObject *image) {
+    PillowArrowOwner *owner = NULL;
+    unsigned long long size = 0;
+    if (parse_pillow_arrow(image, &owner, &size) < 0) return NULL;
+    if (size > NPY_MAX_INTP) {
+        if (owner->array.release) owner->array.release(&owner->array);
+        free(owner);
+        return PyErr_Format(PyExc_OverflowError,
+                            "Pillow Arrow buffer is too large: %llu", size);
+    }
+    npy_intp dims[1] = {(npy_intp)size};
+    PyObject *array =
+        PyArray_SimpleNewFromData(1, dims, NPY_UINT8, (void *)owner->data);
+    if (!array) {
+        if (owner->array.release) owner->array.release(&owner->array);
+        free(owner);
+        return NULL;
+    }
+    PyObject *capsule = PyCapsule_New(owner, "mooncake_pillow_arrow",
+                                      release_moved_pillow_array);
+    if (!capsule) {
+        Py_DECREF(array);
+        if (owner->array.release) owner->array.release(&owner->array);
+        free(owner);
+        return NULL;
+    }
+    if (PyArray_SetBaseObject((PyArrayObject *)array, capsule) < 0) {
+        Py_DECREF(array);
+        return NULL;
+    }
+    PyArray_CLEARFLAGS((PyArrayObject *)array, NPY_ARRAY_WRITEABLE);
+    return array;
+}
+
+static void release_buffer_arrow(struct ArrowArray *array) {
+    if (!array || !array->release) return;
+    BufferArrowOwner *owner = array->private_data;
+    array->release = NULL;
+    PyGILState_STATE state = PyGILState_Ensure();
+    PyBuffer_Release(&owner->view);
+    PyGILState_Release(state);
+    free(owner);
+}
+
+static void release_arrow_schema(struct ArrowSchema *schema) {
+    if (!schema || !schema->release) return;
+    schema->release = NULL;
+}
+
+static void destroy_arrow_array_capsule(PyObject *capsule) {
+    struct ArrowArray *array = PyCapsule_GetPointer(capsule, "arrow_array");
+    if (!array) {
+        PyErr_Clear();
+        return;
+    }
+    if (array->release) array->release(array);
+    free(array);
+}
+
+static void destroy_arrow_schema_capsule(PyObject *capsule) {
+    struct ArrowSchema *schema = PyCapsule_GetPointer(capsule, "arrow_schema");
+    if (!schema) {
+        PyErr_Clear();
+        return;
+    }
+    if (schema->release) schema->release(schema);
+    free(schema);
+}
+
+static PyObject *export_arrow_u8(PyObject *self, PyObject *args) {
+    PyObject *buffer;
+    PyObject *requested = Py_None;
+    if (!PyArg_ParseTuple(args, "O|O", &buffer, &requested)) return NULL;
+    (void)requested;
+    BufferArrowOwner *owner = calloc(1, sizeof(*owner));
+    struct ArrowArray *array = calloc(1, sizeof(*array));
+    struct ArrowSchema *schema = calloc(1, sizeof(*schema));
+    if (!owner || !array || !schema) {
+        free(owner);
+        free(array);
+        free(schema);
+        return PyErr_NoMemory();
+    }
+    if (PyObject_GetBuffer(buffer, &owner->view, PyBUF_CONTIG_RO) < 0) {
+        free(owner);
+        free(array);
+        free(schema);
+        return NULL;
+    }
+    if (owner->view.len < 0 || (owner->view.len > 0 && !owner->view.buf)) {
+        PyBuffer_Release(&owner->view);
+        free(owner);
+        free(array);
+        free(schema);
+        PyErr_SetString(PyExc_ValueError, "invalid Arrow buffer");
+        return NULL;
+    }
+    owner->buffers[1] = owner->view.buf;
+    array->length = owner->view.len;
+    array->null_count = 0;
+    array->n_buffers = 2;
+    array->buffers = owner->buffers;
+    array->release = release_buffer_arrow;
+    array->private_data = owner;
+    schema->format = "C";
+    schema->release = release_arrow_schema;
+    PyObject *schema_capsule =
+        PyCapsule_New(schema, "arrow_schema", destroy_arrow_schema_capsule);
+    if (!schema_capsule) {
+        array->release(array);
+        free(array);
+        free(schema);
+        return NULL;
+    }
+    PyObject *array_capsule =
+        PyCapsule_New(array, "arrow_array", destroy_arrow_array_capsule);
+    if (!array_capsule) {
+        Py_DECREF(schema_capsule);
+        array->release(array);
+        free(array);
+        return NULL;
+    }
+    PyObject *result = PyTuple_Pack(2, schema_capsule, array_capsule);
+    Py_DECREF(schema_capsule);
+    Py_DECREF(array_capsule);
+    return result;
+}
+
 typedef struct {
     void **src_ptrs;
     size_t *src_sizes;
@@ -179,6 +406,10 @@ fail:
 static PyMethodDef module_methods[] = {
     {"concat_arrays_into", concat_arrays_into, METH_VARARGS,
      "Scatter-copy arrays[start:start+count] into dest_ptr (GIL released)."},
+    {"pillow_arrow_view", pillow_arrow_view, METH_O,
+     "Return a read-only uint8 view over Pillow Arrow pixel storage."},
+    {"export_arrow_u8", export_arrow_u8, METH_VARARGS,
+     "Export a contiguous buffer through the Arrow PyCapsule interface."},
     {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef moduledef = {

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import ctypes
 import io
 import json
+import threading
 import uuid
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
@@ -23,6 +24,15 @@ try:
     from mooncake._fast_copy import concat_arrays_into as _concat_arrays_into
 except Exception:  # pragma: no cover
     _concat_arrays_into = None
+
+try:
+    from mooncake._fast_copy import (
+        export_arrow_u8 as _export_arrow_u8,
+        pillow_arrow_view as _pillow_arrow_view,
+    )
+except Exception:  # pragma: no cover
+    _export_arrow_u8 = None
+    _pillow_arrow_view = None
 
 DEFAULT_BUNDLE_CHUNK_BYTES = 64 * 1024**2
 AUTO_PARALLEL_MIN_BYTES = DEFAULT_BUNDLE_CHUNK_BYTES
@@ -215,6 +225,48 @@ class _PoolLeaseOwner:
         if not self.released:
             self.lease.release()
             self.released = True
+
+    def __del__(self) -> None:
+        self.release()
+
+
+class _SharedPoolOwner:
+    def __init__(self, owner: _PoolLeaseOwner) -> None:
+        self._owner = owner
+        self._references = 0
+        self._lock = threading.Lock()
+
+    def acquire(self) -> "_SharedPoolOwnerToken":
+        with self._lock:
+            if self._owner is None:
+                raise RuntimeError("BufferPool owner has already been released")
+            self._references += 1
+        return _SharedPoolOwnerToken(self)
+
+    def release(self) -> None:
+        owner = None
+        with self._lock:
+            if self._references <= 0:
+                return
+            self._references -= 1
+            if self._references == 0:
+                owner, self._owner = self._owner, None
+        if owner is not None:
+            owner.release()
+
+
+class _SharedPoolOwnerToken:
+    def __init__(self, shared: _SharedPoolOwner) -> None:
+        self._shared = shared
+        self._released = False
+        self._lock = threading.Lock()
+
+    def release(self) -> None:
+        with self._lock:
+            if self._released:
+                return
+            self._released = True
+        self._shared.release()
 
     def __del__(self) -> None:
         self.release()
@@ -3074,7 +3126,7 @@ def _validate_pil_state_tree(value: Any) -> None:
             )
 
 
-def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
+def _encode_pil_image(value: Any) -> tuple[bytes | memoryview, bytes]:
     frame_count = int(getattr(value, "n_frames", 1))
     if frame_count != 1:
         raise ValueError(
@@ -3114,8 +3166,26 @@ def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
             )
         ):
             raise ValueError("invalid PIL image palette")
+    pixels = None
+    storage = None
+    if value.mode == "RGB" and _pillow_arrow_view is not None:
+        try:
+            pixels = memoryview(_pillow_arrow_view(value))
+        except (
+            AttributeError,
+            NotImplementedError,
+            RuntimeError,
+            TypeError,
+            ValueError,
+        ):
+            pass
+        else:
+            if len(pixels) == width * height * 4:
+                storage = "RGBX"
+            else:
+                pixels = None
     state = [
-        1,
+        2 if storage is not None else 1,
         value.mode,
         int(width),
         int(height),
@@ -3123,6 +3193,8 @@ def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
         palette,
         dict(value.info),
     ]
+    if storage is not None:
+        state.append(storage)
     _validate_pil_state_tree(state)
     state_bytes = _msgpack.packb(
         state,
@@ -3132,7 +3204,7 @@ def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
     )
     if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
         raise ValueError(f"PIL image state is too large: {len(state_bytes)} bytes")
-    return value.tobytes(), state_bytes
+    return (pixels if pixels is not None else value.tobytes()), state_bytes
 
 
 def _value_to_media_parts(
@@ -3206,7 +3278,19 @@ def _multi_buffer_bytes_payload(
     return _MultiBufferPayload(buffers, tuple(parts))
 
 
-def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
+class _ArrowU8Provider:
+    def __init__(self, data: Any) -> None:
+        self._data = data
+
+    def __arrow_c_array__(self, requested_schema: Any = None) -> Any:
+        if _export_arrow_u8 is None:
+            raise NotImplementedError("Pillow Arrow support is unavailable")
+        return _export_arrow_u8(self._data, requested_schema)
+
+
+def _decode_pil_image(
+    data: Any, state_bytes: Any, *, raw_fallback: bool = False
+) -> Any:
     try:
         if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
             raise ValueError("PIL image state is too large")
@@ -3229,11 +3313,13 @@ def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
         _msgpack.UnpackException,
     ) as exc:
         raise ValueError("invalid PIL image state") from exc
-    if not isinstance(state, list) or len(state) != 7 or type(state[0]) is not int:
+    if not isinstance(state, list) or len(state) not in {7, 8}:
         raise ValueError("unsupported PIL image state")
-    if state[0] != 1:
+    version = state[0]
+    if type(version) is not int or version not in {1, 2} or len(state) != version + 6:
         raise ValueError("unsupported PIL image state")
-    _, mode, width, height, image_format, palette, info = state
+    _, mode, width, height, image_format, palette, info, *storage_state = state
+    storage = storage_state[0] if storage_state else None
     if not isinstance(mode, str) or (
         image_format is not None and not isinstance(image_format, str)
     ):
@@ -3251,17 +3337,18 @@ def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
     ):
         raise ValueError("invalid PIL image mode, format, or dimensions")
     pixels = data
-    expected_pixel_bytes = _pil_pixel_bytes(mode, width, height)
+    if storage not in {None, "RGBX"} or (storage == "RGBX" and mode != "RGB"):
+        raise ValueError("invalid PIL image storage")
+    expected_pixel_bytes = (
+        width * height * 4
+        if storage == "RGBX"
+        else _pil_pixel_bytes(mode, width, height)
+    )
     if len(pixels) != expected_pixel_bytes:
         raise ValueError(
             f"invalid PIL image pixel length: {len(pixels)}, "
             f"expected {expected_pixel_bytes}"
         )
-    try:
-        from PIL import Image
-    except ImportError as exc:
-        raise ImportError("Pillow is required to decode PIL image payloads") from exc
-    image = Image.frombuffer(mode, (width, height), pixels, "raw", mode, 0, 1)
     if palette is not None:
         valid_palette = isinstance(palette, list) and len(palette) == 2
         palette_mode = palette[0] if valid_palette else None
@@ -3274,9 +3361,39 @@ def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
             or len(palette_data) % len(palette_mode)
         ):
             raise ValueError("invalid PIL image palette")
-        image.putpalette(palette_data, palette_mode)
     if not isinstance(info, dict):
         raise ValueError("invalid PIL image info")
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        if not raw_fallback:
+            raise ImportError(
+                "Pillow is required to decode PIL image payloads"
+            ) from exc
+        if storage == "RGBX":
+            return (
+                np.frombuffer(pixels, dtype=np.uint8)
+                .reshape(-1, 4)[:, :3]
+                .tobytes()
+            )
+        return bytes(pixels)
+    if storage == "RGBX":
+        fromarrow = getattr(Image, "fromarrow", None)
+        if _export_arrow_u8 is not None and callable(fromarrow):
+            try:
+                image = fromarrow(_ArrowU8Provider(pixels), mode, (width, height))
+            except (AttributeError, NotImplementedError, TypeError, ValueError):
+                image = Image.frombytes(
+                    mode, (width, height), pixels, "raw", "RGBX", 0, 1
+                )
+        else:
+            image = Image.frombytes(
+                mode, (width, height), pixels, "raw", "RGBX", 0, 1
+            )
+    else:
+        image = Image.frombuffer(mode, (width, height), pixels, "raw", mode, 0, 1)
+    if palette is not None:
+        image.putpalette(palette_data, palette_mode)
     image.info = info
     image.format = image_format
     return image
@@ -3285,7 +3402,7 @@ def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
 def _decode_media_bytes(
     data: Any,
     framed: bool = False,
-    owner: Any = None,
+    owner: _SharedPoolOwner | None = None,
 ) -> Any:
     if not framed:
         return bytes(data)
@@ -3303,12 +3420,9 @@ def _decode_media_bytes(
     if state_size > _PIL_MEDIA_STATE_MAX_BYTES or state_end > len(data):
         raise ValueError("invalid framed PIL state")
     pixels = data[state_end:]
-    try:
-        image = _decode_pil_image(pixels, data[5:state_end])
-    except ImportError:
-        return bytes(pixels)
+    image = _decode_pil_image(pixels, data[5:state_end], raw_fallback=True)
     if owner is not None and bool(getattr(image, "readonly", False)):
-        image._mooncake_pool_owner = owner
+        image._mooncake_pool_owner = owner.acquire()
     return image
 
 
@@ -3327,21 +3441,16 @@ def _decode_bytes_like_values(
     nulls = payload["nulls"]
     framed = _media_framed(metadata)
     owner = getattr(data, "_mooncake_pool_owner", None)
-    has_owner = False
+    shared_owner = _SharedPoolOwner(owner) if owner is not None else None
     values = []
     for row in range(rows):
         if bool(nulls[row]):
             values.append(None)
             continue
         item = memoryview(data)[int(offsets[row]) : int(offsets[row + 1])]
-        value = _decode_media_bytes(item, framed, owner)
-        has_owner = (
-            has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
-        )
+        value = _decode_media_bytes(item, framed, shared_owner)
         values.append(value)
-    return (
-        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
-    )
+    return values
 
 
 def _encode_media_list_values(
@@ -3394,7 +3503,7 @@ def _decode_media_list_values(
     nulls = payload["nulls"]
     framed = _media_framed(metadata)
     owner = getattr(data, "_mooncake_pool_owner", None)
-    has_owner = False
+    shared_owner = _SharedPoolOwner(owner) if owner is not None else None
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -3405,15 +3514,10 @@ def _decode_media_list_values(
             item = memoryview(data)[
                 int(byte_offsets[item_index]) : int(byte_offsets[item_index + 1])
             ]
-            value = _decode_media_bytes(item, framed, owner)
-            has_owner = (
-                has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
-            )
+            value = _decode_media_bytes(item, framed, shared_owner)
             items.append(value)
         values.append(items)
-    return (
-        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
-    )
+    return values
 
 
 class _StructuredObjectLayer:
@@ -6082,7 +6186,7 @@ def _object_array_from_decoded_values(values: list[Any]) -> np.ndarray:
     owner = getattr(values, "_mooncake_pool_owner", None) or next(
         (getattr(v, "_mooncake_pool_owner", None) for v in values if v is not None), None
     )
-    if owner is None:
+    if owner is None or isinstance(owner, _SharedPoolOwnerToken):
         return array
     result = array.view(_OwnerBackedObjectArray)
     result._mooncake_pool_owner = owner

--- a/mooncake-wheel/mooncake/structured_object_store.py
+++ b/mooncake-wheel/mooncake/structured_object_store.py
@@ -40,6 +40,20 @@ _ENCODING_FALLBACK_ERRORS = (
     RuntimeError,
     RecursionError,
 )
+_PIL_MEDIA_STATE_MAX_BYTES = 8 * 1024**2
+_PIL_MEDIA_TUPLE_EXT = 1
+_PIL_MEDIA_FRAMING = "pil_v2"
+_MEDIA_KIND_BYTES = 0
+_MEDIA_KIND_PIL = 1
+_PIL_MEDIA_FORMAT_MODES = {
+    None: frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "CMYK", "I", "I;16"}),
+    "PNG": frozenset({"1", "L", "LA", "P", "RGB", "RGBA", "I", "I;16"}),
+    "JPEG": frozenset({"L", "RGB", "CMYK"}),
+}
+_PIL_MEDIA_BYTES_PER_PIXEL = {
+    "L": 1, "P": 1, "LA": 2, "I;16": 2, "RGB": 3,
+    "RGBA": 4, "CMYK": 4, "I": 4,
+}
 
 
 class BundleStore(Protocol):
@@ -589,8 +603,10 @@ class MooncakeBundleTransfer:
         """Release pool-backed buffers in a GET result.
 
         After get_dataproto / get_dict, ndarray payloads may be backed by
-        the BufferPool. Call this to release those leases deterministically
-        instead of waiting for GC ``__del__``.
+        the BufferPool. PIL images decoded from selected raw modes may retain
+        the same backing memory. Call this after the result is no longer in use
+        to release those leases deterministically instead of waiting for GC
+        ``__del__``. Access after release is invalid.
 
         Works for both flat dicts and nested envelope dicts
         (dataproto: {batch: {...}, non_tensor_batch: {...}, meta_info: {...}}).
@@ -1230,10 +1246,6 @@ class MooncakeBundleTransfer:
                 if count:
                     ranges.append((int(begin), destination_offset, count))
                 destination_offset += count
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = [
-                    metadata["media_encodings"][index] for index in indices
-                ]
             return {
                 "data": read_data_ranges("data", ranges),
                 "offsets": gathered_offsets,
@@ -1267,7 +1279,6 @@ class MooncakeBundleTransfer:
             destination_offset = 0
             source_index = 0
             destination_boundary = 1
-            media_encodings = []
             for begin, count in zip(item_begins, item_counts):
                 for item in range(count):
                     byte_begin = int(byte_offsets[source_index + item])
@@ -1278,13 +1289,7 @@ class MooncakeBundleTransfer:
                     destination_offset += byte_count
                     gathered_byte_offsets[destination_boundary] = destination_offset
                     destination_boundary += 1
-                if "media_encodings" in metadata:
-                    media_encodings.extend(
-                        metadata["media_encodings"][int(begin) : int(begin) + count]
-                    )
                 source_index += count + 1
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = media_encodings
             return {
                 "data": read_data_ranges("data", ranges),
                 "row_offsets": gathered_row_offsets,
@@ -1394,8 +1399,6 @@ class MooncakeBundleTransfer:
             base = int(offsets[0])
             limit = int(offsets[-1])
             offsets = offsets - base
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = metadata["media_encodings"][start:end]
             return {
                 "data": read_bytes("data", base, limit),
                 "offsets": offsets,
@@ -1411,10 +1414,6 @@ class MooncakeBundleTransfer:
             byte_start = int(byte_offsets[0])
             byte_end = int(byte_offsets[-1])
             byte_offsets = byte_offsets - byte_start
-            if "media_encodings" in metadata:
-                metadata["media_encodings"] = metadata["media_encodings"][
-                    item_start:item_end
-                ]
             return {
                 "data": read_bytes("data", byte_start, byte_end),
                 "row_offsets": row_offsets,
@@ -1907,7 +1906,8 @@ def _coerce_flat_dict_non_tensor_field(
                 f"flat dict non_tensor_batch field {name!r} has batch size {len(value)}, expected {row_count}"
             )
         array = np.empty(row_count, dtype=object)
-        array[:] = list(value)
+        for index, item in enumerate(value):
+            array[index] = item
         return array
     raise TypeError(
         f"flat dict non_tensor_batch field {name!r} must be an ndarray or non-string sequence"
@@ -3013,44 +3013,167 @@ def _decode_numeric_scalar_values(payload: dict[str, Any]) -> list[Any]:
     return values.tolist()
 
 
-def _value_to_media_bytes(value: Any) -> tuple[bytes, str | None, dict[str, Any]]:
+def _encode_pil_state_default(value: Any) -> Any:
+    if isinstance(value, (bytearray, memoryview)):
+        return bytes(value)
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, tuple):
+        return _msgpack.ExtType(
+            _PIL_MEDIA_TUPLE_EXT,
+            _msgpack.packb(
+                list(value),
+                use_bin_type=True,
+                strict_types=True,
+                default=_encode_pil_state_default,
+            ),
+        )
+    raise TypeError(
+        f"PIL image info contains unsupported {type(value).__name__}; "
+        "pass encoded PNG or JPEG bytes to preserve custom image state"
+    )
+
+
+def _decode_pil_state_ext(code: int, data: bytes) -> Any:
+    if code != _PIL_MEDIA_TUPLE_EXT:
+        raise ValueError(f"unsupported PIL image state extension: {code}")
+    values = _msgpack.unpackb(
+        data,
+        raw=False,
+        ext_hook=_decode_pil_state_ext,
+        max_str_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        max_bin_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        max_array_len=1024,
+        max_map_len=1024,
+        max_ext_len=_PIL_MEDIA_STATE_MAX_BYTES,
+    )
+    if not isinstance(values, list):
+        raise ValueError("invalid PIL image tuple state")
+    return tuple(values)
+
+
+def _validate_pil_state_tree(value: Any) -> None:
+    stack = [(value, 0)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 4096 or depth > 16:
+            raise ValueError("PIL image state is too complex")
+        if isinstance(item, dict):
+            if len(item) > 1024 or any(not isinstance(key, str) for key in item):
+                raise ValueError("PIL image state keys must be strings")
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, (list, tuple)):
+            if len(item) > 1024:
+                raise ValueError("PIL image state collection is too large")
+            stack.extend((child, depth + 1) for child in item)
+        elif not isinstance(item, (str, bool, int, float, bytes, type(None))):
+            raise ValueError(
+                f"PIL image state contains unsupported {type(item).__name__}"
+            )
+
+
+def _encode_pil_image(value: Any) -> tuple[bytes, bytes]:
+    frame_count = int(getattr(value, "n_frames", 1))
+    if frame_count != 1:
+        raise ValueError(
+            "multi-frame PIL images are not supported; pass the encoded image bytes"
+        )
+    value.load()
+    image_format = getattr(value, "format", None)
+    if image_format is not None:
+        image_format = str(image_format).upper()
+        if image_format == "JPG":
+            image_format = "JPEG"
+    supported_modes = _PIL_MEDIA_FORMAT_MODES.get(image_format)
+    width, height = value.size
+    if (
+        supported_modes is None
+        or value.mode not in supported_modes
+        or width <= 0
+        or height <= 0
+    ):
+        raise ValueError(
+            f"unsupported PIL image format/mode: {image_format!r}/{value.mode!r}; "
+            "pass the encoded image bytes"
+        )
+    palette = None
+    if value.palette is not None:
+        palette_mode, palette_data = value.palette.getdata()
+        if palette_mode not in {"RGB", "RGBA"}:
+            raise ValueError(f"unsupported PIL palette mode: {palette_mode!r}")
+        palette_data = bytes(palette_data)
+        palette = [palette_mode, palette_data] if palette_data else None
+        if (
+            palette is not None
+            and (
+                value.mode != "P"
+                or len(palette_data) > 256 * len(palette_mode)
+                or len(palette_data) % len(palette_mode)
+            )
+        ):
+            raise ValueError("invalid PIL image palette")
+    state = [
+        1,
+        value.mode,
+        int(width),
+        int(height),
+        image_format,
+        palette,
+        dict(value.info),
+    ]
+    _validate_pil_state_tree(state)
+    state_bytes = _msgpack.packb(
+        state,
+        use_bin_type=True,
+        strict_types=True,
+        default=_encode_pil_state_default,
+    )
+    if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
+        raise ValueError(f"PIL image state is too large: {len(state_bytes)} bytes")
+    return value.tobytes(), state_bytes
+
+
+def _value_to_media_parts(
+    value: Any,
+) -> tuple[bytes | bytearray | memoryview, bytes, str | None, int]:
     if value is None:
-        return b"", None, {"kind": "null"}
+        return b"", b"", None, _MEDIA_KIND_BYTES
     if _is_bytes_like(value):
-        return bytes(value), None, {"kind": "bytes"}
+        encoded = value if isinstance(value, bytes) else bytes(value)
+        return encoded, b"", None, _MEDIA_KIND_BYTES
     if _is_pil_image(value):
-        image = (
-            value.convert(value.mode) if getattr(value, "readonly", False) else value
-        )
-        return (
-            image.tobytes(),
-            "image/raw",
-            {
-                "kind": "pil_raw",
-                "mode": image.mode,
-                "size": list(image.size),
-                "format": getattr(value, "format", None),
-            },
-        )
-    return bytes(value), None, {"kind": "bytes"}
+        pixels, state = _encode_pil_image(value)
+        return pixels, state, "image/raw", _MEDIA_KIND_PIL
+    return bytes(value), b"", None, _MEDIA_KIND_BYTES
+
+
+def _pil_pixel_bytes(mode: str, width: int, height: int) -> int:
+    if mode == "1":
+        return ((width + 7) // 8) * height
+    return width * height * _PIL_MEDIA_BYTES_PER_PIXEL[mode]
+
 
 def _encode_bytes_like_values(
     values: list[Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     offsets = [0]
-    parts = []
+    items = []
     media_types = []
-    encodings = []
     for value in values:
-        data, media_type, encoding = _value_to_media_bytes(value)
-        parts.append(data)
+        data, state, media_type, kind = _value_to_media_parts(value)
+        items.append((data, state, kind))
         media_types.append(media_type)
-        encodings.append(encoding)
-        offsets.append(offsets[-1] + len(data))
-    payload_bytes = _multi_buffer_bytes_payload(parts)
+    framed = any(kind == _MEDIA_KIND_PIL for _data, _state, kind in items)
+    parts = []
+    for data, state, kind in items:
+        item_parts = _framed_media_parts(data, state, kind) if framed else (data,)
+        parts.extend(item_parts)
+        offsets.append(offsets[-1] + sum(len(part) for part in item_parts))
     metadata: dict[str, Any] = {}
-    if any(encoding.get("kind") == "pil_raw" for encoding in encodings):
-        metadata["media_encodings"] = encodings
+    if framed:
+        metadata["media_framing"] = _PIL_MEDIA_FRAMING
     non_null_media_types = sorted(
         {media_type for media_type in media_types if media_type}
     )
@@ -3059,7 +3182,7 @@ def _encode_bytes_like_values(
         metadata["encode_source"] = "raw_pixels_from_object"
     return (
         {
-            "data": payload_bytes,
+            "data": _multi_buffer_bytes_payload(parts),
             "offsets": np.asarray(offsets, dtype=np.int64),
             "nulls": np.asarray([value is None for value in values], dtype=np.bool_),
         },
@@ -3067,25 +3190,133 @@ def _encode_bytes_like_values(
     )
 
 
+def _framed_media_parts(
+    data: bytes | bytearray | memoryview, state: bytes, kind: int
+) -> tuple[bytes | bytearray | memoryview, ...]:
+    if kind == _MEDIA_KIND_BYTES:
+        return (bytes((_MEDIA_KIND_BYTES,)), data)
+    header = bytes((_MEDIA_KIND_PIL,)) + len(state).to_bytes(4, "little")
+    return header, state, data
+
+
 def _multi_buffer_bytes_payload(
-    parts: Sequence[bytes | memoryview],
+    parts: Sequence[bytes | bytearray | memoryview],
 ) -> _MultiBufferPayload:
     buffers = tuple(_bytes_view(part, "payload part") for part in parts if part)
     return _MultiBufferPayload(buffers, tuple(parts))
 
 
-def _decode_media_bytes(data: Any, encoding: Optional[Mapping[str, Any]]) -> Any:
-    if not encoding or encoding.get("kind") != "pil_raw":
-        return bytes(data)
+def _decode_pil_image(data: Any, state_bytes: Any) -> Any:
+    try:
+        if len(state_bytes) > _PIL_MEDIA_STATE_MAX_BYTES:
+            raise ValueError("PIL image state is too large")
+        state = _msgpack.unpackb(
+            state_bytes,
+            raw=False,
+            ext_hook=_decode_pil_state_ext,
+            max_str_len=_PIL_MEDIA_STATE_MAX_BYTES,
+            max_bin_len=_PIL_MEDIA_STATE_MAX_BYTES,
+            max_array_len=1024,
+            max_map_len=1024,
+            max_ext_len=_PIL_MEDIA_STATE_MAX_BYTES,
+        )
+        _validate_pil_state_tree(state)
+    except (
+        TypeError,
+        ValueError,
+        OverflowError,
+        RecursionError,
+        _msgpack.UnpackException,
+    ) as exc:
+        raise ValueError("invalid PIL image state") from exc
+    if not isinstance(state, list) or len(state) != 7 or type(state[0]) is not int:
+        raise ValueError("unsupported PIL image state")
+    if state[0] != 1:
+        raise ValueError("unsupported PIL image state")
+    _, mode, width, height, image_format, palette, info = state
+    if not isinstance(mode, str) or (
+        image_format is not None and not isinstance(image_format, str)
+    ):
+        raise ValueError("invalid PIL image mode or format")
+    supported_modes = _PIL_MEDIA_FORMAT_MODES.get(image_format)
+    if (
+        supported_modes is None
+        or mode not in supported_modes
+        or isinstance(width, bool)
+        or not isinstance(width, int)
+        or width <= 0
+        or isinstance(height, bool)
+        or not isinstance(height, int)
+        or height <= 0
+    ):
+        raise ValueError("invalid PIL image mode, format, or dimensions")
+    pixels = data
+    expected_pixel_bytes = _pil_pixel_bytes(mode, width, height)
+    if len(pixels) != expected_pixel_bytes:
+        raise ValueError(
+            f"invalid PIL image pixel length: {len(pixels)}, "
+            f"expected {expected_pixel_bytes}"
+        )
     try:
         from PIL import Image
-    except ImportError:
-        return bytes(data)
-    image = Image.frombuffer(
-        encoding["mode"], tuple(encoding["size"]), data, "raw", encoding["mode"], 0, 1
-    )
-    image.format = encoding.get("format")
+    except ImportError as exc:
+        raise ImportError("Pillow is required to decode PIL image payloads") from exc
+    image = Image.frombuffer(mode, (width, height), pixels, "raw", mode, 0, 1)
+    if palette is not None:
+        valid_palette = isinstance(palette, list) and len(palette) == 2
+        palette_mode = palette[0] if valid_palette else None
+        palette_data = palette[1] if valid_palette else None
+        if (
+            mode != "P"
+            or palette_mode not in {"RGB", "RGBA"}
+            or not isinstance(palette_data, bytes)
+            or not 0 < len(palette_data) <= 256 * len(palette_mode)
+            or len(palette_data) % len(palette_mode)
+        ):
+            raise ValueError("invalid PIL image palette")
+        image.putpalette(palette_data, palette_mode)
+    if not isinstance(info, dict):
+        raise ValueError("invalid PIL image info")
+    image.info = info
+    image.format = image_format
     return image
+
+
+def _decode_media_bytes(
+    data: Any,
+    framed: bool = False,
+    owner: Any = None,
+) -> Any:
+    if not framed:
+        return bytes(data)
+    if not data:
+        raise ValueError("invalid framed media payload")
+    kind = int(data[0])
+    if kind == _MEDIA_KIND_BYTES:
+        return bytes(data[1:])
+    if kind != _MEDIA_KIND_PIL:
+        raise ValueError(f"unsupported media encoding: {kind!r}")
+    if len(data) < 5:
+        raise ValueError("invalid framed PIL payload")
+    state_size = int.from_bytes(data[1:5], "little")
+    state_end = 5 + state_size
+    if state_size > _PIL_MEDIA_STATE_MAX_BYTES or state_end > len(data):
+        raise ValueError("invalid framed PIL state")
+    pixels = data[state_end:]
+    try:
+        image = _decode_pil_image(pixels, data[5:state_end])
+    except ImportError:
+        return bytes(pixels)
+    if owner is not None and bool(getattr(image, "readonly", False)):
+        image._mooncake_pool_owner = owner
+    return image
+
+
+def _media_framed(metadata: Optional[Mapping[str, Any]]) -> bool:
+    framing = (metadata or {}).get("media_framing")
+    if framing not in {None, _PIL_MEDIA_FRAMING}:
+        raise ValueError(f"unsupported media framing: {framing!r}")
+    return framing == _PIL_MEDIA_FRAMING
 
 
 def _decode_bytes_like_values(
@@ -3094,16 +3325,23 @@ def _decode_bytes_like_values(
     data = payload["data"]
     offsets = payload["offsets"]
     nulls = payload["nulls"]
-    encodings = (metadata or {}).get("media_encodings", [])
+    framed = _media_framed(metadata)
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    has_owner = False
     values = []
     for row in range(rows):
         if bool(nulls[row]):
             values.append(None)
             continue
         item = memoryview(data)[int(offsets[row]) : int(offsets[row + 1])]
-        encoding = encodings[row] if row < len(encodings) else None
-        values.append(_decode_media_bytes(item, encoding))
-    return values
+        value = _decode_media_bytes(item, framed, owner)
+        has_owner = (
+            has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
+        )
+        values.append(value)
+    return (
+        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
+    )
 
 
 def _encode_media_list_values(
@@ -3111,30 +3349,34 @@ def _encode_media_list_values(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     row_offsets = [0]
     byte_offsets = [0]
-    parts = []
+    encoded_items = []
     media_types = []
-    encodings = []
     for value in values:
-        items = [] if value is None else list(value)
-        for item in items:
-            data, media_type, encoding = _value_to_media_bytes(item)
-            parts.append(data)
+        row_items = [] if value is None else list(value)
+        for item in row_items:
+            data, state, media_type, kind = _value_to_media_parts(item)
+            encoded_items.append((data, state, kind))
             media_types.append(media_type)
-            encodings.append(encoding)
-            byte_offsets.append(byte_offsets[-1] + len(data))
-        row_offsets.append(row_offsets[-1] + len(items))
-    metadata: dict[str, Any] = {
-        "encode_source": "raw_pixels_from_object",
-        "media_encodings": encodings,
-    }
+        row_offsets.append(len(encoded_items))
+    framed = any(
+        kind == _MEDIA_KIND_PIL for _data, _state, kind in encoded_items
+    )
+    parts = []
+    for data, state, kind in encoded_items:
+        item_parts = _framed_media_parts(data, state, kind) if framed else (data,)
+        parts.extend(item_parts)
+        byte_offsets.append(byte_offsets[-1] + sum(len(part) for part in item_parts))
+    metadata: dict[str, Any] = {"encode_source": "raw_pixels_from_object"}
     non_null_media_types = sorted(
         {media_type for media_type in media_types if media_type}
     )
     if non_null_media_types:
         metadata["media_types"] = non_null_media_types
+    if framed:
+        metadata["media_framing"] = _PIL_MEDIA_FRAMING
     return (
         {
-            "data": b"".join(parts),
+            "data": _multi_buffer_bytes_payload(parts),
             "row_offsets": np.asarray(row_offsets, dtype=np.int64),
             "byte_offsets": np.asarray(byte_offsets, dtype=np.int64),
             "nulls": np.asarray([value is None for value in values], dtype=np.bool_),
@@ -3150,7 +3392,9 @@ def _decode_media_list_values(
     row_offsets = payload["row_offsets"]
     byte_offsets = payload["byte_offsets"]
     nulls = payload["nulls"]
-    encodings = (metadata or {}).get("media_encodings", [])
+    framed = _media_framed(metadata)
+    owner = getattr(data, "_mooncake_pool_owner", None)
+    has_owner = False
     values = []
     for row in range(rows):
         if bool(nulls[row]):
@@ -3161,10 +3405,15 @@ def _decode_media_list_values(
             item = memoryview(data)[
                 int(byte_offsets[item_index]) : int(byte_offsets[item_index + 1])
             ]
-            encoding = encodings[item_index] if item_index < len(encodings) else None
-            items.append(_decode_media_bytes(item, encoding))
+            value = _decode_media_bytes(item, framed, owner)
+            has_owner = (
+                has_owner or getattr(value, "_mooncake_pool_owner", None) is not None
+            )
+            items.append(value)
         values.append(items)
-    return values
+    return (
+        _OwnerBackedList(values, owner) if owner is not None and has_owner else values
+    )
 
 
 class _StructuredObjectLayer:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ctypes
+import gc
+import io
 import json
 import os
 import threading
@@ -1979,6 +1981,175 @@ def test_unified_dict_put_accepts_field_schemas() -> None:
     assert result["global_batch_sizes"] == [2]
     assert result["num_microbatches"] == 1
     assert result["step"] == 7
+
+
+def _pil_fixture(image_format: str):
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.new("RGB", (12, 9), (1, 2, 3))
+    output = io.BytesIO()
+    options = {"icc_profile": b"test-icc-profile"}
+    if image_format == "PNG":
+        PngImagePlugin = pytest.importorskip("PIL.PngImagePlugin")
+        png_info = PngImagePlugin.PngInfo()
+        png_info.add_text("source", "mooncake-test")
+        options.update(pnginfo=png_info, dpi=(96, 96))
+    else:
+        exif = Image.Exif()
+        exif[0x010E] = "mooncake-test"
+        options.update(quality=95, dpi=(144, 144), exif=exif)
+    image.save(output, format=image_format, **options)
+    encoded = output.getvalue()
+    decoded = Image.open(io.BytesIO(encoded))
+    return decoded, encoded
+
+
+def _assert_pil_roundtrip(actual, expected) -> None:
+    assert actual.mode == expected.mode
+    assert actual.size == expected.size
+    assert actual.format == expected.format
+    assert actual.tobytes() == expected.tobytes()
+    assert actual.info == expected.info
+    expected_palette = expected.palette.getdata() if expected.palette else None
+    actual_palette = actual.palette.getdata() if actual.palette else None
+    assert actual_palette == expected_palette
+
+
+def _palette_image():
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.fromarray(np.arange(20, dtype=np.uint8).reshape(4, 5), mode="P")
+    image.putpalette(bytes([0, 255, 0, 255, 0, 127]))
+    image.info = {
+        "transparency": 0,
+        "dpi": (72, 72),
+        "nested": (("source", 1), 2),
+    }
+    image.format = "PNG"
+    return image
+
+
+@pytest.mark.parametrize("image_format", ["PNG", "JPEG"])
+def test_unified_dict_pil_codec_preserves_common_image_state(image_format) -> None:
+    _store, transfer = make_transfer()
+    image, _encoded = _pil_fixture(image_format)
+
+    ref = transfer.put(
+        {"image": [image]},
+        type="dict",
+        field_schemas={
+            "image": FieldSchema(
+                codec="media_bytes", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+    actual = transfer.get(ref, type="dict")["image"][0]
+
+    _assert_pil_roundtrip(actual, image)
+
+
+def test_unified_dict_pil_codec_preserves_palette_and_partial_reads() -> None:
+    png, png_bytes = _pil_fixture("PNG")
+    jpeg, jpeg_bytes = _pil_fixture("JPEG")
+    palette = _palette_image()
+    rows = [[png, png_bytes], None, [], [jpeg, jpeg_bytes, palette]]
+    _store, transfer = make_transfer()
+    ref = transfer.put(
+        {"media": rows},
+        type="dict",
+        field_schemas={
+            "media": FieldSchema(
+                codec="media_list_ragged",
+                metadata={"section": "non_tensor_batch"},
+            )
+        },
+    )
+
+    sliced = transfer.get(ref, type="dict", rows=slice(2, 4))["media"]
+    gathered = transfer.get(ref, type="dict", rows=[3, 0])["media"]
+
+    assert sliced[0] == []
+    _assert_pil_roundtrip(sliced[1][0], jpeg)
+    assert sliced[1][1] == jpeg_bytes
+    _assert_pil_roundtrip(sliced[1][2], palette)
+    assert [
+        item.tobytes() if hasattr(item, "tobytes") else item for item in gathered[0]
+    ] == [
+        jpeg.tobytes(),
+        jpeg_bytes,
+        palette.tobytes(),
+    ]
+    _assert_pil_roundtrip(gathered[1][0], png)
+    assert gathered[1][1] == png_bytes
+
+
+@pytest.mark.parametrize("mode", ["1", "L", "LA", "RGB", "RGBA", "CMYK", "I", "I;16"])
+def test_pil_codec_roundtrips_supported_raw_modes(mode) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.new(mode, (5, 3))
+
+    pixels, state = sos._encode_pil_image(image)
+    actual = sos._decode_pil_image(memoryview(pixels), memoryview(state))
+
+    _assert_pil_roundtrip(actual, image)
+
+
+def test_unified_dict_pil_codec_releases_buffer_pool_once() -> None:
+    image = _palette_image()
+    pool = FakeBufferPool()
+    _store, transfer = make_transfer(buffer_pool=pool)
+    ref = transfer.put(
+        {"image": [image]},
+        type="dict",
+        field_schemas={
+            "image": FieldSchema(
+                codec="media_bytes", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+    result = transfer.get(ref, type="dict")
+    actual = result["image"][0]
+    _assert_pil_roundtrip(actual, image)
+    assert hasattr(actual, "_mooncake_pool_owner")
+    del result
+    gc.collect()
+    assert pool.release_count < pool.acquire_count
+    MooncakeBundleTransfer.release_result(actual)
+    assert pool.release_count == pool.acquire_count
+    after_release = pool.release_count
+    MooncakeBundleTransfer.release_result(actual)
+    assert pool.release_count == after_release
+
+
+def test_pil_codec_rejects_multiframe_images() -> None:
+    Image = pytest.importorskip("PIL.Image")
+    encoded = io.BytesIO()
+    Image.new("RGB", (2, 2), "red").save(
+        encoded,
+        format="PNG",
+        save_all=True,
+        append_images=[Image.new("RGB", (2, 2), "blue")],
+    )
+    image = Image.open(io.BytesIO(encoded.getvalue()))
+
+    with pytest.raises(ValueError, match="multi-frame PIL images"):
+        sos._encode_pil_image(image)
+
+
+@pytest.mark.parametrize(
+    "payload", [b"\x07pixels", b"\x01\x0b\x00\x00\x00not-msgpackpixels"]
+)
+def test_pil_codec_rejects_invalid_encodings(payload) -> None:
+    with pytest.raises(ValueError, match="media encoding|PIL image state"):
+        sos._decode_media_bytes(memoryview(payload), framed=True)
+
+
+def test_pil_codec_rejects_unsupported_state_and_framing() -> None:
+    image = _palette_image()
+    image.info = {1: "non-string key"}
+    with pytest.raises(ValueError, match="keys must be strings"):
+        sos._encode_pil_image(image)
+
+    with pytest.raises(ValueError, match="unsupported media framing"):
+        sos._media_framed({"media_framing": "pil_v3"})
 
 
 def test_release_result_recurses_into_ragged_row_views() -> None:

--- a/mooncake-wheel/tests/test_structured_object_store.py
+++ b/mooncake-wheel/tests/test_structured_object_store.py
@@ -2152,6 +2152,107 @@ def test_pil_codec_rejects_unsupported_state_and_framing() -> None:
         sos._media_framed({"media_framing": "pil_v3"})
 
 
+def test_pil_rgb_arrow_path_avoids_tobytes(monkeypatch) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    if sos._pillow_arrow_view is None:
+        pytest.skip("Pillow Arrow fast path is unavailable")
+    image = Image.new("RGB", (5, 3), (1, 2, 3))
+    monkeypatch.setattr(image, "tobytes", lambda: pytest.fail("tobytes called"))
+
+    pixels, state = sos._encode_pil_image(image)
+    actual = sos._decode_pil_image(pixels, state)
+
+    assert actual.getpixel((0, 0)) == (1, 2, 3)
+
+
+def test_pil_rgb_arrow_path_falls_back_to_packed_rgb(monkeypatch) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    image = Image.new("RGB", (5, 3), (1, 2, 3))
+    monkeypatch.setattr(
+        sos, "_pillow_arrow_view", lambda _image: (_ for _ in ()).throw(ValueError())
+    )
+
+    pixels, state = sos._encode_pil_image(image)
+    actual = sos._decode_pil_image(pixels, state)
+
+    assert len(pixels) == 5 * 3 * 3
+    assert actual.getpixel((0, 0)) == (1, 2, 3)
+
+
+def test_pil_rgb_arrow_path_falls_back_without_arrow_decoder(monkeypatch) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    if sos._pillow_arrow_view is None:
+        pytest.skip("Pillow Arrow fast path is unavailable")
+    image = Image.new("RGB", (5, 3), (1, 2, 3))
+    pixels, state = sos._encode_pil_image(image)
+    monkeypatch.setattr(
+        Image,
+        "fromarrow",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError()),
+    )
+
+    actual = sos._decode_pil_image(pixels, state)
+
+    assert actual.mode == "RGB"
+    assert actual.getpixel((0, 0)) == (1, 2, 3)
+
+
+def test_pil_rgb_arrow_path_returns_packed_bytes_without_pillow(monkeypatch) -> None:
+    import builtins
+
+    Image = pytest.importorskip("PIL.Image")
+    if sos._pillow_arrow_view is None:
+        pytest.skip("Pillow Arrow fast path is unavailable")
+    pixels, state = sos._encode_pil_image(Image.new("RGB", (5, 3), (1, 2, 3)))
+    real_import = builtins.__import__
+
+    def no_pillow(name, *args, **kwargs):
+        if name == "PIL":
+            raise ImportError("Pillow unavailable")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", no_pillow)
+    actual = sos._decode_pil_image(pixels, state, raw_fallback=True)
+
+    assert len(actual) == 5 * 3 * 3
+    assert actual == bytes((1, 2, 3)) * 15
+
+
+def test_pil_rgb_arrow_path_releases_shared_buffer_pool_once(monkeypatch) -> None:
+    Image = pytest.importorskip("PIL.Image")
+    if sos._pillow_arrow_view is None:
+        pytest.skip("Pillow Arrow fast path is unavailable")
+    images = [Image.new("RGB", (5, 3), color) for color in ((1, 2, 3), (4, 5, 6))]
+    for image in images:
+        monkeypatch.setattr(image, "tobytes", lambda: pytest.fail("tobytes called"))
+    pool = FakeBufferPool()
+    _store, transfer = make_transfer(buffer_pool=pool)
+    ref = transfer.put(
+        {"image": images},
+        type="dict",
+        field_schemas={
+            "image": FieldSchema(
+                codec="media_bytes", metadata={"section": "non_tensor_batch"}
+            )
+        },
+    )
+
+    result = transfer.get(ref, type="dict")
+    first, second = result["image"]
+    del result
+    gc.collect()
+    assert pool.release_count < pool.acquire_count
+    MooncakeBundleTransfer.release_result(first)
+    assert second.getpixel((0, 0)) == (4, 5, 6)
+    assert pool.release_count < pool.acquire_count
+    MooncakeBundleTransfer.release_result(second)
+    assert pool.release_count == pool.acquire_count
+
+    result = transfer.get(ref, type="dict")
+    MooncakeBundleTransfer.release_result(result)
+    assert pool.release_count == pool.acquire_count
+
+
 def test_release_result_recurses_into_ragged_row_views() -> None:
     class FakeOwner:
         def __init__(self) -> None:


### PR DESCRIPTION
## Motivation

The structured-object PIL codec introduced by #3412 uses `Image.tobytes()` for RGB pixels. That creates a full packed-RGB allocation before Mooncake copies the payload into BufferPool staging. GET then reconstructs another full pixel buffer. For rollout dictionaries containing many decoded images, those CPU copies dominate transfer latency.

This PR is stacked on #3412 and contains only the follow-up performance change. It should be rebased onto `main` after #3412 merges.

## Description

- Read Pillow's immutable RGBX storage through the Arrow C Data Interface without an intermediate `tobytes()` allocation.
- Copy that view directly into the existing BufferPool payload path.
- Reconstruct full-GET images with `Image.fromarrow`, keeping the BufferPool lease alive until the last decoded image is released.
- Keep the packed-RGB codec as a compatibility fallback when Pillow or the requested layout does not support Arrow.
- Validate the Arrow schema, array layout, dimensions, and ownership transitions before exposing a view.

Three implementations were measured with the same wheel, master, client, Kodak24 RGB inputs, 64 MiB chunks, one warmup, and seven cross-node RDMA trials. Values are median PUT+GET latency; lower is better.

| Logical payload | Packed RGB with `tobytes()` | RGBX Arrow view | RGBX fused to packed RGB in BufferPool |
| ---: | ---: | ---: | ---: |
| 128 MiB | 186.8 ms | **63.9 ms** | 164.0 ms |
| 512 MiB | 861.6 ms | **177.4 ms** | 538.4 ms |

The fused packed path reduces wire bytes but still requires a full reconstruction copy on GET. Direct RGBX sends 33% more pixel bytes, yet wins at every measured size because it removes the expensive copies on both sides. It also remained fastest for 1, 8, and 24-image payloads, so the implementation does not add a size threshold.

The final reviewed wheel was rebuilt and retested independently:

| Logical payload | Layout | PUT | GET | PUT+GET | Speedup |
| ---: | --- | ---: | ---: | ---: | ---: |
| 128 MiB | Packed RGB | 76.1 ms | 112.1 ms | 188.1 ms | 1.00x |
| 128 MiB | RGBX Arrow | **43.2 ms** | **20.2 ms** | **63.2 ms** | **2.98x** |
| 512 MiB | Packed RGB | 397.9 ms | 431.0 ms | 828.8 ms | 1.00x |
| 512 MiB | RGBX Arrow | **105.8 ms** | **71.9 ms** | **178.9 ms** | **4.63x** |

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
python -m pytest mooncake-wheel/tests/test_structured_object_store.py
python -m py_compile mooncake-wheel/mooncake/structured_object_store.py mooncake-wheel/tests/test_structured_object_store.py
clang-format-20 --dry-run --Werror mooncake-wheel/mooncake/_fast_copy.c
SKIP=ruff,ruff-format pre-commit run --files \
  mooncake-wheel/mooncake/_fast_copy.c \
  mooncake-wheel/mooncake/structured_object_store.py \
  mooncake-wheel/tests/test_structured_object_store.py
```

**Test results:**

- [x] Unit tests pass: 106 passed, 27 skipped
- [x] Integration tests pass: two-node RDMA PUT/GET passed with pixel verification
- [x] Manual testing done: 30,000 Arrow create/release cycles passed

The skipped unit tests require a working CUDA/Torch runtime, which is unavailable in the test environment. `ruff` and `ruff-format` were intentionally not run; all other applicable pre-commit hooks passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable to the 473-line performance commit; the draft comparison temporarily includes #3412

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to compare codec designs, review lifetime and fallback paths, run the validation matrix, and prepare this PR description. The submitted implementation and results were manually reviewed.