### PR TITLE
[BugFix][TENT] Fix race condition in DispatchesOnlyOneWindowOnSubmit test

### DIFF
--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -103,7 +103,9 @@ class FakeTransport : public Transport {
             return Status::InvalidArgument("bad task_id" LOC_MARK);
         }
         ++fake->poll_counts[task_id];
-        if (poll_status_factory_) {
+        if (fake->statuses[task_id].s == TransferStatusEnum::CANCELED) {
+            status = fake->statuses[task_id];
+        } else if (poll_status_factory_) {
             status = poll_status_factory_(fake->requests[task_id],
                                           fake->poll_counts[task_id]);
         } else {
@@ -430,7 +432,10 @@ TEST(RuntimeQueueDispatch, CancelsDispatchedRdmaTaskIdempotently) {
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
-    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, [](const Request&, int) {
+            return TransferStatus{TransferStatusEnum::PENDING, 0};
+        });
     installFakeRdma(engine, fake_rdma);
 
     constexpr size_t kReqLen = 4096;

--- a/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/runtime_queue_dispatch_test.cpp
@@ -293,7 +293,15 @@ TEST(RuntimeQueueDispatch, DispatchesOnlyOneWindowOnSubmit) {
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
-    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    std::atomic<bool> complete_first{false};
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, [&complete_first](const Request& request, int) {
+            if (!complete_first.load()) {
+                return TransferStatus{TransferStatusEnum::PENDING, 0};
+            }
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        });
     installFakeRdma(engine, fake_rdma);
 
     constexpr size_t kReqLen = 4096;
@@ -310,6 +318,8 @@ TEST(RuntimeQueueDispatch, DispatchesOnlyOneWindowOnSubmit) {
                              makeLocalWrite(buffer.data() + kReqLen, kReqLen)})
             .ok());
     EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
+
+    complete_first.store(true);
 
     TransferStatus first{};
     ASSERT_TRUE(engine.getTransferStatus(batch, 0, first).ok());
@@ -432,8 +442,8 @@ TEST(RuntimeQueueDispatch, CancelsDispatchedRdmaTaskIdempotently) {
     TransferEngineImpl engine(cfg);
     ASSERT_TRUE(engine.available());
 
-    auto fake_rdma = std::make_shared<FakeTransport>(
-        RDMA, [](const Request&, int) {
+    auto fake_rdma =
+        std::make_shared<FakeTransport>(RDMA, [](const Request&, int) {
             return TransferStatus{TransferStatusEnum::PENDING, 0};
         });
     installFakeRdma(engine, fake_rdma);


### PR DESCRIPTION
Fixes #3459

## Description

Fixes an intermittent unit-test race condition in `RuntimeQueueDispatch.DispatchesOnlyOneWindowOnSubmit` where `FakeTransport` defaulted to `COMPLETED` during `submitTransfer`. This allowed the background `ProgressWorker` thread to advance the dispatch window before the test assertion `EXPECT_EQ(fake_rdma->submit_calls.load(), 1)` executed.

The fix configures `FakeTransport` with a `PENDING` poll factory until after the single-window submit check completes, preventing premature window refills.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Ran the affected test binary repeatedly to verify stability under high CPU load:

**Test commands:**
```bash
cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF -DBUILD_UNIT_TESTS=ON
cmake --build build-tent --target tent_runtime_queue_dispatch_test -j
./build-tent/mooncake-transfer-engine/tent/tests/tent_runtime_queue_dispatch_test --gtest_filter=RuntimeQueueDispatch.DispatchesOnlyOneWindowOnSubmit
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Ran `tent_runtime_queue_dispatch_test` repeatedly; all 12 tests passed consistently.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)