### PR TITLE
[TE] Add rdma_twosided control-plane notify channel

### DIFF
--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -128,6 +128,21 @@ struct GlobalConfig {
     // + 1. num_lag_ports is queried from hardware; if the device is not in LAG
     // mode the setting is a no-op. Requires USE_MLX5DV.
     bool mlx5_qp_lag_port_balance = false;
+    // Install RdmaTwoSidedTransport (CtrlChannel notify) instead of classic
+    // one-sided RdmaTransport. MC_USE_RDMA_TWOSIDED.
+    bool use_rdma_twosided = false;
+    // RDMA CtrlChannel notify path. MC_RDMA_NOTIFY_ENABLED.
+    bool rdma_notify_enabled = true;
+    // Ctrl recv/send slot count and slot size. MC_RDMA_NOTIFY_RECV_COUNT /
+    // MC_RDMA_NOTIFY_BUFFER_SIZE.
+    size_t rdma_notify_recv_count = 64;
+    size_t rdma_notify_buffer_size = 4096;
+    // Local pending SEND cap; actual cap is min(this, peer notify_rq_depth).
+    // MC_RDMA_NOTIFY_MAX_PENDING_SENDS.
+    size_t rdma_notify_max_pending_sends = 64;
+    // Fall back to OOB RPC notify when CtrlChannel is unavailable.
+    // MC_RDMA_NOTIFY_OOB_FALLBACK.
+    bool rdma_notify_oob_fallback = true;
     // ib_pci_relaxed_ordering_mode: 0: off, 1: on if supported, 2: auto
     int ib_pci_relaxed_ordering_mode = 1;
     bool ascend_use_fabric_mem = false;

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -143,6 +143,11 @@ struct GlobalConfig {
     // Fall back to OOB RPC notify when CtrlChannel is unavailable.
     // MC_RDMA_NOTIFY_OOB_FALLBACK.
     bool rdma_notify_oob_fallback = true;
+    // Upper bound for waiting on an in-flight CtrlChannel connect to the same
+    // peer. On expiry the notify falls back to OOB instead of blocking on a
+    // handshake that may never complete.
+    // MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS.
+    uint32_t rdma_notify_connect_timeout_ms = 10000;
     // ib_pci_relaxed_ordering_mode: 0: off, 1: on if supported, 2: auto
     int ib_pci_relaxed_ordering_mode = 1;
     bool ascend_use_fabric_mem = false;

--- a/mooncake-transfer-engine/include/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/include/transfer_engine_impl.h
@@ -33,6 +33,7 @@
 #include "transfer_metadata.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
+#include "config.h"
 #if (defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_MACA)) && \
     !defined(USE_CXI)
 #include "transport/device/device_transport.h"
@@ -451,6 +452,9 @@ class TransferEngineImpl {
         }
         if (auto_discover_config_.protocol == "efa") {
             return "efa";
+        }
+        if (globalConfig().use_rdma_twosided) {
+            return "rdma_twosided";
         }
         return "rdma";
     }

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -173,6 +173,12 @@ class TransferMetadata {
         // Capability marker. Encoded only by transports that opt into
         // ready_ack; decoded from field presence to detect peer support.
         bool ready_ack_supported = false;
+        // Per-peer RDMA CtrlChannel (notify QP). 0 = not supported / unused.
+        // When ctrl_channel is true, this handshake only sets up the control
+        // path (qp_num may be empty).
+        uint32_t notify_qp_num = 0;
+        uint16_t notify_rq_depth = 0;
+        bool ctrl_channel = false;
         std::string reply_msg;  // on error
 #ifdef USE_EFA
         std::string efa_addr;  // EFA endpoint address (hex encoded)
@@ -231,6 +237,8 @@ class TransferMetadata {
 
     int getRpcMetaEntry(const std::string &server_name, RpcMetaDesc &desc);
     int getNotifies(std::vector<NotifyDesc> &notifies);
+    // Push a notify received from an alternate path (e.g. RDMA CtrlChannel).
+    void pushNotify(const NotifyDesc &notify);
 
     const RpcMetaDesc &localRpcMeta() const { return local_rpc_meta_; }
 

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -109,8 +109,8 @@ class RdmaTransport : public Transport {
     int preTouchMemory(void *addr, size_t length);
 
    public:
-    int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
-                               HandShakeDesc &local_desc);
+    virtual int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
+                                       HandShakeDesc &local_desc);
 
     int sendHandshake(const std::string &peer_server_name,
                       const HandShakeDesc &local_desc,

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
@@ -1,0 +1,129 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_CTRL_CHANNEL_H_
+#define RDMA_CTRL_CHANNEL_H_
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "transfer_metadata.h"
+#include "transport/rdma_twosided/ctrl_frame.h"
+
+namespace mooncake {
+
+class RdmaContext;
+class RdmaTwoSidedTransport;
+
+// Per-peer RDMA control channel: one RC QP dedicated to two-sided SEND/RECV
+// typed CtrlFrames. Owned by RdmaTwoSidedTransport; not part of EndpointStore.
+class CtrlChannel {
+   public:
+    using NotifyDesc = TransferMetadata::NotifyDesc;
+    using HandShakeDesc = TransferMetadata::HandShakeDesc;
+
+    CtrlChannel(RdmaTwoSidedTransport &transport, RdmaContext &context,
+                std::string peer_server_name);
+    ~CtrlChannel();
+
+    CtrlChannel(const CtrlChannel &) = delete;
+    CtrlChannel &operator=(const CtrlChannel &) = delete;
+
+    // Allocate QP/CQ/buffers and move QP to INIT. Does not connect.
+    int construct();
+
+    // Active: exchange ctrl handshake and bring QP to RTS.
+    int connectActive();
+
+    // Passive: complete ctrl handshake against peer_desc; fill local_desc.
+    int acceptPassive(const HandShakeDesc &peer_desc,
+                      HandShakeDesc &local_desc);
+
+    bool connected() const {
+        return connected_.load(std::memory_order_acquire);
+    }
+
+    uint32_t notifyQpNum() const { return qp_ ? qp_->qp_num : 0; }
+    uint16_t notifyRqDepth() const {
+        return static_cast<uint16_t>(recv_count_);
+    }
+
+    const std::string &peerServerName() const { return peer_server_name_; }
+    RdmaContext &context() const { return context_; }
+
+    // Async: post typed CtrlFrame SEND; returns 0 on success.
+    int sendCtrlFrame(const CtrlFrame &frame);
+
+    // Compatibility wrapper: encode NotifyDesc as NOTIFY_COMPAT frame.
+    int sendNotify(const NotifyDesc &notify);
+
+    // Poll notify CQ; dispatch inbound frames via transport callbacks.
+    // Returns number of WC processed.
+    int pollCompletions(int max_entries = 16);
+
+    void disconnect();
+
+   private:
+    int createResources();
+    void destroyResources();
+    int postRecv(size_t idx);
+    int repostAllRecvs();
+    int connectQp(const std::string &peer_gid, uint16_t peer_lid,
+                  uint32_t peer_qp_num);
+    void dispatchRecvPayload(const uint8_t *data, size_t byte_len);
+    void handleSendComplete();
+    void handleRecvComplete(const ibv_wc &wc);
+    // Shared CQ drain for worker poll and send-path opportunistic poll.
+    // Returns successfully handled SEND/RECV count, or <0 on poll failure.
+    int drainCompletions(int max_entries, bool log_poll_error);
+    // Drain SEND (and any stolen RECV) WCs without blocking on send slots.
+    int pollSendCompletions(int max_entries = 16);
+    void fillLocalDesc(HandShakeDesc &local_desc) const;
+    int postSessionOpen();
+
+    RdmaTwoSidedTransport &transport_;
+    RdmaContext &context_;
+    std::string peer_server_name_;
+
+    ibv_cq *cq_ = nullptr;
+    ibv_qp *qp_ = nullptr;
+    ibv_mr *send_mr_ = nullptr;
+    std::vector<ibv_mr *> recv_mrs_;
+    std::vector<char> send_buffer_;
+    std::vector<std::vector<char>> recv_buffers_;
+
+    size_t recv_count_ = 0;
+    size_t buffer_size_ = 0;
+    size_t max_pending_sends_ = 0;
+
+    std::mutex send_mutex_;
+    std::condition_variable send_cv_;
+    size_t pending_sends_ = 0;
+    uint64_t send_wr_id_ = 0;
+    uint64_t next_frame_seq_ = 1;
+
+    std::mutex resource_mutex_;
+    std::atomic<bool> connected_{false};
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_CTRL_CHANNEL_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
@@ -69,10 +69,16 @@ class CtrlChannel {
     const std::string &peerServerName() const { return peer_server_name_; }
     RdmaContext &context() const { return context_; }
 
-    // Async: post typed CtrlFrame SEND; returns 0 on success.
+    // Fire-and-forget: encode and post a typed CtrlFrame SEND. Returns 0 once
+    // the frame is enqueued on the QP (or an error if it cannot be enqueued).
+    // Delivery is confirmed asynchronously by the SEND completion: a failed WC
+    // marks the channel unconnected, and the next ensureCtrlChannel() reclaims
+    // it and (if enabled) falls back to OOB notify. A 0 return therefore means
+    // "queued", not "delivered".
     int sendCtrlFrame(const CtrlFrame &frame);
 
-    // Compatibility wrapper: encode NotifyDesc as NOTIFY_COMPAT frame.
+    // Compatibility wrapper: encode NotifyDesc as NOTIFY_COMPAT frame. Shares
+    // the fire-and-forget delivery semantics of sendCtrlFrame().
     int sendNotify(const NotifyDesc &notify);
 
     // Poll notify CQ; dispatch inbound frames via transport callbacks.

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/ctrl_channel.h
@@ -83,6 +83,9 @@ class CtrlChannel {
 
    private:
     int createResources();
+    // IB teardown only. Caller must hold resource_mutex_ (or be disconnect(),
+    // which acquires it). Must not acquire send_mutex_.
+    void releaseIbResources();
     void destroyResources();
     int postRecv(size_t idx);
     int repostAllRecvs();
@@ -114,6 +117,10 @@ class CtrlChannel {
     size_t buffer_size_ = 0;
     size_t max_pending_sends_ = 0;
 
+    // send_mutex_ guards SQ slot accounting (pending_sends_, send_wr_id_).
+    // resource_mutex_ guards qp_/cq_/MRs. Nested order, when both are held,
+    // is send_mutex_ then resource_mutex_. disconnect() does not nest them:
+    // it wakes send waiters, drops send_mutex_, then tears down IB resources.
     std::mutex send_mutex_;
     std::condition_variable send_cv_;
     size_t pending_sends_ = 0;

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -1,0 +1,83 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_TWOSIDED_TRANSPORT_H_
+#define RDMA_TWOSIDED_TRANSPORT_H_
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_twosided/ctrl_frame.h"
+
+namespace mooncake {
+
+class CtrlChannel;
+
+// RDMA transport with a dedicated CtrlChannel for typed notify frames.
+// One-sided data path is inherited from RdmaTransport; install name is
+// "rdma_twosided" (mutually exclusive with classic "rdma" in MultiTransport).
+class RdmaTwoSidedTransport : public RdmaTransport {
+    friend class CtrlChannel;
+
+   public:
+    using NotifyDesc = TransferMetadata::NotifyDesc;
+    using HandShakeDesc = TransferMetadata::HandShakeDesc;
+
+    RdmaTwoSidedTransport();
+    ~RdmaTwoSidedTransport() override;
+
+    int install(std::string &local_server_name,
+                std::shared_ptr<TransferMetadata> meta,
+                std::shared_ptr<Topology> topo) override;
+
+    const char *getName() const override { return "rdma_twosided"; }
+
+    int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
+                               HandShakeDesc &local_desc) override;
+
+    int sendRdmaNotify(const std::string &peer_server_name,
+                       const NotifyDesc &notify);
+
+    void onCtrlNotifyReceived(const NotifyDesc &notify);
+    void onCtrlFrameReceived(const std::string &peer_server_name,
+                             const CtrlFrame &frame);
+
+    uint64_t localCtrlSessionId() const { return local_ctrl_session_id_; }
+
+   private:
+    int onSetupCtrlChannel(const HandShakeDesc &peer_desc,
+                           HandShakeDesc &local_desc);
+    std::shared_ptr<CtrlChannel> ensureCtrlChannel(
+        const std::string &peer_server_name);
+
+    void startCtrlWorker();
+    void stopCtrlWorker();
+    void ctrlWorkerLoop();
+
+    std::mutex ctrl_mutex_;
+    std::unordered_map<std::string, std::shared_ptr<CtrlChannel>>
+        ctrl_channels_;
+    std::thread ctrl_worker_;
+    std::atomic<bool> ctrl_worker_running_{false};
+    uint64_t local_ctrl_session_id_ = 0;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_TWOSIDED_TRANSPORT_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -67,6 +67,31 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::shared_ptr<CtrlChannel> ensureCtrlChannel(
         const std::string &peer_server_name);
 
+    // RAII publisher for one connect attempt. On construction it installs the
+    // placeholder entry and marks the peer as having a connect in flight; on
+    // destruction it always retracts the marker and wakes waiters, and drops
+    // the placeholder unless markSuccess() was called. Callers must hold
+    // ctrl_mutex_ for the whole lifetime of the scope, so a blocking handshake
+    // has to be wrapped in an UnlockGuard rather than releasing the lock by
+    // hand.
+    class ConnectScope {
+       public:
+        ConnectScope(RdmaTwoSidedTransport &transport, std::string peer,
+                     std::shared_ptr<CtrlChannel> channel);
+        ~ConnectScope();
+
+        ConnectScope(const ConnectScope &) = delete;
+        ConnectScope &operator=(const ConnectScope &) = delete;
+
+        void markSuccess() { success_ = true; }
+
+       private:
+        RdmaTwoSidedTransport &transport_;
+        std::string peer_;
+        std::shared_ptr<CtrlChannel> channel_;
+        bool success_ = false;
+    };
+
     void startCtrlWorker();
     void stopCtrlWorker();
     void ctrlWorkerLoop();
@@ -75,6 +100,15 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::condition_variable ctrl_cv_;
     std::unordered_map<std::string, std::shared_ptr<CtrlChannel>>
         ctrl_channels_;
+    // Peers with a connect handshake in flight. Only such peers are worth
+    // waiting for: an entry in ctrl_channels_ that is not connected and not
+    // listed here is a dead channel, which the next caller reclaims instead of
+    // waiting for a wakeup that never comes. Refcounted because an active and
+    // a passive connect to the same peer can overlap.
+    std::unordered_map<std::string, int> ctrl_connecting_;
+    // Set once by stopCtrlWorker() to release waiters during shutdown.
+    // Guarded by ctrl_mutex_.
+    bool ctrl_stopping_ = false;
     std::thread ctrl_worker_;
     std::atomic<bool> ctrl_worker_running_{false};
     uint64_t local_ctrl_session_id_ = 0;

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -16,6 +16,7 @@
 #define RDMA_TWOSIDED_TRANSPORT_H_
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -71,6 +72,7 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     void ctrlWorkerLoop();
 
     std::mutex ctrl_mutex_;
+    std::condition_variable ctrl_cv_;
     std::unordered_map<std::string, std::shared_ptr<CtrlChannel>>
         ctrl_channels_;
     std::thread ctrl_worker_;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -530,6 +530,55 @@ void loadGlobalConfig(GlobalConfig& config) {
                            config.track_rdma_posted_slices);
     }
 
+    const char* use_rdma_twosided_env = std::getenv("MC_USE_RDMA_TWOSIDED");
+    if (use_rdma_twosided_env) {
+        parseBoolConfigEnv(use_rdma_twosided_env, "MC_USE_RDMA_TWOSIDED",
+                           config.use_rdma_twosided);
+    }
+
+    const char* rdma_notify_enabled_env = std::getenv("MC_RDMA_NOTIFY_ENABLED");
+    if (rdma_notify_enabled_env) {
+        parseBoolConfigEnv(rdma_notify_enabled_env, "MC_RDMA_NOTIFY_ENABLED",
+                           config.rdma_notify_enabled);
+    }
+    const char* rdma_notify_recv_count_env =
+        std::getenv("MC_RDMA_NOTIFY_RECV_COUNT");
+    if (rdma_notify_recv_count_env) {
+        int val = atoi(rdma_notify_recv_count_env);
+        if (val > 0 && val <= 4096)
+            config.rdma_notify_recv_count = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_NOTIFY_RECV_COUNT";
+    }
+    const char* rdma_notify_buffer_size_env =
+        std::getenv("MC_RDMA_NOTIFY_BUFFER_SIZE");
+    if (rdma_notify_buffer_size_env) {
+        int val = atoi(rdma_notify_buffer_size_env);
+        if (val >= 256 && val <= 65536)
+            config.rdma_notify_buffer_size = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_NOTIFY_BUFFER_SIZE";
+    }
+    const char* rdma_notify_max_pending_sends_env =
+        std::getenv("MC_RDMA_NOTIFY_MAX_PENDING_SENDS");
+    if (rdma_notify_max_pending_sends_env) {
+        int val = atoi(rdma_notify_max_pending_sends_env);
+        if (val > 0 && val <= 4096)
+            config.rdma_notify_max_pending_sends = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_NOTIFY_MAX_PENDING_SENDS";
+    }
+    const char* rdma_notify_oob_fallback_env =
+        std::getenv("MC_RDMA_NOTIFY_OOB_FALLBACK");
+    if (rdma_notify_oob_fallback_env) {
+        parseBoolConfigEnv(rdma_notify_oob_fallback_env,
+                           "MC_RDMA_NOTIFY_OOB_FALLBACK",
+                           config.rdma_notify_oob_fallback);
+    }
+
     const char* enable_parallel_reg_mr =
         std::getenv("MC_ENABLE_PARALLEL_REG_MR");
     if (enable_parallel_reg_mr) {
@@ -762,6 +811,16 @@ void dumpGlobalConfig() {
               << (config.log_rdma_slice_affinity ? "true" : "false");
     LOG(INFO) << "track_rdma_posted_slices = "
               << (config.track_rdma_posted_slices ? "true" : "false");
+    LOG(INFO) << "use_rdma_twosided = "
+              << (config.use_rdma_twosided ? "true" : "false");
+    LOG(INFO) << "rdma_notify_enabled = "
+              << (config.rdma_notify_enabled ? "true" : "false");
+    LOG(INFO) << "rdma_notify_recv_count = " << config.rdma_notify_recv_count;
+    LOG(INFO) << "rdma_notify_buffer_size = " << config.rdma_notify_buffer_size;
+    LOG(INFO) << "rdma_notify_max_pending_sends = "
+              << config.rdma_notify_max_pending_sends;
+    LOG(INFO) << "rdma_notify_oob_fallback = "
+              << (config.rdma_notify_oob_fallback ? "true" : "false");
 }
 
 GlobalConfig& globalConfig() {

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -578,6 +578,16 @@ void loadGlobalConfig(GlobalConfig& config) {
                            "MC_RDMA_NOTIFY_OOB_FALLBACK",
                            config.rdma_notify_oob_fallback);
     }
+    const char* rdma_notify_connect_timeout_env =
+        std::getenv("MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS");
+    if (rdma_notify_connect_timeout_env) {
+        int val = atoi(rdma_notify_connect_timeout_env);
+        if (val >= 100 && val <= 600000)
+            config.rdma_notify_connect_timeout_ms = static_cast<uint32_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS";
+    }
 
     const char* enable_parallel_reg_mr =
         std::getenv("MC_ENABLE_PARALLEL_REG_MR");

--- a/mooncake-transfer-engine/src/multi_transport.cpp
+++ b/mooncake-transfer-engine/src/multi_transport.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "multi_transport_locality.h"
 #include "transport/rdma_transport/rdma_transport.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
 #endif
@@ -352,8 +353,18 @@ Transport* MultiTransport::installTransport(const std::string& proto,
     }
 #endif
     Transport* transport = nullptr;
-    if (std::string(proto) == "rdma") {
-        transport = new RdmaTransport();
+    if (std::string(proto) == "rdma" || std::string(proto) == "rdma_twosided") {
+        if ((proto == "rdma" && transport_map_.count("rdma_twosided")) ||
+            (proto == "rdma_twosided" && transport_map_.count("rdma"))) {
+            LOG(ERROR) << "Cannot install both rdma and rdma_twosided "
+                          "transports in the same Transfer Engine instance";
+            return nullptr;
+        }
+        if (std::string(proto) == "rdma") {
+            transport = new RdmaTransport();
+        } else {
+            transport = new RdmaTwoSidedTransport();
+        }
     }
 #ifdef USE_UB
     else if (std::string(proto) == "ub") {
@@ -553,6 +564,10 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
                 "segment " +
                 std::to_string(entry.target_id));
         }
+        if (!transport_map_.count(chosen) && chosen == "rdma" &&
+            transport_map_.count("rdma_twosided")) {
+            chosen = "rdma_twosided";
+        }
         if (!transport_map_.count(chosen)) {
             return Status::NotSupportedTransport("Transport " + chosen +
                                                  " not installed");
@@ -575,6 +590,13 @@ Status MultiTransport::selectTransport(const TransferRequest& entry,
         proto = "ascend";
     }
 #endif
+    // RdmaTwoSidedTransport still publishes segment protocol "rdma" (one-sided
+    // memory path). Route those segments to the installed twosided transport.
+    if (!transport_map_.count(proto) && proto == "rdma" &&
+        transport_map_.count("rdma_twosided")) {
+        transport = transport_map_["rdma_twosided"].get();
+        return Status::OK();
+    }
     if (!transport_map_.count(proto)) {
         return Status::NotSupportedTransport("Transport " + proto +
                                              " not installed");
@@ -631,11 +653,18 @@ Status MultiTransport::mp_selectTransport(const TransferRequest& entry,
         preferred_proto = "ascend";
     }
 #endif
+    if (!transport_map_.count(preferred_proto) && preferred_proto == "rdma" &&
+        transport_map_.count("rdma_twosided")) {
+        preferred_proto = "rdma_twosided";
+    }
     if (!transport_map_.count(preferred_proto)) {
         return Status::NotSupportedTransport("Transport " + preferred_proto +
                                              " not installed");
     }
-    if (std::find(protos.begin(), protos.end(), preferred_proto) ==
+    // Segment metadata still advertises "rdma" for the twosided install.
+    const std::string segment_proto =
+        (preferred_proto == "rdma_twosided") ? "rdma" : preferred_proto;
+    if (std::find(protos.begin(), protos.end(), segment_proto) ==
         protos.end()) {
         return Status::NotSupportedTransport(
             "Transport " + preferred_proto +

--- a/mooncake-transfer-engine/src/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine_impl.cpp
@@ -29,6 +29,7 @@
 
 #include "transfer_metadata_plugin.h"
 #include "transport/transport.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
 #ifdef USE_BAREX
 #include "transport/barex_transport/barex_transport.h"
 #endif
@@ -520,16 +521,30 @@ int TransferEngineImpl::sendNotifyByID(
         LOG(ERROR) << "sendNotifyByID: invalid segment ID " << target_id;
         return ERR_METADATA;
     }
-    Transport::NotifyDesc peer_desc;
-    int ret = metadata_->sendNotify(desc->name, notify_msg, peer_desc);
-    return ret;
+    return sendNotifyByName(desc->name, std::move(notify_msg));
 }
 
 int TransferEngineImpl::sendNotifyByName(
     std::string remote_agent, TransferMetadata::NotifyDesc notify_msg) {
+    if (globalConfig().rdma_notify_enabled) {
+        Transport* transport = getTransport("rdma_twosided");
+        if (!transport) transport = getTransport("rdma");
+        auto* rdma_twosided = dynamic_cast<RdmaTwoSidedTransport*>(transport);
+        if (rdma_twosided) {
+            int ret = rdma_twosided->sendRdmaNotify(remote_agent, notify_msg);
+            if (ret == 0) return 0;
+            if (!globalConfig().rdma_notify_oob_fallback) {
+                LOG(ERROR) << "sendNotifyByName: RDMA notify failed for "
+                           << remote_agent << " ret=" << ret
+                           << " (OOB fallback disabled)";
+                return ret;
+            }
+            VLOG(1) << "sendNotifyByName: RDMA notify unavailable for "
+                    << remote_agent << ", falling back to OOB";
+        }
+    }
     Transport::NotifyDesc peer_desc;
-    int ret = metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
-    return ret;
+    return metadata_->sendNotify(remote_agent, notify_msg, peer_desc);
 }
 
 int TransferEngineImpl::probePeerAliveByID(SegmentID target_id) {

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -81,6 +81,11 @@ struct TransferHandshakeUtil {
         root["qp_num"] = qpNums;
         if (desc.ready_ack_supported || desc.ready_ack)
             root["ready_ack"] = desc.ready_ack;
+        if (desc.notify_qp_num != 0 || desc.ctrl_channel) {
+            root["notify_qp_num"] = Json::UInt(desc.notify_qp_num);
+            root["notify_rq_depth"] = Json::UInt(desc.notify_rq_depth);
+            root["ctrl_channel"] = desc.ctrl_channel;
+        }
         root["reply_msg"] = desc.reply_msg;
 #ifdef USE_EFA
         root["efa_addr"] = desc.efa_addr;  // EFA endpoint address
@@ -124,6 +129,20 @@ struct TransferHandshakeUtil {
             desc.ready_ack = root["ready_ack"].asBool();
         } else {
             desc.ready_ack = false;
+        }
+        desc.notify_qp_num = 0;
+        desc.notify_rq_depth = 0;
+        desc.ctrl_channel = false;
+        if (root.isMember("notify_qp_num") && root["notify_qp_num"].isUInt()) {
+            desc.notify_qp_num = root["notify_qp_num"].asUInt();
+        }
+        if (root.isMember("notify_rq_depth") &&
+            root["notify_rq_depth"].isUInt()) {
+            desc.notify_rq_depth =
+                static_cast<uint16_t>(root["notify_rq_depth"].asUInt());
+        }
+        if (root.isMember("ctrl_channel") && root["ctrl_channel"].isBool()) {
+            desc.ctrl_channel = root["ctrl_channel"].asBool();
         }
         desc.reply_msg = root["reply_msg"].asString();
 #ifdef USE_EFA
@@ -290,6 +309,11 @@ int TransferMetadata::getNotifies(std::vector<NotifyDesc> &notifies) {
         notifys.clear();
     }
     return 0;
+}
+
+void TransferMetadata::pushNotify(const NotifyDesc &notify) {
+    RWSpinlock::WriteGuard guard(notify_lock_);
+    notifys.push_back(notify);
 }
 
 #ifdef ENABLE_MULTI_PROTOCOL

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -138,8 +138,9 @@ struct TransferHandshakeUtil {
         }
         if (root.isMember("notify_rq_depth") &&
             root["notify_rq_depth"].isUInt()) {
-            desc.notify_rq_depth =
-                static_cast<uint16_t>(root["notify_rq_depth"].asUInt());
+            unsigned int depth = root["notify_rq_depth"].asUInt();
+            if (depth > 0xFFFFu) return ERR_INVALID_ARGUMENT;
+            desc.notify_rq_depth = static_cast<uint16_t>(depth);
         }
         if (root.isMember("ctrl_channel") && root["ctrl_channel"].isBool()) {
             desc.ctrl_channel = root["ctrl_channel"].asBool();
@@ -1484,7 +1485,11 @@ int TransferMetadata::startHandshakeDaemon(
         [on_receive_handshake](const Json::Value &peer,
                                Json::Value &local) -> int {
             HandShakeDesc local_desc, peer_desc;
-            TransferHandshakeUtil::decode(peer, peer_desc);
+            if (TransferHandshakeUtil::decode(peer, peer_desc)) {
+                local_desc.reply_msg = "Invalid handshake notify_rq_depth";
+                local = TransferHandshakeUtil::encode(local_desc);
+                return 0;
+            }
             if (on_receive_handshake) {
                 int ret = on_receive_handshake(peer_desc, local_desc);
                 if (ret) {
@@ -1531,7 +1536,11 @@ int TransferMetadata::sendHandshake(const std::string &peer_server_name,
     int ret = handshake_plugin_->send(peer_location.ip_or_host_name,
                                       peer_location.rpc_port, local, peer);
     if (ret) return ret;
-    TransferHandshakeUtil::decode(peer, peer_desc);
+    if (TransferHandshakeUtil::decode(peer, peer_desc)) {
+        LOG(ERROR) << "Handshake from " << peer_server_name
+                   << " has invalid notify_rq_depth";
+        return ERR_INVALID_ARGUMENT;
+    }
     if (!peer_desc.reply_msg.empty()) {
         LOG(ERROR) << "Handshake rejected by " << peer_server_name << ": "
                    << peer_desc.reply_msg;

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
@@ -65,7 +65,7 @@ CtrlChannel::CtrlChannel(RdmaTwoSidedTransport &transport, RdmaContext &context,
     max_pending_sends_ = cfg.rdma_notify_max_pending_sends;
 }
 
-CtrlChannel::~CtrlChannel() { destroyResources(); }
+CtrlChannel::~CtrlChannel() { disconnect(); }
 
 int CtrlChannel::construct() {
     std::lock_guard<std::mutex> lock(resource_mutex_);
@@ -151,13 +151,7 @@ int CtrlChannel::createResources() {
     return 0;
 }
 
-void CtrlChannel::destroyResources() {
-    connected_.store(false, std::memory_order_release);
-    {
-        std::lock_guard<std::mutex> lock(send_mutex_);
-        pending_sends_ = 0;
-        send_cv_.notify_all();
-    }
+void CtrlChannel::releaseIbResources() {
     if (qp_) {
         ibv_destroy_qp(qp_);
         qp_ = nullptr;
@@ -176,6 +170,25 @@ void CtrlChannel::destroyResources() {
     recv_mrs_.clear();
     recv_buffers_.clear();
     send_buffer_.clear();
+}
+
+void CtrlChannel::destroyResources() {
+    // Called from createResources() while resource_mutex_ is already held.
+    // Do not acquire send_mutex_ here (lock-order inversion with
+    // sendCtrlFrame).
+    connected_.store(false, std::memory_order_release);
+    releaseIbResources();
+}
+
+void CtrlChannel::disconnect() {
+    connected_.store(false, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lock(send_mutex_);
+        pending_sends_ = 0;
+        send_cv_.notify_all();
+    }
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    releaseIbResources();
 }
 
 int CtrlChannel::postRecv(size_t idx) {
@@ -570,11 +583,6 @@ int CtrlChannel::pollSendCompletions(int max_entries) {
 
 int CtrlChannel::pollCompletions(int max_entries) {
     return drainCompletions(max_entries, /*log_poll_error=*/true);
-}
-
-void CtrlChannel::disconnect() {
-    std::lock_guard<std::mutex> lock(resource_mutex_);
-    destroyResources();
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
@@ -471,6 +471,9 @@ int CtrlChannel::sendCtrlFrame(const CtrlFrame &frame_in) {
         }
         pending_sends_++;
     }
+    // Queued, not delivered: the SEND completion (handled in drainCompletions)
+    // decides actual success. A failed WC drops connected_, which routes the
+    // next notify to a fresh channel or to OOB fallback.
     return 0;
 }
 
@@ -560,7 +563,14 @@ int CtrlChannel::drainCompletions(int max_entries, bool log_poll_error) {
                        << " opcode=" << wc[i].opcode
                        << " peer=" << peer_server_name_;
             connected_.store(false, std::memory_order_release);
+            // The channel is dead, so every outstanding SEND is now void.
+            // Clear the in-flight count here (error WCs may not carry a
+            // reliable opcode/wr_id) and wake SQ-full waiters, which re-check
+            // connected_ and bail with ERR_ENDPOINT. Delivery failures thus
+            // surface as the channel going unconnected rather than as a
+            // per-frame return code.
             std::lock_guard<std::mutex> lock(send_mutex_);
+            pending_sends_ = 0;
             send_cv_.notify_all();
             continue;
         }

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
@@ -1,0 +1,580 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/ctrl_channel.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+#include "transport/rdma_twosided/ctrl_frame.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr int kCtrlHopLimit = 16;
+constexpr int kCtrlTimeout = 14;
+constexpr int kCtrlRetryCount = 7;
+
+int parseGidString(const std::string &gid_str, ibv_gid &gid_out) {
+    if (gid_str.empty()) return ERR_INVALID_ARGUMENT;
+    std::istringstream iss(":" + gid_str);
+    for (size_t i = 0; i < sizeof(gid_out.raw); i++) {
+        if (iss.get() != ':') return ERR_INVALID_ARGUMENT;
+        uint32_t byte = 0;
+        iss >> std::hex >> byte;
+        if (iss.fail() || byte > 0xFF) return ERR_INVALID_ARGUMENT;
+        gid_out.raw[i] = static_cast<uint8_t>(byte);
+    }
+    char extra;
+    if (iss.get(extra)) return ERR_INVALID_ARGUMENT;
+    return 0;
+}
+
+}  // namespace
+
+CtrlChannel::CtrlChannel(RdmaTwoSidedTransport &transport, RdmaContext &context,
+                         std::string peer_server_name)
+    : transport_(transport),
+      context_(context),
+      peer_server_name_(std::move(peer_server_name)) {
+    auto &cfg = globalConfig();
+    recv_count_ = cfg.rdma_notify_recv_count;
+    buffer_size_ = cfg.rdma_notify_buffer_size;
+    max_pending_sends_ = cfg.rdma_notify_max_pending_sends;
+}
+
+CtrlChannel::~CtrlChannel() { destroyResources(); }
+
+int CtrlChannel::construct() {
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    if (qp_) return 0;
+    return createResources();
+}
+
+int CtrlChannel::createResources() {
+    auto &cfg = globalConfig();
+    recv_count_ = cfg.rdma_notify_recv_count;
+    buffer_size_ = cfg.rdma_notify_buffer_size;
+    max_pending_sends_ = cfg.rdma_notify_max_pending_sends;
+    if (recv_count_ == 0 || buffer_size_ == 0 || max_pending_sends_ == 0) {
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    cq_ = ibv_create_cq(context_.context(), static_cast<int>(cfg.max_cqe),
+                        nullptr, nullptr, 0);
+    if (!cq_) {
+        PLOG(ERROR) << "CtrlChannel: failed to create CQ for peer "
+                    << peer_server_name_;
+        return ERR_ENDPOINT;
+    }
+
+    ibv_qp_init_attr attr{};
+    attr.send_cq = cq_;
+    attr.recv_cq = cq_;
+    attr.qp_type = IBV_QPT_RC;
+    attr.sq_sig_all = 0;
+    attr.cap.max_send_wr = static_cast<uint32_t>(max_pending_sends_);
+    attr.cap.max_recv_wr = static_cast<uint32_t>(recv_count_);
+    attr.cap.max_send_sge = 1;
+    attr.cap.max_recv_sge = 1;
+    attr.cap.max_inline_data = static_cast<uint32_t>(cfg.max_inline);
+
+    qp_ = ibv_create_qp(context_.pd(), &attr);
+    if (!qp_) {
+        PLOG(ERROR) << "CtrlChannel: failed to create QP for peer "
+                    << peer_server_name_;
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+
+    ibv_qp_attr qp_attr{};
+    qp_attr.qp_state = IBV_QPS_INIT;
+    qp_attr.port_num = context_.portNum();
+    qp_attr.pkey_index = cfg.pkey_index;
+    qp_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+    if (ibv_modify_qp(qp_, &qp_attr,
+                      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                          IBV_QP_ACCESS_FLAGS)) {
+        PLOG(ERROR) << "CtrlChannel: failed to modify QP to INIT";
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+
+    send_buffer_.assign(buffer_size_ * max_pending_sends_, 0);
+    send_mr_ = ibv_reg_mr(context_.pd(), send_buffer_.data(),
+                          send_buffer_.size(), IBV_ACCESS_LOCAL_WRITE);
+    if (!send_mr_) {
+        PLOG(ERROR) << "CtrlChannel: failed to register send buffer";
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+
+    recv_buffers_.resize(recv_count_);
+    recv_mrs_.assign(recv_count_, nullptr);
+    for (size_t i = 0; i < recv_count_; ++i) {
+        recv_buffers_[i].assign(buffer_size_, 0);
+        recv_mrs_[i] = ibv_reg_mr(context_.pd(), recv_buffers_[i].data(),
+                                  buffer_size_, IBV_ACCESS_LOCAL_WRITE);
+        if (!recv_mrs_[i]) {
+            PLOG(ERROR) << "CtrlChannel: failed to register recv buffer " << i;
+            destroyResources();
+            return ERR_ENDPOINT;
+        }
+    }
+
+    if (repostAllRecvs()) {
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+    return 0;
+}
+
+void CtrlChannel::destroyResources() {
+    connected_.store(false, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lock(send_mutex_);
+        pending_sends_ = 0;
+        send_cv_.notify_all();
+    }
+    if (qp_) {
+        ibv_destroy_qp(qp_);
+        qp_ = nullptr;
+    }
+    if (cq_) {
+        ibv_destroy_cq(cq_);
+        cq_ = nullptr;
+    }
+    if (send_mr_) {
+        ibv_dereg_mr(send_mr_);
+        send_mr_ = nullptr;
+    }
+    for (auto *mr : recv_mrs_) {
+        if (mr) ibv_dereg_mr(mr);
+    }
+    recv_mrs_.clear();
+    recv_buffers_.clear();
+    send_buffer_.clear();
+}
+
+int CtrlChannel::postRecv(size_t idx) {
+    if (!qp_ || idx >= recv_buffers_.size() || !recv_mrs_[idx]) {
+        return ERR_ENDPOINT;
+    }
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<uint64_t>(recv_buffers_[idx].data());
+    sge.length = static_cast<uint32_t>(buffer_size_);
+    sge.lkey = recv_mrs_[idx]->lkey;
+
+    ibv_recv_wr wr{};
+    wr.wr_id = idx;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+
+    ibv_recv_wr *bad = nullptr;
+    int ret = ibv_post_recv(qp_, &wr, &bad);
+    if (ret) {
+        // ibv_post_recv returns errno value on failure (errno itself may be 0).
+        LOG(ERROR) << "CtrlChannel: ibv_post_recv failed idx=" << idx << ": "
+                   << strerror(std::abs(ret)) << " [" << ret << "]";
+        return ERR_ENDPOINT;
+    }
+    return 0;
+}
+
+int CtrlChannel::repostAllRecvs() {
+    for (size_t i = 0; i < recv_count_; ++i) {
+        if (postRecv(i)) return ERR_ENDPOINT;
+    }
+    return 0;
+}
+
+void CtrlChannel::fillLocalDesc(HandShakeDesc &local_desc) const {
+    local_desc = HandShakeDesc();
+    local_desc.local_nic_path = context_.nicPath();
+    local_desc.local_lid = context_.lid();
+    local_desc.local_gid = context_.gid();
+    local_desc.peer_nic_path = "__ctrl__";
+    local_desc.ctrl_channel = true;
+    local_desc.notify_qp_num = notifyQpNum();
+    local_desc.notify_rq_depth = notifyRqDepth();
+}
+
+int CtrlChannel::connectQp(const std::string &peer_gid, uint16_t peer_lid,
+                           uint32_t peer_qp_num) {
+    if (!qp_ || peer_qp_num == 0) return ERR_INVALID_ARGUMENT;
+
+    ibv_gid peer_gid_raw{};
+    if (parseGidString(peer_gid, peer_gid_raw)) {
+        LOG(ERROR) << "CtrlChannel: invalid peer GID " << peer_gid;
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    // First connect leaves the QP in INIT with recv WRs already posted by
+    // createResources(). Only RESET/repost on reconnect; some providers
+    // (e.g. eRDMA) do not clear the RQ on RESET, so re-posting after an
+    // unnecessary RESET fails with ENOMEM.
+    ibv_qp_attr query_attr{};
+    ibv_qp_init_attr query_init_attr{};
+    if (ibv_query_qp(qp_, &query_attr, IBV_QP_STATE, &query_init_attr)) {
+        PLOG(ERROR) << "CtrlChannel: ibv_query_qp failed";
+        return ERR_ENDPOINT;
+    }
+
+    ibv_qp_attr attr{};
+    if (query_attr.qp_state != IBV_QPS_INIT) {
+        attr.qp_state = IBV_QPS_RESET;
+        if (ibv_modify_qp(qp_, &attr, IBV_QP_STATE)) {
+            PLOG(ERROR) << "CtrlChannel: QP RESET failed";
+            return ERR_ENDPOINT;
+        }
+
+        memset(&attr, 0, sizeof(attr));
+        attr.qp_state = IBV_QPS_INIT;
+        attr.port_num = context_.portNum();
+        attr.pkey_index = globalConfig().pkey_index;
+        attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+        if (ibv_modify_qp(qp_, &attr,
+                          IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                              IBV_QP_ACCESS_FLAGS)) {
+            PLOG(ERROR) << "CtrlChannel: QP INIT failed";
+            return ERR_ENDPOINT;
+        }
+
+        if (repostAllRecvs()) return ERR_ENDPOINT;
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = context_.activeMTU();
+    if (globalConfig().mtu_length < attr.path_mtu)
+        attr.path_mtu = globalConfig().mtu_length;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.dgid = peer_gid_raw;
+    attr.ah_attr.grh.sgid_index = context_.gidIndex();
+    attr.ah_attr.grh.hop_limit = kCtrlHopLimit;
+    if (globalConfig().ib_traffic_class >= 0) {
+        attr.ah_attr.grh.traffic_class =
+            static_cast<uint8_t>(globalConfig().ib_traffic_class);
+    }
+    attr.ah_attr.dlid = peer_lid;
+    attr.ah_attr.sl = 0;
+    if (globalConfig().ib_service_level >= 0) {
+        attr.ah_attr.sl = static_cast<uint8_t>(globalConfig().ib_service_level);
+    }
+    attr.ah_attr.port_num = context_.portNum();
+    attr.dest_qp_num = peer_qp_num;
+    attr.rq_psn = 0;
+    attr.max_dest_rd_atomic = 1;
+    attr.min_rnr_timer = 12;
+    if (ibv_modify_qp(qp_, &attr,
+                      IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_MIN_RNR_TIMER |
+                          IBV_QP_AV | IBV_QP_MAX_DEST_RD_ATOMIC |
+                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN)) {
+        PLOG(ERROR) << "CtrlChannel: QP RTR failed peer_qp=" << peer_qp_num;
+        return ERR_ENDPOINT;
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.timeout = kCtrlTimeout;
+    attr.retry_cnt = kCtrlRetryCount;
+    attr.rnr_retry = 7;
+    attr.sq_psn = 0;
+    attr.max_rd_atomic = 1;
+    if (ibv_modify_qp(qp_, &attr,
+                      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                          IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                          IBV_QP_MAX_QP_RD_ATOMIC)) {
+        PLOG(ERROR) << "CtrlChannel: QP RTS failed";
+        return ERR_ENDPOINT;
+    }
+
+    connected_.store(true, std::memory_order_release);
+    return 0;
+}
+
+int CtrlChannel::connectActive() {
+    if (construct()) return ERR_ENDPOINT;
+
+    HandShakeDesc local_desc, peer_desc;
+    fillLocalDesc(local_desc);
+
+    int ret =
+        transport_.sendHandshake(peer_server_name_, local_desc, peer_desc);
+    if (ret) {
+        LOG(ERROR) << "CtrlChannel: active handshake failed to "
+                   << peer_server_name_ << " ret=" << ret;
+        return ret;
+    }
+    if (peer_desc.notify_qp_num == 0) {
+        LOG(ERROR) << "CtrlChannel: peer " << peer_server_name_
+                   << " has no notify_qp_num";
+        return ERR_ENDPOINT;
+    }
+
+    max_pending_sends_ = std::min(
+        max_pending_sends_, peer_desc.notify_rq_depth
+                                ? static_cast<size_t>(peer_desc.notify_rq_depth)
+                                : max_pending_sends_);
+
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
+                        peer_desc.notify_qp_num);
+    }
+    if (ret == 0) {
+        LOG(INFO) << "CtrlChannel: connected to " << peer_server_name_
+                  << " local_qp=" << notifyQpNum()
+                  << " peer_qp=" << peer_desc.notify_qp_num;
+        // SESSION_OPEN only here; CREDIT_GRANT is sent after we receive the
+        // peer's SESSION_OPEN (both QPs are RTS by then).
+        (void)postSessionOpen();
+    }
+    return ret;
+}
+
+int CtrlChannel::acceptPassive(const HandShakeDesc &peer_desc,
+                               HandShakeDesc &local_desc) {
+    if (construct()) {
+        local_desc.reply_msg = "CtrlChannel construct failed";
+        return ERR_ENDPOINT;
+    }
+    if (peer_desc.notify_qp_num == 0) {
+        local_desc.reply_msg = "Peer notify_qp_num missing";
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    max_pending_sends_ = std::min(
+        max_pending_sends_, peer_desc.notify_rq_depth
+                                ? static_cast<size_t>(peer_desc.notify_rq_depth)
+                                : max_pending_sends_);
+
+    int ret = 0;
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        fillLocalDesc(local_desc);
+        ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
+                        peer_desc.notify_qp_num);
+    }
+    if (ret) {
+        local_desc.reply_msg = "CtrlChannel connectQp failed";
+        return ret;
+    }
+    LOG(INFO) << "CtrlChannel: accepted from " << peer_server_name_
+              << " local_qp=" << notifyQpNum()
+              << " peer_qp=" << peer_desc.notify_qp_num;
+    (void)postSessionOpen();
+    return 0;
+}
+
+int CtrlChannel::postSessionOpen() {
+    // PR2: SESSION_OPEN / credit / MsgChannel deferred to later PRs.
+    (void)transport_;
+    return 0;
+}
+
+int CtrlChannel::sendCtrlFrame(const CtrlFrame &frame_in) {
+    if (!connected_.load(std::memory_order_acquire)) return ERR_ENDPOINT;
+
+    CtrlFrame frame = frame_in;
+    if (frame.version == 0) frame.version = kCtrlFrameVersion;
+    if (frame.session == 0) frame.session = transport_.localCtrlSessionId();
+
+    std::vector<uint8_t> wired;
+    {
+        std::unique_lock<std::mutex> lock(send_mutex_);
+        if (frame.seq == 0) frame.seq = next_frame_seq_++;
+        if (encodeCtrlFrame(frame, wired)) return ERR_INVALID_ARGUMENT;
+        if (wired.size() > buffer_size_) {
+            LOG(ERROR) << "CtrlChannel: frame too large (" << wired.size()
+                       << " > " << buffer_size_
+                       << ") type=" << static_cast<int>(frame.type);
+            return ERR_INVALID_ARGUMENT;
+        }
+
+        // Poll SEND completions while waiting so a full SQ cannot deadlock
+        // when the caller is (or contends with) the ctrl worker.
+        while (connected_.load(std::memory_order_acquire) &&
+               pending_sends_ >= max_pending_sends_) {
+            lock.unlock();
+            pollSendCompletions(16);
+            lock.lock();
+            if (pending_sends_ < max_pending_sends_) break;
+            send_cv_.wait_for(lock, std::chrono::microseconds(50));
+        }
+        if (!connected_.load(std::memory_order_acquire)) return ERR_ENDPOINT;
+
+        std::lock_guard<std::mutex> resource_guard(resource_mutex_);
+        if (!qp_ || !send_mr_) return ERR_ENDPOINT;
+
+        size_t slot = send_wr_id_ % max_pending_sends_;
+        char *slot_ptr = send_buffer_.data() + slot * buffer_size_;
+        std::memcpy(slot_ptr, wired.data(), wired.size());
+
+        ibv_sge sge{};
+        sge.addr = reinterpret_cast<uint64_t>(slot_ptr);
+        sge.length = static_cast<uint32_t>(wired.size());
+        sge.lkey = send_mr_->lkey;
+
+        ibv_send_wr wr{};
+        wr.wr_id = send_wr_id_++;
+        wr.sg_list = &sge;
+        wr.num_sge = 1;
+        wr.opcode = IBV_WR_SEND;
+        wr.send_flags = IBV_SEND_SIGNALED;
+        if (wired.size() <= globalConfig().max_inline) {
+            wr.send_flags |= IBV_SEND_INLINE;
+        }
+
+        ibv_send_wr *bad = nullptr;
+        int ret = ibv_post_send(qp_, &wr, &bad);
+        if (ret) {
+            LOG(ERROR) << "CtrlChannel: ibv_post_send failed to "
+                       << peer_server_name_ << ": " << strerror(std::abs(ret))
+                       << " [" << ret << "]";
+            return ERR_ENDPOINT;
+        }
+        pending_sends_++;
+    }
+    return 0;
+}
+
+int CtrlChannel::sendNotify(const NotifyDesc &notify) {
+    CtrlFrame frame;
+    frame.type = CtrlFrameType::NOTIFY_COMPAT;
+    if (encodeNotifyCompatPayload(notify, frame.payload))
+        return ERR_INVALID_ARGUMENT;
+    return sendCtrlFrame(frame);
+}
+
+void CtrlChannel::dispatchRecvPayload(const uint8_t *data, size_t byte_len) {
+    // Typed CtrlFrame path (Phase 2+).
+    if (isCtrlFrameMagic(data, byte_len)) {
+        CtrlFrame frame;
+        if (decodeCtrlFrame(data, byte_len, frame)) {
+            LOG(ERROR) << "CtrlChannel: malformed typed frame from "
+                       << peer_server_name_ << " len=" << byte_len;
+            return;
+        }
+        transport_.onCtrlFrameReceived(peer_server_name_, frame);
+        return;
+    }
+
+    // Legacy Phase-1 raw notify wire: [name_len][name][msg_len][msg].
+    if (byte_len < 8) {
+        LOG(ERROR) << "CtrlChannel: short notify message len=" << byte_len;
+        return;
+    }
+    NotifyDesc notify;
+    if (decodeNotifyCompatPayload(data, byte_len, notify)) {
+        LOG(ERROR) << "CtrlChannel: invalid legacy notify from "
+                   << peer_server_name_;
+        return;
+    }
+    transport_.onCtrlNotifyReceived(notify);
+}
+
+void CtrlChannel::handleSendComplete() {
+    std::lock_guard<std::mutex> lock(send_mutex_);
+    if (pending_sends_ > 0) pending_sends_--;
+    send_cv_.notify_one();
+}
+
+void CtrlChannel::handleRecvComplete(const ibv_wc &wc) {
+    // Copy payload then release resources before dispatching callbacks.
+    // Callbacks may sendCtrlFrame (e.g. CREDIT_GRANT) which needs
+    // resource_mutex_ / send_mutex_ — must not hold them here.
+    const size_t idx = static_cast<size_t>(wc.wr_id);
+    const size_t byte_len = wc.byte_len;
+    std::vector<uint8_t> payload;
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        if (idx < recv_buffers_.size() && byte_len > 0) {
+            auto *data =
+                reinterpret_cast<const uint8_t *>(recv_buffers_[idx].data());
+            payload.assign(data, data + byte_len);
+        }
+    }
+    if (!payload.empty()) {
+        dispatchRecvPayload(payload.data(), payload.size());
+    }
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        postRecv(idx);
+    }
+}
+
+int CtrlChannel::drainCompletions(int max_entries, bool log_poll_error) {
+    std::vector<ibv_wc> wc(static_cast<size_t>(max_entries));
+    int n = 0;
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        if (!cq_) return 0;
+        n = ibv_poll_cq(cq_, max_entries, wc.data());
+    }
+    if (n < 0) {
+        if (log_poll_error) {
+            LOG(ERROR) << "CtrlChannel: ibv_poll_cq failed";
+        }
+        return n;
+    }
+    int handled = 0;
+    for (int i = 0; i < n; ++i) {
+        if (wc[i].status != IBV_WC_SUCCESS) {
+            LOG(ERROR) << "CtrlChannel: WC error status=" << wc[i].status
+                       << " opcode=" << wc[i].opcode
+                       << " peer=" << peer_server_name_;
+            connected_.store(false, std::memory_order_release);
+            std::lock_guard<std::mutex> lock(send_mutex_);
+            send_cv_.notify_all();
+            continue;
+        }
+        if (wc[i].opcode == IBV_WC_SEND) {
+            handleSendComplete();
+            handled++;
+        } else if (wc[i].opcode == IBV_WC_RECV) {
+            // Also required on send-path poll: opportunistic SEND polling must
+            // not drop RECV WCs stolen from the ctrl worker.
+            handleRecvComplete(wc[i]);
+            handled++;
+        }
+    }
+    return handled;
+}
+
+int CtrlChannel::pollSendCompletions(int max_entries) {
+    return drainCompletions(max_entries, /*log_poll_error=*/false);
+}
+
+int CtrlChannel::pollCompletions(int max_entries) {
+    return drainCompletions(max_entries, /*log_poll_error=*/true);
+}
+
+void CtrlChannel::disconnect() {
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    destroyResources();
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -167,7 +167,8 @@ void RdmaTwoSidedTransport::ctrlWorkerLoop() {
         }
         int processed = 0;
         for (auto &channel : channels) {
-            processed += channel->pollCompletions(16);
+            int ret = channel->pollCompletions(16);
+            if (ret > 0) processed += ret;
         }
         if (processed == 0) {
             std::this_thread::sleep_for(std::chrono::microseconds(100));

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+#include <glog/logging.h>
+
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+#include "transport/rdma_twosided/ctrl_channel.h"
+#include "transport/rdma_twosided/ctrl_frame.h"
+
+namespace mooncake {
+
+int RdmaTwoSidedTransport::onSetupCtrlChannel(const HandShakeDesc &peer_desc,
+                                              HandShakeDesc &local_desc) {
+    if (!globalConfig().rdma_notify_enabled) {
+        local_desc.reply_msg = "RDMA notify disabled";
+        return ERR_INVALID_ARGUMENT;
+    }
+    const auto &contexts = getContextList();
+    if (contexts.empty()) {
+        local_desc.reply_msg = "No local RDMA context for CtrlChannel";
+        return ERR_DEVICE_NOT_FOUND;
+    }
+
+    std::string peer_server_name =
+        getServerNameFromNicPath(peer_desc.local_nic_path);
+    if (peer_server_name.empty()) {
+        local_desc.reply_msg = "Cannot derive peer server name from handshake";
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    std::shared_ptr<CtrlChannel> channel;
+    std::shared_ptr<CtrlChannel> old;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = ctrl_channels_.find(peer_server_name);
+        if (it != ctrl_channels_.end() && it->second) {
+            old = it->second;
+        }
+        channel = std::make_shared<CtrlChannel>(*this, *contexts[0],
+                                                peer_server_name);
+        ctrl_channels_[peer_server_name] = channel;
+    }
+    if (old) old->disconnect();
+    return channel->acceptPassive(peer_desc, local_desc);
+}
+
+std::shared_ptr<CtrlChannel> RdmaTwoSidedTransport::ensureCtrlChannel(
+    const std::string &peer_server_name) {
+    const auto &contexts = getContextList();
+    if (!globalConfig().rdma_notify_enabled || contexts.empty()) {
+        return nullptr;
+    }
+
+    std::unique_lock<std::mutex> lock(ctrl_mutex_);
+    auto it = ctrl_channels_.find(peer_server_name);
+    if (it != ctrl_channels_.end() && it->second && it->second->connected()) {
+        return it->second;
+    }
+
+    // Serialize active connect per peer to avoid duplicate handshakes.
+    auto channel =
+        std::make_shared<CtrlChannel>(*this, *contexts[0], peer_server_name);
+    // Release lock during handshake I/O; re-check afterwards.
+    lock.unlock();
+    if (channel->connectActive()) {
+        return nullptr;
+    }
+    lock.lock();
+    auto again = ctrl_channels_.find(peer_server_name);
+    if (again != ctrl_channels_.end() && again->second &&
+        again->second->connected()) {
+        // Another thread won the race; keep the already-connected channel.
+        channel->disconnect();
+        return again->second;
+    }
+    ctrl_channels_[peer_server_name] = channel;
+    return channel;
+}
+
+int RdmaTwoSidedTransport::sendRdmaNotify(const std::string &peer_server_name,
+                                          const NotifyDesc &notify) {
+    auto channel = ensureCtrlChannel(peer_server_name);
+    if (!channel) return ERR_ENDPOINT;
+    return channel->sendNotify(notify);
+}
+
+void RdmaTwoSidedTransport::onCtrlNotifyReceived(const NotifyDesc &notify) {
+    if (meta()) meta()->pushNotify(notify);
+}
+
+void RdmaTwoSidedTransport::onCtrlFrameReceived(
+    const std::string &peer_server_name, const CtrlFrame &frame) {
+    switch (frame.type) {
+        case CtrlFrameType::NOTIFY_COMPAT: {
+            NotifyDesc notify;
+            if (decodeNotifyCompatPayload(frame.payload.data(),
+                                          frame.payload.size(), notify) == 0) {
+                onCtrlNotifyReceived(notify);
+            } else {
+                LOG(ERROR) << "CtrlChannel: bad NOTIFY_COMPAT from "
+                           << peer_server_name;
+            }
+            break;
+        }
+        case CtrlFrameType::SESSION_OPEN:
+        case CtrlFrameType::SESSION_CLOSE:
+        case CtrlFrameType::CREDIT_GRANT:
+        case CtrlFrameType::CREDIT_REQUEST:
+        case CtrlFrameType::CREDIT_PROGRESS:
+        case CtrlFrameType::DATA_ACK:
+        case CtrlFrameType::FENCE:
+        case CtrlFrameType::DRAIN_ACK:
+        case CtrlFrameType::CTRL_ACK:
+            VLOG(1) << "CtrlChannel: ignoring frame type "
+                    << static_cast<int>(frame.type) << " from "
+                    << peer_server_name << " (PR2 notify-only)";
+            break;
+        default:
+            LOG(WARNING) << "CtrlChannel: unknown frame type "
+                         << static_cast<int>(frame.type) << " from "
+                         << peer_server_name;
+            break;
+    }
+}
+
+void RdmaTwoSidedTransport::startCtrlWorker() {
+    if (ctrl_worker_running_.exchange(true)) return;
+    ctrl_worker_ = std::thread([this] { ctrlWorkerLoop(); });
+}
+
+void RdmaTwoSidedTransport::stopCtrlWorker() {
+    if (!ctrl_worker_running_.exchange(false)) return;
+    if (ctrl_worker_.joinable()) ctrl_worker_.join();
+}
+
+void RdmaTwoSidedTransport::ctrlWorkerLoop() {
+    while (ctrl_worker_running_.load(std::memory_order_acquire)) {
+        std::vector<std::shared_ptr<CtrlChannel>> channels;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            channels.reserve(ctrl_channels_.size());
+            for (auto &entry : ctrl_channels_) {
+                if (entry.second) channels.push_back(entry.second);
+            }
+        }
+        int processed = 0;
+        for (auto &channel : channels) {
+            processed += channel->pollCompletions(16);
+        }
+        if (processed == 0) {
+            std::this_thread::sleep_for(std::chrono::microseconds(100));
+        }
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -31,6 +31,54 @@
 
 namespace mooncake {
 
+namespace {
+
+// Releases an already-held lock for the duration of a blocking call and
+// reacquires it on scope exit, including when that call throws. Keeps the
+// lock state uniform for the enclosing ConnectScope, whose destructor may
+// then assume the lock is held.
+class UnlockGuard {
+   public:
+    explicit UnlockGuard(std::unique_lock<std::mutex> &lock) : lock_(lock) {
+        DCHECK(lock_.owns_lock());
+        lock_.unlock();
+    }
+    ~UnlockGuard() { lock_.lock(); }
+
+    UnlockGuard(const UnlockGuard &) = delete;
+    UnlockGuard &operator=(const UnlockGuard &) = delete;
+
+   private:
+    std::unique_lock<std::mutex> &lock_;
+};
+
+}  // namespace
+
+RdmaTwoSidedTransport::ConnectScope::ConnectScope(
+    RdmaTwoSidedTransport &transport, std::string peer,
+    std::shared_ptr<CtrlChannel> channel)
+    : transport_(transport),
+      peer_(std::move(peer)),
+      channel_(std::move(channel)) {
+    transport_.ctrl_channels_[peer_] = channel_;
+    transport_.ctrl_connecting_[peer_]++;
+}
+
+RdmaTwoSidedTransport::ConnectScope::~ConnectScope() {
+    auto in_flight = transport_.ctrl_connecting_.find(peer_);
+    if (in_flight != transport_.ctrl_connecting_.end() &&
+        --in_flight->second <= 0) {
+        transport_.ctrl_connecting_.erase(in_flight);
+    }
+    if (!success_) {
+        auto it = transport_.ctrl_channels_.find(peer_);
+        if (it != transport_.ctrl_channels_.end() && it->second == channel_) {
+            transport_.ctrl_channels_.erase(it);
+        }
+    }
+    transport_.ctrl_cv_.notify_all();
+}
+
 int RdmaTwoSidedTransport::onSetupCtrlChannel(const HandShakeDesc &peer_desc,
                                               HandShakeDesc &local_desc) {
     if (!globalConfig().rdma_notify_enabled) {
@@ -50,30 +98,27 @@ int RdmaTwoSidedTransport::onSetupCtrlChannel(const HandShakeDesc &peer_desc,
         return ERR_INVALID_ARGUMENT;
     }
 
-    std::shared_ptr<CtrlChannel> channel;
+    std::unique_lock<std::mutex> lock(ctrl_mutex_);
+    if (ctrl_stopping_) {
+        local_desc.reply_msg = "CtrlChannel plane is shutting down";
+        return ERR_ENDPOINT;
+    }
+
     std::shared_ptr<CtrlChannel> old;
+    auto it = ctrl_channels_.find(peer_server_name);
+    if (it != ctrl_channels_.end()) old = it->second;
+
+    auto channel =
+        std::make_shared<CtrlChannel>(*this, *contexts[0], peer_server_name);
+    // Publishes the placeholder; retracted automatically unless we succeed.
+    ConnectScope scope(*this, peer_server_name, channel);
+    int ret = 0;
     {
-        std::lock_guard<std::mutex> lock(ctrl_mutex_);
-        auto it = ctrl_channels_.find(peer_server_name);
-        if (it != ctrl_channels_.end() && it->second) {
-            old = it->second;
-        }
-        channel = std::make_shared<CtrlChannel>(*this, *contexts[0],
-                                                peer_server_name);
-        ctrl_channels_[peer_server_name] = channel;
+        UnlockGuard unlocked(lock);
+        if (old) old->disconnect();
+        ret = channel->acceptPassive(peer_desc, local_desc);
     }
-    if (old) old->disconnect();
-    int ret = channel->acceptPassive(peer_desc, local_desc);
-    {
-        std::lock_guard<std::mutex> lock(ctrl_mutex_);
-        if (ret) {
-            auto it = ctrl_channels_.find(peer_server_name);
-            if (it != ctrl_channels_.end() && it->second == channel) {
-                ctrl_channels_.erase(it);
-            }
-        }
-        ctrl_cv_.notify_all();
-    }
+    if (ret == 0) scope.markSuccess();
     return ret;
 }
 
@@ -84,39 +129,65 @@ std::shared_ptr<CtrlChannel> RdmaTwoSidedTransport::ensureCtrlChannel(
         return nullptr;
     }
 
+    // Absolute deadline for the whole call, so retries and repeated waits
+    // cannot extend it. On expiry we return nullptr and the caller falls back
+    // to OOB notify instead of blocking forever.
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(
+                              globalConfig().rdma_notify_connect_timeout_ms);
+
     std::unique_lock<std::mutex> lock(ctrl_mutex_);
     while (true) {
+        if (ctrl_stopping_) return nullptr;
+
         auto it = ctrl_channels_.find(peer_server_name);
+        const bool connect_in_flight =
+            ctrl_connecting_.find(peer_server_name) != ctrl_connecting_.end();
         if (it != ctrl_channels_.end() && it->second) {
             if (it->second->connected()) return it->second;
-            // Active or passive connect is already in flight for this peer.
-            ctrl_cv_.wait(lock);
-            continue;
+            if (!connect_in_flight) {
+                // Channel died after connect (error WC, disconnect). Nobody
+                // republishes or wakes waiters for it, so reclaim it here and
+                // rebuild on the next iteration.
+                auto dead = it->second;
+                ctrl_channels_.erase(it);
+                UnlockGuard unlocked(lock);
+                dead->disconnect();
+                continue;
+            }
+        } else if (!connect_in_flight) {
+            auto channel = std::make_shared<CtrlChannel>(*this, *contexts[0],
+                                                         peer_server_name);
+            ConnectScope scope(*this, peer_server_name, channel);
+            int ret = 0;
+            {
+                UnlockGuard unlocked(lock);
+                ret = channel->connectActive();
+            }
+            if (ret) {
+                // Report our own failure rather than retrying until the
+                // deadline; the caller decides whether to use OOB notify.
+                return nullptr;
+            }
+            auto again = ctrl_channels_.find(peer_server_name);
+            if (again == ctrl_channels_.end() || again->second != channel) {
+                // A passive accept superseded us while the lock was released.
+                UnlockGuard unlocked(lock);
+                channel->disconnect();
+                continue;
+            }
+            scope.markSuccess();
+            return channel;
         }
 
-        auto channel = std::make_shared<CtrlChannel>(*this, *contexts[0],
-                                                     peer_server_name);
-        ctrl_channels_[peer_server_name] = channel;
-        lock.unlock();
-        int ret = channel->connectActive();
-        lock.lock();
-
-        auto again = ctrl_channels_.find(peer_server_name);
-        const bool still_ours =
-            again != ctrl_channels_.end() && again->second == channel;
-        if (ret) {
-            if (still_ours) ctrl_channels_.erase(again);
-            ctrl_cv_.notify_all();
-            if (still_ours) return nullptr;
-            continue;
+        // A connect really is in flight for this peer: wait for its owner to
+        // publish or retract it, bounded by the deadline.
+        if (ctrl_cv_.wait_until(lock, deadline) == std::cv_status::timeout) {
+            LOG(WARNING) << "CtrlChannel: timed out waiting for in-flight "
+                            "connect to "
+                         << peer_server_name;
+            return nullptr;
         }
-        if (!still_ours) {
-            channel->disconnect();
-            ctrl_cv_.notify_all();
-            continue;
-        }
-        ctrl_cv_.notify_all();
-        return channel;
     }
 }
 
@@ -172,6 +243,14 @@ void RdmaTwoSidedTransport::startCtrlWorker() {
 }
 
 void RdmaTwoSidedTransport::stopCtrlWorker() {
+    {
+        // Release waiters before joining: a thread parked on ctrl_cv_ must not
+        // outlive the plane it is waiting on. Notify under the lock so a waiter
+        // that has not parked yet cannot miss the wakeup.
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        ctrl_stopping_ = true;
+        ctrl_cv_.notify_all();
+    }
     if (!ctrl_worker_running_.exchange(false)) return;
     if (ctrl_worker_.joinable()) ctrl_worker_.join();
 }

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -63,7 +63,18 @@ int RdmaTwoSidedTransport::onSetupCtrlChannel(const HandShakeDesc &peer_desc,
         ctrl_channels_[peer_server_name] = channel;
     }
     if (old) old->disconnect();
-    return channel->acceptPassive(peer_desc, local_desc);
+    int ret = channel->acceptPassive(peer_desc, local_desc);
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        if (ret) {
+            auto it = ctrl_channels_.find(peer_server_name);
+            if (it != ctrl_channels_.end() && it->second == channel) {
+                ctrl_channels_.erase(it);
+            }
+        }
+        ctrl_cv_.notify_all();
+    }
+    return ret;
 }
 
 std::shared_ptr<CtrlChannel> RdmaTwoSidedTransport::ensureCtrlChannel(
@@ -74,29 +85,39 @@ std::shared_ptr<CtrlChannel> RdmaTwoSidedTransport::ensureCtrlChannel(
     }
 
     std::unique_lock<std::mutex> lock(ctrl_mutex_);
-    auto it = ctrl_channels_.find(peer_server_name);
-    if (it != ctrl_channels_.end() && it->second && it->second->connected()) {
-        return it->second;
-    }
+    while (true) {
+        auto it = ctrl_channels_.find(peer_server_name);
+        if (it != ctrl_channels_.end() && it->second) {
+            if (it->second->connected()) return it->second;
+            // Active or passive connect is already in flight for this peer.
+            ctrl_cv_.wait(lock);
+            continue;
+        }
 
-    // Serialize active connect per peer to avoid duplicate handshakes.
-    auto channel =
-        std::make_shared<CtrlChannel>(*this, *contexts[0], peer_server_name);
-    // Release lock during handshake I/O; re-check afterwards.
-    lock.unlock();
-    if (channel->connectActive()) {
-        return nullptr;
+        auto channel = std::make_shared<CtrlChannel>(*this, *contexts[0],
+                                                     peer_server_name);
+        ctrl_channels_[peer_server_name] = channel;
+        lock.unlock();
+        int ret = channel->connectActive();
+        lock.lock();
+
+        auto again = ctrl_channels_.find(peer_server_name);
+        const bool still_ours =
+            again != ctrl_channels_.end() && again->second == channel;
+        if (ret) {
+            if (still_ours) ctrl_channels_.erase(again);
+            ctrl_cv_.notify_all();
+            if (still_ours) return nullptr;
+            continue;
+        }
+        if (!still_ours) {
+            channel->disconnect();
+            ctrl_cv_.notify_all();
+            continue;
+        }
+        ctrl_cv_.notify_all();
+        return channel;
     }
-    lock.lock();
-    auto again = ctrl_channels_.find(peer_server_name);
-    if (again != ctrl_channels_.end() && again->second &&
-        again->second->connected()) {
-        // Another thread won the race; keep the already-connected channel.
-        channel->disconnect();
-        return again->second;
-    }
-    ctrl_channels_[peer_server_name] = channel;
-    return channel;
 }
 
 int RdmaTwoSidedTransport::sendRdmaNotify(const std::string &peer_server_name,

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
@@ -38,6 +38,7 @@ RdmaTwoSidedTransport::~RdmaTwoSidedTransport() {
         if (entry.second) entry.second->disconnect();
     }
     ctrl_channels_.clear();
+    ctrl_cv_.notify_all();
 }
 
 int RdmaTwoSidedTransport::install(std::string &local_server_name,

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
@@ -1,0 +1,62 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+#include <glog/logging.h>
+
+#include <mutex>
+#include <random>
+
+#include "config.h"
+#include "transport/rdma_twosided/ctrl_channel.h"
+
+namespace mooncake {
+
+RdmaTwoSidedTransport::RdmaTwoSidedTransport() {
+    std::random_device rd;
+    std::mt19937_64 gen(rd());
+    local_ctrl_session_id_ = gen();
+    if (local_ctrl_session_id_ == 0) local_ctrl_session_id_ = 1;
+}
+
+RdmaTwoSidedTransport::~RdmaTwoSidedTransport() {
+    stopCtrlWorker();
+    std::lock_guard<std::mutex> lock(ctrl_mutex_);
+    for (auto &entry : ctrl_channels_) {
+        if (entry.second) entry.second->disconnect();
+    }
+    ctrl_channels_.clear();
+}
+
+int RdmaTwoSidedTransport::install(std::string &local_server_name,
+                                   std::shared_ptr<TransferMetadata> meta,
+                                   std::shared_ptr<Topology> topo) {
+    int ret = RdmaTransport::install(local_server_name, meta, topo);
+    if (ret) return ret;
+    if (globalConfig().rdma_notify_enabled) {
+        startCtrlWorker();
+    }
+    return 0;
+}
+
+int RdmaTwoSidedTransport::onSetupRdmaConnections(
+    const HandShakeDesc &peer_desc, HandShakeDesc &local_desc) {
+    if (peer_desc.ctrl_channel) {
+        return onSetupCtrlChannel(peer_desc, local_desc);
+    }
+    return RdmaTransport::onSetupRdmaConnections(peer_desc, local_desc);
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -27,8 +27,7 @@ add_test(NAME endpoint_store_test COMMAND endpoint_store_test)
 # Fingerprint, blob and option checks run without a VMM backend.
 add_executable(shared_segment_test ${WORKSPACE}/shared_segment_test.cpp)
 target_include_directories(
-  shared_segment_test
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/shared_segment)
+  shared_segment_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/shared_segment)
 target_link_libraries(shared_segment_test PUBLIC transfer_engine gtest
                                                  gtest_main)
 add_test(NAME shared_segment_test COMMAND shared_segment_test)
@@ -76,6 +75,13 @@ add_executable(sender_credit_test ${WORKSPACE}/sender_credit_test.cpp)
 target_link_libraries(sender_credit_test PUBLIC transfer_engine gtest
                                                 gtest_main)
 add_test(NAME sender_credit_test COMMAND sender_credit_test)
+
+# CtrlChannel RDMA notify correctness. Self-skips without RDMA.
+add_executable(rdma_notify_test ${WORKSPACE}/rdma_notify_test.cpp)
+target_link_libraries(rdma_notify_test PUBLIC transfer_engine gflags::gflags
+                                              glog::glog gtest)
+add_test(NAME rdma_notify_test COMMAND rdma_notify_test)
+set_tests_properties(rdma_notify_test PROPERTIES LABELS "rdma")
 
 # This test verifies endpoint re-establishment in RDMATransport.
 add_executable(rdma_endpoint_reestablish_test

--- a/mooncake-transfer-engine/tests/rdma_notify_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_notify_test.cpp
@@ -13,13 +13,15 @@
 // limitations under the License.
 //
 // Correctness checks for RDMA CtrlChannel notify path via
-// RdmaTwoSidedTransport. Requires an RDMA device. Self-skips when none is
-// present.
+// RdmaTwoSidedTransport. Requires a usable RDMA device (active port with a
+// GID). Self-skips when none is present, including CI runners that enumerate
+// a phantom mlx5_0.
 //
 // Env:
-//   MC_TE_FILTERS / MC_TEST_DEVICE_NAME — pin NIC (default: first ibv device)
-//   MC_USE_RDMA_TWOSIDED=1               — install rdma_twosided (set by test)
-//   MC_RDMA_NOTIFY_OOB_FALLBACK=0        — force RDMA path (set by this test)
+//   MC_TE_FILTERS / MC_TEST_DEVICE_NAME — pin NIC
+//     (default: first usable ibv device)
+//   MC_USE_RDMA_TWOSIDED=1 — install rdma_twosided (set by test)
+//   MC_RDMA_NOTIFY_OOB_FALLBACK=0 — force RDMA path (set by this test)
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
@@ -41,6 +43,27 @@ using namespace mooncake;
 
 namespace {
 
+bool rdmaDeviceUsable(ibv_device *device) {
+    ibv_context *ctx = ibv_open_device(device);
+    if (!ctx) return false;
+    ibv_device_attr attr{};
+    if (ibv_query_device(ctx, &attr) != 0) {
+        ibv_close_device(ctx);
+        return false;
+    }
+    bool ok = false;
+    for (uint8_t port = 1; port <= attr.phys_port_cnt; ++port) {
+        ibv_port_attr port_attr{};
+        if (ibv_query_port(ctx, port, &port_attr) != 0) continue;
+        if (port_attr.gid_tbl_len > 0 && port_attr.state == IBV_PORT_ACTIVE) {
+            ok = true;
+            break;
+        }
+    }
+    ibv_close_device(ctx);
+    return ok;
+}
+
 std::string pickRdmaDevice() {
     const char *override_name = std::getenv("MC_TEST_DEVICE_NAME");
     if (override_name && *override_name) return override_name;
@@ -50,7 +73,13 @@ std::string pickRdmaDevice() {
         if (list) ibv_free_device_list(list);
         return "";
     }
-    std::string name = ibv_get_device_name(list[0]);
+    std::string name;
+    for (int i = 0; i < num_devices; ++i) {
+        if (rdmaDeviceUsable(list[i])) {
+            name = ibv_get_device_name(list[i]);
+            break;
+        }
+    }
     ibv_free_device_list(list);
     return name;
 }
@@ -78,7 +107,7 @@ class RdmaNotifyTest : public ::testing::Test {
     void SetUp() override {
         device_ = pickRdmaDevice();
         if (device_.empty()) {
-            GTEST_SKIP() << "no RDMA device available";
+            GTEST_SKIP() << "no usable RDMA device available";
         }
         ASSERT_EQ(setenv("MC_TE_FILTERS", device_.c_str(), 1), 0);
         ASSERT_EQ(setenv("MC_USE_RDMA_TWOSIDED", "1", 1), 0);

--- a/mooncake-transfer-engine/tests/rdma_notify_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_notify_test.cpp
@@ -28,6 +28,7 @@
 #include <gtest/gtest.h>
 #include <infiniband/verbs.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <memory>
@@ -113,6 +114,7 @@ class RdmaNotifyTest : public ::testing::Test {
         ASSERT_EQ(setenv("MC_USE_RDMA_TWOSIDED", "1", 1), 0);
         ASSERT_EQ(setenv("MC_RDMA_NOTIFY_ENABLED", "1", 1), 0);
         ASSERT_EQ(setenv("MC_RDMA_NOTIFY_OOB_FALLBACK", "0", 1), 0);
+        ASSERT_EQ(setenv("MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS", "2000", 1), 0);
         loadGlobalConfig(globalConfig());
         ASSERT_TRUE(globalConfig().use_rdma_twosided);
         ASSERT_TRUE(globalConfig().rdma_notify_enabled);
@@ -138,6 +140,7 @@ class RdmaNotifyTest : public ::testing::Test {
         unsetenv("MC_USE_RDMA_TWOSIDED");
         unsetenv("MC_RDMA_NOTIFY_ENABLED");
         unsetenv("MC_RDMA_NOTIFY_OOB_FALLBACK");
+        unsetenv("MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS");
         loadGlobalConfig(globalConfig());
     }
 
@@ -224,6 +227,86 @@ TEST_F(RdmaNotifyTest, BurstNotifyCorrectness) {
         EXPECT_EQ(got[i].name, "n" + std::to_string(i));
         EXPECT_EQ(got[i].notify_msg, "payload-" + std::to_string(i));
     }
+}
+
+// Regression for the unbounded ctrl_cv_ wait: a peer that never completes the
+// ctrl handshake must not park the caller forever. With OOB fallback disabled
+// the notify has to report failure within the connect timeout.
+TEST_F(RdmaNotifyTest, UnreachablePeerNotifyIsBounded) {
+    TransferMetadata::NotifyDesc msg{"unreachable", "x"};
+
+    auto start = std::chrono::steady_clock::now();
+    int ret = sender_->sendNotifyByName("127.0.0.1:19999", msg);
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto elapsed_s =
+        std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+
+    EXPECT_NE(ret, 0)
+        << "notify to an unreachable peer must not report success";
+    EXPECT_LT(elapsed_s, 30)
+        << "sendNotify blocked far beyond the connect timeout";
+}
+
+// Concurrent notifies to the same unreachable peer: the connect stays
+// serialized, but every waiter must still return. A regression shows up as a
+// hung test rather than a failed assertion.
+TEST_F(RdmaNotifyTest, ConcurrentUnreachablePeerNotifyAllReturn) {
+    constexpr int kThreads = 8;
+    std::atomic<int> finished{0};
+    std::vector<std::thread> threads;
+
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < kThreads; ++i) {
+        threads.emplace_back([this, &finished] {
+            TransferMetadata::NotifyDesc msg{"concurrent", "x"};
+            (void)sender_->sendNotifyByName("127.0.0.1:19998", msg);
+            finished.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+    for (auto &thread : threads) thread.join();
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto elapsed_s =
+        std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+
+    EXPECT_EQ(finished.load(), kThreads);
+    EXPECT_LT(elapsed_s, 60)
+        << "concurrent notifies did not settle within the connect timeout";
+}
+
+// Regression for the dead-channel wait: once a connected CtrlChannel fails
+// because the peer is gone, the stale ctrl_channels_ entry must not park later
+// callers forever. Before the fix the entry stayed behind as "not connected"
+// with nobody left to notify ctrl_cv_, so every later notify blocked.
+TEST_F(RdmaNotifyTest, NotifyAfterPeerGoneIsBounded) {
+    TransferMetadata::NotifyDesc first{"before", "x"};
+    ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, first), 0);
+    std::vector<TransferMetadata::NotifyDesc> got;
+    ASSERT_TRUE(waitForNotifies(*receiver_, 1, got));
+
+    // Drop the peer: the ctrl QP moves to error, connected_ flips to false and
+    // the entry is left stale in ctrl_channels_.
+    receiver_.reset();
+
+    // The error WC lands shortly after the peer is gone. Keep notifying until
+    // the transport reports the failure: it must reclaim the stale entry and
+    // return an error rather than block. Before the fix this loop hung.
+    auto start = std::chrono::steady_clock::now();
+    bool reported_failure = false;
+    for (int i = 0; i < 40 && !reported_failure; ++i) {
+        TransferMetadata::NotifyDesc after{"after", "y"};
+        if (sender_->sendNotifyByName(receiver_name_, after) != 0) {
+            reported_failure = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    auto elapsed_s =
+        std::chrono::duration_cast<std::chrono::seconds>(elapsed).count();
+
+    EXPECT_TRUE(reported_failure)
+        << "notify kept reporting success after the peer was gone";
+    EXPECT_LT(elapsed_s, 60) << "notify blocked on a stale CtrlChannel entry";
 }
 
 int main(int argc, char **argv) {

--- a/mooncake-transfer-engine/tests/rdma_notify_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_notify_test.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Correctness checks for RDMA CtrlChannel notify path via
+// RdmaTwoSidedTransport. Requires an RDMA device. Self-skips when none is
+// present.
+//
+// Env:
+//   MC_TE_FILTERS / MC_TEST_DEVICE_NAME — pin NIC (default: first ibv device)
+//   MC_USE_RDMA_TWOSIDED=1               — install rdma_twosided (set by test)
+//   MC_RDMA_NOTIFY_OOB_FALLBACK=0        — force RDMA path (set by this test)
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <infiniband/verbs.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "config.h"
+#include "transfer_engine.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+using namespace mooncake;
+
+namespace {
+
+std::string pickRdmaDevice() {
+    const char *override_name = std::getenv("MC_TEST_DEVICE_NAME");
+    if (override_name && *override_name) return override_name;
+    int num_devices = 0;
+    ibv_device **list = ibv_get_device_list(&num_devices);
+    if (!list || num_devices == 0) {
+        if (list) ibv_free_device_list(list);
+        return "";
+    }
+    std::string name = ibv_get_device_name(list[0]);
+    ibv_free_device_list(list);
+    return name;
+}
+
+bool waitForNotifies(TransferEngine &engine, size_t expect,
+                     std::vector<TransferMetadata::NotifyDesc> &out,
+                     int timeout_ms = 5000) {
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(timeout_ms);
+    out.clear();
+    while (std::chrono::steady_clock::now() < deadline) {
+        std::vector<TransferMetadata::NotifyDesc> batch;
+        engine.getNotifies(batch);
+        out.insert(out.end(), batch.begin(), batch.end());
+        if (out.size() >= expect) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return out.size() >= expect;
+}
+
+}  // namespace
+
+class RdmaNotifyTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        device_ = pickRdmaDevice();
+        if (device_.empty()) {
+            GTEST_SKIP() << "no RDMA device available";
+        }
+        ASSERT_EQ(setenv("MC_TE_FILTERS", device_.c_str(), 1), 0);
+        ASSERT_EQ(setenv("MC_USE_RDMA_TWOSIDED", "1", 1), 0);
+        ASSERT_EQ(setenv("MC_RDMA_NOTIFY_ENABLED", "1", 1), 0);
+        ASSERT_EQ(setenv("MC_RDMA_NOTIFY_OOB_FALLBACK", "0", 1), 0);
+        loadGlobalConfig(globalConfig());
+        ASSERT_TRUE(globalConfig().use_rdma_twosided);
+        ASSERT_TRUE(globalConfig().rdma_notify_enabled);
+        ASSERT_FALSE(globalConfig().rdma_notify_oob_fallback);
+
+        std::vector<std::string> filter{device_};
+        sender_ = std::make_unique<TransferEngine>(true, filter);
+        receiver_ = std::make_unique<TransferEngine>(true, filter);
+        ASSERT_EQ(sender_->init("P2PHANDSHAKE", "127.0.0.1:0"), 0);
+        ASSERT_EQ(receiver_->init("P2PHANDSHAKE", "127.0.0.1:0"), 0);
+        sender_name_ = sender_->getLocalIpAndPort();
+        receiver_name_ = receiver_->getLocalIpAndPort();
+        ASSERT_FALSE(sender_name_.empty());
+        ASSERT_FALSE(receiver_name_.empty());
+        ASSERT_NE(sender_->getTransport("rdma_twosided"), nullptr);
+        ASSERT_NE(receiver_->getTransport("rdma_twosided"), nullptr);
+    }
+
+    void TearDown() override {
+        sender_.reset();
+        receiver_.reset();
+        unsetenv("MC_TE_FILTERS");
+        unsetenv("MC_USE_RDMA_TWOSIDED");
+        unsetenv("MC_RDMA_NOTIFY_ENABLED");
+        unsetenv("MC_RDMA_NOTIFY_OOB_FALLBACK");
+        loadGlobalConfig(globalConfig());
+    }
+
+    std::string device_;
+    std::unique_ptr<TransferEngine> sender_;
+    std::unique_ptr<TransferEngine> receiver_;
+    std::string sender_name_;
+    std::string receiver_name_;
+};
+
+TEST_F(RdmaNotifyTest, SingleNotifyCorrectness) {
+    TransferMetadata::NotifyDesc msg;
+    msg.name = "hello";
+    msg.notify_msg = "world-from-rdma-ctrl";
+
+    ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, msg), 0);
+
+    std::vector<TransferMetadata::NotifyDesc> got;
+    ASSERT_TRUE(waitForNotifies(*receiver_, 1, got))
+        << "timed out waiting for RDMA notify";
+    ASSERT_EQ(got.size(), 1u);
+    EXPECT_EQ(got[0].name, msg.name);
+    EXPECT_EQ(got[0].notify_msg, msg.notify_msg);
+}
+
+TEST_F(RdmaNotifyTest, BidirectionalNotify) {
+    TransferMetadata::NotifyDesc a2b{"a2b", "ping"};
+    TransferMetadata::NotifyDesc b2a{"b2a", "pong"};
+
+    ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, a2b), 0);
+    ASSERT_EQ(receiver_->sendNotifyByName(sender_name_, b2a), 0);
+
+    std::vector<TransferMetadata::NotifyDesc> recv_a, recv_b;
+    ASSERT_TRUE(waitForNotifies(*receiver_, 1, recv_a));
+    ASSERT_TRUE(waitForNotifies(*sender_, 1, recv_b));
+    EXPECT_EQ(recv_a[0].name, "a2b");
+    EXPECT_EQ(recv_a[0].notify_msg, "ping");
+    EXPECT_EQ(recv_b[0].name, "b2a");
+    EXPECT_EQ(recv_b[0].notify_msg, "pong");
+}
+
+TEST_F(RdmaNotifyTest, NotifyLatencySmoke) {
+    constexpr int kWarmup = 32;
+    constexpr int kIters = 2000;
+    TransferMetadata::NotifyDesc warmup{"warmup", "x"};
+    for (int i = 0; i < kWarmup; ++i) {
+        ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, warmup), 0);
+    }
+    std::vector<TransferMetadata::NotifyDesc> drain;
+    ASSERT_TRUE(waitForNotifies(*receiver_, kWarmup, drain, 10000));
+
+    auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < kIters; ++i) {
+        TransferMetadata::NotifyDesc msg;
+        msg.name = "p";
+        msg.notify_msg = "y";
+        ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, msg), 0);
+    }
+    std::vector<TransferMetadata::NotifyDesc> got;
+    ASSERT_TRUE(waitForNotifies(*receiver_, kIters, got, 15000));
+    auto elapsed = std::chrono::steady_clock::now() - start;
+    double us =
+        std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
+    double ops = kIters / (us / 1e6);
+    LOG(INFO) << "NotifyLatencySmoke: " << kIters << " notifies in " << us
+              << " us, ~" << ops << " ops/s, avg " << (us / kIters) << " us";
+}
+
+TEST_F(RdmaNotifyTest, BurstNotifyCorrectness) {
+    constexpr int kCount = 128;
+
+    for (int i = 0; i < kCount; ++i) {
+        TransferMetadata::NotifyDesc msg;
+        msg.name = "n" + std::to_string(i);
+        msg.notify_msg = "payload-" + std::to_string(i);
+        ASSERT_EQ(sender_->sendNotifyByName(receiver_name_, msg), 0)
+            << "failed at i=" << i;
+    }
+
+    std::vector<TransferMetadata::NotifyDesc> got;
+    ASSERT_TRUE(waitForNotifies(*receiver_, kCount, got, 10000));
+    ASSERT_EQ(got.size(), static_cast<size_t>(kCount));
+    for (int i = 0; i < kCount; ++i) {
+        EXPECT_EQ(got[i].name, "n" + std::to_string(i));
+        EXPECT_EQ(got[i].notify_msg, "payload-" + std::to_string(i));
+    }
+}
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Description

Second slice of the classic TE two-sided work ([RFC #3377](https://github.com/kvcache-ai/Mooncake/issues/3377)). Follows merged PR1 (#3324).

Adds an **opt-in** `rdma_twosided` transport whose control plane is a per-peer `CtrlChannel` (RC QP SEND/RECV). Classic `rdma` stays one-sided; a process installs **either** `rdma` **or** `rdma_twosided`.

This PR:
- Adds `RdmaTwoSidedTransport` (`MC_USE_RDMA_TWOSIDED=1`) and wires MultiTransport mutual exclusion
- Implements `CtrlChannel` + handshake fields (`notify_qp_num` / `notify_rq_depth` / `ctrl_channel`)
- Routes `sendNotify*` over RDMA `NOTIFY_COMPAT` frames, with OOB fallback (`MC_RDMA_NOTIFY_OOB_FALLBACK`)
- Adds `rdma_notify_test` (correctness + latency smoke; self-skips without an RDMA device)

No MsgChannel / bounce / managed-buffer data path yet (PR3). TE `submitTransfer` two-sided path remains PR4.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ninja ctrl_frame_test sender_credit_test rdma_notify_test
./mooncake-transfer-engine/tests/ctrl_frame_test
./mooncake-transfer-engine/tests/sender_credit_test
MC_TE_FILTERS=erdma_0 MC_TEST_DEVICE_NAME=erdma_0 MC_MTU=1024 \
  ./mooncake-transfer-engine/tests/rdma_notify_test
```

**Test results:**
- [x] Unit tests pass (`ctrl_frame_test` / `sender_credit_test`)
- [x] `rdma_notify_test` 4/4 on `erdma_0` (single / bidi / latency smoke ~10k ops/s / burst 128)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Notify latency smoke on eRDMA: 2000 notifies in ~191 ms, ~10.5k ops/s, avg ~95 µs.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run `pre-commit` on touched files and hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

RFC: https://github.com/kvcache-ai/Mooncake/issues/3377

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor agent assisted implementing the `rdma_twosided` control-plane channel. Human submitter reviewed the PR2 scope (CtrlChannel + notify path only).

Made with [Cursor](https://cursor.com)