### PR TITLE
[Feature] Add per-file storage mode to storage_benchmark_v1

### DIFF
--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -131,20 +131,26 @@ class StorageBenchmark:
         for access in self.layout.get_operations(req):
             if self.storage.exists(access.page_id):
                 # Page exists, perform READ
-                io_latency_ms += self.storage.read(
+                latency = self.storage.read(
                     access.page_id,
                     offset_in_page=access.offset_in_page,
                     length=access.length
                 )
+                if latency is None:
+                    continue
+                io_latency_ms += latency
                 self.stats['read_pages'] += 1
                 self.stats['page_hits'] += 1
             else:
                 # Page doesn't exist, perform WRITE
-                io_latency_ms += self.storage.write(
+                latency = self.storage.write(
                     access.page_id,
                     offset_in_page=access.offset_in_page,
                     length=access.length
                 )
+                if latency is None:
+                    continue
+                io_latency_ms += latency
                 self.stats['write_pages'] += 1
 
         wall_latency_ms = (time.perf_counter() - request_start) * 1000.0

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -486,7 +486,7 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
     max_size_gb = max_pages * page_size_bytes / (1024**3)
     trace_size_gb = max_pages_needed * page_size_bytes / (1024**3)
 
-    print(f"\n[Storage Configuration]")
+    print("\n[Storage Configuration]")
     print(f"  Max page_id in trace:             {max_page_id:,}")
     print(f"  Pages needed (trace):             {max_pages_needed:,}")
     print(f"  Trace storage size:               {trace_size_gb:.2f} GB")
@@ -538,7 +538,7 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
                 result = run_multi_thread(benchmarks, requests, replay_scale)
     except KeyboardInterrupt:
         print(f"\n\n{'='*80}")
-        print(f"Interrupted! Showing partial results:")
+        print("Interrupted! Showing partial results:")
         print(f"{'='*80}")
         result = result if 'result' in locals() else {
             'completed': 0,
@@ -592,7 +592,7 @@ def format_storage_stats(stats: Dict, title: str = "Storage"):
     output.append(f"\n[{title}]")
 
     # General info
-    output.append(f"\n[General]")
+    output.append("\n[General]")
     output.append(f"  Model:            {stats.get('model', 'N/A')}")
     output.append(f"  Threads:          {stats.get('threads', 1)}")
     replay_scale = stats.get('replay_scale', 0)
@@ -604,48 +604,48 @@ def format_storage_stats(stats: Dict, title: str = "Storage"):
     output.append(f"  Hit Rate:         {stats.get('page_hit_rate', 0):.2%}")
 
     # Request Stats
-    output.append(f"\n[Request Wall Latency]")
+    output.append("\n[Request Wall Latency]")
     output.append(f"  Avg:              {request_wall.get('avg_ms', 0):.3f} ms")
     output.append(f"  P50:              {request_wall.get('p50_ms', 0):.3f} ms")
     output.append(f"  P95:              {request_wall.get('p95_ms', 0):.3f} ms")
     output.append(f"  P99:              {request_wall.get('p99_ms', 0):.3f} ms")
 
-    output.append(f"\n[Request Storage I/O Latency]")
+    output.append("\n[Request Storage I/O Latency]")
     output.append(f"  Avg:              {request_io.get('avg_ms', 0):.3f} ms")
     output.append(f"  P50:              {request_io.get('p50_ms', 0):.3f} ms")
     output.append(f"  P95:              {request_io.get('p95_ms', 0):.3f} ms")
     output.append(f"  P99:              {request_io.get('p99_ms', 0):.3f} ms")
 
     # Read Stats
-    output.append(f"\n[Read Operations]")
+    output.append("\n[Read Operations]")
     output.append(f"  Count:            {read_stats.get('count', 0):,}")
     output.append(f"  Data Volume:      {read_stats.get('mb', 0):.2f} MB")
     read_time = read_stats.get('time_s', 0)
     read_mbps = read_stats.get('mb', 0) / read_time if read_time > 0 else 0
     output.append(f"  Total Time:       {read_time:.3f} s")
     output.append(f"  Bandwidth:        {read_mbps:.2f} MB/s")
-    output.append(f"  Latency:")
+    output.append("  Latency:")
     output.append(f"    Avg:            {read_stats.get('avg_ms', 0):.3f} ms")
     output.append(f"    P50:            {read_stats.get('p50_ms', 0):.3f} ms")
     output.append(f"    P95:            {read_stats.get('p95_ms', 0):.3f} ms")
     output.append(f"    P99:            {read_stats.get('p99_ms', 0):.3f} ms")
 
     # Write Stats
-    output.append(f"\n[Write Operations]")
+    output.append("\n[Write Operations]")
     output.append(f"  Count:            {write_stats.get('count', 0):,}")
     output.append(f"  Data Volume:      {write_stats.get('mb', 0):.2f} MB")
     write_time = write_stats.get('time_s', 0)
     write_mbps = write_stats.get('mb', 0) / write_time if write_time > 0 else 0
     output.append(f"  Total Time:       {write_time:.3f} s")
     output.append(f"  Bandwidth:        {write_mbps:.2f} MB/s")
-    output.append(f"  Latency:")
+    output.append("  Latency:")
     output.append(f"    Avg:            {write_stats.get('avg_ms', 0):.3f} ms")
     output.append(f"    P50:            {write_stats.get('p50_ms', 0):.3f} ms")
     output.append(f"    P95:            {write_stats.get('p95_ms', 0):.3f} ms")
     output.append(f"    P99:            {write_stats.get('p99_ms', 0):.3f} ms")
 
     # Storage Info
-    output.append(f"\n[Storage Info]")
+    output.append("\n[Storage Info]")
     output.append(f"  Max Pages:        {storage.get('max_pages', 0):,}")
     output.append(f"  Written Pages:    {storage.get('written_pages', 0):,}")
     output.append(f"  Sync Count:       {storage.get('sync_count', 0):,}")

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -688,7 +688,10 @@ def main():
     parser.add_argument('--max-pages', type=int, default=2000,
                        help='Maximum number of pages')
     parser.add_argument('--fsync-mode', type=str, choices=['batch', 'always', 'end', 'none'],
-                       default='none', help='When to fsync')
+                       default='none',
+                       help='When to fsync. With --file-mode per-file, end does '
+                            'zero fsyncs and batch fsyncs only the last file in '
+                            'each batch; durability is weaker than single')
     parser.add_argument('--fsync-batch-size', type=int, default=100,
                        help='Number of writes between fsync')
     parser.add_argument('--threads', type=int, default=1,

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -73,6 +73,7 @@ class StorageBenchmark:
     def __init__(self, storage_dir: str, model_config: dict,
                  page_size_tokens: int = 512,
                  max_pages: int = 100000,
+                 file_mode: str = 'single',
                  fsync_mode: str = 'none', fsync_batch_size: int = 100):
         """Initialize benchmark
 
@@ -81,6 +82,8 @@ class StorageBenchmark:
             model_config: Model configuration dict
             page_size_tokens: Tokens per page (default: 512)
             max_pages: Maximum number of pages
+            file_mode: 'single' = one big data.bin with slot offsets (default);
+                       'per-file' = one file per page
             fsync_mode: When to fsync ('none', 'batch', 'always', 'end')
             fsync_batch_size: Number of writes between fsync in batch mode
         """
@@ -93,6 +96,7 @@ class StorageBenchmark:
             storage_dir=storage_dir,
             page_size=self.page_size_bytes,
             max_pages=max_pages,
+            file_mode=file_mode,
             fsync_mode=fsync_mode,
             fsync_batch_size=fsync_batch_size
         )
@@ -412,6 +416,7 @@ def run_multi_thread(benchmarks: List[StorageBenchmark],
 def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
                   max_requests: int = None, max_pages: int = None,
                   page_size_tokens: int = 512,
+                  file_mode: str = 'single',
                   fsync_mode: str = 'none', fsync_batch_size: int = 100,
                   threads: int = 1, replay_scale: float = 0.0,
                   progress_interval: int = 100) -> Dict:
@@ -424,6 +429,8 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
         max_requests: Maximum number of requests (None = all)
         max_pages: Maximum number of pages (None = auto-calculate)
         page_size_tokens: Tokens per page
+        file_mode: 'single' = one big data.bin with slot offsets (default);
+                   'per-file' = one file per page
         fsync_mode: When to fsync
         fsync_batch_size: Number of writes between fsync
         threads: Benchmark client worker threads
@@ -438,6 +445,7 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
     print(f"Model: {model_config['name']}")
     print(f"Layers: {model_config['num_layers']}")
     print(f"Page size: {page_size_tokens} tokens")
+    print(f"File mode: {file_mode}")
     print(f"Threads: {threads}")
     print(f"Fast-forward: {replay_scale:g}x" if replay_scale > 0 else "Fast-forward: unpaced")
     print(f"{'='*80}")
@@ -501,6 +509,7 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
                 model_config=model_config,
                 page_size_tokens=page_size_tokens,
                 max_pages=max_pages,
+                file_mode=file_mode,
                 fsync_mode=fsync_mode,
                 fsync_batch_size=fsync_batch_size
             ) as benchmark:
@@ -514,6 +523,7 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
                         model_config=model_config,
                         page_size_tokens=page_size_tokens,
                         max_pages=max_pages,
+                        file_mode=file_mode,
                         fsync_mode=fsync_mode,
                         fsync_batch_size=fsync_batch_size
                     ))
@@ -667,6 +677,10 @@ def main():
                        help='Model preset')
     parser.add_argument('--page-size-tokens', type=int, default=512,
                        help='Page size in tokens (default: 512)')
+    parser.add_argument('--file-mode', type=str, choices=['single', 'per-file'],
+                       default='single',
+                       help='Storage layout: single = one big data.bin with slot '
+                            'offsets (default); per-file = one file per page')
     parser.add_argument('--max-requests', type=int, default=None,
                        help='Maximum number of requests')
     parser.add_argument('--max-pages', type=int, default=2000,
@@ -725,6 +739,7 @@ def main():
                     args.max_requests,
                     args.max_pages,
                     args.page_size_tokens,
+                    args.file_mode,
                     args.fsync_mode,
                     args.fsync_batch_size,
                     args.threads,

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -24,9 +24,11 @@ from layout import get_model_config, create_layout
 # Data Structures
 # ============================================================================
 
+
 @dataclass
 class KVCacheRequest:
     """KVCache request from trace"""
+
     timestamp: float
     hash_ids: List[int]
     input_length: int
@@ -37,6 +39,7 @@ class KVCacheRequest:
 # Trace Replay
 # ============================================================================
 
+
 class TraceReplay:
     """Trace replay handler"""
 
@@ -46,17 +49,19 @@ class TraceReplay:
     def load_all(self) -> List[KVCacheRequest]:
         """Load all requests from trace file"""
         requests = []
-        with open(self.trace_path, 'r', encoding='utf-8') as f:
+        with open(self.trace_path, "r", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if line:
                     req = json.loads(line)
-                    requests.append(KVCacheRequest(
-                        timestamp=req.get('timestamp', 0),
-                        hash_ids=req.get('hash_ids', []),
-                        input_length=req.get('input_length', 0),
-                        output_length=req.get('output_length', 0),
-                    ))
+                    requests.append(
+                        KVCacheRequest(
+                            timestamp=req.get("timestamp", 0),
+                            hash_ids=req.get("hash_ids", []),
+                            input_length=req.get("input_length", 0),
+                            output_length=req.get("output_length", 0),
+                        )
+                    )
         return requests
 
 
@@ -64,17 +69,23 @@ class TraceReplay:
 # Storage Benchmark
 # ============================================================================
 
+
 class StorageBenchmark:
     """KVCache storage benchmark
 
     Processes KVCache requests using layout-generated access patterns.
     """
 
-    def __init__(self, storage_dir: str, model_config: dict,
-                 page_size_tokens: int = 512,
-                 max_pages: int = 100000,
-                 file_mode: str = 'single',
-                 fsync_mode: str = 'none', fsync_batch_size: int = 100):
+    def __init__(
+        self,
+        storage_dir: str,
+        model_config: dict,
+        page_size_tokens: int = 512,
+        max_pages: int = 100000,
+        file_mode: str = "single",
+        fsync_mode: str = "none",
+        fsync_batch_size: int = 100,
+    ):
         """Initialize benchmark
 
         Args:
@@ -98,18 +109,18 @@ class StorageBenchmark:
             max_pages=max_pages,
             file_mode=file_mode,
             fsync_mode=fsync_mode,
-            fsync_batch_size=fsync_batch_size
+            fsync_batch_size=fsync_batch_size,
         )
 
         # Statistics
         self.stats = {
-            'total_requests': 0,
-            'total_tokens': 0,
-            'read_pages': 0,
-            'write_pages': 0,
-            'page_hits': 0,
-            'request_io_latencies_ms': [],
-            'request_wall_latencies_ms': [],
+            "total_requests": 0,
+            "total_tokens": 0,
+            "read_pages": 0,
+            "write_pages": 0,
+            "page_hits": 0,
+            "request_io_latencies_ms": [],
+            "request_wall_latencies_ms": [],
         }
 
     def process_request(self, req: KVCacheRequest) -> float:
@@ -121,8 +132,8 @@ class StorageBenchmark:
         Returns:
             Total latency in milliseconds
         """
-        self.stats['total_requests'] += 1
-        self.stats['total_tokens'] += req.input_length + req.output_length
+        self.stats["total_requests"] += 1
+        self.stats["total_tokens"] += req.input_length + req.output_length
 
         request_start = time.perf_counter()
         io_latency_ms = 0.0
@@ -134,50 +145,54 @@ class StorageBenchmark:
                 latency = self.storage.read(
                     access.page_id,
                     offset_in_page=access.offset_in_page,
-                    length=access.length
+                    length=access.length,
                 )
                 if latency is None:
                     continue
                 io_latency_ms += latency
-                self.stats['read_pages'] += 1
-                self.stats['page_hits'] += 1
+                self.stats["read_pages"] += 1
+                self.stats["page_hits"] += 1
             else:
                 # Page doesn't exist, perform WRITE
                 latency = self.storage.write(
                     access.page_id,
                     offset_in_page=access.offset_in_page,
-                    length=access.length
+                    length=access.length,
                 )
                 if latency is None:
                     continue
                 io_latency_ms += latency
-                self.stats['write_pages'] += 1
+                self.stats["write_pages"] += 1
 
         wall_latency_ms = (time.perf_counter() - request_start) * 1000.0
-        self.stats['request_io_latencies_ms'].append(io_latency_ms)
-        self.stats['request_wall_latencies_ms'].append(wall_latency_ms)
+        self.stats["request_io_latencies_ms"].append(io_latency_ms)
+        self.stats["request_wall_latencies_ms"].append(wall_latency_ms)
         return io_latency_ms
 
     def get_stats(self) -> Dict:
         """Get statistics"""
         storage_stats = self.storage.get_stats()
-        request_io_latencies = self.stats['request_io_latencies_ms']
-        request_wall_latencies = self.stats['request_wall_latencies_ms']
+        request_io_latencies = self.stats["request_io_latencies_ms"]
+        request_wall_latencies = self.stats["request_wall_latencies_ms"]
 
-        total_pages = self.stats['read_pages'] + self.stats['write_pages']
+        total_pages = self.stats["read_pages"] + self.stats["write_pages"]
 
         return {
-            'total_requests': self.stats['total_requests'],
-            'total_tokens': self.stats['total_tokens'],
-            'total_pages': total_pages,
-            'read_pages': self.stats['read_pages'],
-            'write_pages': self.stats['write_pages'],
-            'page_hits': self.stats['page_hits'],
-            'page_hit_rate': self.stats['read_pages'] / total_pages if total_pages > 0 else 0,
-            'write_ratio': self.stats['write_pages'] / total_pages if total_pages > 0 else 0,
-            'request_io_latency': latency_stats(request_io_latencies),
-            'request_wall_latency': latency_stats(request_wall_latencies),
-            'storage': storage_stats,
+            "total_requests": self.stats["total_requests"],
+            "total_tokens": self.stats["total_tokens"],
+            "total_pages": total_pages,
+            "read_pages": self.stats["read_pages"],
+            "write_pages": self.stats["write_pages"],
+            "page_hits": self.stats["page_hits"],
+            "page_hit_rate": self.stats["read_pages"] / total_pages
+            if total_pages > 0
+            else 0,
+            "write_ratio": self.stats["write_pages"] / total_pages
+            if total_pages > 0
+            else 0,
+            "request_io_latency": latency_stats(request_io_latencies),
+            "request_wall_latency": latency_stats(request_wall_latencies),
+            "storage": storage_stats,
         }
 
     def __enter__(self):
@@ -195,6 +210,7 @@ class StorageBenchmark:
 # Benchmark Runner
 # ============================================================================
 
+
 def get_max_page_id(requests: List[KVCacheRequest]) -> int:
     max_id = 0
     for req in requests:
@@ -204,16 +220,17 @@ def get_max_page_id(requests: List[KVCacheRequest]) -> int:
 
 
 def parse_csv_floats(value: str) -> List[float]:
-    return [float(item.strip()) for item in value.split(',') if item.strip()]
+    return [float(item.strip()) for item in value.split(",") if item.strip()]
 
 
-def wait_for_replay_time(req: KVCacheRequest, base_timestamp: float,
-                         start_time: float, replay_scale: float):
+def wait_for_replay_time(
+    req: KVCacheRequest, base_timestamp: float, start_time: float, replay_scale: float
+):
     if replay_scale <= 0 or req.timestamp == 0:
         return
-    target_time = (start_time +
-                   max(0.0, req.timestamp - base_timestamp) /
-                   (1000.0 * replay_scale))
+    target_time = start_time + max(0.0, req.timestamp - base_timestamp) / (
+        1000.0 * replay_scale
+    )
     delay = target_time - time.perf_counter()
     if delay > 0:
         time.sleep(delay)
@@ -221,7 +238,7 @@ def wait_for_replay_time(req: KVCacheRequest, base_timestamp: float,
 
 def latency_stats(values: List[float]) -> Dict[str, float]:
     if not values:
-        return {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+        return {"avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0}
 
     sorted_values = sorted(values)
 
@@ -232,51 +249,46 @@ def latency_stats(values: List[float]) -> Dict[str, float]:
         lower = int(rank)
         upper = min(lower + 1, len(sorted_values) - 1)
         weight = rank - lower
-        return (sorted_values[lower] * (1.0 - weight) +
-                sorted_values[upper] * weight)
+        return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
 
     return {
-        'avg_ms': statistics.mean(values),
-        'p50_ms': get_percentile(0.50),
-        'p95_ms': get_percentile(0.95),
-        'p99_ms': get_percentile(0.99),
+        "avg_ms": statistics.mean(values),
+        "p50_ms": get_percentile(0.50),
+        "p95_ms": get_percentile(0.95),
+        "p99_ms": get_percentile(0.99),
     }
 
 
 def snapshot_thread_stats(benchmark: StorageBenchmark) -> Dict[str, Any]:
     storage = benchmark.storage
-    total_pages = benchmark.stats['read_pages'] + benchmark.stats['write_pages']
+    total_pages = benchmark.stats["read_pages"] + benchmark.stats["write_pages"]
     return {
-        'total_requests': benchmark.stats['total_requests'],
-        'total_tokens': benchmark.stats['total_tokens'],
-        'read_pages': benchmark.stats['read_pages'],
-        'write_pages': benchmark.stats['write_pages'],
-        'page_hits': benchmark.stats['page_hits'],
-        'request_io_latencies_ms': list(
-            benchmark.stats['request_io_latencies_ms']
-        ),
-        'request_wall_latencies_ms': list(
-            benchmark.stats['request_wall_latencies_ms']
-        ),
-        'read_bytes': storage.stats['read_bytes'],
-        'write_bytes': storage.stats['write_bytes'],
-        'read_time_s': storage.stats['read_time_s'],
-        'write_time_s': storage.stats['write_time_s'],
-        'read_latencies_ms': list(storage.stats['read_latencies_ms']),
-        'write_latencies_ms': list(storage.stats['write_latencies_ms']),
-        'sync_count': storage.stats['sync_count'],
-        'max_pages': storage.max_pages,
-        'written_pages': len(storage._written_pages),
-        'total_pages': total_pages,
+        "total_requests": benchmark.stats["total_requests"],
+        "total_tokens": benchmark.stats["total_tokens"],
+        "read_pages": benchmark.stats["read_pages"],
+        "write_pages": benchmark.stats["write_pages"],
+        "page_hits": benchmark.stats["page_hits"],
+        "request_io_latencies_ms": list(benchmark.stats["request_io_latencies_ms"]),
+        "request_wall_latencies_ms": list(benchmark.stats["request_wall_latencies_ms"]),
+        "read_bytes": storage.stats["read_bytes"],
+        "write_bytes": storage.stats["write_bytes"],
+        "read_time_s": storage.stats["read_time_s"],
+        "write_time_s": storage.stats["write_time_s"],
+        "read_latencies_ms": list(storage.stats["read_latencies_ms"]),
+        "write_latencies_ms": list(storage.stats["write_latencies_ms"]),
+        "sync_count": storage.stats["sync_count"],
+        "max_pages": storage.max_pages,
+        "written_pages": len(storage._written_pages),
+        "total_pages": total_pages,
     }
 
 
 def aggregate_thread_stats(thread_stats: List[Dict[str, Any]]) -> Dict:
-    total_requests = sum(s['total_requests'] for s in thread_stats)
-    total_tokens = sum(s['total_tokens'] for s in thread_stats)
-    read_pages = sum(s['read_pages'] for s in thread_stats)
-    write_pages = sum(s['write_pages'] for s in thread_stats)
-    page_hits = sum(s['page_hits'] for s in thread_stats)
+    total_requests = sum(s["total_requests"] for s in thread_stats)
+    total_tokens = sum(s["total_tokens"] for s in thread_stats)
+    read_pages = sum(s["read_pages"] for s in thread_stats)
+    write_pages = sum(s["write_pages"] for s in thread_stats)
+    page_hits = sum(s["page_hits"] for s in thread_stats)
     total_pages = read_pages + write_pages
 
     request_io_latencies = []
@@ -284,74 +296,83 @@ def aggregate_thread_stats(thread_stats: List[Dict[str, Any]]) -> Dict:
     read_latencies = []
     write_latencies = []
     for stats in thread_stats:
-        request_io_latencies.extend(stats['request_io_latencies_ms'])
-        request_wall_latencies.extend(stats['request_wall_latencies_ms'])
-        read_latencies.extend(stats['read_latencies_ms'])
-        write_latencies.extend(stats['write_latencies_ms'])
+        request_io_latencies.extend(stats["request_io_latencies_ms"])
+        request_wall_latencies.extend(stats["request_wall_latencies_ms"])
+        read_latencies.extend(stats["read_latencies_ms"])
+        write_latencies.extend(stats["write_latencies_ms"])
 
-    read_bytes = sum(s['read_bytes'] for s in thread_stats)
-    write_bytes = sum(s['write_bytes'] for s in thread_stats)
-    read_time = sum(s['read_time_s'] for s in thread_stats)
-    write_time = sum(s['write_time_s'] for s in thread_stats)
+    read_bytes = sum(s["read_bytes"] for s in thread_stats)
+    write_bytes = sum(s["write_bytes"] for s in thread_stats)
+    read_time = sum(s["read_time_s"] for s in thread_stats)
+    write_time = sum(s["write_time_s"] for s in thread_stats)
 
     return {
-        'total_requests': total_requests,
-        'total_tokens': total_tokens,
-        'total_pages': total_pages,
-        'read_pages': read_pages,
-        'write_pages': write_pages,
-        'page_hits': page_hits,
-        'page_hit_rate': read_pages / total_pages if total_pages > 0 else 0,
-        'write_ratio': write_pages / total_pages if total_pages > 0 else 0,
-        'request_io_latency': latency_stats(request_io_latencies),
-        'request_wall_latency': latency_stats(request_wall_latencies),
-        'storage': {
-            'read': {
-                'count': read_pages,
-                'mb': read_bytes / 1024 / 1024,
-                'time_s': read_time,
+        "total_requests": total_requests,
+        "total_tokens": total_tokens,
+        "total_pages": total_pages,
+        "read_pages": read_pages,
+        "write_pages": write_pages,
+        "page_hits": page_hits,
+        "page_hit_rate": read_pages / total_pages if total_pages > 0 else 0,
+        "write_ratio": write_pages / total_pages if total_pages > 0 else 0,
+        "request_io_latency": latency_stats(request_io_latencies),
+        "request_wall_latency": latency_stats(request_wall_latencies),
+        "storage": {
+            "read": {
+                "count": read_pages,
+                "mb": read_bytes / 1024 / 1024,
+                "time_s": read_time,
                 **latency_stats(read_latencies),
             },
-            'write': {
-                'count': write_pages,
-                'mb': write_bytes / 1024 / 1024,
-                'time_s': write_time,
+            "write": {
+                "count": write_pages,
+                "mb": write_bytes / 1024 / 1024,
+                "time_s": write_time,
                 **latency_stats(write_latencies),
             },
-            'sync_count': sum(s['sync_count'] for s in thread_stats),
-            'max_pages': sum(s['max_pages'] for s in thread_stats),
-            'written_pages': sum(s['written_pages'] for s in thread_stats),
-            'page_hits': page_hits,
-            'page_misses': write_pages,
+            "sync_count": sum(s["sync_count"] for s in thread_stats),
+            "max_pages": sum(s["max_pages"] for s in thread_stats),
+            "written_pages": sum(s["written_pages"] for s in thread_stats),
+            "page_hits": page_hits,
+            "page_misses": write_pages,
         },
     }
 
 
-def print_progress(done: int, total: int, start_time: float,
-                   stats: Dict, req: KVCacheRequest = None,
-                   suffix: str = ""):
+def print_progress(
+    done: int,
+    total: int,
+    start_time: float,
+    stats: Dict,
+    req: KVCacheRequest = None,
+    suffix: str = "",
+):
     elapsed = time.perf_counter() - start_time
     qps = done / elapsed if elapsed > 0 else 0
-    storage = stats.get('storage', {})
-    read_stats = storage.get('read', {})
-    write_stats = storage.get('write', {})
-    read_time = read_stats.get('time_s', 0)
-    write_time = write_stats.get('time_s', 0)
-    read_mbps = read_stats.get('mb', 0) / read_time if read_time > 0 else 0
-    write_mbps = write_stats.get('mb', 0) / write_time if write_time > 0 else 0
+    storage = stats.get("storage", {})
+    read_stats = storage.get("read", {})
+    write_stats = storage.get("write", {})
+    read_time = read_stats.get("time_s", 0)
+    write_time = write_stats.get("time_s", 0)
+    read_mbps = read_stats.get("mb", 0) / read_time if read_time > 0 else 0
+    write_mbps = write_stats.get("mb", 0) / write_time if write_time > 0 else 0
 
     if req is None:
         req_info = ""
     else:
-        req_info = (f" ids={len(req.hash_ids):3d} "
-                    f"tokens={req.input_length + req.output_length:6d} |")
+        req_info = (
+            f" ids={len(req.hash_ids):3d} "
+            f"tokens={req.input_length + req.output_length:6d} |"
+        )
 
-    print(f"  [{done:5d}/{total}]{req_info} QPS={qps:7.2f} | "
-          f"R={stats['read_pages']:6d} "
-          f"({read_stats.get('avg_ms', 0):6.2f}ms, {read_mbps:6.1f}MB/s) | "
-          f"W={stats['write_pages']:6d} "
-          f"({write_stats.get('avg_ms', 0):6.2f}ms, {write_mbps:6.1f}MB/s)"
-          f"{suffix}")
+    print(
+        f"  [{done:5d}/{total}]{req_info} QPS={qps:7.2f} | "
+        f"R={stats['read_pages']:6d} "
+        f"({read_stats.get('avg_ms', 0):6.2f}ms, {read_mbps:6.1f}MB/s) | "
+        f"W={stats['write_pages']:6d} "
+        f"({write_stats.get('avg_ms', 0):6.2f}ms, {write_mbps:6.1f}MB/s)"
+        f"{suffix}"
+    )
 
 
 def should_print_progress(done: int, total: int, progress_interval: int) -> bool:
@@ -360,10 +381,12 @@ def should_print_progress(done: int, total: int, progress_interval: int) -> bool
     return progress_interval > 0 and done % progress_interval == 0
 
 
-def run_single_thread(benchmark: StorageBenchmark,
-                      requests: List[KVCacheRequest],
-                      replay_scale: float,
-                      progress_interval: int) -> Dict[str, Any]:
+def run_single_thread(
+    benchmark: StorageBenchmark,
+    requests: List[KVCacheRequest],
+    replay_scale: float,
+    progress_interval: int,
+) -> Dict[str, Any]:
     start_time = time.perf_counter()
     base_timestamp = requests[0].timestamp if requests else 0
     completed = 0
@@ -373,19 +396,22 @@ def run_single_thread(benchmark: StorageBenchmark,
         benchmark.process_request(req)
         completed += 1
         if should_print_progress(completed, len(requests), progress_interval):
-            print_progress(completed, len(requests), start_time,
-                           benchmark.get_stats(), req)
+            print_progress(
+                completed, len(requests), start_time, benchmark.get_stats(), req
+            )
 
     return {
-        'completed': completed,
-        'elapsed': time.perf_counter() - start_time,
-        'stats': benchmark.get_stats(),
+        "completed": completed,
+        "elapsed": time.perf_counter() - start_time,
+        "stats": benchmark.get_stats(),
     }
 
 
-def run_multi_thread(benchmarks: List[StorageBenchmark],
-                     requests: List[KVCacheRequest],
-                     replay_scale: float) -> Dict[str, Any]:
+def run_multi_thread(
+    benchmarks: List[StorageBenchmark],
+    requests: List[KVCacheRequest],
+    replay_scale: float,
+) -> Dict[str, Any]:
     start_time = time.perf_counter()
     base_timestamp = requests[0].timestamp if requests else 0
     total_requests = len(requests) * len(benchmarks)
@@ -407,25 +433,36 @@ def run_multi_thread(benchmarks: List[StorageBenchmark],
         for future in as_completed(futures):
             worker_stats = future.result()
             thread_stats.append(worker_stats)
-            completed += worker_stats['total_requests']
-            print_progress(completed, total_requests, start_time,
-                           aggregate_thread_stats(thread_stats),
-                           suffix=" | completed worker")
+            completed += worker_stats["total_requests"]
+            print_progress(
+                completed,
+                total_requests,
+                start_time,
+                aggregate_thread_stats(thread_stats),
+                suffix=" | completed worker",
+            )
 
     return {
-        'completed': completed,
-        'elapsed': time.perf_counter() - start_time,
-        'stats': aggregate_thread_stats(thread_stats),
+        "completed": completed,
+        "elapsed": time.perf_counter() - start_time,
+        "stats": aggregate_thread_stats(thread_stats),
     }
 
 
-def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
-                  max_requests: int = None, max_pages: int = None,
-                  page_size_tokens: int = 512,
-                  file_mode: str = 'single',
-                  fsync_mode: str = 'none', fsync_batch_size: int = 100,
-                  threads: int = 1, replay_scale: float = 0.0,
-                  progress_interval: int = 100) -> Dict:
+def run_benchmark(
+    trace_path: str,
+    storage_dir: str,
+    model_config: dict,
+    max_requests: int = None,
+    max_pages: int = None,
+    page_size_tokens: int = 512,
+    file_mode: str = "single",
+    fsync_mode: str = "none",
+    fsync_batch_size: int = 100,
+    threads: int = 1,
+    replay_scale: float = 0.0,
+    progress_interval: int = 100,
+) -> Dict:
     """Run benchmark
 
     Args:
@@ -453,7 +490,11 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
     print(f"Page size: {page_size_tokens} tokens")
     print(f"File mode: {file_mode}")
     print(f"Threads: {threads}")
-    print(f"Fast-forward: {replay_scale:g}x" if replay_scale > 0 else "Fast-forward: unpaced")
+    print(
+        f"Fast-forward: {replay_scale:g}x"
+        if replay_scale > 0
+        else "Fast-forward: unpaced"
+    )
     print(f"{'='*80}")
 
     # Load trace
@@ -501,12 +542,18 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
         shortfall = max_pages_needed - max_pages
         shortfall_gb = shortfall * page_size_bytes / (1024**3)
         compression_ratio = max_pages / max_pages_needed
-        print(f"\n  ⚠️  Storage insufficient: {shortfall:,} pages shortfall ({shortfall_gb:.2f} GB)")
-        print(f"  ⚠️  Consider increasing --max-pages to at least {max_pages_needed:,} for full simulation")
+        print(
+            f"\n  ⚠️  Storage insufficient: {shortfall:,} pages shortfall ({shortfall_gb:.2f} GB)"
+        )
+        print(
+            f"  ⚠️  Consider increasing --max-pages to at least {max_pages_needed:,} for full simulation"
+        )
     else:
         surplus = max_pages - max_pages_needed
         surplus_pct = (surplus / max_pages) * 100 if max_pages > 0 else 0
-        print(f"  ✓ Direct mapping: all {max_pages_needed:,} logical pages uniquely mapped")
+        print(
+            f"  ✓ Direct mapping: all {max_pages_needed:,} logical pages uniquely mapped"
+        )
 
     try:
         if threads <= 1:
@@ -517,22 +564,25 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
                 max_pages=max_pages,
                 file_mode=file_mode,
                 fsync_mode=fsync_mode,
-                fsync_batch_size=fsync_batch_size
+                fsync_batch_size=fsync_batch_size,
             ) as benchmark:
-                result = run_single_thread(benchmark, requests, replay_scale,
-                                           progress_interval)
+                result = run_single_thread(
+                    benchmark, requests, replay_scale, progress_interval
+                )
         else:
             with ExitStack() as stack:
                 benchmarks = [
-                    stack.enter_context(StorageBenchmark(
-                        storage_dir=str(Path(storage_dir) / f"thread_{thread_id}"),
-                        model_config=model_config,
-                        page_size_tokens=page_size_tokens,
-                        max_pages=max_pages,
-                        file_mode=file_mode,
-                        fsync_mode=fsync_mode,
-                        fsync_batch_size=fsync_batch_size
-                    ))
+                    stack.enter_context(
+                        StorageBenchmark(
+                            storage_dir=str(Path(storage_dir) / f"thread_{thread_id}"),
+                            model_config=model_config,
+                            page_size_tokens=page_size_tokens,
+                            max_pages=max_pages,
+                            file_mode=file_mode,
+                            fsync_mode=fsync_mode,
+                            fsync_batch_size=fsync_batch_size,
+                        )
+                    )
                     for thread_id in range(threads)
                 ]
                 result = run_multi_thread(benchmarks, requests, replay_scale)
@@ -540,39 +590,48 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
         print(f"\n\n{'='*80}")
         print("Interrupted! Showing partial results:")
         print(f"{'='*80}")
-        result = result if 'result' in locals() else {
-            'completed': 0,
-            'elapsed': 0,
-            'stats': {},
-        }
-        print_results([{
-            'trace_file': Path(trace_path).name,
-            'total_requests': result['completed'],
-            'io_time_s': result['elapsed'],
-            'requests_per_second': (
-                result['completed'] / result['elapsed']
-                if result['elapsed'] > 0 else 0
-            ),
-            'model': model_config['name'],
-            'fsync_mode': fsync_mode,
-            'threads': threads,
-            'replay_scale': replay_scale,
-            **result['stats'],
-        }])
+        result = (
+            result
+            if "result" in locals()
+            else {
+                "completed": 0,
+                "elapsed": 0,
+                "stats": {},
+            }
+        )
+        print_results(
+            [
+                {
+                    "trace_file": Path(trace_path).name,
+                    "total_requests": result["completed"],
+                    "io_time_s": result["elapsed"],
+                    "requests_per_second": (
+                        result["completed"] / result["elapsed"]
+                        if result["elapsed"] > 0
+                        else 0
+                    ),
+                    "model": model_config["name"],
+                    "fsync_mode": fsync_mode,
+                    "threads": threads,
+                    "replay_scale": replay_scale,
+                    **result["stats"],
+                }
+            ]
+        )
         sys.exit(0)
 
     return {
-        'trace_file': Path(trace_path).name,
-        'total_requests': result['completed'],
-        'io_time_s': result['elapsed'],
-        'requests_per_second': (
-            result['completed'] / result['elapsed'] if result['elapsed'] > 0 else 0
+        "trace_file": Path(trace_path).name,
+        "total_requests": result["completed"],
+        "io_time_s": result["elapsed"],
+        "requests_per_second": (
+            result["completed"] / result["elapsed"] if result["elapsed"] > 0 else 0
         ),
-        'model': model_config['name'],
-        'fsync_mode': fsync_mode,
-        'threads': threads,
-        'replay_scale': replay_scale,
-        **result['stats'],
+        "model": model_config["name"],
+        "fsync_mode": fsync_mode,
+        "threads": threads,
+        "replay_scale": replay_scale,
+        **result["stats"],
     }
 
 
@@ -580,13 +639,14 @@ def run_benchmark(trace_path: str, storage_dir: str, model_config: dict,
 # Output Formatting
 # ============================================================================
 
+
 def format_storage_stats(stats: Dict, title: str = "Storage"):
     """Format storage statistics with clear read/write separation"""
-    storage = stats.get('storage', {})
-    read_stats = storage.get('read', {})
-    write_stats = storage.get('write', {})
-    request_wall = stats.get('request_wall_latency', {})
-    request_io = stats.get('request_io_latency', {})
+    storage = stats.get("storage", {})
+    read_stats = storage.get("read", {})
+    write_stats = storage.get("write", {})
+    request_wall = stats.get("request_wall_latency", {})
+    request_io = stats.get("request_io_latency", {})
 
     output = []
     output.append(f"\n[{title}]")
@@ -595,8 +655,10 @@ def format_storage_stats(stats: Dict, title: str = "Storage"):
     output.append("\n[General]")
     output.append(f"  Model:            {stats.get('model', 'N/A')}")
     output.append(f"  Threads:          {stats.get('threads', 1)}")
-    replay_scale = stats.get('replay_scale', 0)
-    output.append(f"  Fast-forward:     {f'{replay_scale:g}x' if replay_scale else 'unpaced'}")
+    replay_scale = stats.get("replay_scale", 0)
+    output.append(
+        f"  Fast-forward:     {f'{replay_scale:g}x' if replay_scale else 'unpaced'}"
+    )
     output.append(f"  Requests:         {stats.get('total_requests', 0):,}")
     output.append(f"  Tokens:           {stats.get('total_tokens', 0):,}")
     output.append(f"  Total I/O Time:    {stats.get('io_time_s', 0):.3f} s")
@@ -620,8 +682,8 @@ def format_storage_stats(stats: Dict, title: str = "Storage"):
     output.append("\n[Read Operations]")
     output.append(f"  Count:            {read_stats.get('count', 0):,}")
     output.append(f"  Data Volume:      {read_stats.get('mb', 0):.2f} MB")
-    read_time = read_stats.get('time_s', 0)
-    read_mbps = read_stats.get('mb', 0) / read_time if read_time > 0 else 0
+    read_time = read_stats.get("time_s", 0)
+    read_mbps = read_stats.get("mb", 0) / read_time if read_time > 0 else 0
     output.append(f"  Total Time:       {read_time:.3f} s")
     output.append(f"  Bandwidth:        {read_mbps:.2f} MB/s")
     output.append("  Latency:")
@@ -634,8 +696,8 @@ def format_storage_stats(stats: Dict, title: str = "Storage"):
     output.append("\n[Write Operations]")
     output.append(f"  Count:            {write_stats.get('count', 0):,}")
     output.append(f"  Data Volume:      {write_stats.get('mb', 0):.2f} MB")
-    write_time = write_stats.get('time_s', 0)
-    write_mbps = write_stats.get('mb', 0) / write_time if write_time > 0 else 0
+    write_time = write_stats.get("time_s", 0)
+    write_mbps = write_stats.get("mb", 0) / write_time if write_time > 0 else 0
     output.append(f"  Total Time:       {write_time:.3f} s")
     output.append(f"  Bandwidth:        {write_mbps:.2f} MB/s")
     output.append("  Latency:")
@@ -666,52 +728,101 @@ def print_results(results: List[Dict]):
 # CLI Entry Point
 # ============================================================================
 
+
 def main():
     """Main entry point"""
     parser = argparse.ArgumentParser(
-        description='Mooncake KVCache Storage Benchmark',
+        description="Mooncake KVCache Storage Benchmark",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    parser.add_argument('--trace-dir', type=str, default='../../FAST25-release/traces',
-                       help='Trace files directory')
-    parser.add_argument('--scenario', type=str, choices=['conversation', 'synthetic', 'toolagent', 'all'],
-                       default='toolagent', help='Test scenario')
-    parser.add_argument('--storage-dir', type=str, default='/tmp/mooncake_bench',
-                       help='Storage directory')
-    parser.add_argument('--model', type=str, default='glm5', choices=['glm5', 'kimi-k2.6'],
-                       help='Model preset')
-    parser.add_argument('--page-size-tokens', type=int, default=512,
-                       help='Page size in tokens (default: 512)')
-    parser.add_argument('--file-mode', type=str, choices=['single', 'per-file'],
-                       default='single',
-                       help='Storage layout: single = one data.bin with slot '
-                            'offsets (default); per-file = one file per page. '
-                            'Per-file writes open with O_TRUNC and replace the '
-                            'whole page file')
-    parser.add_argument('--max-requests', type=int, default=None,
-                       help='Maximum number of requests')
-    parser.add_argument('--max-pages', type=int, default=2000,
-                       help='Maximum number of pages')
-    parser.add_argument('--fsync-mode', type=str, choices=['batch', 'always', 'end', 'none'],
-                       default='none',
-                       help='When to fsync. With --file-mode per-file, end does '
-                            'zero fsyncs and batch fsyncs only the last file in '
-                            'each batch; durability is weaker than single')
-    parser.add_argument('--fsync-batch-size', type=int, default=100,
-                       help='Number of writes between fsync')
-    parser.add_argument('--threads', type=int, default=1,
-                       help='Number of benchmark client worker threads')
-    parser.add_argument('--replay-scales', type=str, default='0',
-                       help='Comma-separated trace fast-forward speeds; 0 means unpaced')
-    parser.add_argument('--progress-interval', type=int, default=100,
-                       help='Print progress every N requests; 0 disables per-request progress')
+    parser.add_argument(
+        "--trace-dir",
+        type=str,
+        default="../../FAST25-release/traces",
+        help="Trace files directory",
+    )
+    parser.add_argument(
+        "--scenario",
+        type=str,
+        choices=["conversation", "synthetic", "toolagent", "all"],
+        default="toolagent",
+        help="Test scenario",
+    )
+    parser.add_argument(
+        "--storage-dir",
+        type=str,
+        default="/tmp/mooncake_bench",
+        help="Storage directory",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="glm5",
+        choices=["glm5", "kimi-k2.6"],
+        help="Model preset",
+    )
+    parser.add_argument(
+        "--page-size-tokens",
+        type=int,
+        default=512,
+        help="Page size in tokens (default: 512)",
+    )
+    parser.add_argument(
+        "--file-mode",
+        type=str,
+        choices=["single", "per-file"],
+        default="single",
+        help="Storage layout: single = one data.bin with slot "
+        "offsets (default); per-file = one file per page. "
+        "Per-file writes open with O_TRUNC and replace the "
+        "whole page file",
+    )
+    parser.add_argument(
+        "--max-requests", type=int, default=None, help="Maximum number of requests"
+    )
+    parser.add_argument(
+        "--max-pages", type=int, default=2000, help="Maximum number of pages"
+    )
+    parser.add_argument(
+        "--fsync-mode",
+        type=str,
+        choices=["batch", "always", "end", "none"],
+        default="none",
+        help="When to fsync. With --file-mode per-file, end does "
+        "zero fsyncs and batch fsyncs only the last file in "
+        "each batch; durability is weaker than single",
+    )
+    parser.add_argument(
+        "--fsync-batch-size",
+        type=int,
+        default=100,
+        help="Number of writes between fsync",
+    )
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=1,
+        help="Number of benchmark client worker threads",
+    )
+    parser.add_argument(
+        "--replay-scales",
+        type=str,
+        default="0",
+        help="Comma-separated trace fast-forward speeds; 0 means unpaced",
+    )
+    parser.add_argument(
+        "--progress-interval",
+        type=int,
+        default=100,
+        help="Print progress every N requests; 0 disables per-request progress",
+    )
 
     args = parser.parse_args()
     if args.threads < 1:
-        parser.error('--threads must be at least 1')
+        parser.error("--threads must be at least 1")
     if args.progress_interval < 0:
-        parser.error('--progress-interval must be non-negative')
+        parser.error("--progress-interval must be non-negative")
 
     print(f"\n{'='*80}")
     print(f"{'Mooncake KVCache Storage Benchmark':^80}")
@@ -721,16 +832,20 @@ def main():
     print(f"Model: {args.model} ({model_config['num_layers']} layers)")
     replay_scales = parse_csv_floats(args.replay_scales)
     if not replay_scales:
-        parser.error('--replay-scales must include at least one value')
+        parser.error("--replay-scales must include at least one value")
     if any(scale < 0 for scale in replay_scales):
-        parser.error('--replay-scales values must be non-negative')
+        parser.error("--replay-scales values must be non-negative")
 
     # Determine scenarios
-    scenarios = ['conversation', 'synthetic', 'toolagent'] if args.scenario == 'all' else [args.scenario]
+    scenarios = (
+        ["conversation", "synthetic", "toolagent"]
+        if args.scenario == "all"
+        else [args.scenario]
+    )
     trace_files = {
-        'conversation': 'conversation_trace.jsonl',
-        'synthetic': 'synthetic_trace.jsonl',
-        'toolagent': 'toolagent_trace.jsonl'
+        "conversation": "conversation_trace.jsonl",
+        "synthetic": "synthetic_trace.jsonl",
+        "toolagent": "toolagent_trace.jsonl",
     }
 
     # Run benchmarks
@@ -755,7 +870,7 @@ def main():
                     args.fsync_batch_size,
                     args.threads,
                     replay_scale,
-                    args.progress_interval
+                    args.progress_interval,
                 )
                 results.append(result)
         else:
@@ -768,5 +883,6 @@ def main():
         print("Error: No trace files were successfully processed.", file=sys.stderr)
         sys.exit(1)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/benchmarks/storage_benchmark_v1/benchmark.py
+++ b/benchmarks/storage_benchmark_v1/benchmark.py
@@ -679,8 +679,10 @@ def main():
                        help='Page size in tokens (default: 512)')
     parser.add_argument('--file-mode', type=str, choices=['single', 'per-file'],
                        default='single',
-                       help='Storage layout: single = one big data.bin with slot '
-                            'offsets (default); per-file = one file per page')
+                       help='Storage layout: single = one data.bin with slot '
+                            'offsets (default); per-file = one file per page. '
+                            'Per-file writes open with O_TRUNC and replace the '
+                            'whole page file')
     parser.add_argument('--max-requests', type=int, default=None,
                        help='Maximum number of requests')
     parser.add_argument('--max-pages', type=int, default=2000,

--- a/benchmarks/storage_benchmark_v1/doc/README.md
+++ b/benchmarks/storage_benchmark_v1/doc/README.md
@@ -24,6 +24,7 @@ python benchmark.py --scenario conversation \
 | `--storage-dir` | `/tmp/mooncake_bench` | Directory for storage files |
 | `--model` | `glm5` | Model preset: `glm5` or `kimi-k2.6` |
 | `--page-size-tokens` | `512` | Page size in tokens |
+| `--file-mode` | `single` | Storage layout: `single` = one `data.bin` with slot offsets; `per-file` = one file per page. Per-file writes open with `O_TRUNC` and replace the whole page file |
 | `--max-requests` | `None` | Maximum number of requests to process |
 | `--max-pages` | `2000` | Maximum number of pages (creates modulo mapping if trace is larger) |
 | `--fsync-mode` | `none` | When to fsync: `none`, `batch`, `always`, or `end` |
@@ -58,10 +59,25 @@ python benchmark.py --scenario toolagent \
 ```
 
 With `--threads > 1`, each benchmark client thread uses an independent storage
-file under `thread_N/data.bin`, similar to running multiple clients at the same
+directory under `thread_N/`, similar to running multiple clients at the same
 time. Final results aggregate the per-thread counters and latency samples. For
 strict single-client trace-order read/write and hit-rate accounting, use
 `--threads 1`.
+
+### File Mode
+
+`--file-mode` selects the on-disk layout:
+
+- `single` (default): one preallocated `data.bin`. Each page is a slot at
+  `physical_page_id * page_size`. Partial writes keep the rest of the file.
+- `per-file`: one `page_<id>.bin` per page. Each operation opens, reads or
+  writes, then closes that file. A write opens with `O_WRONLY | O_CREAT |
+  O_TRUNC`, so it replaces the entire page file and does not preserve earlier
+  bytes in that file.
+
+With `--threads > 1`, each thread still uses its own `thread_N/` directory.
+In `single` mode that directory contains `data.bin`; in `per-file` mode it
+contains `page_*.bin`.
 
 ## Output Format
 

--- a/benchmarks/storage_benchmark_v1/doc/README.md
+++ b/benchmarks/storage_benchmark_v1/doc/README.md
@@ -27,7 +27,7 @@ python benchmark.py --scenario conversation \
 | `--file-mode` | `single` | Storage layout: `single` = one `data.bin` with slot offsets; `per-file` = one file per page. Per-file writes open with `O_TRUNC` and replace the whole page file |
 | `--max-requests` | `None` | Maximum number of requests to process |
 | `--max-pages` | `2000` | Maximum number of pages (creates modulo mapping if trace is larger) |
-| `--fsync-mode` | `none` | When to fsync: `none`, `batch`, `always`, or `end` |
+| `--fsync-mode` | `none` | When to fsync: `none`, `batch`, `always`, or `end`. With `--file-mode per-file`, `end`/`batch` are weaker than in `single` (see File Mode) |
 | `--fsync-batch-size` | `100` | Number of writes between fsync in batch mode |
 | `--threads` | `1` | Number of benchmark client worker threads |
 | `--replay-scales` | `0` | Comma-separated trace fast-forward speeds; `0` means unpaced |
@@ -78,6 +78,26 @@ strict single-client trace-order read/write and hit-rate accounting, use
 With `--threads > 1`, each thread still uses its own `thread_N/` directory.
 In `single` mode that directory contains `data.bin`; in `per-file` mode it
 contains `page_*.bin`.
+
+Per-file mode does not delete leftover `page_*.bin` files or `thread_N/`
+directories between runs. A re-run with a smaller `--max-pages` or fewer
+`--threads` can leave orphaned files. Within a run this is harmless
+(`_written_pages` starts empty and writes use `O_TRUNC`); remove them
+manually from `--storage-dir` if disk space matters.
+
+`--fsync-mode none` and `always` are comparable across file modes. Combined
+with `--file-mode per-file`, `end` and `batch` are weaker than in `single`
+and should not be compared as the same durability cost:
+
+- `end`: `write()` never fsyncs, and `close()` only fsyncs the persistent
+  `data.bin` fd, which per-file never opens. Expected result: zero fsyncs,
+  write latency and `Sync Count` look like `none`.
+- `batch`: `_pending_syncs` counts across files, but `os.fsync(fd)` runs
+  only on the current per-op fd. Expected result: one file per batch is
+  synced (the Nth write); the other N-1 files are already closed, and the
+  trailing partial batch is never flushed. `Sync Count` still increments,
+  but most writes are not durable, so write latency is much closer to
+  `none` than to `single` + `batch`.
 
 ## Output Format
 

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -197,6 +197,9 @@ class DiskHashTable(Storage):
         try:
             fd, base, owned = self._open_page(page_id, write=False)
             os.pread(fd, length, base + offset_in_page)
+            if owned:
+                close_fd, fd = fd, None
+                os.close(close_fd)
 
             latency = (time.perf_counter() - start) * 1000.0
             self.stats['read_count'] += 1
@@ -249,14 +252,18 @@ class DiskHashTable(Storage):
                 os.fsync(fd)
                 self.stats['sync_count'] += 1
                 self._pending_syncs = 0
-                latency = (time.perf_counter() - start) * 1000.0
             elif self.fsync_mode == 'batch':
                 self._pending_syncs += 1
                 if self._pending_syncs >= self.fsync_batch_size:
                     os.fsync(fd)
                     self.stats['sync_count'] += 1
                     self._pending_syncs = 0
-                latency = (write_done - start) * 1000.0
+            if owned:
+                close_fd, fd = fd, None
+                os.close(close_fd)
+
+            if self.fsync_mode == 'always' or owned:
+                latency = (time.perf_counter() - start) * 1000.0
             else:
                 latency = (write_done - start) * 1000.0
 

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -15,8 +15,9 @@ from .interface import Storage
 def calc_percentiles(data):
     """Calculate latency percentiles"""
     if not data:
-        return {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+        return {"avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0}
     import statistics
+
     sorted_data = sorted(data)
 
     def get_percentile(p):
@@ -29,10 +30,10 @@ def calc_percentiles(data):
         return sorted_data[lower] * (1.0 - weight) + sorted_data[upper] * weight
 
     return {
-        'avg_ms': statistics.mean(data),
-        'p50_ms': get_percentile(50),
-        'p95_ms': get_percentile(95),
-        'p99_ms': get_percentile(99),
+        "avg_ms": statistics.mean(data),
+        "p50_ms": get_percentile(50),
+        "p95_ms": get_percentile(95),
+        "p99_ms": get_percentile(99),
     }
 
 
@@ -51,10 +52,15 @@ class DiskHashTable(Storage):
     This allows simulating large traces with limited storage.
     """
 
-    def __init__(self, storage_dir: str, page_size: int,
-                 max_pages: int = 100000,
-                 file_mode: str = 'single',
-                 fsync_mode: str = 'batch', fsync_batch_size: int = 100):
+    def __init__(
+        self,
+        storage_dir: str,
+        page_size: int,
+        max_pages: int = 100000,
+        file_mode: str = "single",
+        fsync_mode: str = "batch",
+        fsync_batch_size: int = 100,
+    ):
         """Initialize disk hash table
 
         Args:
@@ -78,22 +84,22 @@ class DiskHashTable(Storage):
         self.fsync_batch_size = fsync_batch_size
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.storage_file = self.storage_dir / "data.bin"
-        if self.file_mode == 'single':
+        if self.file_mode == "single":
             self._allocate_file()
         self.fd = None
         self._buffer = os.urandom(page_size)
         self.stats = {
-            'read_count': 0,
-            'write_count': 0,
-            'read_bytes': 0,
-            'write_bytes': 0,
-            'read_latencies_ms': [],
-            'write_latencies_ms': [],
-            'read_time_s': 0.0,
-            'write_time_s': 0.0,
-            'sync_count': 0,
-            'hit': 0,
-            'miss': 0,
+            "read_count": 0,
+            "write_count": 0,
+            "read_bytes": 0,
+            "write_bytes": 0,
+            "read_latencies_ms": [],
+            "write_latencies_ms": [],
+            "read_time_s": 0.0,
+            "write_time_s": 0.0,
+            "sync_count": 0,
+            "hit": 0,
+            "miss": 0,
         }
         self._pending_syncs = 0
         self._written_pages: set = set()
@@ -103,30 +109,39 @@ class DiskHashTable(Storage):
         file_size = self.max_pages * self.page_size
         if not self.storage_file.exists():
             print(f"  [Storage] Creating file: {self.storage_file}")
-            print(f"  [Storage] Requested size: {file_size / (1024**3):.2f} GB ({self.max_pages:,} pages × {self.page_size} bytes = {file_size:,} bytes)")
+            print(
+                f"  [Storage] Requested size: {file_size / (1024**3):.2f} GB ({self.max_pages:,} pages × {self.page_size} bytes = {file_size:,} bytes)"
+            )
             # Use fallocate for efficient preallocation (Linux)
             fd = os.open(self.storage_file, os.O_RDWR | os.O_CREAT | os.O_TRUNC, 0o644)
             try:
                 # Try fallocate first (Linux specific, much faster)
                 try:
                     import fcntl
+
                     fcntl.fallocate(fd, 0, file_size)
                     method = "fallocate"
                 except (ImportError, AttributeError, OSError):
                     # Fallback to seek+write method
                     os.lseek(fd, file_size - 1, os.SEEK_SET)
-                    os.write(fd, b'\0')
+                    os.write(fd, b"\0")
                     os.fsync(fd)
                     method = "seek+write"
             finally:
                 os.close(fd)
-            actual_size = self.storage_file.stat().st_size if self.storage_file.exists() else 0
-            print(f"  [Storage] Pre-allocated {actual_size / (1024**3):.2f} GB using {method}")
+            actual_size = (
+                self.storage_file.stat().st_size if self.storage_file.exists() else 0
+            )
+            print(
+                f"  [Storage] Pre-allocated {actual_size / (1024**3):.2f} GB using {method}"
+            )
         else:
             actual_size = self.storage_file.stat().st_size
             actual_pages = actual_size // self.page_size
             print(f"  [Storage] Reusing existing file: {self.storage_file}")
-            print(f"  [Storage] Current file size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)")
+            print(
+                f"  [Storage] Current file size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)"
+            )
 
     def _get_fd(self):
         if self.fd is None:
@@ -135,7 +150,9 @@ class DiskHashTable(Storage):
             if self.storage_file.exists():
                 actual_size = self.storage_file.stat().st_size
                 actual_pages = actual_size // self.page_size
-                print(f"  [Storage] File size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)")
+                print(
+                    f"  [Storage] File size: {actual_size / (1024**3):.2f} GB ({actual_pages:,} pages × {self.page_size} bytes = {actual_size:,} bytes)"
+                )
         return self.fd
 
     # ========================================================================
@@ -165,7 +182,7 @@ class DiskHashTable(Storage):
                   write replaces the whole file.
         """
         physical_page_id = self._map_page_id(page_id)
-        if self.file_mode == 'per-file':
+        if self.file_mode == "per-file":
             path = self.storage_dir / f"page_{physical_page_id}.bin"
             flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC if write else os.O_RDONLY
             return os.open(str(path), flags, 0o644), 0, True
@@ -187,9 +204,13 @@ class DiskHashTable(Storage):
 
         # Validate parameters
         if offset_in_page < 0 or offset_in_page >= self.page_size:
-            raise ValueError(f"offset_in_page {offset_in_page} out of range [0, {self.page_size})")
+            raise ValueError(
+                f"offset_in_page {offset_in_page} out of range [0, {self.page_size})"
+            )
         if length <= 0 or offset_in_page + length > self.page_size:
-            raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
+            raise ValueError(
+                f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})"
+            )
 
         start = time.perf_counter()
         fd = None
@@ -202,11 +223,11 @@ class DiskHashTable(Storage):
                 os.close(close_fd)
 
             latency = (time.perf_counter() - start) * 1000.0
-            self.stats['read_count'] += 1
-            self.stats['read_bytes'] += length
-            self.stats['read_latencies_ms'].append(latency)
-            self.stats['read_time_s'] += latency / 1000.0
-            self.stats['hit'] += 1
+            self.stats["read_count"] += 1
+            self.stats["read_bytes"] += length
+            self.stats["read_latencies_ms"].append(latency)
+            self.stats["read_time_s"] += latency / 1000.0
+            self.stats["hit"] += 1
             return latency
         except OSError as e:
             print(f"Read error (page_id={page_id}): {e}")
@@ -234,9 +255,13 @@ class DiskHashTable(Storage):
 
         # Validate parameters
         if offset_in_page < 0 or offset_in_page >= self.page_size:
-            raise ValueError(f"offset_in_page {offset_in_page} out of range [0, {self.page_size})")
+            raise ValueError(
+                f"offset_in_page {offset_in_page} out of range [0, {self.page_size})"
+            )
         if length <= 0 or offset_in_page + length > self.page_size:
-            raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
+            raise ValueError(
+                f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})"
+            )
 
         start = time.perf_counter()
         fd = None
@@ -248,34 +273,36 @@ class DiskHashTable(Storage):
             write_done = time.perf_counter()
 
             # Fsync
-            if self.fsync_mode == 'always':
+            if self.fsync_mode == "always":
                 os.fsync(fd)
-                self.stats['sync_count'] += 1
+                self.stats["sync_count"] += 1
                 self._pending_syncs = 0
-            elif self.fsync_mode == 'batch':
+            elif self.fsync_mode == "batch":
                 self._pending_syncs += 1
                 if self._pending_syncs >= self.fsync_batch_size:
                     os.fsync(fd)
-                    self.stats['sync_count'] += 1
+                    self.stats["sync_count"] += 1
                     self._pending_syncs = 0
             if owned:
                 close_fd, fd = fd, None
                 os.close(close_fd)
 
-            if self.fsync_mode == 'always' or owned:
+            if self.fsync_mode == "always" or owned:
                 latency = (time.perf_counter() - start) * 1000.0
             else:
                 latency = (write_done - start) * 1000.0
 
             self._written_pages.add(page_id)
-            self.stats['write_count'] += 1
-            self.stats['write_bytes'] += length
-            self.stats['write_latencies_ms'].append(latency)
-            self.stats['write_time_s'] += latency / 1000.0
-            self.stats['miss'] += 1
+            self.stats["write_count"] += 1
+            self.stats["write_bytes"] += length
+            self.stats["write_latencies_ms"].append(latency)
+            self.stats["write_time_s"] += latency / 1000.0
+            self.stats["miss"] += 1
             return latency
         except OSError as e:
-            print(f"Write error (page_id={page_id}, offset_in_page={offset_in_page}, length={length}): {e}")
+            print(
+                f"Write error (page_id={page_id}, offset_in_page={offset_in_page}, length={length}): {e}"
+            )
             return None
         finally:
             if owned and fd is not None:
@@ -317,30 +344,30 @@ class DiskHashTable(Storage):
 
         def calc_stats(latencies):
             if not latencies:
-                return {'avg_ms': 0, 'p50_ms': 0, 'p95_ms': 0, 'p99_ms': 0}
+                return {"avg_ms": 0, "p50_ms": 0, "p95_ms": 0, "p99_ms": 0}
             return {
-                'avg_ms': statistics.mean(latencies),
+                "avg_ms": statistics.mean(latencies),
                 **calc_percentiles(latencies),
             }
 
         return {
-            'read': {
-                'count': self.stats['read_count'],
-                'mb': self.stats['read_bytes'] / 1024 / 1024,
-                'time_s': self.stats['read_time_s'],
-                **calc_stats(self.stats['read_latencies_ms'])
+            "read": {
+                "count": self.stats["read_count"],
+                "mb": self.stats["read_bytes"] / 1024 / 1024,
+                "time_s": self.stats["read_time_s"],
+                **calc_stats(self.stats["read_latencies_ms"]),
             },
-            'write': {
-                'count': self.stats['write_count'],
-                'mb': self.stats['write_bytes'] / 1024 / 1024,
-                'time_s': self.stats['write_time_s'],
-                **calc_stats(self.stats['write_latencies_ms'])
+            "write": {
+                "count": self.stats["write_count"],
+                "mb": self.stats["write_bytes"] / 1024 / 1024,
+                "time_s": self.stats["write_time_s"],
+                **calc_stats(self.stats["write_latencies_ms"]),
             },
-            'sync_count': self.stats['sync_count'],
-            'max_pages': self.max_pages,
-            'written_pages': len(self._written_pages),
-            'page_hits': self.stats['hit'],
-            'page_misses': self.stats['miss'],
+            "sync_count": self.stats["sync_count"],
+            "max_pages": self.max_pages,
+            "written_pages": len(self._written_pages),
+            "page_hits": self.stats["hit"],
+            "page_misses": self.stats["miss"],
         }
 
     # ========================================================================
@@ -349,11 +376,11 @@ class DiskHashTable(Storage):
 
     def close(self, force_sync: bool = True):
         """Close file"""
-        if force_sync and self.fsync_mode in ['end', 'batch']:
+        if force_sync and self.fsync_mode in ["end", "batch"]:
             if self.fd is not None:
                 try:
                     os.fsync(self.fd)
-                    self.stats['sync_count'] += 1
+                    self.stats["sync_count"] += 1
                 except OSError:
                     pass
 

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -210,7 +210,7 @@ class DiskHashTable(Storage):
             return latency
         except OSError as e:
             print(f"Read error (page_id={page_id}): {e}")
-            return 0.0
+            return None
         finally:
             if owned and fd is not None:
                 try:
@@ -276,7 +276,7 @@ class DiskHashTable(Storage):
             return latency
         except OSError as e:
             print(f"Write error (page_id={page_id}, offset_in_page={offset_in_page}, length={length}): {e}")
-            return 0.0
+            return None
         finally:
             if owned and fd is not None:
                 try:

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -53,6 +53,7 @@ class DiskHashTable(Storage):
 
     def __init__(self, storage_dir: str, page_size: int,
                  max_pages: int = 100000,
+                 file_mode: str = 'single',
                  fsync_mode: str = 'batch', fsync_batch_size: int = 100):
         """Initialize disk hash table
 
@@ -60,6 +61,8 @@ class DiskHashTable(Storage):
             storage_dir: Storage directory
             page_size: Size of each entry (page) in bytes
             max_pages: Maximum number of entries (creates circular mapping if trace is larger)
+            file_mode: 'single' = one big data.bin with slot offsets (default);
+                       'per-file' = one file per page (open/read-write/close per op)
             fsync_mode: When to fsync ('batch', 'always', 'end', 'none')
             fsync_batch_size: Writes between fsync
         """
@@ -67,11 +70,13 @@ class DiskHashTable(Storage):
         self.page_size = page_size
         self.max_pages = max_pages
         self.max_page_id = max_pages - 1
+        self.file_mode = file_mode
         self.fsync_mode = fsync_mode
         self.fsync_batch_size = fsync_batch_size
         self.storage_dir.mkdir(parents=True, exist_ok=True)
         self.storage_file = self.storage_dir / "data.bin"
-        self._allocate_file()
+        if self.file_mode == 'single':
+            self._allocate_file()
         self.fd = None
         self._buffer = os.urandom(page_size)
         self.stats = {
@@ -147,6 +152,20 @@ class DiskHashTable(Storage):
         """
         return page_id % self.max_pages
 
+    def _open_page(self, page_id: int, write: bool):
+        """Resolve a page access to (fd, base_offset, owned).
+
+        single: reuse the persistent data.bin fd, base = physical * page_size.
+        per-file: open page_<physical>.bin for this op, base = 0, owned = True
+                  (caller must close fd when done).
+        """
+        physical_page_id = self._map_page_id(page_id)
+        if self.file_mode == 'per-file':
+            path = self.storage_dir / f"page_{physical_page_id}.bin"
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC if write else os.O_RDONLY
+            return os.open(str(path), flags, 0o644), 0, True
+        return self._get_fd(), physical_page_id * self.page_size, False
+
     def read(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
         """Read entry from disk
 
@@ -167,14 +186,12 @@ class DiskHashTable(Storage):
         if length <= 0 or offset_in_page + length > self.page_size:
             raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
 
-        # Map to physical page_id and calculate offset
-        physical_page_id = self._map_page_id(page_id)
-        offset = physical_page_id * self.page_size + offset_in_page
         start = time.perf_counter()
-
+        fd = None
+        owned = False
         try:
-            fd = self._get_fd()
-            os.pread(fd, length, offset)
+            fd, base, owned = self._open_page(page_id, write=False)
+            os.pread(fd, length, base + offset_in_page)
 
             latency = (time.perf_counter() - start) * 1000.0
             self.stats['read_count'] += 1
@@ -184,8 +201,14 @@ class DiskHashTable(Storage):
             self.stats['hit'] += 1
             return latency
         except OSError as e:
-            print(f"Read error (page_id={page_id}, physical_page_id={physical_page_id}): {e}")
+            print(f"Read error (page_id={page_id}): {e}")
             return 0.0
+        finally:
+            if owned and fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
     def write(self, page_id: int, offset_in_page: int = 0, length: int = None) -> float:
         """Write entry to disk
@@ -207,15 +230,13 @@ class DiskHashTable(Storage):
         if length <= 0 or offset_in_page + length > self.page_size:
             raise ValueError(f"length {length} invalid with offset_in_page {offset_in_page} (page_size={self.page_size})")
 
-        # Map to physical page_id and calculate offset
-        physical_page_id = self._map_page_id(page_id)
-        offset = physical_page_id * self.page_size + offset_in_page
         start = time.perf_counter()
-
+        fd = None
+        owned = False
         try:
-            fd = self._get_fd()
+            fd, base, owned = self._open_page(page_id, write=True)
             # Use corresponding portion of buffer
-            os.pwrite(fd, self._buffer[:length], offset)
+            os.pwrite(fd, self._buffer[:length], base + offset_in_page)
             write_done = time.perf_counter()
 
             # Fsync
@@ -244,6 +265,12 @@ class DiskHashTable(Storage):
         except OSError as e:
             print(f"Write error (page_id={page_id}, offset_in_page={offset_in_page}, length={length}): {e}")
             return 0.0
+        finally:
+            if owned and fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
 
     # ========================================================================
     # Storage interface methods

--- a/benchmarks/storage_benchmark_v1/storage/disk.py
+++ b/benchmarks/storage_benchmark_v1/storage/disk.py
@@ -62,7 +62,10 @@ class DiskHashTable(Storage):
             page_size: Size of each entry (page) in bytes
             max_pages: Maximum number of entries (creates circular mapping if trace is larger)
             file_mode: 'single' = one big data.bin with slot offsets (default);
-                       'per-file' = one file per page (open/read-write/close per op)
+                       'per-file' = one file per page (open/read-write/close per op).
+                       Per-file writes use O_TRUNC, so a partial-page
+                       (offset_in_page > 0 or length < page_size) write
+                       replaces the whole file and discards the rest of the page.
             fsync_mode: When to fsync ('batch', 'always', 'end', 'none')
             fsync_batch_size: Writes between fsync
         """
@@ -157,7 +160,9 @@ class DiskHashTable(Storage):
 
         single: reuse the persistent data.bin fd, base = physical * page_size.
         per-file: open page_<physical>.bin for this op, base = 0, owned = True
-                  (caller must close fd when done).
+                  (caller must close fd when done). Writes use O_TRUNC, so a
+                  partial-page(offset_in_page > 0 or length < page_size)
+                  write replaces the whole file.
         """
         physical_page_id = self._map_page_id(page_id)
         if self.file_mode == 'per-file':


### PR DESCRIPTION
## Description

This PR tries to add optional argument for storage benchmark script: `file-mode` which support default `single` (current implementation) and new `per-file` which enable more flexible testing against backend storage. For example, Lustre (parallel file system) could utilize multiple OST write and local PCC read cache to improve tail IO latency

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [X ] Other

## Type of Change

- [ ] Bug fix
- [X ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

ran `benchmark.py with` both `file-mode`: `single` and `per-file`

## Checklist

- [X ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [ X] AI tools were used (specify below)

use augment code and GLM5.2 for the feature