### PR TITLE
[CI][Store] Fix promotion-on-hit e2e flakiness from cross-class segment leaks

### DIFF
--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -110,6 +110,17 @@ class TestPromotionOnHit(unittest.TestCase):
         cls.store = MooncakeDistributedStore()
         get_client(cls.store)
 
+    @classmethod
+    def tearDownClass(cls):
+        # Unmount this class's segment from the master. Without this, each
+        # test class's segment stays mounted for the rest of the run,
+        # inflating the master's mem_total_capacity and pushing used_ratio
+        # right onto the eviction high-watermark boundary — the promotion
+        # watermark gate then becomes timing-dependent (flaky).
+        if getattr(cls, "store", None) is not None:
+            cls.store.close()
+            cls.store = None
+
     def test_promotion_after_repeated_hits(self):
         """A LOCAL_DISK-only key must regain a MEMORY replica after
         clearing the admission threshold via repeated reads.
@@ -269,6 +280,17 @@ class TestPromotionDoesNotFire(unittest.TestCase):
         cls.store = MooncakeDistributedStore()
         get_client(cls.store)
 
+    @classmethod
+    def tearDownClass(cls):
+        # Unmount this class's segment from the master. Without this, each
+        # test class's segment stays mounted for the rest of the run,
+        # inflating the master's mem_total_capacity and pushing used_ratio
+        # right onto the eviction high-watermark boundary — the promotion
+        # watermark gate then becomes timing-dependent (flaky).
+        if getattr(cls, "store", None) is not None:
+            cls.store.close()
+            cls.store = None
+
     def test_below_watermark_workload_stays_memory_only(self):
         VALUE_SIZE = 1024  # 1 KB
         NUM_KEYS = 16  # 16 KB total, well below the 32 MB segment
@@ -345,6 +367,17 @@ class BenchPromotionLatency(unittest.TestCase):
     def setUpClass(cls):
         cls.store = MooncakeDistributedStore()
         get_client(cls.store)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Unmount this class's segment from the master. Without this, each
+        # test class's segment stays mounted for the rest of the run,
+        # inflating the master's mem_total_capacity and pushing used_ratio
+        # right onto the eviction high-watermark boundary — the promotion
+        # watermark gate then becomes timing-dependent (flaky).
+        if getattr(cls, "store", None) is not None:
+            cls.store.close()
+            cls.store = None
 
     def test_latency_comparison(self):
         VALUE_SIZE = 1024 * 1024  # 1 MB


### PR DESCRIPTION
## Description

[Nightly CI has been flaking](https://github.com/kvcache-ai/Mooncake/actions/runs/31957613624/job/95190561542) on `mooncake-wheel/tests/test_promotion_on_hit.py::TestPromotionOnHit::test_promotion_after_repeated_hits`: the test warms up a LOCAL_DISK-only key with 4 reads and waits 25s, but the key never regains a MEMORY replica, failing with


```
AssertionError: Expected a MEMORY replica for poh_12_... after promotion, got types=['LOCAL_DISK', 'DISK'].
```

**Root cause — segment leaks across test classes put `used_ratio` exactly on the watermark boundary.**

The three test classes in this file share a single master process. Each `setUpClass` mounts a 32 MB segment via `store.setup(...)`, but no class ever unmounts it, and the unittest suite keeps every test instance alive for the whole run. `TestPromotionDoesNotFire` runs first (alphabetical order), so by the time `TestPromotionOnHit` executes, the master sees **64 MB** of mounted capacity instead of the intended 32 MB.

The failing run's own replica histogram proves the inflated capacity:

```
replica-type histogram after phase 2: {'DISK,LOCAL_DISK,MEMORY': 55, 'DISK,LOCAL_DISK': 6, 'DISK,MEMORY': 2}
```

57 keys × 1 MB = 57 MB of live MEMORY replicas cannot fit in a 32 MB segment — but they fit in 64 MB, yielding `used_ratio ≈ 57/64 ≈ 0.89`, i.e. **right below the 0.90 promotion watermark gate** (`TryPushPromotionQueue` rejects promotion when `used_ratio >= eviction_high_watermark_ratio_`). Whether the gate admits the promotion then depends on per-run noise (allocator padding, pinned replicas, etc.) — hence flaky, not deterministic.

**Fix.** Add `tearDownClass` to all three test classes (including the `skipUnless`-gated `BenchPromotionLatency`, which would leak a third 32 MB segment if its env var is ever set), calling the existing `store.close()` API (`tearDownAll()` → unmounts the segment; idempotent via `closed_` CAS). After this change each class runs against a deterministic 32 MB capacity.

**Verified effect** (local e2e, master + client both built from upstream/main `596f744b`): the same phase-2 histogram becomes `{'DISK,LOCAL_DISK,MEMORY': 25, 'DISK,LOCAL_DISK': 5, 'DISK,MEMORY': 2}` — ≈ 27 MB / 32 MB ≈ 0.84 used ratio, comfortably below the watermark; the gate deterministically opens and the promoted key regains its MEMORY replica. `OK (skipped=1)`.

**Follow-ups** (deliberately out of scope for this PR; will be proposed separately):

1. *Free the pinned MEMORY replica as soon as its offload completes.* `NotifyOffloadSuccess` only does `dec_refcnt()` + adds the LOCAL_DISK replica; the DRAM copy is reclaimed lazily by a later eviction pass, which never runs without write pressure. Reclaiming it on the completion path makes `used_ratio` fall on every offload heartbeat. This needs careful guards: only under `offload_on_evict_` (never for eager PutEnd mirroring), never under `enable_oplog_` (must not bypass eviction's oplog persistence), only when the read lease has expired and the object is not soft/hard pinned, quota release gated on `enable_multi_tenants_`, and it must call `RecordDynamicReplicaRemoval` like every other pop site.
2. *Do not register retry candidates for watermark rejections.* Retrying promotion while DRAM is under pressure buys nothing (a successful retry would be an immediate eviction victim; a genuinely hot key re-triggers the gate on the next read anyway). The bounded retry budget stays for genuine transient failures (queue-cap / push-failed).
3. Audit other e2e files (e.g. `test_offload_on_eviction.py`) for the same missing-teardown pattern.

> I'll reconsider these follow-ups carefully.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
# master (built from upstream/main 596f744b)
mooncake_master --default_kv_lease_ttl=500 --root_fs_dir=$TEST_ROOT_DIR \
    --enable_offload=true --offload_on_evict=true \
    --promotion_on_hit=true --promotion_admission_threshold=1 &

# e2e (client wheel module also built from the same commit)
cd mooncake-wheel/tests
MC_METADATA_SERVER=P2PHANDSHAKE DEFAULT_KV_LEASE_TTL=500 \
    MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=$TEST_ROOT_DIR \
    MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
    MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
    python3 test_promotion_on_hit.py
```

**Test results:**
- [x] Unit tests pass — `Ran 3 tests in 96.311s, OK (skipped=1)`; the phase-2 replica histogram confirms the deterministic 32 MB capacity (`used_ratio ≈ 0.84`, see Description), and the promoted key regains a MEMORY replica
- [ ] Integration tests pass (if applicable) — relying on CI for the full matrix
- [x] Manual testing done — `python3 -m py_compile` on the changed file; verified `close()` unmounts segments idempotently

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (no C++ changes; Python-only change, style matches surrounding code)
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass — *local pre-commit 2.17 is older than the required 3.6; change is Python-only and minimal, relying on CI pre-commit*
- [x] I have updated the documentation (if applicable) — N/A (test-only)
- [x] I have added tests to prove my changes are effective — the changed file *is* the test; it now deterministically exercises the intended path
- [ ] For changes >500 LOC: I have filed an RFC issue — N/A (+33 LOC)