### PR TITLE
[CI] Adjust build concurrency in build-musa workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -108,7 +108,10 @@ jobs:
         run: |
           cd build
           source ~/.bashrc
-          cmake --build . --parallel 1
+          # Limit concurrency of Mooncake PG's setup.py build to avoid OOM
+          export MAX_JOBS=2
+          # Does not affect the Ninja system
+          cmake --build .
           cmake --install .
         shell: bash
 


### PR DESCRIPTION
Limit concurrency of Mooncake PG's setup.py build to avoid OOM.

## Description



I previously set the concurrency at the wrong place.

It should be set at the setup.py level, rather than the entire CMake level.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [x] No AI tools were used
- [ ] AI tools were used (specify below)