### PR TITLE
[Store] Add chunked standby snapshot artifact writer

### DIFF
--- a/mooncake-store/include/ha/snapshot/batch_oplog/codec.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/codec.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "metadata_store.h"
+
+namespace mooncake {
+
+struct BatchOpLogSnapshotObjectChunk {
+    uint64_t chunk_index{0};
+    std::vector<StandbyObjectEntry> objects;
+
+    YLT_REFL(BatchOpLogSnapshotObjectChunk, chunk_index, objects);
+};
+
+std::vector<uint8_t> EncodeBatchOpLogSnapshotSegments(
+    const std::vector<StandbySegmentInfo>& segments);
+tl::expected<std::vector<StandbySegmentInfo>, std::string>
+DecodeBatchOpLogSnapshotSegments(const std::vector<uint8_t>& encoded);
+
+std::vector<uint8_t> EncodeBatchOpLogSnapshotObjectChunk(
+    uint64_t chunk_index, const std::vector<StandbyObjectEntry>& objects);
+tl::expected<BatchOpLogSnapshotObjectChunk, std::string>
+DecodeBatchOpLogSnapshotObjectChunk(const std::vector<uint8_t>& encoded,
+                                    uint64_t expected_chunk_index,
+                                    uint64_t expected_object_count);
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/batch_oplog/codec.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/codec.h
@@ -23,7 +23,7 @@ tl::expected<std::vector<StandbySegmentInfo>, std::string>
 DecodeBatchOpLogSnapshotSegments(const std::vector<uint8_t>& encoded);
 
 std::vector<uint8_t> EncodeBatchOpLogSnapshotObjectChunk(
-    uint64_t chunk_index, const std::vector<StandbyObjectEntry>& objects);
+    uint64_t chunk_index, std::vector<StandbyObjectEntry> objects);
 tl::expected<BatchOpLogSnapshotObjectChunk, std::string>
 DecodeBatchOpLogSnapshotObjectChunk(const std::vector<uint8_t>& encoded,
                                     uint64_t expected_chunk_index,

--- a/mooncake-store/include/ha/snapshot/batch_oplog/metadata.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/metadata.h
@@ -73,6 +73,8 @@ std::string BuildBatchOpLogSnapshotFallbackKey(const std::string& cluster_id);
 std::string BuildBatchOpLogSnapshotCompactionFloorKey(
     const std::string& cluster_id);
 
+std::string BuildBatchOpLogSnapshotArtifactPrefix(
+    const std::string& snapshot_root, std::string_view snapshot_id);
 std::string BuildBatchOpLogSnapshotDescriptorKey(
     const std::string& snapshot_root, std::string_view snapshot_id);
 std::string BuildBatchOpLogSnapshotManifestKey(const std::string& snapshot_root,

--- a/mooncake-store/include/ha/snapshot/batch_oplog/writer.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/writer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <ylt/util/tl/expected.hpp>
+
+namespace mooncake {
+
+class BatchOpLogSnapshotCapture;
+class HotStandbyService;
+class SnapshotObjectStore;
+
+class BatchOpLogSnapshotWriter {
+   public:
+    explicit BatchOpLogSnapshotWriter(SnapshotObjectStore& object_store)
+        : object_store_(object_store) {}
+
+    tl::expected<std::string, std::string> Write(
+        HotStandbyService& standby, BatchOpLogSnapshotCapture& capture,
+        const std::string& snapshot_root, const std::string& snapshot_id,
+        size_t chunk_object_count, int64_t created_at_ms);
+
+   private:
+    SnapshotObjectStore& object_store_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/object/backends/local/local_file_snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/backends/local/local_file_snapshot_object_store.h
@@ -45,6 +45,9 @@ class LocalFileSnapshotObjectStore final : public SnapshotObjectStore {
         const std::string& prefix,
         std::vector<std::string>& object_keys) override;
 
+    tl::expected<SnapshotObjectInspection, std::string> InspectObject(
+        const std::string& key) override;
+
     bool IsNotFoundError(const std::string& error) const override;
 
     std::string GetConnectionInfo() const override;

--- a/mooncake-store/include/ha/snapshot/object/backends/s3/s3_snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/backends/s3/s3_snapshot_object_store.h
@@ -41,6 +41,9 @@ class S3SnapshotObjectStore final : public SnapshotObjectStore {
         const std::string& prefix,
         std::vector<std::string>& object_keys) override;
 
+    tl::expected<SnapshotObjectInspection, std::string> InspectObject(
+        const std::string& key) override;
+
     bool IsNotFoundError(const std::string& error) const override;
     std::string GetConnectionInfo() const override;
 

--- a/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
+++ b/mooncake-store/include/ha/snapshot/object/snapshot_object_store.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -14,6 +15,11 @@ namespace mooncake {
 enum class SnapshotObjectStoreType {
     LOCAL_FILE = 0,  // Local file system
     S3 = 1           // S3 storage
+};
+
+struct SnapshotObjectInspection {
+    uint64_t stored_size{0};
+    std::optional<uint32_t> crc32c;
 };
 
 // Convert string to SnapshotObjectStoreType
@@ -116,6 +122,15 @@ class SnapshotObjectStore {
      */
     virtual tl::expected<void, std::string> ListObjectsWithPrefix(
         const std::string& prefix, std::vector<std::string>& object_keys) = 0;
+
+    /**
+     * @brief Read stored size and an optional backend-verified CRC32C
+     */
+    virtual tl::expected<SnapshotObjectInspection, std::string> InspectObject(
+        const std::string& key) {
+        return tl::make_unexpected("Object inspection is not supported: " +
+                                   key);
+    }
 
     /**
      * @brief Tell whether an error means the target object is missing

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -2713,10 +2713,8 @@ class MasterService {
     std::string SerializeMetadataForOpLogWithoutMemReplicas(
         const ObjectMetadata& metadata) const;
     std::string SerializeMetadataForOpLogFromReplicaDescriptors(
-        const UUID& client_id, uint64_t size,
-        const std::vector<Replica::Descriptor>& replicas,
-        const std::string& group_id = "",
-        ObjectDataType data_type = ObjectDataType::UNKNOWN) const;
+        const ObjectMetadata& metadata,
+        const std::vector<Replica::Descriptor>& replicas) const;
     ErrorCode InitializeBatchOpLogWriter(std::shared_ptr<HaKvBackend> backend);
     tl::expected<uint64_t, ErrorCode> AppendOpLogVisibleBeforeDurable(
         OpType type, const std::string& tenant_id, const std::string& key,

--- a/mooncake-store/include/metadata_store.h
+++ b/mooncake-store/include/metadata_store.h
@@ -36,11 +36,12 @@ struct StandbyObjectMetadata {
     std::string group_id;  // Tenant group identifier
     ObjectDataType data_type{
         ObjectDataType::UNKNOWN};  // Data type classification
+    struct_pack::compatible<bool, 1> hard_pinned;  // Eviction protection
 
     StandbyObjectMetadata() = default;
 
     YLT_REFL(StandbyObjectMetadata, client_id, size, replicas, group_id,
-             data_type);
+             data_type, hard_pinned);
 
     // Check if this metadata has valid replicas
     bool HasReplicas() const { return !replicas.empty(); }
@@ -100,8 +101,10 @@ struct MetadataPayload {
     std::vector<Replica::Descriptor> replicas;
     struct_pack::compatible<std::string, 1> group_id;      // Tenant group
     struct_pack::compatible<ObjectDataType, 1> data_type;  // Data type
+    struct_pack::compatible<bool, 1> hard_pinned;          // Hard pin state
 
-    YLT_REFL(MetadataPayload, client_id, size, replicas, group_id, data_type);
+    YLT_REFL(MetadataPayload, client_id, size, replicas, group_id, data_type,
+             hard_pinned);
 
     // Convert to StandbyObjectMetadata
     StandbyObjectMetadata ToStandbyMetadata() const {
@@ -111,6 +114,7 @@ struct MetadataPayload {
         meta.replicas = replicas;
         meta.group_id = group_id.value_or("");
         meta.data_type = data_type.value_or(ObjectDataType::UNKNOWN);
+        meta.hard_pinned = hard_pinned.value_or(false);
         return meta;
     }
 };

--- a/mooncake-store/include/metadata_store.h
+++ b/mooncake-store/include/metadata_store.h
@@ -39,6 +39,9 @@ struct StandbyObjectMetadata {
 
     StandbyObjectMetadata() = default;
 
+    YLT_REFL(StandbyObjectMetadata, client_id, size, replicas, group_id,
+             data_type);
+
     // Check if this metadata has valid replicas
     bool HasReplicas() const { return !replicas.empty(); }
 };

--- a/mooncake-store/include/utils/s3_helper.h
+++ b/mooncake-store/include/utils/s3_helper.h
@@ -7,6 +7,8 @@
 
 #include <aws/core/Aws.h>
 #include <aws/s3/S3Client.h>
+#include <cstdint>
+#include <optional>
 #include <string>
 #include <vector>
 #include <ylt/util/tl/expected.hpp>
@@ -73,6 +75,10 @@ class S3Helper {
 
     tl::expected<void, std::string> DeleteObjectsWithPrefix(
         const std::string &prefix);
+
+    tl::expected<void, std::string> InspectObject(
+        const std::string &key, uint64_t &stored_size,
+        std::optional<uint32_t> &crc32c);
 
    private:
     Aws::S3::S3Client s3_client_;

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -65,7 +65,9 @@ set(MOONCAKE_STORE_SOURCES
     ha/standby_controller.cpp
     ha/standby_metadata_store.cpp
     ha/snapshot/catalog_backed_snapshot_provider.cpp
+    ha/snapshot/batch_oplog/codec.cpp
     ha/snapshot/batch_oplog/metadata.cpp
+    ha/snapshot/batch_oplog/writer.cpp
     ha/snapshot/master_snapshot_codec.cpp
     ha/snapshot/local_ssd_codec.cpp
     ha/snapshot/object/snapshot_object_store.cpp

--- a/mooncake-store/src/ha/snapshot/batch_oplog/codec.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/codec.cpp
@@ -1,6 +1,7 @@
 #include "ha/snapshot/batch_oplog/codec.h"
 
 #include <limits>
+#include <utility>
 
 #include <ylt/struct_pack.hpp>
 
@@ -21,8 +22,7 @@ tl::expected<T, std::string> Decode(const std::vector<uint8_t>& encoded,
 
 template <typename T>
 std::vector<uint8_t> Encode(const T& value) {
-    auto encoded = struct_pack::serialize(value);
-    return {encoded.begin(), encoded.end()};
+    return struct_pack::serialize<std::vector<uint8_t>>(value);
 }
 
 }  // namespace
@@ -39,8 +39,9 @@ DecodeBatchOpLogSnapshotSegments(const std::vector<uint8_t>& encoded) {
 }
 
 std::vector<uint8_t> EncodeBatchOpLogSnapshotObjectChunk(
-    uint64_t chunk_index, const std::vector<StandbyObjectEntry>& objects) {
-    return Encode(BatchOpLogSnapshotObjectChunk{chunk_index, objects});
+    uint64_t chunk_index, std::vector<StandbyObjectEntry> objects) {
+    return Encode(
+        BatchOpLogSnapshotObjectChunk{chunk_index, std::move(objects)});
 }
 
 tl::expected<BatchOpLogSnapshotObjectChunk, std::string>

--- a/mooncake-store/src/ha/snapshot/batch_oplog/codec.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/codec.cpp
@@ -1,0 +1,65 @@
+#include "ha/snapshot/batch_oplog/codec.h"
+
+#include <limits>
+
+#include <ylt/struct_pack.hpp>
+
+namespace mooncake {
+
+namespace {
+
+template <typename T>
+tl::expected<T, std::string> Decode(const std::vector<uint8_t>& encoded,
+                                    const char* artifact) {
+    T decoded;
+    if (struct_pack::deserialize_to(decoded, encoded) !=
+        struct_pack::errc::ok) {
+        return tl::make_unexpected(std::string("Invalid ") + artifact);
+    }
+    return decoded;
+}
+
+template <typename T>
+std::vector<uint8_t> Encode(const T& value) {
+    auto encoded = struct_pack::serialize(value);
+    return {encoded.begin(), encoded.end()};
+}
+
+}  // namespace
+
+std::vector<uint8_t> EncodeBatchOpLogSnapshotSegments(
+    const std::vector<StandbySegmentInfo>& segments) {
+    return Encode(segments);
+}
+
+tl::expected<std::vector<StandbySegmentInfo>, std::string>
+DecodeBatchOpLogSnapshotSegments(const std::vector<uint8_t>& encoded) {
+    return Decode<std::vector<StandbySegmentInfo>>(encoded,
+                                                   "snapshot segments");
+}
+
+std::vector<uint8_t> EncodeBatchOpLogSnapshotObjectChunk(
+    uint64_t chunk_index, const std::vector<StandbyObjectEntry>& objects) {
+    return Encode(BatchOpLogSnapshotObjectChunk{chunk_index, objects});
+}
+
+tl::expected<BatchOpLogSnapshotObjectChunk, std::string>
+DecodeBatchOpLogSnapshotObjectChunk(const std::vector<uint8_t>& encoded,
+                                    uint64_t expected_chunk_index,
+                                    uint64_t expected_object_count) {
+    auto decoded =
+        Decode<BatchOpLogSnapshotObjectChunk>(encoded, "snapshot object chunk");
+    if (!decoded) {
+        return decoded;
+    }
+    if (decoded->chunk_index != expected_chunk_index) {
+        return tl::make_unexpected("Snapshot object chunk index mismatch");
+    }
+    if (expected_object_count > std::numeric_limits<size_t>::max() ||
+        decoded->objects.size() != expected_object_count) {
+        return tl::make_unexpected("Snapshot object chunk count mismatch");
+    }
+    return decoded;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/snapshot/batch_oplog/metadata.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/metadata.cpp
@@ -379,6 +379,11 @@ std::string BuildBatchOpLogSnapshotCompactionFloorKey(
     return BuildControlKey(cluster_id, "compaction_floor");
 }
 
+std::string BuildBatchOpLogSnapshotArtifactPrefix(
+    const std::string& snapshot_root, std::string_view snapshot_id) {
+    return BuildArtifactPrefix(snapshot_root, snapshot_id);
+}
+
 std::string BuildBatchOpLogSnapshotDescriptorKey(
     const std::string& snapshot_root, std::string_view snapshot_id) {
     const std::string prefix = BuildArtifactPrefix(snapshot_root, snapshot_id);

--- a/mooncake-store/src/ha/snapshot/batch_oplog/writer.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/writer.cpp
@@ -1,6 +1,5 @@
 #include "ha/snapshot/batch_oplog/writer.h"
 
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -15,10 +14,6 @@
 namespace mooncake {
 
 namespace {
-
-std::vector<uint8_t> ToBytes(std::string_view value) {
-    return {value.begin(), value.end()};
-}
 
 tl::expected<void, std::string> VerifyObject(SnapshotObjectStore& object_store,
                                              const std::string& key,
@@ -135,19 +130,18 @@ tl::expected<std::string, std::string> BatchOpLogSnapshotWriter::Write(
             return fail("Batch OpLog snapshot capture returned an empty chunk");
         }
 
-        auto encoded =
-            EncodeBatchOpLogSnapshotObjectChunk(chunk_index, objects);
+        const size_t object_count = objects.size();
+        auto encoded = EncodeBatchOpLogSnapshotObjectChunk(chunk_index,
+                                                           std::move(objects));
         const std::string key = ha::BuildBatchOpLogSnapshotObjectChunkKey(
             snapshot_root, snapshot_id, chunk_index);
         ha::BatchOpLogSnapshotChunkDescriptor descriptor{
             .chunk_index = chunk_index,
             .key = key,
-            .object_count = objects.size(),
+            .object_count = object_count,
             .stored_size = encoded.size(),
             .crc32c = Crc32cValue(encoded.data(), encoded.size()),
         };
-        std::vector<StandbyObjectEntry>().swap(objects);
-
         upload = object_store_.UploadBuffer(key, encoded);
         if (!upload) {
             return fail("Failed to upload snapshot object chunk: " +
@@ -176,14 +170,13 @@ tl::expected<std::string, std::string> BatchOpLogSnapshotWriter::Write(
         ha::BuildBatchOpLogSnapshotManifestKey(snapshot_root, snapshot_id);
     const std::string manifest_json =
         ha::EncodeBatchOpLogSnapshotManifest(manifest);
-    auto manifest_bytes = ToBytes(manifest_json);
     const uint32_t manifest_crc32c =
-        Crc32cValue(manifest_bytes.data(), manifest_bytes.size());
-    upload = object_store_.UploadBuffer(manifest_key, manifest_bytes);
+        Crc32cValue(manifest_json.data(), manifest_json.size());
+    upload = object_store_.UploadString(manifest_key, manifest_json);
     if (!upload) {
         return fail("Failed to upload snapshot manifest: " + upload.error());
     }
-    verify = VerifyObject(object_store_, manifest_key, manifest_bytes.size(),
+    verify = VerifyObject(object_store_, manifest_key, manifest_json.size(),
                           manifest_crc32c);
     if (!verify) {
         return fail(std::move(verify.error()));
@@ -195,22 +188,21 @@ tl::expected<std::string, std::string> BatchOpLogSnapshotWriter::Write(
     descriptor.last_included_batch_id = capture.last_included_batch_id;
     descriptor.producer_view_version = capture.producer_view_version;
     descriptor.manifest_key = manifest_key;
-    descriptor.manifest_size = manifest_bytes.size();
+    descriptor.manifest_size = manifest_json.size();
     descriptor.manifest_crc32c = manifest_crc32c;
     descriptor.created_at_ms = created_at_ms;
 
     const std::string descriptor_json =
         ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
-    auto descriptor_bytes = ToBytes(descriptor_json);
     const std::string descriptor_key =
         ha::BuildBatchOpLogSnapshotDescriptorKey(snapshot_root, snapshot_id);
-    upload = object_store_.UploadBuffer(descriptor_key, descriptor_bytes);
+    upload = object_store_.UploadString(descriptor_key, descriptor_json);
     if (!upload) {
         return fail("Failed to upload snapshot descriptor: " + upload.error());
     }
     verify = VerifyObject(
-        object_store_, descriptor_key, descriptor_bytes.size(),
-        Crc32cValue(descriptor_bytes.data(), descriptor_bytes.size()));
+        object_store_, descriptor_key, descriptor_json.size(),
+        Crc32cValue(descriptor_json.data(), descriptor_json.size()));
     if (!verify) {
         return fail(std::move(verify.error()));
     }

--- a/mooncake-store/src/ha/snapshot/batch_oplog/writer.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/writer.cpp
@@ -1,0 +1,220 @@
+#include "ha/snapshot/batch_oplog/writer.h"
+
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "crc32c.h"
+#include "ha/snapshot/batch_oplog/codec.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/object/snapshot_object_store.h"
+#include "hot_standby_service.h"
+
+namespace mooncake {
+
+namespace {
+
+std::vector<uint8_t> ToBytes(std::string_view value) {
+    return {value.begin(), value.end()};
+}
+
+tl::expected<void, std::string> VerifyObject(SnapshotObjectStore& object_store,
+                                             const std::string& key,
+                                             uint64_t expected_size,
+                                             uint32_t expected_crc32c) {
+    auto inspection = object_store.InspectObject(key);
+    if (!inspection) {
+        return tl::make_unexpected("Failed to inspect snapshot object " + key +
+                                   ": " + inspection.error());
+    }
+    if (inspection->stored_size != expected_size) {
+        return tl::make_unexpected("Snapshot object size mismatch: " + key);
+    }
+    if (inspection->crc32c) {
+        if (*inspection->crc32c != expected_crc32c) {
+            return tl::make_unexpected("Snapshot object CRC32C mismatch: " +
+                                       key);
+        }
+        return {};
+    }
+
+    std::vector<uint8_t> downloaded;
+    auto download = object_store.DownloadBuffer(key, downloaded);
+    if (!download) {
+        return tl::make_unexpected("Failed to read back snapshot object " +
+                                   key + ": " + download.error());
+    }
+    if (downloaded.size() != expected_size ||
+        Crc32cValue(downloaded.data(), downloaded.size()) != expected_crc32c) {
+        return tl::make_unexpected("Snapshot object readback mismatch: " + key);
+    }
+    return {};
+}
+
+}  // namespace
+
+tl::expected<std::string, std::string> BatchOpLogSnapshotWriter::Write(
+    HotStandbyService& standby, BatchOpLogSnapshotCapture& capture,
+    const std::string& snapshot_root, const std::string& snapshot_id,
+    size_t chunk_object_count, int64_t created_at_ms) {
+    bool capture_active = true;
+    bool candidate_touched = false;
+    const std::string prefix =
+        ha::BuildBatchOpLogSnapshotArtifactPrefix(snapshot_root, snapshot_id);
+
+    auto end_capture = [&] {
+        if (capture_active) {
+            standby.EndBatchOpLogSnapshotCapture(capture);
+            capture_active = false;
+        }
+    };
+    auto fail =
+        [&](std::string error) -> tl::expected<std::string, std::string> {
+        end_capture();
+        if (candidate_touched) {
+            auto cleanup = object_store_.DeleteObjectsWithPrefix(prefix);
+            if (!cleanup) {
+                LOG(WARNING) << "Failed to clean snapshot candidate " << prefix
+                             << ": " << cleanup.error();
+            }
+        }
+        return tl::make_unexpected(std::move(error));
+    };
+
+    const std::string expected_id_prefix =
+        std::to_string(capture.last_included_batch_id) + "-";
+    if (prefix.empty() || !snapshot_id.starts_with(expected_id_prefix) ||
+        (capture.last_included_seq == 0) !=
+            (capture.last_included_batch_id == 0) ||
+        capture.producer_view_version < 0 || chunk_object_count == 0 ||
+        created_at_ms < 0) {
+        return fail("Invalid batch OpLog snapshot writer arguments");
+    }
+
+    std::vector<std::string> existing;
+    auto list = object_store_.ListObjectsWithPrefix(prefix, existing);
+    if (!list) {
+        return fail("Failed to check snapshot candidate prefix: " +
+                    list.error());
+    }
+    if (!existing.empty()) {
+        return fail("Snapshot candidate prefix already exists: " + prefix);
+    }
+
+    ha::BatchOpLogSnapshotManifest manifest;
+    manifest.snapshot_id = snapshot_id;
+    manifest.last_included_seq = capture.last_included_seq;
+    manifest.last_included_batch_id = capture.last_included_batch_id;
+    manifest.producer_view_version = capture.producer_view_version;
+
+    const std::string segments_key =
+        ha::BuildBatchOpLogSnapshotSegmentsKey(snapshot_root, snapshot_id);
+    auto segments = EncodeBatchOpLogSnapshotSegments(capture.segments);
+    manifest.segments = {
+        .key = segments_key,
+        .stored_size = segments.size(),
+        .crc32c = Crc32cValue(segments.data(), segments.size()),
+    };
+    candidate_touched = true;
+    auto upload = object_store_.UploadBuffer(segments_key, segments);
+    if (!upload) {
+        return fail("Failed to upload snapshot segments: " + upload.error());
+    }
+    std::vector<uint8_t>().swap(segments);
+
+    uint64_t chunk_index = 0;
+    while (!capture.done()) {
+        std::vector<StandbyObjectEntry> objects;
+        if (!standby.CopyNextBatchOpLogSnapshotChunk(chunk_object_count,
+                                                     capture, objects)) {
+            return fail("Batch OpLog snapshot capture was cancelled");
+        }
+        if (objects.empty()) {
+            return fail("Batch OpLog snapshot capture returned an empty chunk");
+        }
+
+        auto encoded =
+            EncodeBatchOpLogSnapshotObjectChunk(chunk_index, objects);
+        const std::string key = ha::BuildBatchOpLogSnapshotObjectChunkKey(
+            snapshot_root, snapshot_id, chunk_index);
+        ha::BatchOpLogSnapshotChunkDescriptor descriptor{
+            .chunk_index = chunk_index,
+            .key = key,
+            .object_count = objects.size(),
+            .stored_size = encoded.size(),
+            .crc32c = Crc32cValue(encoded.data(), encoded.size()),
+        };
+        std::vector<StandbyObjectEntry>().swap(objects);
+
+        upload = object_store_.UploadBuffer(key, encoded);
+        if (!upload) {
+            return fail("Failed to upload snapshot object chunk: " +
+                        upload.error());
+        }
+        manifest.object_chunks.push_back(std::move(descriptor));
+        ++chunk_index;
+    }
+    end_capture();
+
+    auto verify =
+        VerifyObject(object_store_, manifest.segments.key,
+                     manifest.segments.stored_size, manifest.segments.crc32c);
+    if (!verify) {
+        return fail(std::move(verify.error()));
+    }
+    for (const auto& chunk : manifest.object_chunks) {
+        verify = VerifyObject(object_store_, chunk.key, chunk.stored_size,
+                              chunk.crc32c);
+        if (!verify) {
+            return fail(std::move(verify.error()));
+        }
+    }
+
+    const std::string manifest_key =
+        ha::BuildBatchOpLogSnapshotManifestKey(snapshot_root, snapshot_id);
+    const std::string manifest_json =
+        ha::EncodeBatchOpLogSnapshotManifest(manifest);
+    auto manifest_bytes = ToBytes(manifest_json);
+    const uint32_t manifest_crc32c =
+        Crc32cValue(manifest_bytes.data(), manifest_bytes.size());
+    upload = object_store_.UploadBuffer(manifest_key, manifest_bytes);
+    if (!upload) {
+        return fail("Failed to upload snapshot manifest: " + upload.error());
+    }
+    verify = VerifyObject(object_store_, manifest_key, manifest_bytes.size(),
+                          manifest_crc32c);
+    if (!verify) {
+        return fail(std::move(verify.error()));
+    }
+
+    ha::BatchOpLogSnapshotDescriptor descriptor;
+    descriptor.snapshot_id = snapshot_id;
+    descriptor.last_included_seq = capture.last_included_seq;
+    descriptor.last_included_batch_id = capture.last_included_batch_id;
+    descriptor.producer_view_version = capture.producer_view_version;
+    descriptor.manifest_key = manifest_key;
+    descriptor.manifest_size = manifest_bytes.size();
+    descriptor.manifest_crc32c = manifest_crc32c;
+    descriptor.created_at_ms = created_at_ms;
+
+    const std::string descriptor_json =
+        ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
+    auto descriptor_bytes = ToBytes(descriptor_json);
+    const std::string descriptor_key =
+        ha::BuildBatchOpLogSnapshotDescriptorKey(snapshot_root, snapshot_id);
+    upload = object_store_.UploadBuffer(descriptor_key, descriptor_bytes);
+    if (!upload) {
+        return fail("Failed to upload snapshot descriptor: " + upload.error());
+    }
+    verify = VerifyObject(
+        object_store_, descriptor_key, descriptor_bytes.size(),
+        Crc32cValue(descriptor_bytes.data(), descriptor_bytes.size()));
+    if (!verify) {
+        return fail(std::move(verify.error()));
+    }
+    return descriptor_json;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/catalog_backed_snapshot_provider.cpp
@@ -214,11 +214,10 @@ DeserializeStandbyObjectMetadata(
             return std::optional<StandbyObjectMetadata>();
         }
 
-        // Read hard_pinned and group_id if present. Standby does not need
-        // hard_pinned, but promotion needs group_id to rebuild group indexes.
+        bool hard_pinned = false;
         if (index < total_elements &&
             array[index].type == msgpack::type::BOOLEAN) {
-            ++index;  // hard_pinned
+            hard_pinned = array[index++].as<bool>();
         }
 
         std::string group_id;
@@ -232,6 +231,7 @@ DeserializeStandbyObjectMetadata(
         metadata.replicas = std::move(replicas);
         metadata.data_type = data_type;
         metadata.group_id = std::move(group_id);
+        metadata.hard_pinned = hard_pinned;
         return std::optional<StandbyObjectMetadata>(std::move(metadata));
     } catch (const std::exception& ex) {
         LOG(ERROR) << "Failed to parse snapshot metadata entry: " << ex.what();

--- a/mooncake-store/src/ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/backends/local/local_file_snapshot_object_store.cpp
@@ -324,6 +324,30 @@ LocalFileSnapshotObjectStore::ListObjectsWithPrefix(
     return {};
 }
 
+tl::expected<SnapshotObjectInspection, std::string>
+LocalFileSnapshotObjectStore::InspectObject(const std::string& key) {
+    fs::path full_path = KeyToPath(key);
+    if (!IsPathWithinBase(full_path)) {
+        return tl::make_unexpected(
+            fmt::format("Security error: Path {} is outside base directory {}",
+                        full_path.string(), base_path_.string()));
+    }
+    if (!fs::exists(full_path)) {
+        return tl::make_unexpected(
+            fmt::format("File not found: {}", full_path.string()));
+    }
+
+    std::error_code ec;
+    const auto size = fs::file_size(full_path, ec);
+    if (ec) {
+        return tl::make_unexpected(
+            fmt::format("Failed to get file size: {}, error: {}",
+                        full_path.string(), ec.message()));
+    }
+    return SnapshotObjectInspection{.stored_size = size,
+                                    .crc32c = std::nullopt};
+}
+
 bool LocalFileSnapshotObjectStore::IsNotFoundError(
     const std::string& error) const {
     return error.starts_with("File not found:");

--- a/mooncake-store/src/ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp
+++ b/mooncake-store/src/ha/snapshot/object/backends/s3/s3_snapshot_object_store.cpp
@@ -81,6 +81,17 @@ tl::expected<void, std::string> S3SnapshotObjectStore::ListObjectsWithPrefix(
     return impl_->s3_helper_.ListObjectsWithPrefix(prefix, object_keys);
 }
 
+tl::expected<SnapshotObjectInspection, std::string>
+S3SnapshotObjectStore::InspectObject(const std::string& key) {
+    SnapshotObjectInspection inspection;
+    auto result = impl_->s3_helper_.InspectObject(key, inspection.stored_size,
+                                                  inspection.crc32c);
+    if (!result) {
+        return tl::make_unexpected(std::move(result.error()));
+    }
+    return inspection;
+}
+
 bool S3SnapshotObjectStore::IsNotFoundError(const std::string& error) const {
     return ContainsAsciiInsensitive(error, "nosuchkey") ||
            ContainsAsciiInsensitive(error, "not found") ||

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2035,11 +2035,9 @@ tl::expected<void, ErrorCode> MasterService::PersistStaleHandleCleanupForHA(
     const auto op_type =
         plan.would_invalidate ? OpType::REMOVE : OpType::PUT_END;
     const std::string payload =
-        plan.would_invalidate
-            ? std::string{}
-            : SerializeMetadataForOpLogFromReplicaDescriptors(
-                  metadata.client_id, metadata.size, plan.remaining,
-                  metadata.group_id, metadata.data_type);
+        plan.would_invalidate ? std::string{}
+                              : SerializeMetadataForOpLogFromReplicaDescriptors(
+                                    metadata, plan.remaining);
 
     auto reservation = ReserveBatchOpLogSlot();
     if (!reservation) {
@@ -3189,7 +3187,8 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
                 std::forward_as_tuple(object.user_key),
                 std::forward_as_tuple(
                     standby_meta.client_id, now, standby_meta.size,
-                    std::move(object.replicas), std::nullopt, false,
+                    std::move(object.replicas), std::nullopt,
+                    standby_meta.hard_pinned.value_or(false),
                     standby_meta.data_type, standby_meta.group_id,
                     object.tenant_id, object.user_key));
             if (!standby_meta.group_id.empty()) {
@@ -3442,8 +3441,7 @@ auto MasterService::BatchReplicaClear(
                             std::move(reservation.value()), OpType::PUT_END,
                             normalized_tenant.value(), key,
                             SerializeMetadataForOpLogFromReplicaDescriptors(
-                                metadata.client_id, metadata.size, remaining,
-                                metadata.group_id, metadata.data_type),
+                                metadata, remaining),
                             [this, removed_ids = std::move(removed_ids)](
                                 const OpLogEntry& durable_entry) {
                                 FinalizeRemovedReplicasAfterDurable(
@@ -4675,9 +4673,7 @@ auto MasterService::AddReplica(const UUID& client_id, const std::string& key,
 
         auto persist_result = AppendOpLogVisibleBeforeDurable(
             OpType::PUT_END, object_id.tenant_id.value(), key,
-            SerializeMetadataForOpLogFromReplicaDescriptors(
-                metadata.client_id, metadata.size, post, metadata.group_id,
-                metadata.data_type));
+            SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post));
         if (!persist_result) {
             return tl::make_unexpected(persist_result.error());
         }
@@ -4791,9 +4787,8 @@ auto MasterService::PutRevoke(const UUID& client_id, const std::string& key,
             persist_result = AppendReservedOpLogWithDurableFinalize(
                 std::move(reservation.value()), OpType::PUT_END,
                 tenant_id.value(), key,
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, remaining,
-                    metadata.group_id, metadata.data_type),
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
+                                                                remaining),
                 [this, removed_ids = std::move(removed_ids)](
                     const OpLogEntry& durable_entry) {
                     FinalizeRemovedReplicasAfterDurable(
@@ -5485,9 +5480,8 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
                 persist_result = AppendReservedOpLogWithDurableFinalize(
                     std::move(reservation.value()), OpType::PUT_END,
                     metadata.tenant_id.value(), key,
-                    SerializeMetadataForOpLogFromReplicaDescriptors(
-                        metadata.client_id, metadata.size, remaining,
-                        metadata.group_id, metadata.data_type),
+                    SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
+                                                                    remaining),
                     [this, removed_ids = std::move(removed_ids)](
                         const OpLogEntry& durable_entry) {
                         FinalizeRemovedReplicasAfterDurable(
@@ -5507,9 +5501,8 @@ auto MasterService::EvictDiskReplica(const UUID& client_id,
         } else {
             persist_result = AppendOpLogWithDurableFinalize(
                 OpType::PUT_END, metadata.tenant_id.value(), key,
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, remaining,
-                    metadata.group_id, metadata.data_type),
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
+                                                                remaining),
                 nullptr);
         }
         if (!persist_result) {
@@ -5872,9 +5865,8 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
                                [&post](const Replica& replica) {
                                    post.push_back(replica.get_descriptor());
                                });
-        auto payload = SerializeMetadataForOpLogFromReplicaDescriptors(
-            metadata.client_id, metadata.size, post, metadata.group_id,
-            metadata.data_type);
+        auto payload =
+            SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post);
         if (batch_reservation) {
             auto persist_result = AppendReservedOpLogWithDurableFinalize(
                 std::move(*batch_reservation), OpType::PUT_END,
@@ -6230,9 +6222,7 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
             persist_result = AppendReservedOpLogWithDurableFinalize(
                 std::move(reservation.value()), OpType::PUT_END,
                 metadata.tenant_id.value(), key,
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, post, metadata.group_id,
-                    metadata.data_type),
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post),
                 [this, removed_ids = std::vector<ReplicaID>{source_id}](
                     const OpLogEntry& durable_entry) {
                     FinalizeRemovedReplicasAfterDurable(
@@ -6241,9 +6231,7 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
         } else {
             persist_result = AppendOpLogWithDurableFinalize(
                 OpType::PUT_END, metadata.tenant_id.value(), key,
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, post, metadata.group_id,
-                    metadata.data_type),
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post),
                 nullptr);
         }
         if (!persist_result) {
@@ -8705,9 +8693,7 @@ auto MasterService::NotifyPromotionSuccess(const UUID& client_id,
                                    });
 
             const auto payload =
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, post, metadata.group_id,
-                    metadata.data_type);
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata, post);
             if (batch_reservation) {
                 auto persist_result = AppendReservedOpLogWithDurableFinalize(
                     std::move(*batch_reservation), OpType::PUT_END,
@@ -8978,9 +8964,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         persist_result = AppendOpLogWithDurableFinalize(
                             OpType::PUT_END, tenant_it->first.value(), *key_it,
                             SerializeMetadataForOpLogFromReplicaDescriptors(
-                                metadata.client_id, metadata.size,
-                                post_descriptors, metadata.group_id,
-                                metadata.data_type),
+                                metadata, post_descriptors),
                             enable_oplog_
                                 ? [this, ttl](const OpLogEntry& durable_entry) {
                                       FinalizeExpiredProcessingReplicasAfterDurable(
@@ -9095,8 +9079,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         OpType::PUT_END, tenant_it->first.value(),
                         task_it->first,
                         SerializeMetadataForOpLogFromReplicaDescriptors(
-                            metadata.client_id, metadata.size, post_descriptors,
-                            metadata.group_id, metadata.data_type),
+                            metadata, post_descriptors),
                         enable_oplog_
                             ? [this, source_id,
                                target_ids = std::move(target_ids),
@@ -9922,9 +9905,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 persist_result = AppendReservedOpLogWithDurableFinalize(
                     std::move(reservation.value()), OpType::PUT_END,
                     tenant_id.value(), key,
-                    SerializeMetadataForOpLogFromReplicaDescriptors(
-                        metadata.client_id, metadata.size, remaining,
-                        metadata.group_id, metadata.data_type),
+                    SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
+                                                                    remaining),
                     [this, removed_ids = std::move(removed_ids)](
                         const OpLogEntry& durable_entry) {
                         FinalizeRemovedReplicasAfterDurable(
@@ -9948,9 +9930,8 @@ void MasterService::BatchEvict(double evict_ratio_target,
         } else {
             persist_result = AppendOpLogWithDurableFinalize(
                 OpType::PUT_END, tenant_id.value(), key,
-                SerializeMetadataForOpLogFromReplicaDescriptors(
-                    metadata.client_id, metadata.size, remaining,
-                    metadata.group_id, metadata.data_type),
+                SerializeMetadataForOpLogFromReplicaDescriptors(metadata,
+                                                                remaining),
                 nullptr);
         }
         if (!persist_result) {
@@ -10686,9 +10667,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
                                 std::move(reservation.value()), OpType::PUT_END,
                                 tenant_it->first.value(), it->first,
                                 SerializeMetadataForOpLogFromReplicaDescriptors(
-                                    metadata.client_id, metadata.size,
-                                    remaining, metadata.group_id,
-                                    metadata.data_type),
+                                    metadata, remaining),
                                 [this, removed_ids = std::move(removed_ids)](
                                     const OpLogEntry& durable_entry) {
                                     FinalizeRemovedReplicasAfterDurable(
@@ -10722,8 +10701,7 @@ void MasterService::NoFBatchEvict(double evict_ratio_target,
                             OpType::PUT_END, tenant_it->first.value(),
                             it->first,
                             SerializeMetadataForOpLogFromReplicaDescriptors(
-                                metadata.client_id, metadata.size, remaining,
-                                metadata.group_id, metadata.data_type),
+                                metadata, remaining),
                             nullptr);
                     }
                     if (!persist_result) {
@@ -12814,6 +12792,7 @@ std::string MasterService::SerializeMetadataForOpLog(
     payload.size = metadata.size;
     payload.group_id = metadata.group_id;
     payload.data_type = metadata.data_type;
+    payload.hard_pinned = metadata.IsHardPinned();
 
     // Extract replica descriptors - get them all at once
     const auto& replicas = metadata.GetAllReplicas();
@@ -12839,6 +12818,7 @@ std::string MasterService::SerializeMetadataForOpLogWithoutMemReplicas(
     payload.size = metadata.size;
     payload.group_id = metadata.group_id;
     payload.data_type = metadata.data_type;
+    payload.hard_pinned = metadata.IsHardPinned();
 
     const auto& replicas = metadata.GetAllReplicas();
     payload.replicas.reserve(replicas.size());
@@ -12854,15 +12834,15 @@ std::string MasterService::SerializeMetadataForOpLogWithoutMemReplicas(
 }
 
 std::string MasterService::SerializeMetadataForOpLogFromReplicaDescriptors(
-    const UUID& client_id, uint64_t size,
-    const std::vector<Replica::Descriptor>& replicas,
-    const std::string& group_id, ObjectDataType data_type) const {
+    const ObjectMetadata& metadata,
+    const std::vector<Replica::Descriptor>& replicas) const {
     MetadataPayload payload;
-    payload.client_id = client_id;
-    payload.size = size;
+    payload.client_id = metadata.client_id;
+    payload.size = metadata.size;
     payload.replicas = replicas;
-    payload.group_id = group_id;
-    payload.data_type = data_type;
+    payload.group_id = metadata.group_id;
+    payload.data_type = metadata.data_type;
+    payload.hard_pinned = metadata.IsHardPinned();
     auto result = struct_pack::serialize(payload);
     return std::string(result.begin(), result.end());
 }

--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -550,6 +550,8 @@ tl::expected<void, std::string> S3Helper::UploadBufferMultipart(
 
                 // Use original buffer pointer directly, avoid copying
                 const uint8_t *part_data = buffer.data() + offset;
+                const std::string part_crc32c =
+                    EncodeCrc32c(Crc32cValue(part_data, current_part_size));
 
                 // Add retry logic
                 const int max_retries = 2;
@@ -564,6 +566,7 @@ tl::expected<void, std::string> S3Helper::UploadBufferMultipart(
                     part_request.SetPartNumber(static_cast<int>(part_num));
                     part_request.SetContentLength(
                         static_cast<long long>(current_part_size));
+                    part_request.SetChecksumCRC32C(part_crc32c);
 
                     // Use temporary stream
                     auto stream =

--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -30,6 +30,7 @@
 #include <aws/core/client/ClientConfiguration.h>
 #include "environ.h"
 #include "fmt/format.h"
+#include "utils/base64.h"
 
 namespace mooncake {
 
@@ -187,6 +188,42 @@ tl::expected<void, std::string> S3Helper::UploadString(
     if (!outcome.IsSuccess()) {
         return tl::make_unexpected(
             fmt::format("Upload failed: {}", outcome.GetError().GetMessage()));
+    }
+    return {};
+}
+
+tl::expected<void, std::string> S3Helper::InspectObject(
+    const std::string &key, uint64_t &stored_size,
+    std::optional<uint32_t> &crc32c) {
+    Aws::S3::Model::HeadObjectRequest request;
+    request.SetBucket(bucket_.c_str());
+    request.SetKey(key.c_str());
+    request.SetChecksumMode(Aws::S3::Model::ChecksumMode::ENABLED);
+
+    auto outcome = s3_client_.HeadObject(request);
+    if (!outcome.IsSuccess()) {
+        return tl::make_unexpected(fmt::format(
+            "HeadObject failed: {}", outcome.GetError().GetMessage()));
+    }
+    const auto content_length = outcome.GetResult().GetContentLength();
+    if (content_length < 0) {
+        return tl::make_unexpected(
+            fmt::format("Invalid content length: {}", content_length));
+    }
+    stored_size = static_cast<uint64_t>(content_length);
+    crc32c.reset();
+
+    const std::string encoded = outcome.GetResult().GetChecksumCRC32C();
+    const std::string decoded = base64::Decode(encoded);
+    if (!encoded.empty() && decoded.size() == sizeof(uint32_t) &&
+        base64::Encode(decoded) == encoded) {
+        crc32c = (static_cast<uint32_t>(static_cast<unsigned char>(decoded[0]))
+                  << 24) |
+                 (static_cast<uint32_t>(static_cast<unsigned char>(decoded[1]))
+                  << 16) |
+                 (static_cast<uint32_t>(static_cast<unsigned char>(decoded[2]))
+                  << 8) |
+                 static_cast<uint32_t>(static_cast<unsigned char>(decoded[3]));
     }
     return {};
 }

--- a/mooncake-store/src/utils/s3_helper.cpp
+++ b/mooncake-store/src/utils/s3_helper.cpp
@@ -26,8 +26,11 @@
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
 #include <aws/s3/model/CompleteMultipartUploadRequest.h>
 #include <aws/s3/model/AbortMultipartUploadRequest.h>
+#include <aws/s3/model/ChecksumAlgorithm.h>
+#include <aws/s3/model/ChecksumType.h>
 #include <aws/s3/model/UploadPartRequest.h>
 #include <aws/core/client/ClientConfiguration.h>
+#include "crc32c.h"
 #include "environ.h"
 #include "fmt/format.h"
 #include "utils/base64.h"
@@ -52,6 +55,15 @@ std::optional<T> ParseChecksumMode(const std::string &value) {
     LOG(WARNING) << "Invalid value: " << value
                  << ", ignoring (keeping AWS SDK default)";
     return std::nullopt;
+}
+
+std::string EncodeCrc32c(uint32_t checksum) {
+    std::string bytes(sizeof(checksum), '\0');
+    bytes[0] = static_cast<char>(checksum >> 24);
+    bytes[1] = static_cast<char>(checksum >> 16);
+    bytes[2] = static_cast<char>(checksum >> 8);
+    bytes[3] = static_cast<char>(checksum);
+    return base64::Encode(bytes);
 }
 
 }  // namespace
@@ -158,6 +170,8 @@ tl::expected<void, std::string> S3Helper::UploadBuffer(
 
     // Set ContentLength correctly (using long long type)
     request.SetContentLength(static_cast<long long>(buffer.size()));
+    request.SetChecksumCRC32C(
+        EncodeCrc32c(Crc32cValue(buffer.data(), buffer.size())));
     const auto buffer_size = static_cast<std::streamsize>(buffer.size());
 
     // Create and write to stream
@@ -179,6 +193,8 @@ tl::expected<void, std::string> S3Helper::UploadString(
     request.SetBucket(bucket_.c_str());
     request.SetKey(key.c_str());
     request.SetContentLength(static_cast<long long>(data.size()));
+    request.SetChecksumCRC32C(
+        EncodeCrc32c(Crc32cValue(data.data(), data.size())));
 
     auto stream = Aws::MakeShared<Aws::StringStream>("UploadString");
     stream->write(data.data(), data.size());
@@ -212,6 +228,11 @@ tl::expected<void, std::string> S3Helper::InspectObject(
     }
     stored_size = static_cast<uint64_t>(content_length);
     crc32c.reset();
+
+    if (outcome.GetResult().GetChecksumType() !=
+        Aws::S3::Model::ChecksumType::FULL_OBJECT) {
+        return {};
+    }
 
     const std::string encoded = outcome.GetResult().GetChecksumCRC32C();
     const std::string decoded = base64::Decode(encoded);
@@ -481,6 +502,9 @@ tl::expected<void, std::string> S3Helper::UploadBufferMultipart(
     Aws::S3::Model::CreateMultipartUploadRequest create_request;
     create_request.SetBucket(bucket_.c_str());
     create_request.SetKey(key.c_str());
+    create_request.SetChecksumAlgorithm(
+        Aws::S3::Model::ChecksumAlgorithm::CRC32C);
+    create_request.SetChecksumType(Aws::S3::Model::ChecksumType::FULL_OBJECT);
 
     auto create_outcome = s3_client_.CreateMultipartUpload(create_request);
     if (!create_outcome.IsSuccess()) {
@@ -635,6 +659,10 @@ tl::expected<void, std::string> S3Helper::UploadBufferMultipart(
     complete_request.SetBucket(bucket_.c_str());
     complete_request.SetKey(key.c_str());
     complete_request.SetUploadId(upload_id);
+    complete_request.SetChecksumCRC32C(
+        EncodeCrc32c(Crc32cValue(buffer.data(), buffer.size())));
+    complete_request.SetChecksumType(Aws::S3::Model::ChecksumType::FULL_OBJECT);
+    complete_request.SetMpuObjectSize(static_cast<long long>(total_size));
 
     Aws::S3::Model::CompletedMultipartUpload completed_upload;
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -179,6 +179,10 @@ add_store_test(master_snapshot_codec_test
                ha/snapshot/master_snapshot_codec_test.cpp)
 add_ha_test(batch_oplog_snapshot_types_test
             ha/snapshot/batch_oplog/metadata_test.cpp)
+add_ha_test(batch_oplog_snapshot_codec_test
+            ha/snapshot/batch_oplog/codec_test.cpp)
+add_ha_test(batch_oplog_snapshot_writer_test
+            ha/snapshot/batch_oplog/writer_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -597,6 +597,14 @@ class MasterServiceHATest : public ::testing::Test {
         return accessor.Exists() ? accessor.Get().CountReplicas() : 0;
     }
 
+    static bool IsHardPinnedForTesting(MasterService& service,
+                                       const TenantId& tenant_id,
+                                       const std::string& key) {
+        MasterService::MetadataAccessorRO accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        return accessor.Exists() && accessor.Get().IsHardPinned();
+    }
+
     static std::vector<Replica::Descriptor> ReplicaDescriptorsForTesting(
         MasterService& service, const TenantId& tenant_id,
         const std::string& key) {
@@ -908,6 +916,22 @@ TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesMemoryBufferDescriptor) {
     EXPECT_EQ(restored.buffer_address_, address);
     EXPECT_EQ(restored.protocol_, "tcp");
     EXPECT_EQ(restored.transport_endpoint_, endpoint);
+}
+
+TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesHardPinned) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+
+    const std::string key = "standby_restore_hard_pinned";
+    const std::string endpoint = "standby_restore_hard_pinned_segment";
+    auto object = MakeStandbyObject(key, endpoint);
+    object.metadata.hard_pinned = true;
+
+    ASSERT_TRUE(service
+                    .RestoreFromStandbySnapshot(
+                        {object}, 7, {MakeStandbyMemorySegment(endpoint)})
+                    .has_value());
+    EXPECT_TRUE(IsHardPinnedForTesting(service, kDefaultTenant, key));
 }
 
 TEST_F(MasterServiceHATest, RestoreFailureKeepsExistingState) {
@@ -2858,6 +2882,7 @@ TEST_F(MasterServiceHATest, PutEndWritesBatchRecordOpLog) {
     ReplicateConfig config;
     config.replica_num = 1;
     config.preferred_segments = {"batch_put_end_segment"};
+    config.with_hard_pin = true;
     const std::string key = "batch_put_end_key";
     auto put_start =
         service.PutStart(mounted.client_id, key, kDefaultTenant, 1024, config);
@@ -2879,6 +2904,10 @@ TEST_F(MasterServiceHATest, PutEndWritesBatchRecordOpLog) {
     EXPECT_EQ(OpType::PUT_END, batch.entries[0].op_type);
     EXPECT_EQ(kDefaultTenant.value(), batch.entries[0].tenant_id);
     EXPECT_EQ(key, batch.entries[0].object_key);
+    MetadataPayload payload;
+    ASSERT_EQ(struct_pack::errc::ok,
+              struct_pack::deserialize_to(payload, batch.entries[0].payload));
+    EXPECT_TRUE(payload.hard_pinned.value_or(false));
     EXPECT_EQ(2u, batch.entries[0].sequence_id);
 
     DurablePrefix prefix;

--- a/mooncake-store/tests/ha/oplog/oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_applier_test.cpp
@@ -43,10 +43,13 @@ OpLogEntry MakeEntry(uint64_t seq, OpType type, const std::string& key,
 // Helper function to create a valid struct_pack payload for PUT_END
 std::string MakeValidPayload(uint64_t client_id_first = 1,
                              uint64_t client_id_second = 2,
-                             uint64_t size = 1024) {
+                             uint64_t size = 1024, bool hard_pinned = false) {
     mooncake::MetadataPayload payload;
     payload.client_id = {client_id_first, client_id_second};
     payload.size = size;
+    if (hard_pinned) {
+        payload.hard_pinned = true;
+    }
     auto result = struct_pack::serialize(payload);
     return std::string(result.begin(), result.end());
 }
@@ -289,6 +292,17 @@ TEST_F(OpLogApplierTest, TestApplyPutEnd_ValidPayload) {
     EXPECT_EQ(1u, meta->client_id.first);
     EXPECT_EQ(2u, meta->client_id.second);
     EXPECT_EQ(2048u, meta->size);
+    EXPECT_FALSE(meta->hard_pinned.value_or(false));
+}
+
+TEST_F(OpLogApplierTest, TestApplyPutEnd_PreservesHardPinned) {
+    std::string payload = MakeValidPayload(1, 2, 2048, true);
+    OpLogEntry entry = MakeEntry(1, OpType::PUT_END, "key1", payload);
+
+    EXPECT_TRUE(applier_->ApplyOpLogEntry(entry));
+    auto meta = mock_metadata_store_->GetMetadata("key1");
+    ASSERT_TRUE(meta.has_value());
+    EXPECT_TRUE(meta->hard_pinned.value_or(false));
 }
 
 TEST_F(OpLogApplierTest, TestApplyPutEnd_InvalidPayload) {

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
@@ -1,0 +1,66 @@
+#include "ha/snapshot/batch_oplog/codec.h"
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace mooncake::test {
+
+TEST(BatchOpLogSnapshotCodecTest, SegmentsRoundTrip) {
+    std::vector<StandbySegmentInfo> segments{{
+        .segment_name = "segment-1",
+        .transport_endpoint = "127.0.0.1:12345",
+        .capacity = 4096,
+        .is_memory_segment = true,
+        .file_path = "",
+    }};
+
+    auto decoded = DecodeBatchOpLogSnapshotSegments(
+        EncodeBatchOpLogSnapshotSegments(segments));
+
+    ASSERT_TRUE(decoded) << decoded.error();
+    ASSERT_EQ(1u, decoded->size());
+    EXPECT_EQ("segment-1", decoded->front().segment_name);
+    EXPECT_EQ("127.0.0.1:12345", decoded->front().transport_endpoint);
+    EXPECT_EQ(4096u, decoded->front().capacity);
+    EXPECT_TRUE(decoded->front().is_memory_segment);
+}
+
+TEST(BatchOpLogSnapshotCodecTest, ObjectChunkRoundTripsAndChecksEnvelope) {
+    StandbyObjectMetadata metadata;
+    metadata.client_id = {1, 2};
+    metadata.size = 8192;
+    metadata.group_id = "group";
+    std::vector<StandbyObjectEntry> objects{
+        {.tenant_id = "tenant", .key = "key", .metadata = metadata}};
+    auto encoded = EncodeBatchOpLogSnapshotObjectChunk(7, objects);
+
+    auto decoded = DecodeBatchOpLogSnapshotObjectChunk(encoded, 7, 1);
+
+    ASSERT_TRUE(decoded) << decoded.error();
+    EXPECT_EQ(7u, decoded->chunk_index);
+    ASSERT_EQ(1u, decoded->objects.size());
+    EXPECT_EQ("tenant", decoded->objects[0].tenant_id);
+    EXPECT_EQ("key", decoded->objects[0].key);
+    EXPECT_EQ(UUID(1, 2), decoded->objects[0].metadata.client_id);
+    EXPECT_EQ(8192u, decoded->objects[0].metadata.size);
+    EXPECT_EQ("group", decoded->objects[0].metadata.group_id);
+
+    EXPECT_FALSE(DecodeBatchOpLogSnapshotObjectChunk(encoded, 8, 1));
+    EXPECT_FALSE(DecodeBatchOpLogSnapshotObjectChunk(encoded, 7, 300000000));
+}
+
+TEST(BatchOpLogSnapshotCodecTest, RejectsTruncatedArtifacts) {
+    auto segments = EncodeBatchOpLogSnapshotSegments({});
+    auto objects = EncodeBatchOpLogSnapshotObjectChunk(
+        0, std::vector<StandbyObjectEntry>{
+               {.tenant_id = "default", .key = "key", .metadata = {}}});
+    segments.pop_back();
+    objects.pop_back();
+
+    EXPECT_FALSE(DecodeBatchOpLogSnapshotSegments(segments));
+    EXPECT_FALSE(DecodeBatchOpLogSnapshotObjectChunk(objects, 0, 1));
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
@@ -7,6 +7,36 @@
 
 namespace mooncake::test {
 
+namespace {
+
+struct LegacyStandbyObjectMetadata {
+    UUID client_id{0, 0};
+    uint64_t size{0};
+    std::vector<Replica::Descriptor> replicas;
+    std::string group_id;
+    ObjectDataType data_type{ObjectDataType::UNKNOWN};
+
+    YLT_REFL(LegacyStandbyObjectMetadata, client_id, size, replicas, group_id,
+             data_type);
+};
+
+struct LegacyStandbyObjectEntry {
+    std::string tenant_id{"default"};
+    std::string key;
+    LegacyStandbyObjectMetadata metadata;
+
+    YLT_REFL(LegacyStandbyObjectEntry, tenant_id, key, metadata);
+};
+
+struct LegacyBatchOpLogSnapshotObjectChunk {
+    uint64_t chunk_index{0};
+    std::vector<LegacyStandbyObjectEntry> objects;
+
+    YLT_REFL(LegacyBatchOpLogSnapshotObjectChunk, chunk_index, objects);
+};
+
+}  // namespace
+
 TEST(BatchOpLogSnapshotCodecTest, SegmentsRoundTrip) {
     std::vector<StandbySegmentInfo> segments{{
         .segment_name = "segment-1",
@@ -32,6 +62,7 @@ TEST(BatchOpLogSnapshotCodecTest, ObjectChunkRoundTripsAndChecksEnvelope) {
     metadata.client_id = {1, 2};
     metadata.size = 8192;
     metadata.group_id = "group";
+    metadata.hard_pinned = true;
     std::vector<StandbyObjectEntry> objects{
         {.tenant_id = "tenant", .key = "key", .metadata = metadata}};
     auto encoded = EncodeBatchOpLogSnapshotObjectChunk(7, objects);
@@ -46,9 +77,22 @@ TEST(BatchOpLogSnapshotCodecTest, ObjectChunkRoundTripsAndChecksEnvelope) {
     EXPECT_EQ(UUID(1, 2), decoded->objects[0].metadata.client_id);
     EXPECT_EQ(8192u, decoded->objects[0].metadata.size);
     EXPECT_EQ("group", decoded->objects[0].metadata.group_id);
+    EXPECT_TRUE(decoded->objects[0].metadata.hard_pinned.value_or(false));
 
     EXPECT_FALSE(DecodeBatchOpLogSnapshotObjectChunk(encoded, 8, 1));
     EXPECT_FALSE(DecodeBatchOpLogSnapshotObjectChunk(encoded, 7, 300000000));
+}
+
+TEST(BatchOpLogSnapshotCodecTest, OldObjectChunkDefaultsHardPinnedToFalse) {
+    LegacyBatchOpLogSnapshotObjectChunk old_chunk{
+        0, {{"tenant", "key", {{1, 2}, 8192, {}, "group", {}}}}};
+    auto old_encoded = struct_pack::serialize(old_chunk);
+    std::vector<uint8_t> encoded(old_encoded.begin(), old_encoded.end());
+
+    auto decoded = DecodeBatchOpLogSnapshotObjectChunk(encoded, 0, 1);
+
+    ASSERT_TRUE(decoded) << decoded.error();
+    EXPECT_FALSE(decoded->objects[0].metadata.hard_pinned.value_or(false));
 }
 
 TEST(BatchOpLogSnapshotCodecTest, RejectsTruncatedArtifacts) {

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/codec_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace mooncake::test {
@@ -65,7 +66,7 @@ TEST(BatchOpLogSnapshotCodecTest, ObjectChunkRoundTripsAndChecksEnvelope) {
     metadata.hard_pinned = true;
     std::vector<StandbyObjectEntry> objects{
         {.tenant_id = "tenant", .key = "key", .metadata = metadata}};
-    auto encoded = EncodeBatchOpLogSnapshotObjectChunk(7, objects);
+    auto encoded = EncodeBatchOpLogSnapshotObjectChunk(7, std::move(objects));
 
     auto decoded = DecodeBatchOpLogSnapshotObjectChunk(encoded, 7, 1);
 

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/metadata_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/metadata_test.cpp
@@ -244,6 +244,8 @@ TEST(BatchOpLogSnapshotTypesTest, BuildsControlAndArtifactKeys) {
 
     const auto snapshot_id = BuildBatchOpLogSnapshotId(9, 12345);
     ASSERT_EQ(snapshot_id, "9-12345");
+    EXPECT_EQ(BuildBatchOpLogSnapshotArtifactPrefix("snapshots/", snapshot_id),
+              "snapshots/batch-oplog/9-12345/");
     EXPECT_EQ(BuildBatchOpLogSnapshotDescriptorKey("snapshots", snapshot_id),
               "snapshots/batch-oplog/9-12345/descriptor.json");
     EXPECT_EQ(BuildBatchOpLogSnapshotManifestKey("snapshots/", snapshot_id),

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
@@ -182,6 +182,9 @@ OpLogBatchRecord MakeObjectBatch(size_t object_count) {
         MetadataPayload metadata;
         metadata.client_id = {0, i + 1};
         metadata.size = 1024 + i;
+        if (i == 1) {
+            metadata.hard_pinned = true;
+        }
         auto encoded = struct_pack::serialize(metadata);
 
         OpLogEntry entry;
@@ -224,8 +227,9 @@ class BatchOpLogSnapshotWriterTest : public ::testing::Test {
                   backend_->Put(BuildDurablePrefixKey(kClusterId),
                                 EncodeDurablePrefix(
                                     {.batch_id = object_count == 0 ? 0u : 1u,
-                                     .last_seq = object_count,
-                                     .producer_view_version = 7})));
+                                     .last_seq = object_count})));
+        EXPECT_EQ(ErrorCode::OK,
+                  backend_->Put(BuildProducerViewKey(kClusterId), "7"));
 
         HotStandbyConfig config;
         config.enable_oplog_following = true;
@@ -268,6 +272,17 @@ TEST_F(BatchOpLogSnapshotWriterTest, WritesAndVerifiesMultipleChunks) {
     ASSERT_EQ(2u, manifest->object_chunks.size());
     EXPECT_EQ(2u, manifest->object_chunks[0].object_count);
     EXPECT_EQ(1u, manifest->object_chunks[1].object_count);
+    for (const auto& chunk : manifest->object_chunks) {
+        std::vector<uint8_t> encoded_chunk;
+        ASSERT_TRUE(object_store.DownloadBuffer(chunk.key, encoded_chunk));
+        auto decoded_chunk = DecodeBatchOpLogSnapshotObjectChunk(
+            encoded_chunk, chunk.chunk_index, chunk.object_count);
+        ASSERT_TRUE(decoded_chunk) << decoded_chunk.error();
+        for (const auto& object : decoded_chunk->objects) {
+            EXPECT_EQ(object.key == "key-1",
+                      object.metadata.hard_pinned.value_or(false));
+        }
+    }
     EXPECT_EQ(5u, object_store.size());
     EXPECT_GT(object_store.download_attempts, 0u);
 }

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
@@ -95,6 +95,7 @@ class FakeObjectStore final : public SnapshotObjectStore {
 
     tl::expected<void, std::string> UploadString(
         const std::string& key, const std::string& data) override {
+        ++string_upload_attempts;
         return UploadBuffer(key, {data.begin(), data.end()});
     }
 
@@ -168,6 +169,7 @@ class FakeObjectStore final : public SnapshotObjectStore {
     size_t upload_attempts{0};
     size_t download_attempts{0};
     size_t cleanup_attempts{0};
+    size_t string_upload_attempts{0};
 
    private:
     std::map<std::string, std::vector<uint8_t>> objects_;
@@ -284,6 +286,7 @@ TEST_F(BatchOpLogSnapshotWriterTest, WritesAndVerifiesMultipleChunks) {
         }
     }
     EXPECT_EQ(5u, object_store.size());
+    EXPECT_EQ(2u, object_store.string_upload_attempts);
     EXPECT_GT(object_store.download_attempts, 0u);
 }
 

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/writer_test.cpp
@@ -1,0 +1,360 @@
+#include "ha/snapshot/batch_oplog/writer.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <ylt/struct_pack.hpp>
+
+#include "crc32c.h"
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_codec.h"
+#include "ha/oplog/oplog_batch_storage.h"
+#include "ha/snapshot/batch_oplog/codec.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/object/snapshot_object_store.h"
+#include "hot_standby_service.h"
+
+namespace mooncake::test {
+
+namespace {
+
+class FakeHaKvBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view begin_key, std::string_view end_key,
+                    size_t limit, std::vector<KvPair>& kvs) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        kvs.clear();
+        for (const auto& [key, value] : values_) {
+            if (key >= begin_key && key < end_key) {
+                kvs.push_back({key, value});
+                if (limit != 0 && kvs.size() == limit) {
+                    break;
+                }
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+    ErrorCode Txn(const KvTxn&) override { return ErrorCode::OK; }
+
+   private:
+    std::mutex mutex_;
+    std::map<std::string, std::string> values_;
+};
+
+class FakeObjectStore final : public SnapshotObjectStore {
+   public:
+    tl::expected<void, std::string> UploadBuffer(
+        const std::string& key, const std::vector<uint8_t>& buffer) override {
+        ++upload_attempts;
+        if (fail_upload_at && upload_attempts == *fail_upload_at) {
+            return tl::make_unexpected("injected upload failure");
+        }
+        objects_[key] = buffer;
+        return {};
+    }
+
+    tl::expected<void, std::string> DownloadBuffer(
+        const std::string& key, std::vector<uint8_t>& buffer) override {
+        ++download_attempts;
+        if (fail_download) {
+            return tl::make_unexpected("injected download failure");
+        }
+        auto it = objects_.find(key);
+        if (it == objects_.end()) {
+            return tl::make_unexpected("not found");
+        }
+        buffer = it->second;
+        return {};
+    }
+
+    tl::expected<void, std::string> UploadString(
+        const std::string& key, const std::string& data) override {
+        return UploadBuffer(key, {data.begin(), data.end()});
+    }
+
+    tl::expected<void, std::string> DownloadString(const std::string& key,
+                                                   std::string& data) override {
+        std::vector<uint8_t> buffer;
+        auto result = DownloadBuffer(key, buffer);
+        if (!result) {
+            return result;
+        }
+        data.assign(buffer.begin(), buffer.end());
+        return {};
+    }
+
+    tl::expected<void, std::string> DeleteObjectsWithPrefix(
+        const std::string& prefix) override {
+        ++cleanup_attempts;
+        for (auto it = objects_.begin(); it != objects_.end();) {
+            if (it->first.starts_with(prefix)) {
+                it = objects_.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        return {};
+    }
+
+    tl::expected<void, std::string> ListObjectsWithPrefix(
+        const std::string& prefix,
+        std::vector<std::string>& object_keys) override {
+        object_keys.clear();
+        for (const auto& [key, value] : objects_) {
+            (void)value;
+            if (key.starts_with(prefix)) {
+                object_keys.push_back(key);
+            }
+        }
+        return {};
+    }
+
+    tl::expected<SnapshotObjectInspection, std::string> InspectObject(
+        const std::string& key) override {
+        auto it = objects_.find(key);
+        if (it == objects_.end()) {
+            return tl::make_unexpected("not found");
+        }
+        SnapshotObjectInspection inspection{.stored_size = it->second.size(),
+                                            .crc32c = std::nullopt};
+        if (provide_checksum) {
+            inspection.crc32c =
+                Crc32cValue(it->second.data(), it->second.size());
+            if (bad_checksum) {
+                *inspection.crc32c ^= 1;
+            }
+        }
+        return inspection;
+    }
+
+    std::string GetConnectionInfo() const override { return "fake"; }
+
+    void PutExisting(const std::string& key) { objects_[key] = {1}; }
+    bool Contains(const std::string& key) const {
+        return objects_.contains(key);
+    }
+    size_t size() const { return objects_.size(); }
+
+    bool provide_checksum{false};
+    bool bad_checksum{false};
+    bool fail_download{false};
+    std::optional<size_t> fail_upload_at;
+    size_t upload_attempts{0};
+    size_t download_attempts{0};
+    size_t cleanup_attempts{0};
+
+   private:
+    std::map<std::string, std::vector<uint8_t>> objects_;
+};
+
+OpLogBatchRecord MakeObjectBatch(size_t object_count) {
+    OpLogBatchRecord batch;
+    batch.batch_id = 1;
+    batch.first_seq = 1;
+    batch.last_seq = object_count;
+    for (size_t i = 0; i < object_count; ++i) {
+        MetadataPayload metadata;
+        metadata.client_id = {0, i + 1};
+        metadata.size = 1024 + i;
+        auto encoded = struct_pack::serialize(metadata);
+
+        OpLogEntry entry;
+        entry.sequence_id = i + 1;
+        entry.op_type = OpType::PUT_END;
+        entry.tenant_id = "tenant";
+        entry.object_key = "key-" + std::to_string(i);
+        entry.payload.assign(encoded.begin(), encoded.end());
+        entry.checksum = ComputeOpLogChecksum(entry.payload);
+        batch.entries.push_back(std::move(entry));
+    }
+    return batch;
+}
+
+}  // namespace
+
+class BatchOpLogSnapshotWriterTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        google::InitGoogleLogging("BatchOpLogSnapshotWriterTest");
+        FLAGS_logtostderr = true;
+    }
+
+    void TearDown() override {
+        if (standby_) {
+            standby_->Stop();
+        }
+        google::ShutdownGoogleLogging();
+    }
+
+    std::optional<BatchOpLogSnapshotCapture> StartCapture(size_t object_count) {
+        backend_ = std::make_shared<FakeHaKvBackend>();
+        if (object_count != 0) {
+            EXPECT_EQ(ErrorCode::OK,
+                      backend_->Put(BuildBatchRecordKey(kClusterId, 1),
+                                    EncodeOpLogBatchRecord(
+                                        MakeObjectBatch(object_count))));
+        }
+        EXPECT_EQ(ErrorCode::OK,
+                  backend_->Put(BuildDurablePrefixKey(kClusterId),
+                                EncodeDurablePrefix(
+                                    {.batch_id = object_count == 0 ? 0u : 1u,
+                                     .last_seq = object_count,
+                                     .producer_view_version = 7})));
+
+        HotStandbyConfig config;
+        config.enable_oplog_following = true;
+        config.enable_verification = false;
+        config.oplog_poll_interval_ms = 1;
+        standby_ = std::make_unique<HotStandbyService>(config);
+        standby_->SetCatchUpBatchKvBackendForTesting(backend_);
+        EXPECT_EQ(ErrorCode::OK, standby_->Start("", "", kClusterId));
+        return standby_->BeginBatchOpLogSnapshotCapture();
+    }
+
+    static constexpr char kClusterId[] = "n03-test";
+    std::shared_ptr<FakeHaKvBackend> backend_;
+    std::unique_ptr<HotStandbyService> standby_;
+};
+
+TEST_F(BatchOpLogSnapshotWriterTest, WritesAndVerifiesMultipleChunks) {
+    auto capture = StartCapture(3);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto descriptor_json =
+        writer.Write(*standby_, *capture, "snapshots", "1-42", 2, 1234);
+
+    ASSERT_TRUE(descriptor_json) << descriptor_json.error();
+    auto descriptor = ha::DecodeBatchOpLogSnapshotDescriptor(*descriptor_json);
+    ASSERT_TRUE(descriptor) << descriptor.error();
+    EXPECT_EQ("1-42", descriptor->snapshot_id);
+    EXPECT_EQ(3u, descriptor->last_included_seq);
+    EXPECT_EQ(1u, descriptor->last_included_batch_id);
+    EXPECT_EQ(7, descriptor->producer_view_version);
+    EXPECT_EQ(1234, descriptor->created_at_ms);
+
+    std::string manifest_json;
+    ASSERT_TRUE(
+        object_store.DownloadString(descriptor->manifest_key, manifest_json));
+    auto manifest = ha::DecodeBatchOpLogSnapshotManifest(manifest_json);
+    ASSERT_TRUE(manifest) << manifest.error();
+    ASSERT_EQ(2u, manifest->object_chunks.size());
+    EXPECT_EQ(2u, manifest->object_chunks[0].object_count);
+    EXPECT_EQ(1u, manifest->object_chunks[1].object_count);
+    EXPECT_EQ(5u, object_store.size());
+    EXPECT_GT(object_store.download_attempts, 0u);
+}
+
+TEST_F(BatchOpLogSnapshotWriterTest, WritesEmptyClusterWithoutObjectChunks) {
+    auto capture = StartCapture(0);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    object_store.provide_checksum = true;
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto descriptor_json =
+        writer.Write(*standby_, *capture, "snapshots", "0-42", 2, 1234);
+
+    ASSERT_TRUE(descriptor_json) << descriptor_json.error();
+    auto descriptor = ha::DecodeBatchOpLogSnapshotDescriptor(*descriptor_json);
+    ASSERT_TRUE(descriptor);
+    std::string manifest_json;
+    ASSERT_TRUE(
+        object_store.DownloadString(descriptor->manifest_key, manifest_json));
+    auto manifest = ha::DecodeBatchOpLogSnapshotManifest(manifest_json);
+    ASSERT_TRUE(manifest);
+    EXPECT_TRUE(manifest->object_chunks.empty());
+}
+
+TEST_F(BatchOpLogSnapshotWriterTest,
+       RejectsExistingCandidateWithoutDeletingIt) {
+    auto capture = StartCapture(1);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    const std::string existing_key =
+        ha::BuildBatchOpLogSnapshotSegmentsKey("snapshots", "1-42");
+    object_store.PutExisting(existing_key);
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto result =
+        writer.Write(*standby_, *capture, "snapshots", "1-42", 2, 1234);
+
+    EXPECT_FALSE(result);
+    EXPECT_TRUE(object_store.Contains(existing_key));
+    EXPECT_EQ(0u, object_store.cleanup_attempts);
+}
+
+TEST_F(BatchOpLogSnapshotWriterTest, CleansCandidateOnUploadFailure) {
+    auto capture = StartCapture(3);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    object_store.fail_upload_at = 2;
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto result =
+        writer.Write(*standby_, *capture, "snapshots", "1-42", 2, 1234);
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0u, object_store.size());
+    EXPECT_EQ(1u, object_store.cleanup_attempts);
+}
+
+TEST_F(BatchOpLogSnapshotWriterTest, CleansCandidateOnChecksumMismatch) {
+    auto capture = StartCapture(1);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    object_store.provide_checksum = true;
+    object_store.bad_checksum = true;
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto result =
+        writer.Write(*standby_, *capture, "snapshots", "1-42", 2, 1234);
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0u, object_store.size());
+    EXPECT_EQ(1u, object_store.cleanup_attempts);
+}
+
+TEST_F(BatchOpLogSnapshotWriterTest, CleansCandidateOnReadbackFailure) {
+    auto capture = StartCapture(1);
+    ASSERT_TRUE(capture);
+    FakeObjectStore object_store;
+    object_store.fail_download = true;
+    BatchOpLogSnapshotWriter writer(object_store);
+
+    auto result =
+        writer.Write(*standby_, *capture, "snapshots", "1-42", 2, 1234);
+
+    EXPECT_FALSE(result);
+    EXPECT_EQ(0u, object_store.size());
+    EXPECT_EQ(1u, object_store.cleanup_attempts);
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/catalog_backed_snapshot_provider_test.cpp
@@ -71,7 +71,7 @@ class CatalogBackedSnapshotProviderTest
 
     // Loads the published snapshot and asserts the single default object
     // round-trips intact, regardless of the metadata on-wire format.
-    void ExpectLoadsDefaultObject() {
+    void ExpectLoadsDefaultObject(bool expected_hard_pinned = false) {
         auto provider = CreateProvider();
         ASSERT_TRUE(provider.has_value()) << toString(provider.error());
 
@@ -86,6 +86,7 @@ class CatalogBackedSnapshotProviderTest
         EXPECT_EQ(key, kDefaultTestObjectKey);
         EXPECT_EQ(metadata.client_id, (UUID{1, 2}));
         EXPECT_EQ(metadata.size, kDefaultTestObjectSize);
+        EXPECT_EQ(metadata.hard_pinned.value_or(false), expected_hard_pinned);
         ASSERT_EQ(metadata.replicas.size(), 1u);
 
         const auto& replica = metadata.replicas.front();
@@ -178,14 +179,14 @@ TEST_P(CatalogBackedSnapshotProviderTest,
     // 8 + replica_count: trailing hard_pinned flag, no data_type. Exercises the
     // type-based disambiguation (first replica is not a positive integer).
     PublishSnapshotPayload(SnapshotMetadataFormat::kHardPinnedOnly);
-    ExpectLoadsDefaultObject();
+    ExpectLoadsDefaultObject(true);
 }
 
 TEST_P(CatalogBackedSnapshotProviderTest,
        LoadLatestSnapshotWithDataTypeAndHardPinned) {
     // 9 + replica_count: data_type + trailing hard_pinned.
     PublishSnapshotPayload(SnapshotMetadataFormat::kDataTypeAndHardPinned);
-    ExpectLoadsDefaultObject();
+    ExpectLoadsDefaultObject(true);
 }
 
 TEST_P(CatalogBackedSnapshotProviderTest, LoadLatestSnapshotWithGroupId) {
@@ -193,13 +194,13 @@ TEST_P(CatalogBackedSnapshotProviderTest, LoadLatestSnapshotWithGroupId) {
     // trailing group_id). Regression test for the live snapshot restore
     // failure against the latest metadata layout.
     PublishSnapshotPayload(SnapshotMetadataFormat::kWithGroupId);
-    ExpectLoadsDefaultObject();
+    ExpectLoadsDefaultObject(true);
 }
 
 TEST_P(CatalogBackedSnapshotProviderTest,
        LoadLatestSnapshotIgnoresObjectChecksum) {
     PublishSnapshotPayload(SnapshotMetadataFormat::kWithObjectChecksum);
-    ExpectLoadsDefaultObject();
+    ExpectLoadsDefaultObject(true);
 }
 
 TEST_P(CatalogBackedSnapshotProviderTest,

--- a/mooncake-store/tests/ha/snapshot/object/backends/local/local_file_snapshot_object_store_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/object/backends/local/local_file_snapshot_object_store_test.cpp
@@ -105,6 +105,15 @@ TEST_F(LocalFileSnapshotObjectStoreTest, GetConnectionInfo) {
     EXPECT_NE(info.find(tmp_dir()), std::string::npos);
 }
 
+TEST_F(LocalFileSnapshotObjectStoreTest, InspectObjectReturnsSize) {
+    ASSERT_TRUE(backend_->UploadString("test/inspect", "data"));
+
+    auto inspection = backend_->InspectObject("test/inspect");
+    ASSERT_TRUE(inspection) << inspection.error();
+    EXPECT_EQ(4u, inspection->stored_size);
+    EXPECT_FALSE(inspection->crc32c.has_value());
+}
+
 TEST_F(LocalFileSnapshotObjectStoreTest, UploadBuffer_CreatesSubdirectories) {
     std::vector<uint8_t> data = {42};
     auto result = backend_->UploadBuffer("a/b/c/deep_file", data);

--- a/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
@@ -77,9 +77,12 @@ class HotStandbySnapshotBootstrapTest
             GetParam(), cluster_id_, FLAGS_redis_endpoint));
     }
 
-    void PublishSnapshot() {
-        auto result = PublishSnapshotPayload(*object_store_, *catalog_store_,
-                                             descriptor_);
+    void PublishSnapshot(
+        SnapshotMetadataFormat format = SnapshotMetadataFormat::kLegacy) {
+        auto result = PublishSnapshotPayload(
+            *object_store_, *catalog_store_, descriptor_, UUID{1, 2},
+            kDefaultTestObjectKey, kDefaultTestDiskFilePath,
+            kDefaultTestObjectSize, format);
         ASSERT_TRUE(result.has_value()) << result.error();
         snapshot_published_ = true;
     }
@@ -218,7 +221,7 @@ TEST(StandbyControllerTest,
 
 TEST_P(HotStandbySnapshotBootstrapTest,
        PromoteStandbyAndExport_SuccessWithSnapshot) {
-    PublishSnapshot();
+    PublishSnapshot(SnapshotMetadataFormat::kHardPinnedOnly);
 
     ha::HABackendSpec spec{
         .type = ha::HABackendType::UNKNOWN,
@@ -244,6 +247,7 @@ TEST_P(HotStandbySnapshotBootstrapTest,
     ASSERT_EQ(1u, ctx.objects.size());
     EXPECT_EQ(kDefaultTestObjectKey, ctx.objects[0].key);
     EXPECT_EQ(kDefaultTestObjectSize, ctx.objects[0].metadata.size);
+    EXPECT_TRUE(ctx.objects[0].metadata.hard_pinned.value_or(false));
     EXPECT_TRUE(ctx.segments.empty());
 }
 


### PR DESCRIPTION
## Description

This PR implements N03 of the standby snapshot roadmap, building on the bounded
complete-batch capture introduced in #3326.

It materializes a frozen standby state into the
`standby-oplog-materialized/v1` artifact set:

- `segments.bin`
- chunked `objects/<index>.bin` files
- `manifest.json`
- `descriptor.json`

The writer processes one object chunk at a time to bound peak memory. It copies
a chunk from the standby store, releases the store lock, encodes and uploads the
chunk, then releases its buffers before continuing. Capture ends immediately
after all segments and object chunks have been materialized; manifest and
descriptor validation no longer hold or reference standby state.

This PR also:

- adds struct_pack codecs for segments and object chunks;
- validates chunk index and object count during decoding;
- records and verifies stored size and CRC32C for every artifact;
- adds object inspection support for local and S3 backends;
- uses backend CRC32C when available and full readback otherwise;
- rejects pre-existing candidate prefixes;
- performs best-effort candidate cleanup after upload or verification failure;
- keeps batch-oplog-specific code under `ha/snapshot/batch_oplog/`.

This PR intentionally does not acquire the maintenance lease, publish etcd
pointers, schedule snapshots, implement restore, or add compression. Those
remain in subsequent roadmap PRs.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

Added focused unit coverage for:

- segments and object-chunk round trips;
- truncated artifacts and chunk index/count mismatches;
- empty and multi-chunk snapshots;
- pre-existing candidate rejection;
- upload failure cleanup;
- backend checksum mismatch;
- checksum-unavailable readback and readback failure;
- local object size inspection.

Manual S3-compatible smoke testing also covered:

- compilation against AWS SDK for C++ `1.11.836`;
- 1 KiB single-PUT upload;
- 101 MiB multipart upload;
- checksum-enabled HEAD and stored-size inspection;
- range readback with byte-for-byte and local CRC32C verification;
- prefix listing, deletion, and unfinished multipart cleanup.

The complete smoke test passed with checksum calculation and validation set to
`when_required`. Moto did not expose server-side CRC32C, so the fallback
readback path was exercised; the positive server-CRC32C path still requires
validation against Amazon S3 or another backend that returns
`x-amz-checksum-crc32c`.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [x] Documentation is not required for this implementation-only slice
- [x] I have added tests to prove my changes are effective
- [x] RFC #3167 covers the architecture for this change

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with implementation analysis, test development, isolated S3
smoke validation, and PR description drafting. The submitter is responsible
for reviewing and understanding every changed line.