### PR TITLE
[CI] Move PR build validation to nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  # Build the artifact tested below through the exact release wheel path. The
+  # Ubuntu jobs remain consumer tests, not an alternate wheel build environment.
+  build-wheel:
     needs: [spell-check, clang-format, check-paths]
     if: &run-ci-for-source-changes >-
       (needs.check-paths.outputs.should-run-downstream == 'true' ||
@@ -29,143 +31,6 @@ jobs:
        github.event_name == 'workflow_dispatch' ||
        github.event.action == 'opened' ||
        contains(github.event.pull_request.labels.*.name, 'run-ci'))
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        python-version: ['3.10', '3.12']
-    env:
-      CI: "true"
-      SCCACHE_GHA_ENABLED: "true"
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        persist-credentials: false
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-
-    - name: Install and start etcd
-      run: |
-        wget https://github.com/etcd-io/etcd/releases/download/v3.6.1/etcd-v3.6.1-linux-amd64.tar.gz
-        tar xzf etcd-v3.6.1-linux-amd64.tar.gz
-        sudo mv etcd-v3.6.1-linux-amd64/etcd* /usr/local/bin/
-        etcd --advertise-client-urls http://127.0.0.1:2379 --listen-client-urls http://127.0.0.1:2379 &
-        sleep 3 # Give etcd time to start
-        etcdctl --endpoints=http://127.0.0.1:2379 endpoint health
-      shell: bash
-
-    - name: Free up disk space
-      uses: ./.github/actions/free-disk-space
-
-    - name: Install CUDA Toolkit
-      uses: Jimver/cuda-toolkit@v0.2.24
-      with:
-        cuda: '12.8.1'
-        linux-local-args: '["--toolkit"]'
-        method: 'network'
-        sub-packages: '["nvcc"]'
-
-    - name: Install build utilities
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y ninja-build
-
-    - name: Test HugeTLB sizing helper
-      run: |
-        python3 scripts/test_hicache_hugepage_requirements.py
-      shell: bash
-
-    - name: Run sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.9
-
-    - name: Configure sccache
-      uses: actions/github-script@v7
-      with:
-        script: |
-          core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-          core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-    - name: Configure project
-      run: |
-        sudo apt update -y
-        sudo bash -x dependencies.sh -y
-        mkdir build
-        cd build
-        cmake -G Ninja .. -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_UB=ON -DUSE_ETCD=ON -DSTORE_USE_ETCD=ON -DENABLE_ASAN=ON -DENABLE_SCCACHE=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_DEBUG_SYMBOLS=OFF
-      shell: bash
-
-    - name: Build project
-      run: |
-        cd build
-        cmake --build .
-        sudo cmake --install .
-      shell: bash
-
-    - name: Build nvlink_allocator.so
-      run: |
-        mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-        cd mooncake-transfer-engine/nvlink-allocator
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-      shell: bash
-
-    - name: Run sccache stat for check
-      if: ${{ env.SCCACHE_PATH != '' }}
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
-    - name: Start Metadata Server
-      run: |
-        cd mooncake-transfer-engine/example/http-metadata-server-python
-        pip install aiohttp
-        python ./bootstrap_server.py &
-      shell: bash
-
-    - name: Run Mooncake Store Rust smoke test and benchmark
-      env:
-        MOONCAKE_STORE_CLUSTER_ID: ci_rust_test_cluster
-        MOONCAKE_STORE_RUST_LINK_ASAN: "1"
-      run: ./scripts/ci/run_store_rust_smoke.sh
-      shell: bash
-
-    - name: Run Go store binding integration tests
-      env:
-        MOONCAKE_STORE_CLUSTER_ID: ci_go_test_cluster
-        MOONCAKE_STORE_GO_LINK_COMMON: "1"
-        MOONCAKE_STORE_GO_SANITIZED: "1"
-      run: ./scripts/ci/run_store_go_integration.sh
-      shell: bash
-
-    - name: Test (in build env)
-      run: |
-        cd build
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        ldconfig -v || echo "always continue"
-        MC_METADATA_SERVER=http://127.0.0.1:8080/metadata DEFAULT_KV_LEASE_TTL=500 ctest -j --output-on-failure
-      shell: bash
-
-    - name: Drain HTTP E2E test
-      if: matrix.python-version == '3.12'
-      run: |
-        cd build
-        export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-        # Keep the sanitizer gate on the C++ integration test. The Python
-        # drain script is manual/nightly only because pybind + ASan teardown in
-        # a Python host process is not stable.
-        DEFAULT_KV_LEASE_TTL=500 ./mooncake-store/tests/task_integration_test --gtest_filter='TaskExecutorIntegrationTest.DrainJobCompleteFlow'
-      shell: bash
-
-  # Build the artifact tested below through the exact release wheel path. The
-  # Ubuntu jobs remain consumer tests, not an alternate wheel build environment.
-  build-wheel:
-    needs: [spell-check, clang-format, check-paths]
-    if: *run-ci-for-source-changes
     uses: ./.github/workflows/_build-wheel.yaml
     with:
       python-versions: '["3.10", "3.12"]'
@@ -746,7 +611,7 @@ jobs:
     secrets: inherit
 
   integration-test:
-    needs: [build, build-wheel-cu13, check-paths]
+    needs: [build-wheel-cu13, check-paths]
     if: needs.check-paths.outputs.should-run-downstream == 'true'
     uses: ./.github/workflows/integration-test.yml
     secrets: inherit
@@ -866,7 +731,6 @@ jobs:
       - spell-check
       - clang-format
       - docs-check
-      - build
       - build-wheel
       - build-flags
       - test-wheel-ubuntu

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -378,6 +378,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y lcov gcovr ninja-build
 
+      - name: Test HugeTLB sizing helper
+        run: python3 scripts/test_hicache_hugepage_requirements.py
+
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -416,6 +419,18 @@ jobs:
           MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
           DEFAULT_KV_LEASE_TTL=500 \
             ctest --parallel $(nproc) --output-on-failure
+
+      - name: Run Mooncake Store Rust sanitizer smoke test
+        env:
+          MOONCAKE_STORE_CLUSTER_ID: nightly_asan_rust_cluster
+          MOONCAKE_STORE_RUST_LINK_ASAN: "1"
+        run: ./scripts/ci/run_store_rust_smoke.sh
+
+      - name: Run Go store binding sanitizer integration tests
+        env:
+          MOONCAKE_STORE_CLUSTER_ID: nightly_asan_go_cluster
+          MOONCAKE_STORE_GO_SANITIZED: "1"
+        run: ./scripts/ci/run_store_go_integration.sh
 
       - name: Generate coverage report
         id: coverage


### PR DESCRIPTION
## Description

Move duplicated PR source-build validation into the existing nightly workflows to reduce concurrent PR CI load.

Nightly already runs the corresponding CTest coverage and Release integration paths. This change moves the remaining PR-only checks into `nightly-coverage`:

- HugeTLB sizing helper unit tests;
- Mooncake Store Rust smoke and benchmark linked against the ASan build; and
- Go Store binding integration linked against the ASan and coverage build.

The PR removes the two-leg `build` matrix from `ci.yml`, removes its stale `needs` entries from the integration workflow and CI gate, and leaves wheel build/consumer validation unchanged. `build-flags` is outside this change.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/nightly.yml].each { |f| YAML.load_file(f, aliases: true); puts "YAML OK: #{f}" }'\npython3 scripts/test_hicache_hugepage_requirements.py\ngit diff --check origin/main...HEAD\n```\n\n**Test results:**\n- [ ] Unit tests pass\n- [ ] Integration tests pass (if applicable)\n- [x] Manual testing done: workflow YAML parsing and diff validation pass; the HugeTLB helper runs six passing tests.\n\nA GitHub Actions nightly run remains the final validation for the migrated checks.\n\n## Checklist\n\n- [x] I have performed a self-review of my own code\n- [ ] I have formatted my code using `./scripts/code_format.sh` (workflow-only change)\n- [ ] I have run pre-commit on the files changed in this PR and all hooks pass\n- [ ] I have updated the documentation (if applicable)\n- [ ] I have added tests to prove my changes are effective\n- [x] For changes >500 LOC: I have filed an RFC issue\n\n## AI Assistance Disclosure\n\n- [ ] No AI tools were used\n- [x] AI tools were used (specify below)\n\nCodex inspected the current CI and nightly workflows, implemented the migration, and ran local YAML, diff, and helper-test validation. The branch owner reviewed the migration scope and is responsible for the submitted change.