### PR TITLE
[Bugfix][Store] Fix MoveEnd source refcnt leak on target gone

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -5941,10 +5941,20 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
             LOG(WARNING)
                 << "key=" << key << ", replica_id=" << target_id
                 << ", move target becomes invalid during data transfer";
+            // Release the refcnt taken in MoveStart. The success path below
+            // does this once the move completes; this error path must do it
+            // too, or the source replica stays pinned.
+            source->dec_refcnt();
+            // Discard target replica and clear the replication task.
+            EraseReplicasWithCacheTotalAccounting(
+                metadata, [&task](const Replica& replica) {
+                    return std::find(task.replica_ids.begin(),
+                                     task.replica_ids.end(),
+                                     replica.id()) != task.replica_ids.end();
+                });
             ReleaseTenantQuota(
                 GetBoundTenantQuotaHandle(accessor.GetTenantState()),
                 task.pending_quota_charge_bytes);
-            // Source untouched; safe to drop the broken task.
             accessor.EraseReplicationTask();
             return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
         }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -169,6 +169,26 @@ class MasterServiceTest : public ::testing::Test {
         return service.soft_pin_deadline_index_.RegistrationCountForTest();
     }
 
+    std::optional<uint32_t> GetReplicaRefcntBySegmentName(
+        MasterService& service, const std::string& key,
+        const std::string& segment_name) {
+        MasterService::MetadataAccessorRO accessor(
+            &service,
+            service.MakeObjectIdentityForRequest(key, TenantId::Default()));
+        if (!accessor.Exists()) {
+            return std::nullopt;
+        }
+
+        for (const auto& replica : accessor.Get().GetAllReplicas()) {
+            for (const auto& name : replica.get_segment_names()) {
+                if (name.has_value() && *name == segment_name) {
+                    return replica.get_refcnt();
+                }
+            }
+        }
+        return std::nullopt;
+    }
+
     void UpsertSoftPinDeadlineIndexForTest(
         MasterService& service, const std::string& key, size_t shard_idx,
         const std::chrono::system_clock::time_point& deadline,
@@ -3464,6 +3484,61 @@ TEST_F(MasterServiceTest, MoveEnd) {
     move_end_result = service_->MoveEnd(client_id, key, TenantId::Default());
     EXPECT_FALSE(move_end_result.has_value());
     EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, move_end_result.error());
+
+    // Remount segment_2 for target-gone test.
+    const auto remounted_context2 =
+        PrepareSimpleSegment(*service_, "segment_2");
+
+    // Put another object with 1 replica on segment_1 for target-gone test.
+    std::string target_gone_key = "target_gone_key";
+    config.preferred_segment = "segment_1";
+    put_start_result = service_->PutStart(
+        client_id, target_gone_key, TenantId::Default(), slice_length, config);
+    ASSERT_TRUE(put_start_result.has_value());
+    put_end_result = service_->PutEnd(client_id, target_gone_key,
+                                      TenantId::Default(), ReplicaType::MEMORY);
+    ASSERT_TRUE(put_end_result.has_value());
+
+    // MoveStart the object from segment_1 to segment_2, then unmount
+    // segment_2
+    move_start_result =
+        service_->MoveStart(client_id, target_gone_key, TenantId::Default(),
+                            "segment_1", "segment_2");
+    ASSERT_TRUE(move_start_result.has_value());
+
+    // Unmount segment_2 to simulate target gone
+    unmount_result = service_->UnmountSegment(remounted_context2.segment_id,
+                                              remounted_context2.client_id);
+    ASSERT_TRUE(unmount_result.has_value());
+
+    // Test Case 7: MoveEnd, should fail because the target is gone, but the
+    // source refcnt must be released before the move task is erased.
+    move_end_result =
+        service_->MoveEnd(client_id, target_gone_key, TenantId::Default());
+    EXPECT_FALSE(move_end_result.has_value());
+    EXPECT_EQ(ErrorCode::REPLICA_IS_GONE, move_end_result.error());
+
+    const auto source_refcnt =
+        GetReplicaRefcntBySegmentName(*service_, target_gone_key, "segment_1");
+    ASSERT_TRUE(source_refcnt.has_value());
+    EXPECT_EQ(0, source_refcnt.value());
+
+    auto upsert_start_result = service_->UpsertStart(
+        client_id, target_gone_key, TenantId::Default(), slice_length, config);
+    EXPECT_TRUE(upsert_start_result.has_value());
+
+    auto move_revoke_result =
+        service_->MoveRevoke(client_id, target_gone_key, TenantId::Default());
+    EXPECT_FALSE(move_revoke_result.has_value());
+    EXPECT_EQ(ErrorCode::OBJECT_NO_REPLICATION_TASK,
+              move_revoke_result.error());
+
+    if (upsert_start_result.has_value()) {
+        EXPECT_TRUE(service_
+                        ->UpsertRevoke(client_id, target_gone_key,
+                                       TenantId::Default(), ReplicaType::MEMORY)
+                        .has_value());
+    }
 }
 
 TEST_F(MasterServiceTest, MoveRevoke) {


### PR DESCRIPTION
## Description

Fixes #3402.

`MoveStart()` pins the source replica while a move is in progress. If the target replica is gone before `MoveEnd()`, the target-gone error path previously erased the replication task without releasing the source refcount, leaving the surviving source replica busy.

This PR releases the source refcount and discards the reserved target replica on the `MoveEnd()` target-gone path. It also extends `MasterServiceTest.MoveEnd` in `mooncake-store/tests/master_service_test.cpp` with Test Case 7 for the target-gone path, verifying that `MoveEnd()` returns `REPLICA_IS_GONE`, `UpsertStart()` succeeds afterward, and `MoveRevoke()` reports `OBJECT_NO_REPLICATION_TASK`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target master_service_test -j 8
ctest --test-dir build -R '^master_service_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped analyze the refcount leak, implement the fix, add the regression test, and verify the targeted test/pre-commit commands.