### PR TITLE
[CI/Build] Install patchelf from PyPI for auditwheel repair

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -306,6 +306,11 @@ rm -rf ${OUTPUT_DIR}/
 mkdir -p ${OUTPUT_DIR}
 
 echo "Installing required build packages"
+# patchelf is installed from PyPI alongside auditwheel: auditwheel >= 6.8
+# requires patchelf >= 0.14.5, but the distro package on Ubuntu 22.04 (and the
+# rocm/musa CI images built on it) is 0.14.3, which makes `auditwheel repair`
+# abort. The PyPI wheel lands ahead of /usr/bin on PATH and works everywhere
+# the Python toolchain does.
 if [ "$NPU_BUILD" = "1" ]; then
     PYTHON_CMD="python${PYTHON_VERSION}"
     if ! command -v "$PYTHON_CMD" &>/dev/null; then
@@ -315,7 +320,7 @@ if [ "$NPU_BUILD" = "1" ]; then
     max_attempts=3
     attempt=1
     while [ $attempt -le $max_attempts ]; do
-        if "$PYTHON_CMD" -m pip install --upgrade pip build setuptools wheel auditwheel numpy; then
+        if "$PYTHON_CMD" -m pip install --upgrade pip build setuptools wheel auditwheel patchelf numpy; then
             break
         fi
         echo "pip install attempt $attempt/$max_attempts failed, retrying in 5s..."
@@ -327,10 +332,10 @@ if [ "$NPU_BUILD" = "1" ]; then
         exit 1
     fi
 elif command -v pip &>/dev/null; then
-    python${PYTHON_VERSION} -m pip install --upgrade pip build setuptools wheel auditwheel
+    python${PYTHON_VERSION} -m pip install --upgrade pip build setuptools wheel auditwheel patchelf
 elif command -v uv &>/dev/null; then
     uv pip install --upgrade pip
-    uv pip install build setuptools wheel auditwheel
+    uv pip install build setuptools wheel auditwheel patchelf
 else
     echo "Error: Neither python${PYTHON_VERSION}, pip nor uv found"
     exit 1


### PR DESCRIPTION
## Description

  `auditwheel repair` in the wheel jobs started failing with:

  ValueError: patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5.

  `scripts/build_wheel.sh` installs an unpinned `auditwheel`; the latest release (6.8.x) raised the minimum patchelf to 0.14.5, while the distro package on Ubuntu 22.04 (used by the rocm/musa wheel images) is 0.14.3.

  This PR adds `patchelf` to the PyPI install list next to `auditwheel` on all three install paths (NPU pip, pip, uv). The PyPI wheel is `py3-none`, ships manylinux/musllinux binaries for x86_64 and aarch64, and lands ahead of `/usr/bin` on `PATH`, so it takes precedence over the apt copy.

  ## Module

  - [x] CI/CD

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  bash -n scripts/build_wheel.sh
  pre-commit run --files scripts/build_wheel.sh
  
  Test results:
  - [x] Manual testing done: syntax check and pre-commit pass; verified PyPI patchelf 0.19.1.0 publishes manylinux/musllinux wheels for x86_64 and aarch64. Wheel-build workflows will validate the fix in CI.

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass

  AI Assistance Disclosure
  
  - [x] AI tools were used (specify below)