### PR TITLE
[WIP] feat(store): add P2P client replay register cursor

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_oplog_types.h
+++ b/mooncake-store/include/ha/oplog/p2p_oplog_types.h
@@ -46,10 +46,12 @@ struct RegisterClientPayload {
     UUID client_id{0, 0};
     std::string ip_address;
     uint16_t rpc_port = 0;
+    uint64_t last_mutation_id = 0;
     // Segments registered by this client at registration time.
     std::vector<Segment> segments;
 
-    YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port, segments);
+    YLT_REFL(RegisterClientPayload, client_id, ip_address, rpc_port,
+             last_mutation_id, segments);
 };
 
 /// Payload for UNREGISTER_CLIENT (OpType=16, sync).

--- a/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
+++ b/mooncake-store/include/ha/oplog/p2p_standby_metadata_store.h
@@ -24,10 +24,12 @@ struct P2PStandbyClientInfo {
     UUID client_id{0, 0};
     std::string ip_address;
     uint16_t rpc_port = 0;
+    uint64_t last_mutation_id = 0;
     // Segments owned by this client.
     std::vector<Segment> segments;
 
-    YLT_REFL(P2PStandbyClientInfo, client_id, ip_address, rpc_port, segments);
+    YLT_REFL(P2PStandbyClientInfo, client_id, ip_address, rpc_port,
+             last_mutation_id, segments);
 };
 
 /// P2P-specific standby metadata store.
@@ -78,8 +80,8 @@ class P2PStandbyMetadataStore : public MetadataStore {
 
     /// Register or update a client.
     void RegisterClient(const UUID& client_id, const std::string& ip_address,
-                        uint16_t rpc_port,
-                        const std::vector<Segment>& segments);
+                        uint16_t rpc_port, const std::vector<Segment>& segments,
+                        uint64_t last_mutation_id = 0);
 
     /// Unregister a client.
     /// Also removes all replicas owned by this client from their objects

--- a/mooncake-store/include/p2p_client_meta.h
+++ b/mooncake-store/include/p2p_client_meta.h
@@ -26,6 +26,8 @@ class P2PClientMeta final : public ClientMeta {
 
     const std::string& get_ip_address() const { return ip_address_; }
     uint16_t get_rpc_port() const { return rpc_port_; }
+    auto RefreshRegistration(const std::string& ip_address, uint16_t rpc_port)
+        -> tl::expected<ClientStatus, ErrorCode>;
 
    public:
     /**

--- a/mooncake-store/include/p2p_master_service.h
+++ b/mooncake-store/include/p2p_master_service.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+#include <unordered_map>
 #include <unordered_set>
 
 #include "master_service.h"
@@ -85,6 +87,7 @@ class P2PMasterService : public MasterService {
 
     ErrorCode RecordOplog(OpType type, const std::string& key,
                           const std::string& payload = std::string());
+    uint64_t GetClientLastMutationId(const UUID& client_id) const;
 
     std::vector<Replica::Descriptor> FilterReplicas(
         const GetReplicaListRequestConfig& config,
@@ -131,6 +134,10 @@ class P2PMasterService : public MasterService {
     tl::expected<void, ErrorCode> InnerRemoveReplica(
         MetadataShard& shard, std::string_view key, const UUID& client_id,
         const UUID& segment_id) NO_THREAD_SAFETY_ANALYSIS;
+    void EnsureClientReplayCursor(const UUID& client_id);
+    void SetClientLastMutationId(const UUID& client_id,
+                                 uint64_t last_mutation_id);
+    void EraseClientReplayCursor(const UUID& client_id);
 
     std::shared_ptr<P2PClientManager> client_manager_;
     std::array<P2PMetadataShard, kNumShards> metadata_shards_;
@@ -139,6 +146,10 @@ class P2PMasterService : public MasterService {
     // 2. max_client_per_key_ > 0 means the max client owner count
     uint64_t max_client_per_key_;
     bool enable_async_oplog_write_{false};
+
+    mutable std::mutex client_replay_cursor_mutex_;
+    std::unordered_map<UUID, uint64_t, boost::hash<UUID>>
+        client_last_mutation_ids_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -151,11 +151,13 @@ YLT_REFL(RegisterClientRequest, client_id, segments, deployment_mode,
 /**
  * @brief Response structure for RegisterClient operation.
  * Returns the master's view_version to client for crash checking.
+ * P2P clients also use last_mutation_id as the HA replay cursor.
  */
 struct RegisterClientResponse {
     ViewVersionId view_version = 0;
+    uint64_t last_mutation_id = 0;
 };
-YLT_REFL(RegisterClientResponse, view_version);
+YLT_REFL(RegisterClientResponse, view_version, last_mutation_id);
 
 /**
  * @brief Request structure for UnregisterClient operation.

--- a/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_oplog_applier.cpp
@@ -125,7 +125,8 @@ bool P2POpLogApplier::ApplyRegisterClient(const OpLogEntry& entry) {
     }
 
     p2p_store_->RegisterClient(payload.client_id, payload.ip_address,
-                               payload.rpc_port, payload.segments);
+                               payload.rpc_port, payload.segments,
+                               payload.last_mutation_id);
     return true;
 }
 

--- a/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_metadata_store.cpp
@@ -1,5 +1,7 @@
 #include "ha/oplog/p2p_standby_metadata_store.h"
 
+#include <algorithm>
+
 #include <glog/logging.h>
 #include <xxhash.h>
 
@@ -159,12 +161,13 @@ void P2PStandbyMetadataStore::RemoveReplica(const std::string& object_key,
 
 void P2PStandbyMetadataStore::RegisterClient(
     const UUID& client_id, const std::string& ip_address, uint16_t rpc_port,
-    const std::vector<Segment>& segments) {
+    const std::vector<Segment>& segments, uint64_t last_mutation_id) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto& info = clients_[client_id];
     info.client_id = client_id;
     info.ip_address = ip_address;
     info.rpc_port = rpc_port;
+    info.last_mutation_id = std::max(info.last_mutation_id, last_mutation_id);
     // Merge segments instead of overwriting to preserve segments added by
     // out-of-order AddSegment (MOUNT_SEGMENT) calls that arrived before
     // REGISTER_CLIENT.
@@ -180,6 +183,7 @@ void P2PStandbyMetadataStore::RegisterClient(
     VLOG(1) << "P2PStandbyMetadataStore::RegisterClient "
             << "client=" << client_id.first << ":" << client_id.second
             << " ip=" << ip_address << ":" << rpc_port
+            << " last_mutation_id=" << info.last_mutation_id
             << " segments=" << segments.size();
 
     // IP/port backfilling is deferred to ExportMetadata() to avoid O(N*M)

--- a/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
+++ b/mooncake-store/src/ha/oplog/p2p_standby_snapshot_service.cpp
@@ -302,7 +302,8 @@ ErrorCode P2PStandbySnapshotClient::Bootstrap(const std::string& endpoint,
         }
         for (const auto& record : chunk->clients) {
             target->RegisterClient(record.client_id, record.info.ip_address,
-                                   record.info.rpc_port, record.info.segments);
+                                   record.info.rpc_port, record.info.segments,
+                                   record.info.last_mutation_id);
         }
         for (const auto& record : chunk->objects) {
             target->RestoreMetadata(record.key, record.metadata);

--- a/mooncake-store/src/p2p_client_meta.cpp
+++ b/mooncake-store/src/p2p_client_meta.cpp
@@ -75,6 +75,24 @@ size_t P2PClientMeta::GetAvailableCapacity() const {
     return client_capacity_ - client_usage_;
 }
 
+auto P2PClientMeta::RefreshRegistration(const std::string& ip_address,
+                                        uint16_t rpc_port)
+    -> tl::expected<ClientStatus, ErrorCode> {
+    SharedMutexLocker lock(&client_mutex_);
+    if (health_state_.status == ClientStatus::CRASHED) {
+        LOG(WARNING) << "RegisterClient(P2P): rejected crashed client"
+                     << ", client_id=" << client_id_;
+        return tl::make_unexpected(ErrorCode::CLIENT_UNHEALTHY);
+    }
+
+    auto old_status = health_state_.status;
+    ip_address_ = ip_address;
+    rpc_port_ = rpc_port;
+    health_state_.last_heartbeat = std::chrono::steady_clock::now();
+    health_state_.status = ClientStatus::HEALTH;
+    return old_status;
+}
+
 P2PClientMeta::CapacityStat P2PClientMeta::GetWriteScoreCapacity(
     const std::vector<std::string>& tag_filters, int priority_limit,
     bool top_tier_only) const {

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -48,32 +48,105 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
     return ErrorCode::OK;
 }
 
+uint64_t P2PMasterService::GetClientLastMutationId(
+    const UUID& client_id) const {
+    std::lock_guard<std::mutex> lock(client_replay_cursor_mutex_);
+    auto it = client_last_mutation_ids_.find(client_id);
+    if (it == client_last_mutation_ids_.end()) {
+        return 0;
+    }
+    return it->second;
+}
+
+void P2PMasterService::EnsureClientReplayCursor(const UUID& client_id) {
+    std::lock_guard<std::mutex> lock(client_replay_cursor_mutex_);
+    client_last_mutation_ids_.try_emplace(client_id, 0);
+}
+
+void P2PMasterService::SetClientLastMutationId(const UUID& client_id,
+                                               uint64_t last_mutation_id) {
+    std::lock_guard<std::mutex> lock(client_replay_cursor_mutex_);
+    client_last_mutation_ids_[client_id] = last_mutation_id;
+}
+
+void P2PMasterService::EraseClientReplayCursor(const UUID& client_id) {
+    std::lock_guard<std::mutex> lock(client_replay_cursor_mutex_);
+    client_last_mutation_ids_.erase(client_id);
+}
+
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
-    if (GetClientManager().GetClient(req.client_id)) {
-        LOG(WARNING) << "RegisterClient(P2P): client already exists"
-                     << ", client_id=" << req.client_id;
-        return tl::make_unexpected(ErrorCode::CLIENT_ALREADY_EXISTS);
+    if (req.deployment_mode != DeploymentMode::P2P) {
+        LOG(ERROR) << "RegisterClient(P2P): architecture mismatch"
+                   << ", client_mode=" << static_cast<int>(req.deployment_mode)
+                   << ", master_mode=" << static_cast<int>(DeploymentMode::P2P)
+                   << ", client_id=" << req.client_id;
+        return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    if (!req.ip_address || !req.rpc_port) {
+    if (!req.ip_address || req.ip_address->empty() || !req.rpc_port ||
+        *req.rpc_port == 0) {
         LOG(ERROR) << "RegisterClient(P2P): missing endpoint"
                    << ", client_id=" << req.client_id;
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    auto build_existing_response =
+        [this, &req](const std::shared_ptr<ClientMeta>& existing_client)
+        -> tl::expected<RegisterClientResponse, ErrorCode> {
+        auto p2p_client =
+            std::dynamic_pointer_cast<P2PClientMeta>(existing_client);
+        if (!p2p_client) {
+            LOG(ERROR) << "RegisterClient(P2P): existing client is not P2P"
+                       << ", client_id=" << req.client_id;
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+
+        auto refresh_result =
+            p2p_client->RefreshRegistration(*req.ip_address, *req.rpc_port);
+        if (!refresh_result.has_value()) {
+            return tl::make_unexpected(refresh_result.error());
+        }
+        if (refresh_result.value() == ClientStatus::DISCONNECTION) {
+            p2p_client->OnRecovered();
+        }
+        p2p_client->SetSyncing(true);
+        EnsureClientReplayCursor(req.client_id);
+
+        RegisterClientResponse response;
+        response.view_version = view_version_;
+        response.last_mutation_id = GetClientLastMutationId(req.client_id);
+        LOG(INFO) << "RegisterClient(P2P): client already registered"
+                  << ", client_id=" << req.client_id
+                  << ", last_mutation_id=" << response.last_mutation_id;
+        return response;
+    };
+
+    auto existing_client = GetClientManager().GetClient(req.client_id);
+    if (existing_client) {
+        return build_existing_response(existing_client);
+    }
+
     auto result = MasterService::RegisterClient(req);
     if (!result.has_value()) {
+        if (result.error() == ErrorCode::CLIENT_ALREADY_EXISTS) {
+            auto raced_client = GetClientManager().GetClient(req.client_id);
+            if (raced_client) {
+                return build_existing_response(raced_client);
+            }
+        }
         LOG(ERROR) << "RegisterClient(P2P): failed"
                    << ", client_id=" << req.client_id
                    << ", error=" << result.error();
         return result;
     }
+    EnsureClientReplayCursor(req.client_id);
 
     RegisterClientPayload payload;
     payload.client_id = req.client_id;
     payload.ip_address = *req.ip_address;
     payload.rpc_port = *req.rpc_port;
+    payload.last_mutation_id = GetClientLastMutationId(req.client_id);
     payload.segments = req.segments;
     auto err =
         RecordOplog(OpType_REGISTER_CLIENT, "", SerializeP2PPayload(payload));
@@ -83,6 +156,7 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
                    << ", error=" << toString(err);
         return tl::make_unexpected(err);
     }
+    result->last_mutation_id = payload.last_mutation_id;
     return result;
 }
 
@@ -95,6 +169,7 @@ auto P2PMasterService::UnregisterClient(const UnregisterClientRequest& req)
                    << ", error=" << result.error();
         return result;
     }
+    EraseClientReplayCursor(req.client_id);
 
     UnregisterClientPayload payload;
     payload.client_id = req.client_id;
@@ -761,6 +836,7 @@ ErrorCode P2PMasterService::RestoreFromStandbyMetadata(
         if (p2p_client) {
             p2p_client->SetSyncing(false);
         }
+        SetClientLastMutationId(client_id, client_info.last_mutation_id);
         ++restored_clients;
     }
 

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -272,6 +272,8 @@ TEST_F(P2PHotStandbyServiceTest, BootstrapsFromStandbySnapshotSource) {
     ASSERT_EQ(source.Start(), ErrorCode::OK);
     ASSERT_TRUE(
         source.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+    source.GetMetadataStore()->RegisterClient(client_id, "127.0.0.1", 50051,
+                                              {MakeSegment(segment_id)}, 321);
 
     auto target_config = MakeStandbyConfig();
     target_config.snapshot_source_endpoints = {
@@ -283,6 +285,7 @@ TEST_F(P2PHotStandbyServiceTest, BootstrapsFromStandbySnapshotSource) {
 
     auto exported = target.ExportMetadata();
     ASSERT_NE(exported.clients.find(client_id), exported.clients.end());
+    EXPECT_EQ(exported.clients.at(client_id).last_mutation_id, 321u);
     auto object = exported.objects.find("snapshot-key");
     ASSERT_NE(object, exported.objects.end());
     EXPECT_EQ(object->second.size, 8192);
@@ -320,7 +323,9 @@ TEST_F(P2PHotStandbyServiceTest,
     ASSERT_EQ(fromInt(chunk.error_code), ErrorCode::OK);
     ASSERT_TRUE(chunk.done);
     ASSERT_EQ(chunk.objects.size(), 1);
+    ASSERT_EQ(chunk.clients.size(), 1);
     EXPECT_EQ(chunk.objects.front().key, "before-snapshot");
+    EXPECT_EQ(chunk.clients.front().info.last_mutation_id, 0u);
     EXPECT_EQ(snapshot.EndSnapshot({begin.session_id}), toInt(ErrorCode::OK));
 }
 

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_applier_test.cpp
@@ -287,6 +287,7 @@ TEST(P2POpLogApplierTest, ApplyRegisterClient) {
     payload.client_id = client;
     payload.ip_address = "192.168.1.100";
     payload.rpc_port = 50051;
+    payload.last_mutation_id = 77;
     payload.segments = {segment};
 
     auto entry = MakeRegisterClientEntry(1, payload);
@@ -296,6 +297,7 @@ TEST(P2POpLogApplierTest, ApplyRegisterClient) {
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "192.168.1.100");
     EXPECT_EQ(info->rpc_port, 50051u);
+    EXPECT_EQ(info->last_mutation_id, 77u);
     ASSERT_EQ(info->segments.size(), 1u);
     EXPECT_EQ(info->segments[0].id, seg_id);
 }

--- a/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_oplog_test.cpp
@@ -50,6 +50,7 @@ TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload) {
     original.client_id = {100, 200};
     original.ip_address = "192.168.1.1";
     original.rpc_port = 50051;
+    original.last_mutation_id = 12345;
     Segment seg;
     seg.id = {300, 400};
     seg.name = "seg_001";
@@ -67,6 +68,7 @@ TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload) {
     EXPECT_EQ(decoded.client_id.second, 200u);
     EXPECT_EQ(decoded.ip_address, "192.168.1.1");
     EXPECT_EQ(decoded.rpc_port, 50051u);
+    EXPECT_EQ(decoded.last_mutation_id, 12345u);
     ASSERT_EQ(decoded.segments.size(), 1u);
     EXPECT_EQ(decoded.segments[0].id.first, 300u);
     EXPECT_EQ(decoded.segments[0].id.second, 400u);
@@ -80,6 +82,7 @@ TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload_EmptyFields) {
     original.client_id = {0, 0};
     original.ip_address = "";
     original.rpc_port = 0;
+    original.last_mutation_id = 0;
 
     std::string data = SerializeP2PPayload(original);
     RegisterClientPayload decoded;
@@ -89,6 +92,7 @@ TEST(P2POpLogTypesTest, RoundTrip_RegisterClientPayload_EmptyFields) {
     EXPECT_EQ(decoded.client_id.second, 0u);
     EXPECT_EQ(decoded.ip_address, "");
     EXPECT_EQ(decoded.rpc_port, 0u);
+    EXPECT_EQ(decoded.last_mutation_id, 0u);
     EXPECT_EQ(decoded.segments.size(), 0u);
 }
 

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -215,9 +215,31 @@ TEST_F(P2PRecordOplogTest, RegisterClientRecordsOplog) {
     EXPECT_EQ(payload.client_id, client_id);
     EXPECT_EQ(payload.ip_address, "127.0.0.1");
     EXPECT_EQ(payload.rpc_port, 50051);
+    EXPECT_EQ(payload.last_mutation_id, 0u);
     ASSERT_EQ(payload.segments.size(), 1);
     EXPECT_EQ(payload.segments[0].id, segment.id);
     EXPECT_EQ(payload.segments[0].name, segment.name);
+}
+
+TEST_F(P2PRecordOplogTest, DuplicateRegisterClientDoesNotRecordOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{1, 1};
+    RegisterClient(service, client_id, MakeSegment({2, 2}));
+
+    RegisterClientRequest duplicate;
+    duplicate.client_id = client_id;
+    duplicate.ip_address = "127.0.0.2";
+    duplicate.rpc_port = 50052;
+    duplicate.segments = {MakeSegment({3, 3})};
+    duplicate.deployment_mode = DeploymentMode::P2P;
+
+    auto result = service.RegisterClient(duplicate);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->last_mutation_id, 0);
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 1);
 }
 
 TEST_F(P2PRecordOplogTest, RegisterClientRejectsMissingEndpoint) {

--- a/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_standby_metadata_store_test.cpp
@@ -229,12 +229,13 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientBasic) {
     std::vector<Segment> segments;
     segments.push_back(MakeSegment(MakeUUID(100, 0)));
 
-    store.RegisterClient(client_id, "192.168.1.1", 50051, segments);
+    store.RegisterClient(client_id, "192.168.1.1", 50051, segments, 42);
 
     auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "192.168.1.1");
     EXPECT_EQ(info->rpc_port, 50051u);
+    EXPECT_EQ(info->last_mutation_id, 42u);
     EXPECT_EQ(info->segments.size(), 1u);
 }
 
@@ -242,14 +243,15 @@ TEST(P2PStandbyMetadataStoreTest, RegisterClientUpdatesExisting) {
     P2PStandbyMetadataStore store;
     auto client_id = MakeUUID(1, 0);
 
-    store.RegisterClient(client_id, "192.168.1.1", 50051, {});
+    store.RegisterClient(client_id, "192.168.1.1", 50051, {}, 100);
     store.RegisterClient(client_id, "10.0.0.1", 50052,
-                         {MakeSegment(MakeUUID(100, 0))});
+                         {MakeSegment(MakeUUID(100, 0))}, 90);
 
     auto info = store.GetClient(client_id);
     ASSERT_NE(info, nullptr);
     EXPECT_EQ(info->ip_address, "10.0.0.1");
     EXPECT_EQ(info->rpc_port, 50052u);
+    EXPECT_EQ(info->last_mutation_id, 100u);
     EXPECT_EQ(info->segments.size(), 1u);
 }
 
@@ -529,7 +531,8 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
     auto seg = MakeUUID(10, 0);
 
     store.AddReplica("key1", client, seg, 1024, 1);
-    store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)});
+    store.RegisterClient(client, "1.2.3.4", 50051, {MakeSegment(seg, 1024)},
+                         123);
 
     auto exported = store.ExportMetadata();
 
@@ -538,6 +541,7 @@ TEST(P2PStandbyMetadataStoreTest, ExportMetadata) {
     EXPECT_EQ(exported.clients.size(), 1u);
     EXPECT_NE(exported.clients.find(client), exported.clients.end());
     EXPECT_EQ(exported.clients.at(client).ip_address, "1.2.3.4");
+    EXPECT_EQ(exported.clients.at(client).last_mutation_id, 123u);
 }
 
 TEST(P2PStandbyMetadataStoreTest, ExportMetadataNoBackfillForUnknownClient) {

--- a/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
+++ b/mooncake-store/tests/ha/oplog/redis_oplog_store_test.cpp
@@ -15,6 +15,7 @@
 
 #include "ha/oplog/oplog_store_factory.h"
 #include "ha/oplog/redis_oplog_store.h"
+#include "ha/oplog/p2p_oplog_types.h"
 #include "ha/oplog/p2p_standby_snapshot_service.h"
 #include "p2p_master_service.h"
 #include "redis_util.h"
@@ -199,6 +200,32 @@ TEST_F(RedisOpLogStoreTest, WriteReadAndLatestSequence) {
     uint64_t latest = 0;
     ASSERT_EQ(ErrorCode::OK, reader->GetLatestSequenceId(latest));
     EXPECT_EQ(2u, latest);
+}
+
+TEST_F(RedisOpLogStoreTest, WriteReadP2PRegisterClientCursorPayload) {
+    auto writer = CreateWriter();
+
+    RegisterClientPayload payload;
+    payload.client_id = {1, 2};
+    payload.ip_address = "127.0.0.1";
+    payload.rpc_port = 50051;
+    payload.last_mutation_id = 789;
+
+    OpLogEntry entry;
+    entry.sequence_id = 1;
+    entry.op_type = OpType_REGISTER_CLIENT;
+    entry.payload = SerializeP2PPayload(payload);
+    ASSERT_EQ(ErrorCode::OK, writer->WriteOpLog(entry, true));
+
+    auto reader = CreateReader();
+    OpLogEntry restored;
+    ASSERT_EQ(ErrorCode::OK, reader->ReadOpLog(1, restored));
+    EXPECT_EQ(restored.op_type, OpType_REGISTER_CLIENT);
+
+    RegisterClientPayload restored_payload;
+    ASSERT_TRUE(DeserializeP2PPayload(restored.payload, restored_payload));
+    EXPECT_EQ(restored_payload.client_id, payload.client_id);
+    EXPECT_EQ(restored_payload.last_mutation_id, 789u);
 }
 
 TEST_F(RedisOpLogStoreTest, OpLogKeysDoNotUseRedisHashTags) {

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -15,8 +15,10 @@
 
 #include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #define private public
@@ -139,7 +141,7 @@ class HAIntegrationTest : public ::testing::Test {
             << "Expected DEGRADED state after MASTER_UNREACHABLE";
     }
 
-    static bool RegisterOrAlreadyRestored(
+    static bool RegisterClientSuccessfully(
         std::shared_ptr<P2PClientService>& client, ErrorCode& error) {
         auto reg = client->RegisterClient();
         if (reg.has_value()) {
@@ -147,7 +149,7 @@ class HAIntegrationTest : public ::testing::Test {
             return true;
         }
         error = reg.error();
-        return error == ErrorCode::CLIENT_ALREADY_EXISTS;
+        return false;
     }
 
     static void ForceRecover(std::shared_ptr<P2PClientService>& client) {
@@ -573,20 +575,13 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
         if (attempt == 9) FAIL() << "Reconnect client2 failed after retries";
     }
 
-    // Re-register clients with the restarted master. After P2P master metadata
-    // restore is enabled, background HA recovery can race with this manual
-    // re-register and restore the same client first. In that case
-    // CLIENT_ALREADY_EXISTS means the restarted master already has the client,
-    // which is acceptable for this recovery test.
-    //
-    // TODO: Split client registration into strict user-initiated register and
-    // HA recovery register, so this idempotent "already restored" case is
-    // modeled by a dedicated recovery API instead of test-side interpretation.
+    // Re-register clients with the restarted master. P2P RegisterClient is
+    // idempotent when the master already has the client.
     ErrorCode reg1_error = ErrorCode::OK;
-    ASSERT_TRUE(RegisterOrAlreadyRestored(client1_, reg1_error))
+    ASSERT_TRUE(RegisterClientSuccessfully(client1_, reg1_error))
         << "Re-register client1 failed: " << static_cast<int>(reg1_error);
     ErrorCode reg2_error = ErrorCode::OK;
-    ASSERT_TRUE(RegisterOrAlreadyRestored(client2_, reg2_error))
+    ASSERT_TRUE(RegisterClientSuccessfully(client2_, reg2_error))
         << "Re-register client2 failed: " << static_cast<int>(reg2_error);
 
     // Recovery: DEGRADED → SYNCING → FULL

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -2,7 +2,9 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #define private public
@@ -12,6 +14,7 @@
 #undef private
 
 #include "master_config.h"
+#include "master_metric_manager.h"
 #include "p2p_client_meta.h"
 #include "p2p_rpc_types.h"
 #include "rpc_types.h"
@@ -108,15 +111,146 @@ TEST_F(P2PMasterServiceTest, RegisterClientDuplicate) {
     auto seg = MakeP2PSegment();
     auto client_id = generate_uuid();
     RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+    ASSERT_TRUE(service->SetSyncCompleted(client_id).has_value());
+    {
+        std::lock_guard<std::mutex> lock(service->client_replay_cursor_mutex_);
+        service->client_last_mutation_ids_[client_id] = 123;
+    }
 
-    // Try registering the same client_id again
+    auto duplicate_segment = MakeP2PSegment("seg2");
     RegisterClientRequest req;
     req.client_id = client_id;
-    req.segments = {MakeP2PSegment("seg2")};
+    req.ip_address = "127.0.0.2";
+    req.rpc_port = 50052;
+    req.segments = {duplicate_segment};
     req.deployment_mode = DeploymentMode::P2P;
     auto res = service->RegisterClient(req);
-    EXPECT_FALSE(res.has_value());
-    EXPECT_EQ(ErrorCode::CLIENT_ALREADY_EXISTS, res.error());
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res->last_mutation_id, 123);
+
+    auto client = service->client_manager_->GetClient(client_id);
+    ASSERT_NE(client, nullptr);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    ASSERT_NE(p2p_client, nullptr);
+    EXPECT_EQ(p2p_client->get_ip_address(), "127.0.0.2");
+    EXPECT_EQ(p2p_client->get_rpc_port(), 50052);
+    EXPECT_TRUE(p2p_client->IsSyncing());
+    EXPECT_FALSE(p2p_client->QuerySegment(duplicate_segment.id).has_value());
+}
+
+TEST_F(P2PMasterServiceTest, RegisterClientDuplicateRejectsWrongMode) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    RegisterClientRequest req;
+    req.client_id = client_id;
+    req.ip_address = "127.0.0.2";
+    req.rpc_port = 50052;
+    req.deployment_mode = DeploymentMode::CENTRALIZATION;
+
+    auto res = service->RegisterClient(req);
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error(), ErrorCode::ILLEGAL_CLIENT);
+
+    auto client = service->client_manager_->GetClient(client_id);
+    ASSERT_NE(client, nullptr);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    ASSERT_NE(p2p_client, nullptr);
+    EXPECT_EQ(p2p_client->get_ip_address(), "127.0.0.1");
+    EXPECT_EQ(p2p_client->get_rpc_port(), 50051);
+}
+
+TEST_F(P2PMasterServiceTest, RegisterClientDuplicateRejectsCrashedClient) {
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+
+    auto client = service->client_manager_->GetClient(client_id);
+    ASSERT_NE(client, nullptr);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    ASSERT_NE(p2p_client, nullptr);
+    {
+        SharedMutexLocker lock(&p2p_client->client_mutex_);
+        p2p_client->health_state_.status = ClientStatus::CRASHED;
+    }
+
+    RegisterClientRequest req;
+    req.client_id = client_id;
+    req.ip_address = "127.0.0.2";
+    req.rpc_port = 50052;
+    req.deployment_mode = DeploymentMode::P2P;
+
+    auto res = service->RegisterClient(req);
+    ASSERT_FALSE(res.has_value());
+    EXPECT_EQ(res.error(), ErrorCode::CLIENT_UNHEALTHY);
+    EXPECT_EQ(p2p_client->get_ip_address(), "127.0.0.1");
+    EXPECT_EQ(p2p_client->get_rpc_port(), 50051);
+}
+
+TEST_F(P2PMasterServiceTest, RegisterClientDuplicateRecoversDisconnected) {
+    MasterMetricManager::instance().reset_all_metrics();
+    auto& metrics = MasterMetricManager::instance();
+
+    auto service = CreateService();
+    auto seg = MakeP2PSegment();
+    auto client_id = generate_uuid();
+    RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
+    ASSERT_EQ(metrics.get_active_clients(), 1);
+
+    auto client = service->client_manager_->GetClient(client_id);
+    ASSERT_NE(client, nullptr);
+    auto p2p_client = std::dynamic_pointer_cast<P2PClientMeta>(client);
+    ASSERT_NE(p2p_client, nullptr);
+    {
+        SharedMutexLocker lock(&p2p_client->client_mutex_);
+        p2p_client->health_state_.status = ClientStatus::DISCONNECTION;
+    }
+    p2p_client->OnDisconnected();
+    ASSERT_EQ(metrics.get_active_clients(), 0);
+
+    RegisterClientRequest req;
+    req.client_id = client_id;
+    req.ip_address = "127.0.0.2";
+    req.rpc_port = 50052;
+    req.deployment_mode = DeploymentMode::P2P;
+
+    auto res = service->RegisterClient(req);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(p2p_client->get_health_state().status, ClientStatus::HEALTH);
+    EXPECT_EQ(metrics.get_clients_recovered_total(), 1);
+    EXPECT_EQ(metrics.get_active_clients(), 1);
+}
+
+TEST_F(P2PMasterServiceTest, RestoreMetadataPreservesRegisterClientCursor) {
+    auto service = CreateService();
+    auto client_id = generate_uuid();
+    auto seg = MakeP2PSegment();
+
+    P2PStandbyMetadataStore::ExportedMetadata metadata;
+    P2PStandbyClientInfo client_info;
+    client_info.client_id = client_id;
+    client_info.ip_address = "127.0.0.1";
+    client_info.rpc_port = 50051;
+    client_info.last_mutation_id = 456;
+    client_info.segments = {seg};
+    metadata.clients.emplace(client_id, client_info);
+
+    ASSERT_EQ(service->RestoreFromStandbyMetadata(metadata), ErrorCode::OK);
+    EXPECT_EQ(service->GetClientLastMutationId(client_id), 456u);
+
+    RegisterClientRequest req;
+    req.client_id = client_id;
+    req.ip_address = "127.0.0.2";
+    req.rpc_port = 50052;
+    req.segments = {seg};
+    req.deployment_mode = DeploymentMode::P2P;
+
+    auto result = service->RegisterClient(req);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->last_mutation_id, 456u);
 }
 
 // ============================================================

--- a/mooncake-store/tests/p2p_register_concurrency_test.cpp
+++ b/mooncake-store/tests/p2p_register_concurrency_test.cpp
@@ -135,12 +135,9 @@ TEST_F(P2PRegisterConcurrencyTest, ConcurrentRegisterNoCrash) {
     go.store(true, std::memory_order_release);
     for (auto& t : threads) t.join();
 
-    // Registers serialize on registration_mutex_, so exactly one re-registers
-    // the client (HTTP 200); the rest hit the master with the same client_id
-    // and get CLIENT_ALREADY_EXISTS -> non-200. The point of the test is no
-    // crash and a consistent terminal state, not that every concurrent register
-    // succeeds.
-    EXPECT_EQ(ok_count.load(), 1);
+    // Registers serialize on registration_mutex_. P2P RegisterClient is
+    // idempotent, so all duplicate register attempts should now succeed.
+    EXPECT_EQ(ok_count.load(), kThreads);
     ASSERT_TRUE(WaitFor([&] { return client->heartbeat_running_.load(); }));
     EXPECT_TRUE(client->registered_.load());
 
@@ -242,16 +239,14 @@ TEST_F(P2PRegisterConcurrencyTest, RegisterFromLocalOnlyRecovers) {
     client->Stop();
 }
 
-// A redundant /register while already registered (master returns
-// CLIENT_ALREADY_EXISTS) must not crash nor change state.
+// A redundant /register while already registered must not crash nor change
+// state.
 TEST_F(P2PRegisterConcurrencyTest, DuplicateRegisterIsNoop) {
     auto client = CreateClient();
     ASSERT_TRUE(WaitFor([&] { return client->registered_.load(); }));
     const bool hb_before = client->heartbeat_running_.load();
 
-    // Status is expected non-200 (ALREADY_EXISTS); we only care that state
-    // holds.
-    HttpPost(Url(client, "/register"));
+    EXPECT_EQ(HttpPost(Url(client, "/register")), 200);
     EXPECT_TRUE(client->registered_.load());
     EXPECT_EQ(client->heartbeat_running_.load(), hb_before);
 

--- a/plans/p2p-client-ha-oplog-recovery-v17.md
+++ b/plans/p2p-client-ha-oplog-recovery-v17.md
@@ -1,0 +1,179 @@
+# P2P Client Redis HA 增量恢复方案
+
+## 目标
+
+v17 目标是直接支持 P2P client 在 Redis HA 模式下的增量恢复，不再把 full
+local metadata recovery 作为 Redis HA 的主要路径。
+
+这里的“增量恢复”不是让 client 补写 master 的全局 oplog sequence。全局 oplog
+仍然由 master 分配和持久化。client 记录自己产生的 metadata mutations，连接到
+新 master 后只 replay 新 master 缺失的部分。
+
+## 第一版范围
+
+第一版只打通 client、master、Redis oplog 的基本闭环：
+
+- client 进程存活，master failover 或重启后可以增量 replay。
+- client journal 先放内存，不写 Redis。
+- client 重启后本地数据和内存 journal 都丢失，不需要恢复；按 fresh client
+  registration 处理。
+- 只面向 Redis HA 模式。
+- 不保留 Redis HA 路径下的 full recovery fallback。
+
+非目标：
+
+- client 重启后的 mutation journal 恢复。
+- client journal 持久化到 Redis 或本地文件。
+- 非 Redis HA 模式兼容。
+
+## Mutation ID
+
+每个 client metadata mutation 携带一个 `client_mutation_id`。
+
+建议格式：
+
+```text
+client_mutation_id = (timestamp_ms << N) | local_counter
+```
+
+要求：
+
+- 在同一个 client 内单调递增。
+- 不要求连续。
+- 同一毫秒内用 `local_counter` 区分。
+- 如果本机时钟回退，使用 `max(now_ms, last_generated_ms)`。
+- 如果同一毫秒 counter 耗尽，等待下一毫秒。
+
+不再使用 `client_epoch/client_op_seq` 作为第一版协议字段。
+
+## Client 流程
+
+正常写入：
+
+1. metadata-changing write 生成 `client_mutation_id`。
+2. mutation 先进入 client 内存 journal。
+3. client 执行本地 metadata 变更。
+4. 如果 master 可达，发送带 `client_id/client_mutation_id` 的有序 mutation RPC。
+5. master ack 返回 durable cursor 后，client 裁剪 `id <= cursor` 的 journal。
+
+master 不可达：
+
+1. client 进入 degraded。
+2. metadata-changing write 仍然可以继续，但必须进入内存 journal。
+3. 不再向旧 master 发送 metadata RPC。
+4. 连接到新 master 后，从 journal 中 replay 缺失 mutations。
+
+连接到新 master：
+
+1. client 调用 `RegisterClient` 上报当前 endpoint/segments。
+2. master 返回该 `client_id` 的 `last_mutation_id`。
+3. client 从内存 journal 中按顺序 replay `id > last_mutation_id` 的 mutations。
+4. replay 完成后，client 通知 master 清除 syncing 状态。
+
+## Master 流程
+
+master 维护内存 map：
+
+```text
+client_id -> last_mutation_id
+```
+
+`RegisterClient` 在 P2P Redis HA 模式下需要明确为幂等：
+
+- client 不存在时，保持现有首次注册语义，创建 client metadata，并写
+  `REGISTER_CLIENT` oplog。
+- client 已存在时，返回成功，更新 endpoint/liveness/syncing 等运行态信息，不再
+  写新的 `REGISTER_CLIENT` oplog。
+- response 返回 `view_version` 和该 client 当前 `last_mutation_id`。
+
+这保留了旧 `RegisterClient` API，同时把现有测试侧把 `CLIENT_ALREADY_EXISTS`
+视为 already restored 的 workaround 收敛到 master 接口语义里。
+
+收到 client mutation：
+
+1. 如果 `client_mutation_id <= last_mutation_id`，认为是重复 replay，直接返回成功。
+2. 如果 `client_mutation_id > last_mutation_id`，按请求顺序应用 mutation。
+3. 写入 P2P master oplog，oplog entry 携带 `client_id/client_mutation_id`。
+4. oplog durable 后推进该 client 的 `last_mutation_id`。
+5. 返回最新 durable cursor 给 client。
+
+顺序要求：
+
+- client 对同一个 `client_id` 的 replay 必须串行发送。
+- master 对同一个 `client_id` 的 mutation 必须串行处理。
+- `client_mutation_id` 不连续，所以 master 不能靠 gap 检测缺失 mutation。
+- 正确性依赖 client 按 journal 顺序 replay。
+
+## Redis / Oplog 流程
+
+Redis 中不需要 client journal。client 重启后不恢复本地数据，因此也不需要从
+Redis 恢复 client journal。
+
+Redis 侧需要保证 master cursor 可恢复：
+
+- P2P master oplog entry 增加 `client_id` 和 `client_mutation_id`。
+- standby replay oplog 时同步维护 `client_id -> last_mutation_id`。
+- standby promote 后，可以直接回答 client 的 `last_mutation_id` 查询。
+- 如果 standby 通过 snapshot bootstrap，snapshot 也要包含 client cursor map。
+
+这样 client 不需要扫描 master oplog，也不需要把 journal 写到 Redis。新 master 的
+点位来自 standby 已经 replay 出来的 cursor map。
+
+## RPC 变化
+
+第一版不新增 reconnect RPC；复用并增强 `RegisterClient` 的 P2P 幂等语义。
+
+第一版仍建议新增 Redis HA 专用 ordered replay RPC，而不是复用
+`BatchSyncReplica`。
+
+原因：
+
+- `BatchSyncReplica` 用 add/remove 数组表达最终状态，不保证全局 mutation 顺序。
+- degraded 期间同一个 key 的 add/remove 顺序不能丢。
+- replay 需要逐条携带 `client_mutation_id` 做幂等。
+
+建议接口：
+
+- `ReplayClientMutations(client_id, mutations)`。
+- `FinishClientReplay(client_id, replay_high_watermark)`。
+
+`ReplayClientMutations` response 返回：
+
+- 每条 mutation 的结果。
+- master 最新 durable `last_mutation_id`。
+
+## Failure 策略
+
+明确的设计边界：
+
+- client 进程重启后内存 journal 丢失，不做自动补 replay。
+- 这种 client 按 fresh registration 处理，不尝试恢复重启前的本地 metadata
+  mutations。
+
+必须避免的错误：
+
+- master ack 早于 oplog durable，导致 client trim 后 failover 丢 mutation。
+- replay 并发乱序，导致较大的 mutation id 先推进 cursor，较小的 mutation 被误判为重复。
+- snapshot bootstrap 不包含 cursor map，导致 promoted master 不知道 client 点位。
+
+## 第一版实现项
+
+第一版需要实现：
+
+- client 内存 mutation journal。
+- `client_mutation_id` 生成器。
+- Redis HA reconnect 后查询 master cursor。
+- ordered replay RPC。
+- master 侧 `client_id -> last_mutation_id` cursor map。
+- master oplog entry 携带 `client_id/client_mutation_id`。
+- standby replay oplog 时恢复 cursor map。
+- snapshot bootstrap 同步 cursor map。
+- replay 完成后清理 syncing 状态。
+
+建议测试：
+
+- master 切换后只 replay 缺失 mutations。
+- degraded 期间同一个 key add/remove 顺序正确。
+- 重复 replay 不会重复生效。
+- master ack 前 crash，新 master 要求 client 继续 replay。
+- snapshot bootstrap 后 promoted master 能返回正确 client cursor。


### PR DESCRIPTION
## Description

  Add the first P2P client replay handshake path for Redis HA mode.

  This change makes P2P `RegisterClient` idempotent across master failover by returning the master's last committed client
  mutation id for already-registered clients. New masters restore that cursor from standby metadata / snapshot bootstrap, so
  reconnecting clients can later replay only missing client-side oplog mutations.

  Also tightens duplicate registration handling:
  - rejects non-P2P `RegisterClient` requests before the duplicate path
  - refreshes endpoint / heartbeat for healthy or disconnected existing clients
  - rejects duplicate registration for clients already marked `CRASHED`
  - avoids writing duplicate `REGISTER_CLIENT` oplog entries for already-known clients

  A Chinese design note is included in `plans/p2p-client-ha-oplog-recovery-v17.md`.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Reshard (`mooncake-reshard`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [x] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  clang-format-20 --dry-run -Werror mooncake-store/include/p2p_client_meta.h mooncake-store/src/p2p_client_meta.cpp mooncake-
  store/src/p2p_master_service.cpp mooncake-store/tests/p2p_master_service_test.cpp

  cmake -S . -B build-noetcd -DWITH_STORE=ON -DWITH_TE=ON -DSTORE_USE_REDIS=ON -DSTORE_USE_ETCD=OFF
  -DCMAKE_BUILD_TYPE=RelWithDebInfo
  cmake --build build-noetcd --target p2p_master_service_test p2p_oplog_test p2p_register_concurrency_test ha_integration_test
  redis_oplog_store_test -j3
  cd build-noetcd && ctest --output-on-failure -R "^(p2p_master_service_test|p2p_oplog_test|p2p_register_concurrency_test|
  ha_integration_test|redis_oplog_store_test)$"
```
  Test results:

  - [x] Unit tests pass
  - [x] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  100% tests passed, 0 tests failed out of 5

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [x] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  Codex was used to help inspect the existing HA / P2P oplog flow, implement the patch, add focused tests, and run local
  validation. The human submitter reviewed the changes and remains responsible for the PR.