### PR TITLE
[Store]: Split segments by transport limit

### DIFF
--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -280,9 +280,10 @@ mc_store_rest_server --config /path/to/mooncake_config.json --port 8080
 ```
 
 ### `/api/mount_shm`
-Mount a named shared memory object as one or more Mooncake store segments. If
-the requested size exceeds the maximum registration size, the service may split
-the region and return multiple segment ids.
+Mount a named shared memory object as one or more Mooncake store segments.
+Protocols with a registration-size limit split oversized regions and return
+multiple segment ids. Protocols without such a limit, such as TCP, use a single
+segment regardless of `max_mr_size`.
 
 **Method**: `POST`
 **Content-Type**: `application/json`
@@ -366,8 +367,9 @@ curl -X POST http://localhost:8080/api/unmount_shm \
 
 ### `/api/mount`
 Allocate memory inside the store process and mount it as one or more Mooncake
-store segments. If the requested size exceeds the maximum registration size,
-the service may split it and return multiple segment ids. The response includes
+store segments. Protocols with a registration-size limit split oversized
+requests and return multiple segment ids. Protocols without such a limit, such
+as TCP, use a single segment regardless of `max_mr_size`. The response includes
 the actual allocated size after alignment.
 
 **Method**: `POST`

--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -282,8 +282,8 @@ mc_store_rest_server --config /path/to/mooncake_config.json --port 8080
 ### `/api/mount_shm`
 Mount a named shared memory object as one or more Mooncake store segments.
 Protocols with a registration-size limit split oversized regions and return
-multiple segment ids. Protocols without such a limit, such as TCP, use a single
-segment regardless of `max_mr_size`.
+multiple segment ids. Protocols without such a Store-level limit, such as TCP
+and RDMA, use a single segment regardless of `max_mr_size`.
 
 **Method**: `POST`
 **Content-Type**: `application/json`
@@ -368,9 +368,9 @@ curl -X POST http://localhost:8080/api/unmount_shm \
 ### `/api/mount`
 Allocate memory inside the store process and mount it as one or more Mooncake
 store segments. Protocols with a registration-size limit split oversized
-requests and return multiple segment ids. Protocols without such a limit, such
-as TCP, use a single segment regardless of `max_mr_size`. The response includes
-the actual allocated size after alignment.
+requests and return multiple segment ids. Protocols without such a Store-level
+limit, such as TCP and RDMA, use a single segment regardless of `max_mr_size`.
+The response includes the actual allocated size after alignment.
 
 **Method**: `POST`
 **Content-Type**: `application/json`

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -34,6 +34,9 @@ class PutOperation;
 class DistributedStorageBackend;
 class RealClient;
 
+std::optional<size_t> GetTransportRegistrationLimit(
+    const std::string& protocol);
+
 /**
  * @brief Result of a query operation containing replica information and lease
  * timeout

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -801,9 +801,9 @@ class RealClient : public PyClient {
 
     /**
      * @brief Mount a shared memory file region and return segment ids.
-     *        If size > max_mr_size, it will be split into multiple chunks
-     *        and mounted separately. RealClient will open(path) + mmap
-     *        internally for each chunk.
+     *        Protocols with a registration limit split larger regions into
+     *        multiple chunks. RealClient will open(path) + mmap internally
+     *        for each chunk.
      */
     int mountSegment(const std::string &path, size_t offset, size_t size,
                      const std::string &protocol, const std::string &location,
@@ -818,7 +818,7 @@ class RealClient : public PyClient {
 
     /**
      * @brief Allocate memory internally and mount segments to master.
-     *        If size > max_mr_size, it will be split into multiple chunks.
+     *        Protocols with a registration limit split larger regions.
      *        Memory is allocated via allocate_buffer_allocator_memory.
      *        The actual allocated size (aligned up to Slab::kSize) is written
      *        to out_allocated_size if non-null.

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -51,6 +51,17 @@
 
 namespace mooncake {
 
+std::optional<size_t> GetTransportRegistrationLimit(
+    const std::string& protocol) {
+    if (protocol == "rdma" || protocol == "efa" || protocol == "cxi") {
+        return globalConfig().max_mr_size;
+    }
+    if (protocol == "ub") {
+        return globalConfig().max_seg_size;
+    }
+    return std::nullopt;
+}
+
 namespace {
 
 constexpr size_t kObjectChecksumD2HChunkSize = 8 * 1024 * 1024;
@@ -603,8 +614,8 @@ tl::expected<std::optional<ha::HABackendSpec>, ErrorCode> ParseHABackendSpec(
     }};
 }
 
-tl::expected<void, ErrorCode> CheckRegisterMemoryParams(const void* addr,
-                                                        size_t length) {
+tl::expected<void, ErrorCode> CheckRegisterMemoryParams(
+    const void* addr, size_t length, const std::string& protocol) {
     if (addr == nullptr) {
         LOG(ERROR) << "addr is nullptr";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
@@ -613,11 +624,10 @@ tl::expected<void, ErrorCode> CheckRegisterMemoryParams(const void* addr,
         LOG(ERROR) << "length is 0";
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
-    // Tcp is not limited by max_mr_size, but we ignore it for now.
-    auto max_mr_size = globalConfig().max_mr_size;  // Max segment size
-    if (length > max_mr_size) {
-        LOG(ERROR) << "length " << length
-                   << " is larger than max_mr_size: " << max_mr_size;
+    if (auto limit = GetTransportRegistrationLimit(protocol);
+        limit.has_value() && length > *limit) {
+        LOG(ERROR) << "length " << length << " exceeds registration limit "
+                   << *limit << " for protocol " << protocol;
         return tl::unexpected(ErrorCode::INVALID_PARAMS);
     }
     return {};
@@ -3483,7 +3493,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
 tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
     const void* buffer, size_t size, const std::string& protocol,
     const std::string& location) {
-    auto check_result = CheckRegisterMemoryParams(buffer, size);
+    auto check_result = CheckRegisterMemoryParams(buffer, size, protocol);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }
@@ -3668,7 +3678,7 @@ void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
 tl::expected<void, ErrorCode> Client::RegisterLocalMemory(
     void* addr, size_t length, const std::string& location,
     bool remote_accessible, bool update_metadata) {
-    auto check_result = CheckRegisterMemoryParams(addr, length);
+    auto check_result = CheckRegisterMemoryParams(addr, length, protocol_);
     if (!check_result) {
         return tl::unexpected(check_result.error());
     }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -53,7 +53,7 @@ namespace mooncake {
 
 std::optional<size_t> GetTransportRegistrationLimit(
     const std::string& protocol) {
-    if (protocol == "rdma" || protocol == "efa" || protocol == "cxi") {
+    if (protocol == "efa" || protocol == "cxi") {
         return globalConfig().max_mr_size;
     }
     if (protocol == "ub") {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -64,6 +64,22 @@ namespace mooncake {
 namespace {
 constexpr std::chrono::seconds kIpcRequestRecvTimeout{5};
 
+size_t DivideRoundUp(size_t value, size_t divisor) {
+    return value / divisor + (value % divisor != 0);
+}
+
+size_t GetNextSegmentSize(size_t remaining,
+                          const std::optional<size_t> &split_limit,
+                          size_t alignment) {
+    if (!split_limit.has_value()) return remaining;
+    const size_t aligned_limit = (*split_limit / alignment) * alignment;
+    if (aligned_limit == 0) return 0;
+    const size_t segment_count = DivideRoundUp(remaining, aligned_limit);
+    const size_t balanced_size = DivideRoundUp(remaining, segment_count);
+    return std::min(remaining,
+                    DivideRoundUp(balanced_size, alignment) * alignment);
+}
+
 bool IsHostStoreSegmentProtocol(const std::string &protocol) {
     return protocol.empty() || protocol == "tcp" || protocol == "rdma" ||
            protocol == "efa" || protocol == "cxi" || protocol == "rpc_only";
@@ -868,9 +884,9 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         LOG(INFO) << "Local buffer size is 0, skip registering local memory";
     }
 
-    // If global_segment_size is 0, skip mount segment;
-    // If global_segment_size is larger than max_mr_size, split to multiple
-    // mapped_shms.
+    // If global_segment_size is 0, skip mount segment. Transports with a
+    // registration limit split it into balanced chunks; other transports use
+    // one segment.
     if (protocol == "cxl") {
         size_t cxl_dev_size = 0;
         const char *env = std::getenv("MC_CXL_DEV_SIZE");
@@ -895,9 +911,11 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         }
 
     } else {
-        auto max_mr_size = globalConfig().max_mr_size;     // Max segment size
         uint64_t total_glbseg_size = global_segment_size;  // For logging
         uint64_t current_glbseg_size = 0;                  // For logging
+
+        const auto split_limit = GetTransportRegistrationLimit(protocol);
+        const size_t alignment = facebook::cachelib::Slab::kSize;
 
         // For RDMA, auto-discover NUMA nodes with NICs and distribute
         // global_segment across them for full NIC utilization.
@@ -921,7 +939,13 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             protocol == "rdma" && should_use_hugepage;
 
         while (global_segment_size > 0) {
-            size_t segment_size = std::min(global_segment_size, max_mr_size);
+            size_t segment_size =
+                GetNextSegmentSize(global_segment_size, split_limit, alignment);
+            if (segment_size == 0) {
+                LOG(ERROR) << "Registration limit is smaller than segment "
+                              "alignment";
+                return tl::unexpected(ErrorCode::INVALID_PARAMS);
+            }
             global_segment_size -= segment_size;
 
             size_t mapped_size = segment_size;
@@ -963,8 +987,10 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 LOG(ERROR) << "Failed to allocate segment memory";
                 return tl::unexpected(ErrorCode::INVALID_PARAMS);
             }
-            current_glbseg_size += mapped_size;
-            LOG(INFO) << "Mounting segment: " << mapped_size << " bytes, "
+            const size_t mount_size =
+                split_limit.has_value() ? segment_size : mapped_size;
+            current_glbseg_size += mount_size;
+            LOG(INFO) << "Mounting segment: " << mount_size << " bytes, "
                       << current_glbseg_size << " of " << total_glbseg_size;
 
             if (this->protocol == "ascend" || this->protocol == "ubshmem") {
@@ -1010,7 +1036,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             auto pinned_region =
                 TryPinStoreSegment(ptr, mapped_size, this->protocol, "setup");
             auto mount_result =
-                client_->MountSegment(ptr, mapped_size, protocol, seg_location);
+                client_->MountSegment(ptr, mount_size, protocol, seg_location);
             if (!mount_result.has_value()) {
                 if (!ReleasePinnedRegionForFree(pinned_region,
                                                 "Store setup segment")) {
@@ -1214,8 +1240,8 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         get_config(config, CONFIG_KEY_IPC_SOCKET_PATH);
 
     // A size of 0 keeps the pure client/server setup semantics.
-    // global_segment_size is a total capacity and may exceed max_mr_size; the
-    // setup path splits it into mountable chunks below.
+    // global_segment_size is a total capacity; protocols with a registration
+    // limit split it into mountable chunks below.
     auto validate_min_size = [](const char *key, size_t value) {
         if (value != 0 && value < MIN_SEGMENT_SIZE) {
             LOG(ERROR) << "Invalid " << key << ": " << value
@@ -1372,18 +1398,7 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
         return -1;
     }
 
-    size_t max_mr_size = globalConfig().max_mr_size;
-    if (max_mr_size == 0) {
-        LOG(ERROR) << "Invalid max_mr_size: 0";
-        return -1;
-    }
-
     size_t page_size = sysconf(_SC_PAGESIZE);
-    if (max_mr_size < page_size) {
-        LOG(ERROR) << "max_mr_size " << max_mr_size
-                   << " is smaller than page_size " << page_size;
-        return -1;
-    }
 
     int fd = open(path.c_str(), O_RDWR);
     if (fd < 0) {
@@ -1412,14 +1427,15 @@ int RealClient::mountSegment(const std::string &path, size_t offset,
         return -1;
     }
 
-    size_t aligned_max_chunk = (max_mr_size / page_size) * page_size;
+    const auto split_limit = GetTransportRegistrationLimit(protocol);
     size_t remaining = size;
     size_t current_offset = offset;
     std::vector<std::string> mounted_ids;
     std::vector<MountedSegmentRecord> mounted_records;
 
     while (remaining > 0) {
-        size_t chunk_size = std::min(remaining, aligned_max_chunk);
+        size_t chunk_size =
+            GetNextSegmentSize(remaining, split_limit, page_size);
         if (chunk_size == 0) break;
 
         void *ptr = mmap(nullptr, chunk_size, PROT_READ | PROT_WRITE,
@@ -1625,34 +1641,12 @@ int RealClient::allocateAndMountSegment(
         return -1;
     }
 
-    size_t max_mr_size = globalConfig().max_mr_size;
-    if (max_mr_size == 0) {
-        LOG(ERROR) << "Invalid max_mr_size: 0";
-        return -1;
-    }
-
     if (size == 0) {
         LOG(ERROR) << "size is 0";
         return -1;
     }
 
     const size_t slab_size = facebook::cachelib::Slab::kSize;
-    size_t page_size = sysconf(_SC_PAGESIZE);
-    if (max_mr_size < page_size) {
-        LOG(ERROR) << "max_mr_size " << max_mr_size
-                   << " is smaller than page_size " << page_size;
-        return -1;
-    }
-
-    size_t aligned_max_chunk = (max_mr_size / page_size) * page_size;
-    if (aligned_max_chunk < slab_size) {
-        LOG(ERROR) << "max_mr_size " << max_mr_size
-                   << " is smaller than slab_size " << slab_size;
-        return -1;
-    }
-    // Round down chunk size to slab_size multiple
-    aligned_max_chunk = (aligned_max_chunk / slab_size) * slab_size;
-
     // Check overflow before aligning up to slab_size
     if (size > std::numeric_limits<size_t>::max() - (slab_size - 1)) {
         LOG(ERROR) << "size " << size
@@ -1662,12 +1656,14 @@ int RealClient::allocateAndMountSegment(
     // Round up total size to slab_size multiple
     size_t aligned_total_size =
         ((size + slab_size - 1) / slab_size) * slab_size;
+    const auto split_limit = GetTransportRegistrationLimit(protocol);
     size_t remaining = aligned_total_size;
     std::vector<std::string> mounted_ids;
     std::vector<AllocatedSegmentRecord> allocated_records;
 
     while (remaining > 0) {
-        size_t chunk_size = std::min(remaining, aligned_max_chunk);
+        size_t chunk_size =
+            GetNextSegmentSize(remaining, split_limit, slab_size);
         if (chunk_size == 0) break;
 
         void *ptr = allocate_buffer_allocator_memory(chunk_size, protocol);

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -21,8 +21,8 @@
 #include <cuda_runtime_api.h>
 #endif
 
-#include "real_client.h"
 #include "config.h"
+#include "real_client.h"
 #include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
@@ -76,6 +76,17 @@ class ScopedMaxMrSize {
    private:
     size_t old_max_mr_size_;
 };
+
+TEST(TransportRegistrationLimitTest, ClassifiesProtocols) {
+    constexpr size_t kMaxMrSize = 64 * 1024 * 1024;
+    ScopedMaxMrSize limit(kMaxMrSize);
+
+    EXPECT_EQ(GetTransportRegistrationLimit("rdma"), std::nullopt);
+    EXPECT_EQ(GetTransportRegistrationLimit("tcp"), std::nullopt);
+    EXPECT_EQ(GetTransportRegistrationLimit("efa"), kMaxMrSize);
+    EXPECT_EQ(GetTransportRegistrationLimit("cxi"), kMaxMrSize);
+    EXPECT_TRUE(GetTransportRegistrationLimit("ub").has_value());
+}
 
 class RealClientTest : public ::testing::Test {
    protected:
@@ -322,14 +333,14 @@ TEST_F(RealClientTest, DynamicMountApisBalanceLimitedSegments) {
     std::vector<std::string> allocated_ids;
     size_t allocated_size = 0;
     ASSERT_EQ(py_client_->allocateAndMountSegment(
-                  6 * slab_size, "rdma", "", allocated_ids, &allocated_size),
+                  6 * slab_size, "efa", "", allocated_ids, &allocated_size),
               0);
     ASSERT_EQ(allocated_ids.size(), 2u);
 
     const std::string path = CreateTempSegmentFile(6 * slab_size);
     ASSERT_FALSE(path.empty());
     std::vector<std::string> mounted_ids;
-    ASSERT_EQ(py_client_->mountSegment(path, 0, 6 * slab_size, "rdma", "",
+    ASSERT_EQ(py_client_->mountSegment(path, 0, 6 * slab_size, "efa", "",
                                        mounted_ids),
               0);
     ASSERT_EQ(mounted_ids.size(), 2u);

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -357,6 +357,42 @@ TEST_F(RealClientTest, DynamicMountApisBalanceLimitedSegments) {
     EXPECT_EQ(std::remove(path.c_str()), 0);
 }
 
+TEST_F(RealClientTest, DynamicMountApisDoNotSplitRdma) {
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    ScopedMaxMrSize limit(4 * slab_size);
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()));
+    master_address_ = master_.master_address();
+    ASSERT_EQ(py_client_->setup_real("localhost:17816", "P2PHANDSHAKE", 0, 0,
+                                     "tcp", "", master_address_),
+              0);
+
+    std::vector<std::string> allocated_ids;
+    size_t allocated_size = 0;
+    ASSERT_EQ(py_client_->allocateAndMountSegment(
+                  6 * slab_size, "rdma", "", allocated_ids, &allocated_size),
+              0);
+    ASSERT_EQ(allocated_ids.size(), 1u);
+
+    const std::string path = CreateTempSegmentFile(6 * slab_size);
+    ASSERT_FALSE(path.empty());
+    std::vector<std::string> mounted_ids;
+    ASSERT_EQ(py_client_->mountSegment(path, 0, 6 * slab_size, "rdma", "",
+                                       mounted_ids),
+              0);
+    ASSERT_EQ(mounted_ids.size(), 1u);
+
+    auto details = master_.service()->GetSegmentsDetailForAdmin();
+    ASSERT_TRUE(details.has_value());
+    ASSERT_EQ(details->size(), 2u);
+    for (const auto& detail : *details) {
+        EXPECT_EQ(detail.size_bytes, 6 * slab_size);
+    }
+
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(allocated_ids), 0);
+    EXPECT_EQ(py_client_->unmountSegment(mounted_ids), 0);
+    EXPECT_EQ(std::remove(path.c_str()), 0);
+}
+
 TEST_F(RealClientTest, AllocateAndMountSegmentRejectsOverflowSize) {
     StartMasterAndSetupClient();
 

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "real_client.h"
+#include "config.h"
 #include "test_server_helpers.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
@@ -61,6 +62,19 @@ class ScopedEnvVar {
    private:
     std::string name_;
     std::optional<std::string> previous_;
+};
+
+class ScopedMaxMrSize {
+   public:
+    explicit ScopedMaxMrSize(size_t max_mr_size)
+        : old_max_mr_size_(globalConfig().max_mr_size) {
+        globalConfig().max_mr_size = max_mr_size;
+    }
+
+    ~ScopedMaxMrSize() { globalConfig().max_mr_size = old_max_mr_size_; }
+
+   private:
+    size_t old_max_mr_size_;
 };
 
 class RealClientTest : public ::testing::Test {
@@ -277,6 +291,59 @@ TEST_F(RealClientTest, AllocateAndMountSegmentAlignsAndUnmounts) {
     EXPECT_EQ(allocated_size, slab_size * 2);
     ASSERT_FALSE(segment_ids.empty());
     EXPECT_EQ(py_client_->unmountAndFreeSegment(segment_ids), 0);
+}
+
+TEST_F(RealClientTest, TcpSetupDoesNotSplitAtMaxMrSize) {
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    ScopedMaxMrSize limit(2 * slab_size);
+
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()));
+    master_address_ = master_.master_address();
+    ASSERT_EQ(
+        py_client_->setup_real("localhost:17814", "P2PHANDSHAKE", 6 * slab_size,
+                               0, "tcp", "", master_address_),
+        0);
+
+    auto details = master_.service()->GetSegmentsDetailForAdmin();
+    ASSERT_TRUE(details.has_value());
+    ASSERT_EQ(details->size(), 1u);
+    EXPECT_EQ(details->front().size_bytes, 6 * slab_size);
+}
+
+TEST_F(RealClientTest, DynamicMountApisBalanceLimitedSegments) {
+    const size_t slab_size = facebook::cachelib::Slab::kSize;
+    ScopedMaxMrSize limit(4 * slab_size);
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()));
+    master_address_ = master_.master_address();
+    ASSERT_EQ(py_client_->setup_real("localhost:17815", "P2PHANDSHAKE", 0, 0,
+                                     "tcp", "", master_address_),
+              0);
+
+    std::vector<std::string> allocated_ids;
+    size_t allocated_size = 0;
+    ASSERT_EQ(py_client_->allocateAndMountSegment(
+                  6 * slab_size, "rdma", "", allocated_ids, &allocated_size),
+              0);
+    ASSERT_EQ(allocated_ids.size(), 2u);
+
+    const std::string path = CreateTempSegmentFile(6 * slab_size);
+    ASSERT_FALSE(path.empty());
+    std::vector<std::string> mounted_ids;
+    ASSERT_EQ(py_client_->mountSegment(path, 0, 6 * slab_size, "rdma", "",
+                                       mounted_ids),
+              0);
+    ASSERT_EQ(mounted_ids.size(), 2u);
+
+    auto details = master_.service()->GetSegmentsDetailForAdmin();
+    ASSERT_TRUE(details.has_value());
+    ASSERT_EQ(details->size(), 4u);
+    for (const auto& detail : *details) {
+        EXPECT_EQ(detail.size_bytes, 3 * slab_size);
+    }
+
+    EXPECT_EQ(py_client_->unmountAndFreeSegment(allocated_ids), 0);
+    EXPECT_EQ(py_client_->unmountSegment(mounted_ids), 0);
+    EXPECT_EQ(std::remove(path.c_str()), 0);
 }
 
 TEST_F(RealClientTest, AllocateAndMountSegmentRejectsOverflowSize) {

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -222,6 +222,7 @@ class InProcMaster {
         return std::string("http://127.0.0.1:") +
                std::to_string(http_metrics_port_);
     }
+    std::shared_ptr<WrappedMasterService> service() const { return wrapped_; }
 
    private:
     std::unique_ptr<coro_rpc::coro_rpc_server> server_;


### PR DESCRIPTION
## Motivation

Segment splitting was previously applied unconditionally using `globalConfig().max_mr_size`, even for transports such as TCP that do not have an MR size limit. The existing greedy strategy could also produce uneven segments (for example, `1 TB + 0.4 TB`), causing allocation skew with the default `RandomAllocationStrategy`.

Thanks to #1677 for identifying the transport-awareness and allocation-balance issues and for providing the original direction for this improvement. This PR implements the same goal with a smaller change rebased on the latest `main`.


## Changes
- Apply `max_mr_size` only to `efa` and `cxi`, and apply `max_seg_size` to `ub`. RDMA relies on Transfer Engine's internal MR chunking, while TCP and other unconstrained transports use a single Store segment.
- Use best-effort balanced partitioning for constrained transports while preserving page/slab alignment and the minimum required segment count.
- Cover all three Store segment creation paths: setup, file-backed mount, and allocate-and-mount.
- Make memory registration validation protocol-aware and document the updated behavior.


## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

- Built with CUDA 13.1 and tested on an NVIDIA A100-SXM4-40GB (`sm80`).
- Passed all 61 `pybind_client_test` tests.
- Verified TCP and RDMA remain a single Store segment when their size exceeds `max_mr_size`.
- Verified a constrained 6-slab region is split evenly into `3 + 3` slabs.
- Verified real RDMA registration and cleanup on `ibp12s0` with `MC_MAX_MR_SIZE=16777216` (16 MiB).
- Built the Sphinx HTML documentation successfully.


**Test results:**
- [x] Unit tests pass

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helps me to write code and run tests, but it's reviewed by human.