### PR TITLE
[Bugfix][TENT] Unpin remote stage buffers after late completion

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -108,6 +108,11 @@ class ControlClient {
     static Status unpinStageBuffer(const std::string& server_addr,
                                    uint64_t addr);
 
+    using UnpinStageBufferCallback = std::function<void(Status)>;
+    static void unpinStageBufferAsync(const std::string& server_addr,
+                                      uint64_t addr,
+                                      UnpinStageBufferCallback callback);
+
     static void subscribeSegmentUpdateAsync(const std::string& server_addr,
                                             const std::string& subscriber_addr);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -97,7 +97,7 @@ class ControlClient {
     static Status delegate(const std::string& server_addr,
                            const Request& request);
 
-    using DelegateCallback = std::function<void(Status)>;
+    using DelegateCallback = std::function<void(Status, bool confirmed)>;
     static void delegateAsync(const std::string& server_addr,
                               const Request& request,
                               DelegateCallback callback);

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -165,12 +165,13 @@ void ControlClient::delegateAsync(const std::string& server_addr,
         [callback = std::move(callback)](Status status,
                                          std::string response_raw) mutable {
             if (!status.ok()) {
-                callback(std::move(status));
+                callback(std::move(status), false);
                 return;
             }
             callback(response_raw.empty()
                          ? Status::OK()
-                         : Status::RpcServiceError(response_raw));
+                         : Status::RpcServiceError(response_raw),
+                     true);
         });
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -196,6 +196,25 @@ Status ControlClient::unpinStageBuffer(const std::string& server_addr,
     return Status::OK();
 }
 
+void ControlClient::unpinStageBufferAsync(const std::string& server_addr,
+                                          uint64_t addr,
+                                          UnpinStageBufferCallback callback) {
+    json j = addr;
+    std::string request_raw = j.dump();
+    tl_rpc_agent.callAsync(
+        server_addr, Unpin, request_raw,
+        [callback = std::move(callback)](Status status,
+                                         std::string response_raw) mutable {
+            if (!status.ok()) {
+                callback(std::move(status));
+                return;
+            }
+            callback(response_raw.empty()
+                         ? Status::OK()
+                         : Status::RpcServiceError(response_raw));
+        });
+}
+
 ControlService::ControlService(const std::string& type,
                                const std::string& servers,
                                TransferEngineImpl* impl)

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -250,8 +250,9 @@ void ProxyManager::submitRemoteStage(
                 });
         });
     ControlClient::delegateAsync(
-        server_addr, remote_stage,
-        [operation](Status status) { operation->complete(std::move(status)); });
+        server_addr, remote_stage, [operation](Status status, bool confirmed) {
+            operation->complete(std::move(status), confirmed);
+        });
 }
 
 Status ProxyManager::waitCrossStage(const Request& request,
@@ -707,8 +708,13 @@ Status ProxyManager::transferEventLoop(
                 }
                 auto result = operation->tryTakeResult();
                 if (result) {
+                    if (!result->confirmed) {
+                        chunk.state = StageState::FAILED;
+                        event_queue.push(id);
+                        break;
+                    }
                     operation.reset();
-                    if (!result->ok()) {
+                    if (!result->status.ok()) {
                         chunk.state = StageState::FAILED;
                         event_queue.push(id);
                         break;

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -129,17 +129,28 @@ Status ProxyManager::deconstruct() {
         has_pending_cleanups_.store(false, std::memory_order_relaxed);
     }
     for (auto& pending : remaining) {
-        if (!pending.remote_operations.empty()) {
+        size_t deferred_remote_buffers = 0;
+        for (auto& operation : pending.remote_operations) {
+            if (!operation) continue;
+            operation->abandonForCleanup();
+            ++deferred_remote_buffers;
+        }
+        if (deferred_remote_buffers != 0) {
             LOG(WARNING)
-                << "Leaving " << pending.remote_addrs.size()
-                << " remote stage buffers pinned because "
-                << pending.remote_operations.size()
-                << " remote staging requests have not reached a confirmed "
-                   "terminal state";
-            continue;
+                << "Deferring cleanup of " << deferred_remote_buffers
+                << " remote stage buffers until their staging requests "
+                   "reach a terminal state";
         }
         for (auto& [server, addr] : pending.remote_addrs) {
-            ControlClient::unpinStageBuffer(server, addr);
+            const bool owned_by_pending_operation = std::any_of(
+                pending.remote_operations.begin(),
+                pending.remote_operations.end(), [&](const auto& operation) {
+                    return operation &&
+                           operation->ownsRemoteBuffer(server, addr);
+                });
+            if (!owned_by_pending_operation) {
+                ControlClient::unpinStageBuffer(server, addr);
+            }
         }
     }
     std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
@@ -225,7 +236,19 @@ void ProxyManager::submitRemoteStage(
     remote_stage.length = chunk_length;
     remote_stage.target_id = LOCAL_SEGMENT_ID;
     remote_stage.target_offset = request.target_offset + offset;
-    operation = std::make_shared<internal::RemoteStageOperation>();
+    operation = std::make_shared<internal::RemoteStageOperation>(
+        server_addr, remote_stage_buffer, [server_addr, remote_stage_buffer] {
+            ControlClient::unpinStageBufferAsync(
+                server_addr, remote_stage_buffer,
+                [server_addr, remote_stage_buffer](Status status) {
+                    if (!status.ok()) {
+                        LOG(WARNING)
+                            << "Failed to unpin deferred remote stage buffer "
+                            << remote_stage_buffer << " on " << server_addr
+                            << ": " << status;
+                    }
+                });
+        });
     ControlClient::delegateAsync(
         server_addr, remote_stage,
         [operation](Status status) { operation->complete(std::move(status)); });

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
@@ -32,17 +32,17 @@ RemoteStageOperation::RemoteStageOperation(std::string server_addr,
       remote_buffer_(remote_buffer),
       deferred_cleanup_(std::move(deferred_cleanup)) {}
 
-void RemoteStageOperation::complete(Status status) {
+void RemoteStageOperation::complete(Status status, bool confirmed) {
     DeferredCleanup cleanup;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        result_ = std::move(status);
+        result_ = RemoteStageResult{std::move(status), confirmed};
         cleanup = takeCleanupIfReadyLocked();
     }
     runDeferredCleanup(std::move(cleanup));
 }
 
-std::optional<Status> RemoteStageOperation::tryTakeResult() {
+std::optional<RemoteStageResult> RemoteStageOperation::tryTakeResult() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (abandoned_ || !result_) return std::nullopt;
     auto result = std::move(result_);
@@ -67,7 +67,8 @@ bool RemoteStageOperation::ownsRemoteBuffer(const std::string& server_addr,
 
 RemoteStageOperation::DeferredCleanup
 RemoteStageOperation::takeCleanupIfReadyLocked() {
-    if (!abandoned_ || !result_ || cleanup_started_ || !deferred_cleanup_) {
+    if (!abandoned_ || !result_ || !result_->confirmed || cleanup_started_ ||
+        !deferred_cleanup_) {
         return {};
     }
     cleanup_started_ = true;
@@ -86,9 +87,15 @@ bool pollRemoteOperations(
             ++it;
             continue;
         }
-        if (!result->ok()) {
+        if (!result->confirmed) {
+            LOG(WARNING) << "Remote staging completion is unconfirmed: "
+                         << result->status;
+            ++it;
+            continue;
+        }
+        if (!result->status.ok()) {
             LOG(WARNING) << "Failed to drain remote staging request: "
-                         << *result;
+                         << result->status;
         }
         it = remote_operations.erase(it);
     }

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.cpp
@@ -1,5 +1,6 @@
 #include "remote_stage_operation.h"
 
+#include <exception>
 #include <utility>
 
 #include <glog/logging.h>
@@ -7,18 +8,70 @@
 namespace mooncake {
 namespace tent {
 namespace internal {
+namespace {
+
+void runDeferredCleanup(RemoteStageOperation::DeferredCleanup cleanup) {
+    if (!cleanup) return;
+    try {
+        cleanup();
+    } catch (const std::exception& ex) {
+        LOG(WARNING) << "Failed to start deferred remote buffer cleanup: "
+                     << ex.what();
+    } catch (...) {
+        LOG(WARNING)
+            << "Failed to start deferred remote buffer cleanup: unknown error";
+    }
+}
+
+}  // namespace
+
+RemoteStageOperation::RemoteStageOperation(std::string server_addr,
+                                           uint64_t remote_buffer,
+                                           DeferredCleanup deferred_cleanup)
+    : server_addr_(std::move(server_addr)),
+      remote_buffer_(remote_buffer),
+      deferred_cleanup_(std::move(deferred_cleanup)) {}
 
 void RemoteStageOperation::complete(Status status) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    result_ = std::move(status);
+    DeferredCleanup cleanup;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        result_ = std::move(status);
+        cleanup = takeCleanupIfReadyLocked();
+    }
+    runDeferredCleanup(std::move(cleanup));
 }
 
 std::optional<Status> RemoteStageOperation::tryTakeResult() {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!result_) return std::nullopt;
+    if (abandoned_ || !result_) return std::nullopt;
     auto result = std::move(result_);
     result_.reset();
     return result;
+}
+
+void RemoteStageOperation::abandonForCleanup() {
+    DeferredCleanup cleanup;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        abandoned_ = true;
+        cleanup = takeCleanupIfReadyLocked();
+    }
+    runDeferredCleanup(std::move(cleanup));
+}
+
+bool RemoteStageOperation::ownsRemoteBuffer(const std::string& server_addr,
+                                            uint64_t remote_buffer) const {
+    return server_addr_ == server_addr && remote_buffer_ == remote_buffer;
+}
+
+RemoteStageOperation::DeferredCleanup
+RemoteStageOperation::takeCleanupIfReadyLocked() {
+    if (!abandoned_ || !result_ || cleanup_started_ || !deferred_cleanup_) {
+        return {};
+    }
+    cleanup_started_ = true;
+    return deferred_cleanup_;
 }
 
 bool pollRemoteOperations(

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
@@ -15,6 +15,11 @@ namespace mooncake {
 namespace tent {
 namespace internal {
 
+struct RemoteStageResult {
+    Status status;
+    bool confirmed;
+};
+
 class RemoteStageOperation {
    public:
     using DeferredCleanup = std::function<void()>;
@@ -23,9 +28,9 @@ class RemoteStageOperation {
     RemoteStageOperation(std::string server_addr, uint64_t remote_buffer,
                          DeferredCleanup deferred_cleanup);
 
-    void complete(Status status);
+    void complete(Status status, bool confirmed);
 
-    std::optional<Status> tryTakeResult();
+    std::optional<RemoteStageResult> tryTakeResult();
 
     void abandonForCleanup();
 
@@ -39,7 +44,7 @@ class RemoteStageOperation {
     uint64_t remote_buffer_{0};
     DeferredCleanup deferred_cleanup_;
     std::mutex mutex_;
-    std::optional<Status> result_;
+    std::optional<RemoteStageResult> result_;
     bool abandoned_{false};
     bool cleanup_started_{false};
 };

--- a/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
+++ b/mooncake-transfer-engine/tent/src/runtime/remote_stage_operation.h
@@ -1,9 +1,12 @@
 #ifndef REMOTE_STAGE_OPERATION_H_
 #define REMOTE_STAGE_OPERATION_H_
 
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <string>
 #include <vector>
 
 #include "tent/common/status.h"
@@ -14,13 +17,31 @@ namespace internal {
 
 class RemoteStageOperation {
    public:
+    using DeferredCleanup = std::function<void()>;
+
+    RemoteStageOperation() = default;
+    RemoteStageOperation(std::string server_addr, uint64_t remote_buffer,
+                         DeferredCleanup deferred_cleanup);
+
     void complete(Status status);
 
     std::optional<Status> tryTakeResult();
 
+    void abandonForCleanup();
+
+    bool ownsRemoteBuffer(const std::string& server_addr,
+                          uint64_t remote_buffer) const;
+
    private:
+    DeferredCleanup takeCleanupIfReadyLocked();
+
+    std::string server_addr_;
+    uint64_t remote_buffer_{0};
+    DeferredCleanup deferred_cleanup_;
     std::mutex mutex_;
     std::optional<Status> result_;
+    bool abandoned_{false};
+    bool cleanup_started_{false};
 };
 
 using RemoteStageOperationPtr = std::shared_ptr<RemoteStageOperation>;

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1101,6 +1101,53 @@ TEST(ProxyManager, RemoteCleanupProbeDoesNotBlockOnPendingOperation) {
     EXPECT_TRUE(remote_operations.empty());
 }
 
+TEST(ProxyManager, UnconfirmedRemoteCompletionKeepsAbandonedBufferPinned) {
+    auto cleanup_calls = std::make_shared<std::atomic<int>>(0);
+    auto callback_done = std::make_shared<std::atomic<bool>>(false);
+    constexpr uint64_t kRemoteBuffer = 0x1234;
+
+    CoroRpcAgent stopped_server;
+    uint16_t port = 0;
+    ASSERT_TRUE(stopped_server.start(port).ok());
+    ASSERT_TRUE(stopped_server.stop().ok());
+    const std::string server_addr =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(port));
+
+    auto operation = std::make_shared<internal::RemoteStageOperation>(
+        server_addr, kRemoteBuffer,
+        [cleanup_calls] {
+            cleanup_calls->fetch_add(1, std::memory_order_relaxed);
+        });
+    operation->abandonForCleanup();
+
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = reinterpret_cast<void*>(kRemoteBuffer);
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = kRemoteBuffer;
+    request.length = 1;
+    ControlClient::delegateAsync(
+        server_addr, request,
+        [operation, callback_done](Status status, auto... completion_info) {
+            operation->complete(std::move(status), completion_info...);
+            callback_done->store(true, std::memory_order_release);
+        });
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!callback_done->load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(callback_done->load(std::memory_order_acquire));
+    EXPECT_EQ(cleanup_calls->load(std::memory_order_acquire), 0);
+
+    std::vector<internal::RemoteStageOperationPtr> remote_operations = {
+        operation};
+    EXPECT_FALSE(internal::pollRemoteOperations(remote_operations));
+    EXPECT_EQ(remote_operations.size(), 1);
+}
+
 TEST(ProxyManager, LateRemoteCompletionReleasesAbandonedStageBuffer) {
     auto cfg = makeMinimalP2PConfig();
     TransferEngineImpl engine(cfg);

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1096,7 +1096,7 @@ TEST(ProxyManager, RemoteCleanupProbeDoesNotBlockOnPendingOperation) {
     EXPECT_FALSE(internal::pollRemoteOperations(remote_operations));
     ASSERT_EQ(remote_operations.size(), 1);
 
-    operation->complete(Status::OK());
+    operation->complete(Status::OK(), true);
     EXPECT_TRUE(internal::pollRemoteOperations(remote_operations));
     EXPECT_TRUE(remote_operations.empty());
 }
@@ -1114,8 +1114,7 @@ TEST(ProxyManager, UnconfirmedRemoteCompletionKeepsAbandonedBufferPinned) {
         "127.0.0.1:" + std::to_string(static_cast<unsigned>(port));
 
     auto operation = std::make_shared<internal::RemoteStageOperation>(
-        server_addr, kRemoteBuffer,
-        [cleanup_calls] {
+        server_addr, kRemoteBuffer, [cleanup_calls] {
             cleanup_calls->fetch_add(1, std::memory_order_relaxed);
         });
     operation->abandonForCleanup();

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1127,27 +1127,26 @@ TEST(ProxyManager, LateRemoteCompletionReleasesAbandonedStageBuffer) {
     const auto remote_stage_addr =
         reinterpret_cast<uint64_t>(remote_stage.data());
 
-    ASSERT_TRUE(
-        remote_server
-            .registerFunction(
-                Pin,
-                [&](const std::string_view&, std::string& response) {
-                    bool expected = false;
-                    response = buffer_pinned.compare_exchange_strong(expected,
-                                                                      true)
-                                   ? std::to_string(remote_stage_addr)
-                                   : "0";
-                })
-            .ok());
-    ASSERT_TRUE(
-        remote_server
-            .registerFunction(
-                Unpin,
-                [&](const std::string_view&, std::string&) {
-                    buffer_pinned.store(false, std::memory_order_release);
-                    unpin_calls.fetch_add(1, std::memory_order_relaxed);
-                })
-            .ok());
+    ASSERT_TRUE(remote_server
+                    .registerFunction(
+                        Pin,
+                        [&](const std::string_view&, std::string& response) {
+                            bool expected = false;
+                            response = buffer_pinned.compare_exchange_strong(
+                                           expected, true)
+                                           ? std::to_string(remote_stage_addr)
+                                           : "0";
+                        })
+                    .ok());
+    ASSERT_TRUE(remote_server
+                    .registerFunction(
+                        Unpin,
+                        [&](const std::string_view&, std::string&) {
+                            buffer_pinned.store(false,
+                                                std::memory_order_release);
+                            unpin_calls.fetch_add(1, std::memory_order_relaxed);
+                        })
+                    .ok());
     ASSERT_TRUE(
         remote_server
             .registerFunction(
@@ -1155,7 +1154,8 @@ TEST(ProxyManager, LateRemoteCompletionReleasesAbandonedStageBuffer) {
                 [&](const std::string_view&, std::string&) {
                     delegate_started.store(true, std::memory_order_release);
                     while (!release_delegate.load(std::memory_order_acquire)) {
-                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                        std::this_thread::sleep_for(
+                            std::chrono::milliseconds(1));
                     }
                 },
                 /*offload=*/true)
@@ -1214,7 +1214,8 @@ TEST(ProxyManager, LateRemoteCompletionReleasesAbandonedStageBuffer) {
             ControlClient::unpinStageBuffer(server_addr, repinned_addr).ok());
     }
 
-    EXPECT_TRUE(engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(source.data(), source.size()).ok());
     EXPECT_TRUE(
         engine.unregisterLocalMemory(remote_stage.data(), remote_stage.size())
             .ok());

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -38,6 +38,7 @@
 
 #include "tent/common/config.h"
 #include "tent/common/types.h"
+#include "tent/rpc/rpc.h"
 #include "tent/runtime/segment.h"
 #include "tent/runtime/proxy_manager.h"
 #include "tent/runtime/transfer_engine_impl.h"
@@ -1098,6 +1099,125 @@ TEST(ProxyManager, RemoteCleanupProbeDoesNotBlockOnPendingOperation) {
     operation->complete(Status::OK());
     EXPECT_TRUE(internal::pollRemoteOperations(remote_operations));
     EXPECT_TRUE(remote_operations.empty());
+}
+
+TEST(ProxyManager, LateRemoteCompletionReleasesAbandonedStageBuffer) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    std::string segment_name = engine.getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(segment_name, nullptr, nullptr).ok());
+    engine.swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 64;
+    std::vector<uint8_t> source(kBufferLength, 0x91);
+    std::vector<uint8_t> remote_stage(kBufferLength, 0x00);
+    ASSERT_TRUE(engine.registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(
+        engine.registerLocalMemory(remote_stage.data(), remote_stage.size())
+            .ok());
+
+    CoroRpcAgent remote_server;
+    std::atomic<bool> buffer_pinned{false};
+    std::atomic<bool> delegate_started{false};
+    std::atomic<bool> release_delegate{false};
+    std::atomic<int> unpin_calls{0};
+    const auto remote_stage_addr =
+        reinterpret_cast<uint64_t>(remote_stage.data());
+
+    ASSERT_TRUE(
+        remote_server
+            .registerFunction(
+                Pin,
+                [&](const std::string_view&, std::string& response) {
+                    bool expected = false;
+                    response = buffer_pinned.compare_exchange_strong(expected,
+                                                                      true)
+                                   ? std::to_string(remote_stage_addr)
+                                   : "0";
+                })
+            .ok());
+    ASSERT_TRUE(
+        remote_server
+            .registerFunction(
+                Unpin,
+                [&](const std::string_view&, std::string&) {
+                    buffer_pinned.store(false, std::memory_order_release);
+                    unpin_calls.fetch_add(1, std::memory_order_relaxed);
+                })
+            .ok());
+    ASSERT_TRUE(
+        remote_server
+            .registerFunction(
+                Delegate,
+                [&](const std::string_view&, std::string&) {
+                    delegate_started.store(true, std::memory_order_release);
+                    while (!release_delegate.load(std::memory_order_acquire)) {
+                        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+                    }
+                },
+                /*offload=*/true)
+            .ok());
+
+    uint16_t port = 0;
+    ASSERT_TRUE(remote_server.start(port).ok());
+    const std::string server_addr =
+        "127.0.0.1:" + std::to_string(static_cast<unsigned>(port));
+
+    auto manager = std::make_unique<ProxyManager>(&engine, kBufferLength, 1);
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = source.data();
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = remote_stage_addr;
+    request.length = kBufferLength;
+    const std::vector<std::string> params = {server_addr, "", "remote"};
+
+    TaskInfo task;
+    task.request = request;
+    task.staging = true;
+    ASSERT_TRUE(manager->submit(&task, 0, params).ok());
+
+    const auto start_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!delegate_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < start_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (!delegate_started.load(std::memory_order_acquire)) {
+        release_delegate.store(true, std::memory_order_release);
+        manager.reset();
+        FAIL() << "remote Delegate never started";
+        return;
+    }
+
+    manager.reset();
+    release_delegate.store(true, std::memory_order_release);
+
+    const auto cleanup_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (unpin_calls.load(std::memory_order_acquire) == 0 &&
+           std::chrono::steady_clock::now() < cleanup_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(unpin_calls.load(std::memory_order_acquire), 1);
+
+    uint64_t repinned_addr = 0;
+    ASSERT_TRUE(
+        ControlClient::pinStageBuffer(server_addr, "remote", repinned_addr)
+            .ok());
+    EXPECT_EQ(repinned_addr, remote_stage_addr);
+    if (repinned_addr != 0) {
+        EXPECT_TRUE(
+            ControlClient::unpinStageBuffer(server_addr, repinned_addr).ok());
+    }
+
+    EXPECT_TRUE(engine.unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine.unregisterLocalMemory(remote_stage.data(), remote_stage.size())
+            .ok());
 }
 
 TEST(ProxyManager, DestructorWaitsForDeferredBatchBeforeFreeingStageMemory) {


### PR DESCRIPTION
## Description
When a remote Delegate request outlived `ProxyManager`, destruction discarded the pending cleanup record. A later terminal callback updated only the detached operation, leaving the remote stage buffer pinned permanently.
This change transfers cleanup ownership to unresolved remote operations during `ProxyManager` destruction. A terminal callback then schedules one asynchronous Unpin RPC. Remote buffers not owned by a pending operation are still released immediately.
The first commit adds a failing loopback regression test. The second commit contains only the cleanup fix.

## Module
- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?
The regression test delays a real loopback Delegate RPC, destroys `ProxyManager`, releases the RPC, and verifies exactly one Unpin followed by a successful repin of the same buffer.
**Test commands:**
```bash
cmake --build build-tent --target tent_progress_worker_test
build-tent/mooncake-transfer-engine/tent/tests/tent_progress_worker_test \
  --gtest_filter='ProxyManager.LateRemoteCompletionReleasesAbandonedStageBuffer'
git diff --check origin/main...HEAD
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```
**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)
  - Verified regression test `ProxyManager.LateRemoteCompletionReleasesAbandonedStageBuffer` fails before fix and passes after fix.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure
- [ ] No AI tools were used
- [x] AI tools were used (specify below)