### PR TITLE
fix(store): deduplicate SSD carryover keys

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2411,6 +2411,11 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
     MutexLocker offloading_locker(&offloading_mutex_);
     auto& ungrouped_offloading_objects = ungrouped_offloading_objects_;
     auto it = offloading_objects.cbegin();
+    std::unordered_set<std::string> carryover_keys;
+    carryover_keys.reserve(ungrouped_offloading_objects.size());
+    for (const auto& [key, _] : ungrouped_offloading_objects) {
+        carryover_keys.insert(key);
+    }
     int64_t residue_count = static_cast<int64_t>(
         offloading_objects.size() + ungrouped_offloading_objects.size());
     int64_t total_count = residue_count;
@@ -2437,8 +2442,8 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
             ungrouped_offloading_objects.clear();
         }
 
-        for (int64_t i = static_cast<int64_t>(bucket_keys.size());
-             i < bucket_backend_config_.bucket_keys_limit; ++i) {
+        while (static_cast<int64_t>(bucket_keys.size()) <
+               bucket_backend_config_.bucket_keys_limit) {
             if (it == offloading_objects.cend()) {
                 for (const auto& bucket_object : bucket_objects) {
                     ungrouped_offloading_objects.emplace(bucket_object.first,
@@ -2448,6 +2453,11 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
                         << "Total ungrouped count: "
                         << ungrouped_offloading_objects.size();
                 return {};
+            }
+
+            if (carryover_keys.find(it->first) != carryover_keys.end()) {
+                ++it;
+                continue;
             }
 
             if (it->second > bucket_backend_config_.bucket_size_limit) {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2409,15 +2409,15 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
     const std::unordered_map<std::string, int64_t>& offloading_objects,
     std::vector<std::vector<std::string>>& buckets_keys) {
     MutexLocker offloading_locker(&offloading_mutex_);
-    auto& ungrouped_offloading_objects = ungrouped_offloading_objects_;
-    auto it = offloading_objects.cbegin();
-    std::unordered_set<std::string> carryover_keys;
-    carryover_keys.reserve(ungrouped_offloading_objects.size());
-    for (const auto& [key, _] : ungrouped_offloading_objects) {
-        carryover_keys.insert(key);
+    if (offloading_objects.empty()) {
+        return {};
     }
+    auto& ungrouped_offloading_objects = ungrouped_offloading_objects_;
+    auto carryover_objects = std::move(ungrouped_offloading_objects);
+    bool carryover_loaded = false;
+    auto it = offloading_objects.cbegin();
     int64_t residue_count = static_cast<int64_t>(
-        offloading_objects.size() + ungrouped_offloading_objects.size());
+        offloading_objects.size() + carryover_objects.size());
     int64_t total_count = residue_count;
 
     auto is_exist_func =
@@ -2430,16 +2430,16 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
         std::unordered_map<std::string, int64_t> bucket_objects;
         int64_t bucket_data_size = 0;
 
-        if (!ungrouped_offloading_objects.empty()) {
-            for (const auto& ungrouped_it : ungrouped_offloading_objects) {
+        if (!carryover_loaded) {
+            for (const auto& ungrouped_it : carryover_objects) {
                 bucket_data_size += ungrouped_it.second;
                 bucket_keys.push_back(ungrouped_it.first);
                 bucket_objects.emplace(ungrouped_it.first, ungrouped_it.second);
             }
             VLOG(1) << "Ungrouped offloading objects have been processed and "
                        "cleared; count="
-                    << ungrouped_offloading_objects.size();
-            ungrouped_offloading_objects.clear();
+                    << carryover_objects.size();
+            carryover_loaded = true;
         }
 
         while (static_cast<int64_t>(bucket_keys.size()) <
@@ -2455,7 +2455,7 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
                 return {};
             }
 
-            if (carryover_keys.find(it->first) != carryover_keys.end()) {
+            if (carryover_objects.find(it->first) != carryover_objects.end()) {
                 ++it;
                 continue;
             }

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2416,8 +2416,8 @@ tl::expected<void, ErrorCode> BucketStorageBackend::GroupOffloadingKeysByBucket(
     auto carryover_objects = std::move(ungrouped_offloading_objects);
     bool carryover_loaded = false;
     auto it = offloading_objects.cbegin();
-    int64_t residue_count = static_cast<int64_t>(
-        offloading_objects.size() + carryover_objects.size());
+    int64_t residue_count = static_cast<int64_t>(offloading_objects.size() +
+                                                 carryover_objects.size());
     int64_t total_count = residue_count;
 
     auto is_exist_func =

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -321,7 +321,7 @@ TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_deduplicates_carryover) {
     ASSERT_EQ(buckets_keys.size(), 1);
     ASSERT_EQ(buckets_keys.front().size(), 10);
     std::unordered_set<std::string> unique_keys(buckets_keys.front().begin(),
-                                                 buckets_keys.front().end());
+                                                buckets_keys.front().end());
     EXPECT_EQ(unique_keys.size(), 10);
     EXPECT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 0);
 }

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -284,6 +284,9 @@ TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_bucket_keys_limit) {
         ASSERT_EQ(bucket_keys.size(), 10);
     }
     ASSERT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 5);
+    for (size_t i = 35; i < 40; ++i) {
+        offloading_objects.emplace("test" + std::to_string(i), 1);
+    }
     buckets_keys.clear();
     ASSERT_TRUE(FileStorageGroupOffloadingKeysByBucket(
         fileStorage, offloading_objects, buckets_keys));
@@ -292,6 +295,35 @@ TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_bucket_keys_limit) {
         ASSERT_EQ(bucket_keys.size(), 10);
     }
     ASSERT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 0);
+}
+
+TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_deduplicates_carryover) {
+    std::unordered_map<std::string, int64_t> offloading_objects;
+    offloading_objects.emplace("duplicate", 1);
+
+    std::vector<std::vector<std::string>> buckets_keys;
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+    SetEnv("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "10");
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+
+    ASSERT_TRUE(FileStorageGroupOffloadingKeysByBucket(
+        fileStorage, offloading_objects, buckets_keys));
+    ASSERT_TRUE(buckets_keys.empty());
+    ASSERT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 1);
+
+    for (size_t i = 0; i < 9; ++i) {
+        offloading_objects.emplace("new" + std::to_string(i), 1);
+    }
+    ASSERT_TRUE(FileStorageGroupOffloadingKeysByBucket(
+        fileStorage, offloading_objects, buckets_keys));
+
+    ASSERT_EQ(buckets_keys.size(), 1);
+    ASSERT_EQ(buckets_keys.front().size(), 10);
+    std::unordered_set<std::string> unique_keys(buckets_keys.front().begin(),
+                                                 buckets_keys.front().end());
+    EXPECT_EQ(unique_keys.size(), 10);
+    EXPECT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 0);
 }
 
 TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_bucket_size_limit) {
@@ -311,6 +343,9 @@ TEST_F(FileStorageTest, GroupOffloadingKeysByBucket_bucket_size_limit) {
         ASSERT_EQ(bucket_keys.size(), 10);
     }
     ASSERT_EQ(GetUngroupedOffloadingObjectsSize(fileStorage), 5);
+    for (size_t i = 35; i < 40; ++i) {
+        offloading_objects.emplace("test" + std::to_string(i), 1);
+    }
     buckets_keys.clear();
     ASSERT_TRUE(FileStorageGroupOffloadingKeysByBucket(
         fileStorage, offloading_objects, buckets_keys));


### PR DESCRIPTION
## Summary

- deduplicate keys carried over in `ungrouped_offloading_objects_` from keys returned in the next heartbeat
- fill buckets according to the number of unique keys rather than loop iterations
- update the existing grouping tests so new keys, rather than duplicate carryover entries, fill subsequent buckets
- add a focused regression test for a carryover key repeated in the next heartbeat batch

## Root cause

`GroupOffloadingKeysByBucket()` prepended carryover keys and then iterated the new heartbeat input without excluding keys already present in that carryover set. The same key could therefore be emitted into more than one bucket. Once the first bucket committed, a later bucket failed atomically with `OBJECT_ALREADY_EXISTS` and all keys in that bucket were NACKed.

## Validation

- `FileStorageTest.GroupOffloadingKeysByBucket*`: 5/5 passed
- pre-fix scaled RDMA workload: 118 duplicate offload reservations
- post-fix scaled RDMA workload: zero `OBJECT_ALREADY_EXISTS` or persistence errors
- post-fix workload: 10,240 × 1 MiB values, 8 concurrent writers, every value matched on readback
- `git diff --check`

Fixes #3478

Related to #3465. This PR fixes the independently reproducible duplicate-bucketing failure; it does not claim to fully resolve the empty-value symptom reported there.