### PR TITLE
feat(store): MOONCAKE_OFFLOAD_MAX_PHYSICAL_BYTES for bucket eviction

### DIFF
--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -216,8 +216,8 @@ struct BucketBackendConfig {
 
     // Optional hard physical cap for container quotas where fs::space() reports
     // the host filesystem instead of the volume sizeLimit / cgroup quota.
-    // When > 0, eviction also treats (max_physical_bytes - total_size_) as
-    // available space. 0 = disabled (rely on fs::space only).
+    // When > 0, eviction also caps available space using logical used bytes
+    // (total + pending eviction/write). 0 = disabled (rely on fs::space only).
     int64_t max_physical_bytes = 0;
 
     bool Validate() const;

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -214,6 +214,12 @@ struct BucketBackendConfig {
     int64_t max_total_size = 0;  // 0 = unlimited; evict when total_size_
                                  // exceeds this threshold (bytes)
 
+    // Optional hard physical cap for container quotas where fs::space() reports
+    // the host filesystem instead of the volume sizeLimit / cgroup quota.
+    // When > 0, eviction also treats (max_physical_bytes - total_size_) as
+    // available space. 0 = disabled (rely on fs::space only).
+    int64_t max_physical_bytes = 0;
+
     bool Validate() const;
 
     static BucketBackendConfig FromEnvironment();

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2906,6 +2906,10 @@ BucketStorageBackend::PrepareEviction(
         // Container quotas (emptyDir sizeLimit / cgroup) are invisible to
         // fs::space(); when configured, also bound available by physical cap.
         if (bucket_backend_config_.max_physical_bytes > 0) {
+            // In-flight evictions count bytes in both total_size_ and
+            // pending_eviction_size_ until removal completes, so `used`
+            // double-counts briefly. That biases toward early eviction
+            // (safer when a kubelet sizeLimit is looming).
             const int64_t used = total_size_ + pending_eviction_size_ +
                                  pending_write_size_;
             const int64_t remaining =

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -105,6 +105,9 @@ BucketBackendConfig BucketBackendConfig::FromEnvironment() {
                           Environ::GetInt64("MOONCAKE_BUCKET_MAX_TOTAL_SIZE",
                                             config.max_total_size));
 
+    config.max_physical_bytes = Environ::GetInt64(
+        "MOONCAKE_OFFLOAD_MAX_PHYSICAL_BYTES", config.max_physical_bytes);
+
     const auto policy_str = Environ::GetString(
         "MOONCAKE_OFFLOAD_BUCKET_EVICTION_POLICY",
         Environ::GetString("MOONCAKE_BUCKET_EVICTION_POLICY", "fifo"));
@@ -2891,8 +2894,31 @@ BucketStorageBackend::PrepareEviction(
         namespace fs = std::filesystem;
         std::error_code ec;
         auto space_info = fs::space(storage_path_, ec);
+        uint64_t actual_available = 0;
+        bool have_space = false;
         if (!ec) {
-            uint64_t actual_available = space_info.available;
+            actual_available = space_info.available;
+            have_space = true;
+        } else {
+            LOG(WARNING) << "[Evict] Failed to get disk space info for "
+                         << storage_path_ << ": " << ec.message();
+        }
+        // Container quotas (emptyDir sizeLimit / cgroup) are invisible to
+        // fs::space(); when configured, also bound available by physical cap.
+        if (bucket_backend_config_.max_physical_bytes > 0) {
+            const int64_t used = total_size_ + pending_eviction_size_ +
+                                 pending_write_size_;
+            const int64_t remaining =
+                bucket_backend_config_.max_physical_bytes > used
+                    ? bucket_backend_config_.max_physical_bytes - used
+                    : 0;
+            const uint64_t capped = static_cast<uint64_t>(remaining);
+            if (!have_space || capped < actual_available) {
+                actual_available = capped;
+                have_space = true;
+            }
+        }
+        if (have_space) {
             constexpr uint64_t kMinFreeSpace = 256 * kMB;
             // Watermark eviction passes a synthetic required_size to drive
             // quota-based cleanup. It is not a real incoming write, so it
@@ -2906,11 +2932,10 @@ BucketStorageBackend::PrepareEviction(
                 LOG(WARNING) << "[Evict] Actual disk space too low: available="
                              << actual_available << ", required=" << req_sz
                              << ", deficit=" << deficit
+                             << ", max_physical_bytes="
+                             << bucket_backend_config_.max_physical_bytes
                              << ". Will evict buckets to free space.";
             }
-        } else {
-            LOG(WARNING) << "[Evict] Failed to get disk space info for "
-                         << storage_path_ << ": " << ec.message();
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `MOONCAKE_OFFLOAD_MAX_PHYSICAL_BYTES` for bucket backends.
- When set, `PrepareEviction` treats available space as `min(fs::space().available, max_physical_bytes - logical_used)` so container quotas that `fs::space()` cannot see still trigger eviction.

## Test plan
- [ ] Set `MOONCAKE_OFFLOAD_MAX_PHYSICAL_BYTES` below host free space and confirm eviction fires before kubelet emptyDir eviction
- [ ] Unset env: behavior matches previous `fs::space()`-only guard

Fixes #3426