### PR TITLE
perf(store): distribute Redis oplog keys across slots

### DIFF
--- a/mooncake-store/include/ha/oplog/redis_oplog_store.h
+++ b/mooncake-store/include/ha/oplog/redis_oplog_store.h
@@ -108,7 +108,9 @@ class RedisOpLogStore : public OpLogStore {
     // - latest: committed progress watermark; dropped entries may leave holes
     // - trimmed: highest sequence already removed by cleanup
     // - entry:<seq>: serialized oplog payload
-    std::string key_tag_;
+    // OpLog keys intentionally avoid Redis Cluster hash tags so
+    // high-cardinality entry keys can spread across slots.
+    std::string key_prefix_;
     std::string latest_key_;
     std::string trimmed_key_;
     std::string snapshot_prefix_;

--- a/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
+++ b/mooncake-store/src/ha/oplog/redis_oplog_store.cpp
@@ -63,10 +63,10 @@ RedisOpLogStore::RedisOpLogStore(
     if (cluster_id_.empty()) {
         cluster_id_ = "default";
     }
-    key_tag_ = "mooncake:{" + cluster_id_ + "}:oplog";
-    latest_key_ = key_tag_ + ":latest";
-    trimmed_key_ = key_tag_ + ":trimmed";
-    snapshot_prefix_ = key_tag_ + ":snapshot:";
+    key_prefix_ = "mooncake:" + cluster_id_ + ":oplog";
+    latest_key_ = key_prefix_ + ":latest";
+    trimmed_key_ = key_prefix_ + ":trimmed";
+    snapshot_prefix_ = key_prefix_ + ":snapshot:";
 }
 
 RedisOpLogStore::~RedisOpLogStore() {
@@ -154,7 +154,7 @@ ErrorCode RedisOpLogStore::Init() {
 }
 
 std::string RedisOpLogStore::EntryKey(uint64_t sequence_id) const {
-    return key_tag_ + ":entry:" + SequenceMember(sequence_id);
+    return key_prefix_ + ":entry:" + SequenceMember(sequence_id);
 }
 
 std::string RedisOpLogStore::SnapshotKey(const std::string& snapshot_id) const {

--- a/mooncake-store/tests/e2e/redis_chaos_test.cpp
+++ b/mooncake-store/tests/e2e/redis_chaos_test.cpp
@@ -119,7 +119,7 @@ void CleanupRedisKeys() {
     keys.push_back("mooncake:{" + FLAGS_redis_cluster_id +
                    "}:masters:metadata");
     std::string oplog_pattern =
-        "mooncake:{" + FLAGS_redis_cluster_id + "}:oplog*";
+        "mooncake:" + FLAGS_redis_cluster_id + ":oplog*";
     redisReply* keys_reply = static_cast<redisReply*>(redisCommand(
         ctx, "KEYS %b", oplog_pattern.data(), oplog_pattern.size()));
     if (keys_reply && keys_reply->type == REDIS_REPLY_ARRAY) {

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
+#include <vector>
 #include <string>
 #include <thread>
 
@@ -35,7 +36,7 @@ TEST(RedisOpLogStoreStandaloneTest, InvalidEndpointReturnsError) {
 }
 
 TEST(RedisOpLogStoreStandaloneTest, EndpointRequiresExplicitPort) {
-    for (const std::string& endpoint : {"", "127.0.0.1", "[::1]", "::1"}) {
+    for (const char* endpoint : {"", "127.0.0.1", "[::1]", "::1"}) {
         RedisOpLogStore store("invalid_endpoint_test", endpoint,
                               /*enable_write=*/true,
                               /*poll_interval_ms=*/10);
@@ -101,16 +102,16 @@ class RedisOpLogStoreTest : public ::testing::Test {
         return {host, port};
     }
 
-    void CleanupKeys() const {
+    std::vector<std::string> ScanKeys(const std::string& pattern) const {
+        std::vector<std::string> keys;
         auto [host, port] = ParseEndpoint();
         redisContext* ctx = redisConnect(host.c_str(), port);
         if (!testing::AuthenticateRedisContext(ctx, redis_username_,
                                                redis_password_)) {
             if (ctx) redisFree(ctx);
-            return;
+            return keys;
         }
         std::string cursor = "0";
-        const std::string pattern = "mooncake:{" + cluster_id_ + "}:oplog*";
         do {
             RedisReplyPtr scan((redisReply*)redisCommand(
                 ctx, "SCAN %b MATCH %b COUNT 100", cursor.data(), cursor.size(),
@@ -123,14 +124,30 @@ class RedisOpLogStoreTest : public ::testing::Test {
                 break;
             }
             cursor.assign(scan->element[0]->str, scan->element[0]->len);
-            redisReply* keys = scan->element[1];
-            for (size_t i = 0; i < keys->elements; ++i) {
-                redisReply* key = keys->element[i];
+            redisReply* scanned_keys = scan->element[1];
+            for (size_t i = 0; i < scanned_keys->elements; ++i) {
+                redisReply* key = scanned_keys->element[i];
                 if (!key || key->type != REDIS_REPLY_STRING) continue;
-                RedisReplyPtr del((redisReply*)redisCommand(
-                    ctx, "DEL %b", key->str, key->len));
+                keys.emplace_back(key->str, key->len);
             }
         } while (cursor != "0");
+        redisFree(ctx);
+        return keys;
+    }
+
+    void CleanupKeys() const {
+        auto keys = ScanKeys("mooncake:" + cluster_id_ + ":oplog*");
+        auto [host, port] = ParseEndpoint();
+        redisContext* ctx = redisConnect(host.c_str(), port);
+        if (!testing::AuthenticateRedisContext(ctx, redis_username_,
+                                               redis_password_)) {
+            if (ctx) redisFree(ctx);
+            return;
+        }
+        for (const auto& key : keys) {
+            RedisReplyPtr del((redisReply*)redisCommand(
+                ctx, "DEL %b", key.data(), key.size()));
+        }
         redisFree(ctx);
     }
 
@@ -182,6 +199,32 @@ TEST_F(RedisOpLogStoreTest, WriteReadAndLatestSequence) {
     uint64_t latest = 0;
     ASSERT_EQ(ErrorCode::OK, reader->GetLatestSequenceId(latest));
     EXPECT_EQ(2u, latest);
+}
+
+TEST_F(RedisOpLogStoreTest, OpLogKeysDoNotUseRedisHashTags) {
+    auto writer = CreateWriter();
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(MakeEntry(1), true));
+    ASSERT_EQ(ErrorCode::OK, writer->RecordSnapshotSequenceId("snap-a", 1));
+
+    const std::string key_prefix = "mooncake:" + cluster_id_ + ":oplog";
+    auto keys = ScanKeys(key_prefix + "*");
+    EXPECT_NE(std::find(keys.begin(), keys.end(), key_prefix + ":latest"),
+              keys.end());
+    EXPECT_NE(std::find(keys.begin(), keys.end(), key_prefix + ":trimmed"),
+              keys.end());
+    EXPECT_NE(std::find(keys.begin(), keys.end(),
+                        key_prefix + ":entry:00000000000000000001"),
+              keys.end());
+    EXPECT_NE(
+        std::find(keys.begin(), keys.end(), key_prefix + ":snapshot:snap-a"),
+        keys.end());
+    for (const auto& key : keys) {
+        EXPECT_EQ(std::string::npos, key.find('{')) << key;
+        EXPECT_EQ(std::string::npos, key.find('}')) << key;
+    }
+
+    auto old_hash_tag_keys = ScanKeys("mooncake:{" + cluster_id_ + "}:oplog*");
+    EXPECT_TRUE(old_hash_tag_keys.empty());
 }
 
 TEST_F(RedisOpLogStoreTest, ReadSinceReturnsOrderedEntries) {


### PR DESCRIPTION
## Description

  Remove Redis hash tags from P2P Redis oplog keys so oplog records can be distributed across Redis Cluster slots instead of being pinned to
  one slot. This improves oplog scalability while keeping the key layout deterministic.

  Also update Redis oplog cleanup/test coverage for the new key format.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Reshard (`mooncake-reshard`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [ ] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [x] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  docker exec mooncake-dev bash -lc 'cd /workspace/.claude/worktrees/p2p-oplog-hashtag-v16 && ./scripts/code_format.sh -b P2P-Mooncake-Store'
  docker exec mooncake-dev bash -lc 'cd /workspace/.claude/worktrees/p2p-oplog-hashtag-v16 && cmake -S . -B build-redis-oplog
  -DSTORE_USE_REDIS=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_UNIT_TESTS=ON'
  docker exec mooncake-dev bash -lc 'cd /workspace/.claude/worktrees/p2p-oplog-hashtag-v16 && cmake --build build-redis-oplog --target
  redis_oplog_store_test -j3'
  docker exec mooncake-dev bash -lc 'cd /workspace/.claude/worktrees/p2p-oplog-hashtag-v16 && ctest --test-dir build-redis-oplog -R
  "^redis_oplog_store_test$" --output-on-failure'
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to help rebase the branch, update the Redis oplog key layout, adjust tests, and run local validation. The human submitter is
  responsible for understanding and defending all changes.