### PR TITLE
[Bugfix][Store] Fix hybrid histogram serialization

### DIFF
--- a/mooncake-store/include/hybrid_metric.h
+++ b/mooncake-store/include/hybrid_metric.h
@@ -289,8 +289,10 @@ class basic_hybrid_histogram : public dynamic_metric {
             return;
         }
 
+        const auto initial_size = str.size();
         serialize_head(str);
 
+        bool emitted_any = false;
         std::string value_str;
         auto bucket_counts = get_bucket_counts();
         for (auto& e : value_map) {
@@ -300,6 +302,7 @@ class basic_hybrid_histogram : public dynamic_metric {
                 continue;
             }
 
+            value_str.clear();
             value_type count = 0;
             for (size_t i = 0; i < bucket_counts.size(); i++) {
                 auto counter = bucket_counts[i];
@@ -324,6 +327,7 @@ class basic_hybrid_histogram : public dynamic_metric {
             }
 
             str.append(value_str);
+            emitted_any = true;
 
             std::string labels_str;
             build_label_string_with_static(labels_str, sum_->labels_name(),
@@ -341,8 +345,8 @@ class basic_hybrid_histogram : public dynamic_metric {
             str.append(std::to_string(count));
             str.append("\n");
         }
-        if (value_str.empty()) {
-            str.clear();
+        if (!emitted_any) {
+            str.resize(initial_size);
         }
     }
 

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -40,6 +40,16 @@ int GetTestPort(std::unordered_set<int>& used_ports) {
     return -1;
 }
 
+size_t CountOccurrences(const std::string& text, const std::string& needle) {
+    size_t count = 0;
+    size_t position = 0;
+    while ((position = text.find(needle, position)) != std::string::npos) {
+        ++count;
+        position += needle.size();
+    }
+    return count;
+}
+
 class ScopedEnv {
    public:
     explicit ScopedEnv(const char* name) : name_(name) {
@@ -248,6 +258,34 @@ TEST_F(ClientMetricsTest, CompareWithSerializedMetrics) {
                 summary.find("No data") != std::string::npos);
     EXPECT_TRUE(summary.find("max<") != std::string::npos ||
                 summary.find("No data") != std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, HybridHistogramSerializesEachLabelOnce) {
+    ylt::metric::hybrid_histogram_1t histogram(
+        "request_latency", "Request latency", {10.0, 20.0}, {}, {"route"});
+    histogram.observe({"alpha"}, 5);
+    histogram.observe({"beta"}, 15);
+
+    std::string serialized;
+    histogram.serialize(serialized);
+
+    EXPECT_EQ(
+        CountOccurrences(serialized, "request_latency_bucket{route=\"alpha\","),
+        3);
+    EXPECT_EQ(
+        CountOccurrences(serialized, "request_latency_bucket{route=\"beta\","),
+        3);
+}
+
+TEST_F(ClientMetricsTest, ZeroSumHybridHistogramPreservesExistingMetrics) {
+    ylt::metric::hybrid_histogram_1t histogram(
+        "request_latency", "Request latency", {10.0}, {}, {"route"});
+    histogram.observe({"idle"}, 0);
+    std::string serialized = "existing_metric 1\n";
+
+    histogram.serialize(serialized);
+
+    EXPECT_EQ(serialized, "existing_metric 1\n");
 }
 
 TEST_F(ClientMetricsTest, BandwidthSummaryRespectsEnvFlag) {

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -41,6 +41,8 @@ int GetTestPort(std::unordered_set<int>& used_ports) {
 }
 
 size_t CountOccurrences(const std::string& text, const std::string& needle) {
+    if (needle.empty()) return 0;
+
     size_t count = 0;
     size_t position = 0;
     while ((position = text.find(needle, position)) != std::string::npos) {


### PR DESCRIPTION
## Description

Closes #3416.

`basic_hybrid_histogram::serialize()` reused its bucket scratch string across label values, so earlier bucket series were emitted repeatedly. It also called `str.clear()` when all stored sums were zero, which erased metrics that earlier serializers had already appended to the shared response buffer.

This change clears the scratch string for each label and rolls back only the bytes appended by the current histogram when it emits no samples.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
g++ -std=c++20 -I. -Iextern/yalantinglibs/include \
  ../mooncake-w1-minimal-test.cpp -lgtest -lgtest_main -pthread \
  -o ../mooncake-w1-minimal-test
../mooncake-w1-minimal-test --gtest_color=no
git clang-format --diff origin/main -- \
  mooncake-store/include/hybrid_metric.h \
  mooncake-store/tests/client_metrics_test.cpp
git diff origin/main...HEAD --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: the focused CPU-only gtest harness failed both cases on `dc549aec` (duplicate count `6` instead of `3`; existing buffer became empty) and passed both cases after the fix.

The registered `client_metrics_test` CMake target was not built locally because it unconditionally links Transfer Engine, cachelib, etcd wrapper, and `ibverbs`; this host does not have the ibverbs headers or library. The added repository tests therefore rely on upstream CI for the full target build. The repository's format script also requires clang-format 20, while this host has clang-format 22.1.8; `git clang-format --diff` with the available version reported no changes. `pre-commit` is not installed locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable; no user-facing contract changed)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 46 insertions and 2 deletions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

AI tools assisted with investigation and drafting. The submitter reviewed every changed line and validation result.
