### PR TITLE
[Bugfix][Store] Preserve RequiredParam names when copied

### DIFF
--- a/mooncake-store/include/config_helper.h
+++ b/mooncake-store/include/config_helper.h
@@ -20,14 +20,8 @@ class RequiredParam {
     RequiredParam() : name_(nullptr) {}
     RequiredParam(const char* name) : name_(name) {}
 
-    // Add copy constructor
-    RequiredParam(const RequiredParam& other) { value_ = other.value_; }
-
-    // Add copy assignment operator
-    RequiredParam& operator=(const RequiredParam& other) {
-        value_ = other.value_;
-        return *this;
-    }
+    RequiredParam(const RequiredParam&) = default;
+    RequiredParam& operator=(const RequiredParam&) = default;
 
     /**
      * @brief Assignment operator to set the value

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ add_store_test(master_scenario_test master_scenario.cpp
                master_scenario_test.cpp)
 add_store_test(master_service_scenario_test master_scenario.cpp
                master_service_scenario_test.cpp)
+add_store_test(config_helper_test config_helper_test.cpp)
 add_store_test(master_service_config_test master_service_config_test.cpp)
 add_store_test(master_service_processing_key_double_erase_test
                master_service_processing_key_double_erase_test.cpp)

--- a/mooncake-store/tests/config_helper_test.cpp
+++ b/mooncake-store/tests/config_helper_test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+#include "config_helper.h"
+
+namespace mooncake::test {
+namespace {
+
+void ExpectUnsetErrorNames(const RequiredParam<int>& param,
+                           const std::string& name) {
+    try {
+        (void)param.Get();
+        FAIL() << "Expected an unset RequiredParam to throw";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find(name), std::string::npos)
+            << error.what();
+    }
+}
+
+TEST(ConfigHelperTest, CopyAssignmentPreservesParameterName) {
+    RequiredParam<int> source("metrics_port");
+    RequiredParam<int> copy("old_name");
+    source = 42;
+
+    copy = source;
+
+    EXPECT_EQ(copy.Get(), 42);
+    copy.Clear();
+    ExpectUnsetErrorNames(copy, "metrics_port");
+}
+
+TEST(ConfigHelperTest, CopyConstructionPreservesParameterName) {
+    RequiredParam<int> source("metrics_port");
+    source = 42;
+    RequiredParam<int> copy(source);
+    RequiredParam<int> observable("old_name");
+
+    EXPECT_EQ(copy.Get(), 42);
+    observable = copy;
+
+    EXPECT_EQ(observable.Get(), 42);
+    observable.Clear();
+    ExpectUnsetErrorNames(observable, "metrics_port");
+}
+
+}  // namespace
+}  // namespace mooncake::test

--- a/mooncake-store/tests/config_helper_test.cpp
+++ b/mooncake-store/tests/config_helper_test.cpp
@@ -8,14 +8,13 @@
 namespace mooncake::test {
 namespace {
 
-void ExpectUnsetErrorNames(const RequiredParam<int>& param,
-                           const std::string& name) {
+void ExpectUnsetError(const RequiredParam<int>& param,
+                      const std::string& expected_message) {
     try {
         (void)param.Get();
         FAIL() << "Expected an unset RequiredParam to throw";
     } catch (const std::runtime_error& error) {
-        EXPECT_NE(std::string(error.what()).find(name), std::string::npos)
-            << error.what();
+        EXPECT_EQ(std::string(error.what()), expected_message);
     }
 }
 
@@ -28,7 +27,7 @@ TEST(ConfigHelperTest, CopyAssignmentPreservesParameterName) {
 
     EXPECT_EQ(copy.Get(), 42);
     copy.Clear();
-    ExpectUnsetErrorNames(copy, "metrics_port");
+    ExpectUnsetError(copy, "Required parameter metrics_port has not been set");
 }
 
 TEST(ConfigHelperTest, CopyConstructionPreservesParameterName) {
@@ -42,7 +41,19 @@ TEST(ConfigHelperTest, CopyConstructionPreservesParameterName) {
 
     EXPECT_EQ(observable.Get(), 42);
     observable.Clear();
-    ExpectUnsetErrorNames(observable, "metrics_port");
+    ExpectUnsetError(observable,
+                     "Required parameter metrics_port has not been set");
+}
+
+TEST(ConfigHelperTest, CopyUnsetPreservesNullName) {
+    RequiredParam<int> source;
+    RequiredParam<int> copy(source);
+    RequiredParam<int> assigned("old_name");
+
+    assigned = source;
+
+    ExpectUnsetError(copy, "Required parameter has not been set");
+    ExpectUnsetError(assigned, "Required parameter has not been set");
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

`RequiredParam<T>` defined copy operations that copied only `value_`. Copy
assignment therefore retained the destination's old parameter name, while copy
construction left `name_` uninitialized. After clearing a copied value,
`Get()` could report the wrong parameter or read an uninitialized pointer while
building the error message.

This change defaults both copy operations so the optional value and parameter
name are preserved together. Focused tests cover copy construction and copy
assignment through the public `Get()` interface.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
g++ -std=c++20 -Imooncake-store/include \
  mooncake-store/tests/config_helper_test.cpp \
  -lgtest -lgtest_main -pthread -o /tmp/config_helper_test
/tmp/config_helper_test --gtest_color=no
git clang-format --diff origin/main -- \
  mooncake-store/include/config_helper.h \
  mooncake-store/tests/config_helper_test.cpp
git diff origin/main...HEAD --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: the exact repository test source failed both cases
  against `dc549aec` (both errors retained `old_name`) and passed both cases
  against the fixed header.

The registered `config_helper_test` CMake target was not built locally because
`add_store_test` unconditionally links Transfer Engine, cachelib, the etcd
wrapper, and `ibverbs`; those Store dependencies are unavailable on this host.
The standalone CPU-only build above compiles and runs the exact added test file,
while the full registered target relies on upstream CI. The repository format
script requires clang-format 20, while this host has clang-format 22.1.8;
`git clang-format --diff` with the available version reported no changes.
`pre-commit` is not installed locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable; no user-facing contract changed)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 53 insertions and 9 deletions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

AI tools assisted with investigation and drafting. The submitter reviewed every
changed line and validation result.