### PR TITLE
tent: make Redis/Http metastore thread-safe

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metastore/http.h
+++ b/mooncake-transfer-engine/tent/include/tent/metastore/http.h
@@ -18,6 +18,7 @@
 #include "tent/runtime/metastore.h"
 
 #include <atomic>
+#include <mutex>
 #include <curl/curl.h>
 
 namespace mooncake {
@@ -55,6 +56,9 @@ class HttpMetaStore : public MetaStore {
 
    private:
     std::atomic<bool> connected_;
+    // Each op uses its own local curl handle (ScopedCurl), so nothing curl is
+    // shared; this lock only serializes ops defensively.
+    std::mutex client_mutex_;
     std::string endpoint_;
 };
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/metastore/redis.h
+++ b/mooncake-transfer-engine/tent/include/tent/metastore/redis.h
@@ -19,6 +19,8 @@
 #include <hiredis/hiredis.h>
 
 #include <atomic>
+#include <cstdarg>
+#include <mutex>
 
 #include "tent/runtime/metastore.h"
 #include "tent/common/utils/ip.h"
@@ -53,9 +55,22 @@ class RedisMetaStore : public MetaStore {
 
     virtual Status remove(const std::string &key);
 
-   private:
+   protected:
+    // Test seam: run a Redis command on client_. Virtual so tests can inject a
+    // fake that fabricates replies without a live server.
+    virtual redisReply *runCommand(const char *format, va_list ap);
+
     std::atomic<bool> connected_;
+
+   private:
+    // Variadic forwarder to runCommand().
+    redisReply *command(const char *format, ...);
+
     redisContext *client_;
+    // hiredis' synchronous redisContext is NOT thread-safe: concurrent
+    // redisCommand() calls corrupt its shared command/reply buffers. tent's
+    // RDMA workers call get() concurrently, so serialize client_ with this lock.
+    std::mutex client_mutex_;
 
     // Helper function for handling Redis replies
     Status handleRedisReply(redisReply *reply,

--- a/mooncake-transfer-engine/tent/include/tent/metastore/redis.h
+++ b/mooncake-transfer-engine/tent/include/tent/metastore/redis.h
@@ -69,7 +69,8 @@ class RedisMetaStore : public MetaStore {
     redisContext *client_;
     // hiredis' synchronous redisContext is NOT thread-safe: concurrent
     // redisCommand() calls corrupt its shared command/reply buffers. tent's
-    // RDMA workers call get() concurrently, so serialize client_ with this lock.
+    // RDMA workers call get() concurrently, so serialize client_ with this
+    // lock.
     std::mutex client_mutex_;
 
     // Helper function for handling Redis replies

--- a/mooncake-transfer-engine/tent/src/metastore/http.cpp
+++ b/mooncake-transfer-engine/tent/src/metastore/http.cpp
@@ -65,6 +65,7 @@ struct ScopedCurl {
 }  // namespace
 
 Status HttpMetaStore::get(const std::string &key, std::string &value) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }
@@ -106,6 +107,7 @@ Status HttpMetaStore::get(const std::string &key, std::string &value) {
 }
 
 Status HttpMetaStore::set(const std::string &key, const std::string &value) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }
@@ -153,6 +155,7 @@ Status HttpMetaStore::set(const std::string &key, const std::string &value) {
 }
 
 Status HttpMetaStore::remove(const std::string &key) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("HTTP connection not available" LOC_MARK);
     }

--- a/mooncake-transfer-engine/tent/src/metastore/redis.cpp
+++ b/mooncake-transfer-engine/tent/src/metastore/redis.cpp
@@ -40,7 +40,19 @@ class RedisReplyGuard {
     redisReply *reply_;
 };
 
-RedisMetaStore::RedisMetaStore() {}
+RedisMetaStore::RedisMetaStore() : connected_(false), client_(nullptr) {}
+
+redisReply *RedisMetaStore::command(const char *format, ...) {
+    va_list ap;
+    va_start(ap, format);
+    redisReply *reply = runCommand(format, ap);
+    va_end(ap);
+    return reply;
+}
+
+redisReply *RedisMetaStore::runCommand(const char *format, va_list ap) {
+    return static_cast<redisReply *>(redisvCommand(client_, format, ap));
+}
 
 RedisMetaStore::~RedisMetaStore() { disconnect(); }
 
@@ -171,13 +183,13 @@ Status RedisMetaStore::handleRedisReply(redisReply *reply,
 }
 
 Status RedisMetaStore::get(const std::string &key, std::string &value) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("Redis connection not available" LOC_MARK);
     }
 
     // Use binary-safe formatting to prevent command injection
-    redisReply *resp =
-        (redisReply *)redisCommand(client_, "GET %b", key.data(), key.size());
+    redisReply *resp = command("GET %b", key.data(), key.size());
     RedisReplyGuard reply_guard(resp);
 
     Status status = handleRedisReply(resp, "GET '" + key + "'");
@@ -189,32 +201,33 @@ Status RedisMetaStore::get(const std::string &key, std::string &value) {
         return Status::InvalidEntry(key);
     }
 
-    value = std::string(resp->str);
+    // Use (str, len): redis values are binary-safe and may contain NULs.
+    value = std::string(resp->str, resp->len);
     return Status::OK();
 }
 
 Status RedisMetaStore::set(const std::string &key, const std::string &value) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("Redis connection not available" LOC_MARK);
     }
 
     // Use binary-safe formatting to prevent command injection
-    redisReply *resp =
-        (redisReply *)redisCommand(client_, "SET %b %b", key.data(), key.size(),
-                                   value.data(), value.size());
+    redisReply *resp = command("SET %b %b", key.data(), key.size(),
+                               value.data(), value.size());
     RedisReplyGuard reply_guard(resp);
 
     return handleRedisReply(resp, "SET '" + key + "'");
 }
 
 Status RedisMetaStore::remove(const std::string &key) {
+    std::lock_guard<std::mutex> lock(client_mutex_);
     if (!connected_) {
         return Status::MetadataError("Redis connection not available" LOC_MARK);
     }
 
     // Use binary-safe formatting to prevent command injection
-    redisReply *resp =
-        (redisReply *)redisCommand(client_, "DEL %b", key.data(), key.size());
+    redisReply *resp = command("DEL %b", key.data(), key.size());
     RedisReplyGuard reply_guard(resp);
 
     return handleRedisReply(resp, "DEL '" + key + "'");

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -108,6 +108,20 @@ target_include_directories(tent_ip_utils_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_ip_utils_test COMMAND tent_ip_utils_test)
 
+# RedisMetaStore thread-safety test: drives the real get()/set()/remove() code
+# paths against a fake command runner (no live Redis), asserting that
+# client_mutex_ serializes concurrent access and that get() preserves binary
+# values with embedded NULs. Only built when hiredis is available.
+if(TARGET metastore_redis)
+  add_executable(tent_redis_metastore_test redis_metastore_test.cpp)
+  target_link_libraries(tent_redis_metastore_test
+                        PRIVATE metastore_redis tent_common gtest gtest_main
+                                glog)
+  target_include_directories(tent_redis_metastore_test
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  add_test(NAME tent_redis_metastore_test COMMAND tent_redis_metastore_test)
+endif()
+
 add_executable(tent_qp_pool_layout_test qp_pool_layout_test.cpp)
 target_link_libraries(tent_qp_pool_layout_test PRIVATE tent_common gtest
                                                        gtest_main)

--- a/mooncake-transfer-engine/tent/tests/redis_metastore_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/redis_metastore_test.cpp
@@ -59,7 +59,8 @@ redisReply *makeStatusReply(const char *status) {
 // ever in flight at once. Without client_mutex_ the widened window overlaps.
 class FakeRedisMetaStore : public RedisMetaStore {
    public:
-    // connected_ is protected; client_ stays nullptr (redisFree() tolerates it).
+    // connected_ is protected; client_ stays nullptr (redisFree() tolerates
+    // it).
     FakeRedisMetaStore() { connected_ = true; }
 
     std::atomic<int> in_flight_{0};

--- a/mooncake-transfer-engine/tent/tests/redis_metastore_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/redis_metastore_test.cpp
@@ -1,0 +1,129 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Tests RedisMetaStore without a live server: a fake runCommand() feeds the
+// real get()/set()/remove() paths fabricated replies. Covers the two fixes:
+// (1) client_mutex_ serializes concurrent ops; (2) get() keeps embedded NULs.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdarg>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/metastore/redis.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Heap redisReply that freeReplyObject() can release: it frees str and the
+// struct with malloc/free, so allocate the same way; calloc zeros the rest.
+redisReply *makeStringReply(const std::string &data) {
+    auto *reply = static_cast<redisReply *>(std::calloc(1, sizeof(redisReply)));
+    reply->type = REDIS_REPLY_STRING;
+    reply->len = data.size();
+    reply->str = static_cast<char *>(std::malloc(data.size() + 1));
+    std::memcpy(reply->str, data.data(), data.size());
+    reply->str[data.size()] = '\0';
+    return reply;
+}
+
+redisReply *makeStatusReply(const char *status) {
+    auto *reply = static_cast<redisReply *>(std::calloc(1, sizeof(redisReply)));
+    reply->type = REDIS_REPLY_STATUS;
+    const size_t len = std::strlen(status);
+    reply->len = len;
+    reply->str = static_cast<char *>(std::malloc(len + 1));
+    std::memcpy(reply->str, status, len + 1);
+    return reply;
+}
+
+// Fake store: runCommand() fabricates replies and flags if two commands are
+// ever in flight at once. Without client_mutex_ the widened window overlaps.
+class FakeRedisMetaStore : public RedisMetaStore {
+   public:
+    // connected_ is protected; client_ stays nullptr (redisFree() tolerates it).
+    FakeRedisMetaStore() { connected_ = true; }
+
+    std::atomic<int> in_flight_{0};
+    std::atomic<bool> saw_concurrent_{false};
+    std::atomic<int> command_count_{0};
+
+    // Embedded NUL proves get() does not truncate at the first '\0'.
+    const std::string stored_value_ = std::string("seg\0desc", 8);
+
+   protected:
+    redisReply *runCommand(const char *format, va_list /*ap*/) override {
+        command_count_.fetch_add(1, std::memory_order_relaxed);
+        if (in_flight_.fetch_add(1, std::memory_order_acq_rel) + 1 > 1) {
+            saw_concurrent_.store(true, std::memory_order_relaxed);
+        }
+        // Widen the critical section so a missing lock reliably overlaps.
+        std::this_thread::sleep_for(std::chrono::microseconds(200));
+        in_flight_.fetch_sub(1, std::memory_order_acq_rel);
+
+        if (std::strncmp(format, "GET", 3) == 0) {
+            return makeStringReply(stored_value_);
+        }
+        return makeStatusReply("OK");
+    }
+};
+
+// get() must preserve the full binary value, including embedded NULs.
+TEST(RedisMetaStore, GetPreservesEmbeddedNul) {
+    FakeRedisMetaStore store;
+    std::string value;
+    Status status = store.get("segment/key", value);
+    ASSERT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(value.size(), store.stored_value_.size());
+    EXPECT_EQ(value, store.stored_value_);
+}
+
+// client_mutex_ must serialize concurrent get()/set()/remove() so that the
+// shared redisContext is never used from two threads at once.
+TEST(RedisMetaStore, ConcurrentAccessIsSerialized) {
+    FakeRedisMetaStore store;
+    constexpr int kThreads = 8;
+    constexpr int kItersPerThread = 40;
+
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&store] {
+            for (int i = 0; i < kItersPerThread; ++i) {
+                std::string value;
+                store.get("segment/key", value);
+                store.set("segment/key", "payload");
+                store.remove("segment/key");
+            }
+        });
+    }
+    for (auto &thread : threads) {
+        thread.join();
+    }
+
+    EXPECT_FALSE(store.saw_concurrent_.load())
+        << "client_mutex_ failed to serialize access to the shared client";
+    EXPECT_EQ(store.command_count_.load(), kThreads * kItersPerThread * 3);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
The central segment registry's metastore backends share a single non-thread-safe client handle across all threads with no locking:

- RedisMetaStore holds one hiredis redisContext; redisCommand() multiplexes the command-output and reply-reader buffers, so concurrent calls corrupt them.
- HttpMetaStore holds one libcurl easy handle; curl_easy_reset/setopt/ perform on a shared handle is not safe for concurrent use.

tent's RDMA worker threads fetch remote segment descriptors concurrently (Workers::getRouteHint -> SegmentManager::getRemote -> CentralSegmentRegistry::getSegmentDesc -> MetaStore::get). The per-thread descriptor cache misses on cold start / TTL expiry, so every worker hits the shared metastore handle at once. This corrupts the reply buffer and surfaces as heap corruption / malloc abort while parsing the fetched descriptor JSON in a worker thread.

Serialize all client_ access in get()/set()/remove() with a per-store mutex. Also read redis GET replies with the length-aware std::string ctor since values are binary-safe and may contain embedded NULs.

## Description



## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)