### PR TITLE
feat(store): simplify P2P client HA recovery

### DIFF
--- a/mooncake-store/include/async_metadata_notifier.h
+++ b/mooncake-store/include/async_metadata_notifier.h
@@ -18,8 +18,9 @@
 
 namespace mooncake {
 
-// Called when an async ADD fails with a non-transient error.
-// Caller should delete the local replica.
+// Called when an async ADD reaches Master but Master rejects the mutation.
+// Caller should delete the local replica. Transport/RPC failures are treated as
+// dropped metadata notifications and do not invoke this callback.
 using SyncFailureCallback = std::function<void(
     std::string_view key, const UUID& segment_id, ErrorCode error)>;
 

--- a/mooncake-store/include/ha_recovery_manager.h
+++ b/mooncake-store/include/ha_recovery_manager.h
@@ -24,7 +24,7 @@ namespace mooncake {
  * State machine (2 events: MASTER_UNREACHABLE, MASTER_REACHABLE):
  *   FULL ──MASTER_UNREACHABLE─────> DEGRADED
  *   FULL ──MASTER_REACHABLE───────> SYNCING  (Master restarted)
- *   DEGRADED ──MASTER_REACHABLE───> SYNCING  (always full re-sync)
+ *   DEGRADED ──MASTER_REACHABLE───> SYNCING  (recovery mode decides work)
  *   SYNCING ──recovery complete───> FULL
  *   SYNCING ──MASTER_UNREACHABLE──> DEGRADED
  *   SYNCING ──MASTER_REACHABLE────> SYNCING  (restart pipeline)
@@ -37,11 +37,18 @@ namespace mooncake {
  */
 class HARecoveryManager {
    public:
-    HARecoveryManager(const UUID& client_id, P2PMasterClient& master_client,
-                      std::optional<DataManager>& data_manager,
-                      std::unique_ptr<AsyncMetadataNotifier>& notifier,
-                      std::atomic<ViewVersionId>& view_version,
-                      HAClientState initial_state = HAClientState::FULL);
+    enum class RecoveryMode {
+        FullMetadataSync,
+        RegisterOnly,
+    };
+
+    HARecoveryManager(
+        const UUID& client_id, P2PMasterClient& master_client,
+        std::optional<DataManager>& data_manager,
+        std::unique_ptr<AsyncMetadataNotifier>& notifier,
+        std::atomic<ViewVersionId>& view_version,
+        HAClientState initial_state = HAClientState::FULL,
+        RecoveryMode recovery_mode = RecoveryMode::FullMetadataSync);
     ~HARecoveryManager();
 
     HARecoveryManager(const HARecoveryManager&) = delete;
@@ -90,6 +97,7 @@ class HARecoveryManager {
     void TransitionState(HAClientState to, const std::string& reason);
     void StartRecoveryThread();
     void RecoveryPipelineMain(AbortToken need_abort);
+    void FinishRecovery(AbortToken need_abort);
 
     /**
      * @brief Retry enqueue until success or abort is signalled.
@@ -114,6 +122,7 @@ class HARecoveryManager {
     std::optional<DataManager>& data_manager_;
     std::unique_ptr<AsyncMetadataNotifier>& notifier_;
     std::atomic<ViewVersionId>& view_version_;
+    RecoveryMode recovery_mode_;
 
     std::atomic<HAClientState> state_;
     std::atomic<bool> ready_for_recovery_{

--- a/mooncake-store/src/async_metadata_notifier.cpp
+++ b/mooncake-store/src/async_metadata_notifier.cpp
@@ -407,15 +407,11 @@ void AsyncMetadataNotifier::SendBatch(std::vector<PendingOp>& batch,
         }
     }
     RecordFailure();
-    LOG(ERROR) << "BatchSyncReplica failed after " << MaxRetryCount + 1
-               << " attempts, dropping " << count << " ops";
-    // Rollback: notify failure for all ADD ops so local replicas get cleaned up
-    if (failure_cb_) {
-        for (size_t i = 0; i < req.add_keys.size(); ++i) {
-            failure_cb_(req.add_keys[i], req.add_segment_ids[i],
-                        ErrorCode::INTERNAL_ERROR);
-        }
-    }
+    LOG(ERROR) << "BatchSyncReplica failed after " << MaxRetryCount
+               << " attempts, dropping " << count << " metadata notifications";
+    // Transport/RPC failures usually mean Master is unreachable or failing
+    // over. Drop only the metadata notification; keep local replicas so HA
+    // recovery can rebuild the Master's route view from current local state.
 }
 
 void AsyncMetadataNotifier::RecordSuccess() {

--- a/mooncake-store/src/ha_recovery_manager.cpp
+++ b/mooncake-store/src/ha_recovery_manager.cpp
@@ -11,12 +11,14 @@ HARecoveryManager::HARecoveryManager(
     const UUID& client_id, P2PMasterClient& master_client,
     std::optional<DataManager>& data_manager,
     std::unique_ptr<AsyncMetadataNotifier>& notifier,
-    std::atomic<ViewVersionId>& view_version, HAClientState initial_state)
+    std::atomic<ViewVersionId>& view_version, HAClientState initial_state,
+    HARecoveryManager::RecoveryMode recovery_mode)
     : client_id_(client_id),
       master_client_(master_client),
       data_manager_(data_manager),
       notifier_(notifier),
       view_version_(view_version),
+      recovery_mode_(recovery_mode),
       state_(initial_state) {
     LOG(INFO) << "HA recovery manager initialized with state: "
               << initial_state;
@@ -167,6 +169,13 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
         return;
     }
 
+    if (recovery_mode_ == RecoveryMode::RegisterOnly) {
+        LOG(INFO) << "Recovery mode RegisterOnly: skipping full metadata sync";
+        FinishRecovery(need_abort);
+        LOG(INFO) << "Recovery pipeline completed";
+        return;
+    }
+
     auto aborted = [&]() {
         return need_abort->load(std::memory_order_acquire);
     };
@@ -280,7 +289,16 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
         }
     }
 
-    // All recovery routes delivered. Notify Master.
+    FinishRecovery(need_abort);
+    LOG(INFO) << "Recovery pipeline completed";
+}
+
+void HARecoveryManager::FinishRecovery(AbortToken need_abort) {
+    auto aborted = [&]() {
+        return need_abort->load(std::memory_order_acquire);
+    };
+
+    // Notify Master that this client's recovery phase is complete.
     // Retry indefinitely until success or abort — if Master restarts again,
     // HandleEvent(MASTER_UNREACHABLE) will set need_abort and this thread
     // exits.
@@ -304,7 +322,6 @@ void HARecoveryManager::RecoveryPipelineMain(AbortToken need_abort) {
                          << ", reason=recovery complete";
         }
     }
-    LOG(INFO) << "Recovery pipeline completed";
 }
 
 // return false when abort

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -190,9 +190,13 @@ ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     //    DEGRADED: connection or registration failed.
     HAClientState initial_state =
         client_registered ? HAClientState::FULL : HAClientState::DEGRADED;
+    auto recovery_mode =
+        config.master_server_entry.rfind("redis://", 0) == 0
+            ? HARecoveryManager::RecoveryMode::RegisterOnly
+            : HARecoveryManager::RecoveryMode::FullMetadataSync;
     ha_manager_ = std::make_unique<HARecoveryManager>(
         client_id_, master_client_, data_manager_, async_route_notifier_,
-        view_version_, initial_state);
+        view_version_, initial_state, recovery_mode);
 
     // 4. Start heartbeat immediately after registration so master does not
     //    consider this client disconnected during a lengthy initialization.

--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -50,6 +50,13 @@ ErrorCode P2PMasterService::RecordOplog(OpType type, const std::string& key,
 
 auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
     -> tl::expected<RegisterClientResponse, ErrorCode> {
+    if (req.deployment_mode != DeploymentMode::P2P) {
+        LOG(ERROR) << "RegisterClient(P2P): rejected non-P2P client"
+                   << ", client_id=" << req.client_id << ", deployment_mode="
+                   << static_cast<int>(req.deployment_mode);
+        return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
+    }
+
     if (GetClientManager().GetClient(req.client_id)) {
         LOG(WARNING) << "RegisterClient(P2P): client already exists"
                      << ", client_id=" << req.client_id;

--- a/mooncake-store/tests/async_metadata_notifier_test.cpp
+++ b/mooncake-store/tests/async_metadata_notifier_test.cpp
@@ -261,6 +261,35 @@ TEST_F(AsyncMetadataNotifierTest, FailureCallbackInvoked) {
     notifier.Stop();
 }
 
+TEST_F(AsyncMetadataNotifierTest, RpcFailureDoesNotInvokeFailureCallback) {
+    auto unreachable_client = std::make_unique<P2PMasterClient>(client_id_);
+    auto unreachable_addr = "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto ec = unreachable_client->Connect(unreachable_addr);
+    ASSERT_NE(ec, ErrorCode::OK);
+
+    std::atomic<int> failure_count{0};
+    SyncFailureCallback cb = [&](std::string_view key, const UUID& seg_id,
+                                 ErrorCode err) {
+        failure_count.fetch_add(1, std::memory_order_relaxed);
+    };
+
+    AsyncMetadataNotifier notifier(*unreachable_client, client_id_,
+                                   /*sender_thread_count=*/1,
+                                   /*max_batch_size=*/2000,
+                                   /*queue_capacity=*/4000, std::move(cb));
+    notifier.Start();
+
+    auto r = notifier.EnqueueAdd("rpc_fail_key", segment_.id, 100);
+    ASSERT_TRUE(r.has_value());
+
+    // MaxRetryCount=3 with backoffs 100ms+200ms; add margin for RPC overhead.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    EXPECT_EQ(failure_count.load(), 0)
+        << "Transport failures should drop only metadata notifications";
+
+    notifier.Stop();
+}
+
 TEST_F(AsyncMetadataNotifierTest, MultipleStartStop) {
     AsyncMetadataNotifier notifier(*master_client_, client_id_,
                                    /*sender_thread_count=*/2,

--- a/mooncake-store/tests/ha_recovery_manager_test.cpp
+++ b/mooncake-store/tests/ha_recovery_manager_test.cpp
@@ -118,20 +118,24 @@ class HARecoveryManagerTest : public ::testing::Test {
         return seg;
     }
 
-    std::unique_ptr<HARecoveryManager> CreateManager() {
-        return std::make_unique<HARecoveryManager>(client_id_, *master_client_,
-                                                   data_manager_, notifier_,
-                                                   view_version_);
+    std::unique_ptr<HARecoveryManager> CreateManager(
+        HARecoveryManager::RecoveryMode recovery_mode =
+            HARecoveryManager::RecoveryMode::FullMetadataSync) {
+        return std::make_unique<HARecoveryManager>(
+            client_id_, *master_client_, data_manager_, notifier_,
+            view_version_, HAClientState::FULL, recovery_mode);
     }
 
-    std::unique_ptr<HARecoveryManager> CreateManagerWithNotifier() {
+    std::unique_ptr<HARecoveryManager> CreateManagerWithNotifier(
+        HARecoveryManager::RecoveryMode recovery_mode =
+            HARecoveryManager::RecoveryMode::FullMetadataSync) {
         notifier_ =
             std::make_unique<AsyncMetadataNotifier>(*master_client_, client_id_,
                                                     /*sender_thread_count=*/1,
                                                     /*max_batch_size=*/2000,
                                                     /*queue_capacity=*/4000);
         notifier_->Start();
-        return CreateManager();
+        return CreateManager(recovery_mode);
     }
 
     std::optional<UUID> InitLocalDataManagerAndPut(const std::string& key,
@@ -407,6 +411,33 @@ TEST_F(HARecoveryManagerTest, ReconnectResyncsLocalReplicaToP2PMaster) {
     const auto& desc = replica.get_p2p_proxy_descriptor();
     EXPECT_EQ(desc.client_id, client_id_);
     EXPECT_EQ(desc.segment_id, tier_id.value());
+}
+
+TEST_F(HARecoveryManagerTest, RegisterOnlyRecoverySkipsLocalReplicaResync) {
+    const std::string key = "register-only-key-" +
+                            std::to_string(client_id_.first) + "-" +
+                            std::to_string(client_id_.second);
+    const std::string value = "register-only-value";
+    auto tier_id = InitLocalDataManagerAndPut(key, value);
+    ASSERT_TRUE(tier_id.has_value());
+    MountLocalTierOnMaster(tier_id.value());
+
+    auto mgr = CreateManagerWithNotifier(
+        HARecoveryManager::RecoveryMode::RegisterOnly);
+    mgr->SetReadyForRecovery();
+
+    mgr->HandleEvent(HAEvent::MASTER_UNREACHABLE);
+    EXPECT_EQ(mgr->GetState(), HAClientState::DEGRADED);
+    EXPECT_FALSE(notifier_->running_.load());
+
+    mgr->HandleEvent(HAEvent::MASTER_RECONNECTED);
+    EXPECT_TRUE(notifier_->running_.load());
+    WaitUntilFull(*mgr);
+
+    auto& svc = master_.GetWrapped().GetMasterService();
+    auto result = svc.GetReplicaList(key);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::OBJECT_NOT_FOUND);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Description

  Simplify P2P client HA recovery for Redis HA mode.

  This PR keeps the existing client HA state machine, but adds a lightweight recovery mode for Redis-backed P2P HA:
  - Redis HA clients skip full local metadata resync after reconnecting to a promoted master.
  - The client still transitions through `DEGRADED -> SYNCING -> FULL` and calls `SetSyncCompleted`.
  - Async metadata RPC/transport failures now drop only metadata notifications instead of deleting local replicas.
  - P2P `RegisterClient` now explicitly rejects non-P2P clients.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Reshard (`mooncake-reshard`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  clang-format-20 -style=file -i mooncake-store/include/async_metadata_notifier.h mooncake-store/include/ha_recovery_manager.h mooncake-store/src/async_metadata_notifier.cpp mooncake-store/src/ha_recovery_manager.cpp mooncake-store/src/
  p2p_client_service.cpp mooncake-store/src/p2p_master_service.cpp mooncake-store/tests/async_metadata_notifier_test.cpp mooncake-store/tests/ha_recovery_manager_test.cpp

  cmake -S . -B build-v19 -DWITH_STORE=ON -DWITH_TE=ON -DSTORE_USE_REDIS=ON -DSTORE_USE_ETCD=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo
  cmake --build build-v19 -j3 --target async_metadata_notifier_test ha_recovery_manager_test p2p_master_service_test
  ctest --output-on-failure -R "p2p_master_service_test|async_metadata_notifier_test|ha_recovery_manager_test"
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to inspect the code path, implement the scoped changes, and draft tests. The human submitter is responsible for reviewing and validating all changes.