### PR TITLE
[Bugfix][Store] Avoid futile PutStart eviction triggers

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3723,6 +3723,7 @@ auto MasterService::AllocateAndInsertMetadata(
     const auto write_mode = DetermineReplicaWriteMode(config);
     size_t allocated_memory_replicas = 0;
     size_t allocated_nof_replicas = 0;
+    bool has_enough_memory_segments = false;
     if (config.replica_num > 0) {
         const bool use_local_first =
             allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST &&
@@ -3736,6 +3737,8 @@ auto MasterService::AllocateAndInsertMetadata(
         ScopedAllocatorAccess allocator_access =
             segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
+        has_enough_memory_segments =
+            allocator_manager.getNames().size() >= config.replica_num;
 
         std::vector<std::string> preferred_segments;
         auto append_preferred_segment = [&preferred_segments](
@@ -3789,7 +3792,9 @@ auto MasterService::AllocateAndInsertMetadata(
             }
             if (write_mode != ReplicaWriteMode::FLEXIBLE_DUAL_REPLICA) {
                 MasterMetricManager::instance().inc_put_start_alloc_failures();
-                need_mem_eviction_ = true;
+                if (has_enough_memory_segments) {
+                    need_mem_eviction_ = true;
+                }
                 refund_pending_quota();
                 return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
             }
@@ -3843,7 +3848,8 @@ auto MasterService::AllocateAndInsertMetadata(
              allocated_nof_replicas != config.nof_replica_num)) {
             MasterMetricManager::instance().inc_put_start_alloc_failures();
             if (config.replica_num > 0 &&
-                allocated_memory_replicas != config.replica_num) {
+                allocated_memory_replicas != config.replica_num &&
+                has_enough_memory_segments) {
                 need_mem_eviction_ = true;
             }
             if (config.nof_replica_num > 0 &&

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -534,6 +534,10 @@ class MasterServiceHATest : public ::testing::Test {
         return service.snapshot_manager_ != nullptr;
     }
 
+    static bool NeedMemoryEvictionForTesting(const MasterService& service) {
+        return service.need_mem_eviction_.load(std::memory_order_relaxed);
+    }
+
     static tl::expected<uint64_t, ErrorCode> AppendVisibleForTesting(
         MasterService& service, OpType type, const std::string& tenant_id,
         const std::string& key, const std::string& payload) {
@@ -689,6 +693,97 @@ class MasterServiceHATest : public ::testing::Test {
 };
 
 class MasterServiceBatchRecordE2ETest : public MasterServiceHATest {};
+
+TEST_F(MasterServiceHATest, PutStartWithoutMemorySegmentsDoesNotArmEviction) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_eviction_ratio(0.0)
+                              .set_eviction_high_watermark_ratio(1.0)
+                              .build());
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    auto result = service.PutStart(generate_uuid(), "no_memory_segments",
+                                   kDefaultTenant, 1024, config);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_FALSE(NeedMemoryEvictionForTesting(service));
+}
+
+TEST_F(MasterServiceHATest,
+       PutStartWithFewerMemorySegmentsThanReplicasDoesNotArmEviction) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_eviction_ratio(0.0)
+                              .set_eviction_high_watermark_ratio(1.0)
+                              .build());
+    const auto mounted =
+        PrepareSimpleSegment(service, "insufficient_segment_count");
+    ReplicateConfig config;
+    config.replica_num = 2;
+
+    auto result =
+        service.PutStart(mounted.client_id, "insufficient_segment_count",
+                         kDefaultTenant, 2 * kDefaultSegmentSize, config);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_FALSE(NeedMemoryEvictionForTesting(service));
+}
+
+TEST_F(MasterServiceHATest,
+       PutStartAllocationFailureWithEnoughMemorySegmentsArmsEviction) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_eviction_ratio(0.0)
+                              .set_eviction_high_watermark_ratio(1.0)
+                              .build());
+    const auto first = PrepareSimpleSegment(service, "full_segment_1");
+    PrepareSimpleSegment(service, "full_segment_2",
+                         kDefaultSegmentBase + kDefaultSegmentSize);
+    ReplicateConfig config;
+    config.replica_num = 2;
+
+    auto result =
+        service.PutStart(first.client_id, "enough_full_segments",
+                         kDefaultTenant, 2 * kDefaultSegmentSize, config);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_TRUE(NeedMemoryEvictionForTesting(service));
+}
+
+TEST_F(MasterServiceHATest,
+       PutStartWithTooFewMemorySegmentsPreservesArmedEviction) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_eviction_ratio(0.0)
+                              .set_eviction_high_watermark_ratio(1.0)
+                              .build());
+    const auto first = PrepareSimpleSegment(service, "preserve_flag_segment_1");
+    const auto second =
+        PrepareSimpleSegment(service, "preserve_flag_segment_2",
+                             kDefaultSegmentBase + kDefaultSegmentSize);
+    ReplicateConfig config;
+    config.replica_num = 2;
+
+    auto first_result =
+        service.PutStart(first.client_id, "arm_eviction", kDefaultTenant,
+                         2 * kDefaultSegmentSize, config);
+    ASSERT_FALSE(first_result.has_value());
+    ASSERT_TRUE(NeedMemoryEvictionForTesting(service));
+    ASSERT_TRUE(service.UnmountSegment(second.segment_id, second.client_id)
+                    .has_value());
+
+    auto second_result =
+        service.PutStart(first.client_id, "preserve_armed_eviction",
+                         kDefaultTenant, 2 * kDefaultSegmentSize, config);
+
+    ASSERT_FALSE(second_result.has_value());
+    EXPECT_EQ(second_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
+    EXPECT_TRUE(NeedMemoryEvictionForTesting(service));
+}
 
 TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesMemoryBufferDescriptor) {
     MasterService service(


### PR DESCRIPTION
## Description

Part of #3139.

`MasterService::AllocateAndInsertMetadata()` currently arms `need_mem_eviction_` whenever memory allocation fails. This also happens when the number of mounted memory segments is smaller than `config.replica_num`.

Eviction may reclaim memory capacity, but it cannot create the missing distinct placement targets. In that case, repeatedly triggering `BatchEvict` is futile.

This change records whether the mounted memory-segment count is at least `config.replica_num` under the existing `ScopedAllocatorAccess`, then uses that same necessary condition at both memory-allocation failure exits before arming `need_mem_eviction_`.

The check intentionally does not attempt to predict capacity, fragmentation, largest free regions, or reclaimability. It also does not clear an eviction flag already set by another request.

### Relationship to #3141

This PR is the focused replacement for the `PutStart` eviction-trigger portion of #3141.

#3141 originally combined several independently reviewable fixes, including:

- allocator recovery gaps;
- `PutStart` eviction triggering;
- remount and lease handling;
- OpLog backpressure behavior.

Following the review request to split those changes, this PR carries only the `PutStart` trigger fix and its boundary tests. It supersedes that specific slice of #3141; it does not replace or include the other fixes from #3141.

It also does not change allocation strategies, NoF eviction behavior, or the allocator fallback work tracked separately from this change.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The new deterministic tests cover:

- no mounted memory segments;
- fewer mounted segments than `replica_num`;
- allocation failure with enough mounted segments;
- preserving a `true` flag set by an earlier request.

The existing positive asynchronous eviction test verifies that capacity pressure still triggers eviction when enough segments are mounted.

**Test commands:**

```bash
cmake --build build --target master_service_ha_test -j32

env LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.PutStartWithoutMemorySegmentsDoesNotArmEviction:MasterServiceHATest.PutStartWithFewerMemorySegmentsThanReplicasDoesNotArmEviction:MasterServiceHATest.PutStartAllocationFailureWithEnoughMemorySegmentsArmsEviction:MasterServiceHATest.PutStartWithTooFewMemorySegmentsPreservesArmedEviction' \
  --gtest_repeat=50 \
  --gtest_break_on_failure

cmake --build build --target master_service_test -j32

env LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/master_service_test \
  --gtest_filter='MasterServiceTest.PutStartExpiringTest' \
  --gtest_break_on_failure

pre-commit run --files \
  mooncake-store/src/master_service.cpp \
  mooncake-store/tests/ha/master_service_ha_test.cpp

git diff --check
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done

The four focused tests passed all 50 repetitions (`200/200` test executions).
The existing `MasterServiceTest.PutStartExpiringTest` also passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to trace the allocation and eviction-trigger paths, implement the focused change, add deterministic tests, and run the validation commands. The human submitter is responsible for reviewing and understanding every changed line before submission.