### PR TITLE
[TransferEngine] Bind buffer device for EFA CUDA loopback

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -408,17 +408,12 @@ int EfaContext::deconstruct() {
 }
 
 #if defined(USE_CUDA)
-// A silent failure here resurfaces as the provider's opaque "Operation not
-// supported" from fi_mr_regattr(), which is the attribution problem this whole
-// helper exists to remove -- so name the driver call that actually failed.
 static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
     const char* err = nullptr;
     cuGetErrorString(ret, &err);
     LOG(WARNING) << "EFA: " << call << " failed for CUDA device "
                  << device_ordinal << ": " << (err ? err : "unknown") << " ("
-                 << ret
-                 << "); GPU memory registration may fail with a bare"
-                    " \"Operation not supported\"";
+                 << ret << "); CUDA operation may fail";
 }
 
 // Make `device_ordinal`'s primary context current on the calling thread, unless
@@ -434,8 +429,9 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
 // Who arrives here without the right context: registerLocalMemoryBatch() runs
 // one std::async(std::launch::async) per buffer and registerLocalMemory() can
 // fan out one std::thread per NIC, so a registering thread may have touched no
-// CUDA API at all; and since std::async may reuse threads, one thread can
-// register buffers on several devices in turn.
+// CUDA API at all.  Loopback copies also run on EFA worker threads.  Since
+// these threads may be reused for buffers on different devices, bind by device
+// rather than merely checking whether any context is current.
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
 // uses, so this attaches to the process's existing context rather than creating
@@ -466,6 +462,17 @@ static void bindCudaContextIfNeeded(int device_ordinal) {
     if (ret != CUDA_SUCCESS)
         logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
 }
+
+static int getCudaDeviceForPointer(const void* ptr) {
+    cudaPointerAttributes attributes;
+    cudaError_t ret = cudaPointerGetAttributes(&attributes, ptr);
+    if (ret != cudaSuccess) {
+        cudaGetLastError();
+        return -1;
+    }
+    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
+    return -1;
+}
 #endif
 
 int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
@@ -495,11 +502,10 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int device_ordinal = 0;
 
 #if defined(USE_CUDA)
-    cudaPointerAttributes attributes;
-    cudaError_t cuda_ret = cudaPointerGetAttributes(&attributes, addr);
-    if (cuda_ret == cudaSuccess && attributes.type == cudaMemoryTypeDevice) {
+    int cuda_device = getCudaDeviceForPointer(addr);
+    if (cuda_device >= 0) {
         iface = FI_HMEM_CUDA;
-        device_ordinal = attributes.device;
+        device_ordinal = cuda_device;
     }
 #elif defined(USE_HIP)
     hipPointerAttribute_t attributes;
@@ -806,16 +812,24 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // including non-EFA GPU backends such as MUSA/MLU/MACA, which never run
     // on AWS EFA hardware — registers loopback buffers as host memory, so a
     // plain memcpy is both correct and the only portable option (those
-    // backends do not expose the cuda* symbols).  *MemcpyDefault picks
-    // H2H/H2D/D2H/D2D from the pointer attributes.
+    // backends do not expose the cuda* symbols).  CUDA host-only copies also
+    // use memcpy; copies involving device memory use cudaMemcpyDefault after
+    // binding the destination device, or the source device for D2H copies.
 #if defined(USE_CUDA)
-    auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
-    if (rc != cudaSuccess) {
-        LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
-                   << cudaGetErrorString(rc) << " (dst=" << dst
-                   << ", src=" << src << ", len=" << len << ")";
-        slice->markFailed();
-        return true;
+    int device = getCudaDeviceForPointer(dst);
+    if (device < 0) device = getCudaDeviceForPointer(src);
+    if (device < 0) {
+        memcpy(dst, src, len);
+    } else {
+        bindCudaContextIfNeeded(device);
+        auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+        if (rc != cudaSuccess) {
+            LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
+                       << cudaGetErrorString(rc) << " (dst=" << dst
+                       << ", src=" << src << ", len=" << len << ")";
+            slice->markFailed();
+            return true;
+        }
     }
 #elif defined(USE_HIP)
     auto rc = hipMemcpy(dst, src, len, hipMemcpyDefault);

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "transfer_engine.h"
@@ -177,9 +178,8 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     std::string local_server_name_;
 };
 
-// A loopback copy on a nonzero GPU must not create a CUDA context on GPU 0.
-// CUDA device selection is thread-local, so this specifically exercises the
-// EFA worker thread that performs the copy.
+// A loopback copy submitted from a fresh thread must bind the buffer's device,
+// not the thread's default CUDA device (GPU 0).
 TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
     int device_count = 0;
     ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
@@ -189,20 +189,13 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
     ASSERT_EQ(cuDeviceGet(&device_zero, 0), CUDA_SUCCESS);
 
     unsigned int flags = 0;
-    int active = 0;
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+    int device_zero_active_before = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
+                                         &device_zero_active_before),
               CUDA_SUCCESS);
-    if (active) GTEST_SKIP() << "CUDA device 0 context is already active";
 
     auto setup = createEngine(1);
     if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
-
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
-              CUDA_SUCCESS);
-    if (active) {
-        destroyEngine(setup);
-        GTEST_SKIP() << "setup activated CUDA device 0";
-    }
 
     auto segment_desc =
         setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
@@ -211,14 +204,44 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
 
     const size_t kDataLength = 4096;
     ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
-    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id,
-                              setup.dev_buf,
-                              remote_base + (setup.buffer_size / 2),
-                              kDataLength, TransferRequest::WRITE));
 
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+    bool started_without_context = false;
+    bool transfer_ok = false;
+    CUresult context_result = CUDA_ERROR_UNKNOWN;
+    CUresult device_result = CUDA_ERROR_UNKNOWN;
+    CUdevice worker_device = -1;
+    std::thread submitter([&] {
+        CUcontext context = nullptr;
+        context_result = cuCtxGetCurrent(&context);
+        started_without_context =
+            context_result == CUDA_SUCCESS && context == nullptr;
+
+        transfer_ok =
+            submitAndWait(setup.engine.get(), setup.segment_id, setup.dev_buf,
+                          remote_base + (setup.buffer_size / 2), kDataLength,
+                          TransferRequest::WRITE);
+
+        context_result = cuCtxGetCurrent(&context);
+        if (context_result == CUDA_SUCCESS && context != nullptr) {
+            device_result = cuCtxGetDevice(&worker_device);
+        }
+    });
+    submitter.join();
+
+    ASSERT_TRUE(started_without_context);
+    ASSERT_TRUE(transfer_ok);
+    ASSERT_EQ(context_result, CUDA_SUCCESS);
+    ASSERT_EQ(device_result, CUDA_SUCCESS);
+    EXPECT_EQ(worker_device, 1);
+
+    int device_zero_active_after = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
+                                         &device_zero_active_after),
               CUDA_SUCCESS);
-    EXPECT_EQ(active, 0) << "loopback copy activated CUDA device 0";
+    if (!device_zero_active_before) {
+        EXPECT_EQ(device_zero_active_after, 0)
+            << "loopback copy activated CUDA device 0";
+    }
 
     destroyEngine(setup);
 }

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -30,6 +30,7 @@
 // Requires EFA hardware (fi_info -p efa) AND at least one CUDA GPU.  Self-
 // skips cleanly when either is absent.
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -37,6 +38,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "transfer_engine.h"
@@ -80,12 +82,13 @@ class EFAGpuLoopbackTest : public ::testing::Test {
 
     // Create engine, install EFA transport, allocate + register a CUDA
     // device buffer, and open our own segment for loopback.
-    EngineSetup createEngine(size_t buffer_size = 1ull << 26 /* 64 MB */) {
+    EngineSetup createEngine(int device_id = 0,
+                             size_t buffer_size = 1ull << 26 /* 64 MB */) {
         EngineSetup s;
         s.buffer_size = buffer_size;
 
-        if (cudaSetDevice(0) != cudaSuccess) {
-            LOG(WARNING) << "cudaSetDevice(0) failed";
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(WARNING) << "cudaSetDevice(" << device_id << ") failed";
             return s;
         }
 
@@ -108,8 +111,9 @@ class EFAGpuLoopbackTest : public ::testing::Test {
 
         // Register as GPU memory so the EFA transport tags the MR with
         // FI_HMEM_CUDA (the registration path under test).
-        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, "cuda:0");
-        EXPECT_EQ(rc, 0) << "registerLocalMemory(cuda:0) failed";
+        std::string location = "cuda:" + std::to_string(device_id);
+        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, location);
+        EXPECT_EQ(rc, 0) << "registerLocalMemory(" << location << ") failed";
         if (rc != 0) return s;
 
         auto actual_addr = s.engine->getLocalIpAndPort();
@@ -172,6 +176,52 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     std::string metadata_server_;
     std::string local_server_name_;
 };
+
+// A loopback copy on a nonzero GPU must not create a CUDA context on GPU 0.
+// CUDA device selection is thread-local, so this specifically exercises the
+// EFA worker thread that performs the copy.
+TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
+
+    CUdevice device_zero;
+    ASSERT_EQ(cuDeviceGet(&device_zero, 0), CUDA_SUCCESS);
+
+    unsigned int flags = 0;
+    int active = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    if (active) GTEST_SKIP() << "CUDA device 0 context is already active";
+
+    auto setup = createEngine(1);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    if (active) {
+        destroyEngine(setup);
+        GTEST_SKIP() << "setup activated CUDA device 0";
+    }
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kDataLength = 4096;
+    ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
+    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id,
+                              setup.dev_buf,
+                              remote_base + (setup.buffer_size / 2),
+                              kDataLength, TransferRequest::WRITE));
+
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    EXPECT_EQ(active, 0) << "loopback copy activated CUDA device 0";
+
+    destroyEngine(setup);
+}
 
 // Test 1: GPU loopback WRITE must not crash.
 //


### PR DESCRIPTION
Superseded by https://github.com/kvcache-ai/Mooncake/pull/3436, reopened from my personal account. Closing this PR to keep discussion in one place.

## Description

EFA same-process loopback copies run on worker threads whose CUDA device is not initialized. Calling `cudaMemcpy` directly can therefore create a primary context on GPU 0 even when both buffers belong to another GPU.

This change:
- determines the loopback buffer's CUDA device and binds its primary context before copying;
- uses plain `memcpy` for host-only loopback copies;
- adds a multi-GPU regression test that verifies a GPU 1 loopback does not activate GPU 0.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" ./scripts/code_format.sh --staged
PATH="/opt/homebrew/opt/llvm@20/bin:$PATH" uvx pre-commit run --files \
  mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp \
  mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
```

**Test results:**
- [x] Formatting and applicable pre-commit hooks pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not applicable
- [x] I have added tests to prove my changes are effective
- [ ] RFC is not applicable (change is under 500 LOC)

## AI Assistance Disclosure

- [x] AI tools were used

Cursor assisted with implementation and regression-test drafting. The submitted diff was reviewed and validated by the author.