### PR TITLE
[Bugfix][Store] Handle BatchEvict OpLog failures

### DIFF
--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -537,6 +537,14 @@ class Replica {
         }
     }
 
+    void cancel_remove() {
+        if (status_ == ReplicaStatus::REMOVED) {
+            status_ = ReplicaStatus::COMPLETE;
+        } else {
+            LOG(ERROR) << "Cannot cancel_remove from status: " << status_;
+        }
+    }
+
     void inc_refcnt() { refcnt_.fetch_add(1); }
 
     void dec_refcnt() { refcnt_.fetch_sub(1); }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -10086,16 +10086,14 @@ void MasterService::BatchEvict(double evict_ratio_target,
         return 0;
     };
 
-    // HA strong-consistency: persist the post-eviction state BEFORE the
-    // helper mutates `metadata`. Returns true on success (or when HA is
-    // disabled). On false, the caller must NOT call try_evict_or_offload
-    // and must NOT erase the metadata entry — local state must stay in
-    // sync with what was published.
+    // HA strong-consistency: persist the post-eviction state before the
+    // helper mutates metadata. Keep the removed IDs local until submission
+    // succeeds so a consumed reservation cannot strand REMOVED replicas.
     auto persist_evict_oplog_or_skip =
         [&, this](const TenantId& tenant_id, const std::string& key,
-                  ObjectMetadata& metadata) -> bool {
-        if (!enable_oplog_ || !ordered_oplog_writer_) {
-            return true;
+                  ObjectMetadata& metadata) -> tl::expected<void, ErrorCode> {
+        if (!enable_oplog_) {
+            return {};
         }
 
         // Predict the descriptor list after evict_replicas() runs:
@@ -10104,76 +10102,61 @@ void MasterService::BatchEvict(double evict_ratio_target,
         auto remaining = BuildRemainingReplicaDescriptors(
             metadata, is_evictable_memory_replica);
 
-        if (enable_oplog_) {
-            auto reservation = ReserveBatchOpLogSlot();
-            if (!reservation) {
-                LOG(WARNING)
-                    << "BatchEvict: OpLog reservation failed for key=" << key
-                    << ", err=" << static_cast<int>(reservation.error())
-                    << ", skipping eviction";
-                return false;
-            }
-            std::vector<ReplicaID> removed_ids;
-            metadata.VisitReplicas(is_evictable_memory_replica,
-                                   [&removed_ids](Replica& replica) {
-                                       removed_ids.push_back(replica.id());
-                                       replica.mark_removed();
-                                   });
-            tl::expected<OpLogEntry, ErrorCode> persist_result;
-            if (remaining.empty()) {
-                persist_result = AppendReservedOpLogWithDurableFinalize(
-                    std::move(reservation.value()), OpType::REMOVE,
-                    tenant_id.value(), key, {},
-                    [this, removed_ids = std::move(removed_ids)](
-                        const OpLogEntry& durable_entry) {
-                        FinalizeRemovedReplicasAfterDurable(
-                            durable_entry, removed_ids, QuotaEraseMode::kFull);
-                    });
-            } else {
-                persist_result = AppendReservedOpLogWithDurableFinalize(
-                    std::move(reservation.value()), OpType::PUT_END,
-                    tenant_id.value(), key,
-                    SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
-                                                                    remaining),
-                    [this, removed_ids = std::move(removed_ids)](
-                        const OpLogEntry& durable_entry) {
-                        FinalizeRemovedReplicasAfterDurable(
-                            durable_entry, removed_ids, QuotaEraseMode::kFull);
-                    });
-            }
-            if (!persist_result) {
-                LOG(WARNING)
-                    << "BatchEvict: OpLog persist failed for key=" << key
-                    << ", err=" << static_cast<int>(persist_result.error())
-                    << ", skipping eviction";
-                return false;
-            }
-            return true;
+        auto reservation = ReserveBatchOpLogSlot();
+        if (!reservation) {
+            LOG(WARNING) << "BatchEvict: OpLog reservation failed for key="
+                         << key
+                         << ", err=" << static_cast<int>(reservation.error())
+                         << ", stopping eviction scan";
+            return tl::make_unexpected(reservation.error());
         }
-
+        std::vector<ReplicaID> removed_ids;
+        metadata.VisitReplicas(is_evictable_memory_replica,
+                               [&removed_ids](Replica& replica) {
+                                   removed_ids.push_back(replica.id());
+                                   replica.mark_removed();
+                               });
         tl::expected<OpLogEntry, ErrorCode> persist_result;
         if (remaining.empty()) {
-            persist_result = AppendOpLogWithDurableFinalize(
-                OpType::REMOVE, tenant_id.value(), key, {}, nullptr);
+            persist_result = AppendReservedOpLogWithDurableFinalize(
+                std::move(reservation.value()), OpType::REMOVE,
+                tenant_id.value(), key, {},
+                [this, removed_ids](const OpLogEntry& durable_entry) {
+                    FinalizeRemovedReplicasAfterDurable(
+                        durable_entry, removed_ids, QuotaEraseMode::kFull);
+                });
         } else {
-            persist_result = AppendOpLogWithDurableFinalize(
-                OpType::PUT_END, tenant_id.value(), key,
+            persist_result = AppendReservedOpLogWithDurableFinalize(
+                std::move(reservation.value()), OpType::PUT_END,
+                tenant_id.value(), key,
                 SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
                                                                 remaining),
-                nullptr);
+                [this, removed_ids](const OpLogEntry& durable_entry) {
+                    FinalizeRemovedReplicasAfterDurable(
+                        durable_entry, removed_ids, QuotaEraseMode::kFull);
+                });
         }
         if (!persist_result) {
+            const ErrorCode error = persist_result.error();
+            for (const auto& id : removed_ids) {
+                if (auto* replica = metadata.GetReplicaByID(id);
+                    replica != nullptr) {
+                    replica->cancel_remove();
+                }
+            }
             LOG(WARNING) << "BatchEvict: OpLog persist failed for key=" << key
-                         << ", err=" << static_cast<int>(persist_result.error())
-                         << ", skipping eviction";
-            return false;
+                         << ", err=" << static_cast<int>(error)
+                         << ", stopping eviction scan";
+            return tl::make_unexpected(error);
         }
-        return true;
+        return {};
     };
 
     struct EvictionResult {
         uint64_t freed_bytes{0};
         long evicted_objects{0};
+        bool stop_scan{false};
+        ErrorCode error{ErrorCode::OK};
     };
 
     auto try_evict_group_or_object =
@@ -10183,8 +10166,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
                   std::vector<std::vector<Replica>>& deferred_replicas,
                   bool allow_soft_pinned) -> EvictionResult {
         if (!metadata.IsGrouped()) {
-            if (!persist_evict_oplog_or_skip(tenant_id, key, metadata)) {
-                return {};
+            auto submission =
+                persist_evict_oplog_or_skip(tenant_id, key, metadata);
+            if (!submission) {
+                return {.stop_scan = true, .error = submission.error()};
             }
             uint64_t freed = try_evict_or_offload(
                 tenant_id, key, metadata, tenant_state, deferred_replicas);
@@ -10193,8 +10178,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
         auto group_it = tenant_state.group_members.find(metadata.group_id);
         if (group_it == tenant_state.group_members.end()) {
-            if (!persist_evict_oplog_or_skip(tenant_id, key, metadata)) {
-                return {};
+            auto submission =
+                persist_evict_oplog_or_skip(tenant_id, key, metadata);
+            if (!submission) {
+                return {.stop_scan = true, .error = submission.error()};
             }
             uint64_t freed = try_evict_or_offload(
                 tenant_id, key, metadata, tenant_state, deferred_replicas);
@@ -10225,9 +10212,12 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 continue;
             }
 
-            if (!persist_evict_oplog_or_skip(tenant_id, member_key,
-                                             member_metadata)) {
-                continue;
+            auto submission = persist_evict_oplog_or_skip(tenant_id, member_key,
+                                                          member_metadata);
+            if (!submission) {
+                result.stop_scan = true;
+                result.error = submission.error();
+                return result;
             }
             uint64_t freed =
                 try_evict_or_offload(tenant_id, member_key, member_metadata,
@@ -10490,6 +10480,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // ===== Phase 2: Serial eviction via key lookup =====
     long evicted_count = 0;
     uint64_t total_freed_size = 0;
+    bool stop_eviction_scan = false;
+    ErrorCode oplog_failure{ErrorCode::OK};
     std::vector<std::chrono::system_clock::time_point> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
     // Shards that actually evicted this cycle; their metadata maps are
@@ -10513,6 +10505,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
         long evicted_this_pass = 0;
         auto evict_candidate_batch = [&](std::vector<Candidate>& batch) {
             for (auto& c : batch) {
+                if (stop_eviction_scan) break;
                 if (evicted_this_pass >= evict_num &&
                     c.lease_timeout > target_timeout) {
                     no_pin_objects.push_back(c.lease_timeout);
@@ -10561,6 +10554,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
                     if (evict_result.evicted_objects > 0) {
                         evicted_shards.set(c.shard_idx);
                     }
+                    if (evict_result.stop_scan) {
+                        stop_eviction_scan = true;
+                        oplog_failure = evict_result.error;
+                    }
                 }
                 deferred_replicas.clear();
             }
@@ -10573,7 +10570,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         // remainder of the current no-soft-pin population. This recovery
         // scan is paid only on churn and preserves the behavior of
         // continuing past the cutoff until evict_num is reached.
-        if (compact_frontier_used && evicted_this_pass < evict_num) {
+        if (!stop_eviction_scan && compact_frontier_used &&
+            evicted_this_pass < evict_num) {
             auto refill_candidates = collect_candidates(
                 /*use_cutoff=*/true, reserve_cutoff,
                 /*collect_older_or_equal=*/false);
@@ -10597,7 +10595,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
     // Do second pass eviction only if 1). there are candidates that can be
     // evicted AND 2). The evicted number in the first pass is less than
     // evict_ratio_lowerbound.
-    if (target_evict_num > 0) {
+    if (!stop_eviction_scan && target_evict_num > 0) {
         if (target_evict_num <= static_cast<long>(no_pin_objects.size())) {
             // Second pass A: only evict objects without soft pin.
             std::nth_element(no_pin_objects.begin(),
@@ -10606,17 +10604,19 @@ void MasterService::BatchEvict(double evict_ratio_target,
             auto target_timeout = no_pin_objects[target_evict_num - 1];
 
             // Evict via key lookup — avoid full metadata traversal
-            for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
+            for (size_t i = 0;
+                 i < kNumShards && target_evict_num > 0 && !stop_eviction_scan;
+                 i++) {
                 const size_t shard_idx = (start_idx + i) % kNumShards;
                 {
                     MetadataShardAccessorRW shard(this, shard_idx);
                     for (auto tenant_it = shard->tenants.begin();
                          tenant_it != shard->tenants.end() &&
-                         target_evict_num > 0;) {
+                         target_evict_num > 0 && !stop_eviction_scan;) {
                         auto& tenant_state = tenant_it->second;
                         auto it = tenant_state.metadata.begin();
                         while (it != tenant_state.metadata.end() &&
-                               target_evict_num > 0) {
+                               target_evict_num > 0 && !stop_eviction_scan) {
                             if (!it->second.IsHardPinned() &&
                                 it->second.IsLeaseExpired(now) &&
                                 it->second.lease_timeout <= target_timeout &&
@@ -10645,6 +10645,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 if (evict_result.evicted_objects > 0) {
                                     evicted_shards.set(shard_idx);
                                 }
+                                if (evict_result.stop_scan) {
+                                    stop_eviction_scan = true;
+                                    oplog_failure = evict_result.error;
+                                }
                             } else {
                                 ++it;
                             }
@@ -10669,18 +10673,20 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 soft_pin_objects.end());
             auto soft_target_timeout = soft_pin_objects[soft_pin_evict_num - 1];
 
-            for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
+            for (size_t i = 0;
+                 i < kNumShards && target_evict_num > 0 && !stop_eviction_scan;
+                 i++) {
                 const size_t shard_idx = (start_idx + i) % kNumShards;
                 {
                     MetadataShardAccessorRW shard(this, shard_idx);
 
                     for (auto tenant_it = shard->tenants.begin();
                          tenant_it != shard->tenants.end() &&
-                         target_evict_num > 0;) {
+                         target_evict_num > 0 && !stop_eviction_scan;) {
                         auto& tenant_state = tenant_it->second;
                         auto it = tenant_state.metadata.begin();
                         while (it != tenant_state.metadata.end() &&
-                               target_evict_num > 0) {
+                               target_evict_num > 0 && !stop_eviction_scan) {
                             if (it->second.IsHardPinned() ||
                                 !it->second.IsLeaseExpired(now) ||
                                 !can_evict_replicas(it->second)) {
@@ -10712,6 +10718,10 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                     evict_result.evicted_objects;
                                 if (evict_result.evicted_objects > 0) {
                                     evicted_shards.set(shard_idx);
+                                }
+                                if (evict_result.stop_scan) {
+                                    stop_eviction_scan = true;
+                                    oplog_failure = evict_result.error;
                                 }
                             } else {
                                 ++it;
@@ -10752,20 +10762,23 @@ void MasterService::BatchEvict(double evict_ratio_target,
         }
     }
 
-    if (evicted_count > 0 || released_discarded_cnt > 0) {
+    const bool made_progress = evicted_count > 0 || released_discarded_cnt > 0;
+    const bool success = made_progress || offload_deferred_count > 0;
+    if (stop_eviction_scan) {
+        need_mem_eviction_ =
+            oplog_failure == ErrorCode::TASK_PENDING_LIMIT_EXCEEDED;
+    } else if (success) {
         need_mem_eviction_ = false;
+    } else if (total_eviction_base == 0) {
+        need_mem_eviction_ = false;
+    }
+
+    if (success) {
         MasterMetricManager::instance().inc_eviction_success(evicted_count,
                                                              total_freed_size);
         MasterMetricManager::instance().inc_mem_eviction_success(
             evicted_count, total_freed_size);
-    } else if (offload_deferred_count > 0) {
-        need_mem_eviction_ = false;
-        MasterMetricManager::instance().inc_eviction_success(0, 0);
-        MasterMetricManager::instance().inc_mem_eviction_success(0, 0);
     } else {
-        if (total_eviction_base == 0) {
-            need_mem_eviction_ = false;
-        }
         MasterMetricManager::instance().inc_eviction_fail();
         MasterMetricManager::instance().inc_mem_eviction_fail();
     }

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -218,6 +218,32 @@ class GatedOrderedOpLogWriter : public OrderedOpLogWriter {
     bool stopping_{false};
 };
 
+class RejectingOrderedOpLogWriter : public OrderedOpLogWriter {
+   public:
+    RejectingOrderedOpLogWriter(OrderedOpLogWriterConfig config,
+                                WriteBatchFn write_batch)
+        : OrderedOpLogWriter(std::move(config), std::move(write_batch)) {}
+
+    tl::expected<PendingHandle, ErrorCode> Commit(
+        Reservation&& reservation, OpLogEntry entry,
+        DurableCallback callback) override {
+        if (commit_error_ != ErrorCode::OK) {
+            ++rejected_commits_;
+            return tl::make_unexpected(commit_error_);
+        }
+        return OrderedOpLogWriter::Commit(
+            std::move(reservation), std::move(entry), std::move(callback));
+    }
+
+    void RejectCommitsWith(ErrorCode error) { commit_error_ = error; }
+
+    size_t rejected_commits() const { return rejected_commits_; }
+
+   private:
+    ErrorCode commit_error_{ErrorCode::OK};
+    size_t rejected_commits_{0};
+};
+
 class MasterServiceHATest : public ::testing::Test {
    protected:
     static void EnableDfsForTesting(MasterService& service) {
@@ -404,6 +430,20 @@ class MasterServiceHATest : public ::testing::Test {
         EXPECT_EQ(ErrorCode::OK,
                   service.SetBatchOpLogBackendForTesting(std::move(backend)));
         return static_cast<GatedOrderedOpLogWriter*>(
+            service.ordered_oplog_writer_.get());
+    }
+
+    static RejectingOrderedOpLogWriter* InstallRejectingWriter(
+        MasterService& service, std::shared_ptr<HaKvBackend> backend) {
+        service.SetBatchOpLogWriterFactoryForTesting(
+            [](OrderedOpLogWriterConfig config,
+               OrderedOpLogWriter::WriteBatchFn write_batch) {
+                return std::make_unique<RejectingOrderedOpLogWriter>(
+                    std::move(config), std::move(write_batch));
+            });
+        EXPECT_EQ(ErrorCode::OK,
+                  service.SetBatchOpLogBackendForTesting(std::move(backend)));
+        return static_cast<RejectingOrderedOpLogWriter*>(
             service.ordered_oplog_writer_.get());
     }
 
@@ -603,6 +643,15 @@ class MasterServiceHATest : public ::testing::Test {
             return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
         return service.ordered_oplog_writer_->Reserve();
+    }
+
+    static void SetNeedMemEvictionForTesting(MasterService& service,
+                                             bool value) {
+        service.need_mem_eviction_.store(value);
+    }
+
+    static bool NeedMemEvictionForTesting(const MasterService& service) {
+        return service.need_mem_eviction_.load();
     }
 
     static void ClearInvalidHandlesForTesting(
@@ -4261,6 +4310,194 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
     EXPECT_TRUE(after_finalize.has_value()) << toString(after_finalize.error());
 }
 #endif
+
+TEST_F(MasterServiceHATest, BatchEvictStopsAfterFirstOpLogReservationFailure) {
+    const std::string cluster_id = "test_batch_evict_reservation_failure";
+    auto backend = std::make_shared<FakeBatchHaKvBackend>();
+    auto service_config = MasterServiceConfig::builder()
+                              .set_default_kv_lease_ttl(50)
+                              .set_enable_ha(true)
+                              .set_enable_oplog(true)
+                              .set_cluster_id(cluster_id)
+                              .set_oplog_batch_max_entries(1)
+                              .set_eviction_ratio(0.0)
+                              .build();
+    MasterService service(service_config);
+    auto* writer = InstallGatedWriter(service, backend);
+
+    auto mounted = PrepareSimpleSegment(service, "batch_evict_reserve_segment");
+    OpLogBatchStorage storage(cluster_id, *backend);
+    OpLogBatchRecord batch;
+    ReadBatchEventually(storage, 1, batch);
+
+    const std::string first_key = "batch_evict_reserve_first";
+    const std::string second_key = "batch_evict_reserve_second";
+    PutObjectOnSegment(service, mounted.client_id, first_key,
+                       "batch_evict_reserve_segment");
+    ReadBatchEventually(storage, 2, batch);
+    PutObjectOnSegment(service, mounted.client_id, second_key,
+                       "batch_evict_reserve_segment");
+    ReadBatchEventually(storage, 3, batch);
+    ASSERT_TRUE(writer->PauseCallbacksAfter(batch.last_seq));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    {
+        auto held_reservation = ReserveBatchSlotForTesting(service);
+        ASSERT_TRUE(held_reservation.has_value())
+            << toString(held_reservation.error());
+        SetNeedMemEvictionForTesting(service, true);
+
+        ::testing::internal::CaptureStderr();
+        service.RunBatchEvictForTesting(/*evict_ratio_target=*/0.5,
+                                        /*evict_ratio_lowerbound=*/0.5);
+        const std::string logs = ::testing::internal::GetCapturedStderr();
+        const std::string warning = "OpLog reservation failed";
+        const auto first_warning = logs.find(warning);
+        ASSERT_NE(std::string::npos, first_warning) << logs;
+        EXPECT_EQ(std::string::npos,
+                  logs.find(warning, first_warning + warning.size()))
+            << logs;
+        EXPECT_NE(std::string::npos, logs.find("err=-1401")) << logs;
+        EXPECT_TRUE(NeedMemEvictionForTesting(service));
+        EXPECT_EQ(1u,
+                  ReplicaCountForTesting(service, kDefaultTenant, first_key));
+        EXPECT_EQ(1u,
+                  ReplicaCountForTesting(service, kDefaultTenant, second_key));
+    }
+
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    ReadBatchEventually(storage, 4, batch);
+    ReadBatchEventually(storage, 5, batch);
+    EXPECT_EQ(1u, ReplicaCountForTesting(service, kDefaultTenant, first_key));
+    EXPECT_EQ(1u, ReplicaCountForTesting(service, kDefaultTenant, second_key));
+
+    ASSERT_TRUE(writer->RunCallbacksThrough(batch.last_seq));
+    EXPECT_EQ(0u, ReplicaCountForTesting(service, kDefaultTenant, first_key));
+    EXPECT_EQ(0u, ReplicaCountForTesting(service, kDefaultTenant, second_key));
+}
+
+TEST_F(MasterServiceHATest,
+       BatchEvictStopsWithoutRetryWhenOpLogWriterIsFenced) {
+    const std::string cluster_id = "test_batch_evict_writer_fenced";
+    auto backend = std::make_shared<FailingBatchHaKvBackend>();
+    auto service_config = MasterServiceConfig::builder()
+                              .set_default_kv_lease_ttl(50)
+                              .set_enable_ha(true)
+                              .set_enable_oplog(true)
+                              .set_cluster_id(cluster_id)
+                              .set_oplog_batch_max_entries(1)
+                              .set_eviction_ratio(0.0)
+                              .build();
+    MasterService service(service_config);
+    auto* writer = InstallGatedWriter(service, backend);
+
+    auto mounted = PrepareSimpleSegment(service, "batch_evict_fenced_segment");
+    OpLogBatchStorage storage(cluster_id, *backend);
+    OpLogBatchRecord batch;
+    ReadBatchEventually(storage, 1, batch);
+    const std::string first_key = "batch_evict_fenced_first";
+    const std::string second_key = "batch_evict_fenced_second";
+    PutObjectOnSegment(service, mounted.client_id, first_key,
+                       "batch_evict_fenced_segment");
+    ReadBatchEventually(storage, 2, batch);
+    PutObjectOnSegment(service, mounted.client_id, second_key,
+                       "batch_evict_fenced_segment");
+    ReadBatchEventually(storage, 3, batch);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    backend->SetTxnError(ErrorCode::ETCD_TRANSACTION_FAIL);
+    ASSERT_TRUE(AppendVisibleForTesting(service, OpType::PUT_END,
+                                        kDefaultTenant,
+                                        "batch_evict_fence_writer", {})
+                    .has_value());
+    ASSERT_TRUE(backend->WaitForTxnCalls(1));
+    for (int i = 0; i < 100 && !writer->GetTerminalState().has_value(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const auto terminal_state = writer->GetTerminalState();
+    ASSERT_TRUE(terminal_state.has_value());
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, terminal_state->error);
+    EXPECT_EQ(OrderedOpLogWriterTerminalReason::kFenced,
+              terminal_state->reason);
+
+    SetNeedMemEvictionForTesting(service, true);
+    ::testing::internal::CaptureStderr();
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    const std::string logs = ::testing::internal::GetCapturedStderr();
+    const std::string warning = "OpLog reservation failed";
+    const auto first_warning = logs.find(warning);
+    ASSERT_NE(std::string::npos, first_warning) << logs;
+    EXPECT_EQ(std::string::npos,
+              logs.find(warning, first_warning + warning.size()))
+        << logs;
+    EXPECT_NE(std::string::npos, logs.find("err=-1002")) << logs;
+    EXPECT_FALSE(NeedMemEvictionForTesting(service));
+    for (const auto& key : {first_key, second_key}) {
+        auto replicas = service.GetReplicaList(key, kDefaultTenant);
+        ASSERT_TRUE(replicas.has_value())
+            << key << ": " << toString(replicas.error());
+        ASSERT_EQ(1u, replicas->replicas.size());
+        EXPECT_EQ(ReplicaStatus::COMPLETE, replicas->replicas.front().status);
+    }
+}
+
+TEST_F(MasterServiceHATest, BatchEvictCommitFailureRestoresRemovedReplicas) {
+    const std::string cluster_id = "test_batch_evict_commit_failure";
+    auto backend = std::make_shared<FakeBatchHaKvBackend>();
+    auto service_config = MasterServiceConfig::builder()
+                              .set_default_kv_lease_ttl(50)
+                              .set_enable_ha(true)
+                              .set_enable_oplog(true)
+                              .set_cluster_id(cluster_id)
+                              .set_oplog_batch_max_entries(1)
+                              .set_eviction_ratio(0.0)
+                              .build();
+    MasterService service(service_config);
+    auto* writer = InstallRejectingWriter(service, backend);
+
+    auto mounted =
+        PrepareSimpleSegment(service, "batch_evict_commit_failure_segment");
+    OpLogBatchStorage storage(cluster_id, *backend);
+    OpLogBatchRecord batch;
+    ReadBatchEventually(storage, 1, batch);
+    const std::string first_key = "batch_evict_commit_failure_first";
+    const std::string second_key = "batch_evict_commit_failure_second";
+    PutObjectOnSegment(service, mounted.client_id, first_key,
+                       "batch_evict_commit_failure_segment");
+    ReadBatchEventually(storage, 2, batch);
+    PutObjectOnSegment(service, mounted.client_id, second_key,
+                       "batch_evict_commit_failure_segment");
+    ReadBatchEventually(storage, 3, batch);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(60));
+    writer->RejectCommitsWith(ErrorCode::INVALID_PARAMS);
+    SetNeedMemEvictionForTesting(service, true);
+    ::testing::internal::CaptureStderr();
+    service.RunBatchEvictForTesting(/*evict_ratio_target=*/1.0,
+                                    /*evict_ratio_lowerbound=*/1.0);
+    const std::string logs = ::testing::internal::GetCapturedStderr();
+
+    EXPECT_EQ(1u, writer->rejected_commits());
+    EXPECT_NE(std::string::npos, logs.find("OpLog persist failed")) << logs;
+    EXPECT_NE(std::string::npos, logs.find("err=-600")) << logs;
+    EXPECT_FALSE(NeedMemEvictionForTesting(service));
+    for (const auto& key : {first_key, second_key}) {
+        auto replicas = service.GetReplicaList(key, kDefaultTenant);
+        ASSERT_TRUE(replicas.has_value())
+            << key << ": " << toString(replicas.error());
+        ASSERT_EQ(1u, replicas->replicas.size());
+        EXPECT_EQ(ReplicaStatus::COMPLETE, replicas->replicas.front().status);
+    }
+
+    auto released_reservation = ReserveBatchSlotForTesting(service);
+    ASSERT_TRUE(released_reservation.has_value())
+        << toString(released_reservation.error());
+    auto full = ReserveBatchSlotForTesting(service);
+    ASSERT_FALSE(full.has_value());
+    EXPECT_EQ(ErrorCode::TASK_PENDING_LIMIT_EXCEEDED, full.error());
+}
 
 TEST_F(MasterServiceHATest, PutStartExpiredOverwriteWritesBatchRecordOpLog) {
     const std::string cluster_id =


### PR DESCRIPTION
## Description

Part of #3139.

`BatchEvict()` previously represented OpLog reservation and submission with a boolean result. This caused several problems:

- the original `ErrorCode` was lost;
- the scan continued after a reservation failure;
- stopped, unavailable, invalid, and terminal writer failures could trigger repeated eviction attempts as if they were transient backpressure;
- replicas were marked `REMOVED` before `Commit()`, but a rejected commit has no durable callback to finalize or restore them;
- eviction success/failure metrics were updated through duplicated branches.

This PR:

- preserves the exact reservation or submission `ErrorCode`;
- stops the current eviction scan after the first OpLog failure;
- automatically retries only `TASK_PENDING_LIMIT_EXCEEDED`;
- does not arm a busy retry for non-transient writer failures;
- rolls replicas changed by a rejected commit back from `REMOVED` to `COMPLETE`;
- records eviction and memory-eviction metrics through one common outcome block.

The rollback is intentionally narrow: it only permits `REMOVED -> COMPLETE` for replicas changed by the failed submission attempt.

## Relationship to #3141

PR #3141 combines several independent recovery and eviction fixes, including allocator recovery, `PutStart` eviction triggering, segment remount/recovery behavior, and `BatchEvict` OpLog failure handling.

This PR is the focused replacement for only the `BatchEvict` OpLog reservation/submission failure-handling portion of #3141. It does not replace or include #3141's allocator, `PutStart`, remount, lease, or recovery-eligibility changes.

Once this PR lands, the overlapping `BatchEvict` OpLog changes can be removed from #3141 while its other recovery fixes remain independent.

The tests reuse the gated writer and callback controls merged in #3333. This PR does not duplicate those helpers. It also does not implement the ordered-writer terminal-state machinery from #3204; terminal and other non-queue errors are handled through their existing `ErrorCode`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The regression coverage verifies:

- queue-full reservation failure stops after the first failure and retains retry;
- unavailable writer failure stops without scheduling retry;
- rejected commit restores affected replicas to `COMPLETE`;
- persisted removal records are observable before durable-finalize callbacks;
- replicas are released immediately after gated callbacks run;
- failed reservation ownership releases its batch slot through RAII.

**Test commands:**

```bash
cmake --build build --target master_service_ha_test -j32

env TMPDIR=/tmp/mooncake-pr3141-fix-batch-eviction-oplog-failure \
  LSAN_OPTIONS=detect_leaks=0 \
  GLOG_minloglevel=1 \
  ./build/mooncake-store/tests/master_service_ha_test \
  --gtest_brief=1

env TMPDIR=/tmp/mooncake-pr3141-fix-batch-eviction-oplog-failure \
  LSAN_OPTIONS=detect_leaks=0 \
  GLOG_minloglevel=1 \
  ./build/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.BatchEvictStopsAfterFirstOpLogReservationFailure:MasterServiceHATest.BatchEvictStopsWithoutRetryWhenOpLogWriterUnavailable:MasterServiceHATest.BatchEvictCommitFailureRestoresRemovedReplicas:MasterServiceBatchRecordE2ETest.RemoveDurableCallbackReleasesResources:MasterServiceHATest.RemoveHidesBeforeDurableAndReleasesAfterFinalize:MasterServiceHATest.BatchRemoveFinalizesEachObjectAfterDurable:MasterServiceHATest.RemoveAllFinalizesAfterDurable:MasterServiceHATest.BatchReplicaClearAllReleasesAfterDurable:MasterServiceHATest.BatchReplicaClearSegmentReleasesAfterDurable:MasterServiceHATest.EvictDiskReplicaReleasesLocalDiskAfterDurable' \
  --gtest_repeat=100 \
  --gtest_break_on_failure \
  --gtest_brief=1

pre-commit run --files \
  mooncake-store/include/replica.h \
  mooncake-store/src/master_service.cpp \
  mooncake-store/tests/ha/master_service_ha_test.cpp

git diff --check HEAD^ HEAD
```

**Test results:**

- [x] Unit tests pass: full `master_service_ha_test` suite, 70/70
- [x] Focused failure and gated-callback tests pass: 1000/1000 across 100 iterations
- [x] Post-format targeted regression tests pass: 3/3
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using the repository formatting hook
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not required for this internal failure-handling change
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required because the production change is below 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex assisted with code-path analysis, implementation, test development, and test execution. The human submitter will review every changed line before submission and remains responsible for understanding and defending the change.