### PR TITLE
[Docs][TENT] Document the FakeTransport runtime test mechanism

### DIFF
--- a/docs/source/design/tent/failover.md
+++ b/docs/source/design/tent/failover.md
@@ -1,3 +1,4 @@
+(tent-failover)=
 # TENT Failover
 
 TENT hides transfer failures from the application by recovering inside the data path.
@@ -135,56 +136,19 @@ The counter is only built when TENT is compiled with `-DTENT_METRICS_ENABLED=ON`
 | `Rail recovered: local_nic=... remote_nic=... (cooldown expired)` | Cooldown elapsed and the rail is back in service. |
 | `Rail recovered: ... (un-paused by successful transfer)` | Live success on a previously paused rail brought it back early. |
 
+(tent-failover-testing)=
 ## Testing
 
-Real hardware faults are hard to stage, so TENT tests the failover machinery with decorator-style fault injection.
+Real hardware faults are hard to stage, so failover is tested by driving the real `TransferEngineImpl` with FakeTransport backends and a fault-injecting decorator. The engine is unmodified: a completion-stage `FAILED` looks like a WC error or a dropped peer, and `resubmitTransferTask` runs as it would in production.
 
-### FaultProxyTransport
+The harness — why a fake `Transport` is enough, how fakes are swapped in, and what this can and cannot prove — is in {ref}`TENT Testing <tent-testing>`. That page is the mechanism; this section only notes what failover uses it for:
 
-`FaultProxyTransport` wraps any `Transport` and injects four policy-driven faults:
+* Completion-stage `FAILED` on the primary must resubmit on the next available transport.
+* Exhausting `max_failover_attempts` (including `0` and `1`) must surface `FAILED` and must not touch a transport beyond the budget.
+* `failover_count` is per-task: one failing request must not spend another request's budget.
+* With `enable_auto_failover_on_poll=false`, status polling is observational; `progressBatch` / `waitTransferCompletion` / `transferSync` still recover.
 
-* `submit_fail_rate` — probability that `submitTransferTasks` returns an error.
-* `status_corrupt_rate` — probability that `getTransferStatus` flips `COMPLETED → FAILED`.
-* `fail_after_n_submits` — deterministic variant: succeed the first N submits, then always fail.
-* `fail_install` — make `install()` fail, simulating a transport that cannot come up.
-
-Because it implements the `Transport` interface, the engine sees an ordinary transport. All failover paths (`submitTransfer`, `getTransferStatus`, `resubmitTransferTask`) run unmodified.
-
-### Test-only injection hook
-
-`TransferEngineImpl::swapTransportForTest` replaces the transport in one slot after `construct()`. This is the only way the end-to-end test can wrap the real transport with `FaultProxyTransport` without bypassing `resolveTransport` or `resubmitTransferTask`. Production code never calls it.
-
-### End-to-end suite
-
-The end-to-end failover test suite drives the real `TransferEngineImpl` with fake transports (`FakeTransport`) wrapped in `FaultProxyTransport`. It uses a `p2p` metadata backend on `127.0.0.1` so no external services are required — the whole suite is self-contained.
-
-Current cases:
-
-| Test | What it exercises |
-|------|-------------------|
-| `StatusCorruptionTriggersFailoverToSecondary` | Primary reports `FAILED` in `getTransferStatus`; engine must resubmit on the secondary. |
-| `BothTransportsFailExhaustsFailoverBudget` | Both transports fail at the completion stage; task must surface `FAILED` once the budget is drained. |
-| `MixedFaultsAcrossManySubmissions` | 10 one-request batches with 30% completion corruption on RDMA; every task must end `COMPLETED`, and submit-counter math must hold. |
-| `MaxFailoverAttemptsZeroDisablesFailover` | `max_failover_attempts = 0` → the first completion fault is permanent, TCP is never touched. |
-| `MaxFailoverAttemptsOneAllowsSingleFailover` | `max_failover_attempts = 1` → one switch allowed; RDMA fault → TCP success. |
-| `PerTaskFailoverCountsAreIndependent` | A failing task must not consume another task's budget; `failover_count` is strictly per-task. |
-
-A test-local `PerRequestFaultProxy` (in the same file) subclasses `FaultProxyTransport` to take a `std::function` predicate, remembers which sub-task ids it marked as "poisoned" at submit time, and flips only those completions from `COMPLETED` to `FAILED` at status-query time.
-
-### Running manually
-
-The TENT tests are **not** in CI today (the upstream workflow builds with `USE_TENT=OFF`). Run them locally:
-
-```bash
-cmake -S . -B build-tent -DUSE_TENT=ON -DUSE_CUDA=OFF
-cmake --build build-tent --target tent_failover_test tent_engine_failover_e2e_test -j
-./build-tent/mooncake-transfer-engine/tent/tests/tent_failover_test
-./build-tent/mooncake-transfer-engine/tent/tests/tent_engine_failover_e2e_test
-```
-
-Setting `USE_CUDA=OFF` forces `CpuPlatform`, which always reports `MTYPE_CPU`. With `USE_CUDA=ON` on a host without a GPU, `cudaPointerGetAttributes` fails, `getMemoryType` returns `MTYPE_UNKNOWN`, every transport reports unavailable, and `resolveTransport` returns `UNSPEC` before the fault injection ever runs.
-
-Companion unit tests cover the rail monitor and related building blocks: `tent_rail_monitor_test`, `tent_failover_test`, `tent_fault_proxy_test`.
+Submit-stage failures are intentionally not covered here; see Known Gaps.
 
 ## Known Gaps
 
@@ -194,4 +158,4 @@ Companion unit tests cover the rail monitor and related building blocks: `tent_r
   A safe submit-stage recovery needs either (a) a transport-level "atomic submit" capability flag plus per-task skip of derived ids, or (b) per-request status returned from `submitTransferTasks`. Neither exists today.
 * `markRecovered` (and cooldown expiry in `available`) clears the exponential-backoff memory entirely. A rail that flaps repeatedly therefore does not accumulate a growing cooldown across recovery cycles. If this becomes a problem the fix is to decay rather than reset.
 * Cross-transport failover is driven purely by return status; there is no latency-based "this transport is healthy but too slow, try another" signal. That belongs to the scheduler, not this document.
-* TENT tests are not exercised by CI. A follow-up can add a CI job that builds with `-DUSE_TENT=ON -DUSE_CUDA=OFF` and runs the `tent_*` test targets; none of the code in this document changes in that case.
+* Runtime-layer failover is covered by FakeTransport tests in the `tent-ci` `cuda-off` legs. DMA integrity, real WC errors, and staging under NVLink still need hardware runners; see {ref}`TENT Testing <tent-testing>`.

--- a/docs/source/design/tent/overview.md
+++ b/docs/source/design/tent/overview.md
@@ -116,3 +116,11 @@ slice-spraying
 
 failover
 :::
+
+## TENT Testing
+
+:::{toctree}
+:maxdepth: 1
+
+testing
+:::

--- a/docs/source/design/tent/testing.md
+++ b/docs/source/design/tent/testing.md
@@ -1,0 +1,181 @@
+(tent-testing)=
+# TENT Testing
+
+TENT's runtime does not inspect how a byte moved. It decides from a small
+`Transport` contract: capabilities, a submit `Status`, and a
+`TransferStatus` (`PENDING` / `COMPLETED` / `FAILED`). That is the
+opening for FakeTransport: an in-memory backend that speaks the same
+contract, moves no bytes, and lets tests drive the real
+`TransferEngineImpl` with deterministic faults.
+
+This page is about that mechanism. Individual test names and binaries
+change; the contract does not. Transport-layer tests (RDMA work-request
+errors, NVLink, GPU registration) stay with each real backend and need
+hardware.
+
+## Why a Fake Transport Works
+
+Correctness splits into two layers:
+
+1. **Transport-layer** — how a backend moves bytes and reports hardware
+   faults. Owned by each `Transport`.
+2. **Runtime-layer** — failover, batch lifecycle, progress worker,
+   shutdown. Owned by `TransferEngineImpl` and `ProxyManager`. The
+   runtime never looks at DMA; it only consumes the contract above.
+
+A real transport produces those values as a side effect of moving data.
+A fake that returns the same values at the same times drives
+`submitTransfer`, `getTransferStatus`, `resubmitTransferTask`,
+`progressBatch`, and shutdown identically. Failures that are hard to
+stage on hardware — a completion that never arrives, the Nth submit
+failing, a batch still `PENDING` when memory is freed — become a
+controlled return value.
+
+The production runtime is not stubbed. Tests wrap or replace the
+transport slots, then exercise the engine as an application would.
+
+```
+Test
+  |
+  v
+TransferEngineImpl / ProxyManager     (unmodified production code)
+  |
+  +-- swapTransportForTest(...)
+  |
+  v
+[optional] fault-injecting decorator
+  |
+  v
+FakeTransport                         (programmable Status, no DMA)
+```
+
+## The Transport Contract Tests Actually Use
+
+FakeTransport implements `Transport` with the minimum surface the
+runtime needs:
+
+- **Capabilities.** Advertise `dram_to_dram` so the engine considers the
+  slot available. Leave GPU capability bits off; FakeTransport tests
+  register CPU buffers. The runtime will not route a CUDA request to a
+  CPU-only fake.
+- **Buffer tagging.** `addMemoryBuffer` records the fake's slot on
+  `BufferDesc::transports`. Without that tag, `resolveTransport()` will
+  not pick the swapped-in backend.
+- **Submit.** Record the request and stamp a `TransferStatus`. Submit
+  itself succeeds unless a decorator or subclass fails it.
+- **Poll.** Return the stamped status, or override it from the poll
+  count (for example `PENDING` for N polls, then `COMPLETED`).
+- **Memory.** `malloc` / `free`. No pinning, no GPU registration, no
+  DMA. `warmupMemory` declines so the engine uses its own warmup path.
+
+Two optional hooks cover most status control without subclassing:
+
+- stamp a status at submit time
+- override the status on each `getTransferStatus`, given the poll count
+
+Call counts on install / submit / poll / register are how a test proves
+the runtime took a path (for example primary submitted once, secondary
+submitted after failover) without looking inside the engine.
+
+Copies of FakeTransport live in the test files that need them, not in a
+shared header. Each test can extend its copy; divergence is expected.
+The point of the fake is the contract, not a single implementation.
+
+## Fault Injection Is a Decorator
+
+FakeTransport, by itself, completes successfully. Faults are layered on
+top so the engine still sees an ordinary `Transport`:
+
+| Layer | Role |
+|-------|------|
+| FakeTransport | In-memory success path; programmable completions. |
+| `FaultProxyTransport` | Wraps any `Transport` and injects policy-driven faults: failed submit, `COMPLETED → FAILED` on poll, failed `install()`, optional delay. |
+| Test-local subclass | When the fault is not a policy (poison only some requests; flip an atomic mid-loop). |
+
+The engine's failover and retry paths run unmodified. The decorator is
+what makes a completion-stage `FAILED` look like a WC error or a dropped
+peer, without a verbs layer.
+
+`FaultProxyTransport` lives under
+`mooncake-transfer-engine/tent/transport/fault_proxy/`. Its policy
+fields are the source of truth; this page does not duplicate them.
+
+## Installing Fakes Without Bypassing the Runtime
+
+`TransferEngineImpl::swapTransportForTest` replaces one slot in
+`transport_list_` after `construct()`. That is the only test hook that
+installs a fake (or a wrapped fake) while leaving `resolveTransport()`
+and `resubmitTransferTask()` on the production path. Production code
+never calls it.
+
+A typical setup:
+
+1. Build a config with `p2p` metadata on loopback and **real transports
+   disabled**, so `construct()` does not require Redis, etcd, or an RDMA
+   device.
+2. Construct the engine.
+3. `install()` the fake (or proxy), then `swapTransportForTest` into the
+   slots under test. Swap only replaces the slot; it does not re-run
+   engine availability.
+4. Register memory *after* the swap, so `addMemoryBuffer` tags the
+   buffers.
+5. Submit and poll through the public engine API.
+
+Install two slots when the scenario needs a fallback (typically RDMA +
+TCP). Install one slot when the test wants no failover.
+
+`USE_CUDA=OFF` is required on CPU-only hosts. With CUDA enabled and no
+GPU, pointer queries fail, memory type becomes unknown, every transport
+looks unavailable, and `resolveTransport()` returns `UNSPEC` before any
+injected fault runs.
+
+## What the Mechanism Can Prove
+
+FakeTransport proves how the runtime *reacts* to the transport contract.
+It cannot prove that a backend moved the right bytes.
+
+**In scope.** Cross-transport failover and budget exhaustion; poll vs
+`progressBatch` recovery; progress-worker and `freeBatch` races; queue /
+hint / metrics behavior that only depends on submit and poll results;
+concurrency of runtime maps that FakeTransport can reach.
+
+**Out of scope.** DMA integrity; verbs-level failures (WC error, QP
+failure); GPU registration; NVLink link faults; true async RPC timing
+(in-process callbacks fire synchronously). Those belong to each
+transport's tests, `tebench --check_consistency=true` on real peers, or
+multi-node hardware CI.
+
+(staging-trigger-constraints)=
+
+**Staging is decided before the request reaches a transport.**
+`findStagingPolicy()` inspects which hardware backends are installed and
+what memory types the request uses, then `ProxyManager` runs the staging
+loop. Swapping FakeTransport into RDMA or TCP does not change that
+decision, and every current trigger is gated on NVLink, MNNVL, or TPU —
+none of which a CPU-only fake replaces. A CPU-only host therefore cannot
+exercise `transferEventLoop` with either real transports or fakes.
+Covering that path is a hardware-runner problem, or a product change to
+the staging policy, not a missing FakeTransport feature.
+
+## Running
+
+```bash
+cmake -S . -B build-tent \
+  -DUSE_TENT=ON -DUSE_CUDA=OFF \
+  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF \
+  -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release
+
+cmake --build build-tent --target mooncake_common -j
+ctest --test-dir build-tent/mooncake-transfer-engine/tent/tests \
+  --output-on-failure
+```
+
+`tent_link_group` links `mooncake_common` by archive path, which does
+not create a CMake build-order dependency — build `mooncake_common`
+first. The `tent-ci` `cuda-off` legs in GitHub Actions run the same
+`ctest` directory. The `cuda-on` leg compiles only: runners have no GPU,
+and CUDA stubs would bypass the fakes.
+
+Concurrency tests that touch shared runtime maps should also be run
+under ThreadSanitizer (`-fsanitize=thread`). Which binaries those are
+belongs in the test sources, not here.


### PR DESCRIPTION
## Description

Adds a design page for TENT's FakeTransport runtime-test mechanism, and points the failover doc at that mechanism instead of duplicating harness details.

TENT's runtime decides from a small `Transport` contract (capabilities, submit `Status`, `TransferStatus`). An in-memory fake that speaks the same contract can drive unmodified `TransferEngineImpl` with deterministic faults. The new page documents why that works, how fakes are installed (`swapTransportForTest`) and wrapped (`FaultProxyTransport`), and what this can and cannot prove (including why staging cannot be triggered by swapping fakes into RDMA/TCP). Individual test names are left in the sources so the doc does not rot when cases are added.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Docs-only change. Built the Sphinx HTML and checked that the new page renders, the overview toctree links to it, and `{ref}` cross-links with failover.md resolve.

**Test commands:**
```bash
cd docs
make html
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`make html` succeeded. Generated `design/tent/testing.html` with working prev/next and sidebar entry under TENT. Cross-refs `tent-testing` and `tent-failover-testing` resolve.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok) helped restructure the page around the FakeTransport mechanism and drop per-case inventories. The human submitter reviewed every changed line.


Made with [Cursor](https://cursor.com)