### PR TITLE
[Store] Fix NoF benchmark build: gflags flags inside anonymous namespace

### DIFF
--- a/mooncake-store/benchmarks/nof_worker_pool_bench.cpp
+++ b/mooncake-store/benchmarks/nof_worker_pool_bench.cpp
@@ -25,8 +25,6 @@
 #include "spdk/spdk_wrapper.h"
 #include "transfer_task.h"
 
-namespace {
-
 constexpr uint64_t KiB = 1024;
 constexpr uint64_t MiB = 1024 * KiB;
 constexpr uint64_t GiB = 1024 * MiB;
@@ -95,6 +93,8 @@ DEFINE_int32(socket_id, -1,
              "NUMA socket for benchmark buffers. -1 lets SPDK choose.");
 DEFINE_bool(fill_on_write, true,
             "Fill buffers with a deterministic pattern for write/mixed ops.");
+
+namespace {
 
 using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;


### PR DESCRIPTION
## Description
DEFINE_string/DEFINE_uint64/DEFINE_bool expand to unqualified references to gflags-internal types (e.g. StringFlagDestructor) that only resolve at namespace-qualified scope. Placing them inside `namespace { ... }` breaks the non-NoF/NoF benchmark build with "StringFlagDestructor does not name a type". Move the flag definitions (and the KiB/MiB/GiB constants they depend on) out of the anonymous namespace, matching the other store benchmarks and the fix in b87377e.



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)