### PR TITLE
[Bugfix][Store] Protect unreadable recovered replicas from eviction

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1893,8 +1893,8 @@ class MasterService {
     auto AllocateAndInsertMetadata(
         MetadataShardAccessorRW& shard, const UUID& client_id,
         const std::string& key, uint64_t value_length,
-        const ReplicateConfig& config, const std::string& group_id,
-        const TenantId& tenant_id,
+        const ReplicateConfig& config, const std::string& writer_host_id,
+        const std::string& group_id, const TenantId& tenant_id,
         const std::chrono::system_clock::time_point& now,
         const ResolvedSoftPinRequest& soft_pin_request,
         uint64_t& quota_deficit_bytes,

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -940,14 +940,11 @@ class MasterService {
     TenantQuotaEvictionResult EvictTenantMemoryForQuota(
         const TenantId& tenant_id, uint64_t target_bytes);
 
-    // Helper to get a snapshot of alive clients (under client_mutex_ shared
-    // lock)
-    std::unordered_set<UUID, boost::hash<UUID>> getAliveClientsSnapshot() const;
     void UpdateClientHostId(const UUID& client_id, const std::string& host_id);
     std::string GetClientHostId(const UUID& client_id) const;
 
-    // Clear invalid handles in all shards
     void ClearInvalidHandles();
+    // Caller owns snapshot_mutex_ (shared) while metadata is swept.
     void ClearInvalidHandles(
         const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients);
 
@@ -2746,6 +2743,7 @@ class MasterService {
 
     bool IsReplicaReadable(const Replica& replica) const;
     bool HasReadableReplica(const ObjectMetadata& metadata) const;
+    bool IsEvictableMemoryReplica(const Replica& replica) const;
 
     /**
      * Segment lifecycle persist helper. Tries to durably persist the

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -866,8 +866,8 @@ MasterService::DeleteTenantQuotaPolicy(const TenantId& tenant_id) {
 auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     ErrorCode mount_result = ErrorCode::OK;
-    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     {
+        std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
         ScopedSegmentAccess segment_access =
             segment_manager_.getSegmentAccess();
 
@@ -976,9 +976,9 @@ ErrorCode MasterService::ValidateStandbyRemountSegment(
 auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                                    const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
-    std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
     {
-        std::unique_lock<std::shared_mutex> lock(client_mutex_);
+        std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
+        std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
         for (const auto& segment : segments) {
             if (!segment.host_id.empty()) {
                 client_host_id_[client_id] = segment.host_id;
@@ -1007,40 +1007,54 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
             return {};
         }
 
+        struct SegmentRestore {
+            Segment segment;
+            std::shared_ptr<BufferAllocatorBase> old_allocator;
+            std::shared_ptr<BufferAllocatorBase> restored_allocator;
+            std::vector<Replica*> replicas;
+            std::vector<AllocatedBuffer::Descriptor> descriptors;
+            std::vector<std::unique_ptr<AllocatedBuffer>> buffers;
+            uint64_t imported_size{0};
+        };
+        std::vector<SegmentRestore> restores;
+        restores.reserve(segments.size());
+        std::vector<bool> segment_existed(segments.size());
+        auto rollback_new_segments = [&] {
+            ScopedSegmentAccess segment_access =
+                segment_manager_.getSegmentAccess();
+            for (size_t i = 0; i < segments.size(); ++i) {
+                if (segment_existed[i] ||
+                    !segment_access.GetAllocator(segments[i].id)) {
+                    continue;
+                }
+                size_t capacity = 0;
+                if (segment_access.PrepareUnmountSegment(
+                        segments[i].id, capacity) != ErrorCode::OK) {
+                    LOG(ERROR) << "segment_name=" << segments[i].name
+                               << ", error=remount_rollback_prepare_failed";
+                    continue;
+                }
+                if (segment_access.CommitUnmountSegment(
+                        segments[i].id, client_id, capacity) != ErrorCode::OK) {
+                    LOG(ERROR) << "segment_name=" << segments[i].name
+                               << ", error=remount_rollback_commit_failed";
+                }
+            }
+        };
+        auto fail_remount =
+            [&](ErrorCode error) -> tl::expected<void, ErrorCode> {
+            rollback_new_segments();
+            return tl::make_unexpected(error);
+        };
+
+        ErrorCode remount_error = ErrorCode::OK;
         {
             ScopedSegmentAccess segment_access =
                 segment_manager_.getSegmentAccess();
-            std::vector<bool> segment_existed(segments.size());
             for (size_t i = 0; i < segments.size(); ++i) {
                 segment_existed[i] =
                     segment_access.GetAllocator(segments[i].id) != nullptr;
             }
-            auto rollback_new_segments = [&] {
-                for (size_t i = 0; i < segments.size(); ++i) {
-                    if (segment_existed[i] ||
-                        !segment_access.GetAllocator(segments[i].id)) {
-                        continue;
-                    }
-                    size_t capacity = 0;
-                    if (segment_access.PrepareUnmountSegment(
-                            segments[i].id, capacity) != ErrorCode::OK) {
-                        LOG(ERROR) << "segment_name=" << segments[i].name
-                                   << ", error=remount_rollback_prepare_failed";
-                        continue;
-                    }
-                    if (segment_access.CommitUnmountSegment(
-                            segments[i].id, client_id, capacity) !=
-                        ErrorCode::OK) {
-                        LOG(ERROR) << "segment_name=" << segments[i].name
-                                   << ", error=remount_rollback_commit_failed";
-                    }
-                }
-            };
-            auto fail_remount =
-                [&](ErrorCode error) -> tl::expected<void, ErrorCode> {
-                rollback_new_segments();
-                return tl::make_unexpected(error);
-            };
 
             // Tell the client monitor thread to start timing for this client.
             // To avoid the following undesired situations, this message must be
@@ -1063,174 +1077,173 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
 
-            ErrorCode err = segment_access.ReMountSegment(segments, client_id);
-            if (err != ErrorCode::OK) {
-                return fail_remount(err);
-            }
-
-            struct SegmentRestore {
-                Segment segment;
-                std::shared_ptr<BufferAllocatorBase> old_allocator;
-                std::shared_ptr<BufferAllocatorBase> restored_allocator;
-                std::vector<Replica*> replicas;
-                std::vector<AllocatedBuffer::Descriptor> descriptors;
-                std::vector<std::unique_ptr<AllocatedBuffer>> buffers;
-                uint64_t imported_size{0};
-            };
-            std::vector<SegmentRestore> restores;
-            restores.reserve(segments.size());
-            for (const auto& segment : segments) {
-                auto allocator = segment_access.GetAllocator(segment.id);
-                Segment authoritative;
-                if (!allocator ||
-                    !segment_access.GetSegment(segment.id, authoritative)) {
-                    return fail_remount(ErrorCode::INTERNAL_ERROR);
+            remount_error = segment_access.ReMountSegment(segments, client_id);
+            if (remount_error == ErrorCode::OK) {
+                for (const auto& segment : segments) {
+                    auto allocator = segment_access.GetAllocator(segment.id);
+                    Segment authoritative;
+                    if (!allocator ||
+                        !segment_access.GetSegment(segment.id, authoritative)) {
+                        remount_error = ErrorCode::INTERNAL_ERROR;
+                        break;
+                    }
+                    restores.push_back({std::move(authoritative),
+                                        std::move(allocator),
+                                        nullptr,
+                                        {},
+                                        {},
+                                        {},
+                                        0});
                 }
-                restores.push_back({std::move(authoritative),
-                                    std::move(allocator),
-                                    nullptr,
-                                    {},
-                                    {},
-                                    {},
-                                    0});
             }
+        }
+        if (remount_error != ErrorCode::OK) {
+            return fail_remount(remount_error);
+        }
 
-            bool ambiguous_endpoint = false;
-            bool unsupported_cxl = false;
-            for (size_t shard_index = 0; shard_index < kNumShards;
-                 ++shard_index) {
-                MetadataShardAccessorRW shard(this, shard_index);
-                for (auto& [tenant_id, tenant] : shard->tenants) {
-                    (void)tenant_id;
-                    for (auto& [key, metadata] : tenant.metadata) {
-                        (void)key;
-                        metadata.VisitReplicas(
-                            [](const Replica& replica) {
-                                return replica.is_memory_replica() &&
-                                       replica.status() !=
-                                           ReplicaStatus::REMOVED &&
-                                       replica.status() !=
-                                           ReplicaStatus::FAILED;
-                            },
-                            [&](Replica& replica) {
-                                auto descriptor = replica.get_descriptor()
-                                                      .get_memory_descriptor()
-                                                      .buffer_descriptor;
-                                SegmentRestore* match = nullptr;
-                                for (auto& restore : restores) {
-                                    if (descriptor.transport_endpoint_ ==
-                                            restore.segment.te_endpoint ||
-                                        descriptor.transport_endpoint_ ==
-                                            restore.segment.name) {
-                                        if (match != nullptr) {
-                                            ambiguous_endpoint = true;
-                                            return;
-                                        }
-                                        match = &restore;
-                                    }
-                                }
-                                if (match != nullptr) {
-                                    if (descriptor.protocol_ == "cxl") {
-                                        unsupported_cxl = true;
+        bool ambiguous_endpoint = false;
+        bool unsupported_cxl = false;
+        std::unordered_set<ObjectMetadata*> affected_objects;
+        for (size_t shard_index = 0; shard_index < kNumShards; ++shard_index) {
+            MetadataShardAccessorRW shard(this, shard_index);
+            for (auto& [tenant_id, tenant] : shard->tenants) {
+                (void)tenant_id;
+                for (auto& [key, metadata] : tenant.metadata) {
+                    (void)key;
+                    metadata.VisitReplicas(
+                        [](const Replica& replica) {
+                            return replica.is_memory_replica() &&
+                                   replica.status() != ReplicaStatus::REMOVED &&
+                                   replica.status() != ReplicaStatus::FAILED;
+                        },
+                        [&](Replica& replica) {
+                            auto descriptor = replica.get_descriptor()
+                                                  .get_memory_descriptor()
+                                                  .buffer_descriptor;
+                            SegmentRestore* match = nullptr;
+                            for (auto& restore : restores) {
+                                if (descriptor.transport_endpoint_ ==
+                                        restore.segment.te_endpoint ||
+                                    descriptor.transport_endpoint_ ==
+                                        restore.segment.name) {
+                                    if (match != nullptr) {
+                                        ambiguous_endpoint = true;
                                         return;
                                     }
-                                    descriptor.transport_endpoint_ =
-                                        match->segment.te_endpoint;
-                                    match->replicas.push_back(&replica);
-                                    match->descriptors.push_back(descriptor);
+                                    match = &restore;
                                 }
-                            });
-                    }
+                            }
+                            if (match != nullptr) {
+                                if (descriptor.protocol_ == "cxl") {
+                                    unsupported_cxl = true;
+                                    return;
+                                }
+                                descriptor.transport_endpoint_ =
+                                    match->segment.te_endpoint;
+                                match->replicas.push_back(&replica);
+                                match->descriptors.push_back(descriptor);
+                                affected_objects.insert(&metadata);
+                            }
+                        });
                 }
             }
-            if (ambiguous_endpoint) {
-                return fail_remount(ErrorCode::INVALID_PARAMS);
+        }
+        if (ambiguous_endpoint) {
+            return fail_remount(ErrorCode::INVALID_PARAMS);
+        }
+        if (unsupported_cxl) {
+            return fail_remount(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+        }
+
+        for (auto& restore : restores) {
+            if (restore.descriptors.empty()) {
+                continue;
             }
-            if (unsupported_cxl) {
+            if (std::dynamic_pointer_cast<OffsetBufferAllocator>(
+                    restore.old_allocator)) {
+                auto restored = RestoreOffsetBufferAllocator(
+                    restore.segment.name, restore.segment.base,
+                    restore.segment.size, restore.segment.te_endpoint,
+                    restore.descriptors);
+                if (!restored) {
+                    return fail_remount(ErrorCode::INVALID_PARAMS);
+                }
+                restore.restored_allocator = std::move(restored->allocator);
+                restore.buffers = std::move(restored->buffers);
+            } else if (std::dynamic_pointer_cast<CachelibBufferAllocator>(
+                           restore.old_allocator)) {
+                auto restored = RestoreCachelibBufferAllocator(
+                    restore.segment.name, restore.segment.base,
+                    restore.segment.size, restore.segment.te_endpoint,
+                    restore.descriptors);
+                if (!restored) {
+                    return fail_remount(ErrorCode::INVALID_PARAMS);
+                }
+                restore.restored_allocator = std::move(restored->allocator);
+                restore.buffers = std::move(restored->buffers);
+            } else {
                 return fail_remount(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
             }
+        }
 
-            for (auto& restore : restores) {
-                if (restore.descriptors.empty()) {
-                    continue;
+        std::vector<ScopedSegmentAccess::AllocatorReplacement>
+            allocator_replacements;
+        for (auto& restore : restores) {
+            if (restore.restored_allocator) {
+                if (restore.buffers.size() != restore.replicas.size() ||
+                    std::any_of(restore.buffers.begin(), restore.buffers.end(),
+                                [](const auto& buffer) { return !buffer; })) {
+                    return fail_remount(ErrorCode::INTERNAL_ERROR);
                 }
-                if (std::dynamic_pointer_cast<OffsetBufferAllocator>(
-                        restore.old_allocator)) {
-                    auto restored = RestoreOffsetBufferAllocator(
-                        restore.segment.name, restore.segment.base,
-                        restore.segment.size, restore.segment.te_endpoint,
-                        restore.descriptors);
-                    if (!restored) {
-                        return fail_remount(ErrorCode::INVALID_PARAMS);
-                    }
-                    restore.restored_allocator = std::move(restored->allocator);
-                    restore.buffers = std::move(restored->buffers);
-                } else if (std::dynamic_pointer_cast<CachelibBufferAllocator>(
-                               restore.old_allocator)) {
-                    auto restored = RestoreCachelibBufferAllocator(
-                        restore.segment.name, restore.segment.base,
-                        restore.segment.size, restore.segment.te_endpoint,
-                        restore.descriptors);
-                    if (!restored) {
-                        return fail_remount(ErrorCode::INVALID_PARAMS);
-                    }
-                    restore.restored_allocator = std::move(restored->allocator);
-                    restore.buffers = std::move(restored->buffers);
-                } else {
-                    return fail_remount(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
+                restore.imported_size = std::accumulate(
+                    restore.descriptors.begin(), restore.descriptors.end(),
+                    uint64_t{0}, [](uint64_t sum, const auto& descriptor) {
+                        return sum + descriptor.size_;
+                    });
+                auto accounted =
+                    standby_accounted_memory_bytes_.find(restore.segment.name);
+                if (accounted == standby_accounted_memory_bytes_.end() ||
+                    accounted->second < restore.imported_size) {
+                    return fail_remount(ErrorCode::INTERNAL_ERROR);
+                }
+                allocator_replacements.push_back({restore.segment.id,
+                                                  restore.old_allocator,
+                                                  restore.restored_allocator});
+            }
+        }
+        bool allocators_replaced = false;
+        {
+            ScopedSegmentAccess segment_access =
+                segment_manager_.getSegmentAccess();
+            allocators_replaced =
+                segment_access.ReplaceAllocators(allocator_replacements);
+        }
+        if (!allocators_replaced) {
+            return fail_remount(ErrorCode::INTERNAL_ERROR);
+        }
+        for (auto& restore : restores) {
+            if (restore.imported_size != 0) {
+                MasterMetricManager::instance().dec_allocated_mem_size(
+                    restore.segment.name,
+                    static_cast<int64_t>(restore.imported_size));
+                auto accounted =
+                    standby_accounted_memory_bytes_.find(restore.segment.name);
+                accounted->second -= restore.imported_size;
+                if (accounted->second == 0) {
+                    standby_accounted_memory_bytes_.erase(accounted);
                 }
             }
-
-            std::vector<ScopedSegmentAccess::AllocatorReplacement>
-                allocator_replacements;
-            for (auto& restore : restores) {
-                if (restore.restored_allocator) {
-                    if (restore.buffers.size() != restore.replicas.size() ||
-                        std::any_of(
-                            restore.buffers.begin(), restore.buffers.end(),
-                            [](const auto& buffer) { return !buffer; })) {
-                        return fail_remount(ErrorCode::INTERNAL_ERROR);
-                    }
-                    restore.imported_size = std::accumulate(
-                        restore.descriptors.begin(), restore.descriptors.end(),
-                        uint64_t{0}, [](uint64_t sum, const auto& descriptor) {
-                            return sum + descriptor.size_;
-                        });
-                    auto accounted = standby_accounted_memory_bytes_.find(
-                        restore.segment.name);
-                    if (accounted == standby_accounted_memory_bytes_.end() ||
-                        accounted->second < restore.imported_size) {
-                        return fail_remount(ErrorCode::INTERNAL_ERROR);
-                    }
-                    allocator_replacements.push_back(
-                        {restore.segment.id, restore.old_allocator,
-                         restore.restored_allocator});
-                }
+            for (size_t i = 0; i < restore.replicas.size(); ++i) {
+                (void)restore.replicas[i]->replace_memory_buffer(
+                    std::move(restore.buffers[i]));
             }
-            if (!segment_access.ReplaceAllocators(allocator_replacements)) {
-                return fail_remount(ErrorCode::INTERNAL_ERROR);
-            }
-            for (auto& restore : restores) {
-                if (restore.imported_size != 0) {
-                    MasterMetricManager::instance().dec_allocated_mem_size(
-                        restore.segment.name,
-                        static_cast<int64_t>(restore.imported_size));
-                    auto accounted = standby_accounted_memory_bytes_.find(
-                        restore.segment.name);
-                    accounted->second -= restore.imported_size;
-                    if (accounted->second == 0) {
-                        standby_accounted_memory_bytes_.erase(accounted);
-                    }
-                }
-                for (size_t i = 0; i < restore.replicas.size(); ++i) {
-                    (void)restore.replicas[i]->replace_memory_buffer(
-                        std::move(restore.buffers[i]));
-                }
-                invalid_replica_endpoints_.erase(restore.segment.te_endpoint);
-                invalid_replica_endpoints_.erase(restore.segment.name);
-                standby_allocator_keepalive_.erase(restore.segment.te_endpoint);
-                standby_allocator_keepalive_.erase(restore.segment.name);
-            }
+            invalid_replica_endpoints_.erase(restore.segment.te_endpoint);
+            invalid_replica_endpoints_.erase(restore.segment.name);
+            standby_allocator_keepalive_.erase(restore.segment.te_endpoint);
+            standby_allocator_keepalive_.erase(restore.segment.name);
+        }
+        for (const auto* metadata : affected_objects) {
+            metadata->GrantReadLease(default_kv_lease_ttl_);
         }
 
         // Change the client status to OK
@@ -1274,12 +1287,6 @@ auto MasterService::ReMountNoFSegment(const std::vector<NoFSegment>& segments,
     }
     return {};
 #endif
-}
-
-std::unordered_set<UUID, boost::hash<UUID>>
-MasterService::getAliveClientsSnapshot() const {
-    std::shared_lock<std::shared_mutex> lock(client_mutex_);
-    return ok_client_;
 }
 
 void MasterService::UpdateClientHostId(const UUID& client_id,
@@ -2480,7 +2487,11 @@ void MasterService::GrantLeaseForGroup(const TenantState& tenant_state,
 }
 
 void MasterService::ClearInvalidHandles() {
-    ClearInvalidHandles(getAliveClientsSnapshot());
+    std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
+    std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+    auto alive_clients = ok_client_;
+    client_lock.unlock();
+    ClearInvalidHandles(alive_clients);
 }
 
 void MasterService::ClearInvalidHandles(
@@ -2588,7 +2599,10 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
     -> tl::expected<void, ErrorCode> {
     size_t metrics_dec_capacity = 0;  // to update the metrics
 
+    std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    auto alive_clients = ok_client_;
+    client_lock.unlock();
     // 1. Prepare to unmount the segment by deleting its allocator
     {
         ScopedSegmentAccess segment_access =
@@ -2610,7 +2624,7 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
     if (enable_async_segment_cleanup_) {
         replica_cleanup_worker_.Schedule();
     } else {
-        ClearInvalidHandles();
+        ClearInvalidHandles(alive_clients);
     }
 
     // Cache endpoint before commit removes segment from registry.
@@ -2691,6 +2705,11 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
 #else
     size_t metrics_dec_capacity = 0;  // to update the metrics
 
+    std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+    auto alive_clients = ok_client_;
+    client_lock.unlock();
+
     // 1. Prepare to unmount the segment by deleting its allocator
     {
         ScopedNoFSegmentAccess segment_access =
@@ -2708,7 +2727,7 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
        // deadlocks
 
     // 2. Remove the metadata of the related objects
-    ClearInvalidHandles();
+    ClearInvalidHandles(alive_clients);
 
     // 3. Commit the unmount operation
     ScopedNoFSegmentAccess segment_access =
@@ -3518,6 +3537,11 @@ bool MasterService::IsReplicaReadable(const Replica& replica) const {
 bool MasterService::HasReadableReplica(const ObjectMetadata& metadata) const {
     return metadata.HasReplica(
         [this](const Replica& replica) { return IsReplicaReadable(replica); });
+}
+
+bool MasterService::IsEvictableMemoryReplica(const Replica& replica) const {
+    return replica.is_memory_replica() && IsReplicaReadable(replica) &&
+           replica.get_refcnt() == 0;
 }
 
 auto MasterService::GetReplicaListByRegex(const std::string& regex_pattern,
@@ -4339,8 +4363,10 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
         auto now = std::chrono::system_clock::now();
         std::optional<size_t> retry_shard_idx;
         {
-            auto alive_clients = getAliveClientsSnapshot();
+            std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
             std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            auto alive_clients = ok_client_;
+            client_lock.unlock();
             const size_t lookup_shard_idx =
                 getMetadataShardIndex(object_id.tenant_id, object_id.user_key);
             MetadataShardAccessorRW shard(this, lookup_shard_idx);
@@ -4984,8 +5010,10 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             case_a_committed_soft_pin_timeout;
         {
             // --- Lock acquisition ---
-            auto alive_clients = getAliveClientsSnapshot();
+            std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
             std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            auto alive_clients = ok_client_;
+            client_lock.unlock();
             // Use getMetadataShardIndex to find the object at its current shard
             // (handles both grouped and ungrouped routing).
             const size_t lookup_shard_idx =
@@ -6737,9 +6765,10 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
         keys_by_shard[shard_idx].emplace_back(i, &keys[i]);
     }
 
+    std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
     std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
-
-    auto alive_clients = getAliveClientsSnapshot();
+    auto alive_clients = ok_client_;
+    client_lock.unlock();
 
     // Process each shard once, acquiring lock per shard
     for (auto& [shard_idx, key_group] : keys_by_shard) {
@@ -9678,9 +9707,8 @@ MasterService::EvictTenantMemoryForQuota(const TenantId& tenant_id,
     auto now = std::chrono::system_clock::now();
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
 
-    auto is_evictable_memory_replica = [](const Replica& replica) {
-        return replica.is_memory_replica() && replica.is_completed() &&
-               replica.get_refcnt() == 0;
+    auto is_evictable_memory_replica = [this](const Replica& replica) {
+        return IsEvictableMemoryReplica(replica);
     };
     auto can_evict_replicas = [&](const ObjectMetadata& metadata) {
         return metadata.HasReplica(is_evictable_memory_replica);
@@ -9923,9 +9951,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
     auto now = std::chrono::system_clock::now();
 
-    auto is_evictable_memory_replica = [](const Replica& replica) {
-        return replica.is_memory_replica() && replica.is_completed() &&
-               replica.get_refcnt() == 0;
+    auto is_evictable_memory_replica = [this](const Replica& replica) {
+        return IsEvictableMemoryReplica(replica);
     };
 
     auto can_evict_replicas = [&](const ObjectMetadata& metadata) {
@@ -10012,12 +10039,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // Queue one MEMORY replica for offload; others will be evicted below.
         bool queued = false;
         metadata.VisitReplicas(
-            [](const Replica& r) {
-                return r.is_memory_replica() && r.is_completed() &&
-                       r.get_refcnt() == 0;
-            },
-            [this, &tenant_id, &key, &tenant_state, &queued,
-             &now](Replica& replica) {
+            is_evictable_memory_replica, [this, &tenant_id, &key, &tenant_state,
+                                          &queued, &now](Replica& replica) {
                 if (queued) return;  // only need to pin one replica for offload
                 std::vector<UUID> mirror_clients;
                 auto result =
@@ -10067,11 +10090,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // Predict the descriptor list after evict_replicas() runs:
         // drop COMPLETE memory replicas with refcnt==0; keep everything else
         // that is COMPLETE.
-        auto remaining =
-            BuildRemainingReplicaDescriptors(metadata, [](const Replica& r) {
-                return r.is_memory_replica() && r.is_completed() &&
-                       r.get_refcnt() == 0;
-            });
+        auto remaining = BuildRemainingReplicaDescriptors(
+            metadata, is_evictable_memory_replica);
 
         if (enable_oplog_) {
             auto reservation = ReserveBatchOpLogSlot();
@@ -10777,6 +10797,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
     long evicted_count = 0;
     long object_count = 0;
     uint64_t total_freed_size = 0;
+    std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
 
     auto is_evictable_nof_replica = [](const Replica& replica) {
         return replica.is_nof_replica() && replica.is_completed() &&
@@ -11007,10 +11028,12 @@ void MasterService::ClientMonitorFunc() {
             std::vector<size_t> dec_capacities;
             std::vector<UUID> client_ids;
             std::vector<std::string> segment_names;
-            std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
+            std::unordered_set<UUID, boost::hash<UUID>> alive_clients;
+            std::shared_lock<std::shared_mutex> snapshot_lock;
             {
-                // Lock client_mutex and segment_mutex
-                std::unique_lock<std::shared_mutex> lock(client_mutex_);
+                std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
+                snapshot_lock =
+                    std::shared_lock<std::shared_mutex>(snapshot_mutex_);
                 for (auto& client_id : expired_clients) {
                     auto it = ok_client_.find(client_id);
                     if (it != ok_client_.end()) {
@@ -11019,6 +11042,7 @@ void MasterService::ClientMonitorFunc() {
                     }
                     client_host_id_.erase(client_id);
                 }
+                alive_clients = ok_client_;
 
                 ScopedSegmentAccess segment_access =
                     segment_manager_.getSegmentAccess();
@@ -11050,7 +11074,7 @@ void MasterService::ClientMonitorFunc() {
             // Always clean up invalid handles when there are expired clients,
             // even if no memory segments were unmounted. This is necessary
             // to clean up local_disk replicas whose owner client has expired.
-            ClearInvalidHandles();
+            ClearInvalidHandles(alive_clients);
 
             // Commit unmount of memory segments and clean up local_disk
             // segments for expired clients. Both require the exclusive
@@ -11109,6 +11133,10 @@ bool MasterService::TryUnmountNoFSegmentByHeartbeat(
     const MountedNoFSegmentSnapshot& snapshot,
     const std::string& error_reason) {
     size_t metrics_dec_capacity = 0;
+    std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
+    std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+    auto alive_clients = ok_client_;
+    client_lock.unlock();
     {
         auto nof_segment_access = nof_segment_manager_.getNoFSegmentAccess();
         ErrorCode err = nof_segment_access.PrepareUnmountSegment(
@@ -11132,7 +11160,7 @@ bool MasterService::TryUnmountNoFSegmentByHeartbeat(
         }
     }
 
-    ClearInvalidHandles();
+    ClearInvalidHandles(alive_clients);
 
     {
         auto nof_segment_access = nof_segment_manager_.getNoFSegmentAccess();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3993,8 +3993,9 @@ MasterService::BatchGetReplicaListForAdmin(const std::vector<std::string>& keys,
 auto MasterService::AllocateAndInsertMetadata(
     MetadataShardAccessorRW& shard, const UUID& client_id,
     const std::string& key, uint64_t value_length,
-    const ReplicateConfig& config, const std::string& group_id,
-    const TenantId& tenant_id, const std::chrono::system_clock::time_point& now,
+    const ReplicateConfig& config, const std::string& writer_host_id,
+    const std::string& group_id, const TenantId& tenant_id,
+    const std::chrono::system_clock::time_point& now,
     const ResolvedSoftPinRequest& soft_pin_request,
     uint64_t& quota_deficit_bytes,
     std::optional<std::chrono::system_clock::time_point>
@@ -4030,16 +4031,6 @@ auto MasterService::AllocateAndInsertMetadata(
     size_t allocated_nof_replicas = 0;
     bool has_enough_memory_segments = false;
     if (config.replica_num > 0) {
-        const bool use_local_first =
-            (allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST ||
-             config.prefer_alloc_in_same_node) &&
-            config.replica_num == 1;
-        std::string writer_host_id;
-        if (use_local_first) {
-            writer_host_id = config.host_id.empty() ? GetClientHostId(client_id)
-                                                    : config.host_id;
-        }
-
         ScopedAllocatorAccess allocator_access =
             segment_manager_.getAllocatorAccess();
         const auto& allocator_manager = allocator_access.getAllocatorManager();
@@ -4335,6 +4326,13 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
     }
 
     UpdateClientHostId(client_id, config.host_id);
+    std::string writer_host_id;
+    if ((allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST ||
+         config.prefer_alloc_in_same_node) &&
+        config.replica_num == 1) {
+        writer_host_id = config.host_id.empty() ? GetClientHostId(client_id)
+                                                : config.host_id;
+    }
 
     if ((memory_allocator_type_ == BufferAllocatorType::CACHELIB) &&
         (slice_length > kMaxSliceSize)) {
@@ -4449,9 +4447,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                     }
                 } else {
                     return AllocateAndInsertMetadata(
-                        shard, client_id, key, slice_length, config, group_id,
-                        object_id.tenant_id, now, *soft_pin_request,
-                        quota_deficit_bytes);
+                        shard, client_id, key, slice_length, config,
+                        writer_host_id, group_id, object_id.tenant_id, now,
+                        *soft_pin_request, quota_deficit_bytes);
                 }
             }
         }
@@ -4467,8 +4465,9 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
         return AllocateAndInsertMetadata(
-            shard, client_id, key, slice_length, config, group_id,
-            object_id.tenant_id, now, *soft_pin_request, quota_deficit_bytes);
+            shard, client_id, key, slice_length, config, writer_host_id,
+            group_id, object_id.tenant_id, now, *soft_pin_request,
+            quota_deficit_bytes);
     };
 
     for (int attempt = 0; attempt <= kMaxTenantQuotaEvictionRetries;
@@ -4979,6 +4978,13 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
     }
 
     UpdateClientHostId(client_id, config.host_id);
+    std::string writer_host_id;
+    if ((allocation_strategy_type_ == AllocationStrategyType::LOCAL_FIRST ||
+         config.prefer_alloc_in_same_node) &&
+        config.replica_num == 1) {
+        writer_host_id = config.host_id.empty() ? GetClientHostId(client_id)
+                                                : config.host_id;
+    }
 
     if ((memory_allocator_type_ == BufferAllocatorType::CACHELIB) &&
         (slice_length > kMaxSliceSize)) {
@@ -5155,9 +5161,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                     }
                 } else {
                     return AllocateAndInsertMetadata(
-                        shard, client_id, key, slice_length, config, group_id,
-                        object_id.tenant_id, now, *soft_pin_request,
-                        quota_deficit_bytes,
+                        shard, client_id, key, slice_length, config,
+                        writer_host_id, group_id, object_id.tenant_id, now,
+                        *soft_pin_request, quota_deficit_bytes,
                         std::move(case_a_committed_soft_pin_timeout));
                 }
             } else {
@@ -5296,7 +5302,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                         << ", action=upsert_start_case_c_reallocate";
                 auto allocate_result = AllocateAndInsertMetadata(
                     shard, client_id, key, slice_length, merged_config,
-                    existing_group_id, object_id.tenant_id, now,
+                    writer_host_id, existing_group_id, object_id.tenant_id, now,
                     *soft_pin_request, quota_deficit_bytes,
                     std::move(committed_soft_pin_timeout));
                 if (!allocate_result) {
@@ -5356,9 +5362,9 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
             return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
         }
         return AllocateAndInsertMetadata(
-            shard, client_id, key, slice_length, config, group_id,
-            object_id.tenant_id, now, *soft_pin_request, quota_deficit_bytes,
-            std::move(case_a_committed_soft_pin_timeout));
+            shard, client_id, key, slice_length, config, writer_host_id,
+            group_id, object_id.tenant_id, now, *soft_pin_request,
+            quota_deficit_bytes, std::move(case_a_committed_soft_pin_timeout));
     };
 
     for (int attempt = 0; attempt <= kMaxTenantQuotaEvictionRetries;

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -1341,11 +1341,11 @@ TEST_F(MasterServiceHATest, FailedRemountKeepsReplicaInvalidAndCanBeRetried) {
         .get_memory_descriptor()
         .buffer_descriptor.buffer_address_ =
         kDefaultSegmentBase + kDefaultSegmentSize - 1;
-    ASSERT_TRUE(service
-                    .RestoreFromStandbySnapshot(
-                        {first, out_of_range}, 7,
-                        {MakeStandbyMemorySegment(endpoint)})
-                    .has_value());
+    ASSERT_TRUE(
+        service
+            .RestoreFromStandbySnapshot({first, out_of_range}, 7,
+                                        {MakeStandbyMemorySegment(endpoint)})
+            .has_value());
     SetLeaseDeadlineForTesting(service, kDefaultTenant, "standby_retry_first",
                                std::chrono::system_clock::time_point{});
 

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -586,6 +586,10 @@ class MasterServiceHATest : public ::testing::Test {
         service.ClearInvalidHandles(alive_clients);
     }
 
+    static void ClearInvalidHandlesForTesting(MasterService& service) {
+        service.ClearInvalidHandles();
+    }
+
     static size_t ReplicaCountForTesting(MasterService& service,
                                          const TenantId& tenant_id,
                                          const std::string& key) {
@@ -623,6 +627,53 @@ class MasterServiceHATest : public ::testing::Test {
             }
         }
         return false;
+    }
+
+    static bool HasReadableReplicaForTesting(MasterService& service,
+                                             const TenantId& tenant_id,
+                                             const std::string& key) {
+        MasterService::MetadataAccessorRO accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        return accessor.Exists() &&
+               accessor.Get().HasReplica([&service](const Replica& replica) {
+                   return service.IsReplicaReadable(replica);
+               });
+    }
+
+    static void SetLeaseDeadlineForTesting(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key,
+        std::chrono::system_clock::time_point deadline) {
+        MasterService::MetadataAccessorRW accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        ASSERT_TRUE(accessor.Exists());
+        SpinLocker locker(&accessor.Get().lock);
+        accessor.Get().lease_timeout = deadline;
+    }
+
+    static std::chrono::system_clock::time_point LeaseDeadlineForTesting(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key) {
+        MasterService::MetadataAccessorRO accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        EXPECT_TRUE(accessor.Exists());
+        if (!accessor.Exists()) {
+            return {};
+        }
+        SpinLocker locker(&accessor.Get().lock);
+        return accessor.Get().lease_timeout;
+    }
+
+    static uint64_t EvictTenantMemoryForQuotaForTesting(
+        MasterService& service, const TenantId& tenant_id,
+        uint64_t target_bytes) {
+        return service.EvictTenantMemoryForQuota(tenant_id, target_bytes)
+            .freed_bytes;
+    }
+
+    static std::unique_lock<std::shared_mutex> LockSnapshotForTesting(
+        MasterService& service) {
+        return std::unique_lock<std::shared_mutex>(service.snapshot_mutex_);
     }
 
     static size_t SegmentAllocatedSizeForTesting(MasterService& service,
@@ -947,6 +998,152 @@ TEST_F(MasterServiceHATest, RestoreFromStandbyRebuildsTenantQuotaAccounting) {
     EXPECT_EQ(service.GetTenantQuotaSnapshot(tenant_id)->charged_bytes, 0);
 }
 
+TEST_F(MasterServiceHATest, UnreadableRestoredMemoryReplicaIsNotEvictable) {
+    constexpr uint64_t object_size = 1024;
+    auto config = MasterServiceConfig::builder()
+                      .set_default_kv_lease_ttl(10000)
+                      .set_enable_multi_tenants(true)
+                      .set_tenant_quota_connector_type("file")
+                      .set_tenant_quota_connector_uri(WriteTenantPolicyFile(
+                          {{kDefaultTenant.value(), object_size}}))
+                      .build();
+    MasterService service(config);
+    const std::string key = "unreadable_restored_evict_key";
+    const std::string endpoint = "unreadable_restored_evict_segment";
+    ASSERT_TRUE(service
+                    .RestoreFromStandbySnapshot(
+                        {MakeStandbyObject(key, endpoint, object_size)}, 7,
+                        {MakeStandbyMemorySegment(endpoint)})
+                    .has_value());
+    SetLeaseDeadlineForTesting(service, kDefaultTenant, key,
+                               std::chrono::system_clock::time_point{});
+
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant, key), 1);
+    EXPECT_EQ(EvictTenantMemoryForQuotaForTesting(service, kDefaultTenant,
+                                                  object_size),
+              0);
+    EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant, key), 1);
+    EXPECT_FALSE(HasReadableReplicaForTesting(service, kDefaultTenant, key));
+    auto get = service.GetReplicaList(key, kDefaultTenant);
+    ASSERT_FALSE(get.has_value());
+    EXPECT_EQ(get.error(), ErrorCode::REPLICA_IS_NOT_READY);
+}
+
+TEST_F(MasterServiceHATest, SuccessfulRemountGrantsEvictionLease) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_default_kv_lease_ttl(10000)
+                              .build());
+    const std::string key = "remount_lease_key";
+    const std::string endpoint = "remount_lease_segment";
+    auto object = MakeStandbyObject(key, endpoint);
+    object.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+    ASSERT_TRUE(service
+                    .RestoreFromStandbySnapshot(
+                        {object}, 7, {MakeStandbyMemorySegment(endpoint)})
+                    .has_value());
+    SetLeaseDeadlineForTesting(service, kDefaultTenant, key,
+                               std::chrono::system_clock::time_point{});
+
+    ASSERT_TRUE(service.ReMountSegment({MakeSegment(endpoint)}, generate_uuid())
+                    .has_value());
+    EXPECT_TRUE(HasReadableReplicaForTesting(service, kDefaultTenant, key));
+    EXPECT_GT(LeaseDeadlineForTesting(service, kDefaultTenant, key),
+              std::chrono::system_clock::now());
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant, key), 1);
+
+    SetLeaseDeadlineForTesting(service, kDefaultTenant, key,
+                               std::chrono::system_clock::time_point{});
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant, key), 0);
+}
+
+TEST_F(MasterServiceHATest, RemountRefreshesLeaseWhenAnotherReplicaIsReadable) {
+    MasterService service(MasterServiceConfig::builder()
+                              .set_enable_ha(false)
+                              .set_default_kv_lease_ttl(10000)
+                              .build());
+    const std::string key = "remount_existing_readable_key";
+    const std::string recovered_endpoint = "remount_recovered_segment";
+    const std::string readable_endpoint = "remount_readable_segment";
+    Segment readable_segment = MakeSegment(
+        readable_endpoint, kDefaultSegmentBase + kDefaultSegmentSize);
+    ASSERT_TRUE(
+        service.MountSegment(readable_segment, generate_uuid()).has_value());
+
+    auto object = MakeStandbyObject(key, recovered_endpoint);
+    object.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+    auto readable_replica = MakeStandbyMemoryReplica(readable_endpoint);
+    readable_replica.id = 2;
+    readable_replica.get_memory_descriptor().buffer_descriptor.buffer_address_ =
+        kDefaultSegmentBase + kDefaultSegmentSize;
+    object.metadata.replicas.push_back(std::move(readable_replica));
+    ASSERT_TRUE(service
+                    .RestoreFromStandbySnapshot(
+                        {object}, 7,
+                        {MakeStandbyMemorySegment(recovered_endpoint),
+                         MakeStandbyMemorySegment(readable_endpoint)})
+                    .has_value());
+    ASSERT_TRUE(HasReadableReplicaForTesting(service, kDefaultTenant, key));
+    SetLeaseDeadlineForTesting(service, kDefaultTenant, key,
+                               std::chrono::system_clock::time_point{});
+
+    ASSERT_TRUE(
+        service
+            .ReMountSegment({MakeSegment(recovered_endpoint)}, generate_uuid())
+            .has_value());
+    EXPECT_GT(LeaseDeadlineForTesting(service, kDefaultTenant, key),
+              std::chrono::system_clock::now());
+}
+
+TEST_F(MasterServiceHATest, NoFBatchEvictWaitsForSnapshotBarrier) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+    auto snapshot_lock = LockSnapshotForTesting(service);
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto eviction = std::async(std::launch::async, [&] {
+        started.set_value();
+        service.RunNoFBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                           /*evict_ratio_lowerbound=*/1.0);
+    });
+    started_future.wait();
+    EXPECT_EQ(eviction.wait_for(std::chrono::milliseconds(100)),
+              std::future_status::timeout);
+    snapshot_lock.unlock();
+    ASSERT_EQ(eviction.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    eviction.get();
+}
+
+TEST_F(MasterServiceHATest, InvalidHandleCleanupWaitsForSnapshotBarrier) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+    auto snapshot_lock = LockSnapshotForTesting(service);
+    std::promise<void> started;
+    auto started_future = started.get_future();
+    auto cleanup = std::async(std::launch::async, [&] {
+        started.set_value();
+        ClearInvalidHandlesForTesting(service);
+    });
+    started_future.wait();
+    EXPECT_EQ(cleanup.wait_for(std::chrono::milliseconds(100)),
+              std::future_status::timeout);
+    snapshot_lock.unlock();
+    ASSERT_EQ(cleanup.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    cleanup.get();
+}
+
 TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
     MasterService service(
         MasterServiceConfig::builder().set_enable_ha(false).build());
@@ -1127,6 +1324,64 @@ TEST_F(MasterServiceHATest, RestoreRejectsOverlappingMemoryDescriptors) {
     EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant,
                                      "standby_overlap_second"),
               0);
+}
+
+TEST_F(MasterServiceHATest, FailedRemountKeepsReplicaInvalidAndCanBeRetried) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+
+    const std::string endpoint = "standby_retry_remount_segment";
+    auto first = MakeStandbyObject("standby_retry_first", endpoint);
+    auto out_of_range =
+        MakeStandbyObject("standby_retry_out_of_range", endpoint);
+    first.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+    out_of_range.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ =
+        kDefaultSegmentBase + kDefaultSegmentSize - 1;
+    ASSERT_TRUE(service
+                    .RestoreFromStandbySnapshot(
+                        {first, out_of_range}, 7,
+                        {MakeStandbyMemorySegment(endpoint)})
+                    .has_value());
+    SetLeaseDeadlineForTesting(service, kDefaultTenant, "standby_retry_first",
+                               std::chrono::system_clock::time_point{});
+
+    Segment segment = MakeSegment(endpoint);
+    auto failed = service.ReMountSegment({segment}, generate_uuid());
+    ASSERT_FALSE(failed.has_value());
+    EXPECT_EQ(failed.error(), ErrorCode::INVALID_PARAMS);
+    auto get_after_failure =
+        service.GetReplicaList("standby_retry_first", kDefaultTenant);
+    ASSERT_FALSE(get_after_failure.has_value());
+    EXPECT_EQ(get_after_failure.error(), ErrorCode::REPLICA_IS_NOT_READY);
+    auto batch_after_failure =
+        service.BatchGetReplicaList({"standby_retry_first"}, kDefaultTenant);
+    ASSERT_EQ(batch_after_failure.size(), 1);
+    ASSERT_FALSE(batch_after_failure[0].has_value());
+    EXPECT_EQ(batch_after_failure[0].error(), ErrorCode::REPLICA_IS_NOT_READY);
+    EXPECT_EQ(
+        LeaseDeadlineForTesting(service, kDefaultTenant, "standby_retry_first"),
+        std::chrono::system_clock::time_point{});
+    ReplicateConfig config;
+    config.replica_num = 1;
+    config.preferred_segments = {endpoint};
+    auto allocation = service.PutStart(generate_uuid(), "must_not_allocate",
+                                       kDefaultTenant, 1024, config);
+    EXPECT_FALSE(allocation.has_value());
+
+    EraseObjectForTesting(service, kDefaultTenant,
+                          "standby_retry_out_of_range");
+    ASSERT_TRUE(service.ReMountSegment({segment}, generate_uuid()).has_value());
+    EXPECT_FALSE(HasInvalidMemoryHandleForTesting(service, kDefaultTenant,
+                                                  "standby_retry_first"));
+    EXPECT_GT(
+        LeaseDeadlineForTesting(service, kDefaultTenant, "standby_retry_first"),
+        std::chrono::system_clock::now());
+    EXPECT_TRUE(service.GetReplicaList("standby_retry_first", kDefaultTenant)
+                    .has_value());
 }
 
 TEST_F(MasterServiceHATest, MultiSegmentRemountFailurePublishesNeitherSegment) {

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -676,6 +676,40 @@ class MasterServiceHATest : public ::testing::Test {
         return std::unique_lock<std::shared_mutex>(service.snapshot_mutex_);
     }
 
+    static std::unique_lock<SharedMutex> LockMetadataShardForTesting(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key) {
+        const size_t shard_idx = service.getMetadataShardIndex(tenant_id, key);
+        return std::unique_lock<SharedMutex>(
+            service.metadata_shards_[shard_idx].mutex);
+    }
+
+    static bool PutStartHoldsSnapshotAfterClientReleaseForTesting(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key) {
+        const auto scoped_key = tenant_id.MakeScopedKey(key);
+        const size_t stripe_idx = std::hash<std::string>{}(scoped_key) %
+                                  MasterService::kObjectOperationLockStripes;
+        std::unique_lock<std::mutex> object_lock(
+            service.object_operation_locks_[stripe_idx], std::try_to_lock);
+        if (object_lock.owns_lock()) {
+            return false;
+        }
+        std::unique_lock<std::shared_mutex> client_lock(service.client_mutex_,
+                                                        std::try_to_lock);
+        if (!client_lock.owns_lock()) {
+            return false;
+        }
+        std::unique_lock<std::shared_mutex> snapshot_lock(
+            service.snapshot_mutex_, std::try_to_lock);
+        return !snapshot_lock.owns_lock();
+    }
+
+    static std::unique_lock<std::shared_mutex> LockClientForTesting(
+        MasterService& service) {
+        return std::unique_lock<std::shared_mutex>(service.client_mutex_);
+    }
+
     static size_t SegmentAllocatedSizeForTesting(MasterService& service,
                                                  const std::string& name) {
         auto access = service.segment_manager_.getAllocatorAccess();
@@ -1103,6 +1137,61 @@ TEST_F(MasterServiceHATest, RemountRefreshesLeaseWhenAnotherReplicaIsReadable) {
             .has_value());
     EXPECT_GT(LeaseDeadlineForTesting(service, kDefaultTenant, key),
               std::chrono::system_clock::now());
+}
+
+TEST_F(MasterServiceHATest,
+       LocalFirstAllocationDoesNotReacquireClientLockUnderSnapshotBarrier) {
+    MasterService service(
+        MasterServiceConfig::builder()
+            .set_allocation_strategy_type(AllocationStrategyType::LOCAL_FIRST)
+            .build());
+    const UUID client_id = generate_uuid();
+    const std::string key = "local_first_lock_order_key";
+    Segment segment = MakeSegment("local_first_lock_order_segment");
+    segment.host_id = "writer-host";
+    ASSERT_TRUE(service.MountSegment(segment, client_id).has_value());
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    auto shard_lock = LockMetadataShardForTesting(service, kDefaultTenant, key);
+    auto put = std::async(std::launch::async, [&] {
+        return service.PutStart(client_id, key, kDefaultTenant, 1024, config);
+    });
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    bool reached_snapshot = false;
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (PutStartHoldsSnapshotAfterClientReleaseForTesting(
+                service, kDefaultTenant, key)) {
+            reached_snapshot = true;
+            break;
+        }
+        std::this_thread::yield();
+    }
+    if (!reached_snapshot) {
+        shard_lock.unlock();
+        EXPECT_EQ(put.wait_for(std::chrono::seconds(5)),
+                  std::future_status::ready);
+        if (put.wait_for(std::chrono::seconds(0)) ==
+            std::future_status::ready) {
+            (void)put.get();
+        }
+        FAIL() << "PutStart did not reach the snapshot barrier";
+    }
+
+    // ReMountSegment holds client_mutex_ exclusively while waiting for the
+    // snapshot barrier. PutStart must not reacquire it inside that barrier.
+    auto client_lock = LockClientForTesting(service);
+    shard_lock.unlock();
+    const bool completed_while_client_locked =
+        put.wait_for(std::chrono::seconds(1)) == std::future_status::ready;
+    client_lock.unlock();
+
+    ASSERT_EQ(put.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    auto result = put.get();
+    ASSERT_TRUE(result.has_value()) << toString(result.error());
+    EXPECT_TRUE(completed_while_client_locked);
 }
 
 TEST_F(MasterServiceHATest, NoFBatchEvictWaitsForSnapshotBarrier) {


### PR DESCRIPTION
## Description

Part of #3139.

This PR fixes the recovery/remount safety issues found while reviewing #3141.

After restoring metadata from a standby snapshot, a memory replica may be `COMPLETE` but still unreadable because its segment has not remounted and its endpoint remains in `invalid_replica_endpoints_`.

Before this change:

- `BatchEvict` and tenant-quota eviction could select such unreadable recovered replicas after the object lease expired.
- `ReMountSegment()` retained raw `Replica*` and `ObjectMetadata*` pointers after releasing individual shard locks, while several metadata mutation paths did not participate in `snapshot_mutex_`.
- `NoFBatchEvict()`, NoF unmount cleanup, and heartbeat-triggered NoF cleanup could therefore race with remount and invalidate retained pointers.
- Remount refreshed the ordinary read lease only in some readability transitions, rather than for every successfully affected object.

This PR addresses those problems by:

- using one readability-aware memory eviction predicate in both `BatchEvict` and tenant-quota memory eviction, including offload selection and HA descriptor prediction/mutation;
- keeping `ReMountSegment()` under an exclusive snapshot barrier from pointer collection through allocator/buffer replacement, endpoint publication, and lease grant;
- granting `default_kv_lease_ttl_` unconditionally to every affected object after a successful remount, including objects that already had another readable replica;
- publishing neither endpoint readability nor a lease when remount fails;
- making `NoFBatchEvict()`, `UnmountNoFSegment()`, `TryUnmountNoFSegmentByHeartbeat()`, and `ClearInvalidHandles()` participate in the snapshot barrier;
- acquiring locks in the documented order: `client_mutex_ -> tenant policy -> snapshot_mutex_ -> shard/segment`.

### Relationship to #3141

#3141 originally combined four independently reviewable fixes:

1. restored allocator gap accounting;
2. `PutStart` eviction-trigger behavior;
3. recovery/remount eviction and lease safety;
4. OpLog backpressure handling.

A maintainer requested that these be split into focused PRs for correctness review, rollback, and regression diagnosis.

This PR is the focused replacement for item 3 only. It supersedes the recovery/remount slice of #3141 and does not include its allocator, `PutStart`, or OpLog changes.

It also resolves the two recovery-specific review concerns raised on #3141:

- [retained pointer lifetime and incomplete snapshot-barrier coverage](https://github.com/kvcache-ai/Mooncake/pull/3141#discussion_r3763496662);
- [availability state and cleanup of replicas that never remount](https://github.com/kvcache-ai/Mooncake/pull/3141#discussion_r3763496665).

For the second point, this PR keeps the existing state model:

- `ReplicaStatus::COMPLETE` describes completed data construction;
- `IsReplicaReadable()` derives runtime availability from handle validity and endpoint availability;
- the normal object lease protects data only after successful remount.

It intentionally does not add `RECOVERING`/`AVAILABLE` states, a recovery TTL, heartbeat inventory, orphan cleanup, or persisted pin semantics. Those broader lifecycle decisions remain in RFC #3321.

### Lock audit

All production `MetadataShardAccessorRW` and `MetadataAccessorRW` mutation entries were audited.

- Entry-owned shared barrier: regular write/remove paths, disk eviction, offload, promotion, `BatchEvict`, tenant-quota eviction, `NoFBatchEvict`, DFS eviction, processing cleanup, task cleanup, and durable-finalize paths.
- Entry-owned exclusive barrier: `ReMountSegment()`.
- Caller-held barrier: `ClearInvalidHandles()`, `AllocateAndInsertMetadata()`, `CleanupStaleHandles()`, `DiscardExpiredProcessingReplicas()`, `TryPushPromotionQueue()`, `EraseCandidate()`, `BackoffCandidate()`, and `EraseMetadata()`.
- Startup/restore-only paths remain lifecycle-isolated and do not acquire unnecessary runtime locks.

No recursive `snapshot_mutex_` acquisition was introduced. Remount never holds a metadata shard lock and segment lock at the same time.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
pre-commit run --files \
  mooncake-store/include/master_service.h \
  mooncake-store/src/master_service.cpp \
  mooncake-store/tests/ha/master_service_ha_test.cpp

cmake --build build --target master_service_ha_test -j32

./build/mooncake-store/tests/master_service_ha_test --gtest_list_tests

env GLOG_minloglevel=3 LSAN_OPTIONS=detect_leaks=0 \
  ./build/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.UnreadableRestoredMemoryReplicaIsNotEvictable:MasterServiceHATest.SuccessfulRemountGrantsEvictionLease:MasterServiceHATest.RemountRefreshesLeaseWhenAnotherReplicaIsReadable:MasterServiceHATest.FailedRemountKeepsReplicaInvalidAndCanBeRetried:MasterServiceHATest.NoFBatchEvictWaitsForSnapshotBarrier:MasterServiceHATest.RemountMakesRestoredMemoryReplicaReady:MasterServiceHATest.RemountRestoresCachelibMemoryReplica:MasterServiceHATest.MultiSegmentRemountFailurePublishesNeitherSegment:MasterServiceHATest.EmptyStandbySegmentCanRemount' \
  --gtest_repeat=50 \
  --gtest_break_on_failure \
  --gtest_brief=1

cmake -S . -B /tmp/pr3141-nof-final \
  -DBUILD_UNIT_TESTS=ON \
  -DWITH_STORE_RUST=OFF \
  -DWITH_P2P_STORE=OFF \
  -DUSE_NOF=ON

cmake --build /tmp/pr3141-nof-final \
  --target master_service_ha_test -j32
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done

The focused normal-build matrix passed 50 repetitions: 9 tests per iteration, 450 test executions total.

The `USE_NOF=ON` configuration completed successfully, but the NoF build could not finish in the current environment because the SPDK development header `spdk/env.h` is not installed. The deterministic `NoFBatchEvictWaitsForSnapshotBarrier` test is included and passes in the normal build.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not applicable; this does not change the public API
- [x] I have added tests to prove my changes are effective
- [x] The broader recovery design is tracked by RFC #3321

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used for call-chain and lock-order analysis, implementation assistance, test development, and validation. The human submitter will review every changed line and is responsible for understanding and defending the change.