### PR TITLE
[Store] Clean up behavior-focused tests

### DIFF
--- a/mooncake-store/tests/ha/standby/ha_metric_manager_test.cpp
+++ b/mooncake-store/tests/ha/standby/ha_metric_manager_test.cpp
@@ -5,10 +5,38 @@
 
 #include <atomic>
 #include <chrono>
+#include <optional>
+#include <sstream>
 #include <string>
 #include <thread>
 
 namespace mooncake::test {
+
+namespace {
+
+std::optional<int64_t> FindSerializedMetricValue(
+    const std::string& metrics, const std::string& metric_name) {
+    std::istringstream lines(metrics);
+    std::string line;
+    const std::string prefix = metric_name + " ";
+    while (std::getline(lines, line)) {
+        if (line.rfind(prefix, 0) != 0) {
+            continue;
+        }
+
+        std::istringstream value_stream(line.substr(prefix.size()));
+        int64_t value = 0;
+        if (!(value_stream >> value)) {
+            return std::nullopt;
+        }
+        value_stream >> std::ws;
+        return value_stream.eof() ? std::optional<int64_t>(value)
+                                  : std::nullopt;
+    }
+    return std::nullopt;
+}
+
+}  // namespace
 
 class HAMetricManagerTest : public ::testing::Test {
    protected:
@@ -95,16 +123,47 @@ TEST_F(HAMetricManagerTest, TestIncWatchDisconnectionsAndAppliedEntries) {
 }
 
 TEST_F(HAMetricManagerTest, TestRecordOpLogEtcdWriteLatency) {
-    // Call histogram observe functions, mainly to ensure they do not crash
+    const std::string count_name = "ha_oplog_etcd_write_latency_us_count";
+    const std::string sum_name = "ha_oplog_etcd_write_latency_us_sum";
+    const std::string before_metrics = M().serialize_metrics();
+    const int64_t count_before =
+        FindSerializedMetricValue(before_metrics, count_name).value_or(0);
+    const int64_t sum_before =
+        FindSerializedMetricValue(before_metrics, sum_name).value_or(0);
+
     M().observe_oplog_etcd_write_latency_us(100);
     M().observe_oplog_etcd_write_latency_us(5000);
-    SUCCEED();
+
+    const std::string after_metrics = M().serialize_metrics();
+    const auto count_after =
+        FindSerializedMetricValue(after_metrics, count_name);
+    const auto sum_after = FindSerializedMetricValue(after_metrics, sum_name);
+    ASSERT_TRUE(count_after.has_value());
+    ASSERT_TRUE(sum_after.has_value());
+    EXPECT_EQ(count_before + 2, *count_after);
+    EXPECT_EQ(sum_before + 5100, *sum_after);
 }
 
 TEST_F(HAMetricManagerTest, TestRecordOpLogApplyLatency) {
+    const std::string count_name = "ha_oplog_apply_latency_us_count";
+    const std::string sum_name = "ha_oplog_apply_latency_us_sum";
+    const std::string before_metrics = M().serialize_metrics();
+    const int64_t count_before =
+        FindSerializedMetricValue(before_metrics, count_name).value_or(0);
+    const int64_t sum_before =
+        FindSerializedMetricValue(before_metrics, sum_name).value_or(0);
+
     M().observe_oplog_apply_latency_us(50);
     M().observe_oplog_apply_latency_us(1000);
-    SUCCEED();
+
+    const std::string after_metrics = M().serialize_metrics();
+    const auto count_after =
+        FindSerializedMetricValue(after_metrics, count_name);
+    const auto sum_after = FindSerializedMetricValue(after_metrics, sum_name);
+    ASSERT_TRUE(count_after.has_value());
+    ASSERT_TRUE(sum_after.has_value());
+    EXPECT_EQ(count_before + 2, *count_after);
+    EXPECT_EQ(sum_before + 1050, *sum_after);
 }
 
 #ifdef MOONCAKE_ENABLE_OPLOG_PERF_METRICS

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -112,103 +112,14 @@ std::unique_ptr<HotStandbyService> CreateSnapshotOnlyReadyStandby(
 
 }  // namespace
 
-// ========== 6.1.1 Start/Stop tests ==========
-
-TEST_F(HotStandbyServiceTest, TestStart) {
-#ifdef STORE_USE_ETCD
-    // Requires a real etcd cluster and valid cluster configuration; acts as an
-    // integration placeholder
-    GTEST_SKIP()
-        << "Requires real etcd connection, run in integration environment.";
-#else
-    ErrorCode err =
-        service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
-    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestStart_AlreadyRunning) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Requires real etcd connection to verify double start semantics.";
-#else
-    // After the first Start fails and state becomes FAILED, the second Start
-    // should still return INTERNAL_ERROR
-    ErrorCode err1 =
-        service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err1);
-    ErrorCode err2 =
-        service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err2);
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestStart_InvalidEtcdEndpoints) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd to simulate invalid endpoints.";
-#else
-    std::string invalid_endpoints = "invalid_endpoint";
-    ErrorCode err =
-        service_->Start("primary_unused", invalid_endpoints, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestStop) {
-    // Stop should be safe and idempotent even if Start was never called
-    service_->Stop();
-    SUCCEED();
-}
+// ========== 6.1.1 Stop tests ==========
 
 TEST_F(HotStandbyServiceTest, TestStop_WhenNotRunning) {
-    // Multiple Stop calls should be idempotent
-    service_->Stop();
-    service_->Stop();
-    SUCCEED();
-}
-
-// ========== 6.1.2 State transition tests ==========
-
-TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Requires real etcd to drive full state transition to WATCHING.";
-#else
-    // In non-STORE_USE_ETCD builds, Start will set the state machine directly
-    // to FAILED
     EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
-    ErrorCode err =
-        service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
-    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Connection failure requires real etcd and invalid endpoints.";
-#else
-    // In non-etcd mode we cannot distinguish detailed connection errors; only
-    // verify it doesn't crash
-    ErrorCode err =
-        service_->Start("primary_unused", "bad_endpoint", cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Sync failure requires real etcd and OpLog watcher behavior.";
-#else
-    // In non-etcd mode, the sync phase is not actually executed; just ensure
-    // the call is safe
-    ErrorCode err =
-        service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
-#endif
+    service_->Stop();
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
+    service_->Stop();
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
 }
 
 // ========== 6.1.3 Sync status tests ==========
@@ -221,27 +132,6 @@ TEST_F(HotStandbyServiceTest, TestGetSyncStatus_InitialState) {
     EXPECT_FALSE(status.is_syncing);
     EXPECT_FALSE(status.is_connected);
     EXPECT_EQ(StandbyState::STOPPED, status.state);
-}
-
-TEST_F(HotStandbyServiceTest, TestGetSyncStatus_AfterSync) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Requires real etcd and OpLog activity to change sync status.";
-#else
-    // In non-etcd mode, calling Start will not change applied/primary, but the
-    // state machine enters FAILED
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    StandbySyncStatus status = service_->GetSyncStatus();
-    EXPECT_EQ(StandbyState::FAILED, status.state);
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestGetSyncStatus) {
-    // Basic coverage: multiple calls should return consistent values and not
-    // crash
-    StandbySyncStatus s1 = service_->GetSyncStatus();
-    StandbySyncStatus s2 = service_->GetSyncStatus();
-    EXPECT_EQ(s1.state, s2.state);
 }
 
 // ========== 6.1.4 Promotion tests ==========
@@ -301,41 +191,6 @@ TEST_F(HotStandbyServiceTest, TestPromoteAndExportSnapshot_FinalCatchUp) {
     EXPECT_EQ(10u, post_snapshot.oplog_sequence_id);
     ASSERT_EQ(1u, post_snapshot.objects.size());
     EXPECT_EQ("key-1", post_snapshot.objects[0].key);
-}
-
-// ========== 6.1.5 Warm start tests ==========
-
-TEST_F(HotStandbyServiceTest, TestWarmStart_WithLocalState) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd and pre-populated local metadata to "
-                    "test warm start.";
-#else
-    // In non-etcd mode, only verify that Start is safe to call
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    SUCCEED();
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestWarmStart_WithoutLocalState) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd and snapshot provider configuration.";
-#else
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    SUCCEED();
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestWarmStart_WithSnapshot) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires snapshot provider and real etcd to exercise "
-                    "snapshot bootstrap.";
-#else
-    config_.enable_snapshot_bootstrap = true;
-    // Recreate service to apply the new configuration
-    service_.reset(new HotStandbyService(config_));
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    SUCCEED();
-#endif
 }
 
 TEST_F(HotStandbyServiceTest, TestStart_SnapshotOnlyWithSnapshot) {
@@ -468,60 +323,9 @@ TEST_F(HotStandbyServiceTest, TestExportStandbySnapshot_Empty) {
     EXPECT_TRUE(snapshot.segments.empty());
 }
 
-// ========== 6.1.7 Replication loop tests ==========
-
-TEST_F(HotStandbyServiceTest, TestReplicationLoop_UpdatesMetrics) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP()
-        << "Requires real etcd and running replication loop to update metrics.";
-#else
-    // In non-etcd mode, ReplicationLoop is never started, but calling Stop
-    // should be safe
-    service_->Stop();
-    SUCCEED();
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd and watcher disconnect to exercise "
-                    "disconnect path.";
-#else
-    // DisconnectFromPrimary is private; verify Stop() is safe instead
-    service_->Stop();
-    SUCCEED();
-#endif
-}
-
-// ========== 6.1.8 Verification loop tests ==========
-
-TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd and running verification loop to "
-                    "observe behavior.";
-#else
-    config_.enable_verification = true;
-    service_.reset(new HotStandbyService(config_));
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    service_->Stop();
-    SUCCEED();
-#endif
-}
-
-TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenDisabled) {
-    // By default config_.enable_verification = false, so Start should not spawn
-    // a verification thread
-#ifdef STORE_USE_ETCD
-    GTEST_SKIP() << "Requires real etcd connection to start service.";
-#else
-    (void)service_->Start("primary_unused", oplog_endpoints_, cluster_id_);
-    service_->Stop();
-    SUCCEED();
-#endif
-}
-
 // ========== Issue 2 fail-closed catch-up ==========
 
+#ifdef STORE_USE_ETCD
 namespace {
 
 // Helper to create a valid OpLogEntry with checksum (mirrors the helper in
@@ -970,6 +774,7 @@ TEST_F(PromotionCatchUpTest, FailsPromotionWhenTargetBatchUnreadable) {
     EXPECT_EQ(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, promote_err);
     EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 }
+#endif
 
 }  // namespace mooncake::test
 

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -87,6 +87,9 @@ class HotStandbyServiceTest : public ::testing::Test {
 
 namespace {
 
+constexpr char kEtcdBehaviorCoverageIssue[] =
+    "https://github.com/kvcache-ai/Mooncake/issues/3496";
+
 std::unique_ptr<HotStandbyService> CreateSnapshotOnlyReadyStandby(
     HotStandbyConfig config, const std::string& cluster_id) {
     config.enable_snapshot_bootstrap = true;
@@ -112,7 +115,25 @@ std::unique_ptr<HotStandbyService> CreateSnapshotOnlyReadyStandby(
 
 }  // namespace
 
-// ========== 6.1.1 Stop tests ==========
+// ========== 6.1.1 Start/Stop tests ==========
+
+TEST_F(HotStandbyServiceTest, TestStart) {
+    GTEST_SKIP() << "Requires deterministic etcd-backed Start coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestStart_AlreadyRunning) {
+    service_ = CreateSnapshotOnlyReadyStandby(config_, cluster_id_);
+
+    EXPECT_EQ(ErrorCode::OK,
+              service_->Start("unused", "unused", "unused-cluster"));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+}
+
+TEST_F(HotStandbyServiceTest, TestStart_InvalidEtcdEndpoints) {
+    GTEST_SKIP() << "Requires deterministic invalid-endpoint coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
+}
 
 TEST_F(HotStandbyServiceTest, TestStop_WhenNotRunning) {
     EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
@@ -120,6 +141,24 @@ TEST_F(HotStandbyServiceTest, TestStop_WhenNotRunning) {
     EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
     service_->Stop();
     EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
+}
+
+// ========== 6.1.2 State transition tests ==========
+
+TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
+    GTEST_SKIP() << "Requires deterministic etcd-backed state coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
+    GTEST_SKIP() << "Requires deterministic connection-failure coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
+    GTEST_SKIP() << "Requires deterministic synchronization-failure coverage; "
+                    "see "
+                 << kEtcdBehaviorCoverageIssue;
 }
 
 // ========== 6.1.3 Sync status tests ==========
@@ -132,6 +171,11 @@ TEST_F(HotStandbyServiceTest, TestGetSyncStatus_InitialState) {
     EXPECT_FALSE(status.is_syncing);
     EXPECT_FALSE(status.is_connected);
     EXPECT_EQ(StandbyState::STOPPED, status.state);
+}
+
+TEST_F(HotStandbyServiceTest, TestGetSyncStatus_AfterSync) {
+    GTEST_SKIP() << "Requires deterministic post-sync status coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
 }
 
 // ========== 6.1.4 Promotion tests ==========
@@ -191,6 +235,26 @@ TEST_F(HotStandbyServiceTest, TestPromoteAndExportSnapshot_FinalCatchUp) {
     EXPECT_EQ(10u, post_snapshot.oplog_sequence_id);
     ASSERT_EQ(1u, post_snapshot.objects.size());
     EXPECT_EQ("key-1", post_snapshot.objects[0].key);
+}
+
+// ========== 6.1.5 Warm start tests ==========
+
+TEST_F(HotStandbyServiceTest, TestWarmStart_WithLocalState) {
+    GTEST_SKIP() << "Requires deterministic local-state warm-start coverage; "
+                    "see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestWarmStart_WithoutLocalState) {
+    GTEST_SKIP() << "Requires deterministic empty-state warm-start coverage; "
+                    "see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestWarmStart_WithSnapshot) {
+    GTEST_SKIP() << "Requires deterministic etcd-backed snapshot warm-start "
+                    "coverage; see "
+                 << kEtcdBehaviorCoverageIssue;
 }
 
 TEST_F(HotStandbyServiceTest, TestStart_SnapshotOnlyWithSnapshot) {
@@ -321,6 +385,35 @@ TEST_F(HotStandbyServiceTest, TestExportStandbySnapshot_Empty) {
     EXPECT_EQ(0u, snapshot.oplog_sequence_id);
     EXPECT_TRUE(snapshot.objects.empty());
     EXPECT_TRUE(snapshot.segments.empty());
+}
+
+// ========== 6.1.7 Replication loop tests ==========
+
+TEST_F(HotStandbyServiceTest, TestReplicationLoop_UpdatesMetrics) {
+    GTEST_SKIP() << "Requires deterministic replication-loop metric coverage; "
+                    "see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
+    GTEST_SKIP() << "Requires deterministic replication disconnect coverage; "
+                    "see "
+                 << kEtcdBehaviorCoverageIssue;
+}
+
+// ========== 6.1.8 Verification loop tests ==========
+
+TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
+    GTEST_SKIP()
+        << "Requires deterministic enabled verification-loop coverage; "
+           "see "
+        << kEtcdBehaviorCoverageIssue;
+}
+
+TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenDisabled) {
+    GTEST_SKIP()
+        << "Requires deterministic disabled verification-loop coverage; see "
+        << kEtcdBehaviorCoverageIssue;
 }
 
 // ========== Issue 2 fail-closed catch-up ==========

--- a/mooncake-store/tests/mutex_test.cpp
+++ b/mooncake-store/tests/mutex_test.cpp
@@ -79,58 +79,83 @@ TEST(SharedMutexTest, SharedAccessIsConcurrent) {
 
 TEST(SharedMutexTest, WriterBlocksReaders) {
     SharedMutex mtx;
-    std::atomic<bool> reader_started{false};
-    std::atomic<bool> writer_proceeded{false};
-
-    std::thread reader([&]() {
-        mtx.lock_shared();
-        reader_started = true;
-        while (!writer_proceeded) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        }
-        mtx.unlock_shared();
-    });
-
-    // Give reader time to start
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    auto try_write =
-        mtx.try_lock();  // Should fail because reader holds shared lock
-    EXPECT_FALSE(try_write);
-
-    // Let reader finish
-    writer_proceeded = true;
-    reader.join();
-
-    // Now writer should be able to acquire the lock
     mtx.lock();
-    EXPECT_TRUE(true);  // No deadlock occurred
+
+    bool reader_acquired = false;
+    std::thread reader([&]() {
+        reader_acquired = mtx.try_lock_shared();
+        if (reader_acquired) {
+            mtx.unlock_shared();
+        }
+    });
+    reader.join();
+    EXPECT_FALSE(reader_acquired);
+
     mtx.unlock();
+
+    const bool reader_acquired_after_unlock = mtx.try_lock_shared();
+    EXPECT_TRUE(reader_acquired_after_unlock);
+    if (reader_acquired_after_unlock) {
+        mtx.unlock_shared();
+    }
 }
 
 TEST(SharedMutexTest, LocksOnConstructionExclusive) {
     SharedMutex mtx;
     {
         SharedMutexLocker locker(&mtx);
-        // Lock should still be held before destruction
-        EXPECT_FALSE(mtx.try_lock());  // Cannot acquire another exclusive lock
-        EXPECT_FALSE(mtx.try_lock_shared());  // Shared lock may also be blocked
-                                              // (implementation-defined)
-    }  // Destructor automatically unlocks
-    EXPECT_TRUE(mtx.try_lock());  // After destruction, lock should be available
+        bool exclusive_acquired = false;
+        bool shared_acquired = false;
+        std::thread contender([&]() {
+            exclusive_acquired = mtx.try_lock();
+            if (exclusive_acquired) {
+                mtx.unlock();
+            }
+            shared_acquired = mtx.try_lock_shared();
+            if (shared_acquired) {
+                mtx.unlock_shared();
+            }
+        });
+        contender.join();
+
+        EXPECT_FALSE(exclusive_acquired);
+        EXPECT_FALSE(shared_acquired);
+    }
+
+    const bool exclusive_acquired = mtx.try_lock();
+    EXPECT_TRUE(exclusive_acquired);
+    if (exclusive_acquired) {
+        mtx.unlock();
+    }
 }
 
 TEST(SharedMutexTest, LocksOnConstructionShared) {
     SharedMutex mtx;
     {
         SharedMutexLocker locker(&mtx, shared_lock);
-        EXPECT_TRUE(
-            mtx.try_lock_shared());  // Multiple shared locks should be allowed
-        // Note: This test does not attempt recursive locking (UB), just checks
-        // concurrent shared access.
+        bool shared_acquired = false;
+        bool exclusive_acquired = false;
+        std::thread contender([&]() {
+            shared_acquired = mtx.try_lock_shared();
+            if (shared_acquired) {
+                mtx.unlock_shared();
+            }
+            exclusive_acquired = mtx.try_lock();
+            if (exclusive_acquired) {
+                mtx.unlock();
+            }
+        });
+        contender.join();
+
+        EXPECT_TRUE(shared_acquired);
+        EXPECT_FALSE(exclusive_acquired);
     }
-    EXPECT_TRUE(
-        mtx.try_lock_shared());  // Should still be available after unlock
+
+    const bool shared_acquired = mtx.try_lock_shared();
+    EXPECT_TRUE(shared_acquired);
+    if (shared_acquired) {
+        mtx.unlock_shared();
+    }
 }
 
 TEST(SharedMutexTest, ManualLockUnlock) {
@@ -139,8 +164,12 @@ TEST(SharedMutexTest, ManualLockUnlock) {
     EXPECT_NO_THROW(locker.unlock());  // Unlocking a null locker should be safe
 
     SharedMutexLocker temp(&mtx);
-    temp.unlock();                // Manually release the lock
-    EXPECT_TRUE(mtx.try_lock());  // Now we should be able to acquire it
+    temp.unlock();
+    const bool acquired = mtx.try_lock();
+    EXPECT_TRUE(acquired);
+    if (acquired) {
+        mtx.unlock();
+    }
 }
 
 TEST(SharedMutexTest, TryLockSuccess) {
@@ -151,6 +180,7 @@ TEST(SharedMutexTest, TryLockSuccess) {
     bool result = locker.try_lock();
     EXPECT_TRUE(result);
     EXPECT_FALSE(locker.try_lock());  // Should not allow re-locking
+    locker.unlock();
 }
 
 TEST(SharedMutexTest, TryLockSharedSuccess) {
@@ -161,6 +191,7 @@ TEST(SharedMutexTest, TryLockSharedSuccess) {
     bool result = locker.try_lock_shared();
     EXPECT_TRUE(result);
     EXPECT_FALSE(locker.try_lock_shared());  // Should not allow re-locking
+    locker.unlock();
 }
 
 TEST(SharedMutexTest, HandlesNullptrSafely) {

--- a/mooncake-store/tests/object_data_type_test.cpp
+++ b/mooncake-store/tests/object_data_type_test.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include <sstream>
-#include <vector>
 
 namespace mooncake::test {
 
@@ -79,13 +78,6 @@ TEST_F(ObjectDataTypeTest, ReplicateConfigDefaultDataType) {
     EXPECT_EQ(config.data_type, ObjectDataType::UNKNOWN);
 }
 
-// ReplicateConfig can be set to other types
-TEST_F(ObjectDataTypeTest, ReplicateConfigSetDataType) {
-    ReplicateConfig config;
-    config.data_type = ObjectDataType::WEIGHT;
-    EXPECT_EQ(config.data_type, ObjectDataType::WEIGHT);
-}
-
 // ReplicateConfig stream output includes data_type
 TEST_F(ObjectDataTypeTest, ReplicateConfigStreamIncludesDataType) {
     ReplicateConfig config;
@@ -95,32 +87,7 @@ TEST_F(ObjectDataTypeTest, ReplicateConfigStreamIncludesDataType) {
     EXPECT_NE(oss.str().find("data_type: TENSOR"), std::string::npos);
 }
 
-// PutStart with data_type propagates to ObjectMetadata
-TEST_F(ObjectDataTypeTest, PutStartWithDataType) {
-    std::unique_ptr<MasterService> service(new MasterService());
-    Segment segment = MakeSegment();
-    UUID client_id = generate_uuid();
-    auto mount_result = service->MountSegment(segment, client_id);
-    ASSERT_TRUE(mount_result.has_value());
-
-    UUID put_client = generate_uuid();
-
-    // Put with WEIGHT type
-    ReplicateConfig config;
-    config.replica_num = 1;
-    config.data_type = ObjectDataType::WEIGHT;
-
-    auto result = service->PutStart(put_client, "key_weight",
-                                    TenantId::Default(), 1024, config);
-    ASSERT_TRUE(result.has_value());
-    EXPECT_FALSE(result.value().empty());
-
-    auto end_result = service->PutEnd(put_client, "key_weight",
-                                      TenantId::Default(), ReplicaType::MEMORY);
-    EXPECT_TRUE(end_result.has_value());
-}
-
-// PutStart with default UNKNOWN data_type still works (backward compat)
+// PutStart accepts the default UNKNOWN data type.
 TEST_F(ObjectDataTypeTest, PutStartDefaultDataType) {
     std::unique_ptr<MasterService> service(new MasterService());
     Segment segment = MakeSegment();
@@ -137,23 +104,6 @@ TEST_F(ObjectDataTypeTest, PutStartDefaultDataType) {
                                     TenantId::Default(), 1024, config);
     ASSERT_TRUE(result.has_value());
     EXPECT_FALSE(result.value().empty());
-}
-
-// Verify all enum values can roundtrip through uint8_t cast
-TEST_F(ObjectDataTypeTest, EnumRoundtrip) {
-    std::vector<ObjectDataType> all_types = {
-        ObjectDataType::UNKNOWN,  ObjectDataType::KVCACHE,
-        ObjectDataType::TENSOR,   ObjectDataType::WEIGHT,
-        ObjectDataType::SAMPLE,   ObjectDataType::ACTIVATION,
-        ObjectDataType::GRADIENT, ObjectDataType::OPTIMIZER_STATE,
-        ObjectDataType::METADATA, ObjectDataType::GENERAL,
-    };
-
-    for (auto type : all_types) {
-        uint8_t raw = static_cast<uint8_t>(type);
-        auto recovered = static_cast<ObjectDataType>(raw);
-        EXPECT_EQ(type, recovered);
-    }
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/ssd_metrics_test.cpp
+++ b/mooncake-store/tests/ssd_metrics_test.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <map>
 #include <thread>
-#include <vector>
 
 #include "client_metric.h"
 
@@ -18,165 +18,6 @@ class SsdMetricsTest : public ::testing::Test {
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
 };
-
-TEST_F(SsdMetricsTest, InitialValuesTest) {
-    SsdMetric metrics;
-
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 0);
-    ASSERT_EQ(metrics.ssd_write_bytes.value(), 0);
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_write_ops.value(), 0);
-
-    // Histogram bucket counts should all be 0
-    auto read_buckets = metrics.ssd_read_latency_us.get_bucket_counts();
-    for (auto& bucket : read_buckets) {
-        ASSERT_EQ(bucket->value(), 0);
-    }
-    auto write_buckets = metrics.ssd_write_latency_us.get_bucket_counts();
-    for (auto& bucket : write_buckets) {
-        ASSERT_EQ(bucket->value(), 0);
-    }
-
-    // Total metrics
-    ASSERT_EQ(metrics.ssd_total_bytes.value(), 0);
-    ASSERT_EQ(metrics.ssd_total_ops.value(), 0);
-}
-
-TEST_F(SsdMetricsTest, ReadMetricsTest) {
-    SsdMetric metrics;
-
-    // Simulate a successful BatchLoad of 3 keys totaling 1MB
-    metrics.ssd_read_ops.inc(3);
-    metrics.ssd_read_bytes.inc(1024 * 1024);
-    metrics.ssd_read_latency_us.observe(1500);  // 1.5ms
-
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 3);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 1024 * 1024);
-
-    // Simulate another BatchLoad of 5 keys totaling 2MB
-    metrics.ssd_read_ops.inc(5);
-    metrics.ssd_read_bytes.inc(2 * 1024 * 1024);
-    metrics.ssd_read_latency_us.observe(3000);  // 3ms
-
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 8);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 3 * 1024 * 1024);
-
-    // Write metrics should remain 0
-    ASSERT_EQ(metrics.ssd_write_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_write_bytes.value(), 0);
-}
-
-TEST_F(SsdMetricsTest, WriteMetricsTest) {
-    SsdMetric metrics;
-
-    // Simulate a successful BatchOffload of 10 keys totaling 5MB
-    metrics.ssd_write_ops.inc(10);
-    metrics.ssd_write_bytes.inc(5 * 1024 * 1024);
-    metrics.ssd_write_latency_us.observe(50000);  // 50ms
-
-    ASSERT_EQ(metrics.ssd_write_ops.value(), 10);
-    ASSERT_EQ(metrics.ssd_write_bytes.value(), 5 * 1024 * 1024);
-
-    // Read metrics should remain 0
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 0);
-}
-
-TEST_F(SsdMetricsTest, TotalMetricsTest) {
-    SsdMetric metrics;
-
-    // Simulate read: 3 keys, 1MB
-    metrics.ssd_read_ops.inc(3);
-    metrics.ssd_read_bytes.inc(1024 * 1024);
-    metrics.ssd_read_latency_us.observe(1500);
-    metrics.ssd_read_latency_summary.observe(1500);
-    metrics.ssd_total_ops.inc(3);
-    metrics.ssd_total_bytes.inc(1024 * 1024);
-    metrics.ssd_total_latency_us.observe(1500);
-    metrics.ssd_total_latency_summary.observe(1500);
-
-    // Simulate write: 5 keys, 2MB
-    metrics.ssd_write_ops.inc(5);
-    metrics.ssd_write_bytes.inc(2 * 1024 * 1024);
-    metrics.ssd_write_latency_us.observe(3000);
-    metrics.ssd_write_latency_summary.observe(3000);
-    metrics.ssd_total_ops.inc(5);
-    metrics.ssd_total_bytes.inc(2 * 1024 * 1024);
-    metrics.ssd_total_latency_us.observe(3000);
-    metrics.ssd_total_latency_summary.observe(3000);
-
-    // Verify totals = read + write
-    ASSERT_EQ(metrics.ssd_total_ops.value(), 3 + 5);
-    ASSERT_EQ(metrics.ssd_total_bytes.value(), 1024 * 1024 + 2 * 1024 * 1024);
-
-    // Total latency histogram should have 2 observations
-    auto buckets = metrics.ssd_total_latency_us.get_bucket_counts();
-    int64_t total_count = 0;
-    for (auto& b : buckets) total_count += b->value();
-    ASSERT_EQ(total_count, 2);
-
-    // Verify summary shows Total line
-    std::string summary = metrics.summary_metrics();
-    EXPECT_TRUE(summary.find("SSD Total:") != std::string::npos);
-    EXPECT_TRUE(summary.find("Total:") != std::string::npos);
-
-    std::cout << "Total Metrics Summary:\n" << summary << std::endl;
-}
-
-TEST_F(SsdMetricsTest, FailureNotCountedTest) {
-    SsdMetric metrics;
-
-    // Simulate: nothing recorded (as if BatchLoad failed and we skipped
-    // metrics) All metrics should remain 0
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 0);
-    ASSERT_EQ(metrics.ssd_write_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_write_bytes.value(), 0);
-
-    // Now simulate a success after a failure
-    metrics.ssd_read_ops.inc(1);
-    metrics.ssd_read_bytes.inc(4096);
-    metrics.ssd_read_latency_us.observe(100);
-
-    // Only the successful operation should be counted
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 1);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 4096);
-}
-
-TEST_F(SsdMetricsTest, ConcurrentTest) {
-    SsdMetric metrics;
-
-    const int num_threads = 8;
-    const int ops_per_thread = 1000;
-
-    std::vector<std::thread> threads;
-    for (int i = 0; i < num_threads; ++i) {
-        threads.emplace_back([&metrics, ops_per_thread]() {
-            for (int j = 0; j < ops_per_thread; ++j) {
-                metrics.ssd_read_ops.inc(1);
-                metrics.ssd_read_bytes.inc(4096);
-                metrics.ssd_read_latency_us.observe(500);
-                metrics.ssd_write_ops.inc(1);
-                metrics.ssd_write_bytes.inc(8192);
-                metrics.ssd_write_latency_us.observe(1000);
-                metrics.ssd_total_ops.inc(2);
-                metrics.ssd_total_bytes.inc(4096 + 8192);
-            }
-        });
-    }
-
-    for (auto& t : threads) {
-        t.join();
-    }
-
-    int64_t expected_ops = num_threads * ops_per_thread;
-    ASSERT_EQ(metrics.ssd_read_ops.value(), expected_ops);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), expected_ops * 4096);
-    ASSERT_EQ(metrics.ssd_write_ops.value(), expected_ops);
-    ASSERT_EQ(metrics.ssd_write_bytes.value(), expected_ops * 8192);
-    ASSERT_EQ(metrics.ssd_total_ops.value(), expected_ops * 2);
-    ASSERT_EQ(metrics.ssd_total_bytes.value(), expected_ops * (4096 + 8192));
-}
 
 TEST_F(SsdMetricsTest, SerializeTest) {
     SsdMetric metrics;
@@ -409,28 +250,6 @@ TEST_F(SsdMetricsTest, LatencyBucketBoundaryTest) {
 
     std::cout << "Bucket boundary test serialization:\n"
               << serialized << std::endl;
-}
-
-TEST_F(SsdMetricsTest, EmptyBatchMetricsTest) {
-    SsdMetric metrics;
-
-    // Simulate recording metrics for an empty batch (0 keys, 0 bytes)
-    // This mirrors what happens if FileStorage::BatchLoad is called with
-    // an empty map and succeeds - the instrumentation code would compute
-    // total_bytes=0 and batch_object.size()=0
-    metrics.ssd_read_ops.inc(0);
-    metrics.ssd_read_bytes.inc(0);
-    metrics.ssd_read_latency_us.observe(10);  // Still takes some time
-
-    // Counters should remain 0 (inc(0) is a no-op for counters)
-    ASSERT_EQ(metrics.ssd_read_ops.value(), 0);
-    ASSERT_EQ(metrics.ssd_read_bytes.value(), 0);
-
-    // But latency histogram should record the observation
-    auto buckets = metrics.ssd_read_latency_us.get_bucket_counts();
-    int64_t total = 0;
-    for (auto& b : buckets) total += b->value();
-    EXPECT_EQ(total, 1);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/task_executor_test.cpp
+++ b/mooncake-store/tests/task_executor_test.cpp
@@ -1,499 +1,58 @@
-#include "client_service.h"
-#include "master_client.h"
 #include "task_manager.h"
-#include "rpc_types.h"
-#include "gtest/gtest.h"
-#include "glog/logging.h"
-#include <ylt/struct_json/json_writer.h>
+
+#include <gtest/gtest.h>
 #include <ylt/struct_json/json_reader.h>
-#include <memory>
-#include <thread>
-#include <chrono>
-#include <vector>
-#include <cstring>
-#include <map>
-#include <atomic>
-#include <set>
+#include <ylt/struct_json/json_writer.h>
+
 #include <string>
 
 namespace mooncake {
 
-// Test class for Client Copy/Move and task execution functionality
-// Note: TaskExecutor has been merged into Client class.
-// These are unit tests for the logic that can be tested without full
-// integration. Full end-to-end tests are in task_integration_test.cpp
-class TaskExecutorTest : public ::testing::Test {
-   protected:
-    void SetUp() override {
-        google::InitGoogleLogging("TaskExecutorTest");
-        FLAGS_logtostderr = 1;
-    }
-
-    void TearDown() override { google::ShutdownGoogleLogging(); }
-
-    // Helper to create a valid memory replica descriptor
-    Replica::Descriptor CreateMemoryReplicaDescriptor(
-        ReplicaID id, const std::string& segment_name, size_t size = 1024) {
-        Replica::Descriptor replica;
-        replica.id = id;
-        replica.status = ReplicaStatus::COMPLETE;
-        MemoryDescriptor mem_desc;
-        mem_desc.buffer_descriptor.size_ = size;
-        mem_desc.buffer_descriptor.buffer_address_ = 0x1000;
-        mem_desc.buffer_descriptor.transport_endpoint_ = segment_name;
-        replica.descriptor_variant = mem_desc;
-        return replica;
-    }
-
-    // Helper to create a query result with replicas
-    QueryResult CreateQueryResultWithReplicas(
-        const std::vector<Replica::Descriptor>& replicas) {
-        std::vector<Replica::Descriptor> replicas_copy =
-            replicas;  // Make a copy to move
-        std::chrono::steady_clock::time_point lease_timeout =
-            std::chrono::steady_clock::now() +
-            std::chrono::seconds(60);  // 60 second lease
-        return QueryResult(std::move(replicas_copy), lease_timeout);
-    }
-};
-
-// Payload Structure Tests
-TEST_F(TaskExecutorTest, ReplicaCopyPayloadStructure) {
+TEST(TaskPayloadSerializationTest, ReplicaCopyPayloadRoundTrip) {
     ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {"target1", "target2"};
+    payload.tenant_id = "tenant-a";
+    payload.key = "copy-key";
+    payload.source = "source-segment";
+    payload.targets = {"target-segment-1", "target-segment-2"};
+    payload.dynamic_replication_lease_id_high = 123;
+    payload.dynamic_replication_lease_id_low = 456;
+    payload.dynamic_replication_version_epoch = 789;
 
-    EXPECT_EQ(payload.key, "test_key");
-    EXPECT_EQ(payload.targets.size(), 2);
-    EXPECT_EQ(payload.targets[0], "target1");
-    EXPECT_EQ(payload.targets[1], "target2");
-}
-
-TEST_F(TaskExecutorTest, ReplicaCopyPayloadMultipleTargets) {
-    ReplicaCopyPayload payload;
-    payload.key = "test_multi_target_key";
-    payload.targets = {"segment1", "segment2", "segment3", "segment4"};
-
-    EXPECT_EQ(payload.key, "test_multi_target_key");
-    EXPECT_EQ(payload.targets.size(), 4);
-    EXPECT_EQ(payload.targets[0], "segment1");
-    EXPECT_EQ(payload.targets[1], "segment2");
-    EXPECT_EQ(payload.targets[2], "segment3");
-    EXPECT_EQ(payload.targets[3], "segment4");
-
-    // Test serialization and deserialization
     std::string json;
     struct_json::to_json(payload, json);
 
-    ReplicaCopyPayload deserialized_payload;
-    struct_json::from_json(deserialized_payload, json);
+    ReplicaCopyPayload round_tripped;
+    struct_json::from_json(round_tripped, json);
 
-    EXPECT_EQ(deserialized_payload.key, payload.key);
-    EXPECT_EQ(deserialized_payload.targets.size(), payload.targets.size());
-    for (size_t i = 0; i < payload.targets.size(); ++i) {
-        EXPECT_EQ(deserialized_payload.targets[i], payload.targets[i]);
-    }
+    EXPECT_EQ(round_tripped.tenant_id, payload.tenant_id);
+    EXPECT_EQ(round_tripped.key, payload.key);
+    EXPECT_EQ(round_tripped.source, payload.source);
+    EXPECT_EQ(round_tripped.targets, payload.targets);
+    EXPECT_EQ(round_tripped.dynamic_replication_lease_id_high,
+              payload.dynamic_replication_lease_id_high);
+    EXPECT_EQ(round_tripped.dynamic_replication_lease_id_low,
+              payload.dynamic_replication_lease_id_low);
+    EXPECT_EQ(round_tripped.dynamic_replication_version_epoch,
+              payload.dynamic_replication_version_epoch);
 }
 
-TEST_F(TaskExecutorTest, ReplicaCopyPayloadEmptyTargets) {
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {};
-
-    EXPECT_EQ(payload.key, "test_key");
-    EXPECT_EQ(payload.targets.size(), 0);
-
-    // Serialization and deserialization should handle empty vector
-    std::string json;
-    struct_json::to_json(payload, json);
-
-    ReplicaCopyPayload deserialized_payload;
-    struct_json::from_json(deserialized_payload, json);
-
-    EXPECT_EQ(deserialized_payload.key, payload.key);
-    EXPECT_EQ(deserialized_payload.targets.size(), 0);
-}
-
-TEST_F(TaskExecutorTest, ReplicaCopyPayloadSingleTarget) {
-    ReplicaCopyPayload payload;
-    payload.key = "test_single_target_key";
-    payload.targets = {"target_segment"};
-
-    EXPECT_EQ(payload.key, "test_single_target_key");
-    EXPECT_EQ(payload.targets.size(), 1);
-    EXPECT_EQ(payload.targets[0], "target_segment");
-}
-
-TEST_F(TaskExecutorTest, ReplicaMovePayloadStructure) {
+TEST(TaskPayloadSerializationTest, ReplicaMovePayloadRoundTrip) {
     ReplicaMovePayload payload;
-    payload.key = "test_key";
-    payload.source = "source_segment";
-    payload.target = "target_segment";
-
-    EXPECT_EQ(payload.key, "test_key");
-    EXPECT_EQ(payload.source, "source_segment");
-    EXPECT_EQ(payload.target, "target_segment");
-}
-
-// Task Payload Tests
-TEST_F(TaskExecutorTest, TaskWithReplicaCopyPayload) {
-    Task task;
-    UUID test_id = generate_uuid();
-    task.id = test_id;
-    task.type = TaskType::REPLICA_COPY;
-    task.status = TaskStatus::PENDING;
-
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {"target1", "target2"};
-
-    struct_json::to_json(payload, task.payload);
-
-    EXPECT_EQ(task.id.first, test_id.first);
-    EXPECT_EQ(task.id.second, test_id.second);
-    EXPECT_EQ(task.type, TaskType::REPLICA_COPY);
-    EXPECT_EQ(task.status, TaskStatus::PENDING);
-    EXPECT_FALSE(task.payload.empty());
-
-    // Verify we can deserialize
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, task.payload);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_EQ(deserialized.targets.size(), 2);
-}
-
-TEST_F(TaskExecutorTest, TaskWithReplicaMovePayload) {
-    Task task;
-    task.id = generate_uuid();
-    task.type = TaskType::REPLICA_MOVE;
-    task.status = TaskStatus::PENDING;
-
-    ReplicaMovePayload payload;
-    payload.key = "test_key";
-    payload.source = "source_segment";
-    payload.target = "target_segment";
-
-    struct_json::to_json(payload, task.payload);
-
-    EXPECT_EQ(task.type, TaskType::REPLICA_MOVE);
-    EXPECT_EQ(task.status, TaskStatus::PENDING);
-    EXPECT_FALSE(task.payload.empty());
-
-    // Verify we can deserialize
-    ReplicaMovePayload deserialized;
-    struct_json::from_json(deserialized, task.payload);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_EQ(deserialized.source, "source_segment");
-    EXPECT_EQ(deserialized.target, "target_segment");
-}
-
-// Replica Descriptor Tests
-TEST_F(TaskExecutorTest, MemoryReplicaDescriptorHandling) {
-    // Test creating memory replica descriptor
-    auto replica = CreateMemoryReplicaDescriptor(1, "test_segment:12345", 1024);
-
-    EXPECT_EQ(replica.id, 1);
-    EXPECT_EQ(replica.status, ReplicaStatus::COMPLETE);
-    EXPECT_TRUE(replica.is_memory_replica());
-
-    const auto& mem_desc = replica.get_memory_descriptor();
-    EXPECT_EQ(mem_desc.buffer_descriptor.size_, 1024);
-    EXPECT_EQ(mem_desc.buffer_descriptor.transport_endpoint_,
-              "test_segment:12345");
-}
-
-TEST_F(TaskExecutorTest, SourceSegmentExtraction) {
-    // Test source segment extraction logic:
-    // For memory replica: use buffer_descriptor.transport_endpoint_
-    // For disk replica: use payload.source (requires src_segment in payload)
-
-    auto memory_replica =
-        CreateMemoryReplicaDescriptor(1, "memory_seg:12345", 1024);
-    EXPECT_TRUE(memory_replica.is_memory_replica());
-
-    const auto& mem_desc = memory_replica.get_memory_descriptor();
-    std::string src_segment = mem_desc.buffer_descriptor.transport_endpoint_;
-    EXPECT_EQ(src_segment, "memory_seg:12345");
-}
-
-// ClientTask and TaskAssignment Tests
-TEST_F(TaskExecutorTest, ClientTaskStructure) {
-    // ClientTask is now a private struct in Client class, but we can test
-    // TaskAssignment which is used to construct ClientTask
-    TaskAssignment assignment;
-    assignment.id = generate_uuid();
-    assignment.type = TaskType::REPLICA_COPY;
-
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {"target1"};
-    struct_json::to_json(payload, assignment.payload);
-
-    EXPECT_EQ(assignment.type, TaskType::REPLICA_COPY);
-    EXPECT_FALSE(assignment.payload.empty());
-
-    // Verify we can deserialize
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, assignment.payload);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_EQ(deserialized.targets.size(), 1);
-}
-
-TEST_F(TaskExecutorTest, TaskAssignmentToClientTaskConversion) {
-    TaskAssignment assignment;
-    assignment.id = generate_uuid();
-    assignment.type = TaskType::REPLICA_COPY;
-
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {"target1", "target2"};
-    struct_json::to_json(payload, assignment.payload);
-
-    // Simulate ClientTask construction (ClientTask is private, so we test the
-    // pattern) In actual Client code: ClientTask client_task;
-    // client_task.assignment = assignment; client_task.retry_count = 0;
-    EXPECT_EQ(assignment.type, TaskType::REPLICA_COPY);
-    EXPECT_FALSE(assignment.payload.empty());
-
-    // Verify payload can be deserialized
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, assignment.payload);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_EQ(deserialized.targets.size(), 2);
-}
-
-// Copy/Move Method Parameter Validation Tests
-TEST_F(TaskExecutorTest, CopyMethodEmptyKey) {
-    // This test documents expected behavior for empty key
-    // Actual implementation will fail at Query stage
-    ReplicaCopyPayload payload;
-    payload.key = "";
-    payload.targets = {"target1"};
-
-    // Serialization should work even with empty key
-    std::string json;
-    struct_json::to_json(payload, json);
-    EXPECT_FALSE(json.empty());
-
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, json);
-    EXPECT_TRUE(deserialized.key.empty());
-    EXPECT_EQ(deserialized.targets.size(), 1);
-}
-
-TEST_F(TaskExecutorTest, CopyMethodEmptyTargets) {
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {};
-
-    // Serialization should handle empty targets
-    std::string json;
-    struct_json::to_json(payload, json);
-
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, json);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_TRUE(deserialized.targets.empty());
-}
-
-TEST_F(TaskExecutorTest, MoveMethodEmptyKey) {
-    ReplicaMovePayload payload;
-    payload.key = "";
-    payload.source = "source_segment";
-    payload.target = "target_segment";
+    payload.tenant_id = "tenant-b";
+    payload.key = "move-key";
+    payload.source = "source-segment";
+    payload.target = "target-segment";
 
     std::string json;
     struct_json::to_json(payload, json);
 
-    ReplicaMovePayload deserialized;
-    struct_json::from_json(deserialized, json);
-    EXPECT_TRUE(deserialized.key.empty());
-    EXPECT_EQ(deserialized.source, "source_segment");
-    EXPECT_EQ(deserialized.target, "target_segment");
-}
+    ReplicaMovePayload round_tripped;
+    struct_json::from_json(round_tripped, json);
 
-TEST_F(TaskExecutorTest, MoveMethodEmptySegments) {
-    ReplicaMovePayload payload;
-    payload.key = "test_key";
-    payload.source = "";
-    payload.target = "target_segment";
-
-    std::string json;
-    struct_json::to_json(payload, json);
-
-    ReplicaMovePayload deserialized;
-    struct_json::from_json(deserialized, json);
-    EXPECT_EQ(deserialized.key, "test_key");
-    EXPECT_TRUE(deserialized.source.empty());
-    EXPECT_EQ(deserialized.target, "target_segment");
-}
-
-// Source Segment Selection Logic Tests
-TEST_F(TaskExecutorTest, SourceSegmentSelectionLogic) {
-    // Create multiple replicas with different segments
-    std::vector<Replica::Descriptor> replicas;
-    replicas.push_back(CreateMemoryReplicaDescriptor(1, "segment1", 1024));
-    replicas.push_back(CreateMemoryReplicaDescriptor(2, "segment2", 1024));
-    replicas.push_back(CreateMemoryReplicaDescriptor(3, "segment3", 1024));
-
-    // Test finding source when targets are segment2 and segment3
-    std::vector<std::string> targets = {"segment2", "segment3"};
-    std::set<std::string> target_set(targets.begin(), targets.end());
-
-    bool found_source = false;
-    std::string selected_segment;
-    for (const auto& replica : replicas) {
-        if (replica.is_memory_replica()) {
-            const auto& mem_desc = replica.get_memory_descriptor();
-            std::string replica_segment =
-                mem_desc.buffer_descriptor.transport_endpoint_;
-            if (target_set.find(replica_segment) == target_set.end()) {
-                selected_segment = replica_segment;
-                found_source = true;
-                break;
-            }
-        }
-    }
-
-    EXPECT_TRUE(found_source);
-    EXPECT_EQ(selected_segment, "segment1");
-}
-
-TEST_F(TaskExecutorTest, SourceSegmentSelectionAllInTargets) {
-    std::vector<Replica::Descriptor> replicas;
-    replicas.push_back(CreateMemoryReplicaDescriptor(1, "segment1", 1024));
-    replicas.push_back(CreateMemoryReplicaDescriptor(2, "segment2", 1024));
-
-    std::vector<std::string> targets = {"segment1", "segment2"};
-    std::set<std::string> target_set(targets.begin(), targets.end());
-
-    bool found_source = false;
-    for (const auto& replica : replicas) {
-        if (replica.is_memory_replica()) {
-            const auto& mem_desc = replica.get_memory_descriptor();
-            std::string replica_segment =
-                mem_desc.buffer_descriptor.transport_endpoint_;
-            if (target_set.find(replica_segment) == target_set.end()) {
-                found_source = true;
-                break;
-            }
-        }
-    }
-
-    EXPECT_FALSE(found_source);
-}
-
-// Retry Logic Tests
-TEST_F(TaskExecutorTest, RetryCountIncrement) {
-    // Simulate ClientTask retry logic
-    uint32_t retry_count = 0;
-    constexpr uint32_t MAX_RETRY_COUNT = 10;
-
-    // Test incrementing retry count
-    for (uint32_t i = 0; i < MAX_RETRY_COUNT; ++i) {
-        EXPECT_EQ(retry_count, i);
-        retry_count++;
-        EXPECT_EQ(retry_count, i + 1);
-    }
-
-    EXPECT_EQ(retry_count, MAX_RETRY_COUNT);
-
-    // Test that retry count can exceed MAX_RETRY_COUNT
-    retry_count++;
-    EXPECT_EQ(retry_count, MAX_RETRY_COUNT + 1);
-}
-
-TEST_F(TaskExecutorTest, RetryDecisionLogic) {
-    constexpr uint32_t MAX_RETRY_COUNT = 10;
-
-    // Test cases for retry decision
-    struct RetryTestCase {
-        ErrorCode error;
-        uint32_t retry_count;
-        bool should_retry;
-    };
-
-    std::vector<RetryTestCase> test_cases = {
-        {ErrorCode::NO_AVAILABLE_HANDLE, 0, true},    // Should retry
-        {ErrorCode::NO_AVAILABLE_HANDLE, 5, true},    // Should retry
-        {ErrorCode::NO_AVAILABLE_HANDLE, 9, true},    // Should retry
-        {ErrorCode::NO_AVAILABLE_HANDLE, 10, false},  // Max retries reached
-        {ErrorCode::NO_AVAILABLE_HANDLE, 11, false},  // Exceeded max
-        {ErrorCode::OBJECT_NOT_FOUND, 0, false},      // Should not retry
-        {ErrorCode::REPLICA_NOT_FOUND, 0, false},     // Should not retry
-        {ErrorCode::INTERNAL_ERROR, 0, false},        // Should not retry
-    };
-
-    for (const auto& test_case : test_cases) {
-        bool should_retry =
-            (test_case.error == ErrorCode::NO_AVAILABLE_HANDLE) &&
-            (test_case.retry_count < MAX_RETRY_COUNT);
-        EXPECT_EQ(should_retry, test_case.should_retry)
-            << "Error: " << static_cast<int>(test_case.error)
-            << ", Retry count: " << test_case.retry_count;
-    }
-}
-
-TEST_F(TaskExecutorTest, RetryDelayCalculation) {
-    constexpr uint32_t MAX_RETRY_COUNT = 10;
-
-    for (uint32_t retry_count = 0; retry_count < MAX_RETRY_COUNT;
-         ++retry_count) {
-        auto retry_delay = std::chrono::milliseconds(50 * (retry_count + 1));
-        EXPECT_EQ(retry_delay.count(), 50 * (retry_count + 1));
-    }
-}
-
-// Task Type and Error Handling Tests
-TEST_F(TaskExecutorTest, TaskTypeHandling) {
-    // Test valid task types
-    EXPECT_EQ(static_cast<int>(TaskType::REPLICA_COPY), 0);
-    EXPECT_EQ(static_cast<int>(TaskType::REPLICA_MOVE), 1);
-
-    // Test invalid task type (should be handled gracefully)
-    TaskType invalid_type = static_cast<TaskType>(999);
-    EXPECT_NE(invalid_type, TaskType::REPLICA_COPY);
-    EXPECT_NE(invalid_type, TaskType::REPLICA_MOVE);
-}
-
-TEST_F(TaskExecutorTest, PayloadDeserializationErrorHandling) {
-    TaskAssignment assignment;
-    assignment.id = generate_uuid();
-    assignment.type = TaskType::REPLICA_COPY;
-    assignment.payload = R"({"invalid": "json"})";  // Missing required fields
-
-    // This should be caught by exception handler in ExecuteTask
-    ReplicaCopyPayload payload;
-    bool exception_caught = false;
-    try {
-        struct_json::from_json(payload, assignment.payload);
-    } catch (const std::exception& e) {
-        exception_caught = true;
-    }
-
-    // struct_json does not throw, but field will be default
-    EXPECT_FALSE(exception_caught);
-    EXPECT_TRUE(payload.key.empty());
-    EXPECT_TRUE(payload.targets.empty());
-}
-
-// Multiple Target Segments Handling Tests
-TEST_F(TaskExecutorTest, MultipleTargetSegmentsHandling) {
-    ReplicaCopyPayload payload;
-    payload.key = "test_key";
-    payload.targets = {"target1", "target2", "target3", "target4", "target5"};
-
-    EXPECT_EQ(payload.targets.size(), 5);
-    EXPECT_EQ(payload.targets[0], "target1");
-    EXPECT_EQ(payload.targets[4], "target5");
-
-    // Test serialization with multiple targets
-    std::string json;
-    struct_json::to_json(payload, json);
-
-    ReplicaCopyPayload deserialized;
-    struct_json::from_json(deserialized, json);
-    EXPECT_EQ(deserialized.targets.size(), 5);
+    EXPECT_EQ(round_tripped.tenant_id, payload.tenant_id);
+    EXPECT_EQ(round_tripped.key, payload.key);
+    EXPECT_EQ(round_tripped.source, payload.source);
+    EXPECT_EQ(round_tripped.target, payload.target);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/task_integration_test.cpp
+++ b/mooncake-store/tests/task_integration_test.cpp
@@ -3,10 +3,11 @@
 #include <gtest/gtest.h>
 
 #include <csignal>
+#include <chrono>
 #include <memory>
+#include <set>
 #include <string>
 #include <thread>
-#include <chrono>
 #include <vector>
 
 #include <ylt/coro_http/coro_http_client.hpp>
@@ -33,6 +34,10 @@ namespace mooncake {
 namespace testing {
 
 namespace {
+
+constexpr char kClient1Endpoint[] = "127.0.0.1:18001";
+constexpr char kClient2Endpoint[] = "127.0.0.1:18002";
+constexpr char kClient3Endpoint[] = "127.0.0.1:18003";
 
 struct HttpCreateDrainJobResponse {
     bool success{false};
@@ -133,7 +138,7 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
     void SetUp() override {
         // Create client 1
         auto client1_opt = Client::Create(
-            "127.0.0.1:18001",
+            kClient1Endpoint,
             metadata_url_.empty() ? "P2PHANDSHAKE" : metadata_url_,
             FLAGS_protocol,
             FLAGS_device_name.empty() ? std::nullopt
@@ -144,7 +149,7 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
 
         // Create client 2
         auto client2_opt = Client::Create(
-            "127.0.0.1:18002",
+            kClient2Endpoint,
             metadata_url_.empty() ? "P2PHANDSHAKE" : metadata_url_,
             FLAGS_protocol,
             FLAGS_device_name.empty() ? std::nullopt
@@ -181,11 +186,6 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
 
         // Wait for segments to be registered and clients to ping master
         std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
-        // Client IDs will be extracted from task assignments when tasks are
-        // created For now, initialize with placeholder values
-        client1_id_ = generate_uuid();
-        client2_id_ = generate_uuid();
     }
 
     void TearDown() override {
@@ -197,21 +197,37 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
             free(client2_segment_ptr_);
             client2_segment_ptr_ = nullptr;
         }
+        if (client3_ && client3_segment_ptr_) {
+            free(client3_segment_ptr_);
+            client3_segment_ptr_ = nullptr;
+        }
     }
 
     static void CleanupClients() {
         // Clients will be cleaned up by shared_ptr
     }
 
-    // Helper to extract client_id from task assignment
-    // When a task is created, we can query it to see which client it's assigned
-    // to
-    UUID GetClientIdFromTask(const UUID& task_id) {
-        auto query_result = master_client_->QueryTask(task_id);
-        if (query_result.has_value()) {
-            return query_result.value().assigned_client;
-        }
-        return generate_uuid();  // Fallback
+    void MountThirdClientSegment() {
+        auto client3_opt = Client::Create(
+            kClient3Endpoint,
+            metadata_url_.empty() ? "P2PHANDSHAKE" : metadata_url_,
+            FLAGS_protocol,
+            FLAGS_device_name.empty() ? std::nullopt
+                                      : std::make_optional(FLAGS_device_name),
+            master_address_);
+        ASSERT_TRUE(client3_opt.has_value());
+        client3_ = client3_opt.value();
+
+        constexpr size_t kSegmentSize = 256 * 1024 * 1024;
+        client3_segment_ptr_ = allocate_buffer_allocator_memory(kSegmentSize);
+        ASSERT_NE(client3_segment_ptr_, nullptr);
+        auto mount_result =
+            client3_->MountSegment(client3_segment_ptr_, kSegmentSize);
+        ASSERT_TRUE(mount_result.has_value())
+            << "Failed to mount segment for client3: "
+            << toString(mount_result.error());
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     }
 
     // Wait for task to complete by polling task status
@@ -296,27 +312,25 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
         return false;
     }
 
-    // Get segment name from a query result
-    // Note: segment name is typically the client's hostname (e.g.,
-    // "127.0.0.1:18001")
-    std::string GetSegmentNameFromQuery(const QueryResult& query_result) {
-        if (query_result.replicas.empty()) {
-            return "";
-        }
+    void ExpectReplicaEndpoints(
+        const std::string& key,
+        const std::set<std::string>& expected_endpoints) {
+        auto query_result = client1_->Query(key);
+        ASSERT_TRUE(query_result.has_value())
+            << "Failed to query replicas for key=" << key << ": "
+            << toString(query_result.error());
+        ASSERT_EQ(query_result->replicas.size(), expected_endpoints.size())
+            << "Unexpected replica count for key=" << key;
 
-        const auto& replica = query_result.replicas[0];
-        if (replica.is_memory_replica()) {
-            // Try to get segment name from the replica descriptor
-            // For memory replicas, the segment name is stored in the buffer
-            // descriptor but transport_endpoint_ might not match segment name
-            // We need to extract it from the replica's segment information
-            const auto& mem_desc = replica.get_memory_descriptor();
-            // The segment name is typically embedded in the buffer descriptor
-            // For now, use transport_endpoint_ as a fallback, but we should
-            // verify it matches the actual segment name used during mount
-            return mem_desc.buffer_descriptor.transport_endpoint_;
+        std::set<std::string> actual_endpoints;
+        for (const auto& replica : query_result->replicas) {
+            ASSERT_TRUE(replica.is_memory_replica())
+                << "Expected memory replica for key=" << key;
+            actual_endpoints.insert(replica.get_memory_descriptor()
+                                        .buffer_descriptor.transport_endpoint_);
         }
-        return "";
+        EXPECT_EQ(actual_endpoints, expected_endpoints)
+            << "Unexpected replica placement for key=" << key;
     }
 
    protected:
@@ -326,13 +340,12 @@ class TaskExecutorIntegrationTest : public ::testing::Test {
 
     std::shared_ptr<Client> client1_;
     std::shared_ptr<Client> client2_;
+    std::shared_ptr<Client> client3_;
     std::unique_ptr<MasterClient> master_client_;
-
-    UUID client1_id_;
-    UUID client2_id_;
 
     void* client1_segment_ptr_ = nullptr;
     void* client2_segment_ptr_ = nullptr;
+    void* client3_segment_ptr_ = nullptr;
 };
 
 InProcMaster TaskExecutorIntegrationTest::master_;
@@ -353,7 +366,8 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaCopyCompleteFlow) {
     std::vector<Slice> slices;
     slices.emplace_back(test_data.data(), test_data.size());
     ReplicateConfig config;
-    config.replica_num = 1;  // Start with 1 replica on client1
+    config.replica_num = 1;
+    config.preferred_segment = kClient1Endpoint;
 
     auto put_result = client1_->Put(test_key, slices, config);
     ASSERT_TRUE(put_result.has_value())
@@ -362,66 +376,25 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaCopyCompleteFlow) {
     // Wait a bit for put to complete
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-    // Step 2: Verify that client1's data was put successfully and get actual
-    // segment name
-    auto client1_query_result = client1_->Query(test_key);
-    ASSERT_TRUE(client1_query_result.has_value())
-        << "Failed to query key for verification";
-    ASSERT_FALSE(client1_query_result.value().replicas.empty())
-        << "No replicas found after Put";
+    ExpectReplicaEndpoints(test_key, {kClient1Endpoint});
 
-    // Extract actual segment name from replica
-    std::string source_segment;
-    const auto& replica = client1_query_result.value().replicas[0];
-    ASSERT_TRUE(replica.is_memory_replica()) << "Expected memory replica";
-    source_segment =
-        replica.get_memory_descriptor().buffer_descriptor.transport_endpoint_;
-    ASSERT_FALSE(source_segment.empty())
-        << "Failed to extract source segment name";
-
-    // Step 3: Determine target segment dynamically (must be different from
-    // source) Choose the other client's segment as target to ensure source !=
-    // target
-    std::string target_segment;
-    if (source_segment == "127.0.0.1:18001") {
-        target_segment = "127.0.0.1:18002";
-    } else if (source_segment == "127.0.0.1:18002") {
-        target_segment = "127.0.0.1:18001";
-    } else {
-        // If source is neither, default to client2's segment
-        target_segment = "127.0.0.1:18002";
-    }
-
-    // Verify source and target are different - this test only covers
-    // inconsistent cases
-    ASSERT_NE(source_segment, target_segment)
-        << "Source and target segments must be different for this test. "
-        << "Source: " << source_segment << ", Target: " << target_segment;
-
-    // Step 4: Create copy task via master
-    std::vector<std::string> targets = {target_segment};
+    // Step 2: Create copy task via master
+    std::vector<std::string> targets = {kClient2Endpoint};
     auto copy_result = master_client_->CreateCopyTask(test_key, targets);
     ASSERT_TRUE(copy_result.has_value())
         << "Failed to create copy task: " << toString(copy_result.error());
 
     UUID task_id = copy_result.value();
 
-    // Step 5: Get the actual client_id from the task assignment
-    client1_id_ = GetClientIdFromTask(task_id);
-
-    // Step 6: Wait for task to be fetched and executed by the assigned client
+    // Step 3: Wait for task to be fetched and executed by the assigned client
     bool task_completed =
         WaitForTaskCompletion(task_id, std::chrono::seconds(30));
     ASSERT_TRUE(task_completed) << "Task did not complete within timeout";
 
-    // Step 7: Verify copy was successful by querying from client2
-    auto client2_query_result = client2_->Query(test_key);
-    ASSERT_TRUE(client2_query_result.has_value())
-        << "Failed to query copied key";
-    ASSERT_FALSE(client2_query_result.value().replicas.empty())
-        << "No replicas found for copied key";
+    // Step 4: Copy adds the target and preserves the source replica.
+    ExpectReplicaEndpoints(test_key, {kClient1Endpoint, kClient2Endpoint});
 
-    // Step 8: Verify data integrity by getting data from client2
+    // Step 5: Verify data integrity.
     std::vector<uint8_t> read_buffer(test_data.size());
     std::vector<Slice> read_slices;
     read_slices.emplace_back(read_buffer.data(), read_buffer.size());
@@ -449,7 +422,8 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaMoveCompleteFlow) {
     std::vector<Slice> slices;
     slices.emplace_back(test_data.data(), test_data.size());
     ReplicateConfig config;
-    config.replica_num = 1;  // Start with 1 replica on client1
+    config.replica_num = 1;
+    config.preferred_segment = kClient1Endpoint;
 
     auto put_result = client1_->Put(test_key, slices, config);
     ASSERT_TRUE(put_result.has_value())
@@ -458,67 +432,25 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaMoveCompleteFlow) {
     // Wait a bit for put to complete
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-    // Step 2: Verify that client1's data was put successfully and get actual
-    // segment name
-    auto query_result = client1_->Query(test_key);
-    ASSERT_TRUE(query_result.has_value())
-        << "Failed to query key for verification";
-    ASSERT_FALSE(query_result.value().replicas.empty())
-        << "No replicas found after Put";
+    ExpectReplicaEndpoints(test_key, {kClient1Endpoint});
 
-    // Extract actual segment name from replica
-    std::string source_segment;
-    const auto& replica = query_result.value().replicas[0];
-    ASSERT_TRUE(replica.is_memory_replica()) << "Expected memory replica";
-    source_segment =
-        replica.get_memory_descriptor().buffer_descriptor.transport_endpoint_;
-    ASSERT_FALSE(source_segment.empty())
-        << "Failed to extract source segment name";
-
-    // Step 3: Determine target segment dynamically (must be different from
-    // source) Choose the other client's segment as target to ensure source !=
-    // target
-    std::string target_segment;
-    if (source_segment == "127.0.0.1:18001") {
-        target_segment = "127.0.0.1:18002";
-    } else if (source_segment == "127.0.0.1:18002") {
-        target_segment = "127.0.0.1:18001";
-    } else {
-        // If source is neither, default to client2's segment
-        target_segment = "127.0.0.1:18002";
-    }
-
-    // Verify source and target are different - this test only covers
-    // inconsistent cases
-    ASSERT_NE(source_segment, target_segment)
-        << "Source and target segments must be different for this test. "
-        << "Source: " << source_segment << ", Target: " << target_segment;
-
-    // Step 4: Create move task via master
-    auto move_result = master_client_->CreateMoveTask(test_key, source_segment,
-                                                      target_segment);
+    // Step 2: Create move task via master
+    auto move_result = master_client_->CreateMoveTask(
+        test_key, kClient1Endpoint, kClient2Endpoint);
     ASSERT_TRUE(move_result.has_value())
         << "Failed to create move task: " << toString(move_result.error());
 
     UUID task_id = move_result.value();
 
-    // Step 5: Get the actual client_id from the task assignment
-    client1_id_ = GetClientIdFromTask(task_id);
-
-    // Step 6: Wait for task to be fetched and executed by the assigned client
+    // Step 3: Wait for task to be fetched and executed by the assigned client
     bool task_completed =
         WaitForTaskCompletion(task_id, std::chrono::seconds(30));
     ASSERT_TRUE(task_completed) << "Task did not complete within timeout";
 
-    // Step 7: Verify move was successful
-    // The replica should now be on client2, not client1
-    auto query_result_client2 = client2_->Query(test_key);
-    ASSERT_TRUE(query_result_client2.has_value())
-        << "Failed to query moved key from client2";
-    ASSERT_FALSE(query_result_client2.value().replicas.empty())
-        << "No replicas found on client2 after move";
+    // Step 4: Move adds the target and removes the source replica.
+    ExpectReplicaEndpoints(test_key, {kClient2Endpoint});
 
-    // Step 8: Verify data integrity
+    // Step 5: Verify data integrity.
     std::vector<uint8_t> read_buffer(test_data.size());
     std::vector<Slice> read_slices;
     read_slices.emplace_back(read_buffer.data(), read_buffer.size());
@@ -532,7 +464,7 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaMoveCompleteFlow) {
     ASSERT_EQ(read_data, test_data) << "Data mismatch after move";
 }
 
-// Test copy to multiple target segments
+// Test complete drain job flow
 TEST_F(TaskExecutorIntegrationTest, DrainJobCompleteFlow) {
     const std::string source_segment = "127.0.0.1:18001";
     const std::string target_segment = "127.0.0.1:18002";
@@ -725,7 +657,8 @@ TEST_F(TaskExecutorIntegrationTest, DrainJobCompleteFlow) {
 }
 
 TEST_F(TaskExecutorIntegrationTest, ReplicaCopyToMultipleTargets) {
-    // Step 1: Put data on client1
+    ASSERT_NO_FATAL_FAILURE(MountThirdClientSegment());
+
     std::string test_key =
         "test_multi_target_copy_key_" +
         std::to_string(
@@ -737,48 +670,17 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaCopyToMultipleTargets) {
     slices.emplace_back(test_data.data(), test_data.size());
     ReplicateConfig config;
     config.replica_num = 1;
+    config.preferred_segment = kClient1Endpoint;
 
     auto put_result = client1_->Put(test_key, slices, config);
     ASSERT_TRUE(put_result.has_value())
         << "Failed to put data: " << toString(put_result.error());
 
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    ExpectReplicaEndpoints(test_key, {kClient1Endpoint});
 
-    // Step 2: Get actual source segment
-    auto query_result = client1_->Query(test_key);
-    ASSERT_TRUE(query_result.has_value())
-        << "Failed to query key for verification";
-    ASSERT_FALSE(query_result.value().replicas.empty())
-        << "No replicas found after Put";
-
-    std::string source_segment;
-    const auto& replica = query_result.value().replicas[0];
-    ASSERT_TRUE(replica.is_memory_replica()) << "Expected memory replica";
-    source_segment =
-        replica.get_memory_descriptor().buffer_descriptor.transport_endpoint_;
-    ASSERT_FALSE(source_segment.empty())
-        << "Failed to extract source segment name";
-
-    // Step 3: Determine target segments (both client1 and client2, excluding
-    // source)
-    std::vector<std::string> target_segments;
-    if (source_segment == "127.0.0.1:18001") {
-        target_segments = {"127.0.0.1:18002"};  // Copy to client2 only
-    } else if (source_segment == "127.0.0.1:18002") {
-        target_segments = {"127.0.0.1:18001"};  // Copy to client1 only
-    } else {
-        // If source is neither, use both segments
-        target_segments = {"127.0.0.1:18001", "127.0.0.1:18002"};
-    }
-
-    // Ensure source is not in targets
-    for (const auto& target : target_segments) {
-        ASSERT_NE(source_segment, target)
-            << "Source segment must not be in target segments. "
-            << "Source: " << source_segment << ", Target: " << target;
-    }
-
-    // Step 4: Create copy task with multiple targets
+    const std::vector<std::string> target_segments = {kClient2Endpoint,
+                                                      kClient3Endpoint};
     auto copy_result =
         master_client_->CreateCopyTask(test_key, target_segments);
     ASSERT_TRUE(copy_result.has_value())
@@ -786,51 +688,35 @@ TEST_F(TaskExecutorIntegrationTest, ReplicaCopyToMultipleTargets) {
 
     UUID task_id = copy_result.value();
 
-    // Step 5: Wait for task to complete
     bool task_completed =
         WaitForTaskCompletion(task_id, std::chrono::seconds(30));
     ASSERT_TRUE(task_completed) << "Task did not complete within timeout";
 
-    // Step 6: Verify copy was successful on all target segments
-    for (const auto& target_segment : target_segments) {
-        std::shared_ptr<Client> target_client;
-        if (target_segment == "127.0.0.1:18001") {
-            target_client = client1_;
-        } else {
-            target_client = client2_;
-        }
+    ExpectReplicaEndpoints(
+        test_key, {kClient1Endpoint, kClient2Endpoint, kClient3Endpoint});
 
-        auto target_query_result = target_client->Query(test_key);
-        ASSERT_TRUE(target_query_result.has_value())
-            << "Failed to query copied key from target segment: "
-            << target_segment;
-        ASSERT_FALSE(target_query_result.value().replicas.empty())
-            << "No replicas found on target segment: " << target_segment;
+    std::vector<uint8_t> read_buffer(test_data.size());
+    std::vector<Slice> read_slices;
+    read_slices.emplace_back(read_buffer.data(), read_buffer.size());
+    auto get_result = client1_->Get(test_key, read_slices);
+    ASSERT_TRUE(get_result.has_value())
+        << "Failed to get data after multi-target copy: "
+        << toString(get_result.error());
 
-        // Verify data integrity
-        std::vector<uint8_t> read_buffer(test_data.size());
-        std::vector<Slice> read_slices;
-        read_slices.emplace_back(read_buffer.data(), read_buffer.size());
-
-        auto get_result = target_client->Get(test_key, read_slices);
-        ASSERT_TRUE(get_result.has_value())
-            << "Failed to get data from target segment: " << target_segment;
-
-        std::string read_data(reinterpret_cast<const char*>(read_buffer.data()),
-                              test_data.size());
-        ASSERT_EQ(read_data, test_data)
-            << "Data mismatch on target segment: " << target_segment;
-    }
+    std::string read_data(reinterpret_cast<const char*>(read_buffer.data()),
+                          test_data.size());
+    EXPECT_EQ(read_data, test_data);
 }
 
 // Test multiple copy tasks
 TEST_F(TaskExecutorIntegrationTest, MultipleCopyTasks) {
+    ASSERT_NO_FATAL_FAILURE(MountThirdClientSegment());
+
     const int num_keys = 3;
     std::vector<std::string> keys;
     std::vector<std::string> test_data_list;
     std::vector<UUID> task_ids;
 
-    // Step 1: Put multiple keys on client1
     for (int i = 0; i < num_keys; ++i) {
         std::string key =
             "test_multi_copy_key_" + std::to_string(i) + "_" +
@@ -844,6 +730,7 @@ TEST_F(TaskExecutorIntegrationTest, MultipleCopyTasks) {
         slices.emplace_back(data.data(), data.size());
         ReplicateConfig config;
         config.replica_num = 1;
+        config.preferred_segment = kClient1Endpoint;
 
         auto put_result = client1_->Put(key, slices, config);
         ASSERT_TRUE(put_result.has_value()) << "Failed to put key " << i;
@@ -851,75 +738,18 @@ TEST_F(TaskExecutorIntegrationTest, MultipleCopyTasks) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-    // Step 2: For each key, determine its source segment and create copy task
-    // with appropriate target Each key may be on a different segment, so we
-    // need to check each one individually
-    for (const auto& key : keys) {
-        // Query to get actual source segment for this key
-        auto query_result = client1_->Query(key);
-        ASSERT_TRUE(query_result.has_value()) << "Failed to query key: " << key;
-        ASSERT_FALSE(query_result.value().replicas.empty())
-            << "No replicas found for key: " << key;
-
-        // Extract actual source segment name from replica
-        std::string source_segment;
-        const auto& replica = query_result.value().replicas[0];
-        ASSERT_TRUE(replica.is_memory_replica())
-            << "Expected memory replica for key: " << key;
-        source_segment = replica.get_memory_descriptor()
-                             .buffer_descriptor.transport_endpoint_;
-        ASSERT_FALSE(source_segment.empty())
-            << "Failed to extract source segment name for key: " << key;
-
-        // Determine target segment dynamically (must be different from source)
-        // Choose the other client's segment as target to ensure source !=
-        // target
-        std::string target_segment;
-        if (source_segment == "127.0.0.1:18001") {
-            target_segment = "127.0.0.1:18002";
-        } else if (source_segment == "127.0.0.1:18002") {
-            target_segment = "127.0.0.1:18001";
-        } else {
-            // If source is neither, default to client2's segment
-            target_segment = "127.0.0.1:18002";
-        }
-
-        // Verify source and target are different - this test only covers
-        // inconsistent cases
-        ASSERT_NE(source_segment, target_segment)
-            << "Source and target segments must be different for key: " << key
-            << ". "
-            << "Source: " << source_segment << ", Target: " << target_segment;
-
-        // Step 3: Create copy task for this key
-        // For the last key, use multiple target segments to test multi-target
-        // copy
-        std::vector<std::string> targets;
-        size_t key_index =
-            task_ids.size();  // Current index before adding this task
-        if (key_index == keys.size() - 1 && keys.size() >= 2) {
-            // Last key: use multiple targets if we have at least 2 clients
-            if (source_segment == "127.0.0.1:18001") {
-                targets = {
-                    "127.0.0.1:18002"};  // Only one other segment available
-            } else if (source_segment == "127.0.0.1:18002") {
-                targets = {
-                    "127.0.0.1:18001"};  // Only one other segment available
-            } else {
-                targets = {"127.0.0.1:18001", "127.0.0.1:18002"};
-            }
-        } else {
-            // Other keys: use single target
-            targets = {target_segment};
-        }
-
-        auto copy_result = master_client_->CreateCopyTask(key, targets);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        ExpectReplicaEndpoints(keys[i], {kClient1Endpoint});
+        const std::vector<std::string> targets =
+            i == keys.size() - 1
+                ? std::vector<std::string>{kClient2Endpoint, kClient3Endpoint}
+                : std::vector<std::string>{kClient2Endpoint};
+        auto copy_result = master_client_->CreateCopyTask(keys[i], targets);
         ASSERT_TRUE(copy_result.has_value())
-            << "Failed to create copy task for " << key;
+            << "Failed to create copy task for " << keys[i];
         task_ids.push_back(copy_result.value());
     }
 
-    // Step 4: Wait for all tasks to complete
     for (size_t i = 0; i < task_ids.size(); ++i) {
         bool completed =
             WaitForTaskCompletion(task_ids[i], std::chrono::seconds(30));
@@ -935,98 +765,24 @@ TEST_F(TaskExecutorIntegrationTest, MultipleCopyTasks) {
             << "Task " << i << " (key: " << keys[i] << ") did not complete";
     }
 
-    // Step 5: Verify all keys are accessible on their target segments
-    // For each key, we need to determine which client should have the replica
     for (size_t i = 0; i < keys.size(); ++i) {
-        // Determine source segment for this key
-        auto query_result = client1_->Query(keys[i]);
-        ASSERT_TRUE(query_result.has_value()) << "Failed to query key " << i;
-        ASSERT_FALSE(query_result.value().replicas.empty())
-            << "No replicas found for key " << i;
-
-        std::string source_segment;
-        const auto& replica = query_result.value().replicas[0];
-        ASSERT_TRUE(replica.is_memory_replica())
-            << "Expected memory replica for key " << i;
-        source_segment = replica.get_memory_descriptor()
-                             .buffer_descriptor.transport_endpoint_;
-
-        // For the last key with multiple targets, verify on all target segments
-        bool is_multi_target = (i == keys.size() - 1 && keys.size() >= 2);
-
-        if (is_multi_target) {
-            // Last key: verify on all target segments
-            std::vector<std::string> target_segments;
-            if (source_segment == "127.0.0.1:18001") {
-                target_segments = {"127.0.0.1:18002"};
-            } else if (source_segment == "127.0.0.1:18002") {
-                target_segments = {"127.0.0.1:18001"};
-            } else {
-                target_segments = {"127.0.0.1:18001", "127.0.0.1:18002"};
-            }
-
-            // Verify on each target segment
-            for (const auto& target_seg : target_segments) {
-                std::shared_ptr<Client> target_client =
-                    (target_seg == "127.0.0.1:18001") ? client1_ : client2_;
-
-                auto target_query = target_client->Query(keys[i]);
-                ASSERT_TRUE(target_query.has_value())
-                    << "Failed to query key " << i
-                    << " from target segment: " << target_seg;
-                ASSERT_FALSE(target_query.value().replicas.empty())
-                    << "No replicas found for key " << i
-                    << " on segment: " << target_seg;
-
-                // Verify data integrity
-                std::vector<uint8_t> read_buffer(test_data_list[i].size());
-                std::vector<Slice> read_slices;
-                read_slices.emplace_back(read_buffer.data(),
-                                         read_buffer.size());
-
-                auto get_result = target_client->Get(keys[i], read_slices);
-                ASSERT_TRUE(get_result.has_value())
-                    << "Failed to get key " << i
-                    << " from target segment: " << target_seg;
-
-                std::string read_data(
-                    reinterpret_cast<const char*>(read_buffer.data()),
-                    test_data_list[i].size());
-                ASSERT_EQ(read_data, test_data_list[i])
-                    << "Data mismatch for key " << i
-                    << " on segment: " << target_seg;
-            }
+        if (i == keys.size() - 1) {
+            ExpectReplicaEndpoints(keys[i], {kClient1Endpoint, kClient2Endpoint,
+                                             kClient3Endpoint});
         } else {
-            // Other keys: verify on single target segment
-            std::shared_ptr<Client> target_client;
-            if (source_segment == "127.0.0.1:18001") {
-                target_client = client2_;  // Copy to client2
-            } else {
-                target_client = client1_;  // Copy to client1
-            }
-
-            // Verify the copied replica is accessible
-            auto query_result_target = target_client->Query(keys[i]);
-            ASSERT_TRUE(query_result_target.has_value())
-                << "Failed to query copied key " << i << " from target client";
-            ASSERT_FALSE(query_result_target.value().replicas.empty())
-                << "No replicas found for copied key " << i;
-
-            // Verify data integrity
-            std::vector<uint8_t> read_buffer(test_data_list[i].size());
-            std::vector<Slice> read_slices;
-            read_slices.emplace_back(read_buffer.data(), read_buffer.size());
-
-            auto get_result = target_client->Get(keys[i], read_slices);
-            ASSERT_TRUE(get_result.has_value())
-                << "Failed to get key " << i << " from target client";
-
-            std::string read_data(
-                reinterpret_cast<const char*>(read_buffer.data()),
-                test_data_list[i].size());
-            ASSERT_EQ(read_data, test_data_list[i])
-                << "Data mismatch for key " << i;
+            ExpectReplicaEndpoints(keys[i],
+                                   {kClient1Endpoint, kClient2Endpoint});
         }
+
+        std::vector<uint8_t> read_buffer(test_data_list[i].size());
+        std::vector<Slice> read_slices;
+        read_slices.emplace_back(read_buffer.data(), read_buffer.size());
+        auto get_result = client1_->Get(keys[i], read_slices);
+        ASSERT_TRUE(get_result.has_value()) << "Failed to get copied key " << i;
+        std::string read_data(reinterpret_cast<const char*>(read_buffer.data()),
+                              test_data_list[i].size());
+        EXPECT_EQ(read_data, test_data_list[i])
+            << "Data mismatch for key " << i;
     }
 }
 
@@ -1051,6 +807,7 @@ TEST_F(TaskExecutorIntegrationTest, MultipleMoveTasks) {
         slices.emplace_back(data.data(), data.size());
         ReplicateConfig config;
         config.replica_num = 1;
+        config.preferred_segment = kClient1Endpoint;
 
         auto put_result = client1_->Put(key, slices, config);
         ASSERT_TRUE(put_result.has_value()) << "Failed to put key " << i;
@@ -1058,47 +815,15 @@ TEST_F(TaskExecutorIntegrationTest, MultipleMoveTasks) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-    // Step 2: For each key, determine source segment and create move task
     for (const auto& key : keys) {
-        // Query to get actual source segment for this key
-        auto query_result = client1_->Query(key);
-        ASSERT_TRUE(query_result.has_value()) << "Failed to query key: " << key;
-        ASSERT_FALSE(query_result.value().replicas.empty())
-            << "No replicas found for key: " << key;
-
-        std::string source_segment;
-        const auto& replica = query_result.value().replicas[0];
-        ASSERT_TRUE(replica.is_memory_replica())
-            << "Expected memory replica for key: " << key;
-        source_segment = replica.get_memory_descriptor()
-                             .buffer_descriptor.transport_endpoint_;
-        ASSERT_FALSE(source_segment.empty())
-            << "Failed to extract source segment name for key: " << key;
-
-        // Determine target segment (must be different from source)
-        std::string target_segment;
-        if (source_segment == "127.0.0.1:18001") {
-            target_segment = "127.0.0.1:18002";
-        } else if (source_segment == "127.0.0.1:18002") {
-            target_segment = "127.0.0.1:18001";
-        } else {
-            target_segment = "127.0.0.1:18002";
-        }
-
-        ASSERT_NE(source_segment, target_segment)
-            << "Source and target segments must be different for key: " << key
-            << ". "
-            << "Source: " << source_segment << ", Target: " << target_segment;
-
-        // Step 3: Create move task
-        auto move_result =
-            master_client_->CreateMoveTask(key, source_segment, target_segment);
+        ExpectReplicaEndpoints(key, {kClient1Endpoint});
+        auto move_result = master_client_->CreateMoveTask(key, kClient1Endpoint,
+                                                          kClient2Endpoint);
         ASSERT_TRUE(move_result.has_value())
             << "Failed to create move task for " << key;
         task_ids.push_back(move_result.value());
     }
 
-    // Step 4: Wait for all tasks to complete
     for (size_t i = 0; i < task_ids.size(); ++i) {
         bool completed =
             WaitForTaskCompletion(task_ids[i], std::chrono::seconds(30));
@@ -1113,45 +838,15 @@ TEST_F(TaskExecutorIntegrationTest, MultipleMoveTasks) {
             << "Task " << i << " (key: " << keys[i] << ") did not complete";
     }
 
-    // Step 5: Verify all keys are moved to target segments
     for (size_t i = 0; i < keys.size(); ++i) {
-        // Determine target client for this key
-        auto query_result = client1_->Query(keys[i]);
-        ASSERT_TRUE(query_result.has_value()) << "Failed to query key " << i;
+        ExpectReplicaEndpoints(keys[i], {kClient2Endpoint});
 
-        std::string source_segment;
-        if (!query_result.value().replicas.empty()) {
-            const auto& replica = query_result.value().replicas[0];
-            if (replica.is_memory_replica()) {
-                source_segment = replica.get_memory_descriptor()
-                                     .buffer_descriptor.transport_endpoint_;
-            }
-        }
-
-        std::shared_ptr<Client> target_client;
-        if (source_segment == "127.0.0.1:18001" || source_segment.empty()) {
-            // Check client2 (may have moved from client1 or was originally on
-            // client1)
-            target_client = client2_;
-        } else {
-            target_client = client1_;
-        }
-
-        // Verify the moved replica is accessible on target client
-        auto target_query_result = target_client->Query(keys[i]);
-        ASSERT_TRUE(target_query_result.has_value())
-            << "Failed to query moved key " << i << " from target client";
-        ASSERT_FALSE(target_query_result.value().replicas.empty())
-            << "No replicas found for moved key " << i;
-
-        // Verify data integrity
         std::vector<uint8_t> read_buffer(test_data_list[i].size());
         std::vector<Slice> read_slices;
         read_slices.emplace_back(read_buffer.data(), read_buffer.size());
 
-        auto get_result = target_client->Get(keys[i], read_slices);
-        ASSERT_TRUE(get_result.has_value())
-            << "Failed to get moved key " << i << " from target client";
+        auto get_result = client1_->Get(keys[i], read_slices);
+        ASSERT_TRUE(get_result.has_value()) << "Failed to get moved key " << i;
 
         std::string read_data(reinterpret_cast<const char*>(read_buffer.data()),
                               test_data_list[i].size());
@@ -1162,13 +857,13 @@ TEST_F(TaskExecutorIntegrationTest, MultipleMoveTasks) {
 
 // Test concurrent copy and move operations
 TEST_F(TaskExecutorIntegrationTest, ConcurrentCopyAndMoveOperations) {
+    ASSERT_NO_FATAL_FAILURE(MountThirdClientSegment());
+
     const int num_copy_keys = 2;
     const int num_move_keys = 2;
     std::vector<std::string> copy_keys, move_keys;
-    std::vector<std::string> copy_data_list, move_data_list;
     std::vector<UUID> copy_task_ids, move_task_ids;
 
-    // Step 1: Put keys for copy operations
     for (int i = 0; i < num_copy_keys; ++i) {
         std::string key =
             "test_concurrent_copy_key_" + std::to_string(i) + "_" +
@@ -1176,18 +871,17 @@ TEST_F(TaskExecutorIntegrationTest, ConcurrentCopyAndMoveOperations) {
                 std::chrono::steady_clock::now().time_since_epoch().count());
         std::string data = "Copy data " + std::to_string(i);
         copy_keys.push_back(key);
-        copy_data_list.push_back(data);
 
         std::vector<Slice> slices;
         slices.emplace_back(data.data(), data.size());
         ReplicateConfig config;
         config.replica_num = 1;
+        config.preferred_segment = kClient1Endpoint;
 
         auto put_result = client1_->Put(key, slices, config);
         ASSERT_TRUE(put_result.has_value()) << "Failed to put copy key " << i;
     }
 
-    // Step 2: Put keys for move operations
     for (int i = 0; i < num_move_keys; ++i) {
         std::string key =
             "test_concurrent_move_key_" + std::to_string(i) + "_" +
@@ -1195,12 +889,12 @@ TEST_F(TaskExecutorIntegrationTest, ConcurrentCopyAndMoveOperations) {
                 std::chrono::steady_clock::now().time_since_epoch().count());
         std::string data = "Move data " + std::to_string(i);
         move_keys.push_back(key);
-        move_data_list.push_back(data);
 
         std::vector<Slice> slices;
         slices.emplace_back(data.data(), data.size());
         ReplicateConfig config;
         config.replica_num = 1;
+        config.preferred_segment = kClient1Endpoint;
 
         auto put_result = client1_->Put(key, slices, config);
         ASSERT_TRUE(put_result.has_value()) << "Failed to put move key " << i;
@@ -1208,72 +902,28 @@ TEST_F(TaskExecutorIntegrationTest, ConcurrentCopyAndMoveOperations) {
 
     std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
-    // Step 3: Create copy tasks concurrently
-    // Use multiple targets for the first copy task to test multi-target copy
-    for (size_t idx = 0; idx < copy_keys.size(); ++idx) {
-        const auto& key = copy_keys[idx];
-        auto query_result = client1_->Query(key);
-        ASSERT_TRUE(query_result.has_value())
-            << "Failed to query copy key: " << key;
-        ASSERT_FALSE(query_result.value().replicas.empty());
-
-        std::string source_segment;
-        const auto& replica = query_result.value().replicas[0];
-        ASSERT_TRUE(replica.is_memory_replica());
-        source_segment = replica.get_memory_descriptor()
-                             .buffer_descriptor.transport_endpoint_;
-
-        std::vector<std::string> targets;
-        if (idx == 0 && copy_keys.size() >= 1) {
-            // First copy task: use multiple targets
-            if (source_segment == "127.0.0.1:18001") {
-                targets = {
-                    "127.0.0.1:18002"};  // Only one other segment available
-            } else if (source_segment == "127.0.0.1:18002") {
-                targets = {
-                    "127.0.0.1:18001"};  // Only one other segment available
-            } else {
-                targets = {"127.0.0.1:18001", "127.0.0.1:18002"};
-            }
-        } else {
-            // Other copy tasks: use single target
-            std::string target_segment = (source_segment == "127.0.0.1:18001")
-                                             ? "127.0.0.1:18002"
-                                             : "127.0.0.1:18001";
-            targets = {target_segment};
-        }
-
-        auto copy_result = master_client_->CreateCopyTask(key, targets);
+    for (size_t i = 0; i < copy_keys.size(); ++i) {
+        ExpectReplicaEndpoints(copy_keys[i], {kClient1Endpoint});
+        const std::vector<std::string> targets =
+            i == 0
+                ? std::vector<std::string>{kClient2Endpoint, kClient3Endpoint}
+                : std::vector<std::string>{kClient2Endpoint};
+        auto copy_result =
+            master_client_->CreateCopyTask(copy_keys[i], targets);
         ASSERT_TRUE(copy_result.has_value())
-            << "Failed to create copy task for " << key;
+            << "Failed to create copy task for " << copy_keys[i];
         copy_task_ids.push_back(copy_result.value());
     }
 
-    // Step 4: Create move tasks concurrently
     for (const auto& key : move_keys) {
-        auto query_result = client1_->Query(key);
-        ASSERT_TRUE(query_result.has_value())
-            << "Failed to query move key: " << key;
-        ASSERT_FALSE(query_result.value().replicas.empty());
-
-        std::string source_segment;
-        const auto& replica = query_result.value().replicas[0];
-        ASSERT_TRUE(replica.is_memory_replica());
-        source_segment = replica.get_memory_descriptor()
-                             .buffer_descriptor.transport_endpoint_;
-
-        std::string target_segment = (source_segment == "127.0.0.1:18001")
-                                         ? "127.0.0.1:18002"
-                                         : "127.0.0.1:18001";
-
-        auto move_result =
-            master_client_->CreateMoveTask(key, source_segment, target_segment);
+        ExpectReplicaEndpoints(key, {kClient1Endpoint});
+        auto move_result = master_client_->CreateMoveTask(key, kClient1Endpoint,
+                                                          kClient2Endpoint);
         ASSERT_TRUE(move_result.has_value())
             << "Failed to create move task for " << key;
         move_task_ids.push_back(move_result.value());
     }
 
-    // Step 5: Wait for all tasks to complete
     for (size_t i = 0; i < copy_task_ids.size(); ++i) {
         bool completed =
             WaitForTaskCompletion(copy_task_ids[i], std::chrono::seconds(30));
@@ -1288,83 +938,19 @@ TEST_F(TaskExecutorIntegrationTest, ConcurrentCopyAndMoveOperations) {
                                << ") did not complete";
     }
 
-    // Step 6: Verify copy results
     for (size_t i = 0; i < copy_keys.size(); ++i) {
-        auto query_result = client1_->Query(copy_keys[i]);
-        ASSERT_TRUE(query_result.has_value());
-
-        std::string source_segment;
-        if (!query_result.value().replicas.empty()) {
-            const auto& replica = query_result.value().replicas[0];
-            if (replica.is_memory_replica()) {
-                source_segment = replica.get_memory_descriptor()
-                                     .buffer_descriptor.transport_endpoint_;
-            }
-        }
-
-        // First copy task uses multiple targets
-        bool is_multi_target = (i == 0 && copy_keys.size() >= 1);
-
-        if (is_multi_target) {
-            // Verify on all target segments
-            std::vector<std::string> target_segments;
-            if (source_segment == "127.0.0.1:18001") {
-                target_segments = {"127.0.0.1:18002"};
-            } else if (source_segment == "127.0.0.1:18002") {
-                target_segments = {"127.0.0.1:18001"};
-            } else {
-                target_segments = {"127.0.0.1:18001", "127.0.0.1:18002"};
-            }
-
-            for (const auto& target_seg : target_segments) {
-                std::shared_ptr<Client> target_client =
-                    (target_seg == "127.0.0.1:18001") ? client1_ : client2_;
-
-                auto target_query = target_client->Query(copy_keys[i]);
-                ASSERT_TRUE(target_query.has_value())
-                    << "Copy key " << i
-                    << " not found on target segment: " << target_seg;
-                ASSERT_FALSE(target_query.value().replicas.empty())
-                    << "No replicas for copy key " << i
-                    << " on segment: " << target_seg;
-            }
+        if (i == 0) {
+            ExpectReplicaEndpoints(
+                copy_keys[i],
+                {kClient1Endpoint, kClient2Endpoint, kClient3Endpoint});
         } else {
-            // Verify on single target segment
-            std::shared_ptr<Client> target_client =
-                (source_segment == "127.0.0.1:18001") ? client2_ : client1_;
-
-            auto target_query = target_client->Query(copy_keys[i]);
-            ASSERT_TRUE(target_query.has_value())
-                << "Copy key " << i << " not found on target";
-            ASSERT_FALSE(target_query.value().replicas.empty())
-                << "No replicas for copy key " << i;
+            ExpectReplicaEndpoints(copy_keys[i],
+                                   {kClient1Endpoint, kClient2Endpoint});
         }
     }
 
-    // Step 7: Verify move results
-    for (size_t i = 0; i < move_keys.size(); ++i) {
-        auto query_result = client1_->Query(move_keys[i]);
-
-        std::string source_segment;
-        if (query_result.has_value() &&
-            !query_result.value().replicas.empty()) {
-            const auto& replica = query_result.value().replicas[0];
-            if (replica.is_memory_replica()) {
-                source_segment = replica.get_memory_descriptor()
-                                     .buffer_descriptor.transport_endpoint_;
-            }
-        }
-
-        std::shared_ptr<Client> target_client =
-            (source_segment == "127.0.0.1:18001" || source_segment.empty())
-                ? client2_
-                : client1_;
-
-        auto target_query = target_client->Query(move_keys[i]);
-        ASSERT_TRUE(target_query.has_value())
-            << "Move key " << i << " not found on target";
-        ASSERT_FALSE(target_query.value().replicas.empty())
-            << "No replicas for move key " << i;
+    for (const auto& key : move_keys) {
+        ExpectReplicaEndpoints(key, {kClient2Endpoint});
     }
 }
 

--- a/mooncake-store/tests/transfer_task_test.cpp
+++ b/mooncake-store/tests/transfer_task_test.cpp
@@ -6,7 +6,6 @@
 
 #include <chrono>
 #include <cstdlib>
-#include <cstring>
 #include <limits>
 #include <memory>
 #include <numeric>
@@ -67,30 +66,6 @@ class TransferTaskTest : public ::testing::Test {
         google::ShutdownGoogleLogging();
     }
 };
-
-// Test basic MemcpyOperation functionality
-TEST_F(TransferTaskTest, MemcpyOperationBasic) {
-    const size_t data_size = 1024;
-    std::vector<char> src_data(data_size, 'A');
-    std::vector<char> dest_data(data_size, 'B');
-
-    // Create memcpy operation
-    MemcpyOperation op(dest_data.data(), src_data.data(), data_size);
-
-    // Verify operation parameters
-    EXPECT_EQ(op.dest, dest_data.data());
-    EXPECT_EQ(op.src, src_data.data());
-    EXPECT_EQ(op.size, data_size);
-
-    // Perform memcpy manually to test
-    std::memcpy(op.dest, op.src, op.size);
-
-    // Verify data was copied correctly
-    EXPECT_EQ(dest_data, src_data);
-    for (size_t i = 0; i < data_size; ++i) {
-        EXPECT_EQ(dest_data[i], 'A');
-    }
-}
 
 // Test MemcpyOperationState functionality
 TEST_F(TransferTaskTest, MemcpyOperationState) {


### PR DESCRIPTION
## Description

Clean up Mooncake Store tests that did not exercise production behavior and strengthen tests that could pass without proving the claimed behavior.

- consolidate copy/move task payload serialization into focused round-trip coverage for every reflected field
- retain valuable etcd-dependent HotStandbyService scenarios as explicit skipped coverage gaps linked to #3496, while adding deterministic production coverage for the already-running behavior
- remove SSD metric, transfer-task, and object-data-type tests that only exercised test-local logic
- replace invalid recursive shared-mutex checks with cross-thread locking assertions
- assert serialized HA histogram count and sum deltas without depending on singleton initial state
- verify exact replica endpoint sets for copy, move, multi-target, and concurrent task integration flows

This is a test-only change. It does not modify production behavior, public APIs, or documentation.

Related issue: #3496

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build <build-dir> --parallel 128
ctest --test-dir <build-dir> --output-on-failure -R 'transfer_task_test|ssd_metrics_test|mutex_test|file_storage_test|task_executor_test|object_data_type_test|ha_metric_manager_test|hot_standby_service_test'
<build-dir>/mooncake-store/tests/ha_metric_manager_test --gtest_repeat=3
<build-dir>/mooncake-store/tests/hot_standby_service_test
<build-dir>/mooncake-store/tests/task_integration_test
pre-commit run
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass
- [ ] Manual testing done

The configured build used the default `STORE_USE_ETCD=OFF`. The HotStandbyService target reports 15 passed tests and 13 explicitly skipped etcd-dependent coverage gaps tracked by #3496; etcd-only production paths were not run.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using the repository formatting hook
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation updates are not applicable
- [x] I have strengthened tests to prove the intended behavior
- [x] RFC is not applicable because this change only modifies tests

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

OpenAI Codex helped inspect weak tests, implement the test-only cleanup, run focused validation, and address review findings. The human submitter reviewed the change and requested publication.
