### PR TITLE
[Store] Stabilize snapshot PutStart eviction test

### DIFF
--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -2418,19 +2418,30 @@ TEST_F(MasterServiceSnapshotTest, PutStartExpiringTest) {
 
     // Put key_2 again, should fail because eviction has not been triggered. And
     // this PutStart should trigger the eviction.
+    const int64_t eviction_attempts_before =
+        MasterMetricManager::instance().get_mem_eviction_attempts();
     put_start_result = service_->PutStart(client_id, key_2, TenantId::Default(),
                                           slice_length, config);
-    EXPECT_FALSE(put_start_result.has_value());
+    ASSERT_FALSE(put_start_result.has_value());
     EXPECT_EQ(put_start_result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 
-    // Wait a moment for the eviction to complete.
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(4);
+    while (MasterMetricManager::instance().get_mem_eviction_attempts() <=
+               eviction_attempts_before &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    ASSERT_GT(MasterMetricManager::instance().get_mem_eviction_attempts(),
+              eviction_attempts_before)
+        << "Timed out waiting for asynchronous eviction";
 
     // Put key_2 again, should success because the previous one has been
     // discarded and released.
     put_start_result = service_->PutStart(client_id, key_2, TenantId::Default(),
                                           slice_length, config);
-    EXPECT_TRUE(put_start_result.has_value());
+    ASSERT_TRUE(put_start_result.has_value())
+        << toString(put_start_result.error());
     replica_list = put_start_result.value();
     EXPECT_EQ(replica_list.size(), kReplicaCnt);
     for (size_t i = 0; i < kReplicaCnt; i++) {


### PR DESCRIPTION
## Description

`MasterServiceSnapshotTest.PutStartExpiringTest` used a fixed 50 ms sleep while waiting for the asynchronous `BatchEvict` triggered by a failed `PutStart`. Under coverage, eviction can take slightly longer, causing the retry to fail and the subsequent `.value()` access to throw.

This change records the memory eviction attempt count before triggering eviction and waits up to four seconds for `BatchEvict` to complete before retrying `PutStart`. It follows the approach already used in #3266 for the corresponding non-snapshot test.

Related: #3245, #3266

### Risk Analysis

The polling loop uses a `steady_clock` deadline, so it exits after approximately four seconds and cannot spin indefinitely under normal scheduling. The counter is process-global and tracks attempts rather than success, but this test runs a single service and the following `PutStart` assertion verifies the expected replica release.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B build-snapshot-flake -G Ninja \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DWITH_STORE_RUST=OFF \
  -DUSE_CUDA=OFF \
  -DUSE_ETCD=OFF \
  -DUSE_REDIS=OFF \
  -DUSE_HTTP=ON \
  -DUSE_CXL=OFF \
  -DUSE_UB=OFF

cmake --build build-snapshot-flake \
  --target master_service_test_for_snapshot -j 16

LSAN_OPTIONS=detect_leaks=0 \
  ./build-snapshot-flake/mooncake-store/tests/master_service_test_for_snapshot \
  --gtest_filter=MasterServiceSnapshotTest.PutStartExpiringTest \
  --gtest_repeat=10 \
  --gtest_break_on_failure

pre-commit run --files \
  mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
```

**Test results:**

- [x] Unit test passed in all 10 iterations
- [x] Pre-commit hooks passed
- [ ] Integration tests pass (not applicable)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable; test-only change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [x] AI tools were used

OpenAI Codex was used to analyze the CI failure, prepare the test-only change, and run focused validation. The human submitter will review every changed line and is responsible for understanding and defending the change.