### PR TITLE
[Build] Stage native _ep extension into ep_pg_staging for wheel packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,20 @@ if (WITH_EP)
     string(REPLACE ";" "|" _ep_torch_versions_pipe "${EP_TORCH_VERSIONS}")
     string(REPLACE ";" "|" _torch_cuda_arch_list_pipe "${TORCH_CUDA_ARCH_LIST}")
 
+    # Stage the native EP extension (_ep) into EP_PG_STAGING_DIR so build_wheel.sh
+    # injects it into the wheel the same way PG extensions are staged below.
+    # Without this, _ep.so stays under build/mooncake-ep/src/ and never reaches the
+    # wheel, so the installed package is missing mooncake._ep (post-#2883 native EP).
+    add_custom_target(mooncake_ep_stage ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory "${EP_PG_STAGING_DIR}"
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              "$<TARGET_FILE:_ep>"
+              "${EP_PG_STAGING_DIR}/"
+      COMMENT "Staging Mooncake EP native extension (_ep)"
+      DEPENDS _ep
+      VERBATIM
+    )
+
     add_custom_target(mooncake_pg_ext ALL
       COMMAND ${CMAKE_COMMAND} -E make_directory "${EP_PG_STAGING_DIR}"
       COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
## Summary

PR #2883 (*[EP] decouple native EP from torch C++ APIs*, commit `90c5ce09`) migrated the
Mooncake EP extension from `setup.py` + `mooncake-ep/BuildEpExt.cmake` to a native
pybind module (`pybind11_add_module(_ep ...)` in `mooncake-ep/src/CMakeLists.txt`).

As part of that migration, the top-level `CMakeLists.txt` **removed** the
`mooncake_ep_ext` custom target — the step that staged the built EP `.so` files into
`EP_PG_STAGING_DIR`. No equivalent staging step was added for the new native `_ep`
module.

As a result, `_ep.so` is built under `build/mooncake-ep/src/` but never reaches
`EP_PG_STAGING_DIR`. Since `scripts/build_wheel.sh` only injects `.so` files located
in `ep_pg_staging` into the wheel (after auditwheel, to keep CUDA fatbins away from
patchelf), `_ep.so` is dropped from the wheel and the installed package is missing
`mooncake._ep`. This breaks the EP path at runtime; the post-install verifier
(`verify_engine_and_ep`, which already documents `# Post-#2883: mooncake._ep`) reports
`missing _ep*.so / ep_*.so`.

## Root cause (the regression in #2883)

The diff of `90c5ce09` against `CMakeLists.txt` deleted:

```cmake
add_custom_target(mooncake_ep_ext ALL
  COMMAND ${CMAKE_COMMAND} -E make_directory "${EP_PG_STAGING_DIR}"
  ...
  -P "${CMAKE_CURRENT_SOURCE_DIR}/mooncake-ep/BuildEpExt.cmake"
  ...
)
```

and replaced it with `add_subdirectory(mooncake-ep)` (which builds `_ep` natively),
without adding a step to copy `_ep.so` into `EP_PG_STAGING_DIR`. The PG path
(`mooncake_pg_ext` / `BuildPgExt.cmake`) still stages its `pg_*.so` correctly — only
the EP side lost its staging when `BuildEpExt.cmake` was removed.

## Fix

Add a `mooncake_ep_stage` custom target that `copy_if_different`s
`$<TARGET_FILE:_ep>` into `EP_PG_STAGING_DIR`, mirroring how `mooncake_pg_ext`
stages the PG extensions. `build_wheel.sh` then injects `_ep.so` into the wheel the
same way it already injects the PG `.so` files, so the installed wheel contains
`mooncake._ep`.

```cmake
# Stage the native EP extension (_ep) into EP_PG_STAGING_DIR so build_wheel.sh
# injects it into the wheel the same way PG extensions are staged below.
# Without this, _ep.so stays under build/mooncake-ep/src/ and never reaches the
# wheel, so the installed package is missing mooncake._ep (post-#2883 native EP).
add_custom_target(mooncake_ep_stage ALL
  COMMAND ${CMAKE_COMMAND} -E make_directory "${EP_PG_STAGING_DIR}"
  COMMAND ${CMAKE_COMMAND} -E copy_if_different
          "$<TARGET_FILE:_ep>"
          "${EP_PG_STAGING_DIR}/"
  COMMENT "Staging Mooncake EP native extension (_ep)"
  DEPENDS _ep
  VERBATIM
)
```

This is the minimal change that restores the staging behavior #2883 inadvertently
dropped; it only runs in the `WITH_EP=ON` native branch (the same `else()` block that
already defines `mooncake_pg_ext`).

## Type of change

- [x] Bug fix (non-breaking)

## Testing

**Root-cause verification (upstream history):**

- Traced the regression to upstream commit `90c5ce09` (this PR's precursor, #2883):
  it removed `mooncake_ep_ext` and `mooncake-ep/BuildEpExt.cmake` without replacing
  the EP staging step.
- Confirmed `scripts/build_wheel.sh` injects only from `ep_pg_staging` and that the PG
  path (`BuildPgExt.cmake`) still stages its `.so` there — the EP path is the only one
  missing staging after #2883.

**Build verification (real wheel build with `WITH_EP=ON`, native `_ep`):**

The fix was built and verified end-to-end on a CUDA host with
`WITH_EP=ON` + native `_ep` (Python 3.12). Before the fix, the build's post-install
verifier (`verify_engine_and_ep`) failed with `missing _ep*.so / ep_*.so`. After
applying this change on top of the same source, the build succeeded and the verifier
found the staged `_ep` module:

```
✓ wheel installed: mooncake_transfer_engine-0.3.12.post1-cp312-cp312-manylinux_2_39_x86_64.whl
=== Exporting mooncake package ===
✓ verified engine.so and EP extension (_ep.cpython-312-x86_64-linux-gnu.so) in /usr/local/lib/python3.12/dist-packages/mooncake
✓ artifact exported to /mooncake-out (container_path=/usr/local/lib/python3.12/dist-packages/mooncake)
=== Build Complete ===
Mooncake overlay build finished successfully!
```

The exported package contains `_ep.cpython-312-x86_64-linux-gnu.so` (and no legacy
`ep_*.so`, as expected on the native-EP path), confirming `build_wheel.sh` now injects
`_ep.so` from `ep_pg_staging`.

> The build was driven by a downstream packaging wrapper (not the upstream CI job
> directly); the Mooncake source, `CMakeLists.txt`, and `build_wheel.sh` are identical
> to upstream `main` for the affected region. The change is a 14-line CMake target
> mirroring the existing, working `mooncake_pg_ext` pattern.

## Checklist

- [x] Code follows the repo style (mirrors the adjacent `mooncake_pg_ext` target)
- [x] PR title uses a documented prefix (`[Build]`, per `CONTRIBUTING.md`)
- [x] Change is well below the RFC threshold (>500 LOC); no RFC needed
- [x] Build-verified with `WITH_EP=ON`: `_ep.so` now reaches the wheel and the
      post-install `verify_engine_and_ep` check passes
- [x] AI assistance disclosure: this change was authored with AI assistance and
  reviewed by the submitter end-to-end