### PR TITLE
[CI] Simplify build-flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,9 +262,6 @@ jobs:
         df -h
       shell: bash
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-
     - name: Build transfer engine only
       run: |
         cd mooncake-transfer-engine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,11 +218,8 @@ jobs:
         python-version: ['3.10', '3.12']
     env:
       CI: "true"
-      TORCH_CUDA_ARCH_LIST: "8.0;9.0"
       SCCACHE_GHA_ENABLED: "true"
       PIP_NO_CACHE_DIR: "1"
-      MAX_JOBS: "2"
-      EP_TORCH_VERSIONS: "2.11.0;2.12.0;2.12.1;2.13.0"
       CMAKE_RELWITHDEBINFO_FLAGS: "-O2 -DNDEBUG"
 
     steps:
@@ -298,130 +295,6 @@ jobs:
         rm -rf build
         df -h
       shell: bash
-
-    - name: Configure project with all settings are ON
-      run: |
-        mkdir build
-        cd build
-        # ENABLE_DEBUG_SYMBOLS=OFF alone still leaves CMake's RelWithDebInfo -g.
-        cmake -G Ninja .. \
-          -DUSE_ETCD=ON \
-          -DUSE_CXL=ON \
-          -DUSE_REDIS=ON \
-          -DUSE_HTTP=ON \
-          -DWITH_STORE=ON \
-          -DWITH_P2P_STORE=ON \
-          -DWITH_METRICS=ON \
-          -DBUILD_UNIT_TESTS=ON \
-          -DBUILD_EXAMPLES=ON \
-          -DENABLE_SCCACHE=ON \
-          -DUSE_CUDA=ON \
-          -DUSE_MNNVL=OFF \
-          -DUSE_UB=OFF \
-          -DCMAKE_EXE_LINKER_FLAGS="-L/usr/local/cuda/lib64/stubs" \
-          "-DCMAKE_C_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
-          "-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=${CMAKE_RELWITHDEBINFO_FLAGS}" \
-          -DENABLE_DEBUG_SYMBOLS=OFF
-      shell: bash
-      # TODO: lack USE_NVMEOF,USE_MNNVL
-
-    - name: Build project with all settings are ON
-      run: |
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        cd build
-        cmake --build .
-        sudo cmake --install .
-        df -h
-      shell: bash
-
-    - name: Configure project with unit tests and examples
-      run: |
-        cd build
-        cmake -G Ninja .. -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=ON -DWITH_STORE_RUST=ON -DENABLE_SCCACHE=ON -DENABLE_DEBUG_SYMBOLS=OFF
-      shell: bash
-
-    - name: Build project with unit tests and examples
-      run: |
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        cd build
-        cmake --build .
-        sudo cmake --install .
-      shell: bash
-
-    - name: Check Mooncake Store Rust bindings, examples, and tests
-      run: |
-        # libcuda.so.1 (SONAME of the CUDA stub) must be findable at runtime.
-        # The toolkit stubs dir only ships libcuda.so; create the versioned symlink.
-        if [ -f /usr/local/cuda/lib64/stubs/libcuda.so ] && \
-           [ ! -e /usr/local/cuda/lib64/stubs/libcuda.so.1 ]; then
-          sudo ln -s libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
-        fi
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        cd mooncake-store/rust
-        export MOONCAKE_BUILD_DIR=$GITHUB_WORKSPACE/build
-        cargo test --lib
-        MOONCAKE_STORE_LIB_DIR=$GITHUB_WORKSPACE/build/mooncake-store/src \
-        MOONCAKE_STORE_INCLUDE_DIR=$GITHUB_WORKSPACE/mooncake-store/include \
-          cargo test --examples --tests --no-run
-        cargo clean
-      shell: bash
-
-    - name: Verify Mooncake Store Rust dlopen bindings and packaging
-      run: |
-        cd mooncake-store/rust
-        # 1. Committed dlopen bindings must stay in sync with store_c.h.
-        cargo run --locked --example generate_dlopen_bindings
-        git diff --exit-code -- src/generated/ffi_dlopen_bindings.rs
-        # 2. The published dlopen crate must build with no header/bindgen: package
-        #    it, extract, and check the dlopen feature against the packaged files.
-        cargo package --no-verify --allow-dirty
-        crate=$(ls target/package/mooncake_store-*.crate | head -1)
-        dest=$(mktemp -d)
-        tar xzf "$crate" -C "$dest"
-        (cd "$dest"/mooncake_store-* && cargo check --no-default-features --features dlopen)
-      shell: bash
-
-    - name: Configure project
-      run: |
-        cd build
-        rm -r */tests
-        cmake -G Ninja .. \
-          -DBUILD_UNIT_TESTS=OFF \
-          -DBUILD_EXAMPLES=OFF \
-          -DUSE_HTTP=ON \
-          -DENABLE_SCCACHE=ON \
-          -DUSE_CXL=ON \
-          -DWITH_EP=ON \
-          "-DEP_TORCH_VERSIONS=${EP_TORCH_VERSIONS}" \
-          -DENABLE_DEBUG_SYMBOLS=OFF
-      shell: bash
-
-    - name: Build project
-      run: |
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        cd build
-        cmake --build .
-        sudo cmake --install .
-      shell: bash
-
-    - name: Build nvlink_allocator.so
-      run: |
-        mkdir -p build/mooncake-transfer-engine/nvlink-allocator
-        cd mooncake-transfer-engine/nvlink-allocator
-        export PATH=/usr/local/nvidia/bin:/usr/local/nvidia/lib64:$PATH
-        export LD_LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH
-        export LIBRARY_PATH=/usr/local/cuda/lib64/stubs:$LIBRARY_PATH
-        bash build.sh ../../build/mooncake-transfer-engine/nvlink-allocator/
-      shell: bash
-
-    - name: Run sccache stat for check
-      if: ${{ env.SCCACHE_PATH != '' }}
-      shell: bash
-      run: ${SCCACHE_PATH} --show-stats
-
 
   spell-check:
     name: Spell Check with Typos

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -248,6 +248,7 @@ jobs:
           mkdir build && cd build
           cmake -G Ninja .. \
             -DUSE_HTTP=ON -DUSE_CXL=ON -DUSE_UB=ON -DUSE_ETCD=ON -DUSE_CUDA=ON \
+            -DWITH_P2P_STORE=ON \
             -DSTORE_USE_ETCD=ON -DCMAKE_BUILD_TYPE=Release \
             -DBUILD_UNIT_TESTS=ON -DENABLE_SCCACHE=ON
 
@@ -303,6 +304,31 @@ jobs:
           MOONCAKE_STORE_CLUSTER_ID: nightly_rust_cluster
           MOONCAKE_STORE_RUST_LINK_ASAN: "0"
         run: ./scripts/ci/run_store_rust_smoke.sh
+
+      - name: Check Mooncake Store Rust bindings, examples, and tests
+        env:
+          MOONCAKE_BUILD_DIR: ${{ github.workspace }}/build
+          MOONCAKE_STORE_LIB_DIR: ${{ github.workspace }}/build/mooncake-store/src
+          MOONCAKE_STORE_INCLUDE_DIR: ${{ github.workspace }}/mooncake-store/include
+        run: |
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/build/mooncake-asio:$GITHUB_WORKSPACE/build/mooncake-store/src:$GITHUB_WORKSPACE/build/mooncake-store/src/cachelib_memory_allocator:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src:$GITHUB_WORKSPACE/build/mooncake-transfer-engine/src/common/base:$GITHUB_WORKSPACE/build/mooncake-common/etcd:/usr/local/lib:${LD_LIBRARY_PATH:-}"
+          cd mooncake-store/rust
+          cargo test --lib
+          cargo test --examples --tests --no-run
+          cargo clean
+
+      - name: Verify Mooncake Store Rust dlopen bindings and packaging
+        env:
+          MOONCAKE_STORE_INCLUDE_DIR: ${{ github.workspace }}/mooncake-store/include
+        run: |
+          cd mooncake-store/rust
+          cargo run --locked --example generate_dlopen_bindings
+          git diff --exit-code -- src/generated/ffi_dlopen_bindings.rs
+          cargo package --no-verify --allow-dirty
+          crate=$(ls target/package/mooncake_store-*.crate | head -1)
+          dest=$(mktemp -d)
+          tar xzf "$crate" -C "$dest"
+          (cd "$dest"/mooncake_store-* && cargo check --no-default-features --features dlopen)
 
       - name: Run Go store binding integration tests
         env:


### PR DESCRIPTION
## Description

Simplify the responsibilities of `build-flags` by removing the redundant top-level feature and EP compilation stages. The job now keeps the standalone Transfer Engine CPU/CXL/Redis compile, while nightly owns the broader top-level coverage.

This change:

- removes the top-level CUDA/Store/P2P/EP/Torch matrix build and its duplicate tests/examples reconfiguration from `build-flags`;
- moves `WITH_P2P_STORE=ON` into the existing nightly top-level Release build;
- moves Rust Store unit/examples compilation, committed dlopen binding consistency, and packaged-crate dlopen checks into `nightly-test`; and
- removes build-only environment variables that were used only by the deleted EP matrix.

The nightly Rust checks use explicit paths to the current CMake build outputs and preserve the CUDA driver runtime path established earlier in the job. The change does not alter the existing EP wheel/integration coverage.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ruby -e 'require "yaml"; %w[.github/workflows/ci.yml .github/workflows/nightly.yml].each { |f| YAML.load_file(f, aliases: true); puts "YAML OK: #{f}" }'\ngit diff --check origin/main...HEAD\nbash -n scripts/ci/run_store_rust_smoke.sh\nbash -n scripts/ci/run_store_go_integration.sh\n```\n\n**Test results:**\n- [ ] Unit tests pass\n- [ ] Integration tests pass (if applicable)\n- [x] Manual testing done: both workflow files parse, diff validation passes, and existing CI helper scripts pass shell syntax checks.\n\nA GitHub Actions nightly run remains the final validation for the migrated P2P and Rust contract checks.\n\n## Checklist\n\n- [x] I have performed a self-review of my own code\n- [ ] I have formatted my code using `./scripts/code_format.sh` (workflow-only change)\n- [ ] I have run pre-commit on the files changed in this PR and all hooks pass\n- [ ] I have updated the documentation (if applicable)\n- [ ] I have added tests to prove my changes are effective\n- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)\n\n## AI Assistance Disclosure\n\n- [ ] No AI tools were used\n- [x] AI tools were used (specify below)\n\nCodex inspected the current CI and nightly workflows, implemented the build-flags simplification, and ran local YAML, diff, and shell syntax validation. The branch owner reviewed the migration scope and is responsible for the submitted change.