### PR TITLE
[TE] Skip same-host device offset when HIXL CS mode is available

### DIFF
--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
@@ -610,8 +610,15 @@ std::string TransferExecutorBase::resolveTargetAdxlEngineName(
 
         auto local_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
         const auto& remote_host_ip = segment_desc->rank_info.hostIp;
-        if (local_desc && !local_desc->rank_info.hostIp.empty() &&
-            !remote_host_ip.empty() &&
+
+        // CS mode (CANN 9.1+) supports same-device connections natively.
+        // The same-host +1 offset was a workaround for older HIXL that did
+        // not support same-device links. When CS mode is available, skip
+        // the offset to allow the optimal same-device HCCS path.
+        bool cs_mode_available =
+            adxl::IsAdxlFeatureSupported(adxl::CLIENT_SERVER_COMM);
+        if (!cs_mode_available && local_desc &&
+            !local_desc->rank_info.hostIp.empty() && !remote_host_ip.empty() &&
             local_desc->rank_info.hostIp == remote_host_ip &&
             endpoints.size() > 1) {
             base_idx = (base_idx + 1) % endpoints.size();


### PR DESCRIPTION
CANN 9.1+ HIXL supports same-device connections natively via CS mode. When the CLIENT_SERVER_COMM capability is detected, skip the legacy +1 device offset so transfers take the optimal same-device HCCS path. Fall back to the legacy offset on older CANN/HIXL for backward compatibility.

## Description

CANN 9.1+ HIXL supports same-device connections natively via CS
(Client-Server) mode. When the `CLIENT_SERVER_COMM` capability is detected,
skip the legacy `+1` device-index offset so KV-cache transfers between two
processes on the same device take the optimal same-device HCCS path instead
of being remapped to a different device. On older CANN/HIXL without CS mode,
the original `+1` offset is preserved for backward compatibility.

Change is in
`mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp`
(`TransferExecutorBase::resolveTargetAdxlEngineName`).

N/A (no related issue)

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Single-node deployment with all three processes on one machine
(4 NPUs: `ASCEND_RT_VISIBLE_DEVICES=0,1,2,3`). The store client and vLLM
both use devices 0–3, so KV-cache transfers between them are same-device
transfers — the exact case the legacy offset used to remap.

The key enabler is `ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'`, which must be
exported in both the store client and vLLM processes to initialize the HIXL
local communication resource for same-device transfer.

**Test commands:**

### 1. Start Mooncake store master

```bash
export POD_IP=$(hostname -I | awk '{print $1}')
export MC_REDIS_USERNAME=mooncake
export MC_REDIS_PASSWORD=<password>
export MC_REDIS_DB_INDEX=6
export MC_STORE_CLUSTER_ID=<cluster_id>

/workspace/Mooncake-0805/build/mooncake-store/src/mooncake_master \
  --port=50051 \
  --enable_http_metadata_server=1 \
  --default_kv_lease_ttl=5000 \
  --rpc-address="${POD_IP}"
```

### 2. Start Mooncake store client (devices 0–3)

```bash
export POD_IP=$(hostname -I | awk '{print $1}')
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
export ASCEND_GLOBAL_RESOURCE_CONFIG='{"comm_resource_config.listen_port":"22112"}'
export HCCL_INTRA_ROCE_ENABLE=1
export ASCEND_AUTO_CONNECT=0
export MOONCAKE_PROTOCOL=ascend
export MC_STORE_MEMCPY=1
export MC_HANDSHAKE_PORT=12529
export MC_NODE_NAME=<node_name>
export MASTER_SERVER=<master_server_address>
export METADATA_SERVER=P2PHANDSHAKE
export LOCAL_HOSTNAME=<node_name>
export MC_REDIS_USERNAME=mooncake
export MC_REDIS_PASSWORD=<password>
export MC_REDIS_DB_INDEX=6
export MC_STORE_CLUSTER_ID=<cluster_id>

/workspace/Mooncake-0805/build/mooncake-store/src/mooncake_client \
  --global_segment_size 512MB \
  --host ${POD_IP} \
  --port 50052 \
  --master_server_address ${MASTER_SERVER} \
  --metadata_server ${METADATA_SERVER} \
  --protocol ${MOONCAKE_PROTOCOL} \
  --enable_offload=true
```

### 3. Start vLLM (KV producer, devices 0–3)

```bash
export POD_IP=$(hostname -I | awk '{print $1}')
export ASCEND_RT_VISIBLE_DEVICES=0,1,2,3
export ASCEND_LOCAL_COMM_RES='{"version":"1.3"}'
export ASCEND_GLOBAL_RESOURCE_CONFIG='{"comm_resource_config.listen_port":"22110"}'
export HCCL_INTRA_ROCE_ENABLE=1
export ASCEND_AUTO_CONNECT=0
export HCCL_IF_IP=${POD_IP}
export MC_NODE_NAME=<node_name>
export MC_REDIS_USERNAME=mooncake
export MC_REDIS_PASSWORD=<password>
export MC_REDIS_DB_INDEX=6
export MC_STORE_CLUSTER_ID=<cluster_id>

vllm serve /data/models/<model-path>/v1 \
  --served-model-name ds1.5b \
  --host 0.0.0.0 \
  --port 8000 \
  --tensor-parallel-size 4 \
  --trust-remote-code \
  --gpu-memory-utilization 0.65 \
  --max-num-seqs 2 \
  --max-model-len 8192 \
  --kv-transfer-config '{"kv_connector":"AscendStoreConnector","kv_role":"kv_producer","kv_port":"20001","kv_connector_extra_config":{"backend":"mooncake","use_layerwise":false}}'
```

### 4. Trigger a request and observe

Send an inference request to vLLM (e.g. `curl http://<POD_IP>:8000/v1/chat/completions ...`)
to make it write KV cache to the store through the ascend direct transport.

**Observed behavior:**

- **CANN 9.1+ (this change):** the capability probe reports
  `CLIENT_SERVER_COMM` as supported, `resolveTargetAdxlEngineName` keeps
  `base_idx = phy_dev` (no `+1` offset), and the same-device HCCS transfer
  completes successfully. The legacy offset log is no longer emitted.
- **Before (CANN < 9.1):** the legacy same-host `+1` offset path was taken,
  which remapped the transfer to a different physical device.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)
Manual test described above. No automated unit test added because the behavior
depends on the CANN/HIXL runtime capability probe and requires a physical
Ascend multi-device node.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Deepseek V4 PRO was used to draft the PR description and review the
change. The change itself — skipping the legacy same-host `+1` device offset
when `adxl::CLIENT_SERVER_COMM` (CS mode) is supported, with fallback to the
original offset on older CANN/HIXL — was implemented and validated by the
submitter, who has reviewed and takes responsibility for every line.