### PR TITLE
[TE] Rename create_shared_segment tp_group to comm_group

### DIFF
--- a/mooncake-integration/shared_segment.py
+++ b/mooncake-integration/shared_segment.py
@@ -19,7 +19,7 @@ here; C++ only shares the raw span.
         },
         world_size=tp_size,
         rank_id=tp_rank,
-        tp_group=tp_group,
+        comm_group=tp_group,
         mmap=False,  # Ascend VMM; tensors() are NPU views of the SVM VA
     )
     k_caches = seg.tensors("k")
@@ -58,15 +58,19 @@ def create_shared_segment(
     rank_id: int,
     owner_rank: int = 0,
     device_id: int | None = None,
-    tp_group: Any = None,
+    comm_group: Any = None,
     mmap: bool = True,
     host_register: bool = False,
+    *,
+    tp_group: Any = None,
 ) -> SharedSegment:
     """Creates a shared host segment and returns it ready to use.
 
     Every rank of the group must call this with an identical declaration; a
     disagreement is reported here rather than silently producing wrong reads.
-    ``tp_group`` may be omitted only when ``world_size`` is 1. ``device_id``
+    ``comm_group`` is the torch process group (or vLLM GroupCoordinator) used
+    to all-gather export blobs; it may be omitted only when ``world_size`` is
+    1. ``tp_group`` is a deprecated alias of ``comm_group``. ``device_id``
     defaults to the rank's current accelerator.
 
     ``mmap`` (default True) uses POSIX shm. Set ``mmap=False`` for the platform
@@ -77,6 +81,7 @@ def create_shared_segment(
     device-accessible after ``MemSetAccess`` (owner ``MallocMem``, peer
     ``ImportAndMap``), so ``tensors().data_ptr()`` is that same VA.
     """
+    comm_group = _select_comm_group(comm_group, tp_group)
     if host_register and not mmap:
         raise SharedSegmentError("host_register requires mmap=True")
     if not shared_segment_supported(mmap=mmap, host_register=host_register):
@@ -122,7 +127,9 @@ def create_shared_segment(
     except RuntimeError as exc:
         create_error = str(exc)
 
-    _raise_if_any_rank_failed(create_error, world_size, rank_id, tp_group, "create")
+    _raise_if_any_rank_failed(
+        create_error, world_size, rank_id, comm_group, "create"
+    )
     if segment is None:
         raise SharedSegmentError("Shared segment create returned no segment")
 
@@ -131,12 +138,14 @@ def create_shared_segment(
         if world_size == 1:
             blobs = [blob]
         else:
-            blobs = _all_gather_blob(blob, world_size, tp_group)
+            blobs = _all_gather_blob(blob, world_size, comm_group)
         segment.complete(blobs)
     except (RuntimeError, SharedSegmentError) as exc:
         complete_error = str(exc)
 
-    _raise_if_any_rank_failed(complete_error, world_size, rank_id, tp_group, "complete")
+    _raise_if_any_rank_failed(
+        complete_error, world_size, rank_id, comm_group, "complete"
+    )
     return SharedSegment(segment, specs, offsets, stride, device)
 
 
@@ -276,21 +285,32 @@ def _current_device_index() -> int:
     return 0
 
 
-def _resolve_cpu_group(tp_group: Any) -> Any:
+def _select_comm_group(comm_group: Any, tp_group: Any) -> Any:
+    """``tp_group`` is a deprecated alias of ``comm_group``."""
+    if tp_group is None:
+        return comm_group
+    if comm_group is None or comm_group is tp_group:
+        return tp_group
+    raise SharedSegmentError(
+        "pass only comm_group; tp_group is a deprecated alias of comm_group"
+    )
+
+
+def _resolve_cpu_group(comm_group: Any) -> Any:
     """Accepts a vLLM GroupCoordinator or a plain process group.
 
     The blobs are exchanged as CPU byte tensors, so a gloo group is required; a
     coordinator exposes one as ``cpu_group``.
     """
-    cpu_group = getattr(tp_group, "cpu_group", None)
-    return cpu_group if cpu_group is not None else tp_group
+    cpu_group = getattr(comm_group, "cpu_group", None)
+    return cpu_group if cpu_group is not None else comm_group
 
 
 def _raise_if_any_rank_failed(
     local_error: str,
     world_size: int,
     rank_id: int,
-    tp_group: Any,
+    comm_group: Any,
     phase: str,
 ) -> None:
     """Makes every rank leave a failed collective phase with the same error."""
@@ -298,12 +318,14 @@ def _raise_if_any_rank_failed(
         if local_error:
             raise SharedSegmentError(local_error)
         return
-    if tp_group is None:
-        raise SharedSegmentError("tp_group is required when world_size > 1")
+    if comm_group is None:
+        raise SharedSegmentError("comm_group is required when world_size > 1")
 
     failures: list[tuple[int, str] | None] = [None] * world_size
     local_failure = (rank_id, local_error) if local_error else None
-    dist.all_gather_object(failures, local_failure, group=_resolve_cpu_group(tp_group))
+    dist.all_gather_object(
+        failures, local_failure, group=_resolve_cpu_group(comm_group)
+    )
     errors = [failure for failure in failures if failure is not None]
     if errors:
         detail = "; ".join(
@@ -312,10 +334,10 @@ def _raise_if_any_rank_failed(
         raise SharedSegmentError(f"Shared segment {phase} failed: {detail}")
 
 
-def _all_gather_blob(blob: bytes, world_size: int, tp_group: Any) -> list[bytes]:
+def _all_gather_blob(blob: bytes, world_size: int, comm_group: Any) -> list[bytes]:
     local = torch.frombuffer(bytearray(blob), dtype=torch.uint8)
     gathered = [torch.empty_like(local) for _ in range(world_size)]
-    dist.all_gather(gathered, local, group=_resolve_cpu_group(tp_group))
+    dist.all_gather(gathered, local, group=_resolve_cpu_group(comm_group))
     return [bytes(tensor.numpy()) for tensor in gathered]
 
 

--- a/mooncake-transfer-engine/src/shared_segment/ascend_shared_segment.cpp
+++ b/mooncake-transfer-engine/src/shared_segment/ascend_shared_segment.cpp
@@ -33,8 +33,9 @@ constexpr size_t kMemAccessDescCount = 1;
 // backed too.
 constexpr uint64_t kReserveHugePageFlag = 1;
 constexpr size_t kBytesPerTB = 1024ULL * 1024ULL * 1024ULL * 1024ULL;
-// HIXL fabric mem defaults to [40TB, 72TB); reserve after that window on A3.
-constexpr uintptr_t kA3ReserveStartAddr = 72ULL * kBytesPerTB;
+// HIXL fabric mem defaults to [40TB, 72TB). Reserve at 78TB on A3 so the
+// shared-segment NoUCMemory window stays past that range.
+constexpr uintptr_t kA3ReserveStartAddr = 78ULL * kBytesPerTB;
 
 static_assert(sizeof(aclrtMemFabricHandle) <= kMaxHandleBytes,
               "Fabric handle must fit into a shared segment blob");
@@ -82,13 +83,27 @@ aclrtPhysicalMemProp BuildHostMemProp() {
 
 // Host pages are only bound to the host by Map; the NPU needs an explicit grant
 // before kernels can touch them. AdxlEngine::MallocMem already does this for
-// the owner.
-Status GrantDeviceAccess(void* addr, uint64_t size, int32_t device_id) {
+// the owner. location.id is a driver logical id; aclrtGetDevice returns a user
+// id (ASCEND_RT_VISIBLE_DEVICES), so convert before SetAccess.
+Status GrantDeviceAccess(void* addr, uint64_t size) {
+    int32_t user_id = -1;
+    int32_t driver_id = -1;
+    auto ret = aclrtGetDevice(&user_id);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory("aclrtGetDevice failed for MemSetAccess, ret " +
+                              std::to_string(ret));
+    }
+    ret = aclrtGetLogicDevIdByUserDevId(user_id, &driver_id);
+    if (ret != ACL_ERROR_NONE) {
+        return Status::Memory(
+            "aclrtGetLogicDevIdByUserDevId failed for MemSetAccess, ret " +
+            std::to_string(ret));
+    }
     aclrtMemAccessDesc desc{};
     desc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
     desc.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
-    desc.location.id = static_cast<uint32_t>(device_id);
-    auto ret = aclrtMemSetAccess(addr, size, &desc, kMemAccessDescCount);
+    desc.location.id = static_cast<uint32_t>(driver_id);
+    ret = aclrtMemSetAccess(addr, size, &desc, kMemAccessDescCount);
     if (ret != ACL_ERROR_NONE) {
         return Status::Memory(
             "aclrtMemSetAccess failed for the imported shared segment, ret " +
@@ -224,6 +239,7 @@ Status AscendSharedSegmentBackend::ReserveLocal(
 Status AscendSharedSegmentBackend::ImportAndMap(
     uint64_t size, const SharedSegmentOptions& options,
     const std::vector<uint8_t>& handle) {
+    (void)options;
     if (reserved_addr_ == nullptr) {
         return Status::InvalidArgument(
             "Shared segment import needs a reserved address window");
@@ -250,7 +266,7 @@ Status AscendSharedSegmentBackend::ImportAndMap(
             std::to_string(ret));
     }
     mapped_ = true;
-    return GrantDeviceAccess(addr, size, options.device_id);
+    return GrantDeviceAccess(addr, size);
 }
 
 void AscendSharedSegmentBackend::Release() {


### PR DESCRIPTION
## Description

`create_shared_segment` takes a torch process group (or vLLM `GroupCoordinator`) only to all-gather export blobs and to run rank-wide error consensus. That group is not intrinsically a TP group, so the argument is renamed to `comm_group`.

Behavior of the communicator is unchanged:

- C++ `SharedSegment::{Create,Complete}` is untouched; the communicator still lives in Python.
- `_resolve_cpu_group` still prefers `GroupCoordinator.cpu_group` (gloo) and otherwise uses the process group as-is.
- Multi-rank create/complete still uses `all_gather_object` / `all_gather` on that CPU group.

`tp_group=` remains a deprecated keyword-only alias so existing callers (positional 7th argument and `tp_group=...`) keep working. Passing both with different objects raises `SharedSegmentError`.

Also on the Ascend VMM shared-segment path:

- **SetAccess device id.** `aclrtMemSetAccess` `location.id` is a driver logical id. `aclrtGetDevice` returns a user id (`ASCEND_RT_VISIBLE_DEVICES`), so peer `GrantDeviceAccess` converts with `aclrtGetLogicDevIdByUserDevId` before SetAccess. Owner `MallocMem` does the same conversion in HIXL.
- **A3 NoUCMemory start.** Shared-segment `aclrtReserveMemAddressNoUCMemory` now starts at **78TB**, past HIXL fabric mem's default `[40TB, 72TB)` window.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python3 -m py_compile mooncake-integration/shared_segment.py
./scripts/code_format.sh --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Python compile plus a stub import of `_select_comm_group` / `_resolve_cpu_group` (alias selection, conflict error, `cpu_group` unwrap). C++ change is `GrantDeviceAccess` + A3 reserve start; `code_format.sh` left `ascend_shared_segment.cpp` unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

Host could not install ruff/pre-commit (network); please treat the CI pre-commit job as authoritative. No RFC (well under 500 LOC).

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok 4.6 assisted with the rename, SetAccess conversion, 78TB reserve, and this PR. Every changed line was reviewed by the submitter.

Made with [Cursor](https://cursor.com)
