### PR TITLE
[TransferEngine] Bind buffer device for EFA CUDA loopback

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -413,9 +413,11 @@ int EfaContext::deconstruct() {
 static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
     const char* err = nullptr;
     cuGetErrorString(ret, &err);
-    LOG(WARNING) << "EFA: " << call << " failed for CUDA device "
-                 << device_ordinal << ": " << (err ? err : "unknown") << " ("
-                 << ret
+    LOG(WARNING) << "EFA: " << call << " failed"
+                 << (device_ordinal >= 0
+                         ? " for CUDA device " + std::to_string(device_ordinal)
+                         : "")
+                 << ": " << (err ? err : "unknown") << " (" << ret
                  << "); GPU memory registration or a GPU-aware copy may fail"
                     " with a bare \"Operation not supported\"";
 }
@@ -438,10 +440,13 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
 // uses, so this attaches to the process's existing context rather than creating
-// another.  The retain is intentionally not released: the primary context
-// outlives every registration, and dropping the last reference here would tear
-// down the context the rest of the process is using.
-static bool bindCudaContextIfNeeded(int device_ordinal) {
+// another.  Registration keeps its retain for the process lifetime.  Scoped
+// callers request `retained_primary` and release that reference after restoring
+// the previous context.
+static bool bindCudaContextIfNeeded(int device_ordinal,
+                                    bool* retained_primary = nullptr) {
+    if (retained_primary) *retained_primary = false;
+
     CUdevice want;
     CUresult ret = cuDeviceGet(&want, device_ordinal);
     if (ret != CUDA_SUCCESS) {
@@ -456,13 +461,15 @@ static bool bindCudaContextIfNeeded(int device_ordinal) {
         logCudaFailure("cuCtxGetCurrent", ret, device_ordinal);
         return false;
     }
+    bool same_device = false;
     if (cur != nullptr) {
         ret = cuCtxGetDevice(&cur_dev);
         if (ret != CUDA_SUCCESS) {
             logCudaFailure("cuCtxGetDevice", ret, device_ordinal);
             return false;
         }
-        if (cur_dev == want) return true;
+        same_device = cur_dev == want;
+        if (same_device && !retained_primary) return true;
     }
 
     CUcontext primary = nullptr;
@@ -471,6 +478,9 @@ static bool bindCudaContextIfNeeded(int device_ordinal) {
         logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal);
         return false;
     }
+    if (retained_primary) *retained_primary = true;
+    if (same_device && cur == primary) return true;
+
     ret = cuCtxSetCurrent(primary);
     if (ret != CUDA_SUCCESS) {
         logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
@@ -832,15 +842,27 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // backends do not expose the cuda* symbols).  CUDA host-only copies also
     // use memcpy; copies involving device memory use cudaMemcpyDefault after
     // binding the destination device, or the source device for D2H copies.
-    // The caller's context is restored afterward, and D2D copies synchronize
+    // The caller's context is restored afterward, and CUDA copies synchronize
     // before the slice is reported complete.
 #if defined(USE_CUDA)
+    CUcontext previous = nullptr;
+    CUresult context_rc = cuCtxGetCurrent(&previous);
+    if (context_rc != CUDA_SUCCESS) {
+        logCudaFailure("cuCtxGetCurrent", context_rc, -1);
+        slice->markFailed();
+        return true;
+    }
+
     cudaError_t dst_status;
     cudaError_t src_status;
     int dst_device = getCudaDeviceForPointer(dst, dst_status);
     int src_device = getCudaDeviceForPointer(src, src_status);
     if (dst_status != cudaSuccess || src_status != cudaSuccess) {
         cudaError_t rc = dst_status != cudaSuccess ? dst_status : src_status;
+        context_rc = cuCtxSetCurrent(previous);
+        if (context_rc != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, -1);
+        }
         LOG(ERROR) << "EFA loopback cudaPointerGetAttributes failed: "
                    << cudaGetErrorString(rc) << " (dst=" << dst
                    << ", src=" << src << ", len=" << len << ")";
@@ -851,27 +873,32 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     int device = dst_device >= 0 ? dst_device : src_device;
     if (device < 0) {
         memcpy(dst, src, len);
-    } else {
-        CUcontext previous = nullptr;
-        CUresult context_rc = cuCtxGetCurrent(&previous);
+        context_rc = cuCtxSetCurrent(previous);
         if (context_rc != CUDA_SUCCESS) {
-            logCudaFailure("cuCtxGetCurrent", context_rc, device);
+            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, -1);
             slice->markFailed();
             return true;
         }
-
-        bool bound = bindCudaContextIfNeeded(device);
+    } else {
+        bool retained_primary = false;
+        bool bound = bindCudaContextIfNeeded(device, &retained_primary);
         cudaError_t rc = cudaSuccess;
         if (bound) {
             rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
-            if (rc == cudaSuccess && dst_device >= 0 && src_device >= 0) {
-                rc = cudaStreamSynchronize(0);
-            }
+            if (rc == cudaSuccess) rc = cudaStreamSynchronize(0);
         }
 
         context_rc = cuCtxSetCurrent(previous);
         if (context_rc != CUDA_SUCCESS) {
             logCudaFailure("cuCtxSetCurrent (restore)", context_rc, device);
+        }
+
+        CUresult release_rc = CUDA_SUCCESS;
+        if (retained_primary) {
+            release_rc = cuDevicePrimaryCtxRelease(device);
+            if (release_rc != CUDA_SUCCESS) {
+                logCudaFailure("cuDevicePrimaryCtxRelease", release_rc, device);
+            }
         }
 
         if (!bound) {
@@ -886,6 +913,10 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
             return true;
         }
         if (context_rc != CUDA_SUCCESS) {
+            slice->markFailed();
+            return true;
+        }
+        if (release_rc != CUDA_SUCCESS) {
             slice->markFailed();
             return true;
         }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -422,67 +422,8 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
                     " with a bare \"Operation not supported\"";
 }
 
-// Make `device_ordinal`'s primary context current on the calling thread, unless
-// a context for that same device already is.
-//
-// Why a context is needed at all: fi_mr_regattr() on FI_HMEM_CUDA memory
-// reaches libfabric's cuda_get_dmabuf_fd(), which calls the driver API
-// cuMemGetHandleForAddressRange() and does no context management of its own.
-// The export also runs against the CURRENT context, so a context belonging to
-// another device is no better than none -- both end up as a bare "Operation not
-// supported" from the provider.
-//
-// Who arrives here without the right context: registerLocalMemoryBatch() runs
-// one std::async(std::launch::async) per buffer and registerLocalMemory() can
-// fan out one std::thread per NIC, so a registering thread may have touched no
-// CUDA API at all; and since std::async may reuse threads, one thread can
-// register buffers on several devices in turn.
-//
-// cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
-// uses, so this attaches to the process's existing context rather than creating
-// another.  The retain is intentionally not released: the primary context
-// outlives every registration, and dropping the last reference here would tear
-// down the context the rest of the process is using.
-static bool bindCudaContextIfNeeded(int device_ordinal) {
-    CUdevice want;
-    CUresult ret = cuDeviceGet(&want, device_ordinal);
-    if (ret != CUDA_SUCCESS) {
-        logCudaFailure("cuDeviceGet", ret, device_ordinal);
-        return false;
-    }
-
-    CUcontext cur = nullptr;
-    CUdevice cur_dev;
-    ret = cuCtxGetCurrent(&cur);
-    if (ret != CUDA_SUCCESS) {
-        logCudaFailure("cuCtxGetCurrent", ret, device_ordinal);
-        return false;
-    }
-    if (cur != nullptr) {
-        ret = cuCtxGetDevice(&cur_dev);
-        if (ret != CUDA_SUCCESS) {
-            logCudaFailure("cuCtxGetDevice", ret, device_ordinal);
-            return false;
-        }
-        if (cur_dev == want) return true;
-    }
-
-    CUcontext primary = nullptr;
-    ret = cuDevicePrimaryCtxRetain(&primary, want);
-    if (ret != CUDA_SUCCESS) {
-        logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal);
-        return false;
-    }
-    ret = cuCtxSetCurrent(primary);
-    if (ret != CUDA_SUCCESS) {
-        logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
-        return false;
-    }
-    return true;
-}
-
-// Loopback runs synchronously on the caller's thread. Temporarily use the
-// buffer's primary context, then restore the caller and balance the retain.
+// RAII guard: temporarily make a device's primary context current, then restore
+// the caller's original context and release the retain on destruction.
 class ScopedCudaContext {
    public:
     ScopedCudaContext() {
@@ -618,7 +559,9 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int ret;
     if (iface != FI_HMEM_SYSTEM) {
 #if defined(USE_CUDA)
-        if (!bindCudaContextIfNeeded(device_ordinal)) return ERR_CONTEXT;
+        ScopedCudaContext reg_context;
+        if (!reg_context.valid() || !reg_context.bind(device_ordinal))
+            return ERR_CONTEXT;
 #endif
         // GPU memory: use fi_mr_regattr with explicit iface and device
         struct iovec iov = {.iov_base = addr, .iov_len = length};
@@ -917,12 +860,6 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // The caller's context is restored afterward, and CUDA copies synchronize
     // before the slice is reported complete.
 #if defined(USE_CUDA)
-    ScopedCudaContext context;
-    if (!context.valid()) {
-        slice->markFailed();
-        return true;
-    }
-
     cudaError_t dst_status;
     cudaError_t src_status;
     int dst_device = getCudaDeviceForPointer(dst, dst_status);
@@ -939,27 +876,20 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     int device = dst_device >= 0 ? dst_device : src_device;
     if (device < 0) {
         memcpy(dst, src, len);
-        if (!context.restore()) {
-            slice->markFailed();
-            return true;
-        }
     } else {
-        if (!context.bind(device)) {
+        ScopedCudaContext context;
+        if (!context.valid() || !context.bind(device)) {
             slice->markFailed();
             return true;
         }
 
         cudaError_t rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
         if (rc == cudaSuccess) rc = cudaStreamSynchronize(0);
-        bool restored = context.restore();
+        context.restore();
         if (rc != cudaSuccess) {
             LOG(ERROR) << "EFA loopback CUDA copy failed: "
                        << cudaGetErrorString(rc) << " (dst=" << dst
                        << ", src=" << src << ", len=" << len << ")";
-            slice->markFailed();
-            return true;
-        }
-        if (!restored) {
             slice->markFailed();
             return true;
         }

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -408,17 +408,12 @@ int EfaContext::deconstruct() {
 }
 
 #if defined(USE_CUDA)
-// A silent failure here resurfaces as the provider's opaque "Operation not
-// supported" from fi_mr_regattr(), which is the attribution problem this whole
-// helper exists to remove -- so name the driver call that actually failed.
 static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
     const char* err = nullptr;
     cuGetErrorString(ret, &err);
     LOG(WARNING) << "EFA: " << call << " failed for CUDA device "
                  << device_ordinal << ": " << (err ? err : "unknown") << " ("
-                 << ret
-                 << "); GPU memory registration may fail with a bare"
-                    " \"Operation not supported\"";
+                 << ret << "); CUDA operation may fail";
 }
 
 // Make `device_ordinal`'s primary context current on the calling thread, unless
@@ -434,8 +429,9 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
 // Who arrives here without the right context: registerLocalMemoryBatch() runs
 // one std::async(std::launch::async) per buffer and registerLocalMemory() can
 // fan out one std::thread per NIC, so a registering thread may have touched no
-// CUDA API at all; and since std::async may reuse threads, one thread can
-// register buffers on several devices in turn.
+// CUDA API at all.  Loopback copies also run on EFA worker threads.  Since
+// these threads may be reused for buffers on different devices, bind by device
+// rather than merely checking whether any context is current.
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
 // uses, so this attaches to the process's existing context rather than creating
@@ -466,6 +462,17 @@ static void bindCudaContextIfNeeded(int device_ordinal) {
     if (ret != CUDA_SUCCESS)
         logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
 }
+
+static int getCudaDeviceForPointer(const void* ptr) {
+    cudaPointerAttributes attributes;
+    cudaError_t ret = cudaPointerGetAttributes(&attributes, ptr);
+    if (ret != cudaSuccess) {
+        cudaGetLastError();
+        return -1;
+    }
+    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
+    return -1;
+}
 #endif
 
 int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
@@ -495,11 +502,10 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int device_ordinal = 0;
 
 #if defined(USE_CUDA)
-    cudaPointerAttributes attributes;
-    cudaError_t cuda_ret = cudaPointerGetAttributes(&attributes, addr);
-    if (cuda_ret == cudaSuccess && attributes.type == cudaMemoryTypeDevice) {
+    int cuda_device = getCudaDeviceForPointer(addr);
+    if (cuda_device >= 0) {
         iface = FI_HMEM_CUDA;
-        device_ordinal = attributes.device;
+        device_ordinal = cuda_device;
     }
 #elif defined(USE_HIP)
     hipPointerAttribute_t attributes;
@@ -806,16 +812,24 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // including non-EFA GPU backends such as MUSA/MLU/MACA, which never run
     // on AWS EFA hardware — registers loopback buffers as host memory, so a
     // plain memcpy is both correct and the only portable option (those
-    // backends do not expose the cuda* symbols).  *MemcpyDefault picks
-    // H2H/H2D/D2H/D2D from the pointer attributes.
+    // backends do not expose the cuda* symbols).  CUDA host-only copies also
+    // use memcpy; copies involving device memory use cudaMemcpyDefault after
+    // binding the destination device, or the source device for D2H copies.
 #if defined(USE_CUDA)
-    auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
-    if (rc != cudaSuccess) {
-        LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
-                   << cudaGetErrorString(rc) << " (dst=" << dst
-                   << ", src=" << src << ", len=" << len << ")";
-        slice->markFailed();
-        return true;
+    int device = getCudaDeviceForPointer(dst);
+    if (device < 0) device = getCudaDeviceForPointer(src);
+    if (device < 0) {
+        memcpy(dst, src, len);
+    } else {
+        bindCudaContextIfNeeded(device);
+        auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+        if (rc != cudaSuccess) {
+            LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
+                       << cudaGetErrorString(rc) << " (dst=" << dst
+                       << ", src=" << src << ", len=" << len << ")";
+            slice->markFailed();
+            return true;
+        }
     }
 #elif defined(USE_HIP)
     auto rc = hipMemcpy(dst, src, len, hipMemcpyDefault);

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -408,12 +408,16 @@ int EfaContext::deconstruct() {
 }
 
 #if defined(USE_CUDA)
+// A silent failure here resurfaces as an opaque provider error, so name the
+// driver call that actually failed.
 static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
     const char* err = nullptr;
     cuGetErrorString(ret, &err);
     LOG(WARNING) << "EFA: " << call << " failed for CUDA device "
                  << device_ordinal << ": " << (err ? err : "unknown") << " ("
-                 << ret << "); CUDA operation may fail";
+                 << ret
+                 << "); GPU memory registration or a GPU-aware copy may fail"
+                    " with a bare \"Operation not supported\"";
 }
 
 // Make `device_ordinal`'s primary context current on the calling thread, unless
@@ -429,48 +433,60 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
 // Who arrives here without the right context: registerLocalMemoryBatch() runs
 // one std::async(std::launch::async) per buffer and registerLocalMemory() can
 // fan out one std::thread per NIC, so a registering thread may have touched no
-// CUDA API at all.  Loopback copies also run on EFA worker threads.  Since
-// these threads may be reused for buffers on different devices, bind by device
-// rather than merely checking whether any context is current.
+// CUDA API at all.  Loopback copies run on the caller's thread, so
+// tryLoopbackCopy() restores a different previous context before returning.
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
 // uses, so this attaches to the process's existing context rather than creating
 // another.  The retain is intentionally not released: the primary context
 // outlives every registration, and dropping the last reference here would tear
 // down the context the rest of the process is using.
-static void bindCudaContextIfNeeded(int device_ordinal) {
+static bool bindCudaContextIfNeeded(int device_ordinal) {
     CUdevice want;
     CUresult ret = cuDeviceGet(&want, device_ordinal);
     if (ret != CUDA_SUCCESS) {
         logCudaFailure("cuDeviceGet", ret, device_ordinal);
-        return;
+        return false;
     }
 
     CUcontext cur = nullptr;
     CUdevice cur_dev;
-    if (cuCtxGetCurrent(&cur) == CUDA_SUCCESS && cur != nullptr &&
-        cuCtxGetDevice(&cur_dev) == CUDA_SUCCESS && cur_dev == want)
-        return;
+    ret = cuCtxGetCurrent(&cur);
+    if (ret != CUDA_SUCCESS) {
+        logCudaFailure("cuCtxGetCurrent", ret, device_ordinal);
+        return false;
+    }
+    if (cur != nullptr) {
+        ret = cuCtxGetDevice(&cur_dev);
+        if (ret != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxGetDevice", ret, device_ordinal);
+            return false;
+        }
+        if (cur_dev == want) return true;
+    }
 
     CUcontext primary = nullptr;
     ret = cuDevicePrimaryCtxRetain(&primary, want);
     if (ret != CUDA_SUCCESS) {
         logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal);
-        return;
+        return false;
     }
     ret = cuCtxSetCurrent(primary);
-    if (ret != CUDA_SUCCESS)
+    if (ret != CUDA_SUCCESS) {
         logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
+        return false;
+    }
+    return true;
 }
 
-static int getCudaDeviceForPointer(const void* ptr) {
+static int getCudaDeviceForPointer(const void* ptr, cudaError_t& status) {
     cudaPointerAttributes attributes;
-    cudaError_t ret = cudaPointerGetAttributes(&attributes, ptr);
-    if (ret != cudaSuccess) {
-        cudaGetLastError();
-        return -1;
+    status = cudaPointerGetAttributes(&attributes, ptr);
+    if (status != cudaSuccess) return -1;
+    if (attributes.type == cudaMemoryTypeDevice ||
+        attributes.type == cudaMemoryTypeManaged) {
+        return attributes.device;
     }
-    if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
     return -1;
 }
 #endif
@@ -502,10 +518,11 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int device_ordinal = 0;
 
 #if defined(USE_CUDA)
-    int cuda_device = getCudaDeviceForPointer(addr);
-    if (cuda_device >= 0) {
+    cudaPointerAttributes attributes;
+    cudaError_t cuda_ret = cudaPointerGetAttributes(&attributes, addr);
+    if (cuda_ret == cudaSuccess && attributes.type == cudaMemoryTypeDevice) {
         iface = FI_HMEM_CUDA;
-        device_ordinal = cuda_device;
+        device_ordinal = attributes.device;
     }
 #elif defined(USE_HIP)
     hipPointerAttribute_t attributes;
@@ -519,7 +536,7 @@ int EfaContext::registerMemoryRegionInternal(void* addr, size_t length,
     int ret;
     if (iface != FI_HMEM_SYSTEM) {
 #if defined(USE_CUDA)
-        bindCudaContextIfNeeded(device_ordinal);
+        if (!bindCudaContextIfNeeded(device_ordinal)) return ERR_CONTEXT;
 #endif
         // GPU memory: use fi_mr_regattr with explicit iface and device
         struct iovec iov = {.iov_base = addr, .iov_len = length};
@@ -815,23 +832,67 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // backends do not expose the cuda* symbols).  CUDA host-only copies also
     // use memcpy; copies involving device memory use cudaMemcpyDefault after
     // binding the destination device, or the source device for D2H copies.
+    // The caller's context is restored afterward, and D2D copies synchronize
+    // before the slice is reported complete.
 #if defined(USE_CUDA)
-    int device = getCudaDeviceForPointer(dst);
-    if (device < 0) device = getCudaDeviceForPointer(src);
+    cudaError_t dst_status;
+    cudaError_t src_status;
+    int dst_device = getCudaDeviceForPointer(dst, dst_status);
+    int src_device = getCudaDeviceForPointer(src, src_status);
+    if (dst_status != cudaSuccess || src_status != cudaSuccess) {
+        cudaError_t rc = dst_status != cudaSuccess ? dst_status : src_status;
+        LOG(ERROR) << "EFA loopback cudaPointerGetAttributes failed: "
+                   << cudaGetErrorString(rc) << " (dst=" << dst
+                   << ", src=" << src << ", len=" << len << ")";
+        slice->markFailed();
+        return true;
+    }
+
+    int device = dst_device >= 0 ? dst_device : src_device;
     if (device < 0) {
         memcpy(dst, src, len);
     } else {
-        bindCudaContextIfNeeded(device);
-        auto rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+        CUcontext previous = nullptr;
+        CUresult context_rc = cuCtxGetCurrent(&previous);
+        if (context_rc != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxGetCurrent", context_rc, device);
+            slice->markFailed();
+            return true;
+        }
+
+        bool bound = bindCudaContextIfNeeded(device);
+        cudaError_t rc = cudaSuccess;
+        if (bound) {
+            rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+            if (rc == cudaSuccess && dst_device >= 0 && src_device >= 0) {
+                rc = cudaStreamSynchronize(0);
+            }
+        }
+
+        context_rc = cuCtxSetCurrent(previous);
+        if (context_rc != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, device);
+        }
+
+        if (!bound) {
+            slice->markFailed();
+            return true;
+        }
         if (rc != cudaSuccess) {
-            LOG(ERROR) << "EFA loopback cudaMemcpy failed: "
+            LOG(ERROR) << "EFA loopback CUDA copy failed: "
                        << cudaGetErrorString(rc) << " (dst=" << dst
                        << ", src=" << src << ", len=" << len << ")";
             slice->markFailed();
             return true;
         }
+        if (context_rc != CUDA_SUCCESS) {
+            slice->markFailed();
+            return true;
+        }
     }
 #elif defined(USE_HIP)
+    // EFA is not deployed with HIP, so CUDA context binding is intentionally
+    // not mirrored here.
     auto rc = hipMemcpy(dst, src, len, hipMemcpyDefault);
     if (rc != hipSuccess) {
         LOG(ERROR) << "EFA loopback hipMemcpy failed: " << hipGetErrorString(rc)

--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp
@@ -435,18 +435,15 @@ static void logCudaFailure(const char* call, CUresult ret, int device_ordinal) {
 // Who arrives here without the right context: registerLocalMemoryBatch() runs
 // one std::async(std::launch::async) per buffer and registerLocalMemory() can
 // fan out one std::thread per NIC, so a registering thread may have touched no
-// CUDA API at all.  Loopback copies run on the caller's thread, so
-// tryLoopbackCopy() restores a different previous context before returning.
+// CUDA API at all; and since std::async may reuse threads, one thread can
+// register buffers on several devices in turn.
 //
 // cuDevicePrimaryCtxRetain() returns the same primary context the CUDA runtime
 // uses, so this attaches to the process's existing context rather than creating
-// another.  Registration keeps its retain for the process lifetime.  Scoped
-// callers request `retained_primary` and release that reference after restoring
-// the previous context.
-static bool bindCudaContextIfNeeded(int device_ordinal,
-                                    bool* retained_primary = nullptr) {
-    if (retained_primary) *retained_primary = false;
-
+// another.  The retain is intentionally not released: the primary context
+// outlives every registration, and dropping the last reference here would tear
+// down the context the rest of the process is using.
+static bool bindCudaContextIfNeeded(int device_ordinal) {
     CUdevice want;
     CUresult ret = cuDeviceGet(&want, device_ordinal);
     if (ret != CUDA_SUCCESS) {
@@ -461,15 +458,13 @@ static bool bindCudaContextIfNeeded(int device_ordinal,
         logCudaFailure("cuCtxGetCurrent", ret, device_ordinal);
         return false;
     }
-    bool same_device = false;
     if (cur != nullptr) {
         ret = cuCtxGetDevice(&cur_dev);
         if (ret != CUDA_SUCCESS) {
             logCudaFailure("cuCtxGetDevice", ret, device_ordinal);
             return false;
         }
-        same_device = cur_dev == want;
-        if (same_device && !retained_primary) return true;
+        if (cur_dev == want) return true;
     }
 
     CUcontext primary = nullptr;
@@ -478,9 +473,6 @@ static bool bindCudaContextIfNeeded(int device_ordinal,
         logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal);
         return false;
     }
-    if (retained_primary) *retained_primary = true;
-    if (same_device && cur == primary) return true;
-
     ret = cuCtxSetCurrent(primary);
     if (ret != CUDA_SUCCESS) {
         logCudaFailure("cuCtxSetCurrent", ret, device_ordinal);
@@ -488,6 +480,86 @@ static bool bindCudaContextIfNeeded(int device_ordinal,
     }
     return true;
 }
+
+// Loopback runs synchronously on the caller's thread. Temporarily use the
+// buffer's primary context, then restore the caller and balance the retain.
+class ScopedCudaContext {
+   public:
+    ScopedCudaContext() {
+        CUresult ret = cuCtxGetCurrent(&previous_);
+        if (ret != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxGetCurrent", ret, -1);
+            return;
+        }
+        valid_ = true;
+    }
+
+    ScopedCudaContext(const ScopedCudaContext&) = delete;
+    ScopedCudaContext& operator=(const ScopedCudaContext&) = delete;
+
+    ~ScopedCudaContext() {
+        if (!restored_) restore();
+    }
+
+    bool valid() const { return valid_; }
+
+    bool bind(int device_ordinal) {
+        if (!valid_ || retained_) return false;
+        device_ordinal_ = device_ordinal;
+
+        CUresult ret = cuDeviceGet(&device_, device_ordinal_);
+        if (ret != CUDA_SUCCESS) {
+            logCudaFailure("cuDeviceGet", ret, device_ordinal_);
+            return false;
+        }
+
+        CUcontext primary = nullptr;
+        ret = cuDevicePrimaryCtxRetain(&primary, device_);
+        if (ret != CUDA_SUCCESS) {
+            logCudaFailure("cuDevicePrimaryCtxRetain", ret, device_ordinal_);
+            return false;
+        }
+        retained_ = true;
+
+        ret = cuCtxSetCurrent(primary);
+        if (ret != CUDA_SUCCESS) {
+            logCudaFailure("cuCtxSetCurrent", ret, device_ordinal_);
+            return false;
+        }
+        return true;
+    }
+
+    bool restore() {
+        if (restored_) return restore_ok_;
+        restored_ = true;
+        if (!valid_) return false;
+
+        CUresult ret = cuCtxSetCurrent(previous_);
+        restore_ok_ = ret == CUDA_SUCCESS;
+        if (!restore_ok_) {
+            logCudaFailure("cuCtxSetCurrent (restore)", ret, device_ordinal_);
+        }
+
+        if (retained_) {
+            ret = cuDevicePrimaryCtxRelease(device_);
+            if (ret != CUDA_SUCCESS) {
+                logCudaFailure("cuDevicePrimaryCtxRelease", ret,
+                               device_ordinal_);
+                restore_ok_ = false;
+            }
+        }
+        return restore_ok_;
+    }
+
+   private:
+    CUcontext previous_ = nullptr;
+    CUdevice device_ = 0;
+    int device_ordinal_ = -1;
+    bool valid_ = false;
+    bool retained_ = false;
+    bool restored_ = false;
+    bool restore_ok_ = false;
+};
 
 static int getCudaDeviceForPointer(const void* ptr, cudaError_t& status) {
     cudaPointerAttributes attributes;
@@ -845,10 +917,8 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     // The caller's context is restored afterward, and CUDA copies synchronize
     // before the slice is reported complete.
 #if defined(USE_CUDA)
-    CUcontext previous = nullptr;
-    CUresult context_rc = cuCtxGetCurrent(&previous);
-    if (context_rc != CUDA_SUCCESS) {
-        logCudaFailure("cuCtxGetCurrent", context_rc, -1);
+    ScopedCudaContext context;
+    if (!context.valid()) {
         slice->markFailed();
         return true;
     }
@@ -859,10 +929,6 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     int src_device = getCudaDeviceForPointer(src, src_status);
     if (dst_status != cudaSuccess || src_status != cudaSuccess) {
         cudaError_t rc = dst_status != cudaSuccess ? dst_status : src_status;
-        context_rc = cuCtxSetCurrent(previous);
-        if (context_rc != CUDA_SUCCESS) {
-            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, -1);
-        }
         LOG(ERROR) << "EFA loopback cudaPointerGetAttributes failed: "
                    << cudaGetErrorString(rc) << " (dst=" << dst
                    << ", src=" << src << ", len=" << len << ")";
@@ -873,38 +939,19 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
     int device = dst_device >= 0 ? dst_device : src_device;
     if (device < 0) {
         memcpy(dst, src, len);
-        context_rc = cuCtxSetCurrent(previous);
-        if (context_rc != CUDA_SUCCESS) {
-            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, -1);
+        if (!context.restore()) {
             slice->markFailed();
             return true;
         }
     } else {
-        bool retained_primary = false;
-        bool bound = bindCudaContextIfNeeded(device, &retained_primary);
-        cudaError_t rc = cudaSuccess;
-        if (bound) {
-            rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
-            if (rc == cudaSuccess) rc = cudaStreamSynchronize(0);
-        }
-
-        context_rc = cuCtxSetCurrent(previous);
-        if (context_rc != CUDA_SUCCESS) {
-            logCudaFailure("cuCtxSetCurrent (restore)", context_rc, device);
-        }
-
-        CUresult release_rc = CUDA_SUCCESS;
-        if (retained_primary) {
-            release_rc = cuDevicePrimaryCtxRelease(device);
-            if (release_rc != CUDA_SUCCESS) {
-                logCudaFailure("cuDevicePrimaryCtxRelease", release_rc, device);
-            }
-        }
-
-        if (!bound) {
+        if (!context.bind(device)) {
             slice->markFailed();
             return true;
         }
+
+        cudaError_t rc = cudaMemcpy(dst, src, len, cudaMemcpyDefault);
+        if (rc == cudaSuccess) rc = cudaStreamSynchronize(0);
+        bool restored = context.restore();
         if (rc != cudaSuccess) {
             LOG(ERROR) << "EFA loopback CUDA copy failed: "
                        << cudaGetErrorString(rc) << " (dst=" << dst
@@ -912,11 +959,7 @@ bool EfaContext::tryLoopbackCopy(Transport::Slice* slice) {
             slice->markFailed();
             return true;
         }
-        if (context_rc != CUDA_SUCCESS) {
-            slice->markFailed();
-            return true;
-        }
-        if (release_rc != CUDA_SUCCESS) {
+        if (!restored) {
             slice->markFailed();
             return true;
         }

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -327,6 +327,60 @@ TEST_F(EFAGpuLoopbackTest, LoopbackPreservesCallerDevice) {
     EXPECT_EQ(free_result, cudaSuccess);
 }
 
+// Loopback WRITE between buffers on two different GPUs.  The engine buffer
+// lives on GPU 1 and the source buffer on GPU 0, exercising the cross-device
+// cudaMemcpyDefault path.
+TEST_F(EFAGpuLoopbackTest, CrossDeviceLoopback) {
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
+
+    // Engine buffer on GPU 1.
+    auto setup = createEngine(1);
+    EngineCleanup cleanup(this, setup);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    // Source buffer on GPU 0.
+    const size_t kDataLength = 4096;
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+    void *dev0_buf = nullptr;
+    ASSERT_EQ(cudaMalloc(&dev0_buf, kDataLength), cudaSuccess);
+
+    std::vector<uint8_t> pattern(kDataLength);
+    for (size_t i = 0; i < kDataLength; ++i) pattern[i] = (uint8_t)(i ^ 0x3C);
+    ASSERT_EQ(cudaMemcpy(dev0_buf, pattern.data(), kDataLength,
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
+
+    // Register the GPU 0 buffer with the engine.
+    int rc = setup.engine->registerLocalMemory(dev0_buf, kDataLength, "cuda:0");
+    ASSERT_EQ(rc, 0) << "registerLocalMemory(cuda:0) failed";
+
+    // WRITE: GPU 0 buffer -> second half of GPU 1 buffer.
+    const uint64_t dst_offset = setup.buffer_size / 2;
+    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id, dev0_buf,
+                              remote_base + dst_offset, kDataLength,
+                              TransferRequest::WRITE))
+        << "cross-device WRITE should succeed";
+
+    // Verify bytes landed on GPU 1.
+    std::vector<uint8_t> readback(kDataLength, 0xFF);
+    ASSERT_EQ(cudaMemcpy(readback.data(), (uint8_t *)setup.dev_buf + dst_offset,
+                         kDataLength, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(0, memcmp(readback.data(), pattern.data(), kDataLength))
+        << "cross-device loopback did not produce the expected bytes";
+
+    setup.engine->unregisterLocalMemory(dev0_buf);
+    cudaFree(dev0_buf);
+}
+
 // Test 1: GPU loopback WRITE must not crash.
 //
 // Without the fix this segfaults inside the EFA provider's SHM path

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -133,6 +133,17 @@ class EFAGpuLoopbackTest : public ::testing::Test {
         }
     }
 
+    class EngineCleanup {
+       public:
+        EngineCleanup(EFAGpuLoopbackTest *test, EngineSetup &setup)
+            : test_(test), setup_(setup) {}
+        ~EngineCleanup() { test_->destroyEngine(setup_); }
+
+       private:
+        EFAGpuLoopbackTest *test_;
+        EngineSetup &setup_;
+    };
+
     bool submitAndWait(TransferEngine *engine, SegmentID segment_id,
                        void *source, uint64_t target_offset, size_t length,
                        TransferRequest::OpCode opcode) {
@@ -178,9 +189,9 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     std::string local_server_name_;
 };
 
-// A loopback copy submitted from a fresh thread must bind the buffer's device,
-// not the thread's default CUDA device (GPU 0).
-TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
+// A loopback copy submitted from a fresh thread must not activate GPU 0 or
+// leave a CUDA context current on the caller's thread.
+TEST_F(EFAGpuLoopbackTest, LoopbackPreservesEmptyCallerContext) {
     int device_count = 0;
     ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
     if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
@@ -196,6 +207,7 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
 
     auto setup = createEngine(1);
     if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+    EngineCleanup cleanup(this, setup);
 
     auto segment_desc =
         setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
@@ -203,36 +215,32 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
     uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
 
     const size_t kDataLength = 4096;
-    ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
+    uint8_t *dev = (uint8_t *)setup.dev_buf;
+    const uint64_t destination = setup.buffer_size / 2;
+    ASSERT_EQ(cudaMemset(dev, 0xAB, kDataLength), cudaSuccess);
+    ASSERT_EQ(cudaMemset(dev + destination, 0, kDataLength), cudaSuccess);
+    ASSERT_EQ(cudaDeviceSynchronize(), cudaSuccess);
 
-    bool started_without_context = false;
     bool transfer_ok = false;
-    CUresult context_result = CUDA_ERROR_UNKNOWN;
-    CUresult device_result = CUDA_ERROR_UNKNOWN;
-    CUdevice worker_device = -1;
+    CUresult before_result = CUDA_ERROR_UNKNOWN;
+    CUresult after_result = CUDA_ERROR_UNKNOWN;
+    CUcontext before_context = nullptr;
+    CUcontext after_context = nullptr;
     std::thread submitter([&] {
-        CUcontext context = nullptr;
-        context_result = cuCtxGetCurrent(&context);
-        started_without_context =
-            context_result == CUDA_SUCCESS && context == nullptr;
-
-        transfer_ok =
-            submitAndWait(setup.engine.get(), setup.segment_id, setup.dev_buf,
-                          remote_base + (setup.buffer_size / 2), kDataLength,
-                          TransferRequest::WRITE);
-
-        context_result = cuCtxGetCurrent(&context);
-        if (context_result == CUDA_SUCCESS && context != nullptr) {
-            device_result = cuCtxGetDevice(&worker_device);
-        }
+        before_result = cuCtxGetCurrent(&before_context);
+        transfer_ok = submitAndWait(setup.engine.get(), setup.segment_id,
+                                    setup.dev_buf, remote_base + destination,
+                                    kDataLength, TransferRequest::WRITE);
+        after_result = cuCtxGetCurrent(&after_context);
     });
     submitter.join();
 
-    ASSERT_TRUE(started_without_context);
+    ASSERT_EQ(before_result, CUDA_SUCCESS);
+    ASSERT_EQ(before_context, nullptr);
     ASSERT_TRUE(transfer_ok);
-    ASSERT_EQ(context_result, CUDA_SUCCESS);
-    ASSERT_EQ(device_result, CUDA_SUCCESS);
-    EXPECT_EQ(worker_device, 1);
+    ASSERT_EQ(after_result, CUDA_SUCCESS);
+    EXPECT_EQ(after_context, before_context)
+        << "loopback copy changed the caller's CUDA context";
 
     int device_zero_active_after = 0;
     ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
@@ -243,7 +251,77 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
             << "loopback copy activated CUDA device 0";
     }
 
-    destroyEngine(setup);
+    std::vector<uint8_t> readback(kDataLength);
+    ASSERT_EQ(cudaMemcpy(readback.data(), dev + destination, kDataLength,
+                         cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    std::vector<uint8_t> expected(kDataLength, 0xAB);
+    EXPECT_EQ(0, memcmp(readback.data(), expected.data(), kDataLength))
+        << "loopback copy did not complete before reporting success";
+}
+
+// A loopback copy to another GPU must preserve an existing caller device so
+// subsequent CUDA work remains on the device selected by the application.
+TEST_F(EFAGpuLoopbackTest, LoopbackPreservesCallerDevice) {
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
+
+    auto setup = createEngine(1);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+    EngineCleanup cleanup(this, setup);
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kDataLength = 4096;
+    ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
+
+    bool transfer_ok = false;
+    int device_before = -1;
+    int device_after = -1;
+    int allocation_device = -1;
+    cudaError_t set_result = cudaErrorUnknown;
+    cudaError_t before_result = cudaErrorUnknown;
+    cudaError_t after_result = cudaErrorUnknown;
+    cudaError_t allocation_result = cudaErrorUnknown;
+    cudaError_t attributes_result = cudaErrorUnknown;
+    cudaError_t free_result = cudaErrorUnknown;
+    std::thread submitter([&] {
+        set_result = cudaSetDevice(0);
+        before_result = cudaGetDevice(&device_before);
+        transfer_ok =
+            submitAndWait(setup.engine.get(), setup.segment_id, setup.dev_buf,
+                          remote_base + (setup.buffer_size / 2), kDataLength,
+                          TransferRequest::WRITE);
+        after_result = cudaGetDevice(&device_after);
+
+        void *probe = nullptr;
+        allocation_result = cudaMalloc(&probe, 1 << 20);
+        if (allocation_result == cudaSuccess) {
+            cudaPointerAttributes attributes;
+            attributes_result = cudaPointerGetAttributes(&attributes, probe);
+            if (attributes_result == cudaSuccess) {
+                allocation_device = attributes.device;
+            }
+            free_result = cudaFree(probe);
+        }
+    });
+    submitter.join();
+
+    ASSERT_EQ(set_result, cudaSuccess);
+    ASSERT_EQ(before_result, cudaSuccess);
+    ASSERT_TRUE(transfer_ok);
+    ASSERT_EQ(after_result, cudaSuccess);
+    EXPECT_EQ(device_after, device_before)
+        << "loopback copy changed the caller's CUDA device";
+    ASSERT_EQ(allocation_result, cudaSuccess);
+    ASSERT_EQ(attributes_result, cudaSuccess);
+    EXPECT_EQ(allocation_device, device_before)
+        << "subsequent allocation landed on the wrong GPU";
+    EXPECT_EQ(free_result, cudaSuccess);
 }
 
 // Test 1: GPU loopback WRITE must not crash.

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -39,6 +39,7 @@
 #include <cstdlib>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include "transfer_engine.h"
@@ -177,9 +178,8 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     std::string local_server_name_;
 };
 
-// A loopback copy on a nonzero GPU must not create a CUDA context on GPU 0.
-// CUDA device selection is thread-local, so this specifically exercises the
-// EFA worker thread that performs the copy.
+// A loopback copy submitted from a fresh thread must bind the buffer's device,
+// not the thread's default CUDA device (GPU 0).
 TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
     int device_count = 0;
     ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
@@ -189,20 +189,13 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
     ASSERT_EQ(cuDeviceGet(&device_zero, 0), CUDA_SUCCESS);
 
     unsigned int flags = 0;
-    int active = 0;
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+    int device_zero_active_before = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
+                                         &device_zero_active_before),
               CUDA_SUCCESS);
-    if (active) GTEST_SKIP() << "CUDA device 0 context is already active";
 
     auto setup = createEngine(1);
     if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
-
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
-              CUDA_SUCCESS);
-    if (active) {
-        destroyEngine(setup);
-        GTEST_SKIP() << "setup activated CUDA device 0";
-    }
 
     auto segment_desc =
         setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
@@ -211,14 +204,44 @@ TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
 
     const size_t kDataLength = 4096;
     ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
-    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id,
-                              setup.dev_buf,
-                              remote_base + (setup.buffer_size / 2),
-                              kDataLength, TransferRequest::WRITE));
 
-    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+    bool started_without_context = false;
+    bool transfer_ok = false;
+    CUresult context_result = CUDA_ERROR_UNKNOWN;
+    CUresult device_result = CUDA_ERROR_UNKNOWN;
+    CUdevice worker_device = -1;
+    std::thread submitter([&] {
+        CUcontext context = nullptr;
+        context_result = cuCtxGetCurrent(&context);
+        started_without_context =
+            context_result == CUDA_SUCCESS && context == nullptr;
+
+        transfer_ok =
+            submitAndWait(setup.engine.get(), setup.segment_id, setup.dev_buf,
+                          remote_base + (setup.buffer_size / 2), kDataLength,
+                          TransferRequest::WRITE);
+
+        context_result = cuCtxGetCurrent(&context);
+        if (context_result == CUDA_SUCCESS && context != nullptr) {
+            device_result = cuCtxGetDevice(&worker_device);
+        }
+    });
+    submitter.join();
+
+    ASSERT_TRUE(started_without_context);
+    ASSERT_TRUE(transfer_ok);
+    ASSERT_EQ(context_result, CUDA_SUCCESS);
+    ASSERT_EQ(device_result, CUDA_SUCCESS);
+    EXPECT_EQ(worker_device, 1);
+
+    int device_zero_active_after = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
+                                         &device_zero_active_after),
               CUDA_SUCCESS);
-    EXPECT_EQ(active, 0) << "loopback copy activated CUDA device 0";
+    if (!device_zero_active_before) {
+        EXPECT_EQ(device_zero_active_after, 0)
+            << "loopback copy activated CUDA device 0";
+    }
 
     destroyEngine(setup);
 }

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -78,6 +78,7 @@ class EFAGpuLoopbackTest : public ::testing::Test {
         void *dev_buf = nullptr;  // CUDA device buffer
         size_t buffer_size = 0;
         SegmentID segment_id = 0;
+        bool registered = false;
         bool ok = false;
     };
 
@@ -116,6 +117,7 @@ class EFAGpuLoopbackTest : public ::testing::Test {
         rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, location);
         EXPECT_EQ(rc, 0) << "registerLocalMemory(" << location << ") failed";
         if (rc != 0) return s;
+        s.registered = true;
 
         auto actual_addr = s.engine->getLocalIpAndPort();
         s.segment_id = s.engine->openSegment(actual_addr);
@@ -124,8 +126,9 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     }
 
     void destroyEngine(EngineSetup &s) {
-        if (s.engine && s.dev_buf) {
+        if (s.engine && s.dev_buf && s.registered) {
             s.engine->unregisterLocalMemory(s.dev_buf);
+            s.registered = false;
         }
         if (s.dev_buf) {
             cudaFree(s.dev_buf);
@@ -199,15 +202,15 @@ TEST_F(EFAGpuLoopbackTest, LoopbackPreservesEmptyCallerContext) {
     CUdevice device_zero;
     ASSERT_EQ(cuDeviceGet(&device_zero, 0), CUDA_SUCCESS);
 
+    auto setup = createEngine(1);
+    EngineCleanup cleanup(this, setup);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
     unsigned int flags = 0;
     int device_zero_active_before = 0;
     ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags,
                                          &device_zero_active_before),
               CUDA_SUCCESS);
-
-    auto setup = createEngine(1);
-    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
-    EngineCleanup cleanup(this, setup);
 
     auto segment_desc =
         setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
@@ -257,7 +260,7 @@ TEST_F(EFAGpuLoopbackTest, LoopbackPreservesEmptyCallerContext) {
               cudaSuccess);
     std::vector<uint8_t> expected(kDataLength, 0xAB);
     EXPECT_EQ(0, memcmp(readback.data(), expected.data(), kDataLength))
-        << "loopback copy did not complete before reporting success";
+        << "loopback copy did not produce the expected bytes";
 }
 
 // A loopback copy to another GPU must preserve an existing caller device so
@@ -268,8 +271,8 @@ TEST_F(EFAGpuLoopbackTest, LoopbackPreservesCallerDevice) {
     if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
 
     auto setup = createEngine(1);
-    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
     EngineCleanup cleanup(this, setup);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
 
     auto segment_desc =
         setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);

--- a/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
@@ -30,6 +30,7 @@
 // Requires EFA hardware (fi_info -p efa) AND at least one CUDA GPU.  Self-
 // skips cleanly when either is absent.
 
+#include <cuda.h>
 #include <cuda_runtime.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -37,6 +38,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "transfer_engine.h"
@@ -80,12 +82,13 @@ class EFAGpuLoopbackTest : public ::testing::Test {
 
     // Create engine, install EFA transport, allocate + register a CUDA
     // device buffer, and open our own segment for loopback.
-    EngineSetup createEngine(size_t buffer_size = 1ull << 26 /* 64 MB */) {
+    EngineSetup createEngine(int device_id = 0,
+                             size_t buffer_size = 1ull << 26 /* 64 MB */) {
         EngineSetup s;
         s.buffer_size = buffer_size;
 
-        if (cudaSetDevice(0) != cudaSuccess) {
-            LOG(WARNING) << "cudaSetDevice(0) failed";
+        if (cudaSetDevice(device_id) != cudaSuccess) {
+            LOG(WARNING) << "cudaSetDevice(" << device_id << ") failed";
             return s;
         }
 
@@ -108,8 +111,9 @@ class EFAGpuLoopbackTest : public ::testing::Test {
 
         // Register as GPU memory so the EFA transport tags the MR with
         // FI_HMEM_CUDA (the registration path under test).
-        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, "cuda:0");
-        EXPECT_EQ(rc, 0) << "registerLocalMemory(cuda:0) failed";
+        std::string location = "cuda:" + std::to_string(device_id);
+        rc = s.engine->registerLocalMemory(s.dev_buf, buffer_size, location);
+        EXPECT_EQ(rc, 0) << "registerLocalMemory(" << location << ") failed";
         if (rc != 0) return s;
 
         auto actual_addr = s.engine->getLocalIpAndPort();
@@ -172,6 +176,52 @@ class EFAGpuLoopbackTest : public ::testing::Test {
     std::string metadata_server_;
     std::string local_server_name_;
 };
+
+// A loopback copy on a nonzero GPU must not create a CUDA context on GPU 0.
+// CUDA device selection is thread-local, so this specifically exercises the
+// EFA worker thread that performs the copy.
+TEST_F(EFAGpuLoopbackTest, LoopbackUsesBufferDevice) {
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    if (device_count < 2) GTEST_SKIP() << "At least two CUDA GPUs required";
+
+    CUdevice device_zero;
+    ASSERT_EQ(cuDeviceGet(&device_zero, 0), CUDA_SUCCESS);
+
+    unsigned int flags = 0;
+    int active = 0;
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    if (active) GTEST_SKIP() << "CUDA device 0 context is already active";
+
+    auto setup = createEngine(1);
+    if (!setup.ok) GTEST_SKIP() << "EFA/CUDA setup unavailable";
+
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    if (active) {
+        destroyEngine(setup);
+        GTEST_SKIP() << "setup activated CUDA device 0";
+    }
+
+    auto segment_desc =
+        setup.engine->getMetadata()->getSegmentDescByID(setup.segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+
+    const size_t kDataLength = 4096;
+    ASSERT_EQ(cudaMemset(setup.dev_buf, 0xAB, kDataLength), cudaSuccess);
+    ASSERT_TRUE(submitAndWait(setup.engine.get(), setup.segment_id,
+                              setup.dev_buf,
+                              remote_base + (setup.buffer_size / 2),
+                              kDataLength, TransferRequest::WRITE));
+
+    ASSERT_EQ(cuDevicePrimaryCtxGetState(device_zero, &flags, &active),
+              CUDA_SUCCESS);
+    EXPECT_EQ(active, 0) << "loopback copy activated CUDA device 0";
+
+    destroyEngine(setup);
+}
 
 // Test 1: GPU loopback WRITE must not crash.
 //


### PR DESCRIPTION
## Description

EFA same-process loopback can run on a submitting thread with no current CUDA context. Calling `cudaMemcpy` directly in that case can initialize a context on GPU 0 even when the buffers belong to another GPU. Fixes #3434. 

This PR:

- determines the CUDA device from the destination or source buffer;
- binds that device’s primary context before copying;
- uses `memcpy` for host-only loopback copies;
- adds a multi-GPU regression test that submits from a fresh thread and verifies GPU 1 is selected instead of GPU 0.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

```bash
./scripts/code_format.sh --staged
pre-commit run --files \
  mooncake-transfer-engine/src/transport/efa_transport/efa_context.cpp \
  mooncake-transfer-engine/tests/efa_gpu_loopback_test.cpp
```

Formatting and applicable pre-commit hooks pass. The EFA GPU regression test was not run locally because it requires Linux, EFA hardware, and at least two CUDA GPUs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [x] AI tools were used

Cursor assisted with drafting the implementation and regression test. I reviewed the resulting changes.