### PR TITLE
[Reshard] Add N-D logical weight transfer planner

### DIFF
--- a/docs/source/design/model-weight-reshard-planner.md
+++ b/docs/source/design/model-weight-reshard-planner.md
@@ -1,0 +1,86 @@
+# Model Weight Logical Reshard Planner
+
+`mooncake-reshard` plans an address-free conversion between complete model
+weight placements. It turns a source placement or committed logical Store
+snapshot and a target placement into compact N-D transfer regions. It does not
+inspect framework runtime objects or assign physical GPU addresses.
+
+## Inputs and Output
+
+The source is either a complete `WeightPlacementManifest` or a committed
+`WeightManifest` snapshot. The target is a complete
+`WeightPlacementManifest`. Both sides must identify the same resource,
+revision, and weight generation.
+
+The public APIs are:
+
+- `plan_placement_transfer(source_placement, target_placement)`;
+- `plan_placement_transfer_to_local_target(source_placement,
+  target_placement, target_participant_id)`;
+- `plan_stored_transfer_to_target_placement(source_manifest,
+  target_placement)`.
+
+Each API returns a `LogicalTransferPlan`. It contains only canonical tensor
+descriptors, selected placement participants, and logical regions. It contains
+no GPU address, endpoint, allocation range, lease, or backend handle.
+
+## N-D Regions
+
+Each `TransferRegion` represents one source/target N-D box overlap. It records
+the overlap offset and shape, source and target base byte offsets, contiguous
+`inner_bytes`, outer loop counts, and source/target byte strides.
+
+The planner preserves a compact strided representation. It does not expand a
+cross-dimension overlap into one operation per row or element. `PlanningLimits`
+bounds the total number of regions and any later segment expansion fails closed
+when it exceeds the configured limit.
+
+## Parallel Semantics
+
+- **TP** changes logical boxes. The same overlap algorithm handles split,
+  merge, and source/target sharding on different dimensions.
+- **PP** is explicit framework-provided tensor or layer ownership. Regions are
+  grouped by source and target PP owner and optional pipeline stage; the
+  planner does not infer ownership from a tensor name or layer-count formula.
+- **EP** is represented by a logical expert coordinate. Independent expert
+  allocations remain independent logical fragments and are never packed or
+  all-gathered by the planner.
+- **DP** does not change tensor geometry. A `ReplicatedAxis(kind="dp")` uses a
+  complete source replica. An `OwnershipAxis(kind="dp")` routes each tensor
+  through its declared owner and does not require every tensor on every DP
+  rank.
+
+All four axes are resolved by one logical-box plan, rather than by model-wide
+per-axis conversion passes.
+
+## Validation
+
+Placement construction validates the complete participant set, tensor
+descriptors, topology, and logical coverage before planning. Planning then
+fails closed when source and target tensor identity, dtype, shape, layout
+fingerprint, ownership, or coverage differ.
+
+A `WeightManifest` source is retained as an immutable logical snapshot. Its
+canonical identity and selected stored fragments are revalidated whenever a
+logical plan is constructed or reconstructed. This proves that the plan still
+refers to the same Store snapshot; it does not make Store persistence or
+runtime loading part of this layer.
+
+Coverage validation uses an ordered interval scan for 1-D inputs and a
+coordinate-compressed sweep for 2-D inputs, both with `O(N log N)` behavior.
+For 3-D and higher logical boxes, exact intersection remains supported under an
+explicit pairwise-comparison budget; inputs that exceed it fail closed rather
+than making validation work unbounded.
+
+## Boundary to the Next Phase
+
+This PR is intentionally limited to logical planning. A later runtime-binding
+phase receives a `LogicalTransferPlan` and concrete
+`WeightRuntimeBindingManifest` values, revalidates physical address bounds,
+leases, generations, and alias scope, then produces an executor-facing bound
+plan.
+
+Transfer Engine lowering, DMA submission, Store persistence/lifecycle, and
+framework activation remain outside this logical planner. Framework adapters
+own model semantics and conversion into canonical manifests; Mooncake core does
+not infer those semantics from framework objects or parameter names.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -126,6 +126,7 @@ performance/vllm/index
 design/architecture
 design/transfer-engine/index
 design/reshard-manifest
+design/model-weight-reshard-planner
 design/tent/overview
 design/store/mooncake-store
 design/nvme-kv-backend

--- a/mooncake-reshard/README.md
+++ b/mooncake-reshard/README.md
@@ -1,90 +1,111 @@
 # Mooncake Reshard
 
-`mooncake-reshard` defines framework-neutral contracts for reusable runtime
-resources. This change adds the model-weight manifest contract; planning,
-storage, and transfer execution are added separately.
+`mooncake-reshard` defines framework-neutral contracts and address-free N-D
+logical planning for reusable runtime resources. This change adds the
+model-weight manifest and logical reshard planner; physical runtime binding,
+storage lifecycle, and transfer execution are separate phases.
 
-Framework-owned adapters outside Mooncake inspect framework runtime objects,
-normalize framework-specific values, and construct the typed canonical
-manifests. Mooncake core accepts only those typed values; it does not import or
-inspect framework objects or accept alternate field names or duck-typed
-records.
+Framework-owned adapters inspect framework runtime objects, normalize
+framework-specific values, and construct typed canonical manifests. Mooncake
+core accepts only those typed values; it does not import or inspect framework
+objects or accept alternate field names or duck-typed records.
 
 The public Python API is split by responsibility:
 
 - `mooncake.reshard.contracts` exposes `ResourceManifest`,
   `PlacementManifest`, and `RuntimeBindingManifest` as structural `Protocol`
   contracts for resource-neutral identity and lifecycle;
-- `mooncake.reshard.weight` defines model-weight placement and runtime binding.
+- `mooncake.reshard.weight` defines model-weight placement, runtime-binding
+  input contracts, and address-free N-D planning.
 
 ## Weight Placement Model
 
 `WeightPlacementManifest` describes one complete, address-free global logical
 placement of a model-weight generation. It contains:
 
-- a `ParallelTopology` with TP, PP, EP, and DP sizes plus the exact selected
+- a `ParallelTopology` with TP, PP, EP, and DP sizes plus the selected
   participants;
 - per-tensor `SplitAxis(kind, dim)`, `ReplicatedAxis(kind)`, and
   `OwnershipAxis(kind)` entries that distinguish logical sharding, complete
-  replicas, and ownership without overloading an optional dimension;
+  replicas, and ownership;
 - canonical `TensorDescriptor` values whose only shard representation is
   `shard_dims`;
 - one `WeightPlacementPart` for every selected participant;
 - canonical global tensor descriptors and N-D logical fragments;
-- a placement ID and digest computed after the full part set validates.
+- a placement ID and digest computed after the complete part set validates.
 
 `ParallelTopology.world_size` is the selected participant count. It is not
 inferred from `tp_size * pp_size * ep_size * dp_size`: parallel axes may share
 workers, and a placement may select one complete DP replica while retaining the
-runtime's declared `dp_size`. The overall participant map may be non-Cartesian,
-but a tensor that declares multiple independent `SplitAxis` values must provide
-the Cartesian rank combinations needed to prove each axis-to-dimension split.
+runtime's declared `dp_size`. A tensor that declares independent `SplitAxis`
+values must provide the rank combinations needed to prove its axis-to-dimension
+splits.
 
-For each framework participant, the framework adapter first constructs an
-address-free `WeightPlacementPart`. A collection barrier assembles the exact
-participant set and validates complete logical tensor coverage. Each part
-declares exactly the tensor descriptors referenced by its fragments. For each
-live participant that owns fragments, the adapter then constructs one
-`WeightRuntimeBindingManifest` with physical fragments, generation, and lease,
-attesting the global placement ID and digest. A physical fragment preserves its
-item size, view shape, byte strides, storage base, byte offset, and allocation
-size so binding validation can prove canonical contiguity and address bounds.
+Framework adapters first construct address-free `WeightPlacementPart` values.
+A collection barrier assembles the complete participant set and validates
+logical tensor coverage. A later runtime phase may attach
+`WeightRuntimeBindingManifest` values with physical fragments, generations, and
+leases, but the logical planner does not consume GPU addresses or allocation
+metadata.
 
-An alias group may span placement parts, so an individual part checks only its
-local fragment invariants. `WeightPlacementManifest` performs the global check
-after collection: every alias member must be in the complete tensor catalog and
-every fragment for every member must declare the identical group. Runtime paths
-consume only this globally validated placement.
+An alias group may span placement parts. `WeightPlacementManifest` performs the
+global check after collection: every alias member must be in the complete
+tensor catalog and every fragment for every member must declare the identical
+group.
 
-Empty participants need no runtime binding; any participant referenced by
-execution must provide one.
+## Logical Planning
 
-The weight implementation is split by responsibility:
+The planner consumes complete source and target placements:
 
-- `types.py` defines tensor and logical-fragment contracts;
-- `topology.py` defines parallel sizes and selected participants;
-- `part.py` defines one participant's address-free contribution;
-- `placement.py` assembles and identifies the complete global placement;
-- `runtime.py` defines typed physical bindings;
-- `validation.py` checks logical geometry, coverage, declared storage alias
-  groups, and addresses;
-- `binding.py` validates placement and binding attestation;
+```python
+logical_plan = plan_placement_transfer(source_placement, target_placement)
+```
+
+The result is a backend-neutral `LogicalTransferPlan`. TP and EP use N-D
+logical-box split and merge, PP routes framework-provided ownership, and DP
+selects a complete source replica or follows a declared DP owner. The plan
+contains compact N-D overlap regions but no runtime addresses, endpoints,
+allocation bounds, leases, or backend request.
+
+`plan_stored_transfer_to_target_placement` accepts a committed address-free
+`WeightManifest` as the logical source. The plan retains the manifest's
+canonical identity and selected fragments so a later binding layer can verify
+that it is still using the intended Store snapshot.
+
+`PlanningLimits` bounds both transfer-region creation and later flattened
+segment expansion. A backend must supply an explicit expansion bound; it cannot
+turn a compact N-D plan into an unbounded number of operations.
+
+The logical planner is copy-only. It does not infer model semantics from tensor
+names or transform dtype, quantization, packing, swizzle, or checkpoint format.
+
+## Module Responsibilities
+
+- `types.py` defines tensor and logical-fragment contracts.
+- `topology.py` defines parallel sizes and selected participants.
+- `part.py` defines one participant's address-free contribution.
+- `placement.py` assembles and identifies a complete global placement.
+- `runtime.py` defines typed physical-binding input contracts for later phases.
+- `validation.py` validates manifest-level geometry, coverage, aliases, and
+  runtime-binding shape contracts.
+- `_planner/` computes N-D logical overlap regions and logical coverage.
+- `planner.py` exposes the address-free public planning API.
 - `manifest.py` preserves the public import surface.
 
-`kv_cache` is reserved as a resource discriminator, but this change does not
-define a KVCache manifest. Framework adapters must provide tensor semantics;
-Mooncake does not infer them from parameter names.
+`kv_cache` remains reserved as a resource discriminator. This change does not
+define a KVCache manifest; a future KVCache reshard adapter can reuse the
+resource/placement/binding boundary without changing the model-weight planner.
 
 `weight_placement_to_json` and `weight_placement_from_json` are the explicit
 public JSON APIs. Their wire format contains only canonical fields, and
 deserialization rejects alternate field names rather than translating
 framework-specific input.
 
-Run the contract and static type checks from the repository root:
+Run the logical planner tests from the repository root:
 
 ```bash
-PYTHONPATH=mooncake-wheel:mooncake-reshard/python \
-python -m pytest -q mooncake-reshard/tests
+PYTHONPATH=mooncake-reshard/python \
+python3 -m pytest -q mooncake-reshard/tests
 
-bash scripts/check_reshard_types.sh
+npx --yes pyright --project mooncake-reshard/pyrightconfig.json
 ```

--- a/mooncake-reshard/python/mooncake/reshard/_compat.py
+++ b/mooncake-reshard/python/mooncake/reshard/_compat.py
@@ -1,0 +1,53 @@
+"""Compatibility helpers for supported Python runtimes."""
+
+from __future__ import annotations
+
+from itertools import zip_longest
+from typing import Iterable, Iterator, TypeVar, cast, overload
+
+
+_T1 = TypeVar("_T1")
+_T2 = TypeVar("_T2")
+_T3 = TypeVar("_T3")
+_T4 = TypeVar("_T4")
+
+
+@overload
+def _strict_zip(first: Iterable[_T1]) -> Iterator[tuple[_T1]]: ...
+
+
+@overload
+def _strict_zip(
+    first: Iterable[_T1], second: Iterable[_T2]
+) -> Iterator[tuple[_T1, _T2]]: ...
+
+
+@overload
+def _strict_zip(
+    first: Iterable[_T1],
+    second: Iterable[_T2],
+    third: Iterable[_T3],
+) -> Iterator[tuple[_T1, _T2, _T3]]: ...
+
+
+@overload
+def _strict_zip(
+    first: Iterable[_T1],
+    second: Iterable[_T2],
+    third: Iterable[_T3],
+    fourth: Iterable[_T4],
+) -> Iterator[tuple[_T1, _T2, _T3, _T4]]: ...
+
+
+@overload
+def _strict_zip(*iterables: Iterable[object]) -> Iterator[tuple[object, ...]]: ...
+
+
+def _strict_zip(*iterables: Iterable[object]) -> Iterator[tuple[object, ...]]:
+    """Provide ``zip(strict=True)`` semantics on Python 3.9."""
+
+    sentinel = object()
+    for values in zip_longest(*iterables, fillvalue=sentinel):
+        if any(value is sentinel for value in values):
+            raise ValueError("zip() arguments have different lengths")
+        yield cast(tuple[object, ...], values)

--- a/mooncake-reshard/python/mooncake/reshard/_typing.py
+++ b/mooncake-reshard/python/mooncake/reshard/_typing.py
@@ -1,0 +1,10 @@
+"""Typing compatibility definitions for the supported Python runtimes."""
+
+import sys
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+__all__ = ["TypeAlias"]

--- a/mooncake-reshard/python/mooncake/reshard/contracts/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/contracts/__init__.py
@@ -1,5 +1,6 @@
 """Public resource-neutral contracts for Mooncake resharding."""
 
+from .fragments import RuntimeBindingFragment
 from .ids import (
     LeaseId,
     ParticipantId,
@@ -10,6 +11,7 @@ from .ids import (
     RevisionId,
     RuntimeFragmentId,
     RuntimeInstanceId,
+    StoredFragmentId,
     TensorId,
     TopologyId,
 )
@@ -18,6 +20,7 @@ from .manifest import (
     ResourceKind,
     ResourceManifest,
     RuntimeBindingManifest,
+    StoredResourceManifest,
     validate_resource_binding_identity,
 )
 
@@ -33,9 +36,12 @@ __all__ = [
     "ResourceManifest",
     "RevisionId",
     "RuntimeBindingManifest",
+    "RuntimeBindingFragment",
     "RuntimeFragmentId",
     "RuntimeInstanceId",
+    "StoredFragmentId",
     "TensorId",
     "TopologyId",
+    "StoredResourceManifest",
     "validate_resource_binding_identity",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/contracts/fragments.py
+++ b/mooncake-reshard/python/mooncake/reshard/contracts/fragments.py
@@ -1,0 +1,171 @@
+"""Resource-neutral physical runtime fragments."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Optional, cast
+
+from .ids import PlacementFragmentId, RuntimeFragmentId
+
+
+_MAX_U64 = (1 << 64) - 1
+
+
+@dataclass(frozen=True)
+class RuntimeBindingFragment:
+    """Contiguous physical view bound to one logical placement fragment."""
+
+    placement_fragment_id: PlacementFragmentId
+    fragment_id: RuntimeFragmentId
+    address: int
+    nbytes: int
+    worker_id: str
+    endpoint: str
+    device: str
+    itemsize: int
+    local_shape: tuple[int, ...]
+    strides_bytes: tuple[int, ...]
+    storage_address: int
+    storage_nbytes: int
+    storage_offset_bytes: int
+    owner: Optional[object] = field(default=None, compare=False, repr=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "placement_fragment_id",
+            "fragment_id",
+            "worker_id",
+            "endpoint",
+            "device",
+        ):
+            value = getattr(self, name)
+            if type(value) is not str or not value:
+                raise ValueError(f"{name} must be a non-empty string")
+        _require_address_range(self.address, self.nbytes)
+        _require_integer(self.itemsize, "runtime itemsize", minimum=1)
+        local_shape = _require_integer_tuple(
+            self.local_shape,
+            "runtime local_shape",
+            minimum=1,
+        )
+        strides_bytes = _require_integer_tuple(
+            self.strides_bytes,
+            "runtime strides_bytes",
+            minimum=0,
+        )
+        if len(strides_bytes) != len(local_shape):
+            raise ValueError("runtime stride rank differs from local_shape")
+        if any(
+            extent > 1 and stride == 0
+            for extent, stride in zip(local_shape, strides_bytes)
+        ):
+            raise ValueError(
+                "runtime stride must be positive for non-singleton dimensions"
+            )
+        strides_bytes = _normalize_singleton_strides_bytes(
+            local_shape,
+            strides_bytes,
+            self.itemsize,
+        )
+        object.__setattr__(self, "local_shape", local_shape)
+        object.__setattr__(self, "strides_bytes", strides_bytes)
+        _require_address_range(self.storage_address, self.storage_nbytes)
+        _require_u64(self.storage_offset_bytes, "storage_offset_bytes")
+        if self.storage_offset_bytes > _MAX_U64 - self.storage_address:
+            raise ValueError("normalized runtime address must fit in 64 bits")
+        if self.address != self.storage_address + self.storage_offset_bytes:
+            raise ValueError(
+                "runtime address must equal storage_address plus storage_offset_bytes"
+            )
+        if self.storage_offset_bytes > self.storage_nbytes - self.nbytes:
+            raise ValueError("runtime view exceeds storage allocation bounds")
+
+    def __reduce__(self):
+        """Keep framework-owned allocation references out of process wire state.
+
+        ``owner`` is intentionally process-local. A receiving runtime must obtain
+        a fresh binding under its framework allocation guard before it can submit
+        Store or TE I/O; serializing an arbitrary Python owner would weaken that
+        boundary and is not reliable across processes.
+        """
+
+        return (
+            type(self),
+            (
+                self.placement_fragment_id,
+                self.fragment_id,
+                self.address,
+                self.nbytes,
+                self.worker_id,
+                self.endpoint,
+                self.device,
+                self.itemsize,
+                self.local_shape,
+                self.strides_bytes,
+                self.storage_address,
+                self.storage_nbytes,
+                self.storage_offset_bytes,
+            ),
+        )
+
+
+def _require_integer(value: object, name: str, *, minimum: int = 0) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an integer")
+    if value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return value
+
+
+def _canonical_strides_bytes(
+    shape: tuple[int, ...],
+    itemsize: int,
+) -> tuple[int, ...]:
+    strides: list[int] = []
+    running = itemsize
+    for extent in reversed(shape):
+        strides.append(running)
+        running *= extent
+    return tuple(reversed(strides))
+
+
+def _normalize_singleton_strides_bytes(
+    shape: tuple[int, ...],
+    strides_bytes: tuple[int, ...],
+    itemsize: int,
+) -> tuple[int, ...]:
+    canonical = _canonical_strides_bytes(shape, itemsize)
+    return tuple(
+        expected if extent == 1 else observed
+        for extent, observed, expected in zip(shape, strides_bytes, canonical)
+    )
+
+
+def _require_integer_tuple(
+    values: object,
+    name: str,
+    *,
+    minimum: int,
+) -> tuple[int, ...]:
+    if type(values) not in (tuple, list):
+        raise ValueError(f"{name} must be a tuple or list")
+    items = cast(Sequence[object], values)
+    return tuple(
+        _require_integer(value, f"{name}[{index}]", minimum=minimum)
+        for index, value in enumerate(items)
+    )
+
+
+def _require_u64(value: object, name: str, *, minimum: int = 0) -> int:
+    integer = _require_integer(value, name, minimum=minimum)
+    if integer > _MAX_U64:
+        raise ValueError(f"{name} must fit in an unsigned 64-bit integer")
+    return integer
+
+
+def _require_address_range(address: object, nbytes: object) -> None:
+    normalized_address = _require_u64(address, "address", minimum=1)
+    normalized_nbytes = _require_u64(nbytes, "nbytes", minimum=1)
+    if normalized_nbytes > _MAX_U64 - normalized_address:
+        raise ValueError("address range must fit in an unsigned 64-bit integer")

--- a/mooncake-reshard/python/mooncake/reshard/contracts/ids.py
+++ b/mooncake-reshard/python/mooncake/reshard/contracts/ids.py
@@ -20,6 +20,7 @@ PlacementSetId = NewType("PlacementSetId", str)
 RevisionId = NewType("RevisionId", str)
 RuntimeInstanceId = NewType("RuntimeInstanceId", str)
 LeaseId = NewType("LeaseId", str)
+StoredFragmentId = NewType("StoredFragmentId", str)
 
 
 __all__ = [
@@ -32,6 +33,7 @@ __all__ = [
     "RevisionId",
     "RuntimeFragmentId",
     "RuntimeInstanceId",
+    "StoredFragmentId",
     "TensorId",
     "TopologyId",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/contracts/manifest.py
+++ b/mooncake-reshard/python/mooncake/reshard/contracts/manifest.py
@@ -72,6 +72,15 @@ class RuntimeBindingManifest(ResourceManifest, Protocol):
         ...
 
 
+class StoredResourceManifest(ResourceManifest, Protocol):
+    """Structural contract for persistent reusable-resource metadata."""
+
+    namespace: str
+    group_id: str
+    manifest_key: str
+    created_at: str
+
+
 def validate_resource_binding_identity(
     placement: PlacementManifest,
     binding: RuntimeBindingManifest,

--- a/mooncake-reshard/python/mooncake/reshard/geometry.py
+++ b/mooncake-reshard/python/mooncake/reshard/geometry.py
@@ -1,0 +1,265 @@
+"""Resource-neutral N-D logical-box helpers for reshard planners."""
+
+from __future__ import annotations
+
+import heapq
+from array import array
+from math import prod
+from typing import Iterable, Protocol, Sequence
+
+from ._compat import _strict_zip
+
+
+_MAX_HIGH_DIMENSIONAL_PAIRWISE_COMPARISONS = 1_000_000
+
+
+class LogicalBox(Protocol):
+    """An address-free logical box supplied by a resource-specific adapter."""
+
+    @property
+    def global_offset(self) -> tuple[int, ...]: ...
+
+    @property
+    def local_shape(self) -> tuple[int, ...]: ...
+
+
+class OverlapRegion(Protocol):
+    """The logical overlap portion of a resource-specific transfer region."""
+
+    @property
+    def overlap_offset(self) -> tuple[int, ...]: ...
+
+    @property
+    def overlap_shape(self) -> tuple[int, ...]: ...
+
+
+def box_contains(
+    outer_offset: tuple[int, ...],
+    outer_shape: tuple[int, ...],
+    inner_offset: tuple[int, ...],
+    inner_shape: tuple[int, ...],
+) -> bool:
+    """Return whether one N-D logical box is wholly inside another."""
+
+    return all(
+        outer_begin <= inner_begin
+        and inner_begin + inner_extent <= outer_begin + outer_extent
+        for outer_begin, outer_extent, inner_begin, inner_extent in _strict_zip(
+            outer_offset,
+            outer_shape,
+            inner_offset,
+            inner_shape,
+        )
+    )
+
+
+def boxes_overlap(
+    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
+) -> bool:
+    """Return whether any two N-D boxes overlap.
+
+    One-dimensional intervals and two-dimensional rectangles use bounded sweep
+    algorithms. Higher-dimensional boxes retain full intersection semantics but
+    fail closed after an explicit pairwise-comparison budget rather than making
+    unbounded validation work part of the public manifest contract.
+    """
+
+    if len(boxes) < 2:
+        return False
+    ndim = len(boxes[0][0])
+    if ndim == 1:
+        return _one_dimensional_boxes_overlap(boxes)
+    if ndim == 2:
+        return _two_dimensional_boxes_overlap(boxes)
+    return _high_dimensional_boxes_overlap(boxes)
+
+
+def _one_dimensional_boxes_overlap(
+    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
+) -> bool:
+    ordered = sorted((offset[0], offset[0] + shape[0]) for offset, shape in boxes)
+    previous_end = ordered[0][1]
+    for begin, end in ordered[1:]:
+        if begin < previous_end:
+            return True
+        previous_end = max(previous_end, end)
+    return False
+
+
+class _RangeMaxTree:
+    """Coordinate-compressed range-add/range-maximum tree for 2-D sweeps."""
+
+    def __init__(self, size: int) -> None:
+        if size <= 0:
+            raise ValueError("range tree size must be positive")
+        capacity = size * 4
+        self._size = size
+        self._maximum = array("i", [0]) * capacity
+        self._lazy = array("i", [0]) * capacity
+
+    def add(self, left: int, right: int, value: int) -> None:
+        self._add(1, 0, self._size - 1, left, right, value)
+
+    def maximum(self, left: int, right: int) -> int:
+        return self._maximum_in(1, 0, self._size - 1, left, right)
+
+    def _add(
+        self,
+        node: int,
+        begin: int,
+        end: int,
+        left: int,
+        right: int,
+        value: int,
+    ) -> None:
+        if left <= begin and end <= right:
+            self._maximum[node] += value
+            self._lazy[node] += value
+            return
+        middle = (begin + end) // 2
+        if left <= middle:
+            self._add(node * 2, begin, middle, left, right, value)
+        if right > middle:
+            self._add(node * 2 + 1, middle + 1, end, left, right, value)
+        self._maximum[node] = self._lazy[node] + max(
+            self._maximum[node * 2], self._maximum[node * 2 + 1]
+        )
+
+    def _maximum_in(
+        self,
+        node: int,
+        begin: int,
+        end: int,
+        left: int,
+        right: int,
+    ) -> int:
+        if left <= begin and end <= right:
+            return self._maximum[node]
+        middle = (begin + end) // 2
+        result = 0
+        if left <= middle:
+            result = self._maximum_in(node * 2, begin, middle, left, right)
+        if right > middle:
+            result = max(
+                result,
+                self._maximum_in(node * 2 + 1, middle + 1, end, left, right),
+            )
+        return self._lazy[node] + result
+
+
+def _two_dimensional_boxes_overlap(
+    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
+) -> bool:
+    coordinates = sorted(
+        {
+            coordinate
+            for offset, shape in boxes
+            for coordinate in (offset[1], offset[1] + shape[1])
+        }
+    )
+    coordinate_index = {
+        coordinate: index for index, coordinate in enumerate(coordinates)
+    }
+    tree = _RangeMaxTree(len(coordinates) - 1)
+    events: list[tuple[int, int, int, int]] = []
+    for offset, shape in boxes:
+        x_begin = offset[0]
+        x_end = offset[0] + shape[0]
+        y_begin = coordinate_index[offset[1]]
+        y_end = coordinate_index[offset[1] + shape[1]] - 1
+        events.append((x_end, 0, y_begin, y_end))
+        events.append((x_begin, 1, y_begin, y_end))
+
+    for _, is_start, y_begin, y_end in sorted(events):
+        if not is_start:
+            tree.add(y_begin, y_end, -1)
+            continue
+        if tree.maximum(y_begin, y_end) > 0:
+            return True
+        tree.add(y_begin, y_end, 1)
+    return False
+
+
+def _high_dimensional_boxes_overlap(
+    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
+) -> bool:
+    sweep_dim = max(
+        range(len(boxes[0][0])),
+        key=lambda dim: len(
+            {(offset[dim], offset[dim] + shape[dim]) for offset, shape in boxes}
+        ),
+    )
+    ordered = sorted(
+        enumerate(boxes),
+        key=lambda item: item[1][0][sweep_dim],
+    )
+    active: dict[int, tuple[tuple[int, ...], tuple[int, ...]]] = {}
+    expirations: list[tuple[int, int]] = []
+    comparisons = 0
+    for index, (offset, shape) in ordered:
+        begin = offset[sweep_dim]
+        while expirations and expirations[0][0] <= begin:
+            _, expired_index = heapq.heappop(expirations)
+            active.pop(expired_index, None)
+        for candidate_offset, candidate_shape in active.values():
+            if comparisons >= _MAX_HIGH_DIMENSIONAL_PAIRWISE_COMPARISONS:
+                raise ValueError(
+                    "high-dimensional overlap budget exceeded before validation"
+                )
+            comparisons += 1
+            if all(
+                left_begin < right_begin + right_extent
+                and right_begin < left_begin + left_extent
+                for left_begin, left_extent, right_begin, right_extent in _strict_zip(
+                    candidate_offset,
+                    candidate_shape,
+                    offset,
+                    shape,
+                )
+            ):
+                return True
+        active[index] = (offset, shape)
+        heapq.heappush(expirations, (offset[sweep_dim] + shape[sweep_dim], index))
+    return False
+
+
+def boxes_exactly_cover(
+    container_offset: tuple[int, ...],
+    container_shape: tuple[int, ...],
+    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
+) -> bool:
+    """Require in-bounds, non-overlapping boxes with exact logical volume."""
+
+    if not boxes:
+        return False
+    if any(
+        not box_contains(container_offset, container_shape, offset, shape)
+        for offset, shape in boxes
+    ):
+        return False
+    if sum(prod(shape) for _, shape in boxes) != prod(container_shape):
+        return False
+    return not boxes_overlap(boxes)
+
+
+def regions_exactly_cover(
+    target: LogicalBox,
+    regions: Iterable[OverlapRegion],
+) -> bool:
+    """Require resource-neutral N-D regions to completely cover one target box."""
+
+    return boxes_exactly_cover(
+        target.global_offset,
+        target.local_shape,
+        tuple((region.overlap_offset, region.overlap_shape) for region in regions),
+    )
+
+
+__all__ = [
+    "LogicalBox",
+    "OverlapRegion",
+    "box_contains",
+    "boxes_exactly_cover",
+    "boxes_overlap",
+    "regions_exactly_cover",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/__init__.py
@@ -17,6 +17,18 @@ from .manifest import (
     validate_runtime_bindings,
 )
 from .serde import weight_placement_from_json, weight_placement_to_json
+from .planner import (
+    LogicalTransferPlan,
+    LogicalTransferOperation,
+    PipelineRouteGroup,
+    PlacementExecutorPlan,
+    PlanningLimits,
+    TransferRegion,
+    plan_placement_transfer,
+    plan_placement_transfer_to_local_target,
+    plan_stored_transfer_to_target_placement,
+)
+from .storage_manifest import StoredFragment, WeightManifest
 
 __all__ = [
     "ParallelRank",
@@ -35,4 +47,15 @@ __all__ = [
     "validate_runtime_bindings",
     "weight_placement_from_json",
     "weight_placement_to_json",
+    "StoredFragment",
+    "WeightManifest",
+    "LogicalTransferPlan",
+    "LogicalTransferOperation",
+    "PipelineRouteGroup",
+    "PlacementExecutorPlan",
+    "PlanningLimits",
+    "TransferRegion",
+    "plan_placement_transfer",
+    "plan_placement_transfer_to_local_target",
+    "plan_stored_transfer_to_target_placement",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/__init__.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/__init__.py
@@ -1,0 +1,32 @@
+from .api import (
+    plan_placement_transfer,
+    plan_placement_transfer_to_local_target,
+    plan_stored_transfer_to_target_placement,
+)
+from .contracts import (
+    LogicalTransferPlan,
+    LogicalTransferOperation,
+    PlanningLimits,
+    PipelineRouteGroup,
+    PlacementExecutorPlan,
+    TransferRegion,
+)
+from .ownership import (
+    complete_parallel_source_replicas,
+    parallel_tensor_owner,
+)
+
+
+__all__ = [
+    "LogicalTransferPlan",
+    "LogicalTransferOperation",
+    "PlanningLimits",
+    "PipelineRouteGroup",
+    "PlacementExecutorPlan",
+    "TransferRegion",
+    "complete_parallel_source_replicas",
+    "parallel_tensor_owner",
+    "plan_placement_transfer",
+    "plan_placement_transfer_to_local_target",
+    "plan_stored_transfer_to_target_placement",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/api.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/api.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ...contracts import ParticipantId
+from ..manifest import WeightPlacementManifest
+from ..storage_manifest import WeightManifest
+from .contracts import LogicalTransferPlan, PlanningLimits
+from .core import (
+    _collect_placements,
+    _logical_transfer_plan,
+    _plan_transfer,
+)
+
+
+def plan_placement_transfer(
+    source_placement: WeightPlacementManifest,
+    target_placement: WeightPlacementManifest,
+    *,
+    planning_limits: Optional[PlanningLimits] = None,
+) -> LogicalTransferPlan:
+    """Plan a reshard between two complete address-free placements."""
+
+    source_tensors, source_fragments = _collect_placements(
+        (source_placement,),
+        "source",
+    )
+    target_tensors, target_fragments = _collect_placements(
+        (target_placement,),
+        "target",
+    )
+    source = source_placement
+    target = target_placement
+    if source.resource_id != target.resource_id:
+        raise ValueError("source and target resource_id differ")
+    if source.revision != target.revision:
+        raise ValueError("source and target revision differ")
+    if source.weight_generation != target.weight_generation:
+        raise ValueError("source and target weight_generation differ")
+    transfer = _plan_transfer(
+        source.resource_id,
+        source.revision,
+        source_tensors,
+        source_fragments,
+        target_tensors,
+        target_fragments,
+        planning_limits=planning_limits,
+    )
+    return _logical_transfer_plan(
+        transfer,
+        source_tensors=source_tensors,
+        target_tensors=target_tensors,
+        source_placement=source_placement,
+        source_manifest=None,
+        target_placement=target_placement,
+    )
+
+
+def plan_placement_transfer_to_local_target(
+    source_placement: WeightPlacementManifest,
+    target_placement: WeightPlacementManifest,
+    target_participant_id: Optional[ParticipantId] = None,
+    *,
+    planning_limits: Optional[PlanningLimits] = None,
+) -> LogicalTransferPlan:
+    """Plan one target executor using address-free source and target layouts."""
+
+    source_tensors, source_fragments = _collect_placements(
+        (source_placement,),
+        "source",
+    )
+    if target_participant_id is None:
+        if target_placement.topology.world_size != 1:
+            raise ValueError(
+                "target_participant_id is required for a multi-participant target"
+            )
+        target_participant_id = target_placement.parts[0].participant_id
+    try:
+        target_part = next(
+            part
+            for part in target_placement.parts
+            if part.participant_id == target_participant_id
+        )
+    except StopIteration as error:
+        raise ValueError(
+            f"unknown target participant: {target_participant_id}"
+        ) from error
+    target_tensors = {tensor.tensor_id: tensor for tensor in target_part.tensors}
+    target_fragments = list(target_part.fragments)
+    source = source_placement
+    if source.resource_id != target_placement.resource_id:
+        raise ValueError("source and target resource_id differ")
+    if source.revision != target_placement.revision:
+        raise ValueError("source and target revision differ")
+    if source.weight_generation != target_placement.weight_generation:
+        raise ValueError("source and target weight_generation differ")
+    transfer = _plan_transfer(
+        source.resource_id,
+        source.revision,
+        source_tensors,
+        source_fragments,
+        target_tensors,
+        target_fragments,
+        local_target=True,
+        planning_limits=planning_limits,
+    )
+    result = _logical_transfer_plan(
+        transfer,
+        source_tensors=source_tensors,
+        target_tensors=target_tensors,
+        source_placement=source_placement,
+        source_manifest=None,
+        target_placement=target_placement,
+        target_participant_ids=frozenset({target_participant_id}),
+    )
+    if len(result.target_executors) != 1:
+        raise ValueError("local target placement must describe exactly one executor")
+    return result
+
+
+def plan_stored_transfer_to_target_placement(
+    source_manifest: WeightManifest,
+    target_placement: WeightPlacementManifest,
+    *,
+    planning_limits: Optional[PlanningLimits] = None,
+) -> LogicalTransferPlan:
+    """Plan a Store-backed transfer into address-free target placements."""
+
+    target_tensors, target_fragments = _collect_placements(
+        (target_placement,),
+        "target",
+    )
+    target = target_placement
+    if source_manifest.resource_id != target.resource_id:
+        raise ValueError("source and target resource_id differ")
+    if source_manifest.revision != target.revision:
+        raise ValueError("source and target revision differ")
+    if source_manifest.weight_generation != target.weight_generation:
+        raise ValueError("source and target weight_generation differ")
+    source_tensors = {tensor.tensor_id: tensor for tensor in source_manifest.tensors}
+    transfer = _plan_transfer(
+        source_manifest.resource_id,
+        source_manifest.revision,
+        source_tensors,
+        source_manifest.fragments,
+        target_tensors,
+        target_fragments,
+        planning_limits=planning_limits,
+    )
+    return _logical_transfer_plan(
+        transfer,
+        source_tensors=source_tensors,
+        target_tensors=target_tensors,
+        source_placement=None,
+        source_manifest=source_manifest,
+        target_placement=target_placement,
+    )
+
+
+__all__ = [
+    "plan_placement_transfer",
+    "plan_placement_transfer_to_local_target",
+    "plan_stored_transfer_to_target_placement",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/contracts.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/contracts.py
@@ -1,0 +1,674 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import prod
+from types import MappingProxyType
+from typing import (
+    ClassVar,
+    Generic,
+    Iterable,
+    Mapping,
+    Optional,
+    Sequence,
+    TypeVar,
+    cast,
+)
+
+from ..._compat import _strict_zip
+from ..._typing import TypeAlias
+from ...contracts import (
+    ParticipantId,
+    PlacementFragmentId,
+    PlacementId,
+    ResourceId,
+    RevisionId,
+    TensorId,
+)
+from ...geometry import box_contains as _box_contains
+from ..manifest import (
+    ParallelRank,
+    PlacementFragment,
+    TensorDescriptor,
+    WeightPlacementManifest,
+)
+from ..storage_manifest import StoredFragment
+from .geometry import (
+    _derive_region_geometry,
+    _fragment_itemsize,
+    _validate_outer_strides,
+)
+from .fragments import (
+    GeometryFragment,
+    LogicalSourceFragment,
+    LogicalTargetFragment,
+)
+
+
+RuntimeTensorOwner = tuple[tuple[str, int], ...]
+_SourceFragmentT = TypeVar("_SourceFragmentT", bound=GeometryFragment)
+_TargetFragmentT = TypeVar("_TargetFragmentT", bound=GeometryFragment)
+
+
+@dataclass(frozen=True)
+class PipelineRouteGroup:
+    source_pp: Optional[int]
+    source_pipeline_stage_id: Optional[int]
+    target_pp: int
+    target_pipeline_stage_id: Optional[int]
+    operation_indices: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "operation_indices", tuple(self.operation_indices))
+        if self.source_pp is not None and (
+            type(self.source_pp) is not int or self.source_pp < 0
+        ):
+            raise ValueError("pipeline route source_pp must be non-negative")
+        if type(self.target_pp) is not int or self.target_pp < 0:
+            raise ValueError("pipeline route target_pp must be non-negative")
+        for name in (
+            "source_pipeline_stage_id",
+            "target_pipeline_stage_id",
+        ):
+            value = getattr(self, name)
+            if value is not None and (type(value) is not int or value < 0):
+                raise ValueError(f"pipeline route {name} must be non-negative")
+        if any(type(index) is not int or index < 0 for index in self.operation_indices):
+            raise ValueError("pipeline route indices must be non-negative integers")
+        if len(self.operation_indices) != len(set(self.operation_indices)):
+            raise ValueError("pipeline route has duplicate operation indices")
+
+
+@dataclass(frozen=True)
+class PlanningLimits:
+    """Fail-closed limits for canonical N-D planning and lowering."""
+
+    max_transfer_regions: int = 1_000_000
+    max_segments_per_region: int = 1_000_000
+    max_total_lowered_segments: int = 10_000_000
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_transfer_regions",
+            "max_segments_per_region",
+            "max_total_lowered_segments",
+        ):
+            value = getattr(self, name)
+            if type(value) is not int or value <= 0:
+                raise ValueError(f"planning limit {name} must be a positive integer")
+
+
+@dataclass(frozen=True)
+class TransferRegion(Generic[_SourceFragmentT, _TargetFragmentT]):
+    tensor_id: TensorId
+    source: _SourceFragmentT
+    target: _TargetFragmentT
+    overlap_offset: tuple[int, ...]
+    overlap_shape: tuple[int, ...]
+    source_base_offset: int
+    target_base_offset: int
+    inner_bytes: int
+    outer_loop_counts: tuple[int, ...]
+    source_strides: tuple[int, ...]
+    target_strides: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        for name in (
+            "overlap_offset",
+            "overlap_shape",
+            "outer_loop_counts",
+            "source_strides",
+            "target_strides",
+        ):
+            value = getattr(self, name)
+            if isinstance(value, (str, bytes, bytearray)):
+                raise ValueError(f"transfer region {name} must contain integers")
+            try:
+                normalized = tuple(value)
+            except TypeError as error:
+                raise ValueError(
+                    f"transfer region {name} must contain integers"
+                ) from error
+            if any(type(item) is not int for item in normalized):
+                raise ValueError(f"transfer region {name} must contain integers")
+            object.__setattr__(self, name, normalized)
+
+        if not self.tensor_id:
+            raise ValueError("transfer region tensor_id must not be empty")
+        if (
+            self.source.tensor_id != self.tensor_id
+            or self.target.tensor_id != self.tensor_id
+        ):
+            raise ValueError("transfer region tensor mismatch")
+        ndim = len(self.overlap_offset)
+        if (
+            ndim == 0
+            or len(self.overlap_shape) != ndim
+            or len(self.source.global_offset) != ndim
+            or len(self.target.global_offset) != ndim
+        ):
+            raise ValueError("transfer region logical rank mismatch")
+        if any(offset < 0 for offset in self.overlap_offset) or any(
+            extent <= 0 for extent in self.overlap_shape
+        ):
+            raise ValueError("transfer region logical box is invalid")
+        if not _box_contains(
+            self.source.global_offset,
+            self.source.local_shape,
+            self.overlap_offset,
+            self.overlap_shape,
+        ):
+            raise ValueError("transfer region exceeds source logical fragment")
+        if not _box_contains(
+            self.target.global_offset,
+            self.target.local_shape,
+            self.overlap_offset,
+            self.overlap_shape,
+        ):
+            raise ValueError("transfer region exceeds target logical fragment")
+
+        for name in ("source_base_offset", "target_base_offset", "inner_bytes"):
+            value = getattr(self, name)
+            if type(value) is not int:
+                raise ValueError(f"transfer region {name} must be an integer")
+        if self.source_base_offset < 0 or self.target_base_offset < 0:
+            raise ValueError("transfer region base offsets must be non-negative")
+        if self.inner_bytes <= 0:
+            raise ValueError("transfer region inner_bytes must be positive")
+        if not (
+            len(self.outer_loop_counts)
+            == len(self.source_strides)
+            == len(self.target_strides)
+        ):
+            raise ValueError("transfer region outer loop rank mismatch")
+        if any(count <= 0 for count in self.outer_loop_counts):
+            raise ValueError("transfer region outer loop counts must be positive")
+        if any(stride < 0 for stride in self.source_strides) or any(
+            stride < 0 for stride in self.target_strides
+        ):
+            raise ValueError("transfer region strides must be non-negative")
+
+        source_itemsize = _fragment_itemsize(self.source)
+        target_itemsize = _fragment_itemsize(self.target)
+        if source_itemsize != target_itemsize:
+            raise ValueError("transfer region source and target itemsize differ")
+        (
+            expected_source_offset,
+            expected_target_offset,
+            expected_inner_bytes,
+            expected_outer_loop_counts,
+            expected_source_strides,
+            expected_target_strides,
+        ) = _derive_region_geometry(
+            self.source,
+            self.target,
+            self.overlap_offset,
+            self.overlap_shape,
+        )
+        expected_bytes = prod(self.overlap_shape) * source_itemsize
+        if self.total_bytes != expected_bytes:
+            raise ValueError("transfer region loop geometry does not match overlap")
+        if self.source_base_offset != expected_source_offset:
+            raise ValueError("transfer region source base offset is inconsistent")
+        if self.target_base_offset != expected_target_offset:
+            raise ValueError("transfer region target base offset is inconsistent")
+        if (
+            self.inner_bytes,
+            self.outer_loop_counts,
+            self.source_strides,
+            self.target_strides,
+        ) != (
+            expected_inner_bytes,
+            expected_outer_loop_counts,
+            expected_source_strides,
+            expected_target_strides,
+        ):
+            raise ValueError("transfer region loop geometry is not canonical")
+
+        _validate_outer_strides(
+            self.outer_loop_counts,
+            self.source_strides,
+            self.inner_bytes,
+            "source",
+        )
+        _validate_outer_strides(
+            self.outer_loop_counts,
+            self.target_strides,
+            self.inner_bytes,
+            "target",
+        )
+        self.validate_bounds()
+
+    @property
+    def segment_count(self) -> int:
+        return prod(self.outer_loop_counts)
+
+    @property
+    def total_bytes(self) -> int:
+        return self.inner_bytes * self.segment_count
+
+    @property
+    def source_offset(self) -> int:
+        return self.source_base_offset
+
+    @property
+    def target_offset(self) -> int:
+        return self.target_base_offset
+
+    @property
+    def nbytes(self) -> int:
+        return self.inner_bytes
+
+    @property
+    def repeat(self) -> int:
+        return self.segment_count
+
+    @property
+    def source_stride(self) -> int:
+        if not self.source_strides:
+            return 0
+        if len(self.source_strides) == 1:
+            return self.source_strides[0]
+        raise ValueError("N-D transfer region has multiple source strides")
+
+    @property
+    def target_stride(self) -> int:
+        if not self.target_strides:
+            return 0
+        if len(self.target_strides) == 1:
+            return self.target_strides[0]
+        raise ValueError("N-D transfer region has multiple target strides")
+
+    def validate_bounds(self) -> None:
+        source_end = (
+            self.source_base_offset
+            + sum(
+                (count - 1) * stride
+                for count, stride in _strict_zip(
+                    self.outer_loop_counts, self.source_strides
+                )
+            )
+            + self.inner_bytes
+        )
+        if source_end > self.source.nbytes:
+            raise ValueError("transfer region exceeds source fragment")
+        target_end = (
+            self.target_base_offset
+            + sum(
+                (count - 1) * stride
+                for count, stride in _strict_zip(
+                    self.outer_loop_counts, self.target_strides
+                )
+            )
+            + self.inner_bytes
+        )
+        if target_end > self.target.nbytes:
+            raise ValueError("transfer region exceeds target fragment")
+
+    def iter_segments(self, *, max_segments: int) -> Iterable[tuple[int, int, int]]:
+        if type(max_segments) is not int or max_segments <= 0:
+            raise ValueError("max_segments must be a positive integer")
+        if self.segment_count > max_segments:
+            raise ValueError(
+                "transfer region exceeds max_segments: "
+                f"{self.segment_count} > {max_segments}"
+            )
+        if not self.outer_loop_counts:
+            yield self.source_base_offset, self.target_base_offset, self.inner_bytes
+            return
+        indices = [0] * len(self.outer_loop_counts)
+        while True:
+            yield (
+                self.source_base_offset
+                + sum(
+                    index * stride
+                    for index, stride in _strict_zip(indices, self.source_strides)
+                ),
+                self.target_base_offset
+                + sum(
+                    index * stride
+                    for index, stride in _strict_zip(indices, self.target_strides)
+                ),
+                self.inner_bytes,
+            )
+            for dim in range(len(indices) - 1, -1, -1):
+                indices[dim] += 1
+                if indices[dim] < self.outer_loop_counts[dim]:
+                    break
+                indices[dim] = 0
+            else:
+                return
+
+
+LogicalTransferRegion: TypeAlias = TransferRegion[
+    LogicalSourceFragment,
+    LogicalTargetFragment,
+]
+LogicalTransferOperation: TypeAlias = LogicalTransferRegion
+
+
+def _is_canonical_operation(value: object) -> bool:
+    return isinstance(value, TransferRegion)
+
+
+def _validate_logical_operation(
+    value: object,
+    source_has_placement: bool,
+) -> None:
+    if not _is_canonical_operation(value):
+        raise ValueError(
+            "logical transfer plan requires a canonical transfer operation"
+        )
+    operation = cast(LogicalTransferOperation, value)
+    if not isinstance(operation.target, PlacementFragment):
+        raise ValueError("logical transfer plan target must be a placement")
+    if source_has_placement:
+        if not isinstance(operation.source, PlacementFragment):
+            raise ValueError("logical transfer plan source must be a placement")
+    elif not isinstance(operation.source, StoredFragment):
+        raise ValueError("logical transfer plan source has no placement")
+    operation.validate_bounds()
+
+
+@dataclass(frozen=True)
+class PlacementExecutorPlan:
+    placement_id: PlacementId
+    participant_id: ParticipantId
+    rank: ParallelRank
+    placement_fragment_ids: tuple[PlacementFragmentId, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "placement_fragment_ids", tuple(self.placement_fragment_ids)
+        )
+        if (
+            not self.placement_id
+            or not self.participant_id
+            or not self.placement_fragment_ids
+        ):
+            raise ValueError("placement executor identifiers must not be empty")
+        if len(self.placement_fragment_ids) != len(set(self.placement_fragment_ids)):
+            raise ValueError("placement executor has duplicate fragment IDs")
+
+
+PlacementExecutorProjectionKey: TypeAlias = tuple[
+    PlacementId,
+    ParticipantId,
+    ParallelRank,
+    tuple[PlacementFragmentId, ...],
+]
+ExecutorProjectionKey: TypeAlias = PlacementExecutorProjectionKey
+FragmentProjectionKey: TypeAlias = PlacementFragmentId
+
+
+@dataclass(frozen=True)
+class _OperationViews:
+    source_indices: Mapping[ExecutorProjectionKey, tuple[int, ...]]
+    target_indices: Mapping[ExecutorProjectionKey, tuple[int, ...]]
+    pipeline_routes: tuple[PipelineRouteGroup, ...]
+
+    def operation_indices_for(
+        self,
+        executor: PlacementExecutorPlan,
+        side: str,
+    ) -> tuple[int, ...]:
+        if side == "source":
+            return self.source_indices.get(_executor_projection_key(executor), ())
+        if side == "target":
+            return self.target_indices.get(_executor_projection_key(executor), ())
+        raise ValueError(f"invalid executor side: {side}")
+
+
+@dataclass(frozen=True)
+class LogicalTransferPlan:
+    _operation_views: ClassVar[_OperationViews]
+
+    resource_id: ResourceId
+    revision: RevisionId
+    source_placement: Optional[WeightPlacementManifest]
+    target_placement: WeightPlacementManifest
+    source_tensors: tuple[TensorDescriptor, ...]
+    target_tensors: tuple[TensorDescriptor, ...]
+    operations: tuple[LogicalTransferOperation, ...]
+    planning_limits: PlanningLimits = field(default_factory=PlanningLimits)
+    source_executors: tuple[PlacementExecutorPlan, ...] = ()
+    target_executors: tuple[PlacementExecutorPlan, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "source_tensors", tuple(self.source_tensors))
+        object.__setattr__(self, "target_tensors", tuple(self.target_tensors))
+        object.__setattr__(self, "operations", tuple(self.operations))
+        object.__setattr__(self, "source_executors", tuple(self.source_executors))
+        object.__setattr__(self, "target_executors", tuple(self.target_executors))
+        if not self.resource_id or not self.revision:
+            raise ValueError("logical transfer plan identifiers must not be empty")
+        if not isinstance(self.target_placement, WeightPlacementManifest):
+            raise ValueError("logical transfer plan target placement is invalid")
+        if not isinstance(self.planning_limits, PlanningLimits):
+            raise ValueError("logical transfer plan planning_limits is invalid")
+        if len(self.operations) > self.planning_limits.max_transfer_regions:
+            raise ValueError("logical transfer plan exceeds max_transfer_regions")
+        total_lowered_segments = 0
+        if self.source_placement is not None and not isinstance(
+            self.source_placement, WeightPlacementManifest
+        ):
+            raise ValueError("logical transfer plan source placement is invalid")
+        for side, placement in (
+            ("source", self.source_placement),
+            ("target", self.target_placement),
+        ):
+            if placement is not None and (
+                placement.resource_id != self.resource_id
+                or placement.revision != self.revision
+            ):
+                raise ValueError(
+                    f"logical transfer plan {side} placement identity differs"
+                )
+        if self.source_placement is not None and (
+            self.source_placement.weight_generation
+            != self.target_placement.weight_generation
+        ):
+            raise ValueError(
+                "logical transfer plan source and target weight_generation differs"
+            )
+        for operation in self.operations:
+            _validate_logical_operation(operation, self.source_placement is not None)
+            if operation.segment_count > self.planning_limits.max_segments_per_region:
+                raise ValueError(
+                    "logical transfer plan exceeds max_segments_per_region"
+                )
+            total_lowered_segments += operation.segment_count
+            if total_lowered_segments > self.planning_limits.max_total_lowered_segments:
+                raise ValueError(
+                    "logical transfer plan exceeds max_total_lowered_segments"
+                )
+        if not all(
+            isinstance(executor, PlacementExecutorPlan)
+            for executor in (*self.source_executors, *self.target_executors)
+        ):
+            raise ValueError(
+                "logical transfer plan has invalid canonical executor metadata"
+            )
+        object.__setattr__(
+            self,
+            "_operation_views",
+            _build_operation_views(
+                self.operations,
+                self.source_executors,
+                self.target_executors,
+            ),
+        )
+        # Keep construction strict without making the data-contract module own
+        # planner geometry validation.
+        from .validation import _validate_logical_target_coverage
+
+        _validate_logical_target_coverage(self)
+
+    @property
+    def total_bytes(self) -> int:
+        return sum(operation.total_bytes for operation in self.operations)
+
+    @property
+    def source_placement_id(self) -> Optional[PlacementId]:
+        return (
+            self.source_placement.placement_id
+            if self.source_placement is not None
+            else None
+        )
+
+    @property
+    def target_placement_id(self) -> PlacementId:
+        return self.target_placement.placement_id
+
+    @property
+    def pipeline_routes(self) -> tuple[PipelineRouteGroup, ...]:
+        return self._operation_views.pipeline_routes
+
+    def operation_indices_for_executor(
+        self,
+        executor: PlacementExecutorPlan,
+        side: str,
+    ) -> tuple[int, ...]:
+        executors = self.source_executors if side == "source" else self.target_executors
+        if side not in ("source", "target"):
+            raise ValueError(f"invalid executor side: {side}")
+        if executor not in executors:
+            raise ValueError(f"{side} executor is not part of this logical plan")
+        return self._operation_views.operation_indices_for(executor, side)
+
+    def __getstate__(self) -> dict[str, object]:
+        return {
+            name: value
+            for name, value in self.__dict__.items()
+            if name != "_operation_views"
+        }
+
+    def __setstate__(self, state: dict[str, object]) -> None:
+        for name, value in state.items():
+            object.__setattr__(self, name, value)
+        self.__post_init__()
+
+
+def _executor_projection_key(executor: PlacementExecutorPlan) -> ExecutorProjectionKey:
+    return (
+        executor.placement_id,
+        executor.participant_id,
+        executor.rank,
+        executor.placement_fragment_ids,
+    )
+
+
+def _fragment_projection_key(
+    fragment: GeometryFragment,
+) -> Optional[FragmentProjectionKey]:
+    if isinstance(fragment, PlacementFragment):
+        return fragment.placement_fragment_id
+    return None
+
+
+def _index_executors_by_fragment(
+    executors: Sequence[PlacementExecutorPlan],
+) -> tuple[
+    dict[ExecutorProjectionKey, list[int]],
+    dict[FragmentProjectionKey, list[ExecutorProjectionKey]],
+]:
+    indices_by_executor: dict[ExecutorProjectionKey, list[int]] = {}
+    executors_by_fragment: dict[FragmentProjectionKey, list[ExecutorProjectionKey]] = {}
+    for executor in executors:
+        executor_key = _executor_projection_key(executor)
+        if executor_key in indices_by_executor:
+            raise ValueError("transfer plan has duplicate executor projection key")
+        indices_by_executor[executor_key] = []
+        for fragment_id in executor.placement_fragment_ids:
+            executors_by_fragment.setdefault(fragment_id, []).append(executor_key)
+    return indices_by_executor, executors_by_fragment
+
+
+def _build_operation_views(
+    operations: Sequence[LogicalTransferOperation],
+    source_executors: Sequence[PlacementExecutorPlan],
+    target_executors: Sequence[PlacementExecutorPlan],
+) -> _OperationViews:
+    source_indices, source_by_fragment = _index_executors_by_fragment(source_executors)
+    target_indices, target_by_fragment = _index_executors_by_fragment(target_executors)
+    for index, operation in enumerate(operations):
+        source_key = _fragment_projection_key(operation.source)
+        if source_key is not None:
+            for executor_key in source_by_fragment.get(source_key, ()):
+                source_indices[executor_key].append(index)
+        target_key = _fragment_projection_key(operation.target)
+        if target_key is not None:
+            for executor_key in target_by_fragment.get(target_key, ()):
+                target_indices[executor_key].append(index)
+    return _OperationViews(
+        source_indices=MappingProxyType(
+            {key: tuple(indices) for key, indices in source_indices.items()}
+        ),
+        target_indices=MappingProxyType(
+            {key: tuple(indices) for key, indices in target_indices.items()}
+        ),
+        pipeline_routes=_pipeline_routes(operations),
+    )
+
+
+def _pipeline_routes(
+    operations: Sequence[LogicalTransferOperation],
+) -> tuple[PipelineRouteGroup, ...]:
+    indices_by_route: dict[
+        tuple[Optional[int], Optional[int], int, Optional[int]],
+        list[int],
+    ] = {}
+    for index, operation in enumerate(operations):
+        source_pp = (
+            operation.source.rank.pp
+            if isinstance(operation.source, PlacementFragment)
+            else None
+        )
+        source_pipeline_stage_id = (
+            operation.source.pipeline_stage_id
+            if isinstance(operation.source, PlacementFragment)
+            else None
+        )
+        indices_by_route.setdefault(
+            (
+                source_pp,
+                source_pipeline_stage_id,
+                operation.target.rank.pp,
+                operation.target.pipeline_stage_id,
+            ),
+            [],
+        ).append(index)
+    return tuple(
+        PipelineRouteGroup(
+            source_pp=source_pp,
+            source_pipeline_stage_id=source_pipeline_stage_id,
+            target_pp=target_pp,
+            target_pipeline_stage_id=target_pipeline_stage_id,
+            operation_indices=tuple(indices),
+        )
+        for (
+            source_pp,
+            source_pipeline_stage_id,
+            target_pp,
+            target_pipeline_stage_id,
+        ), indices in sorted(
+            indices_by_route.items(),
+            key=lambda item: (
+                -1 if item[0][0] is None else item[0][0],
+                -1 if item[0][1] is None else item[0][1],
+                item[0][2],
+                -1 if item[0][3] is None else item[0][3],
+            ),
+        )
+    )
+
+
+__all__ = [
+    "LogicalTransferPlan",
+    "PlanningLimits",
+    "PipelineRouteGroup",
+    "PlacementExecutorPlan",
+    "RuntimeTensorOwner",
+    "LogicalTransferOperation",
+    "LogicalTransferRegion",
+    "TransferRegion",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/contracts.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/contracts.py
@@ -31,7 +31,12 @@ from ..manifest import (
     TensorDescriptor,
     WeightPlacementManifest,
 )
-from ..storage_manifest import StoredFragment
+from ..storage_manifest import (
+    StoredFragment,
+    StoredManifestIdentity,
+    WeightManifest,
+    validate_weight_manifest_snapshot,
+)
 from .geometry import (
     _derive_region_geometry,
     _fragment_itemsize,
@@ -429,9 +434,11 @@ class LogicalTransferPlan:
     source_tensors: tuple[TensorDescriptor, ...]
     target_tensors: tuple[TensorDescriptor, ...]
     operations: tuple[LogicalTransferOperation, ...]
+    source_manifest: Optional[WeightManifest] = None
     planning_limits: PlanningLimits = field(default_factory=PlanningLimits)
     source_executors: tuple[PlacementExecutorPlan, ...] = ()
     target_executors: tuple[PlacementExecutorPlan, ...] = ()
+    source_manifest_identity: Optional[StoredManifestIdentity] = field(init=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "source_tensors", tuple(self.source_tensors))
@@ -452,6 +459,24 @@ class LogicalTransferPlan:
             self.source_placement, WeightPlacementManifest
         ):
             raise ValueError("logical transfer plan source placement is invalid")
+        if self.source_manifest is not None and not isinstance(
+            self.source_manifest, WeightManifest
+        ):
+            raise ValueError("logical transfer plan source manifest is invalid")
+        if (self.source_placement is None) == (self.source_manifest is None):
+            raise ValueError(
+                "logical transfer plan requires exactly one source provenance"
+            )
+        if self.source_manifest is not None:
+            source_manifest = validate_weight_manifest_snapshot(self.source_manifest)
+            object.__setattr__(self, "source_manifest", source_manifest)
+            object.__setattr__(
+                self,
+                "source_manifest_identity",
+                source_manifest.manifest_identity,
+            )
+        else:
+            object.__setattr__(self, "source_manifest_identity", None)
         for side, placement in (
             ("source", self.source_placement),
             ("target", self.target_placement),
@@ -470,6 +495,13 @@ class LogicalTransferPlan:
             raise ValueError(
                 "logical transfer plan source and target weight_generation differs"
             )
+        if self.source_manifest is not None and (
+            self.source_manifest.resource_id != self.resource_id
+            or self.source_manifest.revision != self.revision
+            or self.source_manifest.weight_generation
+            != self.target_placement.weight_generation
+        ):
+            raise ValueError("logical transfer plan source manifest identity differs")
         for operation in self.operations:
             _validate_logical_operation(operation, self.source_placement is not None)
             if operation.segment_count > self.planning_limits.max_segments_per_region:
@@ -488,6 +520,7 @@ class LogicalTransferPlan:
             raise ValueError(
                 "logical transfer plan has invalid canonical executor metadata"
             )
+        self.validate_source_manifest_snapshot()
         object.__setattr__(
             self,
             "_operation_views",
@@ -502,6 +535,7 @@ class LogicalTransferPlan:
         from .validation import _validate_logical_target_coverage
 
         _validate_logical_target_coverage(self)
+        self.validate_source_placement_snapshot()
 
     @property
     def total_bytes(self) -> int:
@@ -518,6 +552,41 @@ class LogicalTransferPlan:
     @property
     def target_placement_id(self) -> PlacementId:
         return self.target_placement.placement_id
+
+    def validate_source_manifest_snapshot(self) -> None:
+        """Fail closed if a stored source no longer matches its plan snapshot."""
+
+        if self.source_manifest is None:
+            if self.source_manifest_identity is not None:
+                raise ValueError("logical plan has unexpected source manifest identity")
+            return
+        source_manifest = validate_weight_manifest_snapshot(self.source_manifest)
+        if self.source_manifest_identity != source_manifest.manifest_identity:
+            raise ValueError("logical plan source manifest identity differs")
+        if self.source_tensors != _canonical_tensor_catalog(source_manifest.tensors):
+            raise ValueError("logical plan source tensor catalog differs")
+        source_by_id = {
+            fragment.fragment_id: fragment for fragment in source_manifest.fragments
+        }
+        for operation in self.operations:
+            source = operation.source
+            if (
+                not isinstance(source, StoredFragment)
+                or source_by_id.get(source.fragment_id) != source
+            ):
+                raise ValueError(
+                    "logical plan and source manifest fragment snapshots differ"
+                )
+
+    def validate_source_placement_snapshot(self) -> None:
+        """Fail closed if a placement source no longer matches its plan snapshot."""
+
+        if self.source_placement is None:
+            return
+
+        from .validation import _validate_logical_source_placement
+
+        _validate_logical_source_placement(self)
 
     @property
     def pipeline_routes(self) -> tuple[PipelineRouteGroup, ...]:
@@ -546,6 +615,14 @@ class LogicalTransferPlan:
         for name, value in state.items():
             object.__setattr__(self, name, value)
         self.__post_init__()
+
+
+def _canonical_tensor_catalog(
+    tensors: Sequence[TensorDescriptor],
+) -> tuple[TensorDescriptor, ...]:
+    """Compare tensor catalogs by canonical identity, not exporter order."""
+
+    return tuple(sorted(tensors, key=lambda item: item.tensor_id))
 
 
 def _executor_projection_key(executor: PlacementExecutorPlan) -> ExecutorProjectionKey:

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/core.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/core.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from ...contracts import (
+    ParticipantId,
+    PlacementFragmentId,
+    PlacementId,
+    ResourceId,
+    RevisionId,
+    TensorId,
+)
+from ...geometry import boxes_exactly_cover
+from ..placement import WeightPlacementManifest
+from ..storage_manifest import StoredFragment, WeightManifest
+from ..types import ParallelRank, PlacementFragment, TensorDescriptor
+from . import geometry
+from .contracts import (
+    LogicalTransferPlan,
+    LogicalTransferOperation,
+    PlacementExecutorPlan,
+    PlanningLimits,
+    TransferRegion,
+)
+from .fragments import LogicalSourceFragment, LogicalTargetFragment
+from .ownership import (
+    _validate_local_target_inventory,
+    _validate_target_coverage,
+    complete_parallel_source_replicas,
+    parallel_tensor_owner,
+    require_supported_dp_semantics,
+)
+from .validation import (
+    _validate_tensor_compatibility,
+    _validate_tensor_sets,
+    _validate_tensor_subset,
+)
+
+
+@dataclass(frozen=True)
+class _PlannedTransfer:
+    resource_id: ResourceId
+    revision: RevisionId
+    operations: tuple[LogicalTransferOperation, ...]
+    planning_limits: PlanningLimits
+
+
+def _collect_placements(
+    manifests: Sequence[WeightPlacementManifest],
+    label: str,
+) -> tuple[dict[TensorId, TensorDescriptor], list[PlacementFragment]]:
+    if not manifests:
+        raise ValueError(f"{label} placement manifests must not be empty")
+    if len(manifests) != 1:
+        raise ValueError(f"{label} requires one complete WeightPlacementManifest")
+    if any(not isinstance(manifest, WeightPlacementManifest) for manifest in manifests):
+        raise ValueError(f"{label} placement manifests must be WeightPlacementManifest")
+    resource_id = manifests[0].resource_id
+    revision = manifests[0].revision
+    placement_ids: set[PlacementId] = set()
+    fragment_ids: set[PlacementFragmentId] = set()
+    tensors: dict[TensorId, TensorDescriptor] = {}
+    fragments: list[PlacementFragment] = []
+    for manifest in manifests:
+        if manifest.resource_id != resource_id or manifest.revision != revision:
+            raise ValueError(
+                f"{label} placement manifests describe different revisions"
+            )
+        if manifest.placement_id in placement_ids:
+            raise ValueError(f"duplicate {label} placement_id: {manifest.placement_id}")
+        placement_ids.add(manifest.placement_id)
+        for tensor in manifest.tensors:
+            previous = tensors.setdefault(tensor.tensor_id, tensor)
+            if previous != tensor:
+                raise ValueError(
+                    f"{label} placement tensor descriptor mismatch: {tensor.tensor_id}"
+                )
+        for fragment in manifest.fragments:
+            if fragment.placement_fragment_id in fragment_ids:
+                raise ValueError(
+                    f"duplicate {label} placement fragment: "
+                    f"{fragment.placement_fragment_id}"
+                )
+            fragment_ids.add(fragment.placement_fragment_id)
+            fragments.append(fragment)
+    return tensors, fragments
+
+
+def _build_placement_executor_plans(
+    manifests: Sequence[WeightPlacementManifest],
+    operations: Sequence[LogicalTransferOperation],
+    side: str,
+    participant_ids: Optional[frozenset[ParticipantId]] = None,
+) -> tuple[PlacementExecutorPlan, ...]:
+    if side not in ("source", "target"):
+        raise ValueError(f"invalid placement executor side: {side}")
+    operation_indices_by_fragment: dict[PlacementFragmentId, list[int]] = {}
+    for index, operation in enumerate(operations):
+        fragment = operation.source if side == "source" else operation.target
+        if not isinstance(fragment, PlacementFragment):
+            raise ValueError(f"placement executor operation {side} is not a placement")
+        operation_indices_by_fragment.setdefault(
+            fragment.placement_fragment_id, []
+        ).append(index)
+
+    result: list[PlacementExecutorPlan] = []
+    ranks: set[ParallelRank] = set()
+    for manifest in manifests:
+        for part in manifest.parts:
+            if (
+                participant_ids is not None
+                and part.participant_id not in participant_ids
+            ):
+                continue
+            fragments = part.fragments
+            if not fragments:
+                continue
+            rank = part.rank
+            if rank in ranks:
+                raise ValueError(f"duplicate {side} placement executor rank: {rank}")
+            ranks.add(rank)
+            fragment_ids = tuple(
+                sorted(fragment.placement_fragment_id for fragment in fragments)
+            )
+            if not any(
+                fragment_id in operation_indices_by_fragment
+                for fragment_id in fragment_ids
+            ):
+                continue
+            result.append(
+                PlacementExecutorPlan(
+                    placement_id=manifest.placement_id,
+                    participant_id=part.participant_id,
+                    rank=rank,
+                    placement_fragment_ids=fragment_ids,
+                )
+            )
+    result.sort(
+        key=lambda item: (item.rank.dp, item.rank.pp, item.rank.ep, item.rank.tp)
+    )
+    return tuple(result)
+
+
+def _plan_transfer(
+    resource_id: ResourceId,
+    revision: RevisionId,
+    source_tensors: dict[TensorId, TensorDescriptor],
+    source_fragments: Sequence[LogicalSourceFragment],
+    target_tensors: dict[TensorId, TensorDescriptor],
+    target_fragments: Sequence[LogicalTargetFragment],
+    *,
+    local_target: bool = False,
+    planning_limits: Optional[PlanningLimits] = None,
+) -> _PlannedTransfer:
+    planning_limits = planning_limits or PlanningLimits()
+    if local_target:
+        _validate_tensor_subset(source_tensors, target_tensors)
+        _validate_local_target_inventory(target_tensors, target_fragments)
+    else:
+        _validate_tensor_sets(source_tensors, target_tensors)
+        _validate_target_coverage(target_tensors, target_fragments)
+    require_supported_dp_semantics((*source_tensors.values(), *target_tensors.values()))
+    placement_source_fragments = tuple(
+        fragment
+        for fragment in source_fragments
+        if isinstance(fragment, PlacementFragment)
+    )
+    stored_source_fragments = tuple(
+        fragment
+        for fragment in source_fragments
+        if isinstance(fragment, StoredFragment)
+    )
+    if (
+        len(placement_source_fragments) + len(stored_source_fragments)
+        != len(source_fragments)
+        or not source_fragments
+    ):
+        raise ValueError("source fragments mix placement and stored locations")
+    if placement_source_fragments and stored_source_fragments:
+        raise ValueError("source fragments mix placement and stored locations")
+    parallel_sources = bool(placement_source_fragments)
+    source_replicas = (
+        complete_parallel_source_replicas(source_tensors, placement_source_fragments)
+        if parallel_sources
+        else {}
+    )
+    source_dp_ranks = sorted(source_replicas)
+    source_dp_by_target_dp = (
+        {
+            target_dp: source_dp_ranks[target_dp % len(source_dp_ranks)]
+            for target_dp in {fragment.rank.dp for fragment in target_fragments}
+        }
+        if parallel_sources and source_dp_ranks
+        else {}
+    )
+    candidates: dict[
+        TensorId,
+        dict[geometry.GeometryKey, list[LogicalSourceFragment]],
+    ] = {}
+    for fragment in source_fragments:
+        candidates.setdefault(fragment.tensor_id, {}).setdefault(
+            geometry._geometry_key(fragment), []
+        ).append(fragment)
+    for tensor_candidates in candidates.values():
+        for group in tensor_candidates.values():
+            group.sort(key=geometry._source_sort_key)
+    candidate_indexes = {
+        tensor_id: geometry._CandidateBoxIndex.build(
+            tuple(tuple(group) for group in tensor_candidates.values())
+        )
+        for tensor_id, tensor_candidates in candidates.items()
+    }
+
+    operations: list[TransferRegion[LogicalSourceFragment, LogicalTargetFragment]] = []
+    total_lowered_segments = 0
+    for target in sorted(target_fragments, key=lambda item: item.fragment_id):
+        target_tensor = target_tensors[target.tensor_id]
+        source_tensor = source_tensors.get(target.tensor_id)
+        if source_tensor is None:
+            raise ValueError(f"missing source tensor: {target.tensor_id}")
+        _validate_tensor_compatibility(source_tensor, target_tensor)
+
+        overlaps: list[
+            tuple[tuple[int, ...], tuple[int, ...], LogicalSourceFragment]
+        ] = []
+        candidate_index = candidate_indexes.get(target.tensor_id)
+        candidate_groups = (
+            candidate_index.query(target) if candidate_index is not None else ()
+        )
+        for group in candidate_groups:
+            if parallel_sources:
+                source_dp = source_dp_by_target_dp[target.rank.dp]
+                source_owner = source_replicas[source_dp][target.tensor_id]
+                eligible = [
+                    fragment
+                    for fragment in group
+                    if isinstance(fragment, PlacementFragment)
+                    and fragment.rank.dp == source_dp
+                    and parallel_tensor_owner(source_tensor, fragment) == source_owner
+                ]
+                if not eligible:
+                    continue
+                representative = eligible[0]
+                selected = representative
+            else:
+                representative = group[0]
+                selected = representative
+            overlap = geometry._overlap_box(representative, target)
+            if overlap is None:
+                continue
+            if (
+                len(operations) + len(overlaps) + 1
+                > planning_limits.max_transfer_regions
+            ):
+                raise ValueError(
+                    "logical transfer plan exceeds max_transfer_regions: "
+                    f"{planning_limits.max_transfer_regions}"
+                )
+            overlaps.append((*overlap, selected))
+        overlaps.sort(key=lambda item: (item[0], item[1], item[2].fragment_id))
+
+        if not boxes_exactly_cover(
+            target.global_offset,
+            target.local_shape,
+            tuple((offset, shape) for offset, shape, _ in overlaps),
+        ):
+            raise ValueError(
+                f"target fragment is not fully covered: {target.fragment_id}"
+            )
+        for overlap_offset, overlap_shape, source in overlaps:
+            region = geometry._transfer_region(
+                target_tensor,
+                source,
+                target,
+                overlap_offset,
+                overlap_shape,
+            )
+            if region.segment_count > planning_limits.max_segments_per_region:
+                raise ValueError(
+                    "logical transfer region exceeds max_segments_per_region: "
+                    f"{region.segment_count} > "
+                    f"{planning_limits.max_segments_per_region}"
+                )
+            next_total_lowered_segments = total_lowered_segments + region.segment_count
+            if next_total_lowered_segments > planning_limits.max_total_lowered_segments:
+                raise ValueError(
+                    "logical transfer plan exceeds max_total_lowered_segments: "
+                    f"{next_total_lowered_segments} > "
+                    f"{planning_limits.max_total_lowered_segments}"
+                )
+            operations.append(region)
+            total_lowered_segments = next_total_lowered_segments
+
+    operations.sort(
+        key=lambda item: (
+            item.target.fragment_id,
+            item.target_base_offset,
+            item.source.fragment_id,
+            item.source_base_offset,
+        )
+    )
+    return _PlannedTransfer(
+        resource_id=resource_id,
+        revision=revision,
+        operations=tuple(operations),
+        planning_limits=planning_limits,
+    )
+
+
+def _logical_transfer_plan(
+    transfer: _PlannedTransfer,
+    *,
+    source_tensors: dict[TensorId, TensorDescriptor],
+    target_tensors: dict[TensorId, TensorDescriptor],
+    source_placement: Optional[WeightPlacementManifest],
+    source_manifest: Optional[WeightManifest],
+    target_placement: WeightPlacementManifest,
+    source_participant_ids: Optional[frozenset[ParticipantId]] = None,
+    target_participant_ids: Optional[frozenset[ParticipantId]] = None,
+) -> LogicalTransferPlan:
+    operations = transfer.operations
+    return LogicalTransferPlan(
+        resource_id=transfer.resource_id,
+        revision=transfer.revision,
+        source_placement=source_placement,
+        target_placement=target_placement,
+        source_tensors=tuple(
+            sorted(source_tensors.values(), key=lambda item: item.tensor_id)
+        ),
+        target_tensors=tuple(
+            sorted(target_tensors.values(), key=lambda item: item.tensor_id)
+        ),
+        operations=operations,
+        source_manifest=source_manifest,
+        planning_limits=transfer.planning_limits,
+        source_executors=(
+            _build_placement_executor_plans(
+                (source_placement,),
+                operations,
+                "source",
+                source_participant_ids,
+            )
+            if source_placement is not None
+            else ()
+        ),
+        target_executors=_build_placement_executor_plans(
+            (target_placement,),
+            operations,
+            "target",
+            target_participant_ids,
+        ),
+    )

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/core.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/core.py
@@ -27,9 +27,10 @@ from .fragments import LogicalSourceFragment, LogicalTargetFragment
 from .ownership import (
     _validate_local_target_inventory,
     _validate_target_coverage,
+    complete_dp_owned_source_owners,
     complete_parallel_source_replicas,
+    has_dp_ownership,
     parallel_tensor_owner,
-    require_supported_dp_semantics,
 )
 from .validation import (
     _validate_tensor_compatibility,
@@ -160,7 +161,6 @@ def _plan_transfer(
     else:
         _validate_tensor_sets(source_tensors, target_tensors)
         _validate_target_coverage(target_tensors, target_fragments)
-    require_supported_dp_semantics((*source_tensors.values(), *target_tensors.values()))
     placement_source_fragments = tuple(
         fragment
         for fragment in source_fragments
@@ -182,6 +182,13 @@ def _plan_transfer(
     parallel_sources = bool(placement_source_fragments)
     source_replicas = (
         complete_parallel_source_replicas(source_tensors, placement_source_fragments)
+        if parallel_sources
+        else {}
+    )
+    source_dp_owners = (
+        complete_dp_owned_source_owners(
+            source_tensors, placement_source_fragments
+        )
         if parallel_sources
         else {}
     )
@@ -230,15 +237,26 @@ def _plan_transfer(
         )
         for group in candidate_groups:
             if parallel_sources:
-                source_dp = source_dp_by_target_dp[target.rank.dp]
-                source_owner = source_replicas[source_dp][target.tensor_id]
-                eligible = [
-                    fragment
-                    for fragment in group
-                    if isinstance(fragment, PlacementFragment)
-                    and fragment.rank.dp == source_dp
-                    and parallel_tensor_owner(source_tensor, fragment) == source_owner
-                ]
+                if has_dp_ownership(source_tensor):
+                    source_owner = source_dp_owners[target.tensor_id]
+                    eligible = [
+                        fragment
+                        for fragment in group
+                        if isinstance(fragment, PlacementFragment)
+                        and parallel_tensor_owner(source_tensor, fragment)
+                        == source_owner
+                    ]
+                else:
+                    source_dp = source_dp_by_target_dp[target.rank.dp]
+                    source_owner = source_replicas[source_dp][target.tensor_id]
+                    eligible = [
+                        fragment
+                        for fragment in group
+                        if isinstance(fragment, PlacementFragment)
+                        and fragment.rank.dp == source_dp
+                        and parallel_tensor_owner(source_tensor, fragment)
+                        == source_owner
+                    ]
                 if not eligible:
                     continue
                 representative = eligible[0]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/fragments.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/fragments.py
@@ -1,0 +1,23 @@
+"""Address-free fragment aliases used by logical planning."""
+
+from __future__ import annotations
+
+from typing import Union
+
+from ..._typing import TypeAlias
+from ..manifest import PlacementFragment
+from ..storage_manifest import StoredFragment
+
+
+# The logical planner only sees immutable placement boxes or Store object
+# ranges. Runtime addresses, leases, and allocation owners belong to PR2B.
+LogicalSourceFragment: TypeAlias = Union[PlacementFragment, StoredFragment]
+LogicalTargetFragment: TypeAlias = PlacementFragment
+GeometryFragment: TypeAlias = Union[PlacementFragment, StoredFragment]
+
+
+__all__ = [
+    "GeometryFragment",
+    "LogicalSourceFragment",
+    "LogicalTargetFragment",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/geometry.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/geometry.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import prod
+from typing import TYPE_CHECKING, Optional, Sequence, Union
+
+from ..._typing import TypeAlias
+
+from ..._compat import _strict_zip
+from ...contracts import TensorId
+from ..types import TensorDescriptor
+from ..storage_manifest import StoredFragment
+from .fragments import (
+    GeometryFragment,
+    LogicalSourceFragment,
+    LogicalTargetFragment,
+)
+
+if TYPE_CHECKING:
+    from .contracts import TransferRegion
+
+
+def _fragment_itemsize(fragment: GeometryFragment) -> int:
+    elements = prod(fragment.local_shape)
+    if elements <= 0 or fragment.nbytes % elements != 0:
+        raise ValueError("transfer region fragment byte size is invalid")
+    itemsize = fragment.nbytes // elements
+    if itemsize <= 0:
+        raise ValueError("transfer region fragment itemsize is invalid")
+    return itemsize
+
+
+def _logical_byte_offset(
+    fragment: GeometryFragment,
+    overlap_offset: tuple[int, ...],
+    itemsize: int,
+) -> int:
+    linear_offset = 0
+    stride = 1
+    for global_begin, local_begin, extent in _strict_zip(
+        reversed(overlap_offset),
+        reversed(fragment.global_offset),
+        reversed(fragment.local_shape),
+    ):
+        linear_offset += (global_begin - local_begin) * stride
+        stride *= extent
+    return linear_offset * itemsize
+
+
+def _validate_outer_strides(
+    counts: tuple[int, ...],
+    strides: tuple[int, ...],
+    inner_bytes: int,
+    side: str,
+) -> None:
+    span = inner_bytes
+    for count, stride in _strict_zip(reversed(counts), reversed(strides)):
+        if count > 1 and stride < span:
+            raise ValueError(f"transfer region {side} strides overlap")
+        span += (count - 1) * stride
+
+
+GeometryKey: TypeAlias = tuple[TensorId, tuple[int, ...], tuple[int, ...]]
+SourceSortKey: TypeAlias = Union[
+    tuple[int, int, int, int, str],
+    tuple[
+        int,
+        int,
+        int,
+        int,
+        str,
+        str,
+    ],
+]
+
+
+def _geometry_key(fragment: LogicalSourceFragment) -> GeometryKey:
+    return fragment.tensor_id, fragment.global_offset, fragment.local_shape
+
+
+def _source_sort_key(fragment: LogicalSourceFragment) -> SourceSortKey:
+    if isinstance(fragment, StoredFragment):
+        return (0, 0, 0, 0, fragment.object_key, fragment.fragment_id)
+    return (
+        fragment.rank.dp,
+        fragment.rank.pp,
+        fragment.rank.ep,
+        fragment.rank.tp,
+        fragment.fragment_id,
+    )
+
+
+@dataclass(frozen=True)
+class _CandidateInterval:
+    begin: int
+    end: int
+    group: tuple[LogicalSourceFragment, ...]
+
+
+@dataclass(frozen=True)
+class _CandidateIntervalNode:
+    center: int
+    crossing_by_begin: tuple[_CandidateInterval, ...]
+    crossing_by_end: tuple[_CandidateInterval, ...]
+    left: Optional[_CandidateIntervalNode] = None
+    right: Optional[_CandidateIntervalNode] = None
+
+    @classmethod
+    def build(
+        cls, intervals: Sequence[_CandidateInterval]
+    ) -> Optional[_CandidateIntervalNode]:
+        if not intervals:
+            return None
+        center = sorted((interval.begin + interval.end) // 2 for interval in intervals)[
+            len(intervals) // 2
+        ]
+        left: list[_CandidateInterval] = []
+        right: list[_CandidateInterval] = []
+        crossing: list[_CandidateInterval] = []
+        for interval in intervals:
+            if interval.end <= center:
+                left.append(interval)
+            elif interval.begin > center:
+                right.append(interval)
+            else:
+                crossing.append(interval)
+        return cls(
+            center=center,
+            crossing_by_begin=tuple(
+                sorted(crossing, key=lambda item: (item.begin, item.end))
+            ),
+            crossing_by_end=tuple(
+                sorted(crossing, key=lambda item: (item.end, item.begin))
+            ),
+            left=cls.build(left),
+            right=cls.build(right),
+        )
+
+    def query(
+        self,
+        begin: int,
+        end: int,
+        result: list[tuple[LogicalSourceFragment, ...]],
+    ) -> None:
+        if end <= self.center:
+            for interval in self.crossing_by_begin:
+                if interval.begin >= end:
+                    break
+                result.append(interval.group)
+            if self.left is not None:
+                self.left.query(begin, end, result)
+            return
+        if begin > self.center:
+            for interval in reversed(self.crossing_by_end):
+                if interval.end <= begin:
+                    break
+                result.append(interval.group)
+            if self.right is not None:
+                self.right.query(begin, end, result)
+            return
+
+        result.extend(interval.group for interval in self.crossing_by_begin)
+        if begin < self.center and self.left is not None:
+            self.left.query(begin, end, result)
+        if self.right is not None:
+            self.right.query(begin, end, result)
+
+
+@dataclass(frozen=True)
+class _CandidateBoxIndex:
+    dimension: int
+    root: _CandidateIntervalNode
+
+    @classmethod
+    def build(
+        cls, groups: Sequence[tuple[LogicalSourceFragment, ...]]
+    ) -> _CandidateBoxIndex:
+        if not groups:
+            raise ValueError("candidate box index requires source fragments")
+        ndim = len(groups[0][0].global_offset)
+        dimension = max(
+            range(ndim),
+            key=lambda dim: (
+                len(
+                    {
+                        (
+                            group[0].global_offset[dim],
+                            group[0].global_offset[dim] + group[0].local_shape[dim],
+                        )
+                        for group in groups
+                    }
+                ),
+                -dim,
+            ),
+        )
+        root = _CandidateIntervalNode.build(
+            tuple(
+                _CandidateInterval(
+                    begin=group[0].global_offset[dimension],
+                    end=(
+                        group[0].global_offset[dimension]
+                        + group[0].local_shape[dimension]
+                    ),
+                    group=group,
+                )
+                for group in groups
+            )
+        )
+        assert root is not None
+        return cls(dimension=dimension, root=root)
+
+    def query(
+        self, target: LogicalTargetFragment
+    ) -> tuple[tuple[LogicalSourceFragment, ...], ...]:
+        begin = target.global_offset[self.dimension]
+        result: list[tuple[LogicalSourceFragment, ...]] = []
+        self.root.query(
+            begin,
+            begin + target.local_shape[self.dimension],
+            result,
+        )
+        return tuple(result)
+
+
+def _overlap_box(
+    source: GeometryFragment,
+    target: GeometryFragment,
+) -> Optional[tuple[tuple[int, ...], tuple[int, ...]]]:
+    overlap_offset = tuple(
+        max(source_begin, target_begin)
+        for source_begin, target_begin in _strict_zip(
+            source.global_offset, target.global_offset
+        )
+    )
+    overlap_end = tuple(
+        min(
+            source_begin + source_extent,
+            target_begin + target_extent,
+        )
+        for source_begin, source_extent, target_begin, target_extent in _strict_zip(
+            source.global_offset,
+            source.local_shape,
+            target.global_offset,
+            target.local_shape,
+        )
+    )
+    overlap_shape = tuple(
+        end - begin for begin, end in _strict_zip(overlap_offset, overlap_end)
+    )
+    if any(extent <= 0 for extent in overlap_shape):
+        return None
+    return overlap_offset, overlap_shape
+
+
+def _canonical_byte_strides(shape: tuple[int, ...], itemsize: int) -> tuple[int, ...]:
+    result: list[int] = []
+    running = itemsize
+    for extent in reversed(shape):
+        result.append(running)
+        running *= extent
+    return tuple(reversed(result))
+
+
+def _derive_region_geometry(
+    source: GeometryFragment,
+    target: GeometryFragment,
+    overlap_offset: tuple[int, ...],
+    overlap_shape: tuple[int, ...],
+) -> tuple[
+    int,
+    int,
+    int,
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+]:
+    source_itemsize = _fragment_itemsize(source)
+    target_itemsize = _fragment_itemsize(target)
+    if source_itemsize != target_itemsize:
+        raise ValueError("transfer region source and target itemsize differ")
+
+    source_byte_strides = _canonical_byte_strides(source.local_shape, source_itemsize)
+    target_byte_strides = _canonical_byte_strides(target.local_shape, target_itemsize)
+    source_base_offset = sum(
+        (overlap_begin - fragment_begin) * stride
+        for overlap_begin, fragment_begin, stride in _strict_zip(
+            overlap_offset,
+            source.global_offset,
+            source_byte_strides,
+        )
+    )
+    target_base_offset = sum(
+        (overlap_begin - fragment_begin) * stride
+        for overlap_begin, fragment_begin, stride in _strict_zip(
+            overlap_offset,
+            target.global_offset,
+            target_byte_strides,
+        )
+    )
+
+    suffix_begin = len(overlap_shape) - 1
+    inner_bytes = overlap_shape[-1] * source_itemsize
+    for dim in range(len(overlap_shape) - 2, -1, -1):
+        if (
+            source_byte_strides[dim] != inner_bytes
+            or target_byte_strides[dim] != inner_bytes
+        ):
+            break
+        inner_bytes *= overlap_shape[dim]
+        suffix_begin = dim
+
+    return (
+        source_base_offset,
+        target_base_offset,
+        inner_bytes,
+        overlap_shape[:suffix_begin],
+        source_byte_strides[:suffix_begin],
+        target_byte_strides[:suffix_begin],
+    )
+
+
+def _transfer_region(
+    tensor: TensorDescriptor,
+    source: LogicalSourceFragment,
+    target: LogicalTargetFragment,
+    overlap_offset: tuple[int, ...],
+    overlap_shape: tuple[int, ...],
+) -> "TransferRegion[LogicalSourceFragment, LogicalTargetFragment]":
+    from .contracts import TransferRegion as transfer_region
+
+    if (
+        _fragment_itemsize(source) != tensor.itemsize
+        or _fragment_itemsize(target) != tensor.itemsize
+    ):
+        raise ValueError("transfer region fragment itemsize differs from descriptor")
+    (
+        source_base_offset,
+        target_base_offset,
+        inner_bytes,
+        outer_loop_counts,
+        source_strides,
+        target_strides,
+    ) = _derive_region_geometry(source, target, overlap_offset, overlap_shape)
+
+    return transfer_region(
+        tensor_id=tensor.tensor_id,
+        source=source,
+        target=target,
+        overlap_offset=overlap_offset,
+        overlap_shape=overlap_shape,
+        source_base_offset=source_base_offset,
+        target_base_offset=target_base_offset,
+        inner_bytes=inner_bytes,
+        outer_loop_counts=outer_loop_counts,
+        source_strides=source_strides,
+        target_strides=target_strides,
+    )

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/ownership.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/ownership.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+from ...contracts import TensorId
+from ...geometry import boxes_exactly_cover
+from ..manifest import OwnershipAxis, PlacementFragment, TensorDescriptor
+from .contracts import (
+    RuntimeTensorOwner,
+)
+from .fragments import LogicalSourceFragment, LogicalTargetFragment
+
+
+def _fragments_fully_cover_tensor(
+    tensor: TensorDescriptor,
+    fragments: Sequence[LogicalSourceFragment],
+) -> bool:
+    geometries = {
+        (fragment.global_offset, fragment.local_shape): fragment
+        for fragment in fragments
+        if fragment.tensor_id == tensor.tensor_id
+    }
+    boxes = tuple(geometries)
+    return boxes_exactly_cover(
+        (0,) * len(tensor.global_shape), tensor.global_shape, boxes
+    )
+
+
+def parallel_tensor_owner(
+    tensor: TensorDescriptor, fragment: PlacementFragment
+) -> RuntimeTensorOwner:
+    return tuple(
+        (axis.kind, getattr(fragment.rank, axis.kind))
+        for axis in tensor.parallel_axes
+        if isinstance(axis, OwnershipAxis)
+    )
+
+
+def has_dp_ownership(tensor: TensorDescriptor) -> bool:
+    """Return whether DP names tensor ownership instead of replica identity."""
+
+    return any(
+        isinstance(axis, OwnershipAxis) and axis.kind == "dp"
+        for axis in tensor.parallel_axes
+    )
+
+
+def require_supported_dp_semantics(
+    tensors: Sequence[TensorDescriptor],
+) -> None:
+    """Reject MoE-DP ownership until a semantic owner resolver is introduced.
+
+    Normal data parallelism is represented by ``ReplicatedAxis("dp")`` and is
+    supported. ``OwnershipAxis("dp")`` means different DP ranks can own
+    different logical parameters; selecting or expanding those parameters
+    requires framework-provided ownership semantics, not rank arithmetic in
+    the canonical planner.
+    """
+
+    unsupported = sorted(
+        tensor.tensor_id for tensor in tensors if has_dp_ownership(tensor)
+    )
+    if unsupported:
+        raise ValueError(
+            "DP ownership reshard is not supported in this version: "
+            + ", ".join(unsupported)
+        )
+
+
+def _validate_target_coverage(
+    target_tensors: dict[TensorId, TensorDescriptor],
+    target_fragments: Sequence[LogicalTargetFragment],
+) -> None:
+    if not target_fragments:
+        raise ValueError("target manifests have no fragments")
+    fragments_by_dp_and_tensor: dict[
+        int, dict[TensorId, list[LogicalTargetFragment]]
+    ] = {}
+    for fragment in target_fragments:
+        fragments_by_dp_and_tensor.setdefault(fragment.rank.dp, {}).setdefault(
+            fragment.tensor_id, []
+        ).append(fragment)
+    for tensor in target_tensors.values():
+        if has_dp_ownership(tensor):
+            fragments_by_owner: dict[
+                RuntimeTensorOwner, list[LogicalTargetFragment]
+            ] = {}
+            for by_tensor in fragments_by_dp_and_tensor.values():
+                for fragment in by_tensor.get(tensor.tensor_id, ()):
+                    fragments_by_owner.setdefault(
+                        parallel_tensor_owner(tensor, fragment), []
+                    ).append(fragment)
+            if not fragments_by_owner or any(
+                not _fragments_fully_cover_tensor(tensor, fragments)
+                for fragments in fragments_by_owner.values()
+            ):
+                raise ValueError(
+                    f"target tensor is not fully covered by its DP owner: "
+                    f"{tensor.tensor_id}"
+                )
+            continue
+        for dp_rank in sorted(fragments_by_dp_and_tensor):
+            fragments_by_owner: dict[
+                RuntimeTensorOwner, list[LogicalTargetFragment]
+            ] = {}
+            for fragment in fragments_by_dp_and_tensor[dp_rank].get(
+                tensor.tensor_id, ()
+            ):
+                fragments_by_owner.setdefault(
+                    parallel_tensor_owner(tensor, fragment), []
+                ).append(fragment)
+            if not fragments_by_owner or any(
+                not _fragments_fully_cover_tensor(tensor, fragments)
+                for fragments in fragments_by_owner.values()
+            ):
+                raise ValueError(
+                    f"target tensor is not fully covered: {tensor.tensor_id}: "
+                    f"dp={dp_rank}"
+                )
+
+
+def complete_parallel_source_replicas(
+    source_tensors: dict[TensorId, TensorDescriptor],
+    source_fragments: Sequence[PlacementFragment],
+) -> dict[int, dict[TensorId, RuntimeTensorOwner]]:
+    replicas: dict[int, dict[TensorId, RuntimeTensorOwner]] = {}
+    fragments_by_dp_and_tensor: dict[int, dict[TensorId, list[PlacementFragment]]] = {}
+    for fragment in source_fragments:
+        dp_rank = fragment.rank.dp
+        fragments_by_dp_and_tensor.setdefault(dp_rank, {}).setdefault(
+            fragment.tensor_id, []
+        ).append(fragment)
+    replica_tensors = tuple(
+        tensor for tensor in source_tensors.values() if not has_dp_ownership(tensor)
+    )
+    if not replica_tensors:
+        return {}
+    for dp_rank in sorted(fragments_by_dp_and_tensor):
+        owner_by_tensor: dict[TensorId, RuntimeTensorOwner] = {}
+        complete = True
+        for tensor in replica_tensors:
+            fragments_by_owner: dict[RuntimeTensorOwner, list[PlacementFragment]] = {}
+            for fragment in fragments_by_dp_and_tensor[dp_rank].get(
+                tensor.tensor_id, ()
+            ):
+                fragments_by_owner.setdefault(
+                    parallel_tensor_owner(tensor, fragment), []
+                ).append(fragment)
+            complete_owners = [
+                owner
+                for owner, fragments in fragments_by_owner.items()
+                if _fragments_fully_cover_tensor(tensor, fragments)
+            ]
+            if not fragments_by_owner or len(complete_owners) != len(
+                fragments_by_owner
+            ):
+                complete = False
+                break
+            owner_by_tensor[tensor.tensor_id] = min(complete_owners)
+        if complete:
+            replicas[dp_rank] = owner_by_tensor
+    if not replicas:
+        raise ValueError(
+            "source manifests have no complete DP replica; tensors are not fully covered"
+        )
+    return replicas
+
+
+def _validate_local_target_inventory(
+    target_tensors: dict[TensorId, TensorDescriptor],
+    target_fragments: Sequence[LogicalTargetFragment],
+) -> None:
+    if not target_fragments:
+        raise ValueError("local target manifest has no fragments")
+    ranks = {fragment.rank for fragment in target_fragments}
+    if len(ranks) != 1:
+        raise ValueError("local target manifest must describe exactly one executor")
+    missing = sorted(
+        set(target_tensors) - {item.tensor_id for item in target_fragments}
+    )
+    if missing:
+        raise ValueError(
+            f"local target manifest is missing fragments: {', '.join(missing)}"
+        )
+
+
+__all__ = [
+    "complete_parallel_source_replicas",
+    "has_dp_ownership",
+    "parallel_tensor_owner",
+    "require_supported_dp_semantics",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/ownership.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/ownership.py
@@ -45,26 +45,54 @@ def has_dp_ownership(tensor: TensorDescriptor) -> bool:
     )
 
 
-def require_supported_dp_semantics(
-    tensors: Sequence[TensorDescriptor],
-) -> None:
-    """Reject MoE-DP ownership until a semantic owner resolver is introduced.
+def complete_dp_owned_source_owners(
+    source_tensors: dict[TensorId, TensorDescriptor],
+    source_fragments: Sequence[PlacementFragment],
+) -> dict[TensorId, RuntimeTensorOwner]:
+    """Return the complete declared source owner for each DP-owned tensor.
 
-    Normal data parallelism is represented by ``ReplicatedAxis("dp")`` and is
-    supported. ``OwnershipAxis("dp")`` means different DP ranks can own
-    different logical parameters; selecting or expanding those parameters
-    requires framework-provided ownership semantics, not rank arithmetic in
-    the canonical planner.
+    Unlike a replicated DP tensor, an ``OwnershipAxis("dp")`` tensor is not
+    expected to exist on every DP rank. Its placement fragments name the owner
+    directly. A logical tensor may have exactly one complete owner; a partial
+    or duplicate owner declaration is ambiguous and rejected before planning.
     """
 
-    unsupported = sorted(
-        tensor.tensor_id for tensor in tensors if has_dp_ownership(tensor)
+    owned_tensors = tuple(
+        tensor for tensor in source_tensors.values() if has_dp_ownership(tensor)
     )
-    if unsupported:
-        raise ValueError(
-            "DP ownership reshard is not supported in this version: "
-            + ", ".join(unsupported)
+    if not owned_tensors:
+        return {}
+
+    fragments_by_tensor: dict[TensorId, list[PlacementFragment]] = {}
+    for fragment in source_fragments:
+        fragments_by_tensor.setdefault(fragment.tensor_id, []).append(fragment)
+
+    owners: dict[TensorId, RuntimeTensorOwner] = {}
+    for tensor in owned_tensors:
+        fragments_by_owner: dict[RuntimeTensorOwner, list[PlacementFragment]] = {}
+        for fragment in fragments_by_tensor.get(tensor.tensor_id, ()):
+            fragments_by_owner.setdefault(
+                parallel_tensor_owner(tensor, fragment), []
+            ).append(fragment)
+        complete_owners = sorted(
+            owner
+            for owner, fragments in fragments_by_owner.items()
+            if _fragments_fully_cover_tensor(tensor, fragments)
         )
+        if len(complete_owners) != 1 or len(complete_owners) != len(
+            fragments_by_owner
+        ):
+            if not complete_owners:
+                raise ValueError(
+                    "DP-owned source tensor has no complete declared owner: "
+                    f"{tensor.tensor_id}"
+                )
+            raise ValueError(
+                "DP-owned source tensor has ambiguous declared owners: "
+                f"{tensor.tensor_id}"
+            )
+        owners[tensor.tensor_id] = complete_owners[0]
+    return owners
 
 
 def _validate_target_coverage(
@@ -185,8 +213,8 @@ def _validate_local_target_inventory(
 
 
 __all__ = [
+    "complete_dp_owned_source_owners",
     "complete_parallel_source_replicas",
     "has_dp_ownership",
     "parallel_tensor_owner",
-    "require_supported_dp_semantics",
 ]

--- a/mooncake-reshard/python/mooncake/reshard/weight/_planner/validation.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/_planner/validation.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from ...contracts import ParticipantId, PlacementFragmentId, TensorId
+from ...geometry import regions_exactly_cover
+from ..manifest import (
+    PlacementFragment,
+    TensorDescriptor,
+)
+from .contracts import (
+    LogicalTransferOperation,
+    LogicalTransferPlan,
+)
+
+
+def _validate_logical_target_coverage(logical_plan: LogicalTransferPlan) -> None:
+    """Reject plans that would leave a selected target fragment unwritten."""
+
+    target_parts = {
+        part.participant_id: part for part in logical_plan.target_placement.parts
+    }
+    participant_by_fragment = {
+        fragment.placement_fragment_id: part.participant_id
+        for part in logical_plan.target_placement.parts
+        for fragment in part.fragments
+    }
+    operation_participants: set[ParticipantId] = set()
+    operations_by_fragment: dict[
+        PlacementFragmentId, list[LogicalTransferOperation]
+    ] = {}
+
+    for operation in logical_plan.operations:
+        target = operation.target
+        if not isinstance(target, PlacementFragment):
+            raise ValueError("logical transfer operation target must be a placement")
+        target_participant_id = participant_by_fragment.get(
+            target.placement_fragment_id
+        )
+        if target_participant_id is None or not any(
+            fragment == target
+            for fragment in target_parts[target_participant_id].fragments
+        ):
+            raise ValueError(
+                "logical plan and target placement fragment snapshots differ"
+            )
+        operations_by_fragment.setdefault(target.placement_fragment_id, []).append(
+            operation
+        )
+        operation_participants.add(target_participant_id)
+
+    if not logical_plan.target_executors:
+        raise ValueError("logical plan has no target executor metadata")
+
+    seen_participants: set[ParticipantId] = set()
+    selected_fragments: dict[PlacementFragmentId, PlacementFragment] = {}
+    selected_tensors: dict[TensorId, TensorDescriptor] = {}
+    for executor in logical_plan.target_executors:
+        if executor.placement_id != logical_plan.target_placement.placement_id:
+            raise ValueError("logical target executor placement differs from target")
+        if executor.participant_id in seen_participants:
+            raise ValueError("logical plan has duplicate target executor participant")
+        seen_participants.add(executor.participant_id)
+        part = target_parts.get(executor.participant_id)
+        if part is None or executor.rank != part.rank:
+            raise ValueError("logical target executor differs from target placement")
+        expected_fragment_ids = tuple(
+            sorted(fragment.placement_fragment_id for fragment in part.fragments)
+        )
+        if executor.placement_fragment_ids != expected_fragment_ids:
+            raise ValueError(
+                "logical target executor fragments differ from target placement"
+            )
+        if not logical_plan.operation_indices_for_executor(executor, "target"):
+            raise ValueError(
+                "logical target executor operations differ from target placement"
+            )
+        selected_fragments.update(
+            {fragment.placement_fragment_id: fragment for fragment in part.fragments}
+        )
+        for tensor in part.tensors:
+            previous = selected_tensors.setdefault(tensor.tensor_id, tensor)
+            if previous != tensor:
+                raise ValueError("logical target tensor catalog differs from placement")
+
+    if seen_participants != operation_participants:
+        raise ValueError("logical target executors differ from planned operations")
+    if logical_plan.target_tensors != tuple(
+        sorted(selected_tensors.values(), key=lambda item: item.tensor_id)
+    ):
+        raise ValueError("logical target tensor catalog differs from placement")
+
+    for fragment_id, target in selected_fragments.items():
+        operations = operations_by_fragment.get(fragment_id, ())
+        if not regions_exactly_cover(target, operations):
+            raise ValueError(
+                f"logical target fragment is not fully covered: {fragment_id}"
+            )
+
+
+def _validate_logical_source_placement(logical_plan: LogicalTransferPlan) -> None:
+    """Reject placement-source plans whose public projections contradict the source."""
+
+    source_placement = logical_plan.source_placement
+    if source_placement is None:
+        return
+    if logical_plan.source_tensors != source_placement.tensors:
+        raise ValueError("logical plan source tensor catalog differs from placement")
+    if not logical_plan.source_executors:
+        raise ValueError("logical plan has no source executor metadata")
+
+    source_parts = {part.participant_id: part for part in source_placement.parts}
+    participant_by_fragment = {
+        fragment.placement_fragment_id: part.participant_id
+        for part in source_placement.parts
+        for fragment in part.fragments
+    }
+    operation_participants: set[ParticipantId] = set()
+    for operation in logical_plan.operations:
+        source = operation.source
+        if not isinstance(source, PlacementFragment):
+            raise ValueError("logical transfer operation source must be a placement")
+        source_participant_id = participant_by_fragment.get(
+            source.placement_fragment_id
+        )
+        if source_participant_id is None or not any(
+            fragment == source
+            for fragment in source_parts[source_participant_id].fragments
+        ):
+            raise ValueError(
+                "logical plan and source placement fragment snapshots differ"
+            )
+        operation_participants.add(source_participant_id)
+
+    seen_participants: set[ParticipantId] = set()
+    for executor in logical_plan.source_executors:
+        if executor.placement_id != source_placement.placement_id:
+            raise ValueError("logical source executor placement differs from source")
+        if executor.participant_id in seen_participants:
+            raise ValueError("logical plan has duplicate source executor participant")
+        seen_participants.add(executor.participant_id)
+        part = source_parts.get(executor.participant_id)
+        if part is None or executor.rank != part.rank:
+            raise ValueError("logical source executor differs from source placement")
+        expected_fragment_ids = tuple(
+            sorted(fragment.placement_fragment_id for fragment in part.fragments)
+        )
+        if executor.placement_fragment_ids != expected_fragment_ids:
+            raise ValueError(
+                "logical source executor fragments differ from source placement"
+            )
+        if not logical_plan.operation_indices_for_executor(executor, "source"):
+            raise ValueError(
+                "logical source executor operations differ from source placement"
+            )
+
+    if seen_participants != operation_participants:
+        raise ValueError("logical source executors differ from planned operations")
+
+
+def _validate_tensor_compatibility(
+    source: TensorDescriptor, target: TensorDescriptor
+) -> None:
+    if source.layout_fingerprint != target.layout_fingerprint:
+        raise ValueError(f"layout mismatch for tensor {source.tensor_id}")
+    if (
+        source.global_shape != target.global_shape
+        or source.dtype != target.dtype
+        or source.itemsize != target.itemsize
+        or source.layer_id != target.layer_id
+        or source.expert_id != target.expert_id
+    ):
+        raise ValueError(f"tensor descriptor mismatch: {source.tensor_id}")
+
+
+def _validate_tensor_sets(
+    source_tensors: dict[TensorId, TensorDescriptor],
+    target_tensors: dict[TensorId, TensorDescriptor],
+) -> None:
+    source_ids = set(source_tensors)
+    target_ids = set(target_tensors)
+    missing = sorted(source_ids - target_ids)
+    if missing:
+        raise ValueError(f"target manifests are missing tensors: {', '.join(missing)}")
+    unexpected = sorted(target_ids - source_ids)
+    if unexpected:
+        raise ValueError(
+            f"target manifests contain unknown tensors: {', '.join(unexpected)}"
+        )
+
+
+def _validate_tensor_subset(
+    source_tensors: dict[TensorId, TensorDescriptor],
+    target_tensors: dict[TensorId, TensorDescriptor],
+) -> None:
+    unexpected = sorted(set(target_tensors) - set(source_tensors))
+    if unexpected:
+        raise ValueError(
+            f"target manifests contain unknown tensors: {', '.join(unexpected)}"
+        )

--- a/mooncake-reshard/python/mooncake/reshard/weight/placement.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/placement.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
+from typing import Optional
 
 from ..contracts import (
     ParticipantId,
@@ -47,7 +48,7 @@ class WeightPlacementManifest:
     parts: tuple[WeightPlacementPart, ...]
     tensors: tuple[TensorDescriptor, ...]
     fragments: tuple[PlacementFragment, ...]
-    _digest_cache: str | None = field(init=False, repr=False, compare=False)
+    _digest_cache: Optional[str] = field(init=False, repr=False, compare=False)
 
     def __init__(
         self,
@@ -58,7 +59,7 @@ class WeightPlacementManifest:
         placement_set_id: PlacementSetId,
         topology: ParallelTopology,
         parts: tuple[WeightPlacementPart, ...],
-        placement_id: PlacementId | None = None,
+        placement_id: Optional[PlacementId] = None,
     ) -> None:
         _require_nonempty_string(resource_id, "resource_id")
         _require_nonempty_string(revision, "revision")
@@ -164,7 +165,7 @@ class WeightPlacementManifest:
         topology: ParallelTopology,
         tensors: Sequence[TensorDescriptor],
         fragments: Sequence[PlacementFragment],
-        placement_id: PlacementId | None = None,
+        placement_id: Optional[PlacementId] = None,
     ) -> WeightPlacementManifest:
         """Group a complete flat fragment inventory by topology participant."""
 
@@ -323,7 +324,10 @@ def _logical_placement_id(
             {
                 "participant_id": part.participant_id,
                 "rank": asdict(part.rank),
-                "fragments": [asdict(fragment) for fragment in part.fragments],
+                "fragments": [
+                    _placement_fragment_identity(fragment)
+                    for fragment in part.fragments
+                ],
             }
             for part in parts
         ],
@@ -339,3 +343,21 @@ def _parallel_axis_identity(axis: object) -> dict[str, object]:
     if isinstance(axis, OwnershipAxis):
         return {"semantics": "ownership", "kind": axis.kind}
     raise ValueError("unsupported parallel axis value")
+
+
+def _placement_fragment_identity(fragment: PlacementFragment) -> dict[str, object]:
+    identity: dict[str, object] = {
+        "placement_fragment_id": fragment.placement_fragment_id,
+        "tensor_id": fragment.tensor_id,
+        "global_offset": fragment.global_offset,
+        "local_shape": fragment.local_shape,
+        "nbytes": fragment.nbytes,
+        "rank": asdict(fragment.rank),
+        "aliases": fragment.aliases,
+    }
+    # Keep the pre-virtual-stage canonical payload byte-for-byte stable. A
+    # stage participates in identity only when a framework explicitly assigns
+    # one, so legacy placements keep their existing placement IDs.
+    if fragment.pipeline_stage_id is not None:
+        identity["pipeline_stage_id"] = fragment.pipeline_stage_id
+    return identity

--- a/mooncake-reshard/python/mooncake/reshard/weight/planner.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/planner.py
@@ -1,0 +1,28 @@
+"""Stable public facade for model-weight transfer planning."""
+
+from ._planner.api import (
+    plan_placement_transfer,
+    plan_placement_transfer_to_local_target,
+    plan_stored_transfer_to_target_placement,
+)
+from ._planner.contracts import (
+    LogicalTransferPlan,
+    LogicalTransferOperation,
+    PlanningLimits,
+    PipelineRouteGroup,
+    PlacementExecutorPlan,
+    TransferRegion,
+)
+
+
+__all__ = [
+    "LogicalTransferPlan",
+    "LogicalTransferOperation",
+    "PlanningLimits",
+    "PipelineRouteGroup",
+    "PlacementExecutorPlan",
+    "TransferRegion",
+    "plan_placement_transfer",
+    "plan_placement_transfer_to_local_target",
+    "plan_stored_transfer_to_target_placement",
+]

--- a/mooncake-reshard/python/mooncake/reshard/weight/runtime.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/runtime.py
@@ -11,10 +11,10 @@ from ..contracts import (
     ResourceId,
     ResourceKind,
     RevisionId,
+    RuntimeBindingFragment,
     RuntimeInstanceId,
 )
 from .types import (
-    RuntimeBindingFragment,
     _require_nonempty_string,
     _require_u64,
     require_manifest_items,

--- a/mooncake-reshard/python/mooncake/reshard/weight/serde.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/serde.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping, Sequence
 from collections.abc import Set as AbstractSet
-from typing import TypeAlias, cast
+from typing import Optional, Union, cast
+
+from .._typing import TypeAlias
 
 from ..contracts import (
     ParticipantId,
@@ -38,8 +40,8 @@ from .types import (
     TensorDescriptor,
 )
 
-JsonScalar: TypeAlias = None | bool | int | float | str
-JsonValue: TypeAlias = JsonScalar | list["JsonValue"] | dict[str, "JsonValue"]
+JsonScalar: TypeAlias = Union[None, bool, int, float, str]
+JsonValue: TypeAlias = Union[JsonScalar, list["JsonValue"], dict[str, "JsonValue"]]
 JsonObject: TypeAlias = Mapping[str, JsonValue]
 
 
@@ -324,7 +326,7 @@ def _axis_from_wire(value: object, index: int) -> ParallelAxis:
 
 
 def _fragment_to_wire(fragment: PlacementFragment) -> dict[str, JsonValue]:
-    return {
+    result: dict[str, JsonValue] = {
         "placement_fragment_id": fragment.placement_fragment_id,
         "tensor_id": fragment.tensor_id,
         "global_offset": list(fragment.global_offset),
@@ -333,22 +335,27 @@ def _fragment_to_wire(fragment: PlacementFragment) -> dict[str, JsonValue]:
         "rank": _rank_to_wire(fragment.rank),
         "aliases": list(fragment.aliases),
     }
+    if fragment.pipeline_stage_id is not None:
+        result["pipeline_stage_id"] = fragment.pipeline_stage_id
+    return result
 
 
 def _fragment_from_wire(value: object, index: int) -> PlacementFragment:
-    fragment = _require_exact_fields(
-        value,
-        {
-            "placement_fragment_id",
-            "tensor_id",
-            "global_offset",
-            "local_shape",
-            "nbytes",
-            "rank",
-            "aliases",
-        },
-        f"placement fragment {index}",
-    )
+    fragment = _require_mapping(value, f"placement fragment {index}")
+    expected_fields = {
+        "placement_fragment_id",
+        "tensor_id",
+        "global_offset",
+        "local_shape",
+        "nbytes",
+        "rank",
+        "pipeline_stage_id",
+        "aliases",
+    }
+    legacy_fields = expected_fields - {"pipeline_stage_id"}
+    fragment_fields = set(fragment)
+    if fragment_fields != expected_fields and fragment_fields != legacy_fields:
+        raise ValueError(f"placement fragment {index} has an invalid schema")
     return PlacementFragment(
         placement_fragment_id=PlacementFragmentId(
             _require_nonempty_string(
@@ -364,6 +371,11 @@ def _fragment_from_wire(value: object, index: int) -> PlacementFragment:
         local_shape=_integer_tuple(fragment["local_shape"], "local_shape", minimum=1),
         nbytes=_require_integer(fragment["nbytes"], "nbytes", minimum=1),
         rank=_rank_from_wire(fragment["rank"], f"placement rank {index}"),
+        pipeline_stage_id=_optional_integer(
+            fragment.get("pipeline_stage_id"),
+            "pipeline_stage_id",
+            minimum=0,
+        ),
         aliases=tuple(
             TensorId(_require_nonempty_string(alias, "alias"))
             for alias in _require_sequence(fragment["aliases"], "aliases")
@@ -448,7 +460,12 @@ def _require_integer(value: object, label: str, *, minimum: int) -> int:
     return value
 
 
-def _optional_integer(value: object, label: str, *, minimum: int) -> int | None:
+def _optional_integer(
+    value: object,
+    label: str,
+    *,
+    minimum: int,
+) -> Optional[int]:
     if value is None:
         return None
     return _require_integer(value, label, minimum=minimum)

--- a/mooncake-reshard/python/mooncake/reshard/weight/storage_manifest.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/storage_manifest.py
@@ -1,0 +1,555 @@
+"""Persisted model-weight fragments and manifest contracts."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from math import prod
+from collections.abc import Mapping, Sequence
+from typing import Optional, Union, cast
+
+from .._typing import TypeAlias
+
+from .._compat import _strict_zip
+from ..contracts import ResourceId, ResourceKind, RevisionId, StoredFragmentId, TensorId
+from .serde import _axis_from_wire, _axis_to_wire
+from .types import (
+    TensorDescriptor,
+    ParallelAxis,
+    _normalize_aliases,
+    _require_integer,
+    _require_integer_tuple,
+    _require_manifest_items,
+    _require_nonempty_string,
+    _require_sequence,
+    _require_u64,
+    validate_fragment_geometry,
+)
+
+
+StoredGeometryKey: TypeAlias = tuple[TensorId, tuple[int, ...], tuple[int, ...]]
+StoredAliasDescriptorKey: TypeAlias = tuple[
+    tuple[int, ...],
+    str,
+    int,
+    tuple[int, ...],
+    tuple[ParallelAxis, ...],
+    Optional[int],
+    Optional[int],
+    str,
+]
+StoredAliasGeometryKey: TypeAlias = tuple[
+    tuple[TensorId, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    int,
+]
+
+
+@dataclass(frozen=True)
+class StoredFragment:
+    fragment_id: StoredFragmentId
+    tensor_id: TensorId
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+    object_key: str
+    object_offset: int
+    nbytes: int
+    aliases: tuple[TensorId, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "global_offset",
+            _require_integer_tuple(self.global_offset, "global_offset", minimum=0),
+        )
+        object.__setattr__(
+            self,
+            "local_shape",
+            _require_integer_tuple(self.local_shape, "local_shape", minimum=1),
+        )
+        for name in ("fragment_id", "tensor_id", "object_key"):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_integer(self.object_offset, "object_offset", minimum=0)
+        _require_integer(self.nbytes, "nbytes", minimum=1)
+        object.__setattr__(self, "aliases", _normalize_aliases(self.aliases))
+        if self.aliases:
+            if len(self.aliases) < 2:
+                raise ValueError("alias group must contain at least two tensor IDs")
+            if self.tensor_id not in self.aliases:
+                raise ValueError("alias group must contain the fragment tensor_id")
+
+
+@dataclass(frozen=True)
+class WeightManifest:
+    namespace: str
+    resource_id: ResourceId
+    revision: RevisionId
+    weight_generation: int
+    group_id: str
+    manifest_key: str
+    tensors: tuple[TensorDescriptor, ...]
+    fragments: tuple[StoredFragment, ...]
+    created_at: str
+
+    @property
+    def resource_kind(self) -> ResourceKind:
+        return ResourceKind.MODEL_WEIGHT
+
+    def __post_init__(self) -> None:
+        for name in (
+            "namespace",
+            "resource_id",
+            "revision",
+            "group_id",
+            "manifest_key",
+            "created_at",
+        ):
+            _require_nonempty_string(getattr(self, name), name)
+        object.__setattr__(
+            self,
+            "tensors",
+            _require_manifest_items(
+                self.tensors,
+                "WeightManifest tensors",
+                TensorDescriptor,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fragments",
+            _require_manifest_items(
+                self.fragments,
+                "WeightManifest fragments",
+                StoredFragment,
+            ),
+        )
+        _require_u64(self.weight_generation, "weight_generation")
+        if self.manifest_key != f"{self.group_id}/manifest":
+            raise ValueError("manifest_key does not belong to manifest group")
+        payload_prefix = f"{self.group_id}/payload/"
+        if any(
+            not fragment.object_key.startswith(payload_prefix)
+            for fragment in self.fragments
+        ):
+            raise ValueError("payload object_key does not belong to manifest group")
+        _validate_stored_fragments(self.tensors, self.fragments)
+        _validate_stored_aliases(self.tensors, self.fragments)
+        _validate_stored_coverage(self.tensors, self.fragments)
+        _validate_stored_object_ranges(self.fragments)
+
+    def to_json(self) -> str:
+        tensors: list[dict[str, object]] = []
+        for tensor in self.tensors:
+            tensors.append(
+                {
+                    "tensor_id": tensor.tensor_id,
+                    "global_shape": tensor.global_shape,
+                    "dtype": tensor.dtype,
+                    "itemsize": tensor.itemsize,
+                    "layer_id": tensor.layer_id,
+                    "expert_id": tensor.expert_id,
+                    "layout_fingerprint": tensor.layout_fingerprint,
+                    "shard_dims": tensor.shard_dims,
+                    "parallel_axes": [
+                        _axis_to_wire(axis) for axis in tensor.parallel_axes
+                    ],
+                }
+            )
+        raw: dict[str, object] = {
+            "resource_kind": self.resource_kind.value,
+            "namespace": self.namespace,
+            "resource_id": self.resource_id,
+            "revision": self.revision,
+            "weight_generation": self.weight_generation,
+            "group_id": self.group_id,
+            "manifest_key": self.manifest_key,
+            "tensors": tensors,
+            "fragments": [asdict(fragment) for fragment in self.fragments],
+            "created_at": self.created_at,
+        }
+        return json.dumps(
+            raw,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+
+    @classmethod
+    def from_json(cls, value: Union[str, bytes, bytearray]) -> WeightManifest:
+        def reject_constant(constant: str) -> None:
+            raise ValueError(f"non-finite JSON number is unsupported: {constant}")
+
+        def reject_duplicate_fields(
+            pairs: list[tuple[str, object]],
+        ) -> dict[str, object]:
+            result: dict[str, object] = {}
+            for key, item in pairs:
+                if key in result:
+                    raise ValueError(f"duplicate JSON field: {key}")
+                result[key] = item
+            return result
+
+        try:
+            raw = json.loads(
+                value,
+                parse_constant=reject_constant,
+                object_pairs_hook=reject_duplicate_fields,
+            )
+        except (TypeError, json.JSONDecodeError) as error:
+            raise ValueError("weight manifest is not valid JSON") from error
+        return cls.from_dict(_require_mapping(cast(object, raw), "weight manifest"))
+
+    @classmethod
+    def from_dict(cls, raw: Mapping[str, object]) -> WeightManifest:
+        raw = _require_exact_fields(
+            raw,
+            frozenset(
+                {
+                    "resource_kind",
+                    "namespace",
+                    "resource_id",
+                    "revision",
+                    "weight_generation",
+                    "group_id",
+                    "manifest_key",
+                    "tensors",
+                    "fragments",
+                    "created_at",
+                }
+            ),
+            "weight manifest",
+        )
+        tensor_fields = frozenset(
+            {
+                "tensor_id",
+                "global_shape",
+                "dtype",
+                "itemsize",
+                "layer_id",
+                "expert_id",
+                "layout_fingerprint",
+                "shard_dims",
+                "parallel_axes",
+            }
+        )
+        fragment_fields = frozenset(
+            {
+                "fragment_id",
+                "tensor_id",
+                "global_offset",
+                "local_shape",
+                "object_key",
+                "object_offset",
+                "nbytes",
+                "aliases",
+            }
+        )
+        tensors: list[TensorDescriptor] = []
+        if raw["resource_kind"] != ResourceKind.MODEL_WEIGHT.value:
+            raise ValueError("weight manifest resource_kind must be model_weight")
+        for index, item in enumerate(
+            _require_sequence(raw["tensors"], "WeightManifest tensors")
+        ):
+            tensor_values: dict[str, object] = dict(
+                _require_exact_fields(item, tensor_fields, "tensor descriptor")
+            )
+            parallel_axes = tuple(
+                _axis_from_wire(axis, axis_index)
+                for axis_index, axis in enumerate(
+                    _require_sequence(
+                        tensor_values["parallel_axes"],
+                        f"stored tensor parallel_axes {index}",
+                    )
+                )
+            )
+            tensors.append(
+                TensorDescriptor(
+                    tensor_id=TensorId(
+                        _require_nonempty_string(
+                            tensor_values["tensor_id"],
+                            "stored tensor tensor_id",
+                        )
+                    ),
+                    global_shape=_require_integer_tuple(
+                        tensor_values["global_shape"],
+                        "stored tensor global_shape",
+                        minimum=1,
+                    ),
+                    dtype=_require_nonempty_string(
+                        tensor_values["dtype"], "stored tensor dtype"
+                    ),
+                    itemsize=_require_integer(
+                        tensor_values["itemsize"], "stored tensor itemsize", minimum=1
+                    ),
+                    layer_id=_optional_integer(
+                        tensor_values["layer_id"], "stored tensor layer_id", minimum=0
+                    ),
+                    expert_id=_optional_integer(
+                        tensor_values["expert_id"], "stored tensor expert_id", minimum=0
+                    ),
+                    layout_fingerprint=_require_nonempty_string(
+                        tensor_values["layout_fingerprint"],
+                        "stored tensor layout_fingerprint",
+                    ),
+                    shard_dims=_require_integer_tuple(
+                        tensor_values["shard_dims"],
+                        "stored tensor shard_dims",
+                        minimum=0,
+                    ),
+                    parallel_axes=parallel_axes,
+                )
+            )
+        fragments: tuple[StoredFragment, ...] = tuple(
+            _stored_fragment_from_wire(item, fragment_fields)
+            for item in _require_sequence(raw["fragments"], "WeightManifest fragments")
+        )
+        return cls(
+            namespace=_require_nonempty_string(raw["namespace"], "namespace"),
+            resource_id=ResourceId(
+                _require_nonempty_string(raw["resource_id"], "resource_id")
+            ),
+            revision=RevisionId(_require_nonempty_string(raw["revision"], "revision")),
+            weight_generation=_require_u64(
+                raw["weight_generation"], "weight_generation"
+            ),
+            group_id=_require_nonempty_string(raw["group_id"], "group_id"),
+            manifest_key=_require_nonempty_string(raw["manifest_key"], "manifest_key"),
+            tensors=tuple(tensors),
+            fragments=fragments,
+            created_at=_require_nonempty_string(raw["created_at"], "created_at"),
+        )
+
+
+def _require_exact_fields(
+    value: object,
+    expected: frozenset[str],
+    label: str,
+) -> Mapping[str, object]:
+    mapping = _require_mapping(value, label)
+    if frozenset(mapping) != expected:
+        raise ValueError(f"{label} schema fields do not match contract")
+    return mapping
+
+
+def _require_mapping(value: object, label: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be a JSON object")
+    raw = cast(Mapping[object, object], value)
+    if any(type(key) is not str for key in raw):
+        raise ValueError(f"{label} must be a JSON object")
+    return {cast(str, key): item for key, item in raw.items()}
+
+
+def _optional_integer(
+    value: object,
+    label: str,
+    *,
+    minimum: int,
+) -> Optional[int]:
+    if value is None:
+        return None
+    return _require_integer(value, label, minimum=minimum)
+
+
+def _stored_fragment_from_wire(
+    value: object,
+    fragment_fields: frozenset[str],
+) -> StoredFragment:
+    fragment = _require_exact_fields(value, fragment_fields, "stored fragment")
+    return StoredFragment(
+        fragment_id=StoredFragmentId(
+            _require_nonempty_string(
+                fragment["fragment_id"], "stored fragment fragment_id"
+            )
+        ),
+        tensor_id=TensorId(
+            _require_nonempty_string(fragment["tensor_id"], "stored fragment tensor_id")
+        ),
+        global_offset=_require_integer_tuple(
+            fragment["global_offset"], "stored fragment global_offset", minimum=0
+        ),
+        local_shape=_require_integer_tuple(
+            fragment["local_shape"], "stored fragment local_shape", minimum=1
+        ),
+        object_key=_require_nonempty_string(
+            fragment["object_key"], "stored fragment object_key"
+        ),
+        object_offset=_require_integer(
+            fragment["object_offset"], "stored fragment object_offset", minimum=0
+        ),
+        nbytes=_require_integer(
+            fragment["nbytes"], "stored fragment nbytes", minimum=1
+        ),
+        aliases=tuple(
+            TensorId(_require_nonempty_string(alias, "stored fragment alias"))
+            for alias in _require_sequence(
+                fragment["aliases"], "stored fragment aliases"
+            )
+        ),
+    )
+
+
+def _validate_stored_fragments(
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[StoredFragment],
+) -> None:
+    tensor_by_id: dict[TensorId, TensorDescriptor] = {}
+    for tensor in tensors:
+        if tensor.tensor_id in tensor_by_id:
+            raise ValueError(f"duplicate tensor_id: {tensor.tensor_id}")
+        tensor_by_id[tensor.tensor_id] = tensor
+
+    fragment_ids: set[StoredFragmentId] = set()
+    for fragment in fragments:
+        if fragment.fragment_id in fragment_ids:
+            raise ValueError(f"duplicate fragment_id: {fragment.fragment_id}")
+        fragment_ids.add(fragment.fragment_id)
+        tensor = tensor_by_id.get(fragment.tensor_id)
+        if tensor is None:
+            raise ValueError(f"unknown tensor_id: {fragment.tensor_id}")
+        validate_fragment_geometry(
+            tensor,
+            fragment_id=fragment.fragment_id,
+            global_offset=fragment.global_offset,
+            local_shape=fragment.local_shape,
+            nbytes=fragment.nbytes,
+        )
+
+
+def _validate_stored_coverage(
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[StoredFragment],
+) -> None:
+    by_tensor: dict[TensorId, list[StoredFragment]] = {}
+    geometries: set[StoredGeometryKey] = set()
+    for fragment in fragments:
+        geometry = (
+            fragment.tensor_id,
+            fragment.global_offset,
+            fragment.local_shape,
+        )
+        if geometry in geometries:
+            raise ValueError(f"duplicate fragment geometry: {fragment.tensor_id}")
+        geometries.add(geometry)
+        by_tensor.setdefault(fragment.tensor_id, []).append(fragment)
+
+    for tensor in tensors:
+        tensor_fragments = by_tensor.get(tensor.tensor_id, [])
+        covered_volume = sum(
+            prod(fragment.local_shape) for fragment in tensor_fragments
+        )
+        if covered_volume != prod(tensor.global_shape) or _has_overlapping_boxes(
+            tensor_fragments
+        ):
+            raise ValueError(f"tensor is not fully covered: {tensor.tensor_id}")
+
+
+def _stored_alias_descriptor_key(
+    tensor: TensorDescriptor,
+) -> StoredAliasDescriptorKey:
+    return (
+        tensor.global_shape,
+        tensor.dtype,
+        tensor.itemsize,
+        tensor.shard_dims,
+        tensor.parallel_axes,
+        tensor.layer_id,
+        tensor.expert_id,
+        tensor.layout_fingerprint,
+    )
+
+
+def _validate_stored_aliases(
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[StoredFragment],
+) -> None:
+    tensor_by_id: dict[TensorId, TensorDescriptor] = {
+        tensor.tensor_id: tensor for tensor in tensors
+    }
+    by_group_and_geometry: dict[StoredAliasGeometryKey, list[StoredFragment]] = {}
+    for fragment in fragments:
+        if not fragment.aliases:
+            continue
+        unknown = sorted(set(fragment.aliases) - set(tensor_by_id))
+        if unknown:
+            raise ValueError(f"stored alias references unknown tensor: {unknown[0]}")
+        key = (
+            fragment.aliases,
+            fragment.global_offset,
+            fragment.local_shape,
+            fragment.nbytes,
+        )
+        by_group_and_geometry.setdefault(key, []).append(fragment)
+
+    for (aliases, *_), alias_fragments in by_group_and_geometry.items():
+        tensor_ids = {fragment.tensor_id for fragment in alias_fragments}
+        if tensor_ids != set(aliases):
+            raise ValueError("stored alias group is incomplete for fragment geometry")
+        descriptor_keys = {
+            _stored_alias_descriptor_key(tensor_by_id[tensor_id])
+            for tensor_id in tensor_ids
+        }
+        if len(descriptor_keys) != 1:
+            raise ValueError("stored alias tensor descriptors differ")
+
+
+def _validate_stored_object_ranges(
+    fragments: Sequence[StoredFragment],
+) -> None:
+    by_object: dict[str, list[StoredFragment]] = {}
+    for fragment in fragments:
+        by_object.setdefault(fragment.object_key, []).append(fragment)
+
+    for object_key, object_fragments in by_object.items():
+        ordered = sorted(object_fragments, key=lambda item: item.object_offset)
+        for previous, current in zip(ordered, ordered[1:]):
+            if current.object_offset < previous.object_offset + previous.nbytes:
+                raise ValueError(
+                    "stored fragment object ranges overlap: "
+                    f"{previous.fragment_id} and {current.fragment_id} "
+                    f"in {object_key}"
+                )
+
+
+def _has_overlapping_boxes(fragments: Sequence[StoredFragment]) -> bool:
+    if len(fragments) < 2:
+        return False
+
+    ndim = len(fragments[0].global_offset)
+    sweep_dim = max(
+        range(ndim),
+        key=lambda dim: len(
+            {
+                (
+                    fragment.global_offset[dim],
+                    fragment.global_offset[dim] + fragment.local_shape[dim],
+                )
+                for fragment in fragments
+            }
+        ),
+    )
+    ordered = sorted(fragments, key=lambda item: item.global_offset[sweep_dim])
+    active: list[StoredFragment] = []
+    for fragment in ordered:
+        begin = fragment.global_offset[sweep_dim]
+        active = [
+            candidate
+            for candidate in active
+            if candidate.global_offset[sweep_dim] + candidate.local_shape[sweep_dim]
+            > begin
+        ]
+        for candidate in active:
+            if all(
+                left_offset < right_offset + right_extent
+                and right_offset < left_offset + left_extent
+                for left_offset, left_extent, right_offset, right_extent in _strict_zip(
+                    candidate.global_offset,
+                    candidate.local_shape,
+                    fragment.global_offset,
+                    fragment.local_shape,
+                )
+            ):
+                return True
+        active.append(fragment)
+    return False

--- a/mooncake-reshard/python/mooncake/reshard/weight/storage_manifest.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/storage_manifest.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from math import prod
 from collections.abc import Mapping, Sequence
 from typing import Optional, Union, cast
@@ -44,6 +45,36 @@ StoredAliasGeometryKey: TypeAlias = tuple[
     tuple[int, ...],
     int,
 ]
+
+
+@dataclass(frozen=True)
+class StoredManifestIdentity:
+    """Stable identity for a committed Store manifest snapshot."""
+
+    namespace: str
+    resource_id: ResourceId
+    revision: RevisionId
+    weight_generation: int
+    group_id: str
+    manifest_key: str
+    content_sha256: str
+
+    def __post_init__(self) -> None:
+        for name in (
+            "namespace",
+            "resource_id",
+            "revision",
+            "group_id",
+            "manifest_key",
+            "content_sha256",
+        ):
+            _require_nonempty_string(getattr(self, name), name)
+        _require_u64(self.weight_generation, "weight_generation")
+        if len(self.content_sha256) != 64 or any(
+            character not in "0123456789abcdef"
+            for character in self.content_sha256
+        ):
+            raise ValueError("content_sha256 must be a SHA-256 hex digest")
 
 
 @dataclass(frozen=True)
@@ -91,6 +122,7 @@ class WeightManifest:
     tensors: tuple[TensorDescriptor, ...]
     fragments: tuple[StoredFragment, ...]
     created_at: str
+    manifest_digest: str = field(init=False)
 
     @property
     def resource_kind(self) -> ResourceKind:
@@ -137,6 +169,25 @@ class WeightManifest:
         _validate_stored_aliases(self.tensors, self.fragments)
         _validate_stored_coverage(self.tensors, self.fragments)
         _validate_stored_object_ranges(self.fragments)
+        object.__setattr__(
+            self,
+            "manifest_digest",
+            hashlib.sha256(self.to_json().encode("utf-8")).hexdigest(),
+        )
+
+    @property
+    def manifest_identity(self) -> StoredManifestIdentity:
+        """Return the Store location plus a canonical content digest."""
+
+        return StoredManifestIdentity(
+            namespace=self.namespace,
+            resource_id=self.resource_id,
+            revision=self.revision,
+            weight_generation=self.weight_generation,
+            group_id=self.group_id,
+            manifest_key=self.manifest_key,
+            content_sha256=self.manifest_digest,
+        )
 
     def to_json(self) -> str:
         tensors: list[dict[str, object]] = []
@@ -319,6 +370,27 @@ class WeightManifest:
             fragments=fragments,
             created_at=_require_nonempty_string(raw["created_at"], "created_at"),
         )
+
+
+def validate_weight_manifest_snapshot(manifest: WeightManifest) -> WeightManifest:
+    """Rebuild a typed manifest before it is trusted at a plan boundary."""
+
+    if not isinstance(manifest, WeightManifest):
+        raise ValueError("weight manifest snapshot is invalid")
+    try:
+        return WeightManifest(
+            namespace=manifest.namespace,
+            resource_id=manifest.resource_id,
+            revision=manifest.revision,
+            weight_generation=manifest.weight_generation,
+            group_id=manifest.group_id,
+            manifest_key=manifest.manifest_key,
+            tensors=manifest.tensors,
+            fragments=manifest.fragments,
+            created_at=manifest.created_at,
+        )
+    except (AttributeError, TypeError) as error:
+        raise ValueError("weight manifest snapshot is invalid") from error
 
 
 def _require_exact_fields(

--- a/mooncake-reshard/python/mooncake/reshard/weight/topology.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/topology.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass
+from typing import Optional
 
 from ..contracts import ParticipantId, TopologyId
 from .types import (
@@ -55,7 +56,7 @@ class ParallelTopology:
         ep_size: int,
         dp_size: int,
         participants: tuple[TopologyParticipant, ...],
-        topology_id: TopologyId | None = None,
+        topology_id: Optional[TopologyId] = None,
     ) -> None:
         for value, name in (
             (tp_size, "tp_size"),

--- a/mooncake-reshard/python/mooncake/reshard/weight/types.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/types.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Sequence
-from dataclasses import asdict, dataclass, field
-from typing import Literal, TypeVar, cast
+from dataclasses import asdict, dataclass
+from math import prod
+from typing import Literal, Optional, TypeVar, Union, cast
 
-from ..contracts.ids import PlacementFragmentId, RuntimeFragmentId, TensorId
+from ..contracts import PlacementFragmentId, TensorId
+from ..contracts import RuntimeBindingFragment as _RuntimeBindingFragment
+
+# Preserve the existing weight.types import surface while keeping the canonical
+# runtime fragment definition resource-neutral in mooncake.reshard.contracts.
+RuntimeBindingFragment = _RuntimeBindingFragment
 
 _MAX_U64 = (1 << 64) - 1
 ParallelAxisKind = Literal["dp", "pp", "ep", "tp"]
@@ -77,7 +83,7 @@ class OwnershipAxis:
         _validate_parallel_axis_kind(self.kind)
 
 
-ParallelAxis = SplitAxis | ReplicatedAxis | OwnershipAxis
+ParallelAxis = Union[SplitAxis, ReplicatedAxis, OwnershipAxis]
 
 
 @dataclass(frozen=True)
@@ -91,8 +97,8 @@ class TensorDescriptor:
     shard_dims: tuple[int, ...]
     layout_fingerprint: str
     parallel_axes: tuple[ParallelAxis, ...]
-    layer_id: int | None = None
-    expert_id: int | None = None
+    layer_id: Optional[int] = None
+    expert_id: Optional[int] = None
 
     def __post_init__(self) -> None:
         shape = _require_integer_tuple(self.global_shape, "global_shape", minimum=1)
@@ -153,6 +159,35 @@ class TensorDescriptor:
         _require_nonempty_string(self.layout_fingerprint, "layout_fingerprint")
 
 
+def validate_fragment_geometry(
+    tensor: TensorDescriptor,
+    *,
+    fragment_id: str,
+    global_offset: tuple[int, ...],
+    local_shape: tuple[int, ...],
+    nbytes: int,
+) -> None:
+    """Validate shared local geometry without requiring complete tensor coverage."""
+
+    ndim = len(tensor.global_shape)
+    if len(global_offset) != ndim or len(local_shape) != ndim:
+        raise ValueError(f"fragment rank mismatch: {fragment_id}")
+    for offset, extent, total in zip(
+        global_offset,
+        local_shape,
+        tensor.global_shape,
+    ):
+        if offset + extent > total:
+            raise ValueError(f"fragment is out of bounds: {fragment_id}")
+
+    expected_nbytes = prod(local_shape) * tensor.itemsize
+    if nbytes != expected_nbytes:
+        raise ValueError(
+            f"fragment byte size mismatch: {fragment_id}: "
+            f"expected {expected_nbytes}, got {nbytes}"
+        )
+
+
 def canonical_strides_bytes(
     shape: tuple[int, ...],
     itemsize: int,
@@ -174,6 +209,7 @@ class PlacementFragment:
     local_shape: tuple[int, ...]
     nbytes: int
     rank: ParallelRank
+    pipeline_stage_id: Optional[int]
     aliases: tuple[TensorId, ...]
     placement_fragment_id: PlacementFragmentId
 
@@ -184,8 +220,9 @@ class PlacementFragment:
         local_shape: tuple[int, ...],
         nbytes: int,
         rank: ParallelRank,
+        pipeline_stage_id: Optional[int] = None,
         aliases: tuple[TensorId, ...] = (),
-        placement_fragment_id: PlacementFragmentId | None = None,
+        placement_fragment_id: Optional[PlacementFragmentId] = None,
     ) -> None:
         normalized_offset = _require_integer_tuple(
             global_offset,
@@ -201,6 +238,8 @@ class PlacementFragment:
         _require_u64(nbytes, "nbytes", minimum=1)
         if not isinstance(rank, ParallelRank):
             raise ValueError("rank must be a ParallelRank")  # noqa: TRY004
+        if pipeline_stage_id is not None:
+            _require_integer(pipeline_stage_id, "pipeline_stage_id", minimum=0)
         normalized_aliases = _normalize_aliases(aliases)
         if normalized_aliases:
             if len(normalized_aliases) < 2:
@@ -220,6 +259,7 @@ class PlacementFragment:
                 local_shape=normalized_shape,
                 nbytes=nbytes,
                 rank=rank,
+                pipeline_stage_id=pipeline_stage_id,
                 aliases=normalized_aliases,
             )
         object.__setattr__(self, "tensor_id", tensor_id)
@@ -227,6 +267,7 @@ class PlacementFragment:
         object.__setattr__(self, "local_shape", normalized_shape)
         object.__setattr__(self, "nbytes", nbytes)
         object.__setattr__(self, "rank", rank)
+        object.__setattr__(self, "pipeline_stage_id", pipeline_stage_id)
         object.__setattr__(self, "aliases", normalized_aliases)
         object.__setattr__(self, "placement_fragment_id", resolved_fragment_id)
 
@@ -235,74 +276,6 @@ class PlacementFragment:
         """Expose the common fragment identifier used by future planners."""
 
         return self.placement_fragment_id
-
-
-@dataclass(frozen=True)
-class RuntimeBindingFragment:
-    """Contiguous physical runtime view for one placement fragment."""
-
-    placement_fragment_id: PlacementFragmentId
-    fragment_id: RuntimeFragmentId
-    address: int
-    nbytes: int
-    worker_id: str
-    endpoint: str
-    device: str
-    itemsize: int
-    local_shape: tuple[int, ...]
-    strides_bytes: tuple[int, ...]
-    storage_address: int
-    storage_nbytes: int
-    storage_offset_bytes: int
-    owner: object | None = field(default=None, compare=False, repr=False)
-
-    def __post_init__(self) -> None:
-        for name in (
-            "placement_fragment_id",
-            "fragment_id",
-            "worker_id",
-            "endpoint",
-            "device",
-        ):
-            _require_nonempty_string(getattr(self, name), name)
-        _require_address_range(self.address, self.nbytes)
-        _require_integer(self.itemsize, "runtime itemsize", minimum=1)
-        local_shape = _require_integer_tuple(
-            self.local_shape,
-            "runtime local_shape",
-            minimum=1,
-        )
-        strides_bytes = _require_integer_tuple(
-            self.strides_bytes,
-            "runtime strides_bytes",
-            minimum=0,
-        )
-        if len(strides_bytes) != len(local_shape):
-            raise ValueError("runtime stride rank differs from local_shape")
-        if any(
-            extent > 1 and stride == 0
-            for extent, stride in zip(local_shape, strides_bytes)
-        ):
-            raise ValueError(
-                "runtime stride must be positive for non-singleton dimensions"
-            )
-        strides_bytes = _normalize_singleton_strides_bytes(
-            local_shape,
-            strides_bytes,
-            self.itemsize,
-        )
-        object.__setattr__(self, "local_shape", local_shape)
-        object.__setattr__(self, "strides_bytes", strides_bytes)
-        _require_address_range(self.storage_address, self.storage_nbytes)
-        _require_u64(self.storage_offset_bytes, "storage_offset_bytes")
-        if self.storage_offset_bytes > _MAX_U64 - self.storage_address:
-            raise ValueError("normalized runtime address must fit in 64 bits")
-        if self.address != self.storage_address + self.storage_offset_bytes:
-            raise ValueError(
-                "runtime address must equal storage_address plus storage_offset_bytes"
-            )
-        if self.storage_offset_bytes > self.storage_nbytes - self.nbytes:
-            raise ValueError("runtime view exceeds storage allocation bounds")
 
 
 def _require_nonempty_string(value: object, name: str) -> str:
@@ -315,7 +288,7 @@ def _require_integer(
     value: object,
     name: str,
     *,
-    minimum: int | None = None,
+    minimum: Optional[int] = None,
 ) -> int:
     if type(value) is not int:
         raise ValueError(f"{name} must be an integer")
@@ -329,13 +302,6 @@ def _require_u64(value: object, name: str, *, minimum: int = 0) -> int:
     if integer > _MAX_U64:
         raise ValueError(f"{name} must fit in an unsigned 64-bit integer")
     return integer
-
-
-def _require_address_range(address: object, nbytes: object) -> None:
-    normalized_address = _require_u64(address, "address", minimum=1)
-    normalized_nbytes = _require_u64(nbytes, "nbytes", minimum=1)
-    if normalized_nbytes > _MAX_U64 - normalized_address:
-        raise ValueError("address range must fit in an unsigned 64-bit integer")
 
 
 def require_sha256_digest(value: object, name: str) -> None:
@@ -392,6 +358,7 @@ def _canonical_placement_fragment_id(
     local_shape: tuple[int, ...],
     nbytes: int,
     rank: ParallelRank,
+    pipeline_stage_id: Optional[int],
     aliases: tuple[TensorId, ...],
 ) -> PlacementFragmentId:
     content = {
@@ -403,20 +370,10 @@ def _canonical_placement_fragment_id(
         "rank": asdict(rank),
         "aliases": aliases,
     }
+    if pipeline_stage_id is not None:
+        content["pipeline_stage_id"] = pipeline_stage_id
     encoded = json.dumps(content, sort_keys=True, separators=(",", ":")).encode()
     return PlacementFragmentId(f"sha256:{hashlib.sha256(encoded).hexdigest()}")
-
-
-def _normalize_singleton_strides_bytes(
-    shape: tuple[int, ...],
-    strides_bytes: tuple[int, ...],
-    itemsize: int,
-) -> tuple[int, ...]:
-    canonical = canonical_strides_bytes(shape, itemsize)
-    return tuple(
-        expected if extent == 1 else observed
-        for extent, observed, expected in zip(shape, strides_bytes, canonical)
-    )
 
 
 def _validate_parallel_axis_kind(kind: ParallelAxisKind) -> None:

--- a/mooncake-reshard/python/mooncake/reshard/weight/validation.py
+++ b/mooncake-reshard/python/mooncake/reshard/weight/validation.py
@@ -4,18 +4,18 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from itertools import product as cartesian_product
-from math import prod
 
-from ..contracts import RuntimeInstanceId, TensorId
+from ..contracts import RuntimeBindingFragment, RuntimeInstanceId, TensorId
+from ..geometry import boxes_exactly_cover, boxes_overlap
 from .topology import ParallelTopology
 from .types import (
     OwnershipAxis,
     ParallelRank,
     PlacementFragment,
     ReplicatedAxis,
-    RuntimeBindingFragment,
     SplitAxis,
     TensorDescriptor,
+    validate_fragment_geometry,
 )
 
 
@@ -356,62 +356,9 @@ def _fragments_exactly_cover_tensor(
     boxes = tuple(
         (fragment.global_offset, fragment.local_shape) for fragment in fragments
     )
-    if not boxes:
-        return False
-    if sum(prod(shape) for _, shape in boxes) != prod(tensor.global_shape):
-        return False
-    if any(
-        any(
-            offset < 0 or offset + extent > total
-            for offset, extent, total in zip(
-                box_offset,
-                box_shape,
-                tensor.global_shape,
-            )
-        )
-        for box_offset, box_shape in boxes
-    ):
-        return False
-    return not _boxes_overlap(boxes)
-
-
-def _boxes_overlap(
-    boxes: Sequence[tuple[tuple[int, ...], tuple[int, ...]]],
-) -> bool:
-    if len(boxes) < 2:
-        return False
-    ndim = len(boxes[0][0])
-    sweep_dim = max(
-        range(ndim),
-        key=lambda dim: len(
-            {(offset[dim], offset[dim] + shape[dim]) for offset, shape in boxes}
-        ),
+    return boxes_exactly_cover(
+        (0,) * len(tensor.global_shape), tensor.global_shape, boxes
     )
-    ordered = sorted(boxes, key=lambda item: item[0][sweep_dim])
-    active: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
-    for offset, shape in ordered:
-        begin = offset[sweep_dim]
-        active = [
-            candidate
-            for candidate in active
-            if candidate[0][sweep_dim] + candidate[1][sweep_dim] > begin
-        ]
-        if any(
-            all(
-                left_begin < right_begin + right_extent
-                and right_begin < left_begin + left_extent
-                for left_begin, left_extent, right_begin, right_extent in zip(
-                    candidate_offset,
-                    candidate_shape,
-                    offset,
-                    shape,
-                )
-            )
-            for candidate_offset, candidate_shape in active
-        ):
-            return True
-        active.append((offset, shape))
-    return False
 
 
 def _validate_logical_fragment_overlaps(
@@ -426,77 +373,27 @@ def _validate_logical_fragment_overlaps(
     for owner_fragments in by_tensor_and_rank.values():
         if len(owner_fragments) < 2:
             continue
-        ndim = len(owner_fragments[0].global_offset)
-        sweep_dim = max(
-            range(ndim),
-            key=lambda dim: len(
-                {
-                    (
-                        fragment.global_offset[dim],
-                        fragment.global_offset[dim] + fragment.local_shape[dim],
-                    )
-                    for fragment in owner_fragments
-                }
-            ),
+        boxes = tuple(
+            (fragment.global_offset, fragment.local_shape)
+            for fragment in owner_fragments
         )
-        ordered = sorted(
-            owner_fragments,
-            key=lambda fragment: fragment.global_offset[sweep_dim],
-        )
-        active: list[PlacementFragment] = []
-        for current in ordered:
-            current_begin = current.global_offset[sweep_dim]
-            active = [
-                previous
-                for previous in active
-                if previous.global_offset[sweep_dim] + previous.local_shape[sweep_dim]
-                > current_begin
-            ]
-            for previous in active:
-                if all(
-                    previous_offset < current_offset + current_extent
-                    and current_offset < previous_offset + previous_extent
-                    for (
-                        previous_offset,
-                        previous_extent,
-                        current_offset,
-                        current_extent,
-                    ) in zip(
-                        previous.global_offset,
-                        previous.local_shape,
-                        current.global_offset,
-                        current.local_shape,
-                    )
-                ):
-                    raise ValueError(
-                        "logical fragment boxes overlap for tensor and "
-                        "parallel rank: "
-                        f"{previous.fragment_id} and {current.fragment_id}"
-                    )
-            active.append(current)
+        if boxes_overlap(boxes):
+            raise ValueError(
+                "logical fragment boxes overlap for tensor and parallel rank"
+            )
 
 
 def _validate_fragment_geometry(
     tensor: TensorDescriptor,
     fragment: PlacementFragment,
 ) -> None:
-    ndim = len(tensor.global_shape)
-    if len(fragment.global_offset) != ndim or len(fragment.local_shape) != ndim:
-        raise ValueError(f"fragment rank mismatch: {fragment.fragment_id}")
-    for offset, extent, total in zip(
-        fragment.global_offset,
-        fragment.local_shape,
-        tensor.global_shape,
-    ):
-        if offset + extent > total:
-            raise ValueError(f"fragment is out of bounds: {fragment.fragment_id}")
-
-    expected_nbytes = prod(fragment.local_shape) * tensor.itemsize
-    if fragment.nbytes != expected_nbytes:
-        raise ValueError(
-            f"fragment byte size mismatch: {fragment.fragment_id}: "
-            f"expected {expected_nbytes}, got {fragment.nbytes}"
-        )
+    validate_fragment_geometry(
+        tensor,
+        fragment_id=fragment.fragment_id,
+        global_offset=fragment.global_offset,
+        local_shape=fragment.local_shape,
+        nbytes=fragment.nbytes,
+    )
 
 
 def _runtime_alias_descriptor_key(tensor: TensorDescriptor) -> tuple[object, ...]:

--- a/mooncake-reshard/tests/model_weight_nd_planner/__init__.py
+++ b/mooncake-reshard/tests/model_weight_nd_planner/__init__.py
@@ -1,0 +1,1 @@
+"""N-D planner tests organized by parallel-axis and serialization coverage."""

--- a/mooncake-reshard/tests/model_weight_nd_planner/helpers.py
+++ b/mooncake-reshard/tests/model_weight_nd_planner/helpers.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from itertools import product
+from math import prod
+
+from mooncake.reshard._compat import _strict_zip
+from mooncake.reshard.weight.manifest import (
+    OwnershipAxis,
+    ParallelRank,
+    PlacementFragment,
+    ReplicatedAxis,
+    RuntimeBindingFragment,
+    SplitAxis,
+    TensorDescriptor,
+)
+
+from model_weight_planner.helpers import (
+    RuntimeInputs,
+    _canonical_strides_bytes,
+    plan_transfer as plan_transfer,
+    runtime_inputs_from_groups,
+)
+
+
+MODEL_ID = "qwen-family-moe"
+REVISION = "step-42"
+
+
+def tensor_descriptor(
+    tensor_id: str,
+    *,
+    global_shape: tuple[int, ...],
+    shard_dims: tuple[int, ...],
+    layer_id: int | None = 0,
+    parallel_axes: tuple[SplitAxis | ReplicatedAxis | OwnershipAxis, ...] | None = None,
+) -> TensorDescriptor:
+    if parallel_axes is None:
+        if not shard_dims:
+            parallel_axes = (
+                ReplicatedAxis(kind="dp"),
+                OwnershipAxis(kind="pp"),
+            )
+        elif len(shard_dims) == 1:
+            parallel_axes = (
+                ReplicatedAxis(kind="dp"),
+                OwnershipAxis(kind="pp"),
+                SplitAxis(kind="tp", dim=shard_dims[0]),
+            )
+        else:
+            parallel_axes = (
+                ReplicatedAxis(kind="dp"),
+                OwnershipAxis(kind="pp"),
+                SplitAxis(kind="ep", dim=shard_dims[0]),
+                SplitAxis(kind="tp", dim=shard_dims[1]),
+            )
+    return TensorDescriptor(
+        tensor_id=tensor_id,
+        global_shape=global_shape,
+        dtype="bfloat16",
+        itemsize=2,
+        layer_id=layer_id,
+        expert_id=None,
+        layout_fingerprint="framework:logical-contiguous:v2",
+        shard_dims=shard_dims,
+        parallel_axes=parallel_axes,
+    )
+
+
+def build_manifests(
+    side: str,
+    placements: list[
+        tuple[
+            TensorDescriptor,
+            ParallelRank,
+            tuple[int, ...],
+            tuple[int, ...],
+        ]
+    ],
+    *,
+    address_base: int,
+) -> RuntimeInputs:
+    grouped: dict[
+        ParallelRank,
+        list[tuple[TensorDescriptor, tuple[int, ...], tuple[int, ...]]],
+    ] = {}
+    for tensor, rank, offset, shape in placements:
+        grouped.setdefault(rank, []).append((tensor, offset, shape))
+
+    groups = []
+    address = address_base
+    for rank in sorted(grouped, key=lambda item: (item.dp, item.pp, item.ep, item.tp)):
+        worker_id = f"{side}-d{rank.dp}-p{rank.pp}-e{rank.ep}-t{rank.tp}"
+        placement_fragments = []
+        binding_fragments = []
+        tensors: dict[str, TensorDescriptor] = {}
+        for tensor, offset, shape in sorted(
+            grouped[rank], key=lambda item: item[0].tensor_id
+        ):
+            nbytes = prod(shape) * tensor.itemsize
+            placement_fragment_id = f"{worker_id}-{tensor.tensor_id}-placement"
+            placement_fragments.append(
+                PlacementFragment(
+                    placement_fragment_id=placement_fragment_id,
+                    tensor_id=tensor.tensor_id,
+                    global_offset=offset,
+                    local_shape=shape,
+                    nbytes=nbytes,
+                    rank=rank,
+                )
+            )
+            binding_fragments.append(
+                RuntimeBindingFragment(
+                    placement_fragment_id=placement_fragment_id,
+                    fragment_id=f"{worker_id}-{tensor.tensor_id}",
+                    address=address,
+                    nbytes=nbytes,
+                    worker_id=worker_id,
+                    endpoint=f"{worker_id}:12345",
+                    device="cuda:0",
+                    itemsize=tensor.itemsize,
+                    local_shape=shape,
+                    strides_bytes=_canonical_strides_bytes(shape, tensor.itemsize),
+                    storage_address=address,
+                    storage_nbytes=nbytes,
+                    storage_offset_bytes=0,
+                )
+            )
+            address += nbytes + 4096
+            tensors[tensor.tensor_id] = tensor
+        groups.append((worker_id, tuple(placement_fragments), tuple(binding_fragments)))
+    return runtime_inputs_from_groups(
+        resource_id=MODEL_ID,
+        revision=REVISION,
+        placement_set_id=side,
+        tensors=tuple(
+            sorted(
+                {tensor.tensor_id: tensor for tensor, _, _, _ in placements}.values(),
+                key=lambda item: item.tensor_id,
+            )
+        ),
+        groups=groups,
+    )
+
+
+def ep_tp_placements(
+    tensors: tuple[TensorDescriptor, ...],
+    *,
+    dp: int,
+    pp_owner: dict[str, int],
+    ep: int,
+    tp: int,
+    tp_dim: int,
+) -> list[tuple[TensorDescriptor, ParallelRank, tuple[int, ...], tuple[int, ...]]]:
+    placements = []
+    for tensor in tensors:
+        assert tensor.global_shape[0] % ep == 0
+        assert tensor.global_shape[tp_dim] % tp == 0
+        expert_extent = tensor.global_shape[0] // ep
+        tp_extent = tensor.global_shape[tp_dim] // tp
+        for dp_rank, ep_rank, tp_rank in product(range(dp), range(ep), range(tp)):
+            shape = list(tensor.global_shape)
+            offset = [0] * len(shape)
+            shape[0] = expert_extent
+            offset[0] = ep_rank * expert_extent
+            shape[tp_dim] = tp_extent
+            offset[tp_dim] = tp_rank * tp_extent
+            placements.append(
+                (
+                    tensor,
+                    ParallelRank(
+                        dp=dp_rank,
+                        pp=pp_owner[tensor.tensor_id],
+                        ep=ep_rank,
+                        tp=tp_rank,
+                    ),
+                    tuple(offset),
+                    tuple(shape),
+                )
+            )
+    return placements
+
+
+def fragment_payload(descriptor: TensorDescriptor, fragment) -> bytearray:
+    global_strides = []
+    running = 1
+    for extent in reversed(descriptor.global_shape):
+        global_strides.append(running)
+        running *= extent
+    global_strides.reverse()
+    payload = bytearray()
+    for local_coordinate in product(
+        *(range(extent) for extent in fragment.local_shape)
+    ):
+        global_coordinate = tuple(
+            begin + local
+            for begin, local in _strict_zip(fragment.global_offset, local_coordinate)
+        )
+        value = 1 + sum(
+            coordinate * stride
+            for coordinate, stride in _strict_zip(global_coordinate, global_strides)
+        )
+        mask = (1 << (descriptor.itemsize * 8)) - 1
+        payload.extend((value & mask).to_bytes(descriptor.itemsize, "little"))
+    return payload
+
+
+def assert_plan_copies_logical_contents(
+    plan,
+    source_manifests: RuntimeInputs,
+    target_manifests: RuntimeInputs,
+) -> None:
+    descriptors = {
+        tensor.tensor_id: tensor for tensor in source_manifests.placement.tensors
+    }
+    source_payloads = {}
+    source_parts = {
+        part.participant_id: part for part in source_manifests.placement.parts
+    }
+    for binding in source_manifests.bindings:
+        part = source_parts[binding.participant_id]
+        placement_by_id = {
+            fragment.placement_fragment_id: fragment for fragment in part.fragments
+        }
+        for runtime_fragment in binding.fragments:
+            placement_fragment = placement_by_id[runtime_fragment.placement_fragment_id]
+            source_payloads[placement_fragment.placement_fragment_id] = fragment_payload(
+                descriptors[placement_fragment.tensor_id], placement_fragment
+            )
+
+    target_payloads = {}
+    target_placements_by_fragment_id = {}
+    target_parts = {
+        part.participant_id: part for part in target_manifests.placement.parts
+    }
+    for binding in target_manifests.bindings:
+        part = target_parts[binding.participant_id]
+        placement_by_id = {
+            fragment.placement_fragment_id: fragment for fragment in part.fragments
+        }
+        for runtime_fragment in binding.fragments:
+            placement_fragment = placement_by_id[runtime_fragment.placement_fragment_id]
+            target_payloads[placement_fragment.placement_fragment_id] = bytearray(
+                runtime_fragment.nbytes
+            )
+            target_placements_by_fragment_id[placement_fragment.placement_fragment_id] = (
+                placement_fragment
+            )
+
+    for operation in plan.operations:
+        source = source_payloads[operation.source.placement_fragment_id]
+        target = target_payloads[operation.target.placement_fragment_id]
+        for source_offset, target_offset, nbytes in operation.iter_segments(
+            max_segments=operation.segment_count
+        ):
+            target[target_offset : target_offset + nbytes] = source[
+                source_offset : source_offset + nbytes
+            ]
+
+    for fragment_id, placement_fragment in target_placements_by_fragment_id.items():
+        assert target_payloads[fragment_id] == fragment_payload(
+            descriptors[placement_fragment.tensor_id], placement_fragment
+        )
+
+
+def pp_placements(
+    tensors: tuple[TensorDescriptor, ...],
+    owners: dict[str, int],
+) -> list[tuple[TensorDescriptor, ParallelRank, tuple[int, ...], tuple[int, ...]]]:
+    return [
+        (
+            tensor,
+            ParallelRank(pp=owners[tensor.tensor_id]),
+            (0,),
+            tensor.global_shape,
+        )
+        for tensor in tensors
+    ]

--- a/mooncake-reshard/tests/model_weight_nd_planner/test_all_axis_operation_count.py
+++ b/mooncake-reshard/tests/model_weight_nd_planner/test_all_axis_operation_count.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.weight.manifest import ParallelRank, SplitAxis
+from mooncake.reshard.weight.planner import (
+    PlanningLimits,
+    TransferRegion,
+    plan_placement_transfer,
+)
+
+from .helpers import (
+    assert_plan_copies_logical_contents,
+    build_manifests,
+    ep_tp_placements,
+    plan_transfer,
+    tensor_descriptor,
+)
+
+
+def test_four_axis_reshard_has_complete_content_and_routes() -> None:
+    source_tensors = tuple(
+        tensor_descriptor(
+            f"layers.{layer}.experts.w1",
+            global_shape=(8, 8, 2),
+            shard_dims=(0, 1),
+            layer_id=layer,
+        )
+        for layer in range(4)
+    )
+    target_tensors = tuple(
+        tensor_descriptor(
+            tensor.tensor_id,
+            global_shape=tensor.global_shape,
+            shard_dims=(0, 1),
+            layer_id=tensor.layer_id,
+        )
+        for tensor in source_tensors
+    )
+    source_owners = {
+        tensor.tensor_id: tensor.layer_id // 2 for tensor in source_tensors
+    }
+    target_owners = {tensor.tensor_id: tensor.layer_id for tensor in target_tensors}
+    sources = build_manifests(
+        "source",
+        ep_tp_placements(
+            source_tensors,
+            dp=2,
+            pp_owner=source_owners,
+            ep=8,
+            tp=4,
+            tp_dim=1,
+        ),
+        address_base=0x10000000,
+    )
+    targets = build_manifests(
+        "target",
+        ep_tp_placements(
+            target_tensors,
+            dp=4,
+            pp_owner=target_owners,
+            ep=2,
+            tp=8,
+            tp_dim=1,
+        ),
+        address_base=0x20000000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert plan.total_bytes == 4 * 8 * 8 * 2 * 2 * 4
+    assert {operation.source.rank.dp for operation in plan.operations} == {0, 1}
+    assert {operation.target.rank.dp for operation in plan.operations} == {
+        0,
+        1,
+        2,
+        3,
+    }
+    assert {operation.source.rank.tp for operation in plan.operations} == set(range(4))
+    assert {operation.target.rank.tp for operation in plan.operations} == set(range(8))
+    assert {operation.source.rank.ep for operation in plan.operations} == set(range(8))
+    assert {operation.target.rank.ep for operation in plan.operations} == {0, 1}
+    assert {(route.source_pp, route.target_pp) for route in plan.pipeline_routes} == {
+        (0, 0),
+        (0, 1),
+        (1, 2),
+        (1, 3),
+    }
+    assert_plan_copies_logical_contents(plan, sources, targets)
+
+
+def test_cross_dim_planner_keeps_operation_count_at_region_granularity() -> None:
+    source_tensor = tensor_descriptor(
+        "layers.0.experts.w1",
+        global_shape=(8, 8192, 8192),
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    target_tensor = tensor_descriptor(
+        source_tensor.tensor_id,
+        global_shape=source_tensor.global_shape,
+        shard_dims=(2,),
+    )
+    source_placements = [
+        (
+            source_tensor,
+            ParallelRank(ep=rank),
+            (rank, 0, 0),
+            (1, 8192, 8192),
+        )
+        for rank in range(8)
+    ]
+    target_placements = [
+        (
+            target_tensor,
+            ParallelRank(tp=rank),
+            (0, 0, rank * 1024),
+            (8, 8192, 1024),
+        )
+        for rank in range(8)
+    ]
+    sources = build_manifests("source", source_placements, address_base=0x100000000)
+    targets = build_manifests("target", target_placements, address_base=0x300000000)
+
+    plan = plan_transfer(sources, targets)
+
+    assert len(plan.operations) == 64
+    assert {operation.segment_count for operation in plan.operations} == {8192}
+    assert all(isinstance(operation, TransferRegion) for operation in plan.operations)
+
+
+def test_cross_dim_planner_rejects_total_region_budget_before_materialization() -> None:
+    source_tensor = tensor_descriptor(
+        "layers.0.experts.w1",
+        global_shape=(8, 8, 8),
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    target_tensor = tensor_descriptor(
+        source_tensor.tensor_id,
+        global_shape=source_tensor.global_shape,
+        shard_dims=(2,),
+    )
+    sources = build_manifests(
+        "source-budget",
+        [
+            (source_tensor, ParallelRank(ep=rank), (rank, 0, 0), (1, 8, 8))
+            for rank in range(8)
+        ],
+        address_base=0x100000000,
+    )
+    targets = build_manifests(
+        "target-budget",
+        [
+            (target_tensor, ParallelRank(tp=rank), (0, 0, rank), (8, 8, 1))
+            for rank in range(8)
+        ],
+        address_base=0x300000000,
+    )
+
+    with pytest.raises(ValueError, match="max_transfer_regions"):
+        plan_placement_transfer(
+            sources.placement,
+            targets.placement,
+            planning_limits=PlanningLimits(max_transfer_regions=63),
+        )

--- a/mooncake-reshard/tests/model_weight_nd_planner/test_pp_ep_cross_dim.py
+++ b/mooncake-reshard/tests/model_weight_nd_planner/test_pp_ep_cross_dim.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard.weight.manifest import ParallelRank, SplitAxis
+from mooncake.reshard.weight.planner import TransferRegion
+
+from .helpers import (
+    assert_plan_copies_logical_contents,
+    build_manifests,
+    ep_tp_placements,
+    plan_transfer,
+    pp_placements,
+    tensor_descriptor,
+)
+
+
+@pytest.mark.parametrize(
+    ("source_owners", "target_owners", "expected_routes"),
+    [
+        (
+            {f"layers.{layer}.weight": layer // 2 for layer in range(4)},
+            {f"layers.{layer}.weight": layer for layer in range(4)},
+            {(0, 0), (0, 1), (1, 2), (1, 3)},
+        ),
+        (
+            {f"layers.{layer}.weight": layer for layer in range(4)},
+            {f"layers.{layer}.weight": layer // 2 for layer in range(4)},
+            {(0, 0), (1, 0), (2, 1), (3, 1)},
+        ),
+    ],
+)
+def test_pp_ownership_routes_are_manifest_derived(
+    source_owners: dict[str, int],
+    target_owners: dict[str, int],
+    expected_routes: set[tuple[int, int]],
+) -> None:
+    tensors = tuple(
+        tensor_descriptor(
+            f"layers.{layer}.weight",
+            global_shape=(8,),
+            shard_dims=(),
+            layer_id=layer,
+        )
+        for layer in range(4)
+    )
+    sources = build_manifests(
+        "source",
+        pp_placements(tensors, source_owners),
+        address_base=0x100000,
+    )
+    targets = build_manifests(
+        "target",
+        pp_placements(tensors, target_owners),
+        address_base=0x200000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert {
+        (route.source_pp, route.target_pp) for route in plan.pipeline_routes
+    } == expected_routes
+    assert sorted(
+        index for route in plan.pipeline_routes for index in route.operation_indices
+    ) == list(range(len(plan.operations)))
+    assert_plan_copies_logical_contents(plan, sources, targets)
+
+
+@pytest.mark.parametrize(("source_ep", "target_ep"), [(8, 2), (2, 8)])
+def test_ep_reshard_uses_leading_expert_coordinate(
+    source_ep: int, target_ep: int
+) -> None:
+    source_tensor = tensor_descriptor(
+        "layers.0.experts.w1",
+        global_shape=(8, 4, 2),
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    target_tensor = tensor_descriptor(
+        source_tensor.tensor_id,
+        global_shape=source_tensor.global_shape,
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    sources = build_manifests(
+        "source",
+        ep_tp_placements(
+            (source_tensor,),
+            dp=1,
+            pp_owner={source_tensor.tensor_id: 0},
+            ep=source_ep,
+            tp=1,
+            tp_dim=1,
+        ),
+        address_base=0x100000,
+    )
+    targets = build_manifests(
+        "target",
+        ep_tp_placements(
+            (target_tensor,),
+            dp=1,
+            pp_owner={target_tensor.tensor_id: 0},
+            ep=target_ep,
+            tp=1,
+            tp_dim=1,
+        ),
+        address_base=0x200000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert all(operation.overlap_shape[0] > 0 for operation in plan.operations)
+    assert {operation.source.rank.ep for operation in plan.operations} == set(
+        range(source_ep)
+    )
+    assert {operation.target.rank.ep for operation in plan.operations} == set(
+        range(target_ep)
+    )
+    assert_plan_copies_logical_contents(plan, sources, targets)
+
+
+@pytest.mark.parametrize("target_dim", [1, 2])
+def test_ep_tp_cross_dim_reshard(target_dim: int) -> None:
+    source_tensor = tensor_descriptor(
+        "layers.0.experts.w1",
+        global_shape=(4, 6, 8),
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    target_tensor = tensor_descriptor(
+        source_tensor.tensor_id,
+        global_shape=source_tensor.global_shape,
+        shard_dims=(target_dim,),
+    )
+    source_placements = []
+    for ep_rank in range(2):
+        source_placements.append(
+            (
+                source_tensor,
+                ParallelRank(ep=ep_rank),
+                (ep_rank * 2, 0, 0),
+                (2, 6, 8),
+            )
+        )
+    target_placements = []
+    for tp_rank in range(2):
+        shape = list(target_tensor.global_shape)
+        offset = [0, 0, 0]
+        shape[target_dim] //= 2
+        offset[target_dim] = tp_rank * shape[target_dim]
+        target_placements.append(
+            (
+                target_tensor,
+                ParallelRank(tp=tp_rank),
+                tuple(offset),
+                tuple(shape),
+            )
+        )
+    sources = build_manifests("source", source_placements, address_base=0x100000)
+    targets = build_manifests("target", target_placements, address_base=0x200000)
+
+    plan = plan_transfer(sources, targets)
+
+    assert len(plan.operations) == 4
+    assert all(isinstance(operation, TransferRegion) for operation in plan.operations)
+    selected = next(
+        operation
+        for operation in plan.operations
+        if operation.source.rank.ep == 0 and operation.target.rank.tp == 1
+    )
+    if target_dim == 1:
+        assert selected.overlap_offset == (0, 3, 0)
+        assert selected.overlap_shape == (2, 3, 8)
+        assert selected.source_base_offset == 48
+        assert selected.target_base_offset == 0
+        assert selected.inner_bytes == 48
+        assert selected.outer_loop_counts == (2,)
+        assert selected.source_strides == (96,)
+        assert selected.target_strides == (48,)
+    else:
+        assert selected.overlap_offset == (0, 0, 4)
+        assert selected.overlap_shape == (2, 6, 4)
+        assert selected.source_base_offset == 8
+        assert selected.target_base_offset == 0
+        assert selected.inner_bytes == 8
+        assert selected.outer_loop_counts == (2, 6)
+        assert selected.source_strides == (96, 16)
+        assert selected.target_strides == (48, 8)
+    assert_plan_copies_logical_contents(plan, sources, targets)

--- a/mooncake-reshard/tests/model_weight_nd_planner/test_tp_serialized_fp8.py
+++ b/mooncake-reshard/tests/model_weight_nd_planner/test_tp_serialized_fp8.py
@@ -1,0 +1,390 @@
+from __future__ import annotations
+
+from itertools import product
+from math import prod
+
+import pytest
+
+from mooncake.reshard.weight.manifest import (
+    OwnershipAxis,
+    ParallelRank,
+    PlacementFragment,
+    RuntimeBindingFragment,
+    TensorDescriptor,
+    SplitAxis,
+)
+
+from .helpers import (
+    MODEL_ID,
+    REVISION,
+    assert_plan_copies_logical_contents,
+    build_manifests,
+    ep_tp_placements,
+    plan_transfer,
+    tensor_descriptor,
+)
+from model_weight_planner.helpers import (
+    RuntimeInputs,
+    _canonical_strides_bytes,
+    runtime_inputs_from_groups,
+)
+
+
+@pytest.mark.parametrize(("source_tp", "target_tp"), [(4, 8), (8, 4)])
+def test_tp_split_and_merge_preserve_logical_bytes(
+    source_tp: int,
+    target_tp: int,
+) -> None:
+    tensor = tensor_descriptor(
+        "layers.0.mlp.down_proj.weight",
+        global_shape=(64, 16),
+        shard_dims=(0,),
+        parallel_axes=(SplitAxis(kind="tp", dim=0),),
+    )
+    owner = {tensor.tensor_id: 0}
+    sources = build_manifests(
+        "source",
+        ep_tp_placements(
+            (tensor,),
+            dp=1,
+            pp_owner=owner,
+            ep=1,
+            tp=source_tp,
+            tp_dim=0,
+        ),
+        address_base=0x100000,
+    )
+    targets = build_manifests(
+        "target",
+        ep_tp_placements(
+            (tensor,),
+            dp=1,
+            pp_owner=owner,
+            ep=1,
+            tp=target_tp,
+            tp_dim=0,
+        ),
+        address_base=0x200000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert plan.total_bytes == prod(tensor.global_shape) * tensor.itemsize
+    assert_plan_copies_logical_contents(plan, sources, targets)
+
+
+def test_serialized_block_fp8_weight_and_scale_reshard_together() -> None:
+    weight = TensorDescriptor(
+        tensor_id="layers.1.mlp.gate_proj.weight",
+        global_shape=(1024, 128),
+        dtype="float8_e4m3fn",
+        itemsize=1,
+        shard_dims=(0,),
+        layer_id=1,
+        expert_id=None,
+        layout_fingerprint=(
+            "sglang:qwen3.5:gate-up:v1|serialized-block-fp8:e4m3fn:128x128:weight:v1"
+        ),
+        parallel_axes=(SplitAxis(kind="tp", dim=0),),
+    )
+    scale = TensorDescriptor(
+        tensor_id="layers.1.mlp.gate_proj.weight_scale_inv",
+        global_shape=(8, 1),
+        dtype="float32",
+        itemsize=4,
+        shard_dims=(0,),
+        layer_id=1,
+        expert_id=None,
+        layout_fingerprint=(
+            "sglang:qwen3.5:gate-up:v1|serialized-block-fp8:"
+            "fp32-inverse-scale:128x128:v1"
+        ),
+        parallel_axes=(SplitAxis(kind="tp", dim=0),),
+    )
+    tensors = (weight, scale)
+    owners = {tensor.tensor_id: 0 for tensor in tensors}
+    sources = build_manifests(
+        "source",
+        ep_tp_placements(
+            tensors,
+            dp=1,
+            pp_owner=owners,
+            ep=1,
+            tp=4,
+            tp_dim=0,
+        ),
+        address_base=0x100000,
+    )
+    targets = build_manifests(
+        "target",
+        ep_tp_placements(
+            tensors,
+            dp=1,
+            pp_owner=owners,
+            ep=1,
+            tp=8,
+            tp_dim=0,
+        ),
+        address_base=0x200000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert {operation.tensor_id for operation in plan.operations} == {
+        weight.tensor_id,
+        scale.tensor_id,
+    }
+    assert plan.total_bytes == sum(
+        fragment.nbytes for manifest in targets for fragment in manifest.fragments
+    )
+    assert_plan_copies_logical_contents(plan, sources, targets)
+
+
+def fused_moe_fp8_manifests(
+    side: str,
+    *,
+    ep: int,
+    tp: int,
+    pp: int,
+    up_first: bool,
+    address_base: int,
+) -> RuntimeInputs:
+    weight_shape = (4, 256, 128)
+    scale_shape = (4, 2, 1)
+    descriptors = {}
+    for component in ("gate_proj", "up_proj"):
+        descriptors[f"{component}.weight"] = TensorDescriptor(
+            tensor_id=f"layers.0.mlp.experts.{component}.weight",
+            global_shape=weight_shape,
+            dtype="float8_e4m3fn",
+            itemsize=1,
+            layer_id=0,
+            layout_fingerprint=(
+                "sglang:qwen3.5:moe-w13:v1|serialized-block-fp8:"
+                "e4m3fn:128x128:weight:v1"
+            ),
+            shard_dims=(0, 1),
+            parallel_axes=(
+                OwnershipAxis(kind="pp"),
+                SplitAxis(kind="ep", dim=0),
+                SplitAxis(kind="tp", dim=1),
+            ),
+        )
+        descriptors[f"{component}.scale"] = TensorDescriptor(
+            tensor_id=f"layers.0.mlp.experts.{component}.weight_scale_inv",
+            global_shape=scale_shape,
+            dtype="float32",
+            itemsize=4,
+            layer_id=0,
+            layout_fingerprint=(
+                "sglang:qwen3.5:moe-w13:v1|serialized-block-fp8:"
+                "fp32-inverse-scale:128x128:v1"
+            ),
+            shard_dims=(0, 1),
+            parallel_axes=(
+                OwnershipAxis(kind="pp"),
+                SplitAxis(kind="ep", dim=0),
+                SplitAxis(kind="tp", dim=1),
+            ),
+        )
+
+    local_experts = weight_shape[0] // ep
+    local_intermediate = weight_shape[1] // tp
+    local_scale_intermediate = scale_shape[1] // tp
+    component_order = (
+        ("up_proj", "gate_proj")
+        if up_first
+        else (
+            "gate_proj",
+            "up_proj",
+        )
+    )
+    groups = []
+    for ep_rank, tp_rank in product(range(ep), range(tp)):
+        rank = ParallelRank(pp=pp, ep=ep_rank, tp=tp_rank)
+        worker_id = f"{side}-p{pp}-e{ep_rank}-t{tp_rank}"
+        rank_index = ep_rank * tp + tp_rank
+        weight_base = address_base + rank_index * 0x1000000
+        scale_base = weight_base + 0x800000
+        weight_component_bytes = local_intermediate * weight_shape[2]
+        scale_component_bytes = local_scale_intermediate * scale_shape[2] * 4
+        placement_fragments = []
+        binding_fragments = []
+        for local_expert in range(local_experts):
+            expert_id = ep_rank * local_experts + local_expert
+            for component_index, component in enumerate(component_order):
+                weight = descriptors[f"{component}.weight"]
+                scale = descriptors[f"{component}.scale"]
+                physical_component = (
+                    local_expert * len(component_order) + component_index
+                )
+                weight_fragment_id = f"{worker_id}-expert{expert_id}-{component}-weight"
+                scale_fragment_id = f"{worker_id}-expert{expert_id}-{component}-scale"
+                placement_fragments.extend(
+                    (
+                        PlacementFragment(
+                            placement_fragment_id=f"{weight_fragment_id}-placement",
+                            tensor_id=weight.tensor_id,
+                            global_offset=(
+                                expert_id,
+                                tp_rank * local_intermediate,
+                                0,
+                            ),
+                            local_shape=(1, local_intermediate, weight_shape[2]),
+                            nbytes=weight_component_bytes,
+                            rank=rank,
+                        ),
+                        PlacementFragment(
+                            placement_fragment_id=f"{scale_fragment_id}-placement",
+                            tensor_id=scale.tensor_id,
+                            global_offset=(
+                                expert_id,
+                                tp_rank * local_scale_intermediate,
+                                0,
+                            ),
+                            local_shape=(
+                                1,
+                                local_scale_intermediate,
+                                scale_shape[2],
+                            ),
+                            nbytes=scale_component_bytes,
+                            rank=rank,
+                        ),
+                    )
+                )
+                binding_fragments.extend(
+                    (
+                        RuntimeBindingFragment(
+                            placement_fragment_id=f"{weight_fragment_id}-placement",
+                            fragment_id=weight_fragment_id,
+                            address=(
+                                weight_base
+                                + physical_component * weight_component_bytes
+                            ),
+                            nbytes=weight_component_bytes,
+                            worker_id=worker_id,
+                            endpoint=f"{worker_id}:12345",
+                            device="cuda:0",
+                            itemsize=weight.itemsize,
+                            local_shape=(
+                                1,
+                                local_intermediate,
+                                weight_shape[2],
+                            ),
+                            strides_bytes=_canonical_strides_bytes(
+                                (1, local_intermediate, weight_shape[2]),
+                                weight.itemsize,
+                            ),
+                            storage_address=(
+                                weight_base
+                                + physical_component * weight_component_bytes
+                            ),
+                            storage_nbytes=weight_component_bytes,
+                            storage_offset_bytes=0,
+                        ),
+                        RuntimeBindingFragment(
+                            placement_fragment_id=f"{scale_fragment_id}-placement",
+                            fragment_id=scale_fragment_id,
+                            address=(
+                                scale_base + physical_component * scale_component_bytes
+                            ),
+                            nbytes=scale_component_bytes,
+                            worker_id=worker_id,
+                            endpoint=f"{worker_id}:12345",
+                            device="cuda:0",
+                            itemsize=scale.itemsize,
+                            local_shape=(
+                                1,
+                                local_scale_intermediate,
+                                scale_shape[2],
+                            ),
+                            strides_bytes=_canonical_strides_bytes(
+                                (1, local_scale_intermediate, scale_shape[2]),
+                                scale.itemsize,
+                            ),
+                            storage_address=(
+                                scale_base + physical_component * scale_component_bytes
+                            ),
+                            storage_nbytes=scale_component_bytes,
+                            storage_offset_bytes=0,
+                        ),
+                    )
+                )
+        groups.append((worker_id, tuple(placement_fragments), tuple(binding_fragments)))
+    return runtime_inputs_from_groups(
+        resource_id=MODEL_ID,
+        revision=REVISION,
+        placement_set_id=side,
+        tensors=tuple(descriptors.values()),
+        groups=groups,
+    )
+
+
+def test_fp8_w31_to_w13_reshard_preserves_component_identity_and_bytes() -> None:
+    sources = fused_moe_fp8_manifests(
+        "source",
+        ep=2,
+        tp=2,
+        pp=0,
+        up_first=True,
+        address_base=0x10000000,
+    )
+    targets = fused_moe_fp8_manifests(
+        "target",
+        ep=4,
+        tp=1,
+        pp=1,
+        up_first=False,
+        address_base=0x40000000,
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    source_fragments = {
+        fragment.fragment_id: fragment
+        for binding in sources.bindings
+        for fragment in binding.fragments
+    }
+    target_fragments = {
+        fragment.fragment_id: fragment
+        for binding in targets.bindings
+        for fragment in binding.fragments
+    }
+    assert (
+        source_fragments["source-p0-e0-t0-expert0-up_proj-weight"].address
+        < source_fragments["source-p0-e0-t0-expert0-gate_proj-weight"].address
+    )
+    assert (
+        target_fragments["target-p1-e0-t0-expert0-gate_proj-weight"].address
+        < target_fragments["target-p1-e0-t0-expert0-up_proj-weight"].address
+    )
+    assert (
+        source_fragments["source-p0-e0-t0-expert0-up_proj-scale"].address
+        < source_fragments["source-p0-e0-t0-expert0-gate_proj-scale"].address
+    )
+    assert (
+        target_fragments["target-p1-e0-t0-expert0-gate_proj-scale"].address
+        < target_fragments["target-p1-e0-t0-expert0-up_proj-scale"].address
+    )
+    assert {operation.tensor_id for operation in plan.operations} == {
+        "layers.0.mlp.experts.gate_proj.weight",
+        "layers.0.mlp.experts.gate_proj.weight_scale_inv",
+        "layers.0.mlp.experts.up_proj.weight",
+        "layers.0.mlp.experts.up_proj.weight_scale_inv",
+    }
+    assert {(route.source_pp, route.target_pp) for route in plan.pipeline_routes} == {
+        (0, 1)
+    }
+    assert plan.total_bytes == sum(
+        fragment.nbytes for manifest in targets for fragment in manifest.fragments
+    )
+    assert len(plan.operations) == 32
+    assert (
+        sum(
+            1
+            for operation in plan.operations
+            for _ in operation.iter_segments(max_segments=operation.segment_count)
+        )
+        == 32
+    )
+    assert_plan_copies_logical_contents(plan, sources, targets)

--- a/mooncake-reshard/tests/model_weight_placement_binding/test_global_planner_api.py
+++ b/mooncake-reshard/tests/model_weight_placement_binding/test_global_planner_api.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight import (
+    ParallelRank,
+    ParallelTopology,
+    PlacementFragment,
+    TensorDescriptor,
+    SplitAxis,
+    TopologyParticipant,
+    WeightPlacementManifest,
+    WeightPlacementPart,
+    plan_placement_transfer,
+    plan_stored_transfer_to_target_placement,
+)
+from mooncake.reshard.weight.storage_manifest import StoredFragment, WeightManifest
+
+
+def _placement(
+    tp_size: int,
+    placement_set_id: str,
+    *,
+    canonical_fragment_ids: bool = False,
+) -> WeightPlacementManifest:
+    participants = tuple(
+        TopologyParticipant(f"{placement_set_id}-worker-{rank}", ParallelRank(tp=rank))
+        for rank in range(tp_size)
+    )
+    topology = ParallelTopology(
+        tp_size=tp_size,
+        pp_size=1,
+        ep_size=1,
+        dp_size=1,
+        participants=participants,
+    )
+    tensor = TensorDescriptor(
+        tensor_id="layers.0.weight",
+        global_shape=(8,),
+        dtype="uint8",
+        itemsize=1,
+        shard_dims=(0,),
+        layout_fingerprint="global-planner:uint8:v1",
+        parallel_axes=(SplitAxis(kind="tp", dim=0),),
+    )
+    extent = 8 // tp_size
+    parts = tuple(
+        WeightPlacementPart(
+            resource_id="model",
+            revision="revision",
+            weight_generation=9,
+            placement_set_id=placement_set_id,
+            topology_id=topology.topology_id,
+            participant_id=participant.participant_id,
+            rank=participant.rank,
+            tensors=(tensor,),
+            fragments=(
+                PlacementFragment(
+                    placement_fragment_id=(
+                        None
+                        if canonical_fragment_ids
+                        else f"{placement_set_id}-fragment-{participant.rank.tp}"
+                    ),
+                    tensor_id=tensor.tensor_id,
+                    global_offset=(participant.rank.tp * extent,),
+                    local_shape=(extent,),
+                    nbytes=extent,
+                    rank=participant.rank,
+                ),
+            ),
+        )
+        for participant in participants
+    )
+    return WeightPlacementManifest(
+        resource_id="model",
+        revision="revision",
+        weight_generation=9,
+        placement_set_id=placement_set_id,
+        topology=topology,
+        parts=parts,
+    )
+
+
+def test_planner_accepts_one_complete_source_and_target_manifest() -> None:
+    source = _placement(4, "source")
+    target = _placement(8, "target")
+
+    plan = plan_placement_transfer(source, target)
+
+    assert len(plan.operations) == 8
+    assert {item.placement_id for item in plan.source_executors} == {
+        source.placement_id
+    }
+    assert {item.placement_id for item in plan.target_executors} == {
+        target.placement_id
+    }
+
+
+def test_planner_accepts_canonical_fragment_ids_generated_by_manifest() -> None:
+    source = _placement(4, "source", canonical_fragment_ids=True)
+    target = _placement(8, "target", canonical_fragment_ids=True)
+
+    plan = plan_placement_transfer(source, target)
+
+    assert len(plan.operations) == 8
+    assert all(
+        fragment.placement_fragment_id.startswith("sha256:")
+        for fragment in source.fragments + target.fragments
+    )
+
+
+def test_logical_plan_rejects_forged_placement_source_provenance() -> None:
+    source = _placement(2, "source")
+    target = _placement(1, "target")
+    plan = plan_placement_transfer(source, target)
+
+    forged_source = replace(plan.operations[0].source, rank=ParallelRank(pp=99))
+    forged_operation = replace(plan.operations[0], source=forged_source)
+
+    with pytest.raises(
+        ValueError,
+        match="source placement fragment snapshots differ",
+    ):
+        replace(plan, operations=(forged_operation, *plan.operations[1:]))
+
+    with pytest.raises(ValueError, match="no source executor metadata"):
+        replace(plan, source_executors=())
+
+    with pytest.raises(ValueError, match="source tensor catalog differs"):
+        replace(plan, source_tensors=())
+
+    with pytest.raises(ValueError, match="target tensor catalog differs"):
+        replace(plan, target_tensors=())
+
+
+def _stored_source(tensor: TensorDescriptor) -> WeightManifest:
+    group_id = "weights/default/model/revision/9"
+    return WeightManifest(
+        namespace="default",
+        resource_id="model",
+        revision="revision",
+        weight_generation=9,
+        group_id=group_id,
+        manifest_key=f"{group_id}/manifest",
+        created_at="2026-08-19T00:00:00Z",
+        tensors=(tensor,),
+        fragments=(
+            StoredFragment(
+                fragment_id="store-source-full",
+                tensor_id=tensor.tensor_id,
+                global_offset=(0,),
+                local_shape=tensor.global_shape,
+                object_key=f"{group_id}/payload/0",
+                object_offset=0,
+                nbytes=8,
+            ),
+        ),
+    )
+
+
+def _two_tensor_placement(placement_set_id: str) -> WeightPlacementManifest:
+    participant = TopologyParticipant(f"{placement_set_id}-worker-0", ParallelRank())
+    topology = ParallelTopology(
+        tp_size=1,
+        pp_size=1,
+        ep_size=1,
+        dp_size=1,
+        participants=(participant,),
+    )
+    tensors = tuple(
+        TensorDescriptor(
+            tensor_id=tensor_id,
+            global_shape=(8,),
+            dtype="uint8",
+            itemsize=1,
+            shard_dims=(0,),
+            layout_fingerprint="global-planner:uint8:v1",
+            parallel_axes=(SplitAxis(kind="tp", dim=0),),
+        )
+        for tensor_id in ("layers.a.weight", "layers.b.weight")
+    )
+    return WeightPlacementManifest(
+        resource_id="model",
+        revision="revision",
+        weight_generation=9,
+        placement_set_id=placement_set_id,
+        topology=topology,
+        parts=(
+            WeightPlacementPart(
+                resource_id="model",
+                revision="revision",
+                weight_generation=9,
+                placement_set_id=placement_set_id,
+                topology_id=topology.topology_id,
+                participant_id=participant.participant_id,
+                rank=participant.rank,
+                tensors=tensors,
+                fragments=tuple(
+                    PlacementFragment(
+                        placement_fragment_id=f"{placement_set_id}-{tensor.tensor_id}",
+                        tensor_id=tensor.tensor_id,
+                        global_offset=(0,),
+                        local_shape=tensor.global_shape,
+                        nbytes=8,
+                        rank=participant.rank,
+                    )
+                    for tensor in tensors
+                ),
+            ),
+        ),
+    )
+
+
+def test_store_backed_planner_attests_selected_source_fragments() -> None:
+    target = _placement(8, "target")
+    source = _stored_source(target.tensors[0])
+
+    plan = plan_stored_transfer_to_target_placement(source, target)
+
+    assert len(plan.operations) == 8
+    assert plan.source_manifest == source
+    assert plan.source_manifest_identity == source.manifest_identity
+    assert {operation.source for operation in plan.operations} == {source.fragments[0]}
+
+    forged_fragment = replace(
+        source.fragments[0],
+        object_key="another-tenant/private-object",
+    )
+    forged_operation = replace(plan.operations[0], source=forged_fragment)
+    with pytest.raises(
+        ValueError,
+        match="source manifest fragment snapshots differ",
+    ):
+        replace(plan, operations=(forged_operation, *plan.operations[1:]))
+
+    with pytest.raises(ValueError, match="weight_generation differ"):
+        plan_stored_transfer_to_target_placement(
+            replace(source, weight_generation=10),
+            target,
+        )
+
+
+def test_store_backed_planner_accepts_reordered_tensor_catalog() -> None:
+    target = _two_tensor_placement("target")
+    tensors = target.tensors
+    group_id = "weights/default/model/revision/9"
+    source = WeightManifest(
+        namespace="default",
+        resource_id="model",
+        revision="revision",
+        weight_generation=9,
+        group_id=group_id,
+        manifest_key=f"{group_id}/manifest",
+        created_at="2026-08-20T00:00:00Z",
+        tensors=(tensors[1], tensors[0]),
+        fragments=tuple(
+            StoredFragment(
+                fragment_id=f"store-{tensor.tensor_id}",
+                tensor_id=tensor.tensor_id,
+                global_offset=(0,),
+                local_shape=tensor.global_shape,
+                object_key=f"{group_id}/payload/{index}",
+                object_offset=0,
+                nbytes=8,
+            )
+            for index, tensor in enumerate((tensors[1], tensors[0]))
+        ),
+    )
+
+    plan = plan_stored_transfer_to_target_placement(source, target)
+
+    assert plan.source_manifest == source
+    assert plan.source_tensors == target.tensors
+    assert len(plan.operations) == 2

--- a/mooncake-reshard/tests/model_weight_planner/__init__.py
+++ b/mooncake-reshard/tests/model_weight_planner/__init__.py
@@ -1,0 +1,1 @@
+"""Model-weight planner tests organized by responsibility."""

--- a/mooncake-reshard/tests/model_weight_planner/helpers.py
+++ b/mooncake-reshard/tests/model_weight_planner/helpers.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, replace
+from itertools import product
+from math import prod
+
+from mooncake.reshard.weight import (
+    OwnershipAxis,
+    ParallelRank,
+    ParallelTopology,
+    PlacementFragment,
+    ReplicatedAxis,
+    RuntimeBindingFragment,
+    SplitAxis,
+    TensorDescriptor,
+    TopologyParticipant,
+    WeightPlacementManifest,
+    WeightPlacementPart,
+    WeightRuntimeBindingManifest,
+    plan_placement_transfer,
+    plan_placement_transfer_to_local_target,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeInputs(Sequence[WeightPlacementPart]):
+    """One complete placement plus its per-participant runtime bindings."""
+
+    placement: WeightPlacementManifest
+    bindings: tuple[WeightRuntimeBindingManifest, ...]
+
+    def __len__(self) -> int:
+        return len(self.nonempty_parts)
+
+    def __iter__(self) -> Iterator[WeightPlacementPart]:
+        return iter(self.nonempty_parts)
+
+    def __getitem__(self, index):
+        return self.nonempty_parts[index]
+
+    @property
+    def nonempty_parts(self) -> tuple[WeightPlacementPart, ...]:
+        return tuple(part for part in self.placement.parts if part.fragments)
+
+    @property
+    def fragments(self) -> tuple[PlacementFragment, ...]:
+        return self.placement.fragments
+
+    @property
+    def binding(self) -> WeightRuntimeBindingManifest:
+        if len(self.bindings) != 1:
+            raise ValueError("runtime inputs do not identify one binding")
+        return self.bindings[0]
+
+
+def _canonical_strides_bytes(shape: tuple[int, ...], itemsize: int) -> tuple[int, ...]:
+    strides = []
+    running = itemsize
+    for extent in reversed(shape):
+        strides.append(running)
+        running *= extent
+    return tuple(reversed(strides))
+
+
+def topology_for_participants(
+    participants: Sequence[tuple[str, ParallelRank]],
+) -> ParallelTopology:
+    """Build a complete topology while keeping fixture-only participants minimal."""
+
+    if not participants:
+        raise ValueError("test topology requires at least one participant")
+    participant_by_rank: dict[ParallelRank, str] = {}
+    for participant_id, rank in participants:
+        participant_by_rank.setdefault(rank, participant_id)
+
+    sizes = {
+        axis: max(getattr(rank, axis) for rank in participant_by_rank) + 1
+        for axis in ("tp", "pp", "ep", "dp")
+    }
+    observed = {
+        axis: {getattr(rank, axis) for rank in participant_by_rank} for axis in sizes
+    }
+    missing = {
+        axis: sorted(set(range(size)) - observed[axis]) for axis, size in sizes.items()
+    }
+    placeholder_count = max((len(values) for values in missing.values()), default=0)
+    defaults = {axis: min(observed[axis]) for axis in sizes}
+    for index in range(placeholder_count):
+        coordinates = {
+            axis: values[index] if index < len(values) else defaults[axis]
+            for axis, values in missing.items()
+        }
+        rank = ParallelRank(**coordinates)
+        participant_by_rank.setdefault(
+            rank,
+            f"fixture-empty-d{rank.dp}-t{rank.tp}-p{rank.pp}-e{rank.ep}",
+        )
+
+    return ParallelTopology(
+        tp_size=sizes["tp"],
+        pp_size=sizes["pp"],
+        ep_size=sizes["ep"],
+        dp_size=sizes["dp"],
+        participants=tuple(
+            TopologyParticipant(participant_id, rank)
+            for rank, participant_id in sorted(
+                participant_by_rank.items(),
+                key=lambda item: (
+                    item[0].dp,
+                    item[0].pp,
+                    item[0].ep,
+                    item[0].tp,
+                ),
+            )
+        ),
+    )
+
+
+def global_placement_from_fragments(
+    *,
+    resource_id: str,
+    revision: str,
+    placement_set_id: str,
+    tensors: Sequence[TensorDescriptor],
+    fragments: Sequence[PlacementFragment],
+    participant_ids: dict[ParallelRank, str] | None = None,
+    weight_generation: int = 1,
+) -> WeightPlacementManifest:
+    fragment_items = tuple(fragments)
+    participant_ids = participant_ids or {
+        rank: (f"{placement_set_id}-d{rank.dp}-t{rank.tp}-p{rank.pp}-e{rank.ep}")
+        for rank in {fragment.rank for fragment in fragment_items}
+    }
+    topology = topology_for_participants(
+        tuple(
+            (participant_id, rank) for rank, participant_id in participant_ids.items()
+        )
+    )
+    return WeightPlacementManifest.from_fragments(
+        resource_id=resource_id,
+        revision=revision,
+        weight_generation=weight_generation,
+        placement_set_id=placement_set_id,
+        topology=topology,
+        tensors=tuple(tensors),
+        fragments=fragment_items,
+    )
+
+
+def rebuild_placement(
+    placement: WeightPlacementManifest,
+    *,
+    tensors: Sequence[TensorDescriptor] | None = None,
+    fragments: Sequence[PlacementFragment] | None = None,
+) -> WeightPlacementManifest:
+    """Re-run the global collection barrier with selected logical content."""
+
+    return WeightPlacementManifest.from_fragments(
+        resource_id=placement.resource_id,
+        revision=placement.revision,
+        weight_generation=placement.weight_generation,
+        placement_set_id=placement.placement_set_id,
+        topology=placement.topology,
+        tensors=tuple(tensors if tensors is not None else placement.tensors),
+        fragments=tuple(fragments if fragments is not None else placement.fragments),
+    )
+
+
+def runtime_inputs_from_groups(
+    *,
+    resource_id: str,
+    revision: str,
+    placement_set_id: str,
+    tensors: Sequence[TensorDescriptor],
+    groups: Sequence[
+        tuple[
+            str,
+            Sequence[PlacementFragment],
+            Sequence[RuntimeBindingFragment],
+        ]
+    ],
+    weight_generation: int = 1,
+) -> RuntimeInputs:
+    """Aggregate participant parts, then bind each non-empty participant."""
+
+    grouped: dict[
+        ParallelRank,
+        tuple[str, list[PlacementFragment], list[RuntimeBindingFragment]],
+    ] = {}
+    for participant_id, placement_fragments, binding_fragments in groups:
+        placement_items = tuple(placement_fragments)
+        if not placement_items:
+            raise ValueError("runtime fixture participant must contain fragments")
+        ranks = {fragment.rank for fragment in placement_items}
+        if len(ranks) != 1:
+            raise ValueError("runtime fixture participant spans parallel ranks")
+        rank = next(iter(ranks))
+        if rank not in grouped:
+            grouped[rank] = (participant_id, [], [])
+        _, grouped_placements, grouped_bindings = grouped[rank]
+        grouped_placements.extend(placement_items)
+        grouped_bindings.extend(binding_fragments)
+
+    participant_ids = {
+        rank: participant_id for rank, (participant_id, _, _) in grouped.items()
+    }
+    placement = global_placement_from_fragments(
+        resource_id=resource_id,
+        revision=revision,
+        weight_generation=weight_generation,
+        placement_set_id=placement_set_id,
+        tensors=tensors,
+        fragments=tuple(
+            fragment
+            for _, placement_fragments, _ in grouped.values()
+            for fragment in placement_fragments
+        ),
+        participant_ids=participant_ids,
+    )
+    bindings = tuple(
+        WeightRuntimeBindingManifest(
+            resource_id=resource_id,
+            revision=revision,
+            placement_id=placement.placement_id,
+            placement_digest=placement.digest,
+            instance_id=participant_id,
+            participant_id=participant_id,
+            generation=1,
+            lease_id=f"{participant_id}-lease",
+            fragments=tuple(binding_fragments),
+        )
+        for participant_id, _, binding_fragments in grouped.values()
+    )
+    return RuntimeInputs(placement, bindings)
+
+
+def descriptor(
+    *,
+    global_shape: tuple[int, ...] = (8, 4),
+    shard_dim: int = 0,
+    fingerprint: str = "sglang:qwen3.5:bf16:v1",
+) -> TensorDescriptor:
+    return TensorDescriptor(
+        tensor_id="layers.2.experts.3.w1",
+        global_shape=global_shape,
+        dtype="bfloat16",
+        itemsize=2,
+        shard_dims=(shard_dim,),
+        layer_id=2,
+        expert_id=3,
+        layout_fingerprint=fingerprint,
+        parallel_axes=(
+            ReplicatedAxis(kind="dp"),
+            OwnershipAxis(kind="pp"),
+            OwnershipAxis(kind="ep"),
+            SplitAxis(kind="tp", dim=shard_dim),
+        ),
+    )
+
+
+def tp_manifests(
+    *,
+    tp: int,
+    dp: int = 1,
+    pp_rank: int,
+    ep_rank: int,
+    address_base: int,
+    worker_prefix: str,
+    tensor: TensorDescriptor | None = None,
+) -> RuntimeInputs:
+    tensor = tensor or descriptor()
+    (dim,) = tensor.shard_dims
+    assert tensor.global_shape[dim] % tp == 0
+    extent = tensor.global_shape[dim] // tp
+    groups = []
+    for dp_rank, tp_rank in product(range(dp), range(tp)):
+        local_shape = list(tensor.global_shape)
+        local_shape[dim] = extent
+        global_offset = [0] * len(tensor.global_shape)
+        global_offset[dim] = tp_rank * extent
+        worker_id = f"{worker_prefix}-d{dp_rank}-t{tp_rank}"
+        placement_fragment_id = f"{worker_id}-placement"
+        nbytes = prod(local_shape) * tensor.itemsize
+        placement_fragment = PlacementFragment(
+            placement_fragment_id=placement_fragment_id,
+            tensor_id=tensor.tensor_id,
+            global_offset=tuple(global_offset),
+            local_shape=tuple(local_shape),
+            nbytes=nbytes,
+            rank=ParallelRank(
+                dp=dp_rank,
+                tp=tp_rank,
+                pp=pp_rank,
+                ep=ep_rank,
+            ),
+        )
+        groups.append(
+            (
+                worker_id,
+                (placement_fragment,),
+                (
+                    RuntimeBindingFragment(
+                        placement_fragment_id=placement_fragment_id,
+                        fragment_id=f"{worker_id}-fragment",
+                        address=address_base + (dp_rank * tp + tp_rank) * 0x1000,
+                        nbytes=nbytes,
+                        worker_id=worker_id,
+                        endpoint=f"{worker_id}:12345",
+                        device="cuda:0",
+                        itemsize=tensor.itemsize,
+                        local_shape=tuple(local_shape),
+                        strides_bytes=_canonical_strides_bytes(
+                            tuple(local_shape), tensor.itemsize
+                        ),
+                        storage_address=(
+                            address_base + (dp_rank * tp + tp_rank) * 0x1000
+                        ),
+                        storage_nbytes=nbytes,
+                        storage_offset_bytes=0,
+                    ),
+                ),
+            )
+        )
+    return runtime_inputs_from_groups(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id=worker_prefix,
+        tensors=(tensor,),
+        groups=groups,
+    )
+
+
+def plan_transfer(source: RuntimeInputs, target: RuntimeInputs):
+    return plan_placement_transfer(source.placement, target.placement)
+
+
+def plan_transfer_to_local_target(
+    source: RuntimeInputs,
+    target: RuntimeInputs,
+    *,
+    target_index: int = 0,
+):
+    target_binding = target.bindings[target_index]
+    return plan_placement_transfer_to_local_target(
+        source.placement,
+        target.placement,
+        target_binding.participant_id,
+    )
+
+
+def combine_runtime_inputs(*inputs: RuntimeInputs) -> RuntimeInputs:
+    if not inputs:
+        raise ValueError("runtime input collection must not be empty")
+    first = inputs[0].placement
+    groups = []
+    tensors: dict[str, TensorDescriptor] = {}
+    for item in inputs:
+        placement = item.placement
+        if (
+            placement.resource_id != first.resource_id
+            or placement.revision != first.revision
+            or placement.weight_generation != first.weight_generation
+        ):
+            raise ValueError("runtime input identities differ")
+        tensors.update({tensor.tensor_id: tensor for tensor in placement.tensors})
+        parts = {part.participant_id: part for part in placement.parts}
+        groups.extend(
+            (
+                binding.participant_id,
+                parts[binding.participant_id].fragments,
+                binding.fragments,
+            )
+            for binding in item.bindings
+        )
+    return runtime_inputs_from_groups(
+        resource_id=first.resource_id,
+        revision=first.revision,
+        weight_generation=first.weight_generation,
+        placement_set_id=f"combined-{first.placement_set_id}",
+        tensors=tuple(tensors.values()),
+        groups=groups,
+    )
+
+
+def replace_placement_fragment(
+    inputs: RuntimeInputs,
+    index: int,
+    fragment: PlacementFragment,
+) -> RuntimeInputs:
+    current_fragment = inputs.fragments[index]
+    parts = {part.participant_id: part for part in inputs.placement.parts}
+    groups = []
+    for binding in inputs.bindings:
+        placement_fragments = tuple(
+            fragment if item == current_fragment else item
+            for item in parts[binding.participant_id].fragments
+        )
+        groups.append((binding.participant_id, placement_fragments, binding.fragments))
+    return runtime_inputs_from_groups(
+        resource_id=inputs.placement.resource_id,
+        revision=inputs.placement.revision,
+        weight_generation=inputs.placement.weight_generation,
+        placement_set_id=inputs.placement.placement_set_id,
+        tensors=inputs.placement.tensors,
+        groups=groups,
+    )
+
+
+def operation_for_target(plan, tp_rank: int, dp_rank: int = 0):
+    return [
+        operation
+        for operation in plan.operations
+        if operation.target.rank.tp == tp_rank and operation.target.rank.dp == dp_rank
+    ]
+
+
+def distribute_tp_shards_across_ep_ranks(manifests: RuntimeInputs) -> RuntimeInputs:
+    parts = {part.participant_id: part for part in manifests.placement.parts}
+    groups = []
+    for binding in manifests.bindings:
+        fragments = tuple(
+            replace(
+                fragment,
+                rank=replace(fragment.rank, ep=fragment.rank.tp),
+            )
+            for fragment in parts[binding.participant_id].fragments
+        )
+        groups.append((binding.participant_id, fragments, binding.fragments))
+    return runtime_inputs_from_groups(
+        resource_id=manifests.placement.resource_id,
+        revision=manifests.placement.revision,
+        weight_generation=manifests.placement.weight_generation,
+        placement_set_id=manifests.placement.placement_set_id,
+        tensors=manifests.placement.tensors,
+        groups=groups,
+    )
+
+
+class CountingFragment:
+    def __init__(self, fragment: PlacementFragment, accesses: list[int]) -> None:
+        self._fragment = fragment
+        self._accesses = accesses
+
+    @property
+    def tensor_id(self) -> str:
+        self._accesses[0] += 1
+        return self._fragment.tensor_id
+
+    def __getattr__(self, name: str):
+        return getattr(self._fragment, name)

--- a/mooncake-reshard/tests/model_weight_planner/test_candidate_index.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_candidate_index.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+import mooncake.reshard.weight._planner.geometry as geometry_module
+from mooncake.reshard.weight._planner.api import plan_placement_transfer_to_local_target
+from mooncake.reshard.weight.manifest import (
+    ParallelRank,
+    PlacementFragment,
+    SplitAxis,
+)
+
+from .helpers import descriptor, global_placement_from_fragments
+
+
+def test_expert_box_index_avoids_scanning_every_source_expert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    expert_count = 256
+    tensor = replace(
+        descriptor(),
+        tensor_id="layers.2.experts.w1",
+        global_shape=(expert_count, 4, 4),
+        shard_dims=(0,),
+        expert_id=None,
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    source_fragments = tuple(
+        PlacementFragment(
+            placement_fragment_id=f"source-e{expert_id}-placement",
+            tensor_id=tensor.tensor_id,
+            global_offset=(expert_id, 0, 0),
+            local_shape=(1, 4, 4),
+            nbytes=32,
+            rank=ParallelRank(ep=expert_id),
+        )
+        for expert_id in range(expert_count)
+    )
+    sources = global_placement_from_fragments(
+        resource_id="qwen-moe",
+        revision="step-42",
+        placement_set_id="source",
+        tensors=(tensor,),
+        fragments=source_fragments,
+    )
+    target_expert = 127
+    target_fragments = tuple(
+        PlacementFragment(
+            placement_fragment_id=f"target-e{expert_id}-placement",
+            tensor_id=tensor.tensor_id,
+            global_offset=(expert_id, 0, 0),
+            local_shape=(1, 4, 4),
+            nbytes=32,
+            rank=ParallelRank(ep=expert_id),
+        )
+        for expert_id in range(expert_count)
+    )
+    target = global_placement_from_fragments(
+        resource_id="qwen-moe",
+        revision="step-42",
+        placement_set_id="target",
+        tensors=(tensor,),
+        fragments=target_fragments,
+    )
+    overlap_calls = 0
+    original_overlap_box = geometry_module._overlap_box
+
+    def counted_overlap_box(source, target):
+        nonlocal overlap_calls
+        overlap_calls += 1
+        return original_overlap_box(source, target)
+
+    monkeypatch.setattr(geometry_module, "_overlap_box", counted_overlap_box)
+
+    plan = plan_placement_transfer_to_local_target(
+        sources,
+        target,
+        f"target-d0-t0-p0-e{target_expert}",
+    )
+
+    assert len(plan.operations) == 1
+    assert plan.operations[0].source.global_offset == (target_expert, 0, 0)
+    assert overlap_calls <= 4

--- a/mooncake-reshard/tests/model_weight_planner/test_contracts_geometry.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_contracts_geometry.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from math import prod
+
+import pytest
+
+import mooncake.reshard.weight._planner.contracts as planner_contracts
+from mooncake.reshard.weight._planner.contracts import TransferRegion
+from mooncake.reshard.weight.manifest import ParallelRank, PlacementFragment
+
+
+def test_canonical_contract_exposes_only_n_dim_transfer_regions() -> None:
+    assert not hasattr(planner_contracts, "CopyRange")
+
+
+def n_dim_fragment(
+    *,
+    fragment_id: str,
+    global_offset: tuple[int, ...],
+    local_shape: tuple[int, ...],
+) -> PlacementFragment:
+    return PlacementFragment(
+        placement_fragment_id=fragment_id,
+        tensor_id="layers.2.experts.w1",
+        global_offset=global_offset,
+        local_shape=local_shape,
+        nbytes=2 * prod(local_shape),
+        rank=ParallelRank(),
+    )
+
+
+@pytest.mark.parametrize(
+    (
+        "target_offset",
+        "target_shape",
+        "overlap_offset",
+        "overlap_shape",
+        "source_base_offset",
+        "target_base_offset",
+        "outer_loop_counts",
+        "source_strides",
+        "target_strides",
+        "inner_bytes",
+    ),
+    [
+        (
+            (0, 2, 0),
+            (4, 3, 8),
+            (1, 2, 0),
+            (2, 3, 8),
+            32,
+            48,
+            (2,),
+            (96,),
+            (48,),
+            48,
+        ),
+        (
+            (0, 0, 4),
+            (4, 6, 4),
+            (1, 0, 4),
+            (2, 6, 4),
+            8,
+            48,
+            (2, 6),
+            (96, 16),
+            (48, 8),
+            8,
+        ),
+    ],
+)
+def test_transfer_region_describes_cross_dim_logical_overlap(
+    target_offset: tuple[int, ...],
+    target_shape: tuple[int, ...],
+    overlap_offset: tuple[int, ...],
+    overlap_shape: tuple[int, ...],
+    source_base_offset: int,
+    target_base_offset: int,
+    outer_loop_counts: tuple[int, ...],
+    source_strides: tuple[int, ...],
+    target_strides: tuple[int, ...],
+    inner_bytes: int,
+) -> None:
+    source = n_dim_fragment(
+        fragment_id="source",
+        global_offset=(1, 0, 0),
+        local_shape=(2, 6, 8),
+    )
+    target = n_dim_fragment(
+        fragment_id="target",
+        global_offset=target_offset,
+        local_shape=target_shape,
+    )
+
+    region = TransferRegion(
+        tensor_id=source.tensor_id,
+        source=source,
+        target=target,
+        overlap_offset=overlap_offset,
+        overlap_shape=overlap_shape,
+        source_base_offset=source_base_offset,
+        target_base_offset=target_base_offset,
+        inner_bytes=inner_bytes,
+        outer_loop_counts=outer_loop_counts,
+        source_strides=source_strides,
+        target_strides=target_strides,
+    )
+
+    assert region.overlap_offset == overlap_offset
+    assert region.overlap_shape == overlap_shape
+    assert region.source_base_offset == source_base_offset
+    assert region.target_base_offset == target_base_offset
+    assert region.inner_bytes == inner_bytes
+    assert region.outer_loop_counts == outer_loop_counts
+    assert region.source_strides == source_strides
+    assert region.target_strides == target_strides
+    assert region.segment_count == prod(outer_loop_counts)
+    assert region.total_bytes == prod(overlap_shape) * 2
+    assert (
+        len(tuple(region.iter_segments(max_segments=region.segment_count)))
+        == region.segment_count
+    )
+    with pytest.raises(ValueError, match="exceeds max_segments"):
+        tuple(region.iter_segments(max_segments=region.segment_count - 1))
+
+def test_transfer_region_mixed_radix_iteration_and_n_dim_bounds() -> None:
+    source = n_dim_fragment(
+        fragment_id="source",
+        global_offset=(1, 0, 0),
+        local_shape=(2, 6, 8),
+    )
+    target = n_dim_fragment(
+        fragment_id="target",
+        global_offset=(0, 2, 0),
+        local_shape=(4, 3, 8),
+    )
+    region = TransferRegion(
+        tensor_id=source.tensor_id,
+        source=source,
+        target=target,
+        overlap_offset=(1, 2, 0),
+        overlap_shape=(2, 3, 8),
+        source_base_offset=32,
+        target_base_offset=48,
+        inner_bytes=48,
+        outer_loop_counts=(2,),
+        source_strides=(96,),
+        target_strides=(48,),
+    )
+
+    assert tuple(region.iter_segments(max_segments=region.segment_count)) == (
+        (32, 48, 48),
+        (128, 96, 48),
+    )
+
+    with pytest.raises(ValueError, match="canonical"):
+        replace(region, source_strides=(193,))
+
+
+def test_transfer_region_rejects_noncanonical_same_volume_geometry() -> None:
+    source = n_dim_fragment(
+        fragment_id="source",
+        global_offset=(1, 0, 0),
+        local_shape=(2, 6, 8),
+    )
+    target = n_dim_fragment(
+        fragment_id="target",
+        global_offset=(0, 2, 0),
+        local_shape=(4, 3, 8),
+    )
+
+    with pytest.raises(ValueError, match="canonical"):
+        TransferRegion(
+            tensor_id=source.tensor_id,
+            source=source,
+            target=target,
+            overlap_offset=(1, 2, 0),
+            overlap_shape=(2, 3, 8),
+            source_base_offset=32,
+            target_base_offset=48,
+            inner_bytes=16,
+            outer_loop_counts=(2, 3),
+            source_strides=(96, 16),
+            target_strides=(80, 16),
+        )

--- a/mooncake-reshard/tests/model_weight_planner/test_coverage.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_coverage.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight import plan_placement_transfer
+
+from .helpers import (
+    combine_runtime_inputs,
+    descriptor,
+    rebuild_placement,
+    tp_manifests,
+)
+
+
+def test_logical_plan_rejects_target_omitting_a_source_tensor() -> None:
+    primary = descriptor()
+    secondary = replace(
+        primary,
+        tensor_id="layers.3.experts.4.w1",
+        layer_id=3,
+        expert_id=4,
+    )
+    source = combine_runtime_inputs(
+        tp_manifests(
+            tp=1,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x10000,
+            worker_prefix="source-primary",
+            tensor=primary,
+        ),
+        tp_manifests(
+            tp=1,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x20000,
+            worker_prefix="source-secondary",
+            tensor=secondary,
+        ),
+    )
+    target = tp_manifests(
+        tp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x30000,
+        worker_prefix="target",
+        tensor=primary,
+    )
+
+    with pytest.raises(ValueError, match="target manifests are missing tensors"):
+        plan_placement_transfer(source.placement, target.placement)
+
+
+def test_global_manifest_barrier_rejects_tensor_missing_from_one_dp_replica() -> None:
+    primary = descriptor()
+    secondary = replace(
+        primary,
+        tensor_id="layers.3.experts.4.w1",
+        layer_id=3,
+        expert_id=4,
+    )
+    complete = combine_runtime_inputs(
+        tp_manifests(
+            tp=1,
+            dp=2,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x10000,
+            worker_prefix="target-primary",
+            tensor=primary,
+        ),
+        tp_manifests(
+            tp=1,
+            dp=2,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x50000,
+            worker_prefix="target-secondary",
+            tensor=secondary,
+        ),
+    )
+    incomplete_fragments = tuple(
+        fragment
+        for fragment in complete.fragments
+        if not (fragment.tensor_id == secondary.tensor_id and fragment.rank.dp == 1)
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=("global placement tensor is not fully covered:.*layers.3.experts.4.w1"),
+    ):
+        rebuild_placement(complete.placement, fragments=incomplete_fragments)
+
+
+def test_global_manifest_barrier_rejects_target_tp_gap() -> None:
+    target = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x30000,
+        worker_prefix="target",
+    )
+
+    with pytest.raises(
+        ValueError, match="global placement tensor is not fully covered"
+    ):
+        rebuild_placement(target.placement, fragments=target.fragments[:1])
+
+
+def test_global_manifest_barrier_rejects_missing_source_coverage() -> None:
+    source = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+
+    with pytest.raises(
+        ValueError, match="global placement tensor is not fully covered"
+    ):
+        rebuild_placement(source.placement, fragments=source.fragments[:1])

--- a/mooncake-reshard/tests/model_weight_planner/test_ownership.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_ownership.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from itertools import product
+
+import pytest
+
+from mooncake.reshard.weight import (
+    ParallelRank,
+    PlacementFragment,
+    RuntimeBindingFragment,
+    OwnershipAxis,
+    ReplicatedAxis,
+    SplitAxis,
+    plan_placement_transfer,
+)
+from mooncake.reshard.weight._planner.ownership import (
+    complete_parallel_source_replicas,
+    parallel_tensor_owner,
+)
+
+from .helpers import (
+    _canonical_strides_bytes,
+    CountingFragment,
+    combine_runtime_inputs,
+    descriptor,
+    distribute_tp_shards_across_ep_ranks,
+    global_placement_from_fragments,
+    operation_for_target,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    replace_placement_fragment,
+    runtime_inputs_from_groups,
+    tp_manifests,
+)
+
+
+def test_target_dp_replicas_on_distinct_devices_are_not_deduplicated() -> None:
+    source = tp_manifests(
+        tp=1,
+        dp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    tensor = source.placement.tensors[0]
+    fragments = tuple(
+        PlacementFragment(
+            placement_fragment_id=f"target-dp{dp}-placement",
+            tensor_id=tensor.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor.global_shape,
+            nbytes=source.placement.fragments[0].nbytes,
+            rank=ParallelRank(dp=dp),
+        )
+        for dp in range(2)
+    )
+    target = runtime_inputs_from_groups(
+        resource_id=source.placement.resource_id,
+        revision=source.placement.revision,
+        placement_set_id="target",
+        tensors=(tensor,),
+        groups=tuple(
+            (
+                f"target-dp{dp}",
+                (fragment,),
+                (
+                    RuntimeBindingFragment(
+                        placement_fragment_id=fragment.placement_fragment_id,
+                        fragment_id=f"target-dp{dp}-runtime",
+                        address=0x40000,
+                        nbytes=fragment.nbytes,
+                        worker_id="target-worker",
+                        endpoint="target-worker:12345",
+                        device=f"cuda:{dp}",
+                        itemsize=tensor.itemsize,
+                        local_shape=fragment.local_shape,
+                        strides_bytes=_canonical_strides_bytes(
+                            fragment.local_shape, tensor.itemsize
+                        ),
+                        storage_address=0x40000,
+                        storage_nbytes=fragment.nbytes,
+                        storage_offset_bytes=0,
+                    ),
+                ),
+            )
+            for dp, fragment in enumerate(fragments)
+        ),
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert len(plan.operations) == 2
+    assert {operation.target.rank.dp for operation in plan.operations} == {0, 1}
+    assert all(
+        plan.operation_indices_for_executor(executor, "target")
+        for executor in plan.target_executors
+    )
+
+
+def test_ep_ownership_is_derived_from_parallel_axis_semantics() -> None:
+    ownership_tensor = replace(
+        descriptor(),
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="ep"),),
+    )
+    split_tensor = replace(
+        descriptor(),
+        expert_id=None,
+        parallel_axes=(SplitAxis(kind="ep", dim=0),),
+    )
+    fragment = PlacementFragment(
+        tensor_id=ownership_tensor.tensor_id,
+        global_offset=(0, 0),
+        local_shape=ownership_tensor.global_shape,
+        nbytes=64,
+        rank=ParallelRank(ep=3),
+    )
+
+    assert parallel_tensor_owner(ownership_tensor, fragment) == (("ep", 3),)
+    assert parallel_tensor_owner(split_tensor, fragment) == ()
+
+
+def test_dp_ownership_routes_each_tensor_through_its_declared_owner() -> None:
+
+    tensor_a = replace(
+        descriptor(),
+        tensor_id="layers.0.weight",
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="dp"),),
+    )
+    tensor_b = replace(
+        descriptor(),
+        tensor_id="layers.1.weight",
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="dp"),),
+    )
+
+    def fragment(tensor, dp_rank: int, prefix: str) -> PlacementFragment:
+        return PlacementFragment(
+            placement_fragment_id=f"{prefix}-{tensor.tensor_id}-dp{dp_rank}",
+            tensor_id=tensor.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor.global_shape,
+            nbytes=64,
+            rank=ParallelRank(dp=dp_rank),
+        )
+
+    source_fragments = (
+        fragment(tensor_a, 0, "source"),
+        fragment(tensor_b, 1, "source"),
+    )
+    target_fragments = (
+        fragment(tensor_a, 0, "target"),
+        fragment(tensor_b, 1, "target"),
+    )
+    source = global_placement_from_fragments(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="source-dp-owners",
+        tensors=(tensor_a, tensor_b),
+        fragments=source_fragments,
+    )
+    target = global_placement_from_fragments(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="target-dp-owners",
+        tensors=(tensor_a, tensor_b),
+        fragments=target_fragments,
+    )
+
+    plan = plan_placement_transfer(source, target)
+
+    assert len(plan.operations) == 2
+    assert {
+        (operation.source.tensor_id, operation.source.rank.dp)
+        for operation in plan.operations
+    } == {
+        (tensor_a.tensor_id, 0),
+        (tensor_b.tensor_id, 1),
+    }
+    assert {
+        (operation.target.tensor_id, operation.target.rank.dp)
+        for operation in plan.operations
+    } == {
+        (tensor_a.tensor_id, 0),
+        (tensor_b.tensor_id, 1),
+    }
+
+
+def test_dp_ownership_rejects_ambiguous_complete_source_owners() -> None:
+    tensor = replace(
+        descriptor(),
+        tensor_id="layers.0.weight",
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="dp"),),
+    )
+
+    def fragment(dp_rank: int, prefix: str) -> PlacementFragment:
+        return PlacementFragment(
+            placement_fragment_id=f"{prefix}-dp{dp_rank}",
+            tensor_id=tensor.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor.global_shape,
+            nbytes=64,
+            rank=ParallelRank(dp=dp_rank),
+        )
+
+    source = global_placement_from_fragments(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="source-ambiguous-dp-owners",
+        tensors=(tensor,),
+        fragments=(fragment(0, "source"), fragment(1, "source")),
+    )
+    target = global_placement_from_fragments(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="target-dp-owner",
+        tensors=(tensor,),
+        fragments=(fragment(0, "target"),),
+    )
+
+    with pytest.raises(ValueError, match="ambiguous declared owners"):
+        plan_placement_transfer(source, target)
+
+
+def test_pipeline_routes_keep_distinct_virtual_stages_on_one_pp_rank() -> None:
+    tensor_a = replace(
+        descriptor(),
+        tensor_id="layers.0.weight",
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="pp"),),
+    )
+    tensor_b = replace(
+        descriptor(),
+        tensor_id="layers.1.weight",
+        shard_dims=(),
+        expert_id=None,
+        parallel_axes=(OwnershipAxis(kind="pp"),),
+    )
+    source_fragments = (
+        PlacementFragment(
+            placement_fragment_id="source-stage-0",
+            tensor_id=tensor_a.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor_a.global_shape,
+            nbytes=64,
+            rank=ParallelRank(pp=0),
+            pipeline_stage_id=0,
+        ),
+        PlacementFragment(
+            placement_fragment_id="source-stage-1",
+            tensor_id=tensor_b.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor_b.global_shape,
+            nbytes=64,
+            rank=ParallelRank(pp=0),
+            pipeline_stage_id=1,
+        ),
+    )
+    target_fragments = (
+        PlacementFragment(
+            placement_fragment_id="target-stage-2",
+            tensor_id=tensor_a.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor_a.global_shape,
+            nbytes=64,
+            rank=ParallelRank(pp=0),
+            pipeline_stage_id=2,
+        ),
+        PlacementFragment(
+            placement_fragment_id="target-stage-3",
+            tensor_id=tensor_b.tensor_id,
+            global_offset=(0, 0),
+            local_shape=tensor_b.global_shape,
+            nbytes=64,
+            rank=ParallelRank(pp=0),
+            pipeline_stage_id=3,
+        ),
+    )
+    source = runtime_inputs_from_groups(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="source-pipeline-stages",
+        tensors=(tensor_a, tensor_b),
+        groups=(("source", source_fragments, ()),),
+    )
+    target = runtime_inputs_from_groups(
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        placement_set_id="target-pipeline-stages",
+        tensors=(tensor_a, tensor_b),
+        groups=(("target", target_fragments, ()),),
+    )
+
+    logical = plan_placement_transfer(source.placement, target.placement)
+
+    assert {
+        (
+            route.source_pp,
+            route.source_pipeline_stage_id,
+            route.target_pp,
+            route.target_pipeline_stage_id,
+        )
+        for route in logical.pipeline_routes
+    } == {
+        (0, 0, 0, 2),
+        (0, 1, 0, 3),
+    }
+
+
+def test_all_parallel_axes_change_in_one_plan() -> None:
+    source = tp_manifests(
+        tp=2,
+        dp=2,
+        pp_rank=1,
+        ep_rank=1,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target = tp_manifests(
+        tp=4,
+        dp=3,
+        pp_rank=2,
+        ep_rank=3,
+        address_base=0x40000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert len(plan.operations) == 12
+    assert {op.target.rank.dp for op in plan.operations} == {0, 1, 2}
+    assert {op.target.rank.pp for op in plan.operations} == {2}
+    assert {op.target.rank.ep for op in plan.operations} == {3}
+    assert {op.source.rank.pp for op in plan.operations} == {1}
+    assert {op.source.rank.ep for op in plan.operations} == {1}
+    assert {op.source.rank.dp for op in operation_for_target(plan, 0, 0)} == {0}
+    assert {op.source.rank.dp for op in operation_for_target(plan, 0, 1)} == {1}
+    assert {op.source.rank.dp for op in operation_for_target(plan, 0, 2)} == {0}
+
+
+def test_dense_source_tp_coverage_cannot_span_ep_replicas() -> None:
+    tensor = replace(
+        descriptor(),
+        tensor_id="layers.2.self_attn.q_proj.weight",
+        expert_id=None,
+        parallel_axes=(
+            ReplicatedAxis(kind="dp"),
+            OwnershipAxis(kind="pp"),
+            ReplicatedAxis(kind="ep"),
+            SplitAxis(kind="tp", dim=0),
+        ),
+    )
+    with pytest.raises(
+        ValueError, match="global placement tensor is not fully covered"
+    ):
+        distribute_tp_shards_across_ep_ranks(
+            tp_manifests(
+                tp=4,
+                pp_rank=0,
+                ep_rank=0,
+                address_base=0x10000,
+                worker_prefix="source",
+                tensor=tensor,
+            )
+        )
+
+
+def test_source_replica_validation_indexes_fragments_by_tensor_once() -> None:
+    tensor_count = 64
+    tensors = tuple(
+        replace(
+            descriptor(),
+            tensor_id=f"layers.{index}.self_attn.q_proj.weight",
+            layer_id=index,
+            expert_id=None,
+            parallel_axes=(SplitAxis(kind="tp", dim=0),),
+        )
+        for index in range(tensor_count)
+    )
+    fragments = tuple(
+        tp_manifests(
+            tp=1,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x10000 + index * 0x1000,
+            worker_prefix=f"source-{index}",
+            tensor=tensor,
+        )[0].fragments[0]
+        for index, tensor in enumerate(tensors)
+    )
+    accesses = [0]
+
+    replicas = complete_parallel_source_replicas(
+        {tensor.tensor_id: tensor for tensor in tensors},
+        tuple(CountingFragment(fragment, accesses) for fragment in fragments),
+    )
+
+    assert set(replicas) == {0}
+    assert accesses[0] <= tensor_count * 3
+
+
+def test_dense_target_tp_coverage_cannot_span_ep_replicas() -> None:
+    tensor = replace(
+        descriptor(),
+        tensor_id="layers.2.self_attn.q_proj.weight",
+        expert_id=None,
+        parallel_axes=(
+            ReplicatedAxis(kind="dp"),
+            OwnershipAxis(kind="pp"),
+            ReplicatedAxis(kind="ep"),
+            SplitAxis(kind="tp", dim=0),
+        ),
+    )
+    with pytest.raises(
+        ValueError, match="global placement tensor is not fully covered"
+    ):
+        distribute_tp_shards_across_ep_ranks(
+            tp_manifests(
+                tp=2,
+                pp_rank=0,
+                ep_rank=0,
+                address_base=0x40000,
+                worker_prefix="target",
+                tensor=tensor,
+            )
+        )
+
+
+def test_global_manifest_barrier_rejects_expert_tp_spanning_ep_owners() -> None:
+    with pytest.raises(
+        ValueError,
+        match="global placement tensor is not fully covered",
+    ):
+        distribute_tp_shards_across_ep_ranks(
+            tp_manifests(
+                tp=2,
+                pp_rank=0,
+                ep_rank=0,
+                address_base=0x10000,
+                worker_prefix="source",
+            )
+        )
+
+
+def test_local_plan_uses_one_complete_source_dp_replica() -> None:
+    sources = tp_manifests(
+        tp=2,
+        dp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target = tp_manifests(
+        tp=1,
+        dp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x40000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer_to_local_target(sources, target, target_index=1)
+
+    assert {operation.source.rank.dp for operation in plan.operations} == {1}
+
+
+def test_global_manifest_barrier_rejects_tp_coverage_split_across_pp_owners() -> None:
+    targets = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x40000,
+        worker_prefix="target",
+    )
+    moved = replace(
+        targets[1].fragments[0],
+        rank=replace(targets[1].fragments[0].rank, pp=1),
+    )
+    with pytest.raises(
+        ValueError, match="global placement tensor is not fully covered"
+    ):
+        replace_placement_fragment(targets, 1, moved)
+
+
+def test_complete_tensor_replicas_across_pp_owners_are_each_transferred() -> None:
+    tensor = replace(
+        descriptor(),
+        tensor_id="lm_head.weight",
+        layer_id=None,
+        expert_id=None,
+        parallel_axes=(
+            OwnershipAxis(kind="pp"),
+            SplitAxis(kind="tp", dim=0),
+        ),
+    )
+    source = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+        tensor=tensor,
+    )
+    target = combine_runtime_inputs(
+        tp_manifests(
+            tp=1,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x40000,
+            worker_prefix="target-pp0",
+            tensor=tensor,
+        ),
+        tp_manifests(
+            tp=1,
+            pp_rank=1,
+            ep_rank=0,
+            address_base=0x50000,
+            worker_prefix="target-pp1",
+            tensor=tensor,
+        ),
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert {operation.target.rank.pp for operation in plan.operations} == {0, 1}
+    assert len(plan.operations) == 4
+
+
+def test_multiple_layers_and_experts_move_pp_ep_tp_dp_ownership_together() -> None:
+    source_inputs = []
+    target_inputs = []
+    for layer_id, expert_id in product(range(2), range(2)):
+        tensor = replace(
+            descriptor(),
+            tensor_id=f"layers.{layer_id}.experts.{expert_id}.w1",
+            layer_id=layer_id,
+            expert_id=expert_id,
+        )
+        source_inputs.append(
+            tp_manifests(
+                tp=2,
+                dp=2,
+                pp_rank=layer_id,
+                ep_rank=expert_id,
+                address_base=0x100000 + (layer_id * 2 + expert_id) * 0x10000,
+                worker_prefix=f"source-l{layer_id}-e{expert_id}",
+                tensor=tensor,
+            )
+        )
+        target_inputs.append(
+            tp_manifests(
+                tp=4,
+                dp=3,
+                pp_rank=1 - layer_id,
+                ep_rank=1 - expert_id,
+                address_base=0x400000 + (layer_id * 2 + expert_id) * 0x10000,
+                worker_prefix=f"target-l{layer_id}-e{expert_id}",
+                tensor=tensor,
+            )
+        )
+
+    plan = plan_transfer(
+        combine_runtime_inputs(*source_inputs),
+        combine_runtime_inputs(*target_inputs),
+    )
+
+    assert plan.resource_id == "qwen3.5-0.8b"
+    assert plan.revision == "step-42"
+    assert plan.total_bytes == 4 * 3 * 8 * 4 * 2
+    assert len(plan.operations) == 4 * 3 * 4
+    for operation in plan.operations:
+        layer_id = operation.target.tensor_id.split(".")[1]
+        expert_id = operation.target.tensor_id.split(".")[3]
+        assert operation.source.tensor_id == operation.target.tensor_id
+        assert operation.source.rank.pp == int(layer_id)
+        assert operation.target.rank.pp == 1 - int(layer_id)
+        assert operation.source.rank.ep == int(expert_id)
+        assert operation.target.rank.ep == 1 - int(expert_id)

--- a/mooncake-reshard/tests/model_weight_planner/test_runtime_api_validation.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_runtime_api_validation.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from mooncake.reshard.weight._planner.api import plan_placement_transfer_to_local_target
+
+from .helpers import (
+    combine_runtime_inputs,
+    descriptor,
+    plan_transfer,
+    plan_transfer_to_local_target,
+    tp_manifests,
+)
+
+
+def test_planner_rejects_incompatible_layout() -> None:
+    source = tp_manifests(
+        tp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target = tp_manifests(
+        tp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x20000,
+        worker_prefix="target",
+        tensor=descriptor(fingerprint="sglang:qwen3.5:fp8:v1"),
+    )
+
+    with pytest.raises(ValueError, match="layout mismatch"):
+        plan_transfer(source, target)
+
+
+@pytest.mark.parametrize("field", ["layer_id", "expert_id"])
+def test_planner_rejects_incompatible_tensor_semantics(field: str) -> None:
+    source = tp_manifests(
+        tp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target_tensor = replace(descriptor(), **{field: 99})
+    target = tp_manifests(
+        tp=1,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x20000,
+        worker_prefix="target",
+        tensor=target_tensor,
+    )
+
+    with pytest.raises(ValueError, match="tensor descriptor mismatch"):
+        plan_transfer(source, target)
+
+
+def test_local_target_plan_supports_independent_tp_rank_startup() -> None:
+    sources = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    targets = tp_manifests(
+        tp=4,
+        pp_rank=2,
+        ep_rank=3,
+        address_base=0x40000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer_to_local_target(sources, targets, target_index=1)
+
+    assert len(plan.target_executors) == 1
+    assert plan.target_executors[0].rank == targets[1].fragments[0].rank
+    assert len(plan.operations) == 1
+    operation = plan.operations[0]
+    assert operation.source.rank.tp == 0
+    assert operation.target.rank.tp == 1
+    assert operation.source_offset == 2 * 4 * 2
+    assert operation.target_offset == 0
+    assert operation.nbytes == 2 * 4 * 2
+    assert len(plan.source_executors) == 1
+    assert plan.source_executors[0].rank.tp == 0
+
+
+def test_local_target_plan_allows_explicit_pp_ep_tensor_subset() -> None:
+    first = descriptor()
+    second = replace(
+        first,
+        tensor_id="layers.7.experts.5.w1",
+        layer_id=7,
+        expert_id=5,
+    )
+    sources = combine_runtime_inputs(
+        tp_manifests(
+            tp=2,
+            pp_rank=0,
+            ep_rank=0,
+            address_base=0x10000,
+            worker_prefix="source-first",
+            tensor=first,
+        ),
+        tp_manifests(
+            tp=2,
+            pp_rank=1,
+            ep_rank=1,
+            address_base=0x30000,
+            worker_prefix="source-second",
+            tensor=second,
+        ),
+    )
+    local_targets = tp_manifests(
+        tp=4,
+        pp_rank=3,
+        ep_rank=2,
+        address_base=0x50000,
+        worker_prefix="target",
+        tensor=second,
+    )
+
+    plan = plan_transfer_to_local_target(sources, local_targets, target_index=2)
+
+    assert {operation.tensor_id for operation in plan.operations} == {second.tensor_id}
+    assert {operation.source.rank.pp for operation in plan.operations} == {1}
+    assert {operation.source.rank.ep for operation in plan.operations} == {1}
+    assert {operation.target.rank.pp for operation in plan.operations} == {3}
+    assert {operation.target.rank.ep for operation in plan.operations} == {2}
+
+
+def test_local_target_plan_rejects_unknown_target_tensor() -> None:
+    sources = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    targets = tp_manifests(
+        tp=4,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x40000,
+        worker_prefix="target",
+        tensor=replace(descriptor(), tensor_id="unknown.weight"),
+    )
+
+    with pytest.raises(ValueError, match="unknown tensors"):
+        plan_transfer_to_local_target(sources, targets)
+
+
+def test_local_target_plan_rejects_tensor_without_local_fragment() -> None:
+    sources = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    targets = tp_manifests(
+        tp=4,
+        pp_rank=1,
+        ep_rank=0,
+        address_base=0x40000,
+        worker_prefix="target",
+    )
+    empty_part = next(part for part in targets.placement.parts if not part.fragments)
+
+    with pytest.raises(ValueError, match="no fragments"):
+        plan_placement_transfer_to_local_target(
+            sources.placement,
+            targets.placement,
+            empty_part.participant_id,
+        )

--- a/mooncake-reshard/tests/model_weight_planner/test_runtime_reshard.py
+++ b/mooncake-reshard/tests/model_weight_planner/test_runtime_reshard.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from .helpers import descriptor, operation_for_target, plan_transfer, tp_manifests
+
+
+def test_tp2_to_tp4_splits_source_fragments_without_full_tensor() -> None:
+    source = tp_manifests(
+        tp=2,
+        pp_rank=1,
+        ep_rank=1,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target = tp_manifests(
+        tp=4,
+        pp_rank=2,
+        ep_rank=3,
+        address_base=0x20000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert len(plan.operations) == 4
+    assert [
+        (op.source_offset, op.target_offset, op.nbytes)
+        for op in operation_for_target(plan, 0)
+    ] == [(0, 0, 16)]
+    assert [
+        (op.source_offset, op.target_offset, op.nbytes)
+        for op in operation_for_target(plan, 1)
+    ] == [(16, 0, 16)]
+    assert operation_for_target(plan, 0)[0].source.rank.pp == 1
+    assert operation_for_target(plan, 0)[0].target.rank.pp == 2
+    assert operation_for_target(plan, 0)[0].source.rank.ep == 1
+    assert operation_for_target(plan, 0)[0].target.rank.ep == 3
+
+
+def test_tp4_to_tp2_merges_into_non_overlapping_target_offsets() -> None:
+    source = tp_manifests(
+        tp=4,
+        pp_rank=2,
+        ep_rank=3,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    target = tp_manifests(
+        tp=2,
+        pp_rank=1,
+        ep_rank=1,
+        address_base=0x20000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert [
+        (op.source_offset, op.target_offset, op.nbytes)
+        for op in operation_for_target(plan, 0)
+    ] == [
+        (0, 0, 16),
+        (0, 16, 16),
+    ]
+
+
+@pytest.mark.parametrize(("source_tp", "target_tp"), [(4, 8), (8, 4)])
+def test_single_axis_manifest_tp4_tp8_same_dim_reshard(
+    source_tp: int, target_tp: int
+) -> None:
+    sources = tp_manifests(
+        tp=source_tp,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+    )
+    targets = tp_manifests(
+        tp=target_tp,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x20000,
+        worker_prefix="target",
+    )
+
+    plan = plan_transfer(sources, targets)
+
+    assert len(plan.operations) == 8
+    assert all(operation.segment_count == 1 for operation in plan.operations)
+    for target in targets:
+        fragment = target.fragments[0]
+        operations = sorted(
+            operation_for_target(plan, fragment.rank.tp),
+            key=lambda operation: operation.target_offset,
+        )
+        cursor = 0
+        for operation in operations:
+            assert operation.target_offset == cursor
+            cursor += operation.nbytes
+        assert cursor == fragment.nbytes
+
+
+def test_shard_dim_one_generates_row_ranges() -> None:
+    tensor = descriptor(global_shape=(2, 8), shard_dim=1)
+    source = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+        tensor=tensor,
+    )
+    target = tp_manifests(
+        tp=4,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x20000,
+        worker_prefix="target",
+        tensor=tensor,
+    )
+
+    plan = plan_transfer(source, target)
+
+    operations = operation_for_target(plan, 0)
+    assert len(operations) == 1
+    assert operations[0].repeat == 2
+    assert operations[0].source_stride == 8
+    assert operations[0].target_stride == 4
+    assert list(
+        operations[0].iter_segments(max_segments=operations[0].segment_count)
+    ) == [
+        (0, 0, 4),
+        (8, 4, 4),
+    ]
+
+
+def test_large_inner_axis_partition_uses_compact_strided_ranges() -> None:
+    tensor = descriptor(global_shape=(8192, 8192), shard_dim=1)
+    source = tp_manifests(
+        tp=2,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x10000,
+        worker_prefix="source",
+        tensor=tensor,
+    )
+    target = tp_manifests(
+        tp=4,
+        pp_rank=0,
+        ep_rank=0,
+        address_base=0x20000,
+        worker_prefix="target",
+        tensor=tensor,
+    )
+
+    plan = plan_transfer(source, target)
+
+    assert len(plan.operations) == 4
+    assert {operation.repeat for operation in plan.operations} == {8192}
+    assert plan.total_bytes == 8192 * 8192 * 2

--- a/mooncake-reshard/tests/test_python_compat.py
+++ b/mooncake-reshard/tests/test_python_compat.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from mooncake.reshard._compat import _strict_zip
+
+
+def test_strict_zip_preserves_equal_length_values() -> None:
+    assert tuple(_strict_zip((1, 2), (3, 4))) == ((1, 3), (2, 4))
+
+
+def test_strict_zip_rejects_different_lengths() -> None:
+    with pytest.raises(ValueError, match="different lengths"):
+        tuple(_strict_zip((1,), (2, 3)))

--- a/mooncake-reshard/tests/test_reshard_geometry.py
+++ b/mooncake-reshard/tests/test_reshard_geometry.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from time import perf_counter
+
+from hypothesis import given, settings, strategies as st
+import pytest
+
+import mooncake.reshard.geometry as geometry
+from mooncake.reshard.geometry import (
+    LogicalBox,
+    OverlapRegion,
+    boxes_exactly_cover,
+    regions_exactly_cover,
+)
+
+
+@dataclass(frozen=True)
+class _Box:
+    global_offset: tuple[int, ...]
+    local_shape: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class _Region:
+    overlap_offset: tuple[int, ...]
+    overlap_shape: tuple[int, ...]
+
+
+def test_geometry_contract_is_structural_and_resource_agnostic() -> None:
+    target: LogicalBox = _Box(global_offset=(8, 4), local_shape=(2, 6))
+    regions: tuple[OverlapRegion, ...] = (
+        _Region(overlap_offset=(8, 4), overlap_shape=(1, 6)),
+        _Region(overlap_offset=(9, 4), overlap_shape=(1, 6)),
+    )
+
+    assert regions_exactly_cover(target, regions)
+    assert boxes_exactly_cover(
+        target.global_offset,
+        target.local_shape,
+        tuple((region.overlap_offset, region.overlap_shape) for region in regions),
+    )
+    assert not regions_exactly_cover(target, (regions[0], regions[0], regions[1]))
+
+
+def _row_split_exact_cover(
+    row_count: int,
+    *,
+    ndim: int = 2,
+) -> tuple[
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+]:
+    if ndim < 2:
+        raise ValueError("row split requires at least two dimensions")
+    container_offset = (0,) * ndim
+    container_shape = (row_count + 1, row_count, *((1,) * (ndim - 2)))
+    boxes = []
+    for row in range(row_count):
+        split = row + 1
+        left_offset = (0, row, *((0,) * (ndim - 2)))
+        right_offset = (split, row, *((0,) * (ndim - 2)))
+        left_shape = (split, 1, *((1,) * (ndim - 2)))
+        right_shape = (row_count + 1 - split, 1, *((1,) * (ndim - 2)))
+        boxes.extend(((left_offset, left_shape), (right_offset, right_shape)))
+    return container_offset, container_shape, tuple(boxes)
+
+
+def test_boxes_exactly_cover_row_split_layout_within_two_dimensional_budget() -> None:
+    container_offset, container_shape, boxes = _row_split_exact_cover(4096)
+
+    started_at = perf_counter()
+    assert boxes_exactly_cover(container_offset, container_shape, boxes)
+    assert perf_counter() - started_at < 2.0
+
+
+def test_high_dimensional_overlap_fails_closed_after_comparison_budget(
+    monkeypatch,
+) -> None:
+    _, _, boxes = _row_split_exact_cover(3, ndim=3)
+    monkeypatch.setattr(
+        geometry,
+        "_MAX_HIGH_DIMENSIONAL_PAIRWISE_COMPARISONS",
+        0,
+        raising=False,
+    )
+
+    with pytest.raises(ValueError, match="high-dimensional overlap budget"):
+        geometry.boxes_overlap(boxes)
+
+
+@st.composite
+def _small_boxes(draw) -> tuple[tuple[tuple[int, ...], tuple[int, ...]], ...]:
+    ndim = draw(st.integers(min_value=1, max_value=3))
+    count = draw(st.integers(min_value=0, max_value=8))
+    boxes = []
+    for _ in range(count):
+        boxes.append(
+            (
+                tuple(draw(st.integers(min_value=0, max_value=6)) for _ in range(ndim)),
+                tuple(draw(st.integers(min_value=1, max_value=4)) for _ in range(ndim)),
+            )
+        )
+    return tuple(boxes)
+
+
+def _brute_boxes_overlap(
+    boxes: tuple[tuple[tuple[int, ...], tuple[int, ...]], ...],
+) -> bool:
+    return any(
+        all(
+            left_begin < right_begin + right_extent
+            and right_begin < left_begin + left_extent
+            for left_begin, left_extent, right_begin, right_extent in zip(
+                left_offset,
+                left_shape,
+                right_offset,
+                right_shape,
+            )
+        )
+        for index, (left_offset, left_shape) in enumerate(boxes)
+        for right_offset, right_shape in boxes[index + 1 :]
+    )
+
+
+@settings(max_examples=200, deadline=None)
+@given(_small_boxes())
+def test_boxes_overlap_matches_brute_force_for_small_inputs(boxes) -> None:
+    assert geometry.boxes_overlap(boxes) is _brute_boxes_overlap(boxes)
+
+
+@st.composite
+def _tiled_target_and_regions(draw) -> tuple[_Box, tuple[_Region, ...]]:
+    ndim = draw(st.integers(min_value=1, max_value=3))
+    split_dim = draw(st.integers(min_value=0, max_value=ndim - 1))
+    origin = tuple(draw(st.integers(min_value=0, max_value=8)) for _ in range(ndim))
+    shape = tuple(
+        draw(st.integers(min_value=2 if dim == split_dim else 1, max_value=6))
+        for dim in range(ndim)
+    )
+    split = draw(st.integers(min_value=1, max_value=shape[split_dim] - 1))
+    left_shape = tuple(
+        split if dim == split_dim else extent for dim, extent in enumerate(shape)
+    )
+    right_offset = tuple(
+        origin[dim] + split if dim == split_dim else origin[dim] for dim in range(ndim)
+    )
+    right_shape = tuple(
+        extent - split if dim == split_dim else extent
+        for dim, extent in enumerate(shape)
+    )
+    return _Box(origin, shape), (
+        _Region(origin, left_shape),
+        _Region(right_offset, right_shape),
+    )
+
+
+@settings(max_examples=80, deadline=None)
+@given(_tiled_target_and_regions())
+def test_regions_exactly_cover_random_n_dim_tilings(
+    tiled: tuple[_Box, tuple[_Region, ...]],
+) -> None:
+    target, regions = tiled
+
+    assert regions_exactly_cover(target, regions)
+    assert not regions_exactly_cover(target, regions[:1])

--- a/mooncake-reshard/tests/test_reshard_weight_module_layout.py
+++ b/mooncake-reshard/tests/test_reshard_weight_module_layout.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import importlib.util
+
 import mooncake.reshard.weight as model_weight
+import mooncake.reshard.weight._planner.contracts as planner_contracts
 from mooncake.reshard.weight.binding import (
     validate_runtime_binding,
     validate_runtime_bindings,
@@ -73,3 +76,14 @@ def test_responsibility_modules_preserve_public_contract_identity() -> None:
     )
     assert model_weight.validate_runtime_binding is validate_runtime_binding
     assert model_weight.validate_runtime_bindings is validate_runtime_bindings
+
+
+def test_logical_planner_does_not_ship_runtime_execution_contracts() -> None:
+    assert not hasattr(planner_contracts, "BoundWeightFragment")
+    assert not hasattr(planner_contracts, "TransferPlan")
+    assert (
+        importlib.util.find_spec(
+            "mooncake.reshard.weight._planner.attestation"
+        )
+        is None
+    )

--- a/mooncake-reshard/tests/weight_manifest/test_placement.py
+++ b/mooncake-reshard/tests/weight_manifest/test_placement.py
@@ -47,6 +47,19 @@ def test_placement_round_trip_is_stable_and_address_free() -> None:
         assert forbidden not in encoded
 
 
+def test_explicit_pipeline_stage_is_canonical_and_round_trips() -> None:
+    legacy = placement_manifest()
+    staged = placement_manifest(
+        fragments=(placement_fragment(pipeline_stage_id=3),),
+    )
+
+    encoded = weight_placement_to_json(staged)
+
+    assert '"pipeline_stage_id":3' in encoded
+    assert weight_placement_from_json(encoded) == staged
+    assert staged.placement_id != legacy.placement_id
+
+
 def test_placement_digest_is_independent_of_inventory_order() -> None:
     tensors = (
         descriptor(

--- a/mooncake-reshard/tests/weight_manifest/test_storage.py
+++ b/mooncake-reshard/tests/weight_manifest/test_storage.py
@@ -1,0 +1,497 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from mooncake.reshard.weight.manifest import (
+    ParallelRank,
+    RuntimeBindingFragment,
+    TensorDescriptor,
+    OwnershipAxis,
+    SplitAxis,
+)
+from mooncake.reshard.weight.storage_manifest import (
+    StoredFragment,
+    WeightManifest,
+)
+
+
+def tensor_descriptor(**overrides) -> TensorDescriptor:
+    values = {
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_shape": (8, 4),
+        "dtype": "bfloat16",
+        "itemsize": 2,
+        "shard_dims": (0,),
+        "layer_id": 2,
+        "expert_id": 3,
+        "layout_fingerprint": "sglang:qwen3.5:bf16:v1",
+        "parallel_axes": (SplitAxis(kind="tp", dim=0),),
+    }
+    values.update(overrides)
+    return TensorDescriptor(**values)
+
+
+def runtime_binding_fragment(**overrides) -> RuntimeBindingFragment:
+    values = {
+        "placement_fragment_id": "placement-0",
+        "fragment_id": "runtime-0",
+        "address": 0x1000,
+        "nbytes": 32,
+        "worker_id": "source-0",
+        "endpoint": "source-0:12345",
+        "device": "cuda:0",
+        "itemsize": 2,
+        "local_shape": (4, 4),
+        "strides_bytes": (8, 2),
+        "storage_address": 0x1000,
+        "storage_nbytes": 32,
+        "storage_offset_bytes": 0,
+    }
+    if "address" in overrides and "storage_address" not in overrides:
+        values["storage_address"] = overrides["address"]
+    if "nbytes" in overrides and "storage_nbytes" not in overrides:
+        values["storage_nbytes"] = overrides["nbytes"]
+    values.update(overrides)
+    return RuntimeBindingFragment(**values)
+
+
+def stored_fragment(**overrides) -> StoredFragment:
+    values = {
+        "fragment_id": "stored-0",
+        "tensor_id": "layers.2.experts.3.w1",
+        "global_offset": (0, 0),
+        "local_shape": (8, 4),
+        "object_key": "weights/default/qwen/rev/payload/0",
+        "object_offset": 0,
+        "nbytes": 64,
+    }
+    values.update(overrides)
+    return StoredFragment(**values)
+
+
+def test_weight_manifest_round_trip_is_stable_and_has_no_runtime_address() -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen3.5-0.8b",
+        revision="step-42",
+        weight_generation=42,
+        group_id="weights/default/qwen3.5-0.8b/step-42",
+        manifest_key="weights/default/qwen3.5-0.8b/step-42/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(
+            stored_fragment(
+                object_key=("weights/default/qwen3.5-0.8b/step-42/payload/0")
+            ),
+        ),
+        created_at="2026-07-17T00:00:00Z",
+    )
+
+    encoded = manifest.to_json()
+
+    assert WeightManifest.from_json(encoded) == manifest
+    assert encoded == manifest.to_json()
+    assert "4096" not in encoded
+    assert "address" not in json.loads(encoded)["fragments"][0]
+
+
+def test_weight_manifest_round_trip_preserves_shard_dims() -> None:
+    tensor = tensor_descriptor(
+        tensor_id="layers.2.experts.w1",
+        global_shape=(2, 8, 4),
+        shard_dims=(0, 1),
+        expert_id=None,
+        parallel_axes=(
+            SplitAxis(kind="ep", dim=0),
+            SplitAxis(kind="tp", dim=1),
+        ),
+    )
+    group_id = "weights/default/qwen/rev"
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id=group_id,
+        manifest_key=f"{group_id}/manifest",
+        tensors=(tensor,),
+        fragments=tuple(
+            StoredFragment(
+                fragment_id=f"stored-e{expert}-o{out_shard}",
+                tensor_id=tensor.tensor_id,
+                global_offset=(expert, out_shard * 4, 0),
+                local_shape=(1, 4, 4),
+                object_key=f"{group_id}/payload/e{expert}-o{out_shard}",
+                object_offset=0,
+                nbytes=32,
+            )
+            for expert in range(2)
+            for out_shard in range(2)
+        ),
+        created_at="2026-07-22T00:00:00Z",
+    )
+
+    encoded = manifest.to_json()
+    decoded = WeightManifest.from_json(encoded)
+
+    assert decoded == manifest
+    assert json.loads(encoded)["tensors"][0]["shard_dims"] == [0, 1]
+
+
+def test_weight_manifest_round_trip_preserves_single_and_multi_axis_shards() -> None:
+    single_axis = tensor_descriptor(tensor_id="layers.0.attn.qkv", expert_id=None)
+    multi_axis_tensor = tensor_descriptor(
+        tensor_id="layers.2.experts.w1",
+        global_shape=(2, 8, 4),
+        shard_dims=(0, 1),
+        expert_id=None,
+        parallel_axes=(
+            SplitAxis(kind="ep", dim=0),
+            SplitAxis(kind="tp", dim=1),
+        ),
+    )
+    group_id = "weights/default/qwen/rev"
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id=group_id,
+        manifest_key=f"{group_id}/manifest",
+        tensors=(single_axis, multi_axis_tensor),
+        fragments=(
+            StoredFragment(
+                fragment_id="single-axis",
+                tensor_id=single_axis.tensor_id,
+                global_offset=(0, 0),
+                local_shape=single_axis.global_shape,
+                object_key=f"{group_id}/payload/single-axis",
+                object_offset=0,
+                nbytes=64,
+            ),
+            *(
+                StoredFragment(
+                    fragment_id=f"multi-e{expert}-o{out_shard}",
+                    tensor_id=multi_axis_tensor.tensor_id,
+                    global_offset=(expert, out_shard * 4, 0),
+                    local_shape=(1, 4, 4),
+                    object_key=(
+                        f"{group_id}/payload/multi-e{expert}-o{out_shard}"
+                    ),
+                    object_offset=0,
+                    nbytes=32,
+                )
+                for expert in range(2)
+                for out_shard in range(2)
+            ),
+        ),
+        created_at="2026-07-22T00:00:00Z",
+    )
+
+    encoded = manifest.to_json()
+    decoded = WeightManifest.from_json(encoded)
+
+    assert decoded == manifest
+    raw_single_axis = next(
+        tensor
+        for tensor in json.loads(encoded)["tensors"]
+        if tensor["tensor_id"] == single_axis.tensor_id
+    )
+    assert raw_single_axis["shard_dims"] == [0]
+
+
+def test_weight_manifest_round_trip_preserves_parallel_axes() -> None:
+    tensor = tensor_descriptor(
+        parallel_axes=(
+            OwnershipAxis(kind="pp"),
+            SplitAxis(kind="tp", dim=0),
+        ),
+    )
+    group_id = "weights/default/qwen/rev"
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id=group_id,
+        manifest_key=f"{group_id}/manifest",
+        tensors=(tensor,),
+        fragments=(stored_fragment(object_key=f"{group_id}/payload/0"),),
+        created_at="2026-07-22T00:00:00Z",
+    )
+
+    encoded = manifest.to_json()
+
+    assert WeightManifest.from_json(encoded) == manifest
+    assert json.loads(encoded)["tensors"][0]["parallel_axes"] == [
+        {"kind": "pp", "semantics": "ownership"},
+        {"kind": "tp", "semantics": "split", "dim": 0},
+    ]
+
+
+def test_weight_manifest_json_emits_single_axis_shard_dims_field() -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id="weights/default/qwen/rev",
+        manifest_key="weights/default/qwen/rev/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(stored_fragment(),),
+        created_at="2026-07-17T00:00:00Z",
+    )
+
+    raw = json.loads(manifest.to_json())
+
+    assert raw["tensors"][0]["shard_dims"] == [0]
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        stored_fragment(tensor_id="missing"),
+        stored_fragment(global_offset=(6, 0), local_shape=(4, 4)),
+        stored_fragment(nbytes=31),
+    ],
+)
+def test_weight_manifest_rejects_invalid_fragment(fragment: StoredFragment) -> None:
+    with pytest.raises(ValueError):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key="weights/default/qwen/rev/manifest",
+            tensors=(tensor_descriptor(),),
+            fragments=(fragment,),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+def test_weight_manifest_rejects_missing_tensor_coverage() -> None:
+    with pytest.raises(ValueError, match="not fully covered"):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key="weights/default/qwen/rev/manifest",
+            tensors=(tensor_descriptor(),),
+            fragments=(stored_fragment(local_shape=(4, 4), nbytes=32),),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+def test_weight_manifest_rejects_duplicate_fragment_geometry() -> None:
+    with pytest.raises(ValueError, match="duplicate fragment geometry"):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key="weights/default/qwen/rev/manifest",
+            tensors=(tensor_descriptor(),),
+            fragments=(
+                stored_fragment(),
+                stored_fragment(
+                    fragment_id="stored-1",
+                    object_key="weights/default/qwen/rev/payload/1",
+                ),
+            ),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+@pytest.mark.parametrize("second_offset", [0, 16])
+def test_weight_manifest_rejects_overlapping_object_ranges(
+    second_offset: int,
+) -> None:
+    with pytest.raises(ValueError, match="object ranges overlap"):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key="weights/default/qwen/rev/manifest",
+            tensors=(tensor_descriptor(),),
+            fragments=(
+                stored_fragment(local_shape=(4, 4), nbytes=32),
+                stored_fragment(
+                    fragment_id="stored-1",
+                    global_offset=(4, 0),
+                    local_shape=(4, 4),
+                    object_offset=second_offset,
+                    nbytes=32,
+                ),
+            ),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+def test_weight_manifest_allows_adjacent_object_ranges() -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id="weights/default/qwen/rev",
+        manifest_key="weights/default/qwen/rev/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(
+            stored_fragment(local_shape=(4, 4), nbytes=32),
+            stored_fragment(
+                fragment_id="stored-1",
+                global_offset=(4, 0),
+                local_shape=(4, 4),
+                object_offset=32,
+                nbytes=32,
+            ),
+        ),
+        created_at="2026-07-17T00:00:00Z",
+    )
+
+    assert tuple(fragment.object_offset for fragment in manifest.fragments) == (0, 32)
+
+
+def test_weight_manifest_allows_same_offset_for_different_objects() -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id="weights/default/qwen/rev",
+        manifest_key="weights/default/qwen/rev/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(
+            stored_fragment(local_shape=(4, 4), nbytes=32),
+            stored_fragment(
+                fragment_id="stored-1",
+                global_offset=(4, 0),
+                local_shape=(4, 4),
+                object_key="weights/default/qwen/rev/payload/1",
+                nbytes=32,
+            ),
+        ),
+        created_at="2026-07-17T00:00:00Z",
+    )
+
+    assert tuple(fragment.object_offset for fragment in manifest.fragments) == (0, 0)
+
+
+def test_manifest_types_cannot_cross_the_runtime_storage_boundary() -> None:
+    with pytest.raises(ValueError, match="WeightManifest fragments"):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key="weights/default/qwen/rev/manifest",
+            tensors=(tensor_descriptor(),),
+            fragments=(runtime_binding_fragment(),),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: ParallelRank(dp=True),
+        lambda: tensor_descriptor(global_shape=(8.0, 4)),
+        lambda: tensor_descriptor(itemsize=2.0),
+        lambda: tensor_descriptor(shard_dims=(0.0,)),
+        lambda: runtime_binding_fragment(address=4096.0),
+        lambda: runtime_binding_fragment(nbytes=False),
+        lambda: stored_fragment(object_offset=0.0),
+        lambda: stored_fragment(nbytes=64.0),
+    ],
+)
+def test_manifest_schema_rejects_non_integer_numeric_fields(factory) -> None:
+    with pytest.raises(ValueError, match="integer"):
+        factory()
+
+
+def test_weight_manifest_json_rejects_non_finite_and_non_mapping_values() -> None:
+    with pytest.raises(ValueError, match="non-finite"):
+        WeightManifest.from_json('{"model_id":NaN}')
+
+    with pytest.raises(ValueError, match="JSON object"):
+        WeightManifest.from_json("[]")
+
+
+def test_weight_manifest_json_rejects_float_geometry() -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id="weights/default/qwen/rev",
+        manifest_key="weights/default/qwen/rev/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(stored_fragment(),),
+        created_at="2026-07-17T00:00:00Z",
+    )
+    raw = json.loads(manifest.to_json())
+    raw["tensors"][0]["global_shape"][0] = 8.0
+
+    with pytest.raises(ValueError, match="integer"):
+        WeightManifest.from_json(json.dumps(raw))
+
+
+@pytest.mark.parametrize(
+    "manifest_key, object_key",
+    [
+        (
+            "weights/default/other/rev/manifest",
+            "weights/default/qwen/rev/payload/0",
+        ),
+        (
+            "weights/default/qwen/rev/manifest",
+            "weights/default/other/rev/payload/0",
+        ),
+    ],
+)
+def test_weight_manifest_binds_manifest_and_payload_keys_to_group(
+    manifest_key: str, object_key: str
+) -> None:
+    with pytest.raises(ValueError, match="group"):
+        WeightManifest(
+            namespace="default",
+            resource_id="qwen",
+            revision="rev",
+            weight_generation=7,
+            group_id="weights/default/qwen/rev",
+            manifest_key=manifest_key,
+            tensors=(tensor_descriptor(),),
+            fragments=(stored_fragment(object_key=object_key),),
+            created_at="2026-07-17T00:00:00Z",
+        )
+
+
+@pytest.mark.parametrize("mutation", ["missing-field", "unknown-field"])
+def test_weight_manifest_json_requires_exact_top_level_schema(mutation: str) -> None:
+    manifest = WeightManifest(
+        namespace="default",
+        resource_id="qwen",
+        revision="rev",
+        weight_generation=7,
+        group_id="weights/default/qwen/rev",
+        manifest_key="weights/default/qwen/rev/manifest",
+        tensors=(tensor_descriptor(),),
+        fragments=(stored_fragment(),),
+        created_at="2026-07-17T00:00:00Z",
+    )
+    raw = json.loads(manifest.to_json())
+    if mutation == "missing-field":
+        del raw["revision"]
+    else:
+        raw["future_semantics"] = "required"
+
+    with pytest.raises(ValueError, match="schema"):
+        WeightManifest.from_json(json.dumps(raw))

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -30,7 +30,7 @@ authors = [
 ]
 requires-python = ">=3.10"
 readme = "README.md"   # local copy of ../README.md, materialized at build time by scripts/build_wheel.sh
-dependencies = ["aiohttp", "requests", "msgpack"]
+dependencies = ["aiohttp", "requests", "msgpack", "typing_extensions>=4.0; python_version < '3.10'"]
 # Single-line arrays: sed-substituted by scripts/build_wheel.sh for each variant.
 keywords = ["mooncake", "transfer engine", "kv cache", "llm inference", "rdma"]
 classifiers = ["Development Status :: 5 - Production/Stable", "Environment :: GPU :: NVIDIA CUDA", "Intended Audience :: Developers", "Intended Audience :: Science/Research", "License :: OSI Approved :: Apache Software License", "Operating System :: POSIX :: Linux", "Programming Language :: C++", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Programming Language :: Python :: Implementation :: CPython", "Topic :: Scientific/Engineering :: Artificial Intelligence", "Topic :: System :: Distributed Computing"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 pre-commit==3.7.1
 ruff==0.6.9
 pyright==1.1.411
+hypothesis==6.141.0
+typing_extensions==4.13.2
 codespell==2.2.6
 cmake-format==0.6.13
 # clang-format is provided via system package (e.g., sudo apt-get install -y clang-format-20) or toolchain

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -48,7 +48,7 @@ echo "Running mooncake config test..."
 python tests/test_mooncake_config.py
 
 echo "Running reshard contract tests..."
-python -m pip install pytest
+python -m pip install pytest hypothesis==6.141.0
 python -m pytest reshard_tests -q
 
 echo "Verifying mooncake_master entry point..."


### PR DESCRIPTION
## Description

This PR adds the address-free logical-planning phase for heterogeneous
model-weight resharding in the new `mooncake-reshard` module.

It consumes complete typed source and target placements, or a committed logical
`WeightManifest` Store snapshot as the source, and produces a backend-neutral
`LogicalTransferPlan`. The plan contains compact N-D `TransferRegion` values:
logical overlap offsets and shapes, source/target base byte offsets,
`inner_bytes`, outer loop counts, and source/target strides.

The planner supports different source and target TP / PP / EP / DP layouts
without embedding framework-specific tensor-name parsing or model-layout
inference in Mooncake core:

- TP and EP use N-D logical-box split and merge, including different source
  and target shard dimensions.
- PP routes through explicit, framework-provided tensor or layer ownership;
  it does not infer stages from parameter names or layer-count formulas.
- EP is represented by a logical expert coordinate, so independent expert
  allocations remain independent fragments rather than being packed or
  all-gathered.
- DP selects a complete source replica or follows explicit DP ownership
  without changing tensor geometry.

The planner validates canonical resource identity, revision, weight
generation, tensor descriptors, ownership, logical coverage, aliases, and
planning limits. It keeps N-D regions compact and fails closed when a later
segment expansion would exceed its explicit limit.

This PR intentionally does not add runtime GPU binding, address or allocation
validation, lease attestation, Mooncake Store persistence/lifecycle, Transfer
Engine lowering/execution, model-specific packing or quantization conversion,
or framework runtime-object parsing. Those belong to later phases.

Related RFC: #3111

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
PYTHONPATH=mooncake-reshard/python \
  python -m pytest -q mooncake-reshard/tests

pyright --project mooncake-reshard/pyrightconfig.json

git diff --check origin/main...HEAD
```

**Test results:**
- [x] Unit tests pass: `284 passed`
- [ ] Integration tests pass (if applicable): not applicable; this PR produces
  an address-free logical plan and adds no runtime Store or Transfer Engine
  execution path.
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3111)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect the existing manifest and planner boundaries, draft
tests and documentation, and run local validation. The submitter reviewed the
design, implementation, and results.
