### PR TITLE
[Bugfix][Store] Keep snapshot unmount test on the synchronous cleanup path

### DIFF
--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -1216,7 +1216,15 @@ TEST_F(MasterServiceSnapshotTest, ConcurrentRemoveAllOperations) {
 }
 
 TEST_F(MasterServiceSnapshotTest, UnmountSegmentImmediateCleanup) {
-    service_.reset(new MasterService());
+    // Snapshot mode keeps the invalid-handle sweep synchronous inside
+    // UnmountSegment. A default-configured MasterService would instead defer
+    // it to the replica cleanup worker, making the key-count assertion below
+    // race with that worker.
+    auto service_config = MasterServiceConfig::builder()
+                              .set_enable_snapshot(true)
+                              .set_snapshot_object_store_type("local")
+                              .build();
+    service_.reset(new MasterService(service_config));
 
     // Mount two segments for testing
     constexpr size_t buffer1 = 0x300000000;


### PR DESCRIPTION
Description

  MasterServiceSnapshotTest.UnmountSegmentImmediateCleanup fails intermittently in CI:

  master_service_test_for_snapshot.cpp:1247: Failure
  Expected equality of these values:
    1
    service_->GetKeyCount()
      Which is: 2

  #2877 made the invalid-handle sweep in UnmountSegment conditional on enable_async_segment_cleanup_(!enable_ha && !enable_snapshot && !enable_cxl). This test builds a default MasterService, so all three flags are false and the sweep is deferred to replica_cleanup_worker_ — while the test still asserts GetKeyCount() == 1 right after UnmountSegment returns. It passes only when the worker wins the race.

  The same race also corrupts the TearDown snapshot: the worker's erase can land between the two passes SerializeShard makes over the shard (pack_array(metadata_count), then a separate traversal that writes entries), so the array declares more elements than are written. That surfaces as Failed to unpack MessagePack data: insufficient bytes, the restore falls back to a fresh service, and every later state comparison fails as a cascade.

  #2877 already updated the other affected tests — the sibling in master_service_test.cpp was renamed to UnmountSegmentHidesReplicasBeforeAsyncCleanup and rewritten around the async semantics, and UnmountSegmentPerformance in this same fixture was switched to an explicit snapshot-enabled config. This one was missed.

  This PR enables snapshot mode here too, matching UnmountSegmentPerformance. That restores the synchronous sweep the assertions were written against, and fits the fixture, whose TearDown snapshots and restores the service on every test. Async-path coverage already lives in master_service_test.cpp.

  Module
  
  - [x] Mooncake Store (mooncake-store)

  Type of Change

  - [x] Bug fix

  How Has This Been Tested?

  Test commands:
  # Not run locally: Docker daemon was unresponsive on the submitter's macOS
  # host, and this project cannot be compiled outside a Linux container there.
  # Intended command:
  ctest --test-dir build -R master_service_snapshot_test

  Test results:
  - [ ] Unit tests pass — not verified locally; relying on this PR's CI run
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  The reasoning is grounded in the CI log for the failing run and the #2877 diff: set_enable_snapshot(true) makes enable_async_segment_cleanup_ false, which routes UnmountSegment back to the synchronous ClearInvalidHandles()
  branch. Confirming that the flake is gone still needs a green CI run.

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [ ] I have added tests to prove my changes are effective — fixes an existing test; no new test added
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure
  
  - [x] AI tools were used (specify below)