### PR TITLE
[TENT] Resolve transport policy device masks once, not per request

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport_selector.h
@@ -120,17 +120,28 @@ struct SelectionPolicy {
     // Transport preference list (evaluated in order)
     std::vector<TransportType> transports;
 
-    // Per-policy link-layer QoS. nullopt = fall back to the global RdmaParams
-    // value. InfiniBand Service Level (0-15) and Traffic Class / DSCP (0-255).
+    // Superseded, and read by nothing: link-layer QoS is a property of the QP
+    // a transfer lands on, so it is defined per pool in
+    // transports/rdma/endpoint/qp_pools and applied at QP setup
+    // (endpoint.cpp, setupOneQP). Still parsed so a config that sets them here
+    // is reported rather than silently ignored.
     std::optional<int> service_level;
     std::optional<int> traffic_class;
-    // Named QP pool this policy's traffic should land on; parsed and stored for
-    // now, routing to be wired later. Unset = the current single "data QP".
+    // Named QP pool this policy's traffic lands on. Routed end to end:
+    // SelectionResult -> TaskInfo -> SubBatch -> RdmaTask -> selectQpInPool().
+    // Unset (or a name no configured pool matches) sprays across *all* QPs --
+    // there is no reserved default pool, so once qp_pools is configured such
+    // traffic also lands on the named pools' QPs and inherits their SL/TC.
     std::optional<std::string> qp_pool;
 
     // Optional business-intent filter. nullopt preserves the historical
     // catch-all behavior; otherwise the request intent must match exactly.
     std::optional<IntentType> intent_type;
+
+    // `devices` resolved against the topology by setTopology(), so select()
+    // does not repeat a name lookup per request. ~0ULL means "all devices":
+    // no device filter, no topology yet, or a filter that resolved to nothing.
+    uint64_t resolved_device_mask{~0ULL};
 };
 
 /**
@@ -139,9 +150,11 @@ struct SelectionPolicy {
 struct SelectionResult {
     TransportType transport = UNSPEC;
     uint64_t device_mask = ~0ULL;  // Bitmask of allowed devices (~0 = all)
-    // Resolved link-layer QoS from the matched policy (nullopt = default).
+    // Copied from the matched policy for diagnostics only; QP setup takes
+    // SL/TC from the QP pool, not from here. See SelectionPolicy.
     std::optional<int> service_level;
     std::optional<int> traffic_class;
+    // Consumed: names the QP pool the transfer is routed to.
     std::optional<std::string> qp_pool;
 };
 
@@ -154,10 +167,12 @@ class TransportSelector {
 
     /**
      * @brief Set topology for device name to ID conversion
+     *
+     * Resolves every policy's `devices` list into a mask here, once, and
+     * reports what did not resolve. Safe to call again if the topology is
+     * replaced.
      */
-    void setTopology(std::shared_ptr<Topology> topology) {
-        topology_ = topology;
-    }
+    void setTopology(std::shared_ptr<Topology> topology);
 
     /**
      * @brief Select the best transport for a given context
@@ -189,8 +204,13 @@ class TransportSelector {
         const std::vector<TransportType>& raw, TransportType hint);
 
    private:
+    // Width of SelectionResult::device_mask; a NIC past this index cannot be
+    // named by a policy at all.
+    static constexpr int kDeviceMaskBits = 64;
+
     std::vector<SelectionPolicy> getDefaultPolicies();
     void loadPolicies();
+    void resolveDeviceMasks();
     bool matchesMemoryPattern(const std::string& pattern,
                               MemoryType type) const;
     bool matchesPolicy(const SelectionPolicy& policy,

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -42,6 +42,15 @@ static const std::unordered_map<std::string, IntentType> kIntentTypeNameMap = {
     {"staging_internal", IntentType::STAGING_INTERNAL},
 };
 
+static std::string joinNames(const std::vector<std::string>& names) {
+    std::string out;
+    for (const auto& name : names) {
+        if (!out.empty()) out += ", ";
+        out += name;
+    }
+    return out;
+}
+
 static std::optional<IntentType> parseIntentType(const json& value) {
     if (value.is_string()) {
         auto name = value.get<std::string>();
@@ -269,16 +278,84 @@ void TransportSelector::loadPolicies() {
             }
         }
 
-        policies_.push_back(std::move(policy));
+        // Link-layer QoS is defined on the QP pool, not on the policy: a QP
+        // carries the SL/TC of the pool it was created in, and a policy only
+        // selects a pool by name. These fields are a superseded duplicate that
+        // nothing reads, so say where the values actually belong.
+        if (policy.service_level || policy.traffic_class) {
+            LOG(WARNING)
+                << "Transport policy " << policy.name
+                << " sets service_level/traffic_class, which have NO effect "
+                   "here. Link-layer QoS belongs to the QP pool: define it in "
+                   "transports/rdma/endpoint/qp_pools and point this policy at "
+                   "it with \"qp_pool\": \"<name>\". Otherwise its traffic "
+                   "runs with the global transports/rdma SL/TC.";
+        }
+
         LOG(INFO) << "Loaded transport policy: " << policy.name
                   << " (segment_type=" << segment_type_str
                   << ", transports_count=" << policy.transports.size() << ")";
+        policies_.push_back(std::move(policy));
     }
 }
 
 TransportSelector::TransportSelector(std::shared_ptr<Config> config)
     : config_(config) {
     loadPolicies();
+}
+
+void TransportSelector::resolveDeviceMasks() {
+    for (auto& policy : policies_) {
+        // Unconditional: a mask resolved against a topology we no longer hold
+        // would keep naming NIC ids that now mean something else.
+        if (!topology_ || policy.devices.empty()) {
+            policy.resolved_device_mask = ~0ULL;
+            continue;
+        }
+        uint64_t mask = 0;
+        std::vector<std::string> unresolved;
+        for (const auto& name : policy.devices) {
+            int dev_id = topology_->getNicId(name);
+            if (dev_id < 0) {
+                unresolved.push_back(name + " (no such device)");
+            } else if (dev_id >= kDeviceMaskBits) {
+                // The NIC exists but sits past the mask width, so no policy
+                // can ever name it. Say so explicitly: "not found" would send
+                // the operator looking for a typo that is not there.
+                unresolved.push_back(
+                    name + " (index " + std::to_string(dev_id) +
+                    " >= " + std::to_string(kDeviceMaskBits) + ")");
+            } else {
+                mask |= (1ULL << dev_id);
+            }
+        }
+
+        if (mask == 0) {
+            // Fail open, as before — a typo must not stop transfers. But an
+            // ignored device filter is the opposite of what it was written
+            // for, so it is an error, reported once with every name that
+            // failed rather than once per request.
+            policy.resolved_device_mask = ~0ULL;
+            LOG(ERROR) << "Transport policy " << policy.name
+                       << ": no device in its list resolved, so the device "
+                          "restriction is IGNORED and all devices are allowed. "
+                          "Unresolved: "
+                       << joinNames(unresolved);
+            continue;
+        }
+
+        policy.resolved_device_mask = mask;
+        if (!unresolved.empty()) {
+            LOG(WARNING) << "Transport policy " << policy.name
+                         << ": ignoring unresolved devices: "
+                         << joinNames(unresolved);
+        }
+    }
+}
+
+void TransportSelector::setTopology(std::shared_ptr<Topology> topology) {
+    topology_ = std::move(topology);
+    resolveDeviceMasks();
 }
 
 bool TransportSelector::matchesMemoryPattern(const std::string& pattern,
@@ -463,29 +540,17 @@ SelectionResult TransportSelector::select(
         return result;  // UNSPEC, all devices
     }
 
-    // Carry the matched policy's link-layer QoS out to the caller (RFC #2519 /
-    // #2568, step 1). These are plumbed but not yet applied at QP setup; that
-    // is the per-class QP pool follow-up (step 2).
+    // qp_pool is what actually routes: it picks the QP pool, and the pool's
+    // own SL/TC were applied when those QPs were set up. The two SL/TC fields
+    // below are carried for diagnostics only (see SelectionPolicy).
     result.service_level = matching_policy->service_level;
     result.traffic_class = matching_policy->traffic_class;
     result.qp_pool = matching_policy->qp_pool;
 
-    // Convert device names to mask
-    result.device_mask = ~0ULL;  // Default: all devices
-    if (!matching_policy->devices.empty() && topology_) {
-        result.device_mask = 0;
-        for (const auto& name : matching_policy->devices) {
-            int dev_id = topology_->getNicId(name);
-            if (dev_id >= 0 && dev_id < 64) {
-                result.device_mask |= (1ULL << dev_id);
-            } else {
-                LOG(WARNING) << "RDMA device not found or ID >= 64: " << name;
-            }
-        }
-        if (result.device_mask == 0) {
-            result.device_mask = ~0ULL;  // Fallback to all if none found
-        }
-    }
+    // Resolved once by setTopology(), not per request: the names and the
+    // topology are both fixed by then, and repeating the lookup here also
+    // repeated its diagnostics on every single select().
+    result.device_mask = matching_policy->resolved_device_mask;
 
     // The "raw" candidate set is whatever the matching policy authorizes:
     // the policy's explicit transports list, or the buffer's registered

--- a/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_selector_test.cpp
@@ -1074,6 +1074,117 @@ TEST(TransportSelectorTest, ExplicitPolicyNameOverridesIntentFilter) {
     EXPECT_EQ(selector.select(ctx, transports).transport, TCP);
 }
 
+// ---------------------------------------------------------------------------
+// Device mask resolution (names -> mask, once, at setTopology)
+// ---------------------------------------------------------------------------
+
+std::shared_ptr<Config> configWithDeviceList(
+    const std::vector<std::string>& devices) {
+    json policy;
+    policy["name"] = "device_pinned";
+    policy["segment_type"] = "memory";
+    policy["transports"] = {"tcp"};
+    policy["devices"] = devices;
+
+    auto conf = std::make_shared<Config>();
+    conf->set("policy", json::array({policy}));
+    return conf;
+}
+
+std::shared_ptr<Topology> topologyWithNics(size_t count) {
+    auto topology = std::make_shared<Topology>();
+    for (size_t i = 0; i < count; ++i) {
+        Topology::NicEntry nic;
+        nic.name = "mlx5_" + std::to_string(i);
+        nic.type = Topology::NIC_RDMA;
+        topology->nic_list_.push_back(nic);
+    }
+    return topology;
+}
+
+uint64_t selectDeviceMask(TransportSelector& selector) {
+    std::array<std::shared_ptr<Transport>, kSupportedTransportTypes>
+        transports{};
+    transports[TCP] = std::make_shared<FakeTransport>(TCP);
+    static_cast<FakeTransport*>(transports[TCP].get())->setDramToDram(true);
+
+    SelectionContext ctx;
+    ctx.segment_type = SegmentType::Memory;
+    ctx.same_machine = false;
+    ctx.local_memory_type = MTYPE_CPU;
+    ctx.remote_memory_type = MTYPE_CPU;
+    ctx.transfer_size = 4096;
+    ctx.priority_level = PRIO_HIGH;
+    ctx.buffer_transports = nullptr;
+    return selector.select(ctx, transports).device_mask;
+}
+
+TEST(TransportSelectorTest, DeviceMaskResolvesNamedNics) {
+    TransportSelector selector(configWithDeviceList({"mlx5_1", "mlx5_3"}));
+    selector.setTopology(topologyWithNics(4));
+
+    EXPECT_EQ(selectDeviceMask(selector), (1ULL << 1) | (1ULL << 3));
+}
+
+// The mask is resolved at setTopology, so it must be stable no matter how many
+// times select() runs -- this is the regression guard for resolving (and
+// re-logging) per request.
+TEST(TransportSelectorTest, DeviceMaskIsStableAcrossSelects) {
+    TransportSelector selector(configWithDeviceList({"mlx5_0"}));
+    selector.setTopology(topologyWithNics(4));
+
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 0);
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 0);
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 0);
+}
+
+// A replaced topology must re-resolve; a stale mask would name the wrong NICs.
+TEST(TransportSelectorTest, DeviceMaskReresolvesOnNewTopology) {
+    TransportSelector selector(configWithDeviceList({"mlx5_2"}));
+
+    selector.setTopology(topologyWithNics(4));
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 2);
+
+    // Same name, fewer NICs: mlx5_2 no longer exists, so the filter empties
+    // and falls open rather than pinning a NIC id that is now someone else's.
+    selector.setTopology(topologyWithNics(2));
+    EXPECT_EQ(selectDeviceMask(selector), ~0ULL);
+}
+
+// Fail-open is deliberate: a typo must not stop transfers. The behavior is
+// pinned here so it stays a decision rather than drifting into a hard failure.
+TEST(TransportSelectorTest, DeviceMaskFailsOpenWhenNothingResolves) {
+    TransportSelector selector(configWithDeviceList({"nope_0", "nope_1"}));
+    selector.setTopology(topologyWithNics(4));
+
+    EXPECT_EQ(selectDeviceMask(selector), ~0ULL);
+}
+
+// Partially unresolved: the names that do resolve still restrict the mask.
+TEST(TransportSelectorTest, DeviceMaskKeepsResolvedNamesOnPartialFailure) {
+    TransportSelector selector(configWithDeviceList({"mlx5_1", "nope"}));
+    selector.setTopology(topologyWithNics(4));
+
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 1);
+}
+
+// device_mask is 64 bits wide, so a NIC at index >= 64 cannot be named. It is
+// dropped from the mask, not silently promoted to "all devices".
+TEST(TransportSelectorTest, DeviceMaskDropsNicsPastMaskWidth) {
+    TransportSelector selector(configWithDeviceList({"mlx5_0", "mlx5_64"}));
+    selector.setTopology(topologyWithNics(66));
+
+    EXPECT_EQ(selectDeviceMask(selector), 1ULL << 0);
+}
+
+// No topology bound: nothing to resolve names against, so the policy cannot
+// restrict anything and must not restrict everything either.
+TEST(TransportSelectorTest, DeviceMaskAllowsAllWithoutTopology) {
+    TransportSelector selector(configWithDeviceList({"mlx5_0"}));
+
+    EXPECT_EQ(selectDeviceMask(selector), ~0ULL);
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake


### PR DESCRIPTION
Description

  TransportSelector::select() re-resolved every SelectionPolicy device name into a NIC mask on each call. Topology::getNicId is a linear scan comparing strings, so every request paid policy_devices × nic_count comparisons, and every failover retry paid it again. Both inputs are fixed once setTopology() runs — the topology is loaded before it and TENT's Topology has no runtime mutator — so resolve there and let select() read a cached mask.

  Resolving per request also fired its diagnostics per request: one mistyped device name emitted a WARNING per transfer. The messages were not actionable either:

  - "RDMA device not found or ID >= 64" conflated a typo with a NIC past the 64-bit mask width; now reported separately.
  - When no name resolved, the mask fell back to ~0ULL, silently turning a device-isolation policy into no isolation. Fallback kept (a typo must not stop transfers), now a single ERROR naming the policy and every unresolved device.
  - setTopology(nullptr) left masks resolved against a topology no longer held. Resolution is now unconditional.

  Also fixes a use-after-move: the "Loaded transport policy" line read policy.name / policy.transports.size() after push_back(std::move(policy)), so transports_count always logged 0.

  Adds a warning when a policy sets service_level/traffic_class. Link-layer QoS belongs to the QP a transfer lands on, so it is configured per pool under transports/rdma/endpoint/qp_pools and applied in setupOneQP(); the SelectionPolicy fields are a superseded duplicate that nothing reads — operators setting them got neither the QoS nor any indication of it. Three stale comments corrected accordingly.

  No behavior change for correctly configured policies.

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Reshard (mooncake-reshard)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [ ] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [x] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  7 new cases in transport_selector_test.cpp covering mask resolution, stability across repeated select() calls, re-resolution on a replaced topology, fail-open when nothing resolves, partial resolution, NICs past the mask width, and the no-topology case. DeviceMaskIsStableAcrossSelects is the regression guard for per-request resolution.

  Test commands:
  cmake --build build-tent --target transport_selector_test
  ctest -R transport_selector_test --output-on-failure

  Test results:
  - [ ] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)