### PR TITLE
MPComm Transport for TENT — an RDMA-native multi-rail transport backend

### DIFF
--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -543,6 +543,14 @@ kunpeng_ub_transport
 sunrise_link_transport
 :::
 
+## MPComm Transport Component
+
+::::{toctree}
+:maxdepth: 1
+
+mpcomm_transport
+::::
+
 ## Benchmark and Tuning Guide
 
 :::{toctree}

--- a/docs/source/design/transfer-engine/mpcomm_transport.md
+++ b/docs/source/design/transfer-engine/mpcomm_transport.md
@@ -1,0 +1,558 @@
+# MPComm Transport
+
+## Overview
+
+UCL-MPComm (Unified Communication Library - Memory Pool Communication) is a high-performance RDMA
+communication library for heterogeneous memory pooling, developed by the Tencent Astral Network
+Team. In Mooncake it is integrated as a transport backend of the TENT transfer framework and
+registered as `MPCOMM`; the library is shortened to MPComm throughout this document.
+
+- Upstream repository: <https://github.com/Tencent/UCL-MPComm>
+
+MPComm drives multiple RDMA NICs concurrently and performs two-level load balancing (across NICs
+and across QPs within a NIC), with NUMA-aware worker placement. It exposes one-sided
+`put`/`get` primitives that the transport maps onto TENT's `WRITE`/`READ` requests.
+
+At runtime, `TransferEngineImpl` loads MPComm Transport when `USE_MPCOMM` is enabled at build time
+and `transports/mpcomm/enable=true` is set in the configuration.
+
+> **TENT only.** This transport is implemented for the TENT runtime
+> (`mooncake-transfer-engine/tent/`) and is not available through the legacy Transfer Engine
+> transport path. Builds must therefore enable `USE_TENT` together with `USE_MPCOMM`, and
+> benchmarks must run with `--backend=tent`.
+
+### Code Structure
+
+The transport is split so that everything reaching MPComm goes through one interface. That keeps the
+provider out of most translation units, which is what makes the TENT-side logic buildable and
+testable without libmpcomm - the same arrangement `TpuPjrtShim` and `UrmaAdapter` use for their
+providers.
+
+| Unit | Responsibility | Needs `mpcomm.h` |
+|------|----------------|:----------------:|
+| `mpcomm_adapter.{h,cpp}` | The MPComm boundary. A thin pass-through: MPComm owns its slicing, NIC/QP selection and worker threads, so there is no scheduling to model here. Compiles to an unavailable stub when `USE_MPCOMM` is off | **yes** (only here) |
+| `mpcomm_peer_registry.{h,cpp}` | Peer cache and endpoint attribute parsing: which peers are connected, whose keys are current, and who may talk to a peer at any moment | no |
+| `mpcomm_task_mapping.{h,cpp}` | Request and completion mapping: WRITE/READ onto put/get, provider outcome onto `TransferStatus`, handle release | no |
+| `mpcomm_transport.{h,cpp}` | What needs the TENT runtime: resolving a `SegmentID` to a peer, reading the endpoint it advertises, driving batches, publishing capabilities | no |
+
+`MpcommTransport` also accepts an adapter through a second constructor, which is how tests
+substitute the provider.
+
+### Transfer Pipeline
+
+1. **Init**: `MPComm::init()` is called with the local segment name as the MPComm host id, the
+   RDMA device list derived from the TENT `Topology`, and a TCP port used for MPComm's own
+   metadata handshake. `startAcceptThread()` then serves incoming handshakes.
+2. **Advertisement**: the transport publishes `v1:<host>:<mpcomm_tcp_port>` into the local segment's
+   `transport_attrs` under the `MPCOMM` key, via `SegmentManager::updateLocal()` followed by
+   `synchronizeLocal()`. Peers read this to learn where to complete the MPComm handshake. The `v1:`
+   prefix makes a later format change detectable instead of silently misparsed; an attribute without
+   a prefix is read as `v1`. Only IPv4 endpoints are accepted.
+3. **Registration**: `addMemoryBuffer()` calls `registerMemory()` and `publishBuffer()` so the
+   buffer's rkeys become visible to peers. NUMA placement is auto-detected by MPComm.
+4. **Connection**: on the first request to a peer, `ensurePeerConnected()` resolves the peer's
+   MPComm endpoint from its `transport_attrs`, calls `connect()`, and then fetches the peer's
+   memory keys with `queryRemoteBuffer()`. Concurrent callers for the same peer wait for the first
+   one rather than starting a second handshake.
+
+   The cache is keyed by **MPComm host id** (the segment name), not by `SegmentID`, because that is
+   what MPComm keys connections by. Closing and reopening a segment yields a fresh `SegmentID` for
+   the same peer, and a second `connect()` to an already connected peer replaces its connection
+   record wholesale - discarding the keys it carries and leaking its queue pairs - so keying on the
+   `SegmentID` would reconnect a peer that is already connected.
+
+   For the same reason the connection and the keys are tracked separately. A connection cannot be
+   closed, so once established it is kept and reused; if only the key query failed, the peer is left
+   in `CONNECTED_NO_KEYS` and the next request retries **the query alone**. A connection that was
+   never established is not cached at all, so the next request retries the full handshake.
+
+   Keys are also refetched when the peer registers memory after they were fetched, which TENT
+   permits at any time. The transport compares the peer's currently published buffer ranges against
+   those the cached keys cover; a range that is not covered triggers a refresh. Unregistered ranges
+   do not, since a key for memory the peer no longer publishes is never used. Because segment
+   descriptors are cached per thread with a TTL, a newly registered buffer becomes visible only
+   after that TTL expires.
+5. **Execution**: `submitTransferTasks()` issues `putAsync()` for `WRITE` and `getAsync()` for
+   `READ`, one MPComm transfer per request. MPComm performs its own slicing and NIC/QP selection
+   internally.
+6. **Completion**: `getTransferStatus()` polls lazily with `isTransferComplete()`, then reads
+   `getTransferResult()` to obtain the error code and a byte count, and releases the handle. The
+   count is of bytes *posted*, which equals the request length once MPComm reports success; a
+   transfer reported as successful but short is demoted to failed rather than trusted.
+
+---
+
+## Additional Dependencies
+
+In addition to Mooncake's base dependencies, MPComm Transport requires the MPComm library:
+
+- **Header**: `${MPCOMM_ROOT}/include/mpcomm.h`
+- **Library**: `${MPCOMM_ROOT}/lib/libmpcomm.so`
+- **Version**: **1.4 or newer, and major version 1.** Configuration reads MPComm's CMake package
+  config and fails with an explicit message if the version is older or the major differs - MPComm
+  declares `SameMajorVersion` compatibility, so a different major is an ABI break by its own
+  definition. Both the standalone install and the wheel ship that config, and the resolved version
+  is printed as `MPComm version: <x.y.z>`. A prefix that has only the headers and the library copied
+  into it reports `unknown` instead, and the version is then not checked.
+
+Both are provided by an MPComm installation, which may come either from a standalone CMake install
+or from the MPComm Python wheel (in which case `MPCOMM_ROOT` is the `mpcomm` package directory
+inside `site-packages`, since the wheel ships `include/` and `lib/` under the package root).
+
+The two routes are not necessarily equivalent: MPComm gates several features behind build options
+that default to `OFF`, notably `USE_CUDA` (device memory support) and `USE_MLNX` (Mellanox-specific
+QP tuning that spreads traffic across ECMP paths, which affects multi-QP throughput). Its own
+`build.sh` turns them on, whereas a plain `pip install` does not. Check how the library you install
+was configured if device memory or multi-QP performance matters.
+
+Make sure `libmpcomm.so` can be found by the dynamic linker at run time, for example via
+`LD_LIBRARY_PATH`.
+
+### Wheel Packaging
+
+The `mooncake-transfer-engine` wheel **deliberately does not bundle MPComm**. `scripts/build_wheel.sh`
+passes `--exclude libmpcomm.so*` to `auditwheel repair`, so `engine.so` keeps its `DT_NEEDED` entry
+on `libmpcomm.so.<N>` and the library stays an external dependency resolved at run time. This keeps
+MPComm independently upgradable: replacing `libmpcomm.so` does not require rebuilding or repackaging
+Mooncake, as long as the MPComm major version (its `SOVERSION`) is unchanged. A major bump does
+require rebuilding Mooncake against the new headers.
+
+Consequently, importing the Python extension without MPComm available fails with:
+
+```
+ImportError: libmpcomm.so.1: cannot open shared object file: No such file or directory
+```
+
+Provide the library through either MPComm installation form, then point the linker at it:
+
+```bash
+# From the MPComm wheel
+export MPCOMM_ROOT=$(python3 -c "import mpcomm, os; print(os.path.dirname(mpcomm.__file__))")
+# ...or from a standalone CMake install, e.g. MPCOMM_ROOT=/opt/mpcomm
+
+export LD_LIBRARY_PATH=$MPCOMM_ROOT/lib:$LD_LIBRARY_PATH
+python3 -c "from mooncake import engine"   # should now import cleanly
+```
+
+---
+
+## Build and Compile
+
+**Prerequisites**
+
+- MPComm is installed, providing both `include/mpcomm.h` and `lib/libmpcomm.so`
+- RDMA devices are available and `libibverbs` is installed
+- Build environment can access Mooncake and its base dependencies
+
+**CMake Configuration**
+
+```bash
+# Clone Mooncake
+git clone https://github.com/kvcache-ai/Mooncake.git
+cd Mooncake
+
+# Enable TENT + MPComm. Add -DUSE_CUDA=ON if you need VRAM segments.
+mkdir build && cd build
+cmake .. -DUSE_TENT=ON -DUSE_MPCOMM=ON -DMPCOMM_ROOT=/opt/mpcomm
+
+# Build
+make -j$(nproc)
+```
+
+`MPCOMM_ROOT` is mandatory when `USE_MPCOMM=ON`. Configuration fails early if it is unset, or if
+the expected header and library cannot be found underneath it. On success the configure log
+reports the resolved paths:
+
+```
+-- MPComm transport is enabled
+--   MPComm include: /opt/mpcomm/include
+--   MPComm library: /opt/mpcomm/lib/libmpcomm.so
+```
+
+---
+
+## Enabling the Transport
+
+Loading the transport and selecting it for a transfer are two separate steps.
+
+**1. Load it.** The transport is only instantiated when its config gate is on:
+
+```json
+{ "transports": { "mpcomm": { "enable": true } } }
+```
+
+**2. Select it.** Any of the standard TENT mechanisms work:
+
+- A transport policy (see [Transport Selector](../tent/transport-selector.md)):
+
+  ```json
+  {
+    "transports": { "mpcomm": { "enable": true } },
+    "policy": [
+      { "name": "mpcomm_memory", "segment_type": "memory", "transports": ["mpcomm"] }
+    ]
+  }
+  ```
+
+- A per-request override, which takes precedence over policies:
+
+  ```cpp
+  Request r{};
+  r.transport_hint = TransportType::MPCOMM;
+  ```
+
+A policy or a hint is effectively **required**. In the default ordering returned by
+`getSupportedTransports()`, `MPCOMM` comes second to last -- only `TPU` follows it -- so leaving
+the choice to the default means MPComm is unlikely to be picked at all.
+
+---
+
+## Run and Test
+
+`tebench` (the TENT benchmark, built at `build/mooncake-transfer-engine/benchmark/tebench`)
+supports `mpcomm` for connectivity and performance validation. The role is determined by
+`--target_seg_name`: empty means target, otherwise initiator.
+
+There is also a unit test, which is built when `USE_MPCOMM=ON` and unit tests are enabled. Its
+functional case needs RDMA devices and MPComm at run time and skips itself otherwise:
+
+```bash
+ctest -R tent_mpcomm_transport_test --output-on-failure
+```
+
+`--xport_type=mpcomm` selects the `MemoryOptions.type` used when registering buffers. It also
+restricts the enabled transports, but setting `MC_TENT_CONF` replaces the configuration wholesale
+and undoes that (see [Important Notes](#important-notes)), so the examples below list the
+`transports` gates explicitly. Keeping them in a shell variable avoids repeating the block:
+
+```bash
+XPORTS='"transports":{"mpcomm":{"enable":true},"rdma":{"enable":false},
+        "tcp":{"enable":false},"shm":{"enable":false},"nvlink":{"enable":false},
+        "mnnvl":{"enable":false},"gds":{"enable":false},"io_uring":{"enable":false}}'
+
+# Terminal 1: target
+MC_TENT_CONF="{\"rpc_server_hostname\":\"10.0.0.1\",$XPORTS}" \
+MPCOMM_TCP_PORT=13579 \
+./tebench --backend=tent --xport_type=mpcomm \
+  --metadata_type=p2p --rpc_server_port=12345 \
+  --seg_type=DRAM --total_buffer_size=2147483648
+
+# Terminal 2: initiator
+MC_TENT_CONF="{\"rpc_server_hostname\":\"10.0.0.2\",$XPORTS}" \
+MPCOMM_TCP_PORT=13579 \
+./tebench --backend=tent --xport_type=mpcomm --tent_transport_hint=mpcomm \
+  --metadata_type=p2p --rpc_server_port=12346 \
+  --target_seg_name=10.0.0.1:12345 \
+  --seg_type=DRAM --total_buffer_size=2147483648 \
+  --op_type=read --start_block_size=262144 --max_block_size=262144 \
+  --start_batch_size=32 --max_batch_size=32 \
+  --start_num_threads=4 --max_num_threads=4 --duration=30
+```
+
+Setting `rpc_server_hostname` is strongly recommended on multi-homed or containerized hosts; see
+[Important Notes](#important-notes). `--seg_name` is deliberately absent: with `metadata_type=p2p`
+TENT derives the local segment name from `rpc_server_hostname` and `rpc_server_port` and ignores
+the flag.
+
+**On a single host** both processes share the port namespace, so give them different handshake
+ports. Avoid the 15000-17000 range, which the TENT RPC server allocates from:
+
+```bash
+MPCOMM_TCP_PORT=13579 ...   # target
+MPCOMM_TCP_PORT=13580 ...   # initiator
+```
+
+To confirm that traffic really went over MPComm, look for these lines:
+
+```
+MpcommTransport: Installed successfully, host_id=10.0.0.2:12346, tcp_port=13579, devices=mlx5_0,mlx5_1
+MpcommTransport: Connected to segment 10.0.0.1:12345
+```
+
+If MPComm fails to start, the engine only logs `Transport mpcomm skipped: ...` and continues with
+the remaining transports. With every other transport disabled the run then fails later and less
+obviously, when buffer registration finds no usable transport.
+
+Add `--check_consistency=true` to verify payload correctness. It writes and reads every block back,
+so it changes the access pattern as well as lowering the reported bandwidth; leave it off when
+measuring throughput.
+
+### Unit Tests
+
+There are two suites, because the data path needs hardware and the logic around it does not.
+
+`tent_mpcomm_boundary_test` drives the transport against an injected `MpcommAdapter`, so it needs
+neither an RDMA device nor libmpcomm and is built in every configuration:
+
+```bash
+cmake .. -DUSE_TENT=ON -DBUILD_UNIT_TESTS=ON   # USE_MPCOMM not required
+make -j tent_mpcomm_boundary_test
+ctest -R tent_mpcomm_boundary_test --output-on-failure
+```
+
+It covers endpoint publication and parsing, single-flight connection under concurrency, key-query
+retry over an existing connection, refreshing keys when a peer registers memory, the WRITE/READ
+mapping, short-transfer and error handling, releasing each handle exactly once, and teardown. It does
+not cover MPComm's own behaviour - slicing, NIC and QP selection, worker scheduling - which is the
+provider's responsibility.
+
+`tent_mpcomm_transport_test` exercises the real data path: it forks a target, drives a WRITE followed
+by a READ over MPComm and verifies the payload. It requires RDMA devices and a working MPComm
+installation, and skips itself when the engine cannot be brought up:
+
+```bash
+cmake .. -DUSE_TENT=ON -DUSE_MPCOMM=ON -DBUILD_UNIT_TESTS=ON -DMPCOMM_ROOT=<prefix>
+make -j tent_mpcomm_transport_test
+ctest -R tent_mpcomm_transport_test --output-on-failure
+```
+
+Parent and child use distinct `MPCOMM_TCP_PORT` values derived from the pid, since MPComm's handshake
+listener would otherwise collide; see the note on port uniqueness above.
+
+---
+
+## GPU (Device) Memory
+
+MPComm transfers device memory as well as host DRAM, so VRAM segments are supported in all four
+combinations (DRAM to DRAM, DRAM to GPU, GPU to DRAM, GPU to GPU).
+
+Three preconditions must all hold, and only the first one is checked at run time:
+
+1. **`nvidia-peermem` is loaded.** Device memory is registered through the ordinary `ibv_reg_mr`
+   path: the kernel's `get_user_pages()` is intercepted by `nvidia-peermem`
+   (`ib_peer_memory_client`) to pin GPU pages. There is no dma-buf fallback. This is the same
+   dependency `RdmaTransport` has for GPU-Direct.
+2. **MPComm itself was built with `-DUSE_CUDA=ON`.** That option defaults to `OFF`, and its device
+   detection is compiled out entirely when it is off, so device pointers are then registered as
+   host memory and NUMA/PCIe affinity selection silently degrades. The upstream `build.sh` enables
+   it; a plain `pip install` of the MPComm package does not.
+3. **Mooncake was built with `-DUSE_CUDA=ON`**, otherwise `--seg_type=VRAM` is rejected outright.
+
+The transport probes `/proc/modules` during `install()` and advertises the GPU capabilities only
+when `nvidia-peermem` is present. Otherwise it logs
+
+```
+MpcommTransport: nvidia_peermem not detected, GPU memory support is disabled
+```
+
+and reports `dram_to_dram` only, so transport selection will not route device memory to MPComm.
+Setting `transports/mpcomm/disable_gpu_direct_rdma` to `true` forces the same behaviour on a host
+that does have the module, which is reported separately:
+
+```
+MpcommTransport: GPU memory support disabled by transports/mpcomm/disable_gpu_direct_rdma
+```
+
+Note that conditions 2 and 3 are **not** detectable by that probe. If GPU transfers behave oddly
+while the module is loaded, confirm how MPComm was built.
+
+Buffer registration is attempted for every loaded transport irrespective of capabilities, so on a
+host without the module registering a VRAM buffer logs a warning from MPComm. That is harmless:
+the buffer simply does not list `MPCOMM` among its transports, and selection skips it.
+
+To exercise device memory with `tebench`, pass `--seg_type=VRAM` on either or both sides, or
+`--seg_type_mix=dram,vram` to drive both memory types from a single process:
+
+```bash
+./tebench --backend=tent --xport_type=mpcomm --seg_type=VRAM ...
+```
+
+---
+
+## Environment Variables
+
+MPComm reads its own tuning parameters directly from the environment. The transport adds the two
+`*_TCP_PORT` variables.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `MPCOMM_TCP_PORT` | Local TCP port for MPComm's metadata handshake. Must be unique per process on a host: MPComm binds it and fails to initialise if it is taken, with no retry. `0` does not mean "pick one". The value is validated, and a non-numeric or out-of-range one fails `install()` rather than being silently treated as `0`. This port hands out remote memory keys - see [Security and Trust Boundary](#security-and-trust-boundary) | `13579` |
+| `MPCOMM_REMOTE_TCP_PORT` | Peer handshake port, used only when the peer published no `transport_attrs`. Without it such a peer is rejected: the attribute is written by `install()`, so its absence means the peer runs no MPComm transport, and guessing a port would point `connect()` at an unrelated process - which, since the handshake has no timeout, can block the submitting thread indefinitely | (none; peer is rejected) |
+| `MPCOMM_GID_INDEX` | RoCE/IB GID index used when creating QPs. Devices whose GID at this index is all zeroes are skipped, which can leave MPComm reporting no usable devices. Use `-1` to pick the first non-zero GID | `3` |
+| `MPCOMM_NIC_FILTER` | Comma-separated list of allowed RDMA device names. When unset, the transport passes the device list derived from the TENT `Topology`; setting this variable overrides that list | (TENT topology) |
+| `MPCOMM_MAX_RDMA_TRANSFER_SIZE` | Maximum bytes per RDMA operation; larger requests are sliced across NICs | `1 GB` |
+| `MPCOMM_QPS_PER_CONNECTION` | Number of QPs per NIC per connection. Values above 16 make initialisation fail | `1` |
+| `MPCOMM_POLL_BATCH_SIZE` | Maximum work completions per `ibv_poll_cq` call | `64` |
+| `MPCOMM_MAX_IDLE_SPINS` | Number of idle polling iterations a worker spins (with a CPU pause hint) before backing off | `10000` |
+| `MPCOMM_MAX_SEND_WR` | QP send queue depth | `512` |
+| `MPCOMM_MAX_OUTSTANDING_PER_QP` | Maximum outstanding work requests per QP | `256` |
+| `MPCOMM_LOG_LEVEL` | `error` / `warn` / `info` / `debug` | `info` |
+| `MPCOMM_TRANSFER_STATS_INTERVAL` | Print statistics every N transfers (requires `debug`) | `0` (every transfer) |
+
+---
+
+## Configuration Options (TENT)
+
+- `transports/mpcomm/enable`: enable or disable the transport (default: `true` once
+  `USE_MPCOMM` is compiled in)
+- `transports/mpcomm/disable_gpu_direct_rdma`: force the GPU capabilities off even when
+  `nvidia-peermem` is loaded (default: `false`). See [GPU (Device) Memory](#gpu-device-memory).
+
+MPComm's own behaviour is tuned through the environment variables above rather than through TENT
+configuration keys.
+
+---
+
+## Important Notes
+
+1. **TENT only.** There is no MPComm backend on the legacy Transfer Engine transport path, so
+   `--backend=classic` and `transfer_engine_bench --protocol=mpcomm` are not supported.
+
+2. **Set `rpc_server_hostname` on multi-homed or containerized hosts.** With
+   `metadata_type=p2p`, TENT overwrites `local_segment_name` with `rpc_server_hostname:port`. When
+   `rpc_server_hostname` is unset it is auto-discovered, which may pick an address that peers
+   cannot route to (for example a container overlay address). Since the published
+   `transport_attrs` are derived from that name, MPComm would then advertise an unreachable
+   endpoint. `tebench` has no command-line flag for it, so pass it through `MC_TENT_CONF`.
+
+3. **`MC_TENT_CONF` replaces the configuration wholesale.** Keys other than the metadata identity
+   (`metadata_type`, `metadata_servers`, `local_segment_name`, `rpc_server_hostname`,
+   `rpc_server_port`) are not preserved across the load. If you set `MC_TENT_CONF` *and* rely on
+   `--xport_type` to disable the other transports, list the `transports` gates explicitly in
+   `MC_TENT_CONF` as well, otherwise they revert to their defaults.
+
+4. **Segment metadata mutation.** The transport publishes its endpoint through
+   `SegmentManager::updateLocal()`. Snapshots returned by `getLocal()` are copy-on-write and must
+   never be written through.
+
+5. **Buffer registration cost.** `registerMemory()` pins and maps memory on every NIC, so
+   registration of large buffers takes noticeable time at startup. Register once and reuse.
+
+6. **Optional transport interfaces are not implemented.** MPComm Transport does not provide
+   cancellation (`supportsCancellation()` returns `false`), notification
+   (`supportNotification()` returns `false`, so `tebench --notifi` is unavailable), bandwidth
+   estimation, or NIC load statistics, and it does not consume the `qp_pool` or
+   progress-notification facilities of `Transport::SubBatch`. Failover and QoS features that
+   depend on those hooks fall back to their defaults.
+
+7. **The first transfer to a peer performs the MPComm handshake inline.** Connection setup happens
+   on the submitting thread the first time a segment is used, so that submission takes noticeably
+   longer than subsequent ones.
+
+---
+
+## Security and Trust Boundary
+
+MPComm's metadata handshake is a plain TCP exchange with **no authentication and no encryption**,
+and what it exchanges is remote memory metadata:
+
+```c++
+struct RemoteBufferEntry {
+    uint64_t addr;
+    uint64_t length;
+    int numa_node;
+    std::vector<uint32_t> rkeys;   // <- remote keys
+};
+```
+
+An address together with its rkey is exactly what an RDMA READ or WRITE needs. Anything that can
+reach `MPCOMM_TCP_PORT` can therefore obtain the means to read and write the process's registered
+memory directly, without going through TENT at all.
+
+**Treat that port as being at the same trust level as the RDMA fabric itself.** In practice:
+
+- Keep it on the same trusted network as the fabric, and do not expose it to untrusted networks or
+  to the internet. Restrict it with host firewall rules if the host also carries untrusted traffic.
+- Registered buffers are reachable by any peer that completes the handshake. There is no per-peer
+  authorisation, and no per-buffer permission model beyond what the fabric enforces.
+- This is the same exposure model as raw RDMA between trusted nodes; MPComm adds no protection of
+  its own and does not weaken the fabric's either.
+
+### Addressing
+
+- **Only IPv4 endpoints are supported.** The handshake sockets are `AF_INET`, and the endpoint
+  attribute is parsed as `<ipv4>:<port>`; an IPv6 literal is rejected at parse time rather than
+  being silently split at the wrong colon.
+- **The listener binds all interfaces** (`INADDR_ANY`) and this is not configurable - it is
+  MPComm's own behaviour. Use firewall rules to restrict which interfaces are actually reachable.
+- **The advertised address follows `rpc_server_hostname`**, since the endpoint attribute is derived
+  from the local segment name. On a multi-homed host this ties the handshake path to whichever
+  address TENT uses for RPC. Setting `rpc_server_hostname` explicitly is therefore the way to
+  control it today; a dedicated setting for advertising an address separate from the RPC one is not
+  implemented yet.
+
+---
+
+## Troubleshooting
+
+### Configuration fails with a missing `MPCOMM_ROOT`
+
+```
+USE_MPCOMM=ON requires MPCOMM_ROOT to point at the MPComm install prefix
+```
+
+Pass `-DMPCOMM_ROOT=<prefix>`. The prefix must contain `include/mpcomm.h` and
+`lib/libmpcomm.so` (`lib64` is searched as well).
+
+### Configuration fails with MPComm not found
+
+```
+MPComm not found under MPCOMM_ROOT=<prefix>
+```
+
+Verify the layout, and remember that CMake caches find results:
+
+```bash
+ls $MPCOMM_ROOT/include/mpcomm.h $MPCOMM_ROOT/lib/libmpcomm.so
+cmake .. -UMPCOMM_LIBRARY -UMPCOMM_INCLUDE_DIR
+```
+
+### `error while loading shared libraries: libmpcomm.so`
+
+The library is resolved by absolute path at link time, but the dynamic linker still needs to find
+it at run time:
+
+```bash
+export LD_LIBRARY_PATH=$MPCOMM_ROOT/lib:$LD_LIBRARY_PATH
+ldd ./tebench | grep -E "mpcomm|not found"
+```
+
+### The peer connects to an unexpected address
+
+Symptom: the initiator logs `MPComm: Connecting to <host_id> at <ip>:<port>` with an address peers
+cannot reach, and stalls, while the segment itself was opened successfully.
+
+The address MPComm uses comes from the peer's segment name and `transport_attrs`, which are
+derived from `rpc_server_hostname`. Set it explicitly on **both** sides, then confirm the target
+advertises the intended address:
+
+```
+MpcommTransport: Installed successfully, host_id=<expected-ip>:<port>, ...
+```
+
+### `MPComm: No RDMA devices found`
+
+MPComm skips any device whose GID at `MPCOMM_GID_INDEX` (default `3`) is all zeroes, which is
+common on InfiniBand and on RoCE setups with a different GID layout. Set `MPCOMM_GID_INDEX=-1` to
+pick the first non-zero GID, or point it at the correct index.
+
+### `Failed to query remote buffers`
+
+```
+MpcommTransport: Failed to query remote buffers from <host>, error=<code>
+```
+
+The connection succeeded but fetching the peer's memory keys did not. Those keys are the only way
+to address the peer's memory, so this is a hard failure and the request fails.
+
+The connection itself is kept - MPComm cannot close one, and reconnecting would replace its
+connection record and leak its queue pairs - so the peer is left in `CONNECTED_NO_KEYS` and the
+next request retries **only the query**, not the handshake.
+
+The usual cause is that the peer had not finished registering its buffers yet, so start the target
+and let it finish registration before starting the initiator. Since the retry is a query, the
+recovery needs no restart on either side.
+
+### Lower than expected bandwidth
+
+- Remove `--check_consistency=true`; it writes and reads every block back.
+- Increase `--duration`; the inline handshake on the first transfer to a peer is included in the
+  measurement.
+- Increase `--start_batch_size` / `--max_batch_size`; with a batch size of 1 there are not enough
+  in-flight requests to fill `MPCOMM_MAX_OUTSTANDING_PER_QP`.
+- Check `MPCOMM_MAX_RDMA_TRANSFER_SIZE` against the block size. Slicing is what spreads a transfer
+  over several NICs, so a request smaller than this limit becomes a single chunk on a single NIC.
+  Lower it to engage more NICs per request.
+- For `--seg_type=DRAM`, `tebench` allocates one buffer of `--total_buffer_size` per NUMA node.
+  Restricting memory to a single node with `numactl --membind` while NICs on another node drive
+  traffic results in cross-socket access.

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -31,11 +31,11 @@ sudo make install
 
 ### Build with VRAM Segment
 
-To enable VRAM Segment, install CUDA toolkit and build Mooncake with 
+To enable VRAM Segment, install CUDA toolkit and build Mooncake with
 `USE_VRAM_SEGMENT` enabled:
 
 ```bash
-sudo bash dependencies.sh 
+sudo bash dependencies.sh
 
 mkdir build
 cd build
@@ -44,7 +44,7 @@ make -j
 sudo make install
 ```
 
-If NVLink is available in your environment, you can also enable it 
+If NVLink is available in your environment, you can also enable it
 with `-DUSE_INTRA_NVLINK=ON`:
 
 ```bash
@@ -211,6 +211,7 @@ The following options can be passed to `cmake ..`.
 | `-DUSE_INTRA_NVLINK=ON/OFF` | `OFF` | Enable intranode NVLink transport. |
 | `-DUSE_VRAM_SEGMENT=ON/OFF` | `OFF` | Enable create VRAM Segment instead of (default) DRAM Segment. |
 | `-DUSE_CXL=ON/OFF` | `OFF` | Enable CXL support. |
+| `-DUSE_MPCOMM=ON/OFF` | `OFF` | Enable the MPComm transport in TENT (multi-NIC memory pooling over RDMA). Requires `-DUSE_TENT=ON` and `-DMPCOMM_ROOT=<prefix>`. See [MPComm Transport](../design/transfer-engine/mpcomm_transport.md). |
 
 ### Vendor SDK Path Overrides
 
@@ -229,6 +230,7 @@ The following options can be passed to `cmake ..`.
 | `-DNEUWARE_ROOT=/path/to/neuware` | `-DUSE_MLU=ON` | Override the Neuware SDK root. `NEUWARE_HOME` is also honored; default is `/usr/local/neuware`. |
 | `-DMLU_INCLUDE_DIR=/path/to/include` | `-DUSE_MLU=ON` | Override the Neuware include directory. |
 | `-DMLU_LIB_DIR=/path/to/lib64` | `-DUSE_MLU=ON` | Override the Neuware library directory. |
+| `-DMPCOMM_ROOT=/path/to/mpcomm` | `-DUSE_MPCOMM=ON` | **Required.** MPComm install prefix; must contain `include/mpcomm.h` and `lib/libmpcomm.so`. Configuration fails if unset or if either file is missing. |
 
 ### Transport and Metadata Options
 

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -17,6 +17,7 @@ Mooncake Transfer Engine supports multiple communication protocols for data tran
 | **cxl** | CXL-capable hardware | Memory pooling and sharing | ⚠️ Advanced |
 | **ascend** | Huawei Ascend NPU | Ascend NPU communication | ⚠️ Advanced |
 | **tpu** | Google TPU (PJRT) | TPU KV-cache transfer via host-DRAM staging | 🧪 Experimental (TENT) |
+| **mpcomm** | RDMA-capable NIC(s) | Multi-NIC memory pooling with NIC/QP load balancing | ⚠️ Advanced (TENT) |
 
 ## Commonly Used Protocols (Python API)
 
@@ -299,6 +300,35 @@ planned as a follow-up.
   transport and the cross-node hop to RDMA/TCP.
 - DMA-mapped (pinned) staging buffers for true async device DMA are a planned
   performance follow-up.
+
+### MPComm Transport (mpcomm)
+
+**Description:** UCL-MPComm (Unified Communication Library - Memory Pool Communication) is an RDMA
+library for heterogeneous memory pooling, integrated as a TENT transport. It drives multiple RDMA
+NICs concurrently with two-level load balancing (across NICs, and across QPs within a NIC) and
+NUMA-aware worker placement, exposing one-sided put/get primitives. It is shortened to MPComm
+below.
+
+**Status:** TENT only. There is no MPComm backend on the legacy Transfer Engine transport path,
+so it cannot be selected through `MOONCAKE_PROTOCOL` or `transfer_engine_bench --protocol=`.
+
+**Use When:**
+- The host has several RDMA NICs and you want them saturated by a single transfer stream
+- Multi-NUMA hosts where NIC-to-NUMA affinity matters
+
+**Requirements:**
+- Built with `-DUSE_TENT=ON -DUSE_MPCOMM=ON -DMPCOMM_ROOT=<prefix>`
+- MPComm installed, providing `include/mpcomm.h` and `lib/libmpcomm.so`
+  (<https://github.com/Tencent/UCL-MPComm>)
+- `libmpcomm.so` reachable by the dynamic linker at run time
+
+**Enable:**
+```json
+{ "transports": { "mpcomm": { "enable": true } } }
+```
+
+See [MPComm Transport](../design/transfer-engine/mpcomm_transport.md) for the full guide,
+including selection via transport policy, tuning environment variables, and troubleshooting.
 
 ## Configuration Examples
 

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -74,7 +74,8 @@ if(BUILD_UNIT_TESTS)
 endif()
 option(BUILD_BENCHMARK "Build benchmarks" ON)
 option(USE_CUDA "option for enabling gpu features for NVIDIA GPU" OFF)
-option(USE_NCCL_DEVICE "option for enabling the NCCL DeviceTransport backend" OFF)
+option(USE_NCCL_DEVICE "option for enabling the NCCL DeviceTransport backend"
+       OFF)
 option(USE_NCCL_HOST "option for enabling the NCCL host RMA transport" OFF)
 option(USE_MLU "option for enabling Cambricon MLU features" OFF)
 option(USE_MUSA "option for enabling gpu features for MTHREADS GPU" OFF)
@@ -97,10 +98,12 @@ option(USE_EFA "option for using AWS EFA transport" OFF)
 option(USE_UB "option for using UB protocol transport" OFF)
 option(USE_SUNRISE
        "option for enabling gpu features for Sunrise GPU with Tang runtime" OFF)
-option(USE_TPU
-       "option for enabling TPU (PJRT) staging support in TENT; the PJRT adapter is loaded at runtime via dlopen, no build-time SDK required"
-       OFF)
+option(
+  USE_TPU
+  "option for enabling TPU (PJRT) staging support in TENT; the PJRT adapter is loaded at runtime via dlopen, no build-time SDK required"
+  OFF)
 option(USE_VRAM_SEGMENT "option for vram segment" OFF)
+option(USE_MPCOMM "option for using MPComm transport in TENT" OFF)
 
 if(USE_UB)
   add_compile_definitions(USE_UB)
@@ -207,7 +210,7 @@ if(USE_MNNVL)
   message(STATUS "Multi-Node NVLink support is enabled")
 endif()
 
-if (USE_VRAM_SEGMENT)
+if(USE_VRAM_SEGMENT)
   set(USE_CUDA ON)
   add_compile_definitions(USE_VRAM_SEGMENT)
   message(STATUS "VRAM SEGMENT is ON")
@@ -227,8 +230,7 @@ endif()
 
 if(USE_NCCL_DEVICE OR USE_NCCL_HOST)
   if(NOT USE_CUDA)
-    message(FATAL_ERROR
-      "USE_NCCL_DEVICE and USE_NCCL_HOST require USE_CUDA=ON")
+    message(FATAL_ERROR "USE_NCCL_DEVICE and USE_NCCL_HOST require USE_CUDA=ON")
   endif()
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
   find_package(NCCLDevice 2.30.4 REQUIRED MODULE)
@@ -236,14 +238,15 @@ endif()
 
 if(USE_NCCL_DEVICE)
   add_compile_definitions(USE_NCCL_DEVICE)
-  message(STATUS
-    "NCCL DeviceTransport support is enabled (NCCL ${NCCLDevice_VERSION})")
+  message(
+    STATUS
+      "NCCL DeviceTransport support is enabled (NCCL ${NCCLDevice_VERSION})")
 endif()
 
 if(USE_NCCL_HOST)
   add_compile_definitions(USE_NCCL_HOST)
-  message(STATUS
-    "NCCL host RMA transport is enabled (NCCL ${NCCLDevice_VERSION})")
+  message(
+    STATUS "NCCL host RMA transport is enabled (NCCL ${NCCLDevice_VERSION})")
 endif()
 
 if(USE_SUPA)
@@ -470,6 +473,85 @@ endfunction()
 if(USE_CXL)
   add_compile_definitions(USE_CXL)
   message(STATUS "CXL support is enabled")
+endif()
+
+if(USE_MPCOMM)
+  if(NOT DEFINED MPCOMM_ROOT)
+    message(
+      FATAL_ERROR
+        "USE_MPCOMM=ON requires MPCOMM_ROOT to point at the MPComm install prefix, e.g. -DMPCOMM_ROOT=/opt/mpcomm"
+    )
+  endif()
+
+  # Oldest MPComm whose ABI this transport is written against, and the major it
+  # is written for - MPComm's own package config declares SameMajorVersion
+  # compatibility, so a different major is an ABI break by its own definition. A
+  # bare find_library() can express neither, since it accepts whatever
+  # libmpcomm.so happens to be on the prefix.
+  #
+  # Queried without a version so that an install that is present but too old is
+  # reported as such, rather than looking the same as no package config at all.
+  #
+  # find_package() also consults an upper-case <PACKAGENAME>_ROOT variable, and
+  # for this package that name is exactly our own MPCOMM_ROOT, which makes CMake
+  # 3.27+ emit a CMP0144 developer warning. Opting into the new behaviour is
+  # what we want anyway - the prefix really is where the package lives - and the
+  # setting is scoped so that no other find_package() is affected.
+  set(MPCOMM_MINIMUM_VERSION 1.4)
+  set(MPCOMM_SUPPORTED_MAJOR 1)
+  if(POLICY CMP0144)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0144 NEW)
+  endif()
+  find_package(mpcomm CONFIG QUIET HINTS ${MPCOMM_ROOT})
+  if(POLICY CMP0144)
+    cmake_policy(POP)
+  endif()
+  if(mpcomm_FOUND)
+    if(mpcomm_VERSION VERSION_LESS MPCOMM_MINIMUM_VERSION)
+      message(
+        FATAL_ERROR
+          "MPComm ${mpcomm_VERSION} found under MPCOMM_ROOT=${MPCOMM_ROOT} is too old; this transport requires >= ${MPCOMM_MINIMUM_VERSION}"
+      )
+    endif()
+    if(NOT mpcomm_VERSION_MAJOR EQUAL MPCOMM_SUPPORTED_MAJOR)
+      message(
+        FATAL_ERROR
+          "MPComm ${mpcomm_VERSION} has major ${mpcomm_VERSION_MAJOR}, but this transport is written against major ${MPCOMM_SUPPORTED_MAJOR}; MPComm declares SameMajorVersion compatibility, so this is an ABI break"
+      )
+    endif()
+  endif()
+
+  find_path(MPCOMM_INCLUDE_DIR mpcomm.h HINTS ${MPCOMM_ROOT}/include)
+  # Resolve to an absolute library path instead of relying on -L/-l. Link
+  # directories are usage requirements and get stripped when a dependency is
+  # consumed through $<LINK_ONLY:...> (mooncake_store links transfer_engine
+  # PRIVATE, so mooncake_master would otherwise see -lmpcomm without the
+  # matching -L). An absolute path survives that stripping.
+  find_library(MPCOMM_LIBRARY mpcomm HINTS ${MPCOMM_ROOT}/lib
+                                           ${MPCOMM_ROOT}/lib64)
+  if(NOT MPCOMM_INCLUDE_DIR OR NOT MPCOMM_LIBRARY)
+    message(
+      FATAL_ERROR
+        "MPComm not found under MPCOMM_ROOT=${MPCOMM_ROOT} (expected ${MPCOMM_ROOT}/include/mpcomm.h and ${MPCOMM_ROOT}/lib/libmpcomm.so)"
+    )
+  endif()
+  add_compile_definitions(USE_MPCOMM)
+  message(STATUS "MPComm transport is enabled")
+  message(STATUS "  MPComm include: ${MPCOMM_INCLUDE_DIR}")
+  message(STATUS "  MPComm library: ${MPCOMM_LIBRARY}")
+  if(mpcomm_FOUND)
+    message(STATUS "  MPComm version: ${mpcomm_VERSION}")
+  else()
+    # No package config under the prefix - for example a tree where only the
+    # headers and the library were copied into place. Say so rather than imply
+    # the version was verified: the transport still builds, but an ABI mismatch
+    # would then only surface at run time.
+    message(
+      STATUS
+        "  MPComm version: unknown (no CMake package config under ${MPCOMM_ROOT}; requires >= ${MPCOMM_MINIMUM_VERSION})"
+    )
+  endif()
 endif()
 
 if(USE_TCP)

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -65,7 +65,8 @@ std::shared_ptr<Config> loadConfig() {
             {"gds", "gds"},
             {"mnnvl", "mnnvl"},
             {"nvlink", "nvlink"},
-            {"sunrise_link", "sunrise_link"}};
+            {"sunrise_link", "sunrise_link"},
+            {"mpcomm", "mpcomm"}};
 
         // Disable all transports by default
         for (const auto& entry : transport_map) {
@@ -91,6 +92,7 @@ static TransportType getTransportType(const std::string& xport_type) {
     if (xport_type == "tcp") return TCP;
     if (xport_type == "iouring") return IOURING;
     if (xport_type == "sunrise_link") return SUNRISE_LINK;
+    if (xport_type == "mpcomm") return MPCOMM;
     return UNSPEC;
 }
 

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -83,14 +83,14 @@ DEFINE_int32(
     rpc_server_port, 0,
     "RPC server port used for p2p metadata service (0 = auto-select).");
 DEFINE_string(xport_type, "",
-              "Transport type: rdma|shm|mnnvl|gds|iouring|sunrise_link");
+              "Transport type: rdma|shm|mnnvl|gds|iouring|sunrise_link|mpcomm");
 DEFINE_string(backend, "tent", "Transport backend: classic|tent");
 DEFINE_bool(notifi, false,
             "Enable RDMA notification for performance measurement.");
 DEFINE_string(
     tent_transport_hint, "unspec",
     "tent only: per-request transport_hint. "
-    "unspec|rdma|tcp|shm|nvlink|gds|io_uring|mnnvl|ascend|sunrise_link");
+    "unspec|rdma|tcp|shm|nvlink|gds|io_uring|mnnvl|ascend|sunrise_link|mpcomm");
 DEFINE_string(tent_intent_type, "unspec",
               "tent only: intent_type attached to every benchmark request. "
               "unspec|foreground_get|background_prefetch|migration|checkpoint|"

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -56,6 +56,7 @@ enum TransportType : int {
     SUNRISE_LINK,
     TPU,
     UB,
+    MPCOMM,
     // Sentinel: must remain the last enumerator.
     kNumTransportTypes,
 };
@@ -93,6 +94,8 @@ inline const char* transportTypeName(TransportType type) {
             return "tpu";
         case UB:
             return "ub";
+        case MPCOMM:
+            return "mpcomm";
         case kNumTransportTypes:
             return "unknown";
     }
@@ -112,6 +115,7 @@ inline TransportType parseTransportType(const std::string& str) {
     if (str == "sunrise_link") return SUNRISE_LINK;
     if (str == "tpu") return TPU;
     if (str == "ub") return UB;
+    if (str == "mpcomm") return MPCOMM;
     return UNSPEC;
 }
 

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -111,6 +111,7 @@ typedef struct tent_notifi_info tent_notifi_info;
 #define TRANSPORT_SUNRISE_LINK (9)
 #define TRANSPORT_TPU (10)
 #define TRANSPORT_UB (11)
+#define TRANSPORT_MPCOMM (12)
 
 struct tent_memory_options {
     char location[64];

--- a/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_adapter.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_adapter.h
@@ -1,0 +1,144 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_TRANSPORT_MPCOMM_MPCOMM_ADAPTER_H
+#define TENT_TRANSPORT_MPCOMM_MPCOMM_ADAPTER_H
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "tent/common/status.h"
+
+namespace mooncake {
+namespace tent {
+
+// A transfer issued to the MPComm data plane. Zero is never a valid handle,
+// matching MPComm's own convention for an invalid one.
+using MpcommTransferHandle = uint64_t;
+constexpr MpcommTransferHandle kInvalidMpcommTransferHandle = 0;
+
+// Outcome of a transfer that has reached a terminal state, in adapter-neutral
+// terms so that nothing above this boundary needs the provider's headers.
+struct MpcommTransferOutcome {
+    // Whether the provider reported success. MPComm only reports success once
+    // every chunk of the transfer has completed, so this implies the full
+    // request length was moved.
+    bool ok = false;
+    // Bytes the provider accounted for. MPComm counts bytes at post time, so
+    // on success this equals the request length.
+    size_t bytes_transferred = 0;
+    // Provider status, kept for diagnostics only. Zero means success.
+    int native_status = 0;
+};
+
+// Injectable MPComm boundary.
+//
+// This interface deliberately knows nothing about TENT Request, SubBatch,
+// MpcommTask, SegmentDesc or the peer cache: everything above this line is
+// TENT's own logic, and keeping it behind an interface is what lets that logic
+// be tested without RDMA hardware or a real libmpcomm - the same reason
+// UrmaAdapter and TpuPjrtShim exist for their providers.
+//
+// It is a thin pass-through rather than a device abstraction. MPComm owns its
+// own slicing, NIC and QP selection and worker threads, so there is no
+// scheduling here to model; the operations map one to one onto the provider.
+//
+// Threading: implementations must tolerate concurrent calls, because TENT
+// submits and polls transfers from several threads. MPComm itself is
+// thread-safe, so the real adapter adds no locking of its own.
+class MpcommAdapter {
+   public:
+    virtual ~MpcommAdapter() = default;
+
+    // False when the provider is not usable at all - for example when this
+    // build has no libmpcomm. install() must fail in that case rather than
+    // advertise a transport that cannot move data.
+    [[nodiscard]] virtual bool available() const noexcept = 0;
+
+    // --- Lifecycle -------------------------------------------------------
+
+    virtual Status init(const std::string &host_id,
+                        const std::string &device_names, int tcp_port) = 0;
+
+    // The port actually bound for the metadata handshake, which may differ
+    // from the one requested by init().
+    [[nodiscard]] virtual int tcpPort() const = 0;
+
+    virtual Status startAcceptThread() = 0;
+
+    // Teardown is best effort and must be safe to call when init() was never
+    // called or failed part way, since uninstall() runs unconditionally.
+    virtual void stopAcceptThread() = 0;
+    virtual void shutdown() = 0;
+
+    // --- Memory ----------------------------------------------------------
+
+    virtual Status registerMemory(void *addr, size_t length) = 0;
+    virtual void unregisterMemory(void *addr) = 0;
+    virtual Status publishBuffer(void *addr, size_t length, int numa_node) = 0;
+    virtual void unpublishBuffer(void *addr) = 0;
+
+    // --- Peers -----------------------------------------------------------
+
+    // Establishes the provider-level connection to a peer. MPComm keys its
+    // connections by host id and offers no way to close one, so callers must
+    // not call this twice for the same host id: a second call replaces the
+    // connection record wholesale, dropping the remote keys it carries and
+    // leaking the previous queue pairs.
+    virtual Status connect(const std::string &host_id,
+                           const std::string &tcp_addr, int tcp_port) = 0;
+
+    // Fetches the peer's memory keys into the provider's own cache. Idempotent
+    // and safe to repeat: the provider replaces the whole key set atomically,
+    // which is what makes a refresh possible without reconnecting.
+    virtual Status queryRemoteBuffer(const std::string &host_id,
+                                     const std::string &tcp_addr,
+                                     int tcp_port) = 0;
+
+    // --- Data path -------------------------------------------------------
+
+    // Returns kInvalidMpcommTransferHandle when the transfer could not be
+    // issued. A valid handle must eventually be passed to releaseTransfer()
+    // exactly once.
+    virtual MpcommTransferHandle putAsync(uintptr_t local_addr,
+                                          const std::string &host_id,
+                                          uintptr_t remote_addr,
+                                          size_t length) = 0;
+    virtual MpcommTransferHandle getAsync(uintptr_t local_addr,
+                                          const std::string &host_id,
+                                          uintptr_t remote_addr,
+                                          size_t length) = 0;
+
+    [[nodiscard]] virtual bool isTransferComplete(
+        MpcommTransferHandle handle) = 0;
+    virtual MpcommTransferOutcome getTransferResult(
+        MpcommTransferHandle handle) = 0;
+    virtual void releaseTransfer(MpcommTransferHandle handle) = 0;
+};
+
+// Returns the libmpcomm-backed adapter when this build has the provider,
+// otherwise an unavailable stub whose operations fail with an explicit
+// message. Tests inject their own implementation instead of calling this.
+//
+// Shared rather than unique because uninstall() drops the transport's
+// reference: a test that injected an adapter keeps its own so that it can
+// still inspect what the transport did during teardown.
+std::shared_ptr<MpcommAdapter> createDefaultMpcommAdapter();
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_TRANSPORT_MPCOMM_MPCOMM_ADAPTER_H

--- a/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_peer_registry.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_peer_registry.h
@@ -1,0 +1,161 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_TRANSPORT_MPCOMM_MPCOMM_PEER_REGISTRY_H
+#define TENT_TRANSPORT_MPCOMM_MPCOMM_PEER_REGISTRY_H
+
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "tent/common/status.h"
+#include "tent/transport/mpcomm/mpcomm_adapter.h"
+
+namespace mooncake {
+namespace tent {
+
+// Endpoint attribute published in the segment descriptor:
+//   "v1:<ipv4>:<port>"
+// The version prefix makes a later format change detectable instead of being
+// silently misparsed by an older peer. An attribute without a prefix is read
+// as v1 so that a peer predating the prefix still interoperates.
+inline constexpr char kMpcommEndpointAttrPrefix[] = "v1:";
+
+// Parses a decimal TCP port. Rejects everything atoi() would quietly turn into
+// 0 or a truncated value, which would then be used as if it were a real port.
+Status parseMpcommTcpPort(const std::string &text, int &port);
+
+// Splits "[v1:]<ipv4>:<port>" into address and port.
+Status parseMpcommEndpointAttr(const std::string &attr, std::string &addr,
+                               int &port);
+
+// Builds the attribute a peer will read, from the local segment name (which is
+// "host:rpc_port") and the port MPComm actually bound. Paired with
+// parseMpcommEndpointAttr so that the published and parsed formats cannot drift
+// apart unnoticed.
+std::string buildMpcommEndpointAttr(const std::string &local_segment_name,
+                                    int tcp_port);
+
+// One buffer range as published by a peer.
+struct MpcommBufferRange {
+    uint64_t addr{0};
+    uint64_t length{0};
+};
+
+// Lifecycle of a cached peer. The connection and the remote memory keys are
+// tracked separately because they are not equally recoverable: MPComm offers no
+// way to close a connection, so a live one must be kept and reused, whereas the
+// keys can be fetched again at any time.
+enum class MpcommPeerState {
+    // No connection yet; the owning caller is establishing one.
+    CONNECTING,
+    // The connection is established but the keys are absent or stale.
+    // Recoverable by querying again - never by reconnecting.
+    CONNECTED_NO_KEYS,
+    // Connection and keys are both valid, the keys covering covered_buffers.
+    READY,
+};
+
+// Cached state of one MPComm peer, keyed by its host id (the segment name).
+struct MpcommPeerInfo {
+    // Endpoint of the live connection. Retained so that a key refresh reaches
+    // the process we are actually connected to, even if the peer has since
+    // started advertising a different endpoint.
+    std::string tcp_addr;
+    int tcp_port{0};
+    MpcommPeerState state{MpcommPeerState::CONNECTING};
+    // Fingerprint of the peer's buffer set when its keys were last fetched,
+    // used as a cheap equality check on the hot path.
+    uint64_t buffers_epoch{0};
+    // The ranges those keys are known to cover. A differing fingerprint alone
+    // is not a reason to refetch: descriptors are cached per thread and expire
+    // independently, so two threads routinely observe different buffer sets for
+    // the same peer during a refresh window. Comparing coverage instead of
+    // equality keeps the decision monotonic - keys are refetched only when a
+    // range appears that they do not cover - which stops threads from
+    // alternately invalidating each other's work and issuing a blocking query
+    // every time. It also avoids refetching when the peer merely unregistered
+    // memory, since keys the peer no longer publishes are harmless.
+    std::vector<MpcommBufferRange> covered_buffers;
+    // Non-zero while a caller is connecting or refetching keys. Kept separate
+    // from the state so that a refresh never has to invalidate keys that are
+    // still usable: a request whose ranges the current keys cover proceeds
+    // while the refresh runs, instead of blocking behind it. The value also
+    // identifies the owner, so that a late cleanup cannot touch the work of a
+    // later one.
+    uint64_t owner_generation{0};
+};
+
+// Owns the MPComm peer cache: which peers are connected, whose keys are
+// current, and who is allowed to talk to a peer at any moment.
+//
+// Split out of MpcommTransport for two reasons. It is the part of the transport
+// with non-trivial concurrency, and it depends only on MpcommAdapter - not on
+// SegmentDesc, ControlService or the TENT runtime - so it can be constructed
+// directly and driven against an injected adapter without RDMA hardware.
+//
+// Keyed by MPComm host id rather than SegmentID because that is what MPComm
+// keys connections by: closing and reopening a segment yields a fresh
+// SegmentID for the same peer, and a second connect() to an already connected
+// peer replaces its connection record wholesale, discarding the remote keys it
+// carries and leaking the queue pairs of the previous one.
+class MpcommPeerRegistry {
+   public:
+    explicit MpcommPeerRegistry(std::shared_ptr<MpcommAdapter> adapter);
+
+    MpcommPeerRegistry(const MpcommPeerRegistry &) = delete;
+    MpcommPeerRegistry &operator=(const MpcommPeerRegistry &) = delete;
+
+    // Makes the peer usable for transfers touching `buffers`: connects if it
+    // has never been connected, and fetches its keys if they are missing or do
+    // not cover those ranges. Concurrent callers for the same peer wait for the
+    // one that owns it rather than contacting the peer a second time.
+    //
+    // `tcp_addr` / `tcp_port` are the endpoint the peer currently advertises.
+    // They are used for a first connection only; afterwards the endpoint the
+    // connection was actually made to is used, since that is the process the
+    // keys must come from.
+    Status ensure(const std::string &host_id, const std::string &tcp_addr,
+                  int tcp_port, const std::vector<MpcommBufferRange> &buffers);
+
+    // Drops every entry and wakes every waiter. Used by uninstall(): a caller
+    // released this way finds its entry gone and fails through the adapter,
+    // which by then reports that the provider is no longer initialised.
+    void clear();
+
+    // Diagnostics. Also what the hardware-free tests assert on, since the
+    // observable effect of this class is which peers it keeps and in what
+    // state.
+    [[nodiscard]] size_t size() const;
+    [[nodiscard]] bool contains(const std::string &host_id) const;
+    // Returns false when the peer is not cached at all.
+    [[nodiscard]] bool stateOf(const std::string &host_id,
+                               MpcommPeerState &state) const;
+
+   private:
+    std::shared_ptr<MpcommAdapter> adapter_;
+    std::unordered_map<std::string, MpcommPeerInfo> peers_;
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    uint64_t next_generation_{0};
+};
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_TRANSPORT_MPCOMM_MPCOMM_PEER_REGISTRY_H

--- a/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_task_mapping.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_task_mapping.h
@@ -1,0 +1,64 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_TRANSPORT_MPCOMM_MPCOMM_TASK_MAPPING_H
+#define TENT_TRANSPORT_MPCOMM_MPCOMM_TASK_MAPPING_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "tent/common/types.h"
+#include "tent/runtime/transport.h"
+#include "tent/transport/mpcomm/mpcomm_adapter.h"
+
+namespace mooncake {
+namespace tent {
+
+// Per-task state for tracking mpcomm async transfers
+struct MpcommTask {
+    Request request;
+    volatile TransferStatusEnum status_word{TransferStatusEnum::PENDING};
+    size_t transferred_bytes{0};
+    MpcommTransferHandle mpcomm_handle{kInvalidMpcommTransferHandle};
+};
+
+// SubBatch implementation for mpcomm transport
+struct MpcommSubBatch : public Transport::SubBatch {
+    std::vector<MpcommTask> task_list;
+    size_t max_size{0};
+    size_t size() const override { return task_list.size(); }
+};
+
+// Issues one request on the adapter, returning the provider handle or
+// kInvalidMpcommTransferHandle.
+//
+// This and pollMpcommTask() are free functions in their own translation unit
+// rather than private methods so that the request/completion mapping can be
+// driven against an injected adapter. That keeps the WRITE/READ mapping, the
+// short-transfer guard and releasing each handle exactly once under test in a
+// build that has neither RDMA hardware nor libmpcomm.
+MpcommTransferHandle issueMpcommTransfer(MpcommAdapter &adapter,
+                                         const Request &request,
+                                         const std::string &host_id);
+
+// Polls one task once and, if the transfer reached a terminal state, records
+// the outcome and releases the handle. A task that is not pending, or that has
+// no outstanding handle, is left untouched.
+void pollMpcommTask(MpcommAdapter &adapter, MpcommTask &task);
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_TRANSPORT_MPCOMM_MPCOMM_TASK_MAPPING_H

--- a/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/mpcomm/mpcomm_transport.h
@@ -1,0 +1,94 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_MPCOMM_TRANSPORT_H
+#define TENT_MPCOMM_TRANSPORT_H
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tent/common/concurrent/rw_spinlock.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/runtime/transport.h"
+#include "tent/transport/mpcomm/mpcomm_adapter.h"
+#include "tent/transport/mpcomm/mpcomm_peer_registry.h"
+#include "tent/transport/mpcomm/mpcomm_task_mapping.h"
+
+namespace mooncake {
+namespace tent {
+
+// Maps TENT requests onto MPComm transfers.
+//
+// The transport keeps only what needs the TENT runtime: resolving a SegmentID
+// to a peer, reading the endpoint that peer advertises, and driving batches.
+// Everything that talks to MPComm goes through MpcommAdapter, the peer cache
+// lives in MpcommPeerRegistry and the request/completion mapping in
+// mpcomm_task_mapping - which is what lets all three be exercised in a build
+// with neither RDMA hardware nor libmpcomm.
+class MpcommTransport : public Transport {
+   public:
+    MpcommTransport();
+
+    // Test seam: runs against the supplied MPComm boundary instead of the real
+    // provider. The adapter is shared so that a test still observes what the
+    // transport did after uninstall() has dropped the transport's reference.
+    explicit MpcommTransport(std::shared_ptr<MpcommAdapter> adapter);
+
+    ~MpcommTransport() override;
+
+    Status install(std::string &local_segment_name,
+                   std::shared_ptr<ControlService> metadata,
+                   std::shared_ptr<Topology> local_topology,
+                   std::shared_ptr<Config> conf = nullptr) override;
+
+    Status uninstall() override;
+
+    Status allocateSubBatch(SubBatchRef &batch, size_t max_size) override;
+
+    Status freeSubBatch(SubBatchRef &batch) override;
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request> &request_list) override;
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus &status) override;
+
+    Status addMemoryBuffer(BufferDesc &desc,
+                           const MemoryOptions &options) override;
+
+    Status removeMemoryBuffer(BufferDesc &desc) override;
+
+    const char *getName() const override { return "mpcomm"; }
+
+   private:
+    // Resolve remote segment ID to mpcomm host_id, connecting if needed
+    Status ensurePeerConnected(SegmentID target_id, std::string &host_id);
+
+   private:
+    bool installed_{false};
+    std::string local_segment_name_;
+    std::shared_ptr<ControlService> metadata_;
+    std::shared_ptr<Topology> local_topology_;
+
+    std::shared_ptr<MpcommAdapter> adapter_;
+    std::unique_ptr<MpcommPeerRegistry> peers_;
+    int tcp_port_{0};
+};
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_MPCOMM_TRANSPORT_H

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -145,6 +145,7 @@ foreach(
   tent_xport_ascend_direct
   tent_xport_sunrise_link
   tent_xport_tpu
+  tent_xport_mpcomm
   tent_metrics)
   if(TARGET ${tgt})
     target_link_libraries(tent_link_group INTERFACE ${tgt})

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -29,6 +29,15 @@
 namespace py = pybind11;
 using namespace mooncake::tent;
 
+// The enumerators below are exposed to Python as plain integers, so their
+// values are a compatibility contract shared with the C API macros. Pin them
+// here so that any divergence is a build failure instead of a protocol break
+// that only shows up between mismatched peers.
+static_assert(static_cast<int>(TransportType::UB) == TRANSPORT_UB,
+              "UB wire value must match the C API macro");
+static_assert(static_cast<int>(TransportType::MPCOMM) == TRANSPORT_MPCOMM,
+              "MPCOMM wire value must match the C API macro");
+
 // =============================================================================
 // Custom Exception Hierarchy
 // =============================================================================
@@ -302,6 +311,7 @@ PYBIND11_MODULE(tent, m) {
         .value("SUNRISE_LINK", TransportType::SUNRISE_LINK)
         .value("TPU", TransportType::TPU)
         .value("UB", TransportType::UB)
+        .value("MPCOMM", TransportType::MPCOMM)
         .export_values();
 
     py::enum_<IntentType>(m, "IntentType")

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -681,6 +681,7 @@ std::vector<TransportType> TransferEngineImpl::getSupportedTransports(
     if (transport_list_[SHM]) result.push_back(SHM);
     if (transport_list_[TCP]) result.push_back(TCP);
     if (transport_list_[GDS]) result.push_back(GDS);
+    if (transport_list_[MPCOMM]) result.push_back(MPCOMM);
     if (transport_list_[TPU]) result.push_back(TPU);
     return result;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transport_loader.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_loader.cpp
@@ -45,6 +45,10 @@
 #include "tent/transport/tpu/tpu_transport.h"
 #endif
 
+#ifdef USE_MPCOMM
+#include "tent/transport/mpcomm/mpcomm_transport.h"
+#endif
+
 namespace mooncake {
 namespace tent {
 
@@ -102,6 +106,11 @@ Status TransferEngineImpl::loadTransports() {
 #ifdef USE_TPU
     if (conf_->get("transports/tpu/enable", true))
         transport_list_[TPU] = std::make_shared<TpuTransport>();
+#endif
+
+#ifdef USE_MPCOMM
+    if (conf_->get("transports/mpcomm/enable", true))
+        transport_list_[MPCOMM] = std::make_shared<MpcommTransport>();
 #endif
 
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(ascend)
 add_subdirectory(sunrise_link)
 add_subdirectory(tpu)
 add_subdirectory(ub)
+add_subdirectory(mpcomm)
 
 add_library(tent_transport_all INTERFACE)
 foreach(
@@ -25,7 +26,8 @@ foreach(
   tent_xport_ub
   tent_xport_ascend_direct
   tent_xport_sunrise_link
-  tent_xport_tpu)
+  tent_xport_tpu
+  tent_xport_mpcomm)
   if(TARGET ${tgt})
     target_link_libraries(tent_transport_all INTERFACE ${tgt})
   endif()

--- a/mooncake-transfer-engine/tent/src/transport/mpcomm/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/transport/mpcomm/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright 2026 KVCache.AI
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+
+# Built in every configuration. Only mpcomm_adapter.cpp includes mpcomm.h, and
+# it compiles to an unavailable stub when the provider is absent; the remaining
+# translation units reach MPComm solely through MpcommAdapter. That is what
+# keeps the TENT-side logic - peer caching, endpoint parsing, request and
+# completion mapping - unit-testable in a build without libmpcomm, the same
+# arrangement TpuPjrtShim and UrmaAdapter use for their providers.
+#
+# When USE_MPCOMM is off the transport is not registered by transport_loader, so
+# these objects are simply never pulled out of the archive.
+add_library(
+  tent_xport_mpcomm STATIC mpcomm_adapter.cpp mpcomm_peer_registry.cpp
+                           mpcomm_task_mapping.cpp mpcomm_transport.cpp)
+target_link_libraries(tent_xport_mpcomm PUBLIC tent_common tent_rpc)
+
+if(USE_MPCOMM)
+  # MPCOMM_INCLUDE_DIR / MPCOMM_LIBRARY are resolved in
+  # mooncake-common/common.cmake.
+  target_include_directories(tent_xport_mpcomm PRIVATE ${MPCOMM_INCLUDE_DIR})
+  target_link_libraries(tent_xport_mpcomm PUBLIC ${MPCOMM_LIBRARY})
+endif()

--- a/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_adapter.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_adapter.cpp
@@ -1,0 +1,253 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/mpcomm/mpcomm_adapter.h"
+
+#ifdef USE_MPCOMM
+#include "mpcomm.h"
+#endif
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// The provider's numeric status is kept in the message: MPComm logs the same
+// code, which is how a user correlates a TENT failure with the library's own
+// output.
+Status providerMissing(const char *op) {
+    return Status::InternalError(
+        "MPComm " + std::string(op) +
+        " unavailable: this build was compiled without USE_MPCOMM");
+}
+
+#ifdef USE_MPCOMM
+
+Status providerFailed(const char *op, int code) {
+    return Status::InternalError(
+        "MPComm " + std::string(op) +
+        " failed, provider status=" + std::to_string(code));
+}
+
+// Thin pass-through onto libmpcomm. It adds no locking of its own because
+// MPComm is thread-safe, and no policy: every decision that could be made
+// differently lives above this boundary so that it can be tested there.
+class LibMpcommAdapter final : public MpcommAdapter {
+   public:
+    bool available() const noexcept override { return true; }
+
+    Status init(const std::string &host_id, const std::string &device_names,
+                int tcp_port) override {
+        // Constructed here rather than in the constructor so that merely
+        // creating the transport does not touch the provider, matching the
+        // lifetime the transport had before this boundary existed.
+        impl_ = std::make_unique<mpcomm::MPComm>();
+        int rc = impl_->init(host_id, device_names, tcp_port);
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            impl_.reset();
+            return providerFailed("init", rc);
+        }
+        return Status::OK();
+    }
+
+    int tcpPort() const override { return impl_ ? impl_->getTcpPort() : 0; }
+
+    Status startAcceptThread() override {
+        if (!impl_) return notInitialized("startAcceptThread");
+        int rc = impl_->startAcceptThread();
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            return providerFailed("startAcceptThread", rc);
+        }
+        return Status::OK();
+    }
+
+    void stopAcceptThread() override {
+        if (impl_) impl_->stopAcceptThread();
+    }
+
+    void shutdown() override {
+        if (!impl_) return;
+        impl_->shutdown();
+        impl_.reset();
+    }
+
+    Status registerMemory(void *addr, size_t length) override {
+        if (!impl_) return notInitialized("registerMemory");
+        int rc = impl_->registerMemory(addr, length);
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            return providerFailed("registerMemory", rc);
+        }
+        return Status::OK();
+    }
+
+    void unregisterMemory(void *addr) override {
+        if (impl_) impl_->unregisterMemory(addr);
+    }
+
+    Status publishBuffer(void *addr, size_t length, int numa_node) override {
+        if (!impl_) return notInitialized("publishBuffer");
+        int rc = impl_->publishBuffer(addr, length, numa_node);
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            return providerFailed("publishBuffer", rc);
+        }
+        return Status::OK();
+    }
+
+    void unpublishBuffer(void *addr) override {
+        if (impl_) impl_->unpublishBuffer(addr);
+    }
+
+    Status connect(const std::string &host_id, const std::string &tcp_addr,
+                   int tcp_port) override {
+        if (!impl_) return notInitialized("connect");
+        int rc = impl_->connect(host_id, tcp_addr, tcp_port);
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            return providerFailed("connect", rc);
+        }
+        return Status::OK();
+    }
+
+    Status queryRemoteBuffer(const std::string &host_id,
+                             const std::string &tcp_addr,
+                             int tcp_port) override {
+        if (!impl_) return notInitialized("queryRemoteBuffer");
+        // The provider stores the keys in its own connection record; the
+        // returned description is of no use above this boundary.
+        mpcomm::RemoteBufferInfo unused;
+        int rc = impl_->queryRemoteBuffer(host_id, tcp_addr, tcp_port, unused);
+        if (rc != mpcomm::MPCOMM_SUCCESS) {
+            return providerFailed("queryRemoteBuffer", rc);
+        }
+        return Status::OK();
+    }
+
+    MpcommTransferHandle putAsync(uintptr_t local_addr,
+                                  const std::string &host_id,
+                                  uintptr_t remote_addr,
+                                  size_t length) override {
+        if (!impl_) return kInvalidMpcommTransferHandle;
+        return toHandle(
+            impl_->putAsync(local_addr, host_id, remote_addr, length));
+    }
+
+    MpcommTransferHandle getAsync(uintptr_t local_addr,
+                                  const std::string &host_id,
+                                  uintptr_t remote_addr,
+                                  size_t length) override {
+        if (!impl_) return kInvalidMpcommTransferHandle;
+        return toHandle(
+            impl_->getAsync(local_addr, host_id, remote_addr, length));
+    }
+
+    bool isTransferComplete(MpcommTransferHandle handle) override {
+        if (!impl_ || handle == kInvalidMpcommTransferHandle) return false;
+        return impl_->isTransferComplete(handle);
+    }
+
+    MpcommTransferOutcome getTransferResult(
+        MpcommTransferHandle handle) override {
+        MpcommTransferOutcome outcome;
+        if (!impl_ || handle == kInvalidMpcommTransferHandle) return outcome;
+        auto result = impl_->getTransferResult(handle);
+        outcome.ok = result.error_code == mpcomm::MPCOMM_SUCCESS;
+        outcome.bytes_transferred = result.bytes_transferred;
+        outcome.native_status = result.error_code;
+        return outcome;
+    }
+
+    void releaseTransfer(MpcommTransferHandle handle) override {
+        if (impl_ && handle != kInvalidMpcommTransferHandle) {
+            impl_->releaseTransfer(handle);
+        }
+    }
+
+   private:
+    static Status notInitialized(const char *op) {
+        return Status::InternalError("MPComm " + std::string(op) +
+                                     " called before init()");
+    }
+
+    // MPComm's invalid handle is normalised to this boundary's own, so that
+    // nothing above needs the provider's constant.
+    static MpcommTransferHandle toHandle(mpcomm::TransferHandle handle) {
+        return handle == mpcomm::INVALID_TRANSFER_HANDLE
+                   ? kInvalidMpcommTransferHandle
+                   : static_cast<MpcommTransferHandle>(handle);
+    }
+
+    std::unique_ptr<mpcomm::MPComm> impl_;
+};
+
+#endif  // USE_MPCOMM
+
+// Used when the provider was not compiled in. It keeps a USE_MPCOMM=OFF build
+// linkable and lets the transport report a clear reason instead of failing at
+// an arbitrary later point.
+class UnavailableMpcommAdapter final : public MpcommAdapter {
+   public:
+    bool available() const noexcept override { return false; }
+
+    Status init(const std::string &, const std::string &, int) override {
+        return providerMissing("init");
+    }
+    int tcpPort() const override { return 0; }
+    Status startAcceptThread() override {
+        return providerMissing("startAcceptThread");
+    }
+    void stopAcceptThread() override {}
+    void shutdown() override {}
+
+    Status registerMemory(void *, size_t) override {
+        return providerMissing("registerMemory");
+    }
+    void unregisterMemory(void *) override {}
+    Status publishBuffer(void *, size_t, int) override {
+        return providerMissing("publishBuffer");
+    }
+    void unpublishBuffer(void *) override {}
+
+    Status connect(const std::string &, const std::string &, int) override {
+        return providerMissing("connect");
+    }
+    Status queryRemoteBuffer(const std::string &, const std::string &,
+                             int) override {
+        return providerMissing("queryRemoteBuffer");
+    }
+
+    MpcommTransferHandle putAsync(uintptr_t, const std::string &, uintptr_t,
+                                  size_t) override {
+        return kInvalidMpcommTransferHandle;
+    }
+    MpcommTransferHandle getAsync(uintptr_t, const std::string &, uintptr_t,
+                                  size_t) override {
+        return kInvalidMpcommTransferHandle;
+    }
+    bool isTransferComplete(MpcommTransferHandle) override { return false; }
+    MpcommTransferOutcome getTransferResult(MpcommTransferHandle) override {
+        return MpcommTransferOutcome{};
+    }
+    void releaseTransfer(MpcommTransferHandle) override {}
+};
+
+}  // namespace
+
+std::shared_ptr<MpcommAdapter> createDefaultMpcommAdapter() {
+#ifdef USE_MPCOMM
+    return std::make_shared<LibMpcommAdapter>();
+#else
+    return std::make_shared<UnavailableMpcommAdapter>();
+#endif
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_peer_registry.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_peer_registry.cpp
@@ -1,0 +1,335 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/mpcomm/mpcomm_peer_registry.h"
+
+#include <glog/logging.h>
+
+#include <utility>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Fingerprint of a peer's published buffer set, used only as a cheap equality
+// check before the coverage comparison.
+uint64_t computeBuffersEpoch(const std::vector<MpcommBufferRange> &buffers) {
+    uint64_t hash = 1469598103934665603ULL;  // FNV-1a 64-bit offset basis
+    auto mix = [&hash](uint64_t value) {
+        hash ^= value;
+        hash *= 1099511628211ULL;  // FNV-1a 64-bit prime
+    };
+    mix(buffers.size());
+    for (const auto &buffer : buffers) {
+        mix(buffer.addr);
+        mix(buffer.length);
+    }
+    return hash;
+}
+
+// Whether the keys cached for a peer already cover every range the peer is
+// currently observed to publish. Ranges the peer has dropped are ignored: a key
+// for memory that is no longer published is never used.
+bool keysCoverBuffers(const MpcommPeerInfo &peer,
+                      const std::vector<MpcommBufferRange> &buffers) {
+    for (const auto &buffer : buffers) {
+        bool covered = false;
+        for (const auto &range : peer.covered_buffers) {
+            if (range.addr == buffer.addr && range.length == buffer.length) {
+                covered = true;
+                break;
+            }
+        }
+        if (!covered) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
+Status parseMpcommTcpPort(const std::string &text, int &port) {
+    if (text.empty() || text.size() > 5) {
+        return Status::InvalidArgument("MpcommTransport: malformed port '" +
+                                       text + "'");
+    }
+    int value = 0;
+    for (char c : text) {
+        if (c < '0' || c > '9') {
+            return Status::InvalidArgument(
+                "MpcommTransport: non-numeric port '" + text + "'");
+        }
+        value = value * 10 + (c - '0');
+    }
+    if (value <= 0 || value > 65535) {
+        return Status::InvalidArgument("MpcommTransport: port out of range '" +
+                                       text + "'");
+    }
+    port = value;
+    return Status::OK();
+}
+
+Status parseMpcommEndpointAttr(const std::string &attr, std::string &addr,
+                               int &port) {
+    std::string body = attr;
+    // A version prefix is 'v', digits, then a colon. Host names may also begin
+    // with 'v', so require that exact shape before treating it as a version.
+    if (body.size() > 1 && body[0] == 'v') {
+        size_t i = 1;
+        while (i < body.size() && body[i] >= '0' && body[i] <= '9') ++i;
+        if (i > 1 && i < body.size() && body[i] == ':') {
+            if (body.compare(0, i + 1, kMpcommEndpointAttrPrefix) != 0) {
+                return Status::InvalidArgument(
+                    "MpcommTransport: unsupported endpoint attribute '" + attr +
+                    "', this build understands " + kMpcommEndpointAttrPrefix);
+            }
+            body.erase(0, i + 1);
+        }
+    }
+    auto sep = body.rfind(':');
+    if (sep == std::string::npos || sep == 0 || sep + 1 >= body.size()) {
+        return Status::InvalidArgument(
+            "MpcommTransport: malformed endpoint attribute '" + attr + "'");
+    }
+    addr = body.substr(0, sep);
+    if (addr.find(':') != std::string::npos) {
+        // MPComm's handshake sockets are AF_INET, and an IPv6 literal would
+        // additionally need bracket syntax to be unambiguous here.
+        return Status::InvalidArgument(
+            "MpcommTransport: only IPv4 endpoints are supported, got '" + attr +
+            "'");
+    }
+    return parseMpcommTcpPort(body.substr(sep + 1), port);
+}
+
+std::string buildMpcommEndpointAttr(const std::string &local_segment_name,
+                                    int tcp_port) {
+    // The segment name is "host:rpc_port"; only the host part identifies where
+    // this process can be reached, and the port is MPComm's own.
+    std::string host = local_segment_name;
+    auto sep = host.rfind(':');
+    if (sep != std::string::npos) host.erase(sep);
+    return std::string(kMpcommEndpointAttrPrefix) + host + ":" +
+           std::to_string(tcp_port);
+}
+
+MpcommPeerRegistry::MpcommPeerRegistry(std::shared_ptr<MpcommAdapter> adapter)
+    : adapter_(std::move(adapter)) {}
+
+Status MpcommPeerRegistry::ensure(
+    const std::string &host_id, const std::string &tcp_addr, int tcp_port,
+    const std::vector<MpcommBufferRange> &buffers) {
+    const uint64_t buffers_epoch = computeBuffersEpoch(buffers);
+
+    // Fast path: there is nothing to do while the peer is connected and its
+    // keys still describe the buffer set just observed. This runs once per
+    // submitted request, so it stays ahead of everything else.
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = peers_.find(host_id);
+        if (it != peers_.end() && it->second.state == MpcommPeerState::READY &&
+            (it->second.buffers_epoch == buffers_epoch ||
+             keysCoverBuffers(it->second, buffers))) {
+            return Status::OK();
+        }
+    }
+
+    uint64_t my_generation = 0;
+    bool needs_connect = false;
+    std::string endpoint_addr;
+    int endpoint_port = 0;
+
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        for (;;) {
+            auto it = peers_.find(host_id);
+            if (it == peers_.end()) {
+                // Never connected: claim the entry and run the full handshake.
+                MpcommPeerInfo entry;
+                entry.tcp_addr = tcp_addr;
+                entry.tcp_port = tcp_port;
+                entry.state = MpcommPeerState::CONNECTING;
+                entry.owner_generation = ++next_generation_;
+                my_generation = entry.owner_generation;
+                endpoint_addr = tcp_addr;
+                endpoint_port = tcp_port;
+                needs_connect = true;
+                peers_.emplace(host_id, std::move(entry));
+                break;
+            }
+            // Keys that already cover the observed ranges are usable whatever
+            // another caller may be doing to this entry: the connection is live
+            // and those keys stay valid, so a refresh in progress must not
+            // block a request that does not need its result.
+            if (it->second.state == MpcommPeerState::READY &&
+                (it->second.buffers_epoch == buffers_epoch ||
+                 keysCoverBuffers(it->second, buffers))) {
+                return Status::OK();
+            }
+            if (it->second.owner_generation != 0) {
+                // Owned by another caller. Re-evaluate once it is done rather
+                // than trusting the outcome: it may have failed and left work.
+                cv_.wait(lock);
+                continue;
+            }
+            // Unowned, and the keys are missing or do not cover what this
+            // request needs. Take ownership of a key refresh over the existing
+            // connection - reconnecting would replace MPComm's record for this
+            // host, dropping the keys it carries and leaking its queue pairs.
+            // Query the endpoint the connection was made to rather than the
+            // newly advertised one, so the keys match the live connection.
+            needs_connect = it->second.state == MpcommPeerState::CONNECTING;
+            endpoint_addr = it->second.tcp_addr;
+            endpoint_port = it->second.tcp_port;
+            if (!needs_connect &&
+                (endpoint_addr != tcp_addr || endpoint_port != tcp_port)) {
+                LOG(WARNING)
+                    << "MpcommTransport: peer " << host_id << " now advertises "
+                    << tcp_addr << ":" << tcp_port
+                    << " but the live connection uses " << endpoint_addr << ":"
+                    << endpoint_port
+                    << "; MPComm cannot replace a connection, so this peer "
+                       "stays reachable only at the old endpoint";
+            }
+            it->second.owner_generation = ++next_generation_;
+            my_generation = it->second.owner_generation;
+            break;
+        }
+    }
+
+    // Every exit that does not publish usable keys has to release ownership, or
+    // later callers would wait on this entry forever. A guard covers early
+    // returns and exceptions alike, which a hand-written cleanup at each return
+    // would not. An established connection is kept rather than dropped: MPComm
+    // cannot close one, so discarding the entry would only cause a reconnect,
+    // which is exactly what has to be avoided.
+    struct PeerGuard {
+        MpcommPeerRegistry *self;
+        const std::string *host;
+        uint64_t generation;
+        bool committed{false};
+        ~PeerGuard() {
+            if (committed) return;
+            bool changed = false;
+            try {
+                std::lock_guard<std::mutex> lock(self->mutex_);
+                auto it = self->peers_.find(*host);
+                // Touch only our own claim: clear() may have emptied the map,
+                // and another caller may already own a newer entry.
+                if (it != self->peers_.end() &&
+                    it->second.owner_generation == generation) {
+                    if (it->second.state == MpcommPeerState::CONNECTING) {
+                        // No connection was established, nothing to keep.
+                        self->peers_.erase(it);
+                    } else {
+                        it->second.owner_generation = 0;
+                    }
+                    changed = true;
+                }
+            } catch (...) {
+                return;  // a destructor must not throw
+            }
+            if (changed) self->cv_.notify_all();
+        }
+    } guard{this, &host_id, my_generation};
+
+    if (needs_connect) {
+        auto status = adapter_->connect(host_id, endpoint_addr, endpoint_port);
+        if (!status.ok()) {
+            LOG(ERROR) << "MpcommTransport: Failed to connect to " << host_id
+                       << " at " << endpoint_addr << ":" << endpoint_port
+                       << ": " << status.ToString();
+            return status;
+        }
+        // Record that the connection now exists before the keys are fetched:
+        // if the query fails, the guard has to keep the connection rather than
+        // erase the entry and let the next caller reconnect.
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto it = peers_.find(host_id);
+            if (it != peers_.end() &&
+                it->second.owner_generation == my_generation) {
+                it->second.state = MpcommPeerState::CONNECTED_NO_KEYS;
+            }
+        }
+    }
+
+    // Fetch the peer's memory keys. This is the only source of its rkeys, so
+    // without them every transfer to this peer fails; report the failure rather
+    // than publish an entry that cannot work. The usual cause is a peer that
+    // has not finished registering its buffers, which a retry resolves - a
+    // retry of the query alone, since the entry stays CONNECTED_NO_KEYS.
+    auto status =
+        adapter_->queryRemoteBuffer(host_id, endpoint_addr, endpoint_port);
+    if (!status.ok()) {
+        LOG(ERROR) << "MpcommTransport: Failed to query remote buffers from "
+                   << host_id << ": " << status.ToString();
+        return status;
+    }
+
+    // Publish and release the waiters. Look the entry up rather than inserting
+    // it: if it is gone the registry was cleared while we worked, and
+    // re-creating it would resurrect a stale entry.
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = peers_.find(host_id);
+        if (it == peers_.end() ||
+            it->second.owner_generation != my_generation) {
+            return Status::InternalError(
+                "MpcommTransport: peer entry dropped during handshake");
+        }
+        it->second.state = MpcommPeerState::READY;
+        it->second.owner_generation = 0;
+        it->second.buffers_epoch = buffers_epoch;
+        it->second.covered_buffers = buffers;
+    }
+    guard.committed = true;
+    cv_.notify_all();
+
+    if (needs_connect) {
+        LOG(INFO) << "MpcommTransport: Connected to segment " << host_id
+                  << " at " << endpoint_addr << ":" << endpoint_port;
+    }
+    return Status::OK();
+}
+
+void MpcommPeerRegistry::clear() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        peers_.clear();
+    }
+    // Release anyone blocked waiting for work that will never finish.
+    cv_.notify_all();
+}
+
+size_t MpcommPeerRegistry::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return peers_.size();
+}
+
+bool MpcommPeerRegistry::contains(const std::string &host_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return peers_.find(host_id) != peers_.end();
+}
+
+bool MpcommPeerRegistry::stateOf(const std::string &host_id,
+                                 MpcommPeerState &state) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = peers_.find(host_id);
+    if (it == peers_.end()) return false;
+    state = it->second.state;
+    return true;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_task_mapping.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_task_mapping.cpp
@@ -1,0 +1,79 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/mpcomm/mpcomm_task_mapping.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace tent {
+
+MpcommTransferHandle issueMpcommTransfer(MpcommAdapter &adapter,
+                                         const Request &request,
+                                         const std::string &host_id) {
+    // MPComm performs its own slicing and NIC/QP selection, so one request maps
+    // onto exactly one provider transfer.
+    auto local_addr = reinterpret_cast<uintptr_t>(request.source);
+    auto remote_addr = static_cast<uintptr_t>(request.target_offset);
+    if (request.opcode == Request::WRITE) {
+        return adapter.putAsync(local_addr, host_id, remote_addr,
+                                request.length);
+    }
+    return adapter.getAsync(local_addr, host_id, remote_addr, request.length);
+}
+
+void pollMpcommTask(MpcommAdapter &adapter, MpcommTask &task) {
+    if (task.status_word != TransferStatusEnum::PENDING ||
+        task.mpcomm_handle == kInvalidMpcommTransferHandle) {
+        return;
+    }
+    if (!adapter.isTransferComplete(task.mpcomm_handle)) return;
+
+    auto outcome = adapter.getTransferResult(task.mpcomm_handle);
+    if (!outcome.ok) {
+        LOG(WARNING) << "MpcommTransport: Transfer failed, provider status="
+                     << outcome.native_status;
+        task.status_word = TransferStatusEnum::FAILED;
+        // The cached peer is deliberately kept even for connection errors:
+        // MPComm has no disconnect API, so a second connect() to the same host
+        // replaces its connection record wholesale, leaking the previous queue
+        // pairs and blanking the remote memory keys that concurrent transfers
+        // are still using. Recovering from a peer restart therefore needs
+        // library support and is left out of this version.
+    } else if (outcome.bytes_transferred < task.request.length) {
+        // Defensive: MPComm only reports success once every chunk has
+        // completed, so this is not expected to trigger. It is kept so that a
+        // future change in the library's success semantics cannot silently
+        // surface a partial copy as a full transfer, which matters because the
+        // engine accumulates request.length for completed tasks. Compared with
+        // '<' rather than '!=': the reported count is a posted-byte count, so
+        // it must never be trusted to be short, but a larger value is not an
+        // error.
+        LOG(WARNING) << "MpcommTransport: Short transfer, "
+                     << outcome.bytes_transferred << " of "
+                     << task.request.length << " bytes";
+        task.transferred_bytes = outcome.bytes_transferred;
+        task.status_word = TransferStatusEnum::FAILED;
+    } else {
+        task.status_word = TransferStatusEnum::COMPLETED;
+        task.transferred_bytes = outcome.bytes_transferred;
+    }
+    // Released on every terminal outcome, and the handle is cleared so that a
+    // repeated poll of the same task cannot release it a second time.
+    adapter.releaseTransfer(task.mpcomm_handle);
+    task.mpcomm_handle = kInvalidMpcommTransferHandle;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mpcomm/mpcomm_transport.cpp
@@ -1,0 +1,454 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/transport/mpcomm/mpcomm_transport.h"
+
+#include <glog/logging.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <utility>
+
+#include "tent/common/config.h"
+#include "tent/common/status.h"
+#include "tent/common/types.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/slab.h"
+
+namespace mooncake {
+namespace tent {
+
+// MPComm registers device memory through the standard ibv_reg_mr path and
+// relies on the nvidia-peermem kernel module to pin GPU pages; it has no
+// dma-buf fallback. That is the same dependency RdmaTransport gates its GPU
+// capabilities on, so the same probe is applied here.
+static bool isGpuDirectRdmaSupported(const std::shared_ptr<Config> &conf) {
+    if (conf && conf->get("transports/mpcomm/disable_gpu_direct_rdma", false)) {
+        return false;
+    }
+    std::ifstream modules("/proc/modules");
+    std::string line;
+    while (std::getline(modules, line)) {
+        if (line.find("nvidia_peermem") != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+MpcommTransport::MpcommTransport()
+    : MpcommTransport(createDefaultMpcommAdapter()) {}
+
+MpcommTransport::MpcommTransport(std::shared_ptr<MpcommAdapter> adapter)
+    : adapter_(std::move(adapter)),
+      peers_(std::make_unique<MpcommPeerRegistry>(adapter_)) {}
+
+MpcommTransport::~MpcommTransport() { uninstall(); }
+
+Status MpcommTransport::install(std::string &local_segment_name,
+                                std::shared_ptr<ControlService> metadata,
+                                std::shared_ptr<Topology> local_topology,
+                                std::shared_ptr<Config> conf) {
+    if (installed_) {
+        return Status::InvalidArgument(
+            "MpcommTransport has already been installed" LOC_MARK);
+    }
+    if (!adapter_ || !adapter_->available()) {
+        return Status::InternalError(
+            "MpcommTransport: MPComm provider is not available" LOC_MARK);
+    }
+
+    metadata_ = metadata;
+    local_segment_name_ = local_segment_name;
+    local_topology_ = local_topology;
+
+    // A previous uninstall() may have left entries behind if a handshake was
+    // still running; they refer to connections the provider has torn down.
+    peers_->clear();
+
+    // Resolve the listener port before initialising the provider, so that a
+    // malformed value fails with nothing to unwind. MPComm needs a non-zero
+    // port and does not fall back to an ephemeral one, so a value that atoi()
+    // would quietly turn into 0 has to be rejected rather than used.
+    tcp_port_ = 13579;
+    if (const char *env_port = std::getenv("MPCOMM_TCP_PORT")) {
+        auto status = parseMpcommTcpPort(env_port, tcp_port_);
+        if (!status.ok()) {
+            LOG(ERROR) << "MpcommTransport: invalid MPCOMM_TCP_PORT: "
+                       << status.ToString();
+            return status;
+        }
+    }
+
+    // Extract device names from TENT Topology
+    std::string device_names;
+    if (local_topology_) {
+        bool first = true;
+        for (size_t i = 0; i < local_topology_->nic_list_.size(); ++i) {
+            auto &nic = local_topology_->nic_list_[i];
+            if (nic.type == Topology::NIC_RDMA) {
+                if (!first) device_names += ",";
+                device_names += nic.name;
+                first = false;
+            }
+        }
+    }
+
+    // Initialize mpcomm with local_segment_name as host_id
+    // mpcomm manages its own topology discovery internally
+    auto status = adapter_->init(local_segment_name_, device_names, tcp_port_);
+    if (!status.ok()) {
+        LOG(ERROR) << "MpcommTransport: Failed to initialize mpcomm: "
+                   << status.ToString();
+        uninstall();
+        return status;
+    }
+
+    // Update tcp_port_ with the actual assigned port
+    tcp_port_ = adapter_->tcpPort();
+
+    // Start accept thread for incoming connections
+    status = adapter_->startAcceptThread();
+    if (!status.ok()) {
+        LOG(ERROR) << "MpcommTransport: Failed to start accept thread: "
+                   << status.ToString();
+        uninstall();
+        return status;
+    }
+
+    // MPComm always handles host DRAM. Device memory additionally requires the
+    // nvidia-peermem module (see isGpuDirectRdmaSupported above). Capabilities
+    // feed transport selection, so advertising them unconditionally would let
+    // routing pick MPComm on a host without the module for device memory
+    // published by a peer that has it, where local registration never
+    // succeeded.
+    caps.dram_to_dram = true;
+    if (isGpuDirectRdmaSupported(conf)) {
+        caps.dram_to_gpu = true;
+        caps.gpu_to_dram = true;
+        caps.gpu_to_gpu = true;
+    } else if (conf &&
+               conf->get("transports/mpcomm/disable_gpu_direct_rdma", false)) {
+        LOG(INFO) << "MpcommTransport: GPU memory support disabled by "
+                     "transports/mpcomm/disable_gpu_direct_rdma";
+    } else {
+        LOG(INFO) << "MpcommTransport: nvidia_peermem not detected, GPU memory "
+                     "support is disabled";
+    }
+
+    // Publish mpcomm connection info to segment transport_attrs so remote
+    // peers know how to connect via mpcomm. All mutations of the local
+    // SegmentDesc must go through updateLocal(): snapshots returned by
+    // getLocal() are copy-on-write and must never be written through.
+    {
+        std::string mpcomm_addr =
+            buildMpcommEndpointAttr(local_segment_name_, tcp_port_);
+
+        auto &manager = metadata_->segmentManager();
+        auto publish = manager.updateLocal([&](SegmentDesc &segment) -> Status {
+            auto &detail = std::get<MemorySegmentDesc>(segment.detail);
+            detail.transport_attrs[static_cast<int>(TransportType::MPCOMM)] =
+                mpcomm_addr;
+            return Status::OK();
+        });
+        if (publish.ok()) publish = manager.synchronizeLocal();
+        if (!publish.ok()) {
+            LOG(ERROR) << "MpcommTransport: Failed to publish transport attrs: "
+                       << publish.ToString();
+            uninstall();
+            return publish;
+        }
+    }
+
+    installed_ = true;
+
+    LOG(INFO) << "MpcommTransport: Installed successfully, host_id="
+              << local_segment_name_ << ", tcp_port=" << tcp_port_
+              << ", devices=" << device_names;
+
+    return Status::OK();
+}
+
+Status MpcommTransport::uninstall() {
+    // Tear down unconditionally rather than gating on installed_: install()
+    // may fail after the provider was initialised and its accept thread
+    // started, leaving installed_ false while resources still need releasing.
+    if (adapter_) {
+        adapter_->stopAcceptThread();
+        adapter_->shutdown();
+    }
+
+    // Entries describe connections the provider has just released. Clearing
+    // also wakes anyone waiting on a handshake that will never finish; such a
+    // caller then fails through the adapter, which now reports that the
+    // provider is no longer initialised.
+    if (peers_) peers_->clear();
+
+    installed_ = false;
+    return Status::OK();
+}
+
+Status MpcommTransport::allocateSubBatch(SubBatchRef &batch, size_t max_size) {
+    auto mpcomm_batch = Slab<MpcommSubBatch>::Get().allocate();
+    if (!mpcomm_batch)
+        return Status::InternalError(
+            "Unable to allocate mpcomm sub-batch" LOC_MARK);
+    batch = mpcomm_batch;
+    mpcomm_batch->task_list.reserve(max_size);
+    mpcomm_batch->max_size = max_size;
+    return Status::OK();
+}
+
+Status MpcommTransport::freeSubBatch(SubBatchRef &batch) {
+    auto mpcomm_batch = dynamic_cast<MpcommSubBatch *>(batch);
+    if (!mpcomm_batch)
+        return Status::InvalidArgument("Invalid mpcomm sub-batch" LOC_MARK);
+
+    // Handles are released in getTransferStatus() once a transfer reaches a
+    // terminal state. Do not call into MPComm from here: the engine documents
+    // that freeSubBatch() must not touch transport-internal state, and that
+    // callers ensure no transfer is in flight. A non-zero handle at this point
+    // means the transfer was not drained; the handle is reclaimed when MPComm
+    // shuts down. Logged as a warning rather than an error because the engine
+    // frees active batches during teardown without draining them first.
+    for (auto &task : mpcomm_batch->task_list) {
+        if (task.mpcomm_handle != kInvalidMpcommTransferHandle) {
+            LOG(WARNING) << "MpcommTransport: sub-batch freed while a transfer "
+                            "is still in flight (handle="
+                         << task.mpcomm_handle << ")";
+        }
+    }
+
+    Slab<MpcommSubBatch>::Get().deallocate(mpcomm_batch);
+    batch = nullptr;
+    return Status::OK();
+}
+
+Status MpcommTransport::submitTransferTasks(
+    SubBatchRef batch, const std::vector<Request> &request_list) {
+    if (!installed_ || !adapter_) {
+        return Status::InternalError(
+            "MpcommTransport: mpcomm not initialized" LOC_MARK);
+    }
+
+    auto mpcomm_batch = dynamic_cast<MpcommSubBatch *>(batch);
+    if (!mpcomm_batch)
+        return Status::InvalidArgument("Invalid mpcomm sub-batch" LOC_MARK);
+    if (request_list.size() + mpcomm_batch->task_list.size() >
+        mpcomm_batch->max_size)
+        return Status::TooManyRequests("Exceed batch capacity" LOC_MARK);
+
+    // Pre-allocate task slots to avoid vector reallocation during the loop,
+    // which would invalidate pointers/references to earlier tasks.
+    size_t base_index = mpcomm_batch->task_list.size();
+    mpcomm_batch->task_list.resize(base_index + request_list.size());
+
+    for (size_t i = 0; i < request_list.size(); ++i) {
+        auto &request = request_list[i];
+        size_t task_index = base_index + i;
+        auto &task = mpcomm_batch->task_list[task_index];
+        task.request = request;
+        task.status_word = TransferStatusEnum::PENDING;
+        task.transferred_bytes = 0;
+        task.mpcomm_handle = kInvalidMpcommTransferHandle;
+
+        // Resolve the remote host_id from SegmentID
+        std::string remote_host_id;
+        auto status = ensurePeerConnected(request.target_id, remote_host_id);
+        if (!status.ok()) {
+            LOG(ERROR) << "MpcommTransport: Failed to connect to target "
+                       << request.target_id << ": " << status.ToString();
+            task.status_word = TransferStatusEnum::FAILED;
+            continue;
+        }
+
+        task.mpcomm_handle =
+            issueMpcommTransfer(*adapter_, request, remote_host_id);
+        if (task.mpcomm_handle == kInvalidMpcommTransferHandle) {
+            LOG(ERROR) << "MpcommTransport: Async transfer failed for "
+                       << (request.opcode == Request::WRITE ? "WRITE" : "READ")
+                       << " to " << remote_host_id;
+            task.status_word = TransferStatusEnum::FAILED;
+        }
+    }
+
+    return Status::OK();
+}
+
+Status MpcommTransport::getTransferStatus(SubBatchRef batch, int task_id,
+                                          TransferStatus &status) {
+    auto mpcomm_batch = dynamic_cast<MpcommSubBatch *>(batch);
+    if (!mpcomm_batch)
+        return Status::InvalidArgument("Invalid mpcomm sub-batch" LOC_MARK);
+    if (task_id < 0 || task_id >= (int)mpcomm_batch->task_list.size()) {
+        return Status::InvalidArgument("Invalid task id" LOC_MARK);
+    }
+    auto &task = mpcomm_batch->task_list[task_id];
+
+    if (task.status_word == TransferStatusEnum::PENDING &&
+        task.mpcomm_handle != kInvalidMpcommTransferHandle) {
+        if (!installed_ || !adapter_) {
+            // uninstall() ran with this transfer still outstanding, so its
+            // outcome can no longer be learned. Fail it rather than leave the
+            // caller polling a task that can never reach a terminal state.
+            LOG(WARNING) << "MpcommTransport: transfer abandoned, transport "
+                            "was uninstalled";
+            task.status_word = TransferStatusEnum::FAILED;
+            task.mpcomm_handle = kInvalidMpcommTransferHandle;
+        } else {
+            // Lazy poll: check mpcomm completion status on demand.
+            pollMpcommTask(*adapter_, task);
+        }
+    }
+
+    status.s = task.status_word;
+    status.transferred_bytes = task.transferred_bytes;
+    return Status::OK();
+}
+
+Status MpcommTransport::addMemoryBuffer(BufferDesc &desc,
+                                        const MemoryOptions &options) {
+    if (!installed_ || !adapter_) {
+        return Status::InternalError(
+            "MpcommTransport: mpcomm not initialized" LOC_MARK);
+    }
+
+    void *addr = reinterpret_cast<void *>(desc.addr);
+    size_t length = desc.length;
+
+    auto status = adapter_->registerMemory(addr, length);
+    if (!status.ok()) {
+        LOG(ERROR) << "MpcommTransport: Failed to register memory at " << addr
+                   << " length=" << length << ": " << status.ToString();
+        return status;
+    }
+
+    // Publish buffer so remote peers can discover it
+    // mpcomm handles NUMA awareness internally
+    int numa_node = -1;  // Auto-detect
+    status = adapter_->publishBuffer(addr, length, numa_node);
+    if (!status.ok()) {
+        LOG(ERROR) << "MpcommTransport: Failed to publish buffer: "
+                   << status.ToString();
+        adapter_->unregisterMemory(addr);
+        return status;
+    }
+
+    // Mark this buffer as using MPCOMM transport
+    desc.transports.push_back(TransportType::MPCOMM);
+
+    return Status::OK();
+}
+
+Status MpcommTransport::removeMemoryBuffer(BufferDesc &desc) {
+    if (!installed_ || !adapter_) return Status::OK();
+
+    void *addr = reinterpret_cast<void *>(desc.addr);
+
+    // Unpublish and unregister from mpcomm
+    adapter_->unpublishBuffer(addr);
+    adapter_->unregisterMemory(addr);
+
+    return Status::OK();
+}
+
+Status MpcommTransport::ensurePeerConnected(SegmentID target_id,
+                                            std::string &host_id) {
+    // Pin the snapshot. getLocal() returns the owning reference by value, and
+    // the raw-pointer form of getRemoteCached() hands out a pointer into a
+    // per-thread snapshot cache; either pointer outlives its guarantee once the
+    // reference is dropped or the cache is refreshed. SegmentManager offers
+    // owning variants for exactly this, and the descriptor is read throughout
+    // this function, so hold the reference rather than a bare pointer.
+    SegmentDescRef desc_ref;
+    if (target_id == LOCAL_SEGMENT_ID) {
+        desc_ref = metadata_->segmentManager().getLocal();
+    } else {
+        auto status =
+            metadata_->segmentManager().getRemoteCached(desc_ref, target_id);
+        if (!status.ok()) {
+            return Status::InvalidArgument(
+                "MpcommTransport: Cannot find segment descriptor for sid=" +
+                std::to_string(target_id));
+        }
+    }
+    SegmentDesc *desc = desc_ref.get();
+    if (!desc) {
+        return Status::InvalidArgument(
+            "MpcommTransport: Null segment descriptor for sid=" +
+            std::to_string(target_id));
+    }
+    if (desc->type != SegmentType::Memory) {
+        // getMemory() would throw on a file segment. MPComm advertises no file
+        // capability, so reaching here means a selection bug upstream.
+        return Status::InvalidArgument(
+            "MpcommTransport: Not a memory segment, sid=" +
+            std::to_string(target_id));
+    }
+
+    // The segment name serves as the remote host_id
+    const std::string remote_host_id = desc->name;
+    const auto &mem_desc = desc->getMemory();
+
+    std::string advertised_addr;
+    int advertised_port = 0;
+    const auto *attr =
+        mem_desc.getTransportAttrs(static_cast<int>(TransportType::MPCOMM));
+    if (attr && !attr->empty()) {
+        auto status =
+            parseMpcommEndpointAttr(*attr, advertised_addr, advertised_port);
+        if (!status.ok()) return status;
+    } else {
+        // install() publishes this attribute, so its absence means the peer
+        // runs no MPComm transport. Deriving a port from our own would hand
+        // connect() an endpoint owned by an unrelated process, and MPComm's
+        // handshake has no timeout, so a wrong guess can block the submitting
+        // thread indefinitely. Require an explicit override instead.
+        const char *env_port = std::getenv("MPCOMM_REMOTE_TCP_PORT");
+        if (!env_port) {
+            return Status::InvalidArgument("MpcommTransport: segment " +
+                                           remote_host_id +
+                                           " publishes no mpcomm endpoint");
+        }
+        auto status = parseMpcommTcpPort(env_port, advertised_port);
+        if (!status.ok()) return status;
+        advertised_addr = remote_host_id;
+        auto sep = advertised_addr.rfind(':');
+        if (sep != std::string::npos) advertised_addr.erase(sep);
+        LOG(WARNING) << "MpcommTransport: segment " << remote_host_id
+                     << " publishes no mpcomm endpoint, using "
+                     << advertised_addr << ":" << advertised_port
+                     << " from MPCOMM_REMOTE_TCP_PORT";
+    }
+
+    // Reused per thread: this runs once per submitted request, so a fresh
+    // vector here would allocate on every transfer.
+    thread_local std::vector<MpcommBufferRange> buffers;
+    buffers.clear();
+    buffers.reserve(mem_desc.buffers.size());
+    for (const auto &buffer : mem_desc.buffers) {
+        buffers.push_back({buffer.addr, buffer.length});
+    }
+
+    auto status = peers_->ensure(remote_host_id, advertised_addr,
+                                 advertised_port, buffers);
+    if (!status.ok()) return status;
+
+    host_id = remote_host_id;
+    return Status::OK();
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -216,6 +216,31 @@ if(USE_SUNRISE)
   add_test(NAME tent_sunrise_link_transport_test
            COMMAND tent_sunrise_link_transport_test)
 endif()
+
+if(USE_MPCOMM)
+  add_executable(tent_mpcomm_transport_test mpcomm_transport_test.cpp)
+  target_link_libraries(tent_mpcomm_transport_test PRIVATE gtest gtest_main
+                                                           tent_link_group)
+  target_include_directories(
+    tent_mpcomm_transport_test
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+  add_test(NAME tent_mpcomm_transport_test COMMAND tent_mpcomm_transport_test)
+endif()
+
+# Boundary tests of the TENT side of the mpcomm transport, driven through an
+# injected MpcommAdapter. Built unconditionally: nothing here includes mpcomm.h
+# and nothing needs an RDMA device, so these run wherever the rest of the suite
+# runs. The hardware data path stays in tent_mpcomm_transport_test above, which
+# skips itself when no device is present.
+add_executable(tent_mpcomm_boundary_test mpcomm_boundary_test.cpp)
+target_link_libraries(tent_mpcomm_boundary_test PRIVATE gtest gtest_main
+                                                        tent_link_group)
+target_include_directories(
+  tent_mpcomm_boundary_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include
+                                    ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
+add_test(NAME tent_mpcomm_boundary_test COMMAND tent_mpcomm_boundary_test)
+
 add_executable(tent_fault_proxy_test fault_proxy_test.cpp)
 target_link_libraries(tent_fault_proxy_test PRIVATE gtest gtest_main
                                                     tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/mpcomm_boundary_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/mpcomm_boundary_test.cpp
@@ -1,0 +1,600 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Hardware-free tests of the TENT side of the MPComm transport. Everything the
+// transport does to the provider goes through MpcommAdapter, so an injected
+// fake is enough to drive the boundary: endpoint publication and parsing,
+// single-flight connection, key-query retry, dynamic buffer refresh, the
+// request and completion mapping, short-transfer handling, releasing each
+// handle exactly once, and teardown.
+//
+// These need neither RDMA devices nor libmpcomm and therefore run in CI. What
+// they deliberately do not cover is MPComm's own behaviour - slicing, NIC and
+// QP selection, worker scheduling - which is the provider's responsibility and
+// is exercised by mpcomm_transport_test.cpp on real hardware.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "tent/transport/mpcomm/mpcomm_peer_registry.h"
+#include "tent/transport/mpcomm/mpcomm_task_mapping.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Programmable stand-in for libmpcomm. Counts what the transport asked for and
+// can be told to fail a given number of times, which is how the recovery paths
+// are reached without a peer.
+class FakeMpcommAdapter final : public MpcommAdapter {
+   public:
+    bool available() const noexcept override { return true; }
+
+    Status init(const std::string &, const std::string &, int port) override {
+        bound_port = port;
+        return Status::OK();
+    }
+    int tcpPort() const override { return bound_port; }
+    Status startAcceptThread() override {
+        ++accept_thread_starts;
+        return Status::OK();
+    }
+    void stopAcceptThread() override { ++accept_thread_stops; }
+    void shutdown() override { ++shutdowns; }
+
+    Status registerMemory(void *, size_t) override { return Status::OK(); }
+    void unregisterMemory(void *) override {}
+    Status publishBuffer(void *, size_t, int) override { return Status::OK(); }
+    void unpublishBuffer(void *) override {}
+
+    Status connect(const std::string &host_id, const std::string &tcp_addr,
+                   int tcp_port) override {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            ++connect_calls;
+            last_connect_host = host_id;
+            last_connect_addr = tcp_addr;
+            last_connect_port = tcp_port;
+        }
+        // Held open long enough that every thread in the single-flight test is
+        // inside ensure() while the first connect is still running.
+        if (connect_delay.count() > 0) {
+            std::this_thread::sleep_for(connect_delay);
+        }
+        if (connect_failures > 0) {
+            --connect_failures;
+            return Status::InternalError("injected connect failure");
+        }
+        return Status::OK();
+    }
+
+    Status queryRemoteBuffer(const std::string &host_id,
+                             const std::string &tcp_addr,
+                             int tcp_port) override {
+        std::lock_guard<std::mutex> lock(mutex);
+        ++query_calls;
+        last_query_host = host_id;
+        last_query_addr = tcp_addr;
+        last_query_port = tcp_port;
+        if (query_failures > 0) {
+            --query_failures;
+            return Status::InternalError("injected query failure");
+        }
+        return Status::OK();
+    }
+
+    MpcommTransferHandle putAsync(uintptr_t local_addr,
+                                  const std::string &host_id,
+                                  uintptr_t remote_addr,
+                                  size_t length) override {
+        ++put_calls;
+        return record(local_addr, host_id, remote_addr, length);
+    }
+    MpcommTransferHandle getAsync(uintptr_t local_addr,
+                                  const std::string &host_id,
+                                  uintptr_t remote_addr,
+                                  size_t length) override {
+        ++get_calls;
+        return record(local_addr, host_id, remote_addr, length);
+    }
+
+    bool isTransferComplete(MpcommTransferHandle) override {
+        return transfer_complete;
+    }
+    MpcommTransferOutcome getTransferResult(MpcommTransferHandle) override {
+        ++result_calls;
+        return outcome;
+    }
+    void releaseTransfer(MpcommTransferHandle handle) override {
+        ++release_calls;
+        last_released = handle;
+    }
+
+    // --- knobs ---
+    int connect_failures{0};
+    int query_failures{0};
+    std::chrono::milliseconds connect_delay{0};
+    bool issue_fails{false};
+    bool transfer_complete{true};
+    MpcommTransferOutcome outcome{};
+
+    // --- observations ---
+    mutable std::mutex mutex;
+    int connect_calls{0};
+    int query_calls{0};
+    int accept_thread_starts{0};
+    int accept_thread_stops{0};
+    int shutdowns{0};
+    int put_calls{0};
+    int get_calls{0};
+    int result_calls{0};
+    int release_calls{0};
+    int bound_port{0};
+    std::string last_connect_host;
+    std::string last_connect_addr;
+    int last_connect_port{0};
+    std::string last_query_host;
+    std::string last_query_addr;
+    int last_query_port{0};
+    uintptr_t last_local_addr{0};
+    uintptr_t last_remote_addr{0};
+    size_t last_length{0};
+    std::string last_transfer_host;
+    MpcommTransferHandle last_released{kInvalidMpcommTransferHandle};
+
+   private:
+    MpcommTransferHandle record(uintptr_t local_addr,
+                                const std::string &host_id,
+                                uintptr_t remote_addr, size_t length) {
+        last_local_addr = local_addr;
+        last_remote_addr = remote_addr;
+        last_length = length;
+        last_transfer_host = host_id;
+        if (issue_fails) return kInvalidMpcommTransferHandle;
+        return ++next_handle;
+    }
+
+    MpcommTransferHandle next_handle{0};
+};
+
+std::vector<MpcommBufferRange> makeRanges(
+    std::initializer_list<std::pair<uint64_t, uint64_t>> list) {
+    std::vector<MpcommBufferRange> out;
+    for (const auto &entry : list) {
+        out.push_back(MpcommBufferRange{entry.first, entry.second});
+    }
+    return out;
+}
+
+// MpcommTask::status_word is volatile, which cannot bind to the const
+// references gtest's matchers take, so read it out as a plain value first.
+TransferStatusEnum statusOf(const MpcommTask &task) { return task.status_word; }
+
+// ===================================================================
+// Endpoint publication and parsing
+// ===================================================================
+
+TEST(MpcommEndpointAttr, PublishedFormatRoundTripsThroughTheParser) {
+    // The published attribute is derived from the segment name, whose port is
+    // the tent RPC port and must not be mistaken for MPComm's.
+    auto attr = buildMpcommEndpointAttr("10.0.0.1:12345", 13579);
+    EXPECT_EQ(attr, "v1:10.0.0.1:13579");
+
+    std::string addr;
+    int port = 0;
+    ASSERT_TRUE(parseMpcommEndpointAttr(attr, addr, port).ok());
+    EXPECT_EQ(addr, "10.0.0.1");
+    EXPECT_EQ(port, 13579);
+}
+
+TEST(MpcommEndpointAttr, UnversionedAttributeIsReadAsV1) {
+    // Interoperability with a peer that predates the version prefix.
+    std::string addr;
+    int port = 0;
+    ASSERT_TRUE(parseMpcommEndpointAttr("10.0.0.1:13579", addr, port).ok());
+    EXPECT_EQ(addr, "10.0.0.1");
+    EXPECT_EQ(port, 13579);
+}
+
+TEST(MpcommEndpointAttr, UnknownVersionIsRejectedRatherThanMisparsed) {
+    std::string addr;
+    int port = 0;
+    EXPECT_FALSE(parseMpcommEndpointAttr("v2:10.0.0.1:13579", addr, port).ok());
+}
+
+TEST(MpcommEndpointAttr, HostnameStartingWithVIsNotTakenForAVersion) {
+    // The reason the prefix check requires 'v' + digits + ':' rather than just
+    // a leading 'v'.
+    std::string addr;
+    int port = 0;
+    ASSERT_TRUE(parseMpcommEndpointAttr("vm-node1:13579", addr, port).ok());
+    EXPECT_EQ(addr, "vm-node1");
+    EXPECT_EQ(port, 13579);
+
+    ASSERT_TRUE(parseMpcommEndpointAttr("v1:vm-node1:13579", addr, port).ok());
+    EXPECT_EQ(addr, "vm-node1");
+}
+
+TEST(MpcommEndpointAttr, Ipv6LiteralIsRejected) {
+    // MPComm's handshake sockets are AF_INET, and rfind(':') would otherwise
+    // split an IPv6 literal at the wrong colon.
+    std::string addr;
+    int port = 0;
+    EXPECT_FALSE(parseMpcommEndpointAttr("fe80::1:13579", addr, port).ok());
+    EXPECT_FALSE(parseMpcommEndpointAttr("v1:fe80::1:13579", addr, port).ok());
+}
+
+TEST(MpcommEndpointAttr, MalformedAttributesAreRejected) {
+    std::string addr;
+    int port = 0;
+    EXPECT_FALSE(parseMpcommEndpointAttr("", addr, port).ok());
+    EXPECT_FALSE(parseMpcommEndpointAttr("10.0.0.1", addr, port).ok());
+    EXPECT_FALSE(parseMpcommEndpointAttr(":13579", addr, port).ok());
+    EXPECT_FALSE(parseMpcommEndpointAttr("10.0.0.1:", addr, port).ok());
+}
+
+TEST(MpcommTcpPort, RejectsEverythingAtoiWouldAccept) {
+    // atoi() turns each of these into 0 or a truncated value, which MPComm
+    // would then try to bind.
+    int port = 0;
+    EXPECT_FALSE(parseMpcommTcpPort("", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("abc", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("13579x", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("0", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("-1", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("65536", port).ok());
+    EXPECT_FALSE(parseMpcommTcpPort("123456", port).ok());
+
+    ASSERT_TRUE(parseMpcommTcpPort("1", port).ok());
+    EXPECT_EQ(port, 1);
+    ASSERT_TRUE(parseMpcommTcpPort("65535", port).ok());
+    EXPECT_EQ(port, 65535);
+}
+
+// ===================================================================
+// Peer registry: single flight, retry, refresh, teardown
+// ===================================================================
+
+TEST(MpcommPeerRegistryTest, FirstEnsureConnectsThenQueries) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+
+    ASSERT_TRUE(
+        registry.ensure("peer", "10.0.0.1", 13579, makeRanges({{0x1000, 4096}}))
+            .ok());
+    EXPECT_EQ(adapter->connect_calls, 1);
+    EXPECT_EQ(adapter->query_calls, 1);
+    EXPECT_EQ(adapter->last_connect_addr, "10.0.0.1");
+    EXPECT_EQ(adapter->last_connect_port, 13579);
+
+    MpcommPeerState state{};
+    ASSERT_TRUE(registry.stateOf("peer", state));
+    EXPECT_EQ(state, MpcommPeerState::READY);
+}
+
+TEST(MpcommPeerRegistryTest, CachedPeerIsNotContactedAgain) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+
+    EXPECT_EQ(adapter->connect_calls, 1);
+    EXPECT_EQ(adapter->query_calls, 1);
+}
+
+TEST(MpcommPeerRegistryTest, ConcurrentCallersConnectThePeerOnce) {
+    // A second connect() to a connected host replaces MPComm's connection
+    // record wholesale, dropping its keys and leaking its queue pairs, so this
+    // is the property the whole ownership scheme exists to guarantee.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->connect_delay = std::chrono::milliseconds(100);
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    constexpr int kThreads = 8;
+    std::vector<std::thread> threads;
+    std::atomic<int> failures{0};
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([&] {
+            if (!registry.ensure("peer", "10.0.0.1", 13579, buffers).ok()) {
+                ++failures;
+            }
+        });
+    }
+    for (auto &thread : threads) thread.join();
+
+    EXPECT_EQ(failures.load(), 0);
+    EXPECT_EQ(adapter->connect_calls, 1);
+    EXPECT_EQ(adapter->query_calls, 1);
+    EXPECT_EQ(registry.size(), 1u);
+}
+
+TEST(MpcommPeerRegistryTest, ConnectFailureLeavesNothingCached) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->connect_failures = 1;
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    EXPECT_FALSE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    // Nothing was established, so the entry must not linger and block a later
+    // attempt from connecting.
+    EXPECT_FALSE(registry.contains("peer"));
+    EXPECT_EQ(adapter->query_calls, 0);
+
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    EXPECT_EQ(adapter->connect_calls, 2);
+}
+
+TEST(MpcommPeerRegistryTest, QueryFailureKeepsTheConnectionAndRetriesTheQuery) {
+    // The behaviour the CONNECTED_NO_KEYS state exists for: the connection
+    // cannot be closed, so a failed key query must not lead to a reconnect.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->query_failures = 1;
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    EXPECT_FALSE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    MpcommPeerState state{};
+    ASSERT_TRUE(registry.stateOf("peer", state));
+    EXPECT_EQ(state, MpcommPeerState::CONNECTED_NO_KEYS);
+
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    EXPECT_EQ(adapter->connect_calls, 1);  // not reconnected
+    EXPECT_EQ(adapter->query_calls, 2);    // query alone was retried
+    ASSERT_TRUE(registry.stateOf("peer", state));
+    EXPECT_EQ(state, MpcommPeerState::READY);
+}
+
+TEST(MpcommPeerRegistryTest, NewlyRegisteredRemoteBufferRefreshesKeys) {
+    // TENT allows a peer to register memory after a segment is opened, and the
+    // provider snapshots rkeys at query time, so the keys have to be refetched.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+
+    ASSERT_TRUE(
+        registry.ensure("peer", "10.0.0.1", 13579, makeRanges({{0x1000, 4096}}))
+            .ok());
+    ASSERT_EQ(adapter->query_calls, 1);
+
+    ASSERT_TRUE(registry
+                    .ensure("peer", "10.0.0.1", 13579,
+                            makeRanges({{0x1000, 4096}, {0x8000, 4096}}))
+                    .ok());
+    EXPECT_EQ(adapter->query_calls, 2);
+    EXPECT_EQ(adapter->connect_calls, 1);  // refreshed, not reconnected
+}
+
+TEST(MpcommPeerRegistryTest, UnregisteredRemoteBufferDoesNotRefreshKeys) {
+    // Keys for memory the peer no longer publishes are never used, and the
+    // decision has to stay monotonic: descriptors are cached per thread, so
+    // threads routinely observe smaller buffer sets than one another.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+
+    ASSERT_TRUE(registry
+                    .ensure("peer", "10.0.0.1", 13579,
+                            makeRanges({{0x1000, 4096}, {0x8000, 4096}}))
+                    .ok());
+    ASSERT_EQ(adapter->query_calls, 1);
+
+    ASSERT_TRUE(
+        registry.ensure("peer", "10.0.0.1", 13579, makeRanges({{0x1000, 4096}}))
+            .ok());
+    EXPECT_EQ(adapter->query_calls, 1);
+}
+
+TEST(MpcommPeerRegistryTest, RefreshQueriesTheConnectedEndpoint) {
+    // Keys must come from the process the connection was made to, not from
+    // whatever endpoint the peer advertises now.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+
+    ASSERT_TRUE(
+        registry.ensure("peer", "10.0.0.1", 13579, makeRanges({{0x1000, 4096}}))
+            .ok());
+    ASSERT_TRUE(registry
+                    .ensure("peer", "10.0.0.9", 20000,
+                            makeRanges({{0x1000, 4096}, {0x8000, 4096}}))
+                    .ok());
+
+    EXPECT_EQ(adapter->connect_calls, 1);
+    EXPECT_EQ(adapter->last_query_addr, "10.0.0.1");
+    EXPECT_EQ(adapter->last_query_port, 13579);
+}
+
+TEST(MpcommPeerRegistryTest, DistinctPeersAreConnectedIndependently) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    ASSERT_TRUE(registry.ensure("peer_a", "10.0.0.1", 13579, buffers).ok());
+    ASSERT_TRUE(registry.ensure("peer_b", "10.0.0.2", 13579, buffers).ok());
+
+    EXPECT_EQ(adapter->connect_calls, 2);
+    EXPECT_EQ(registry.size(), 2u);
+}
+
+TEST(MpcommPeerRegistryTest, ClearDropsEveryPeer) {
+    // uninstall() clears the cache after the provider has been shut down; a
+    // later install() must be able to connect again.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    MpcommPeerRegistry registry(adapter);
+    auto buffers = makeRanges({{0x1000, 4096}});
+
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    ASSERT_EQ(registry.size(), 1u);
+
+    registry.clear();
+    EXPECT_EQ(registry.size(), 0u);
+    EXPECT_FALSE(registry.contains("peer"));
+
+    ASSERT_TRUE(registry.ensure("peer", "10.0.0.1", 13579, buffers).ok());
+    EXPECT_EQ(adapter->connect_calls, 2);
+}
+
+// ===================================================================
+// Request and completion mapping
+// ===================================================================
+
+Request makeRequest(Request::OpCode opcode, size_t length) {
+    Request request{};
+    request.opcode = opcode;
+    request.source = reinterpret_cast<void *>(0x4000);
+    request.target_offset = 0x9000;
+    request.length = length;
+    return request;
+}
+
+TEST(MpcommTaskMapping, WriteBecomesPutAndReadBecomesGet) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+
+    auto write = makeRequest(Request::WRITE, 1024);
+    auto handle = issueMpcommTransfer(*adapter, write, "peer");
+    EXPECT_NE(handle, kInvalidMpcommTransferHandle);
+    EXPECT_EQ(adapter->put_calls, 1);
+    EXPECT_EQ(adapter->get_calls, 0);
+    EXPECT_EQ(adapter->last_local_addr, 0x4000u);
+    EXPECT_EQ(adapter->last_remote_addr, 0x9000u);
+    EXPECT_EQ(adapter->last_length, 1024u);
+    EXPECT_EQ(adapter->last_transfer_host, "peer");
+
+    auto read = makeRequest(Request::READ, 2048);
+    EXPECT_NE(issueMpcommTransfer(*adapter, read, "peer"),
+              kInvalidMpcommTransferHandle);
+    EXPECT_EQ(adapter->put_calls, 1);
+    EXPECT_EQ(adapter->get_calls, 1);
+    EXPECT_EQ(adapter->last_length, 2048u);
+}
+
+TEST(MpcommTaskMapping, RejectedIssueReportsAnInvalidHandle) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->issue_fails = true;
+    auto request = makeRequest(Request::WRITE, 1024);
+    EXPECT_EQ(issueMpcommTransfer(*adapter, request, "peer"),
+              kInvalidMpcommTransferHandle);
+}
+
+MpcommTask makeTask(size_t length, MpcommTransferHandle handle) {
+    MpcommTask task;
+    task.request = makeRequest(Request::WRITE, length);
+    task.status_word = TransferStatusEnum::PENDING;
+    task.mpcomm_handle = handle;
+    return task;
+}
+
+TEST(MpcommTaskMapping, FullTransferCompletesAndReportsItsBytes) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->outcome = MpcommTransferOutcome{true, 1024, 0};
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(task.transferred_bytes, 1024u);
+    EXPECT_EQ(task.mpcomm_handle, kInvalidMpcommTransferHandle);
+    EXPECT_EQ(adapter->release_calls, 1);
+}
+
+TEST(MpcommTaskMapping, ProviderFailureFailsTheTask) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->outcome = MpcommTransferOutcome{false, 0, -4};
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::FAILED);
+    EXPECT_EQ(adapter->release_calls, 1);
+}
+
+TEST(MpcommTaskMapping, SuccessfulButShortTransferIsDemotedToFailed) {
+    // The engine accumulates request.length for completed tasks, so a success
+    // that moved fewer bytes must not be reported as complete.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->outcome = MpcommTransferOutcome{true, 512, 0};
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::FAILED);
+    EXPECT_EQ(task.transferred_bytes, 512u);
+    EXPECT_EQ(adapter->release_calls, 1);
+}
+
+TEST(MpcommTaskMapping, ByteCountAboveRequestLengthStillCompletes) {
+    // The provider reports posted bytes, so a larger count is not an error;
+    // only a short one is.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->outcome = MpcommTransferOutcome{true, 2048, 0};
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::COMPLETED);
+}
+
+TEST(MpcommTaskMapping, IncompleteTransferIsLeftPendingAndNotReleased) {
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->transfer_complete = false;
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::PENDING);
+    EXPECT_EQ(task.mpcomm_handle, 7u);
+    EXPECT_EQ(adapter->release_calls, 0);
+}
+
+TEST(MpcommTaskMapping, HandleIsReleasedExactlyOnceAcrossRepeatedPolls) {
+    // getTransferStatus() may be called any number of times per task; a second
+    // release of the same handle would corrupt the provider's handle table.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    adapter->outcome = MpcommTransferOutcome{true, 1024, 0};
+    auto task = makeTask(1024, 7);
+
+    pollMpcommTask(*adapter, task);
+    pollMpcommTask(*adapter, task);
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(adapter->release_calls, 1);
+    EXPECT_EQ(adapter->result_calls, 1);
+    EXPECT_EQ(statusOf(task), TransferStatusEnum::COMPLETED);
+}
+
+TEST(MpcommTaskMapping, TaskWithoutHandleIsIgnored) {
+    // A task whose issue failed is already terminal and owns no handle.
+    auto adapter = std::make_shared<FakeMpcommAdapter>();
+    auto task = makeTask(1024, kInvalidMpcommTransferHandle);
+    task.status_word = TransferStatusEnum::FAILED;
+
+    pollMpcommTask(*adapter, task);
+
+    EXPECT_EQ(adapter->result_calls, 0);
+    EXPECT_EQ(adapter->release_calls, 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/mpcomm_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/mpcomm_transport_test.cpp
@@ -1,0 +1,248 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests for MpcommTransport.
+//
+// TransportTypeMapping needs no hardware and always runs.
+//
+// WriteAndRead forks a target process and drives a WRITE followed by a READ
+// back over MPComm, verifying the payload. It requires RDMA devices and a
+// working MPComm installation, and is skipped when the engine cannot be
+// brought up. Parent and child use distinct MPCOMM_TCP_PORT values because
+// MPComm's metadata handshake listener would otherwise collide; the ports are
+// derived from the pid to keep concurrent runs apart, and are kept outside
+// 15000-17000 which CoroRpcAgent may pick at random for the tent RPC server.
+//
+// The target publishes its real segment name (host:port, assigned by the tent
+// RPC server) over a pipe, so no tent port has to be hardcoded here.
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/transfer_engine.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr size_t kDataLength = 4 * 1024 * 1024;
+constexpr size_t kPageSize = 4096;
+constexpr char kPattern = 'M';
+
+// Allocate page-aligned host memory directly instead of going through
+// TransferEngine::allocateLocalMemory(): that helper maps UNSPEC to RDMA or
+// TCP and fails outright when neither is enabled, and this test deliberately
+// leaves mpcomm as the only enabled transport.
+void* AllocAligned(size_t size) {
+    void* p = nullptr;
+    if (posix_memalign(&p, kPageSize, size) != 0) return nullptr;
+    return p;
+}
+
+std::shared_ptr<Config> makeConfig(const std::string& segment_name) {
+    auto conf = std::make_shared<Config>();
+    conf->set("metadata_type", "p2p");
+    conf->set("metadata_servers", "P2PHANDSHAKE");
+    conf->set("local_segment_name", segment_name);
+    // Enable mpcomm only: with every other transport disabled a routing
+    // regression fails the test instead of silently falling back to RDMA.
+    conf->set("transports/mpcomm/enable", true);
+    conf->set("transports/rdma/enable", false);
+    conf->set("transports/tcp/enable", false);
+    conf->set("transports/shm/enable", false);
+    conf->set("transports/nvlink/enable", false);
+    conf->set("transports/mnnvl/enable", false);
+    conf->set("transports/gds/enable", false);
+    conf->set("transports/io_uring/enable", false);
+    return conf;
+}
+
+void SetMpcommPort(int port) {
+    const std::string value = std::to_string(port);
+    setenv("MPCOMM_TCP_PORT", value.c_str(), 1);
+}
+
+void WaitBatchDone(TransferEngine* engine, BatchID batch_id) {
+    TransferStatus status;
+    for (int i = 0; i < 5000; ++i) {
+        auto s = engine->getTransferStatus(batch_id, status);
+        ASSERT_TRUE(s.ok()) << "getTransferStatus failed: " << s.ToString();
+        if (status.s == TransferStatusEnum::COMPLETED) return;
+        ASSERT_NE(status.s, TransferStatusEnum::FAILED);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    FAIL() << "timeout waiting batch completion";
+}
+
+// Exercises the mpcomm-specific entries of the transport name mappings. A
+// missing entry would make policies naming "mpcomm" silently resolve to
+// UNSPEC, so keep this covered even though it needs no hardware.
+TEST(MpcommTransportTest, TransportTypeMapping) {
+    EXPECT_STREQ(transportTypeName(MPCOMM), "mpcomm");
+    EXPECT_EQ(parseTransportType("mpcomm"), MPCOMM);
+    EXPECT_LT(static_cast<int>(MPCOMM), kSupportedTransportTypes);
+}
+
+TEST(MpcommTransportTest, WriteAndRead) {
+    const int base_port = 23000 + static_cast<int>(getpid() % 1000);
+    const std::string target_name = "mpcomm_ut_target";
+
+    int ready_pipe[2];
+    int stop_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0);
+    ASSERT_EQ(pipe(stop_pipe), 0);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(ready_pipe[0]);
+        close(stop_pipe[1]);
+        SetMpcommPort(base_port);
+        auto engine = std::make_unique<TransferEngine>(makeConfig(target_name));
+        if (!engine->available()) _exit(2);
+
+        void* buffer = AllocAligned(kDataLength);
+        if (buffer == nullptr) {
+            fprintf(stderr, "[target] posix_memalign failed\n");
+            _exit(3);
+        }
+        MemoryOptions options;
+        options.location = "cpu:0";
+        auto rs = engine->registerLocalMemory(buffer, kDataLength, options);
+        if (!rs.ok()) {
+            fprintf(stderr, "[target] registerLocalMemory failed: %s\n",
+                    rs.ToString().c_str());
+            _exit(4);
+        }
+
+        // The tent RPC port is assigned during construction, so the segment
+        // name is only final at this point.
+        const std::string segment = engine->getSegmentName();
+        const uint32_t len = static_cast<uint32_t>(segment.size());
+        if (write(ready_pipe[1], &len, sizeof(len)) != sizeof(len)) _exit(5);
+        if (write(ready_pipe[1], segment.data(), len) !=
+            static_cast<ssize_t>(len))
+            _exit(6);
+
+        char stop = 0;
+        (void)read(stop_pipe[0], &stop, 1);
+        (void)engine->unregisterLocalMemory(buffer, kDataLength);
+        free(buffer);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(stop_pipe[0]);
+
+    uint32_t segment_len = 0;
+    const ssize_t got = read(ready_pipe[0], &segment_len, sizeof(segment_len));
+    if (got != static_cast<ssize_t>(sizeof(segment_len))) {
+        int wstatus = 0;
+        (void)waitpid(child, &wstatus, 0);
+        if (got == 0 && WIFEXITED(wstatus)) {
+            GTEST_SKIP() << "mpcomm target init failed, child exit="
+                         << WEXITSTATUS(wstatus)
+                         << " (2=engine unavailable, 3=alloc, 4=register;"
+                            " see [target] lines above for details)";
+        }
+        ASSERT_EQ(got, static_cast<ssize_t>(sizeof(segment_len)));
+    }
+    ASSERT_GT(segment_len, 0u);
+    std::string target_segment(segment_len, '\0');
+    ASSERT_EQ(read(ready_pipe[0], target_segment.data(), segment_len),
+              static_cast<ssize_t>(segment_len));
+
+    // Distinct handshake port: the target already listens on base_port.
+    SetMpcommPort(base_port + 1);
+    auto engine = std::make_unique<TransferEngine>(makeConfig("mpcomm_ut"));
+    ASSERT_TRUE(engine->available());
+
+    // Two halves: the first is written out, the second receives the read back.
+    void* buffer = AllocAligned(kDataLength * 2);
+    ASSERT_NE(buffer, nullptr);
+    MemoryOptions options;
+    options.location = "cpu:0";
+    auto s = engine->registerLocalMemory(buffer, kDataLength * 2, options);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+
+    auto* bytes = static_cast<uint8_t*>(buffer);
+    memset(bytes, kPattern, kDataLength);
+    memset(bytes + kDataLength, 0, kDataLength);
+
+    SegmentID segment_id = 0;
+    for (int i = 0; i < 100; ++i) {
+        s = engine->openSegment(segment_id, target_segment);
+        if (s.ok()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(s.ok()) << s.ToString();
+
+    SegmentInfo segment_info;
+    s = engine->getSegmentInfo(segment_id, segment_info);
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    ASSERT_FALSE(segment_info.buffers.empty());
+    const uint64_t remote_base = segment_info.buffers[0].base;
+
+    BatchID batch = engine->allocateBatch(1);
+    Request request;
+    request.opcode = Request::WRITE;
+    request.length = kDataLength;
+    request.source = bytes;
+    request.target_id = segment_id;
+    request.target_offset = remote_base;
+    request.transport_hint = TransportType::MPCOMM;
+    s = engine->submitTransfer(batch, {request});
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    WaitBatchDone(engine.get(), batch);
+    ASSERT_TRUE(engine->freeBatch(batch).ok());
+
+    batch = engine->allocateBatch(1);
+    request.opcode = Request::READ;
+    request.source = bytes + kDataLength;
+    s = engine->submitTransfer(batch, {request});
+    ASSERT_TRUE(s.ok()) << s.ToString();
+    WaitBatchDone(engine.get(), batch);
+    ASSERT_TRUE(engine->freeBatch(batch).ok());
+
+    for (size_t i = 0; i < kDataLength; ++i) {
+        ASSERT_EQ(bytes[kDataLength + i], kPattern) << "mismatch at " << i;
+    }
+
+    ASSERT_TRUE(engine->unregisterLocalMemory(buffer, kDataLength * 2).ok());
+    free(buffer);
+
+    const char stop = 'Q';
+    ASSERT_EQ(write(stop_pipe[1], &stop, 1), 1);
+    int wstatus = 0;
+    ASSERT_EQ(waitpid(child, &wstatus, 0), child);
+    ASSERT_TRUE(WIFEXITED(wstatus));
+    ASSERT_EQ(WEXITSTATUS(wstatus), 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
@@ -21,6 +21,7 @@
 
 #include "tent/common/config.h"
 #include "tent/common/types.h"
+#include "tent/transfer_engine.h"
 #include "tent/runtime/transport_selector.h"
 #include "tent/runtime/transport.h"
 
@@ -186,6 +187,7 @@ TEST(TransportSelectorTest, TransportTypeNameMapping) {
     EXPECT_STREQ(transportTypeName(AscendDirect), "ascend");
     EXPECT_STREQ(transportTypeName(SUNRISE_LINK), "sunrise_link");
     EXPECT_STREQ(transportTypeName(UB), "ub");
+    EXPECT_STREQ(transportTypeName(MPCOMM), "mpcomm");
 }
 
 TEST(TransportSelectorTest, ParseTransportType) {
@@ -200,6 +202,7 @@ TEST(TransportSelectorTest, ParseTransportType) {
     EXPECT_EQ(parseTransportType("ascend"), AscendDirect);
     EXPECT_EQ(parseTransportType("sunrise_link"), SUNRISE_LINK);
     EXPECT_EQ(parseTransportType("ub"), UB);
+    EXPECT_EQ(parseTransportType("mpcomm"), MPCOMM);
     EXPECT_EQ(parseTransportType("unknown"), UNSPEC);
 }
 
@@ -222,7 +225,24 @@ TEST(TransportTypeTest, WireValuesRemainStableWithUbAppended) {
     EXPECT_EQ(static_cast<int>(SUNRISE_LINK), 9);
     EXPECT_EQ(static_cast<int>(TPU), 10);
     EXPECT_EQ(static_cast<int>(UB), 11);
-    EXPECT_EQ(static_cast<int>(kNumTransportTypes), 12);
+    EXPECT_EQ(static_cast<int>(MPCOMM), 12);
+    EXPECT_EQ(static_cast<int>(kNumTransportTypes), 13);
+}
+
+// MPComm is appended after UB, so it takes wire value 12. The same integer is
+// exposed through the C API macros and the Python binding, which makes it a
+// compatibility contract rather than an implementation detail. pybind.cpp
+// carries a matching static_assert so a divergence fails the build.
+TEST(TransportTypeTest, MpcommWireValueMatchesCApiAndRoundTrips) {
+    EXPECT_EQ(static_cast<int>(MPCOMM), 12);
+    EXPECT_EQ(TRANSPORT_MPCOMM, static_cast<int>(MPCOMM));
+    EXPECT_EQ(TRANSPORT_UB, static_cast<int>(UB));
+    // The conversion the C API actually performs on an incoming hint.
+    EXPECT_EQ(c_to_transport_hint(TRANSPORT_MPCOMM), MPCOMM);
+    // Name mapping is what policy parsing relies on; a gap here would make
+    // "transports": ["mpcomm"] resolve to UNSPEC silently.
+    EXPECT_STREQ(transportTypeName(MPCOMM), "mpcomm");
+    EXPECT_EQ(parseTransportType("mpcomm"), MPCOMM);
 }
 
 // Topology::NicType is serialized as an integer. These values are therefore a

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -388,6 +388,15 @@ else
     AUDITWHEEL_CMD="auditwheel"
 fi
 
+# `--exclude libmpcomm.so*` below is deliberate, not an oversight. MPComm ships
+# its own wheel / CMake install and is upgraded independently of Mooncake, so
+# engine.so keeps its DT_NEEDED on libmpcomm.so.<N> and the dynamic linker
+# resolves it at run time (e.g. LD_LIBRARY_PATH=$MPCOMM_ROOT/lib). Vendoring it
+# would: (a) freeze one MPComm build inside the wheel, where the RPATH injected
+# by auditwheel outranks LD_LIBRARY_PATH and would silently shadow any newer
+# libmpcomm.so; and (b) let patchelf rewrite a library carrying CUDA fatbins
+# (MPComm builds TMA kernels with USE_CUDA_KERNELS=ON by default), the same
+# corruption risk the EP/PG extensions are kept away from below.
 ${AUDITWHEEL_CMD} repair ${OUTPUT_DIR}/*.whl \
     --exclude libcurl.so* \
     --exclude libfabric.so* \
@@ -479,6 +488,7 @@ ${AUDITWHEEL_CMD} repair ${OUTPUT_DIR}/*.whl \
     --exclude ascend_transport*.so \
     --exclude libaccl_barex.so* \
     --exclude liburma.so* \
+    --exclude libmpcomm.so* \
     -w ${REPAIRED_DIR}/ --plat ${PLATFORM_TAG}
 
 # Inject CUDA extensions into the repaired wheel.  patchelf (used by auditwheel)


### PR DESCRIPTION
## Description

Adds a transport backend for the TENT runtime built on **UCL-MPComm** (Unified Communication
Library - Memory Pool Communication), an RDMA-native, multi-rail data plane from the Tencent Astral
Network Team, published at [Tencent/UCL-MPComm](https://github.com/Tencent/UCL-MPComm) under
Apache-2.0. The transport is registered under the name `mpcomm`, and the library is shortened to
MPComm in the rest of this description and in the code.

Design discussed in RFC #3322, including the open questions and the follow-up review items; this PR
is the implementation of what was agreed there.

**Why another RDMA transport.** UCL-MPComm keeps slicing, NIC selection, QP selection and its worker
threads inside the library, and drives multiple rails from one transfer. On the same hardware its own
benchmarks report **~195.7 GB/s** against **~142.2 GB/s** for TENT's RDMA transport (≈1.38x, AMD Turin + 4x
CX-7; ≈1.36x on H20) — numbers from the UCL-MPComm repository, reproducible with the commands in the
doc added here. In this integration `tebench` reaches >390 GB/s aggregate across two nodes.

### Structure

Everything that reaches MPComm goes through a single injectable boundary, so the TENT-side logic
builds and tests without the provider. This follows `UrmaAdapter` and `TpuPjrtShim`.

| Unit | Responsibility | Needs `mpcomm.h` |
|---|---|:---:|
| `mpcomm_adapter.{h,cpp}` | The provider boundary. A thin pass-through — MPComm owns its own scheduling, so there is none to model. Compiles to an unavailable stub without the provider | **yes, only here** |
| `mpcomm_peer_registry.{h,cpp}` | Peer cache and endpoint attribute parsing | no |
| `mpcomm_task_mapping.{h,cpp}` | Request and completion mapping | no |
| `mpcomm_transport.{h,cpp}` | What needs the TENT runtime: SegmentID resolution, capabilities, batch driving | no |

### Notable behaviour

- **Peers are keyed by MPComm host id**, not `SegmentID`. MPComm keys connections by host id and
  cannot close one, and a second `connect()` replaces its connection record wholesale — dropping the
  remote keys it carries and leaking the previous queue pairs. Reopening a segment must therefore
  reuse the existing connection.
- **Connection and remote keys are tracked separately.** A failed key query leaves the peer in
  `CONNECTED_NO_KEYS` and the next request retries the query alone. Keys are refetched when the
  peer's published buffer set grows, compared by coverage rather than equality — descriptors are
  cached per thread and expire independently, so an equality test makes threads alternately
  invalidate each other and issue a blocking query each time.
- **GPU capabilities are gated on `nvidia_peermem`**, the same probe `RdmaTransport` uses: MPComm
  registers device memory through the ordinary `ibv_reg_mr` path and has no dma-buf fallback. A host
  without the module is excluded during selection rather than failing at registration.
- **`MPCOMM` is appended as wire value 12**, leaving `UB` at 11. Assertions cover the C++ enum, the C
  API macro (checked through the conversion function rather than by repeating the constant) and the
  Python binding (`static_assert`).
- **Security.** MPComm's handshake is unauthenticated plain TCP and exchanges buffer addresses and
  rkeys, which is everything an RDMA operation needs. The doc states that this port belongs at the
  same trust level as the fabric itself.

### Known limitations

Recorded rather than worked around; none blocks the DRAM or VRAM data path.

1. The first transfer to a peer performs the MPComm handshake **inline on the submitting thread**.
   `RdmaTransport` connects lazily on the transfer path too, but its handshake runs over an RPC with
   a timeout, whereas MPComm's is a bare TCP exchange with none. Adding one requires a change in the
   library.
2. **A restarted peer is not recovered automatically.** With no way to close a connection, dropping
   and rebuilding one would leak queue pairs and blank the keys concurrent transfers are using, so
   the transport keeps the cached peer instead.
3. **The listener binds `INADDR_ANY` and this is not configurable** (MPComm's own behaviour). The
   advertised endpoint follows `rpc_server_hostname`; a setting for advertising an address separate
   from the RPC one is not implemented.
4. No cancellation, bandwidth estimation or NIC load statistics, and the `qp_pool` and
   progress-notification hooks are not consumed. These stay at the base-class defaults, so they
   report as unsupported rather than being assumed by policy code.
5. **CI does not cover the data path** — that needs RDMA devices and libmpcomm. See testing below for
   how the boundary is covered instead.
6. The MPComm ABI is pinned at configure time only; there is no run-time version check, since the
   library exposes no version query.

### Out of scope

- The legacy Transfer Engine transport path. This is TENT-only, so `MOONCAKE_PROTOCOL=mpcomm` and
  `transfer_engine_bench --protocol=mpcomm` are intentionally unsupported.
- CXL, file and other non-RDMA segment types.
- Changes to UCL-MPComm itself.

### Review focus

- `mpcomm_peer_registry.cpp` — the only non-trivial concurrency here: claim-then-connect ownership,
  the wait loop, and the RAII cleanup that has to leave the entry in a state later callers can make
  progress from.
- `mpcomm_adapter.h` — whether the boundary is drawn where you would want it for a provider that
  brings its own scheduling.
- `common.cmake` — the MPComm version check, and the scoped `CMP0144` policy: `find_package(mpcomm)`
  consults an upper-case `<PACKAGENAME>_ROOT`, which for this package is exactly the `MPCOMM_ROOT`
  the build already uses, so CMake 3.27+ warns unless the policy is set explicitly.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Three layers: a hardware-free suite that runs anywhere, a hardware suite, and a two-node benchmark.

**Test commands:**
```bash
# 1. Boundary tests - no RDMA device, no libmpcomm, built in every configuration
cmake .. -DUSE_TENT=ON -DBUILD_UNIT_TESTS=ON
make -j tent_mpcomm_boundary_test
ctest -R tent_mpcomm_boundary_test --output-on-failure
#   => 26 tests from 4 suites, 0.10 s, all passed

# 2. Real data path - requires RDMA devices and libmpcomm
cmake .. -DUSE_TENT=ON -DUSE_MPCOMM=ON -DUSE_CUDA=ON -DBUILD_UNIT_TESTS=ON \
         -DMPCOMM_ROOT=<prefix>
make -j tent_mpcomm_transport_test
ctest -R tent_mpcomm_transport_test --output-on-failure
#   => passed in 1.61 s (forks a target, WRITE then READ, verifies the payload)

# 3. Two nodes, RoCE, multi-NIC, dual NUMA
./tebench --backend=tent --xport_type=mpcomm --tent_transport_hint=mpcomm \
          --metadata_type=p2p --seg_type=DRAM ...
#   => >390 GB/s aggregate; also run with --seg_type=VRAM on one and both sides,
#      and with --check_consistency=true
```

The boundary suite drives the transport against an injected `MpcommAdapter` and covers endpoint
publication and parsing, single-flight connection under concurrency, key-query retry over an existing
connection, refreshing keys after a peer registers memory, the WRITE/READ mapping, short-transfer and
error handling, releasing each handle exactly once, and teardown. It deliberately does not model
MPComm's own scheduling.

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Manual: two-node runs over DRAM and VRAM segments (both sides VRAM, and one side only), payload
verification enabled, plus a single-node RDMA loopback test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue — #3322

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

An AI coding assistant was used for drafting code, documentation and tests, and for reviewing the
result. Every change has been read, built and tested on real hardware by the submitter, who is
responsible for defending all of it.