### PR TITLE
test(store): exercise local SSD offload regression

### DIFF
--- a/mooncake-wheel/tests/test_ssd_offload_regression.py
+++ b/mooncake-wheel/tests/test_ssd_offload_regression.py
@@ -1,0 +1,68 @@
+import hashlib
+import os
+import time
+import unittest
+
+from mooncake.store import MooncakeDistributedStore
+
+
+VALUE_SIZE = 1024 * 1024
+OBJECT_COUNT = 768
+GLOBAL_SEGMENT_SIZE = 256 * 1024 * 1024
+LOCAL_BUFFER_SIZE = 128 * 1024 * 1024
+PUT_TIMEOUT_SECONDS = 120
+
+
+def make_value(key):
+    digest = hashlib.sha256(key.encode()).digest()
+    return (digest * (VALUE_SIZE // len(digest) + 1))[:VALUE_SIZE]
+
+
+class TestSsdOffloadRegression(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.store = MooncakeDistributedStore()
+        result = cls.store.setup(
+            os.getenv("LOCAL_HOSTNAME", "localhost"),
+            os.getenv("MC_METADATA_SERVER", "http://127.0.0.1:8080/metadata"),
+            GLOBAL_SEGMENT_SIZE,
+            LOCAL_BUFFER_SIZE,
+            os.getenv("PROTOCOL", "tcp"),
+            os.getenv("DEVICE_NAME", "eth0"),
+            os.getenv("MASTER_SERVER", "127.0.0.1:50051"),
+            None,
+            True,
+            os.environ["MOONCAKE_OFFLOAD_FILE_STORAGE_PATH"],
+        )
+        if result != 0:
+            raise RuntimeError(f"Failed to setup store client: {result}")
+
+    def test_values_survive_ssd_offload_on_eviction(self):
+        keys = [f"ssd-offload-regression-{index}" for index in range(OBJECT_COUNT)]
+
+        for key in keys:
+            deadline = time.monotonic() + PUT_TIMEOUT_SECONDS
+            value = make_value(key)
+            while True:
+                result = self.store.put(key, value)
+                if result == 0:
+                    break
+                if result != -200 or time.monotonic() >= deadline:
+                    self.fail(f"Put failed for {key}: {result}")
+                time.sleep(0.01)
+
+        time.sleep(5)
+
+        for key in keys:
+            self.assertEqual(
+                self.store.get(key),
+                make_value(key),
+                f"SSD offload returned invalid data for {key}",
+            )
+
+        for key in keys:
+            self.store.remove(key)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -161,23 +161,34 @@ kill $MASTER_PID || true
 wait $MASTER_PID 2>/dev/null || true
 
 
-# Check if MOONCAKE_STORAGE_ROOT_DIR is set and not empty
 if [ -n "$TEST_SSD_OFFLOAD_IN_EVICT" ]; then
-    TEST_ROOT_DIR="/tmp/mooncake_test_ssd"
-    mkdir -p $TEST_ROOT_DIR
-    echo "MOONCAKE_STORAGE_ROOT_DIR is set to: $TEST_ROOT_DIR"
-    echo "Running with ssd offload in evict tests..."
-    # Set a small kv lease ttl to make the test faster.
-    # Must be consistent with the client test parameters.
-    mooncake_master --default_kv_lease_ttl=500 --root_fs_dir=$TEST_ROOT_DIR &
+    TEST_ROOT_DIR="${MOONCAKE_STORAGE_ROOT_DIR:-/tmp}/mooncake_test_ssd_$$"
+    mkdir -p "$TEST_ROOT_DIR"
+    echo "SSD offload path: $TEST_ROOT_DIR"
+    echo "Running SSD offload-on-eviction tests..."
+    # Keep root_fs_dir empty so a global DISK replica cannot mask failures in
+    # the LOCAL_DISK offload path exercised by this test.
+    mooncake_master --default_kv_lease_ttl=500 \
+        --enable_offload=true --offload_on_evict=true --root_fs_dir= &
     MASTER_PID=$!
     sleep 1
-    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 python test_ssd_offload_in_evict.py
+    set +e
+    MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
+        DEFAULT_KV_LEASE_TTL=500 \
+        MOONCAKE_OFFLOAD_FILE_STORAGE_PATH="$TEST_ROOT_DIR" \
+        MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=1 \
+        MOONCAKE_OFFLOAD_USE_URING=true \
+        python test_ssd_offload_regression.py
+    SSD_TEST_STATUS=$?
+    set -e
     kill $MASTER_PID || true
     wait $MASTER_PID 2>/dev/null || true
-    rm -rf $TEST_ROOT_DIR
+    rm -rf "$TEST_ROOT_DIR"
+    if [ "$SSD_TEST_STATUS" -ne 0 ]; then
+        exit "$SSD_TEST_STATUS"
+    fi
 else
-    echo "Skipping test: MOONCAKE_STORAGE_ROOT_DIR environment variable is not set"
+    echo "Skipping SSD offload-on-eviction tests"
 fi
 
 if [ -n "$TEST_PROMOTION_ON_HIT" ]; then


### PR DESCRIPTION
## Summary

- add a focused regression test that writes beyond the in-memory segment and verifies every value after LOCAL_DISK offload
- explicitly enable `offload_on_evict`, client SSD offload, and the bucket io_uring path in the test runner
- keep `root_fs_dir` empty so a global DISK replica cannot mask LOCAL_DISK read failures
- always stop the master and clean the dedicated test directory when the regression fails

## Motivation

The existing `test_ssd_offload_in_evict.py` runner supplied `root_fs_dir`, but did not enable client SSD offload or master offload-on-eviction. The global DISK replica could therefore make the test pass without exercising the LOCAL_DISK path involved in #3465.

This PR adds coverage for that path; it does not claim to fix #3465 itself.

## Validation

- `python3 -m py_compile mooncake-wheel/tests/test_ssd_offload_regression.py`
- `bash -n scripts/run_tests.sh`
- regression test passed with a 256 MiB memory segment and 768 MiB of values
- verified that global persistence was disabled and io_uring fixed-buffer registration succeeded