### PR TITLE
[Store] Gate HA serving on successful standby restore

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -304,8 +304,11 @@ When the Primary fails, the Standby is promoted through the following steps:
    - `applied_seq_id`: The latest applied OpLog sequence ID.
    - `objects`: All object metadata from the in-memory store.
    - `segments`: All segment registry entries.
-4. **State Restoration**: The new Primary restores its state from the `PromotionContext`, populating metadata shards and the segment manager.
-5. **Invalid Endpoint Filtering**: During restoration, any replica endpoints that correspond to segments no longer in the registry are automatically filtered out from `GetReplicaList` results.
+4. **State Restoration**: The new Primary restores and validates the complete `PromotionContext`, populating metadata shards and the segment manager. A context with zero objects and segments still passes through restoration so that unsupported recovery modes cannot bypass validation.
+5. **Serving Gate**: The supervisor revalidates leadership and exposes the RPC service only after restoration succeeds. Promotion, restoration, or leadership validation failure leaves `service_ready=false`, keeps data endpoints unavailable, and releases leadership. Failure to release leadership does not make the candidate serviceable.
+6. **Invalid Endpoint Filtering**: During restoration, any replica endpoints that correspond to segments no longer in the registry are automatically filtered out from `GetReplicaList` results.
+
+This fail-closed behavior is intentional. Older versions could log a restoration error and continue serving from empty or partially restored metadata. That behavior was a correctness bug, not a supported availability fallback: the serving state could disagree with the durable OpLog and poison later recovery attempts. Mooncake does not automatically discard snapshots, OpLog records, or metadata after a recovery error.
 
 ### Example: HA Deployment with etcd
 
@@ -356,6 +359,18 @@ mooncake_master --config_path=primary.yaml
 # Start Standby
 mooncake_master --config_path=standby.yaml
 ```
+
+### Recovery from Unusable HA State
+
+First repair temporary backend, configuration, or snapshot-access failures and restart the affected Standby. If the recovery history is confirmed unusable and losing all cached metadata is acceptable, start a new empty cluster explicitly:
+
+1. Stop every Primary and Standby process that uses the old `cluster_id`.
+2. Confirm that losing the old cache metadata and snapshots is acceptable.
+3. Change every node to a new, previously unused `cluster_id`.
+4. Start the new cluster and allow applications to repopulate the cache.
+5. Keep the old namespace for diagnosis, then remove it separately after confirming that no old process can reconnect.
+
+Using a new `cluster_id` isolates the new cluster from the old OpLog, durable prefix, producer view, and snapshot namespace. Do not delete individual recovery keys or reuse the old `cluster_id` while any old process may still run. There is no automatic reset-on-restore-failure option.
 
 ### Resetting a Legacy OpLog Namespace
 

--- a/docs/source/design/store/mooncake-store.md
+++ b/docs/source/design/store/mooncake-store.md
@@ -45,7 +45,7 @@ The `Client` can be used in three ways:
 Mooncake store supports two deployment methods to accommodate different availability requirements:
 1. **Default mode**: In this mode, the master service consists of a single master node, which simplifies deployment but introduces a single point of failure. If the master crashes or becomes unreachable, the system cannot continue to serve requests until it is restored.
 2. **High availability mode**: This mode enhances fault tolerance by running the master service as a cluster of multiple master nodes coordinated through an etcd cluster. The master nodes use etcd to elect a leader, which is responsible for handling client requests.
-If the current leader fails or becomes partitioned from the network, the remaining master nodes automatically perform a new leader election, ensuring continuous availability.
+If the current leader fails or becomes partitioned from the network, the remaining master nodes automatically perform a new leader election. Election alone does not make a node ready to serve: the elected node must complete standby catch-up, export and validate the complete promotion context, restore that context (including a valid empty context), and revalidate leadership. If any step fails, the node remains unavailable rather than serving from unverified or partial metadata.
 
 In both modes, the leader monitors the health of all client nodes through periodic heartbeats. If a client crashes or becomes unreachable, the leader quickly detects the failure and takes appropriate action. When a client node recovers or reconnects, it can automatically rejoin the cluster without manual intervention.
 

--- a/mooncake-store/include/ha/leadership/master_service_supervisor.h
+++ b/mooncake-store/include/ha/leadership/master_service_supervisor.h
@@ -1,18 +1,9 @@
 #pragma once
 
-#include <memory>
-
-#include "ha/ha_types.h"
 #include "master_config.h"
 
 namespace mooncake {
-
-class MasterAdminServer;
-
 namespace ha {
-
-class LeaderCoordinator;
-class StandbyController;
 
 class MasterServiceSupervisor {
    public:
@@ -24,13 +15,6 @@ class MasterServiceSupervisor {
    private:
     MasterServiceSupervisorConfig config_;
 };
-
-// Runs the production supervisor loop with injected HA components.
-int RunSupervisorLoopForTesting(
-    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
-    MasterAdminServer& admin_server,
-    std::unique_ptr<LeaderCoordinator> coordinator,
-    std::unique_ptr<StandbyController> standby_controller);
 
 }  // namespace ha
 }  // namespace mooncake

--- a/mooncake-store/include/ha/leadership/master_service_supervisor.h
+++ b/mooncake-store/include/ha/leadership/master_service_supervisor.h
@@ -1,9 +1,18 @@
 #pragma once
 
+#include <memory>
+
+#include "ha/ha_types.h"
 #include "master_config.h"
 
 namespace mooncake {
+
+class MasterAdminServer;
+
 namespace ha {
+
+class LeaderCoordinator;
+class StandbyController;
 
 class MasterServiceSupervisor {
    public:
@@ -15,6 +24,13 @@ class MasterServiceSupervisor {
    private:
     MasterServiceSupervisorConfig config_;
 };
+
+// Runs the production supervisor loop with injected HA components.
+int RunSupervisorLoopForTesting(
+    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
+    MasterAdminServer& admin_server,
+    std::unique_ptr<LeaderCoordinator> coordinator,
+    std::unique_ptr<StandbyController> standby_controller);
 
 }  // namespace ha
 }  // namespace mooncake

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -215,17 +215,13 @@ void EnterStandbyMode(MasterAdminServer& admin_server,
     SetRuntimeState(admin_server, standby_controller.GetStandbyRuntimeState());
 }
 
-int RunSupervisorLoop(
-    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
-    MasterAdminServer& admin_server,
-    std::unique_ptr<LeaderCoordinator> coordinator_override = nullptr,
-    std::unique_ptr<StandbyController> standby_controller = nullptr) {
+int RunSupervisorLoop(const HABackendSpec& spec,
+                      const MasterServiceSupervisorConfig& config,
+                      MasterAdminServer& admin_server) {
     auto label_reconciler = MakeLeaderLabelReconciler(config);
     label_reconciler.SetLeader(false);
     SetRuntimeState(admin_server, MasterRuntimeState::kStarting);
-    if (!standby_controller) {
-        standby_controller = CreateStandbyController(spec, config);
-    }
+    auto standby_controller = CreateStandbyController(spec, config);
     std::atomic<bool> accept_standby_runtime_updates{false};
     standby_controller->SetStandbyRuntimeStateCallback(
         [&](MasterRuntimeState state) {
@@ -240,10 +236,7 @@ int RunSupervisorLoop(
                      accept_standby_runtime_updates, std::nullopt);
 
     while (true) {
-        auto coordinator = coordinator_override
-                               ? decltype(CreateLeaderCoordinator(spec))(
-                                     std::move(coordinator_override))
-                               : CreateLeaderCoordinator(spec);
+        auto coordinator = CreateLeaderCoordinator(spec);
         if (!coordinator) {
             if (HandleSupervisorError("create leader coordinator",
                                       coordinator.error(), spec.type)) {
@@ -525,15 +518,6 @@ int RunSupervisorLoop(
 }
 
 }  // namespace
-
-int RunSupervisorLoopForTesting(
-    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
-    MasterAdminServer& admin_server,
-    std::unique_ptr<LeaderCoordinator> coordinator,
-    std::unique_ptr<StandbyController> standby_controller) {
-    return RunSupervisorLoop(spec, config, admin_server, std::move(coordinator),
-                             std::move(standby_controller));
-}
 
 MasterServiceSupervisor::MasterServiceSupervisor(
     const MasterServiceSupervisorConfig& config)

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -390,18 +390,30 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             wrapped_config, config.http_metadata_server,
             config.http_metadata_remote_url);
 
-        // Restore from standby if we have context
-        if (promotion_ctx->applied_seq_id > 0 ||
-            !promotion_ctx->objects.empty() ||
-            !promotion_ctx->segments.empty()) {
-            auto restore_result = wrapped_master_service->RestoreFromStandby(
-                promotion_ctx->objects, promotion_ctx->applied_seq_id,
-                promotion_ctx->segments);
-            if (!restore_result) {
-                LOG(ERROR) << "Standby restore failed: "
-                           << toString(restore_result.error());
+        // Restore is the serving gate: do not register or expose a candidate
+        // service until the complete promotion context has been applied.
+        SetRuntimeState(admin_server, MasterRuntimeState::kRecovering);
+        auto restore_result = wrapped_master_service->RestoreFromStandby(
+            promotion_ctx->objects, promotion_ctx->applied_seq_id,
+            promotion_ctx->segments);
+        if (!restore_result) {
+            LOG(ERROR) << "Standby restore failed: "
+                       << toString(restore_result.error());
+            wrapped_master_service.reset();
+            DeactivateServingState(admin_server, label_reconciler);
+            EnterStandbyMode(admin_server, *standby_controller,
+                             accept_standby_runtime_updates,
+                             leadership_session->view);
+            SetRuntimeState(admin_server, MasterRuntimeState::kRecovering);
+            if (HandleLeadershipPhaseError(
+                    "standby restore failure", "restore standby state",
+                    leader_coordinator, *leadership_session,
+                    restore_result.error(), spec.type)) {
+                return -1;
             }
+            continue;
         }
+        SetRuntimeState(admin_server, MasterRuntimeState::kLeaderWarmup);
 
         mooncake::RegisterRpcService(server, *wrapped_master_service);
 

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -215,13 +215,17 @@ void EnterStandbyMode(MasterAdminServer& admin_server,
     SetRuntimeState(admin_server, standby_controller.GetStandbyRuntimeState());
 }
 
-int RunSupervisorLoop(const HABackendSpec& spec,
-                      const MasterServiceSupervisorConfig& config,
-                      MasterAdminServer& admin_server) {
+int RunSupervisorLoop(
+    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
+    MasterAdminServer& admin_server,
+    std::unique_ptr<LeaderCoordinator> coordinator_override = nullptr,
+    std::unique_ptr<StandbyController> standby_controller = nullptr) {
     auto label_reconciler = MakeLeaderLabelReconciler(config);
     label_reconciler.SetLeader(false);
     SetRuntimeState(admin_server, MasterRuntimeState::kStarting);
-    auto standby_controller = CreateStandbyController(spec, config);
+    if (!standby_controller) {
+        standby_controller = CreateStandbyController(spec, config);
+    }
     std::atomic<bool> accept_standby_runtime_updates{false};
     standby_controller->SetStandbyRuntimeStateCallback(
         [&](MasterRuntimeState state) {
@@ -236,7 +240,10 @@ int RunSupervisorLoop(const HABackendSpec& spec,
                      accept_standby_runtime_updates, std::nullopt);
 
     while (true) {
-        auto coordinator = CreateLeaderCoordinator(spec);
+        auto coordinator = coordinator_override
+                               ? decltype(CreateLeaderCoordinator(spec))(
+                                     std::move(coordinator_override))
+                               : CreateLeaderCoordinator(spec);
         if (!coordinator) {
             if (HandleSupervisorError("create leader coordinator",
                                       coordinator.error(), spec.type)) {
@@ -336,8 +343,10 @@ int RunSupervisorLoop(const HABackendSpec& spec,
             EnterStandbyMode(admin_server, *standby_controller,
                              accept_standby_runtime_updates,
                              leadership_session->view);
-            if (HandleSupervisorError("promote standby for serve",
-                                      promotion_ctx.error(), spec.type)) {
+            if (HandleLeadershipPhaseError(
+                    "standby promotion failure", "promote standby for serve",
+                    leader_coordinator, *leadership_session,
+                    promotion_ctx.error(), spec.type)) {
                 return -1;
             }
             continue;
@@ -516,6 +525,15 @@ int RunSupervisorLoop(const HABackendSpec& spec,
 }
 
 }  // namespace
+
+int RunSupervisorLoopForTesting(
+    const HABackendSpec& spec, const MasterServiceSupervisorConfig& config,
+    MasterAdminServer& admin_server,
+    std::unique_ptr<LeaderCoordinator> coordinator,
+    std::unique_ptr<StandbyController> standby_controller) {
+    return RunSupervisorLoop(spec, config, admin_server, std::move(coordinator),
+                             std::move(standby_controller));
+}
 
 MasterServiceSupervisor::MasterServiceSupervisor(
     const MasterServiceSupervisorConfig& config)

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -1,5 +1,6 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
+#include <ylt/coro_http/coro_http_client.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -14,8 +15,13 @@
 #endif
 #include "ha/leadership/leader_coordinator_factory.h"
 #include "ha/leadership/high_availability_test_fixture.h"
+#include "ha/leadership/master_service_supervisor.h"
+#include "ha/standby_controller.h"
+#include "master_admin_service.h"
 #include "master_service.h"
+#include "replica.h"
 #include "types.h"
+#include "utils.h"
 
 namespace mooncake {
 namespace testing {
@@ -98,11 +104,18 @@ std::unique_ptr<ha::LeaderCoordinator> CreateEtcdCoordinatorOrNull(
 
 class FakeLeaderCoordinator : public ha::LeaderCoordinator {
    public:
-    explicit FakeLeaderCoordinator(ViewVersionId view_version)
+    struct State {
+        int release_calls{0};
+        ErrorCode release_result{ErrorCode::OK};
+    };
+
+    explicit FakeLeaderCoordinator(ViewVersionId view_version,
+                                   std::shared_ptr<State> state = nullptr)
         : session_{.view = {.leader_address = "fake-leader",
                             .view_version = view_version},
                    .owner_token = "fake-owner",
-                   .lease_ttl = std::chrono::milliseconds(0)} {}
+                   .lease_ttl = std::chrono::milliseconds(0)},
+          state_(std::move(state)) {}
 
     tl::expected<std::optional<ha::MasterView>, ErrorCode> ReadCurrentView()
         override {
@@ -138,12 +151,137 @@ class FakeLeaderCoordinator : public ha::LeaderCoordinator {
 
     ErrorCode ReleaseLeadership(
         const ha::LeadershipSession& /*session*/) override {
-        return ErrorCode::OK;
+        if (!state_) {
+            return ErrorCode::OK;
+        }
+        ++state_->release_calls;
+        return state_->release_result;
     }
 
    private:
     ha::LeadershipSession session_;
+    std::shared_ptr<State> state_;
 };
+
+class FakeStandbyController : public ha::StandbyController {
+   public:
+    explicit FakeStandbyController(ErrorCode promotion_error)
+        : promotion_result_(tl::make_unexpected(promotion_error)) {}
+
+    explicit FakeStandbyController(ha::PromotionContext promotion_context)
+        : promotion_result_(std::move(promotion_context)) {}
+
+    ErrorCode StartStandby(
+        const std::optional<ha::MasterView>& /*observed_leader*/) override {
+        return ErrorCode::OK;
+    }
+
+    void StopStandby() override {}
+
+    ErrorCode PromoteStandby() override { return ErrorCode::OK; }
+
+    tl::expected<ha::PromotionContext, ErrorCode> PromoteStandbyAndExport()
+        override {
+        return std::move(promotion_result_);
+    }
+
+    void UpdateObservedLeader(
+        const std::optional<ha::MasterView>& /*observed_leader*/) override {}
+
+    ha::MasterRuntimeState GetStandbyRuntimeState() const override {
+        return ha::MasterRuntimeState::kStandby;
+    }
+
+    void SetStandbyRuntimeStateCallback(
+        RuntimeStateCallback callback) override {
+        runtime_state_callback_ = std::move(callback);
+    }
+
+   private:
+    tl::expected<ha::PromotionContext, ErrorCode> promotion_result_;
+    RuntimeStateCallback runtime_state_callback_;
+};
+
+MasterServiceSupervisorConfig MakeSupervisorConfig() {
+    MasterServiceSupervisorConfig config;
+    config.enable_metric_reporting = false;
+    config.metrics_port = 0;
+    config.default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
+    config.default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
+    config.allow_evict_soft_pinned_objects = true;
+    config.eviction_ratio = DEFAULT_EVICTION_RATIO;
+    config.eviction_high_watermark_ratio =
+        DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
+    config.nof_eviction_ratio = DEFAULT_NOF_EVICTION_RATIO;
+    config.nof_eviction_high_watermark_ratio =
+        DEFAULT_NOF_EVICTION_HIGH_WATERMARK_RATIO;
+    config.client_live_ttl_sec = DEFAULT_CLIENT_LIVE_TTL_SEC;
+    config.nof_heartbeat_interval_sec = DEFAULT_NOF_HEARTBEAT_INTERVAL_SEC;
+    config.nof_heartbeat_probe_timeout_ms =
+        DEFAULT_NOF_HEARTBEAT_PROBE_TIMEOUT_MS;
+    config.nof_heartbeat_failures_threshold =
+        DEFAULT_NOF_HEARTBEAT_FAILURES_THRESHOLD;
+    config.enable_offload = false;
+    config.rpc_port = getFreeTcpPort();
+    config.rpc_thread_num = 1;
+    return config;
+}
+
+StandbyObjectEntry MakeStandbyObject(const std::string& key,
+                                     const std::string& endpoint, size_t size,
+                                     uintptr_t address) {
+    Replica::Descriptor replica;
+    replica.id = 1;
+    replica.status = ReplicaStatus::COMPLETE;
+    MemoryDescriptor memory;
+    memory.buffer_descriptor.transport_endpoint_ = endpoint;
+    memory.buffer_descriptor.buffer_address_ = address;
+    memory.buffer_descriptor.size_ = size;
+    replica.descriptor_variant = std::move(memory);
+
+    StandbyObjectMetadata metadata;
+    metadata.client_id = generate_uuid();
+    metadata.size = size;
+    metadata.replicas.push_back(std::move(replica));
+    return StandbyObjectEntry{"default", key, std::move(metadata)};
+}
+
+ha::PromotionContext MakeInvalidPromotionContext(bool overlap) {
+    constexpr char kEndpoint[] = "supervisor_restore_segment";
+    constexpr size_t kObjectSize = 64;
+    ha::PromotionContext context;
+    context.applied_seq_id = 1;
+    context.segments.push_back(StandbySegmentInfo{
+        .segment_name = kEndpoint,
+        .transport_endpoint = kEndpoint,
+        .capacity = 4096,
+        .is_memory_segment = true,
+        .file_path = "",
+    });
+    context.objects.push_back(MakeStandbyObject(
+        "supervisor_restore_first", kEndpoint, kObjectSize, 0x1000));
+    if (overlap) {
+        context.objects.push_back(MakeStandbyObject(
+            "supervisor_restore_second", kEndpoint, kObjectSize, 0x1000));
+    } else {
+        context.objects.front()
+            .metadata.replicas.front()
+            .get_memory_descriptor()
+            .buffer_descriptor.size_ = kObjectSize + 1;
+    }
+    return context;
+}
+
+struct HttpResponse {
+    int status;
+    std::string body;
+};
+
+HttpResponse HttpGet(int port, const std::string& path) {
+    coro_http::coro_http_client client;
+    auto result = client.get("http://127.0.0.1:" + std::to_string(port) + path);
+    return {.status = result.status, .body = std::string(result.resp_body)};
+}
 
 }  // namespace
 
@@ -182,6 +320,61 @@ TEST_F(HighAvailabilityTest, AcquiredViewFlowsIntoServingMasterService) {
     auto ping = service.Ping(generate_uuid());
     ASSERT_TRUE(ping.has_value());
     EXPECT_EQ(kAcquiredView, ping->view_version_id);
+}
+
+TEST_F(HighAvailabilityTest,
+       PromotionFailureReleasesLeadershipAndKeepsServiceUnavailable) {
+    auto state = std::make_shared<FakeLeaderCoordinator::State>();
+    state->release_result = ErrorCode::ETCD_OPERATION_ERROR;
+    auto config = MakeSupervisorConfig();
+    const int admin_port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
+                            "127.0.0.1");
+    ASSERT_TRUE(admin.Start());
+
+    EXPECT_EQ(-1, ha::RunSupervisorLoopForTesting(
+                      MakeEtcdBackendSpec("unused"), config, admin,
+                      std::make_unique<FakeLeaderCoordinator>(1, state),
+                      std::make_unique<FakeStandbyController>(
+                          ErrorCode::INVALID_PARAMS)));
+    EXPECT_EQ(state->release_calls, 1);
+
+    const auto health = HttpGet(admin_port, "/health");
+    EXPECT_EQ(health.status, 200);
+    EXPECT_NE(health.body.find("\"service_ready\":false"), std::string::npos);
+    EXPECT_EQ(HttpGet(admin_port, "/get_all_keys").status, 503);
+    admin.Stop();
+}
+
+TEST_F(HighAvailabilityTest,
+       RestoreFailureReleasesLeadershipAndKeepsServiceUnavailable) {
+    for (const bool overlap : {false, true}) {
+        SCOPED_TRACE(overlap ? "overlapping descriptors"
+                             : "descriptor size mismatch");
+        auto state = std::make_shared<FakeLeaderCoordinator::State>();
+        state->release_result = ErrorCode::ETCD_OPERATION_ERROR;
+        auto config = MakeSupervisorConfig();
+        const int admin_port = getFreeTcpPort();
+        MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
+                                "127.0.0.1");
+        ASSERT_TRUE(admin.Start());
+
+        EXPECT_EQ(-1, ha::RunSupervisorLoopForTesting(
+                          MakeEtcdBackendSpec("unused"), config, admin,
+                          std::make_unique<FakeLeaderCoordinator>(1, state),
+                          std::make_unique<FakeStandbyController>(
+                              MakeInvalidPromotionContext(overlap))));
+        EXPECT_EQ(state->release_calls, 1);
+
+        const auto health = HttpGet(admin_port, "/health");
+        EXPECT_EQ(health.status, 200);
+        EXPECT_NE(health.body.find("\"ha_state\":\"recovering\""),
+                  std::string::npos);
+        EXPECT_NE(health.body.find("\"service_ready\":false"),
+                  std::string::npos);
+        EXPECT_EQ(HttpGet(admin_port, "/get_all_keys").status, 503);
+        admin.Stop();
+    }
 }
 
 #ifdef STORE_USE_ETCD

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -106,7 +106,10 @@ class FakeLeaderCoordinator : public ha::LeaderCoordinator {
    public:
     struct State {
         int release_calls{0};
+        int monitor_start_calls{0};
         ErrorCode release_result{ErrorCode::OK};
+        ErrorCode monitor_start_result{
+            ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS};
     };
 
     explicit FakeLeaderCoordinator(ViewVersionId view_version,
@@ -146,6 +149,10 @@ class FakeLeaderCoordinator : public ha::LeaderCoordinator {
     StartLeadershipMonitor(
         const ha::LeadershipSession& /*session*/,
         ha::LeadershipLostCallback /*on_leadership_lost*/) override {
+        if (state_) {
+            ++state_->monitor_start_calls;
+            return tl::make_unexpected(state_->monitor_start_result);
+        }
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
 
@@ -343,6 +350,30 @@ TEST_F(HighAvailabilityTest,
     EXPECT_EQ(health.status, 200);
     EXPECT_NE(health.body.find("\"service_ready\":false"), std::string::npos);
     EXPECT_EQ(HttpGet(admin_port, "/get_all_keys").status, 503);
+    admin.Stop();
+}
+
+TEST_F(HighAvailabilityTest, EmptyPromotionContextPassesRestoreGate) {
+    auto state = std::make_shared<FakeLeaderCoordinator::State>();
+    state->monitor_start_result = ErrorCode::INVALID_PARAMS;
+    auto config = MakeSupervisorConfig();
+    const int admin_port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
+                            "127.0.0.1");
+    ASSERT_TRUE(admin.Start());
+
+    EXPECT_EQ(
+        -1,
+        ha::RunSupervisorLoopForTesting(
+            MakeEtcdBackendSpec("unused"), config, admin,
+            std::make_unique<FakeLeaderCoordinator>(1, state),
+            std::make_unique<FakeStandbyController>(ha::PromotionContext{})));
+    EXPECT_EQ(state->monitor_start_calls, 1);
+    EXPECT_EQ(state->release_calls, 1);
+
+    const auto health = HttpGet(admin_port, "/health");
+    EXPECT_EQ(health.status, 200);
+    EXPECT_NE(health.body.find("\"service_ready\":false"), std::string::npos);
     admin.Stop();
 }
 

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -1,9 +1,13 @@
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <ylt/coro_http/coro_http_client.hpp>
 
 #include <atomic>
 #include <chrono>
+#include <csignal>
 #include <future>
 #include <mutex>
 #include <optional>
@@ -16,10 +20,7 @@
 #include "ha/leadership/leader_coordinator_factory.h"
 #include "ha/leadership/high_availability_test_fixture.h"
 #include "ha/leadership/master_service_supervisor.h"
-#include "ha/standby_controller.h"
-#include "master_admin_service.h"
 #include "master_service.h"
-#include "replica.h"
 #include "types.h"
 #include "utils.h"
 
@@ -29,6 +30,11 @@ namespace testing {
 DEFINE_string(etcd_endpoints, "127.0.0.1:2379", "Etcd endpoints");
 DEFINE_string(etcd_test_key_prefix, "mooncake-store/test/",
               "The prefix of the test keys in ETCD");
+DEFINE_bool(ha_supervisor_child, false,
+            "Run a real HA supervisor for the parent integration test");
+DEFINE_int32(ha_supervisor_rpc_port, 0, "Child supervisor RPC port");
+DEFINE_int32(ha_supervisor_admin_port, 0, "Child supervisor admin port");
+DEFINE_string(ha_supervisor_cluster_id, "", "Child supervisor cluster ID");
 
 void HighAvailabilityTest::SetUpTestSuite() {
     // Initialize glog
@@ -104,21 +110,11 @@ std::unique_ptr<ha::LeaderCoordinator> CreateEtcdCoordinatorOrNull(
 
 class FakeLeaderCoordinator : public ha::LeaderCoordinator {
    public:
-    struct State {
-        int release_calls{0};
-        int monitor_start_calls{0};
-        ErrorCode release_result{ErrorCode::OK};
-        ErrorCode monitor_start_result{
-            ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS};
-    };
-
-    explicit FakeLeaderCoordinator(ViewVersionId view_version,
-                                   std::shared_ptr<State> state = nullptr)
+    explicit FakeLeaderCoordinator(ViewVersionId view_version)
         : session_{.view = {.leader_address = "fake-leader",
                             .view_version = view_version},
                    .owner_token = "fake-owner",
-                   .lease_ttl = std::chrono::milliseconds(0)},
-          state_(std::move(state)) {}
+                   .lease_ttl = std::chrono::milliseconds(0)} {}
 
     tl::expected<std::optional<ha::MasterView>, ErrorCode> ReadCurrentView()
         override {
@@ -149,70 +145,108 @@ class FakeLeaderCoordinator : public ha::LeaderCoordinator {
     StartLeadershipMonitor(
         const ha::LeadershipSession& /*session*/,
         ha::LeadershipLostCallback /*on_leadership_lost*/) override {
-        if (state_) {
-            ++state_->monitor_start_calls;
-            return tl::make_unexpected(state_->monitor_start_result);
-        }
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
 
     ErrorCode ReleaseLeadership(
         const ha::LeadershipSession& /*session*/) override {
-        if (!state_) {
-            return ErrorCode::OK;
-        }
-        ++state_->release_calls;
-        return state_->release_result;
+        return ErrorCode::OK;
     }
 
    private:
     ha::LeadershipSession session_;
-    std::shared_ptr<State> state_;
 };
 
-class FakeStandbyController : public ha::StandbyController {
+class SupervisorChildProcess {
    public:
-    explicit FakeStandbyController(ErrorCode promotion_error)
-        : promotion_result_(tl::make_unexpected(promotion_error)) {}
+    SupervisorChildProcess(int rpc_port, int admin_port, std::string cluster_id)
+        : rpc_port_(rpc_port),
+          admin_port_(admin_port),
+          cluster_id_(std::move(cluster_id)) {}
 
-    explicit FakeStandbyController(ha::PromotionContext promotion_context)
-        : promotion_result_(std::move(promotion_context)) {}
+    ~SupervisorChildProcess() { Stop(); }
 
-    ErrorCode StartStandby(
-        const std::optional<ha::MasterView>& /*observed_leader*/) override {
-        return ErrorCode::OK;
+    bool Start() {
+        pid_ = fork();
+        if (pid_ != 0) {
+            return pid_ > 0;
+        }
+
+        const std::string endpoints_arg =
+            "--etcd_endpoints=" + FLAGS_etcd_endpoints;
+        const std::string rpc_port_arg =
+            "--ha_supervisor_rpc_port=" + std::to_string(rpc_port_);
+        const std::string admin_port_arg =
+            "--ha_supervisor_admin_port=" + std::to_string(admin_port_);
+        const std::string cluster_arg =
+            "--ha_supervisor_cluster_id=" + cluster_id_;
+        execl("/proc/self/exe", "/proc/self/exe", "--ha_supervisor_child=true",
+              endpoints_arg.c_str(), rpc_port_arg.c_str(),
+              admin_port_arg.c_str(), cluster_arg.c_str(), nullptr);
+        _exit(127);
     }
 
-    void StopStandby() override {}
-
-    ErrorCode PromoteStandby() override { return ErrorCode::OK; }
-
-    tl::expected<ha::PromotionContext, ErrorCode> PromoteStandbyAndExport()
-        override {
-        return std::move(promotion_result_);
+    bool IsRunning() {
+        if (pid_ <= 0) {
+            return false;
+        }
+        int status = 0;
+        if (waitpid(pid_, &status, WNOHANG) == 0) {
+            return true;
+        }
+        pid_ = 0;
+        return false;
     }
 
-    void UpdateObservedLeader(
-        const std::optional<ha::MasterView>& /*observed_leader*/) override {}
-
-    ha::MasterRuntimeState GetStandbyRuntimeState() const override {
-        return ha::MasterRuntimeState::kStandby;
-    }
-
-    void SetStandbyRuntimeStateCallback(
-        RuntimeStateCallback callback) override {
-        runtime_state_callback_ = std::move(callback);
+    void Stop() {
+        if (pid_ <= 0) {
+            return;
+        }
+        kill(pid_, SIGKILL);
+        waitpid(pid_, nullptr, 0);
+        pid_ = 0;
     }
 
    private:
-    tl::expected<ha::PromotionContext, ErrorCode> promotion_result_;
-    RuntimeStateCallback runtime_state_callback_;
+    pid_t pid_{0};
+    int rpc_port_;
+    int admin_port_;
+    std::string cluster_id_;
 };
 
-MasterServiceSupervisorConfig MakeSupervisorConfig() {
+struct HttpResponse {
+    int status;
+    std::string body;
+};
+
+HttpResponse HttpGet(int port, const std::string& path) {
+    coro_http::coro_http_client client;
+    auto result = client.get("http://127.0.0.1:" + std::to_string(port) + path);
+    return {.status = result.status, .body = std::string(result.resp_body)};
+}
+
+bool WaitForServing(SupervisorChildProcess& child, int admin_port,
+                    std::chrono::seconds timeout) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline && child.IsRunning()) {
+        const auto health = HttpGet(admin_port, "/health");
+        if (health.status == 200 &&
+            health.body.find("\"ha_state\":\"serving\"") != std::string::npos &&
+            health.body.find("\"service_ready\":true") != std::string::npos) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return false;
+}
+
+}  // namespace
+
+int RunSupervisorChild() {
     MasterServiceSupervisorConfig config;
     config.enable_metric_reporting = false;
-    config.metrics_port = 0;
+    config.metrics_port = FLAGS_ha_supervisor_admin_port;
+    config.metrics_host = "127.0.0.1";
     config.default_kv_lease_ttl = DEFAULT_DEFAULT_KV_LEASE_TTL;
     config.default_kv_soft_pin_ttl = DEFAULT_KV_SOFT_PIN_TTL_MS;
     config.allow_evict_soft_pinned_objects = true;
@@ -229,68 +263,20 @@ MasterServiceSupervisorConfig MakeSupervisorConfig() {
     config.nof_heartbeat_failures_threshold =
         DEFAULT_NOF_HEARTBEAT_FAILURES_THRESHOLD;
     config.enable_offload = false;
-    config.rpc_port = getFreeTcpPort();
+    config.rpc_address = "127.0.0.1";
+    config.rpc_port = FLAGS_ha_supervisor_rpc_port;
     config.rpc_thread_num = 1;
-    return config;
+    config.local_hostname =
+        config.rpc_address + ":" + std::to_string(FLAGS_ha_supervisor_rpc_port);
+    config.ha_backend_type = "etcd";
+    config.ha_backend_connstring = FLAGS_etcd_endpoints;
+    config.etcd_endpoints = FLAGS_etcd_endpoints;
+    config.cluster_id = FLAGS_ha_supervisor_cluster_id;
+    config.enable_oplog = false;
+
+    ha::MasterServiceSupervisor supervisor(config);
+    return supervisor.Start();
 }
-
-StandbyObjectEntry MakeStandbyObject(const std::string& key,
-                                     const std::string& endpoint, size_t size,
-                                     uintptr_t address) {
-    Replica::Descriptor replica;
-    replica.id = 1;
-    replica.status = ReplicaStatus::COMPLETE;
-    MemoryDescriptor memory;
-    memory.buffer_descriptor.transport_endpoint_ = endpoint;
-    memory.buffer_descriptor.buffer_address_ = address;
-    memory.buffer_descriptor.size_ = size;
-    replica.descriptor_variant = std::move(memory);
-
-    StandbyObjectMetadata metadata;
-    metadata.client_id = generate_uuid();
-    metadata.size = size;
-    metadata.replicas.push_back(std::move(replica));
-    return StandbyObjectEntry{"default", key, std::move(metadata)};
-}
-
-ha::PromotionContext MakeInvalidPromotionContext(bool overlap) {
-    constexpr char kEndpoint[] = "supervisor_restore_segment";
-    constexpr size_t kObjectSize = 64;
-    ha::PromotionContext context;
-    context.applied_seq_id = 1;
-    context.segments.push_back(StandbySegmentInfo{
-        .segment_name = kEndpoint,
-        .transport_endpoint = kEndpoint,
-        .capacity = 4096,
-        .is_memory_segment = true,
-        .file_path = "",
-    });
-    context.objects.push_back(MakeStandbyObject(
-        "supervisor_restore_first", kEndpoint, kObjectSize, 0x1000));
-    if (overlap) {
-        context.objects.push_back(MakeStandbyObject(
-            "supervisor_restore_second", kEndpoint, kObjectSize, 0x1000));
-    } else {
-        context.objects.front()
-            .metadata.replicas.front()
-            .get_memory_descriptor()
-            .buffer_descriptor.size_ = kObjectSize + 1;
-    }
-    return context;
-}
-
-struct HttpResponse {
-    int status;
-    std::string body;
-};
-
-HttpResponse HttpGet(int port, const std::string& path) {
-    coro_http::coro_http_client client;
-    auto result = client.get("http://127.0.0.1:" + std::to_string(port) + path);
-    return {.status = result.status, .body = std::string(result.resp_body)};
-}
-
-}  // namespace
 
 TEST_F(HighAvailabilityTest, AcquiredViewFlowsIntoServingMasterService) {
     constexpr ViewVersionId kAcquiredView = 42;
@@ -329,86 +315,23 @@ TEST_F(HighAvailabilityTest, AcquiredViewFlowsIntoServingMasterService) {
     EXPECT_EQ(kAcquiredView, ping->view_version_id);
 }
 
-TEST_F(HighAvailabilityTest,
-       PromotionFailureReleasesLeadershipAndKeepsServiceUnavailable) {
-    auto state = std::make_shared<FakeLeaderCoordinator::State>();
-    state->release_result = ErrorCode::ETCD_OPERATION_ERROR;
-    auto config = MakeSupervisorConfig();
-    const int admin_port = getFreeTcpPort();
-    MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
-                            "127.0.0.1");
-    ASSERT_TRUE(admin.Start());
-
-    EXPECT_EQ(-1, ha::RunSupervisorLoopForTesting(
-                      MakeEtcdBackendSpec("unused"), config, admin,
-                      std::make_unique<FakeLeaderCoordinator>(1, state),
-                      std::make_unique<FakeStandbyController>(
-                          ErrorCode::INVALID_PARAMS)));
-    EXPECT_EQ(state->release_calls, 1);
-
-    const auto health = HttpGet(admin_port, "/health");
-    EXPECT_EQ(health.status, 200);
-    EXPECT_NE(health.body.find("\"service_ready\":false"), std::string::npos);
-    EXPECT_EQ(HttpGet(admin_port, "/get_all_keys").status, 503);
-    admin.Stop();
-}
-
-TEST_F(HighAvailabilityTest, EmptyPromotionContextPassesRestoreGate) {
-    auto state = std::make_shared<FakeLeaderCoordinator::State>();
-    state->monitor_start_result = ErrorCode::INVALID_PARAMS;
-    auto config = MakeSupervisorConfig();
-    const int admin_port = getFreeTcpPort();
-    MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
-                            "127.0.0.1");
-    ASSERT_TRUE(admin.Start());
-
-    EXPECT_EQ(
-        -1,
-        ha::RunSupervisorLoopForTesting(
-            MakeEtcdBackendSpec("unused"), config, admin,
-            std::make_unique<FakeLeaderCoordinator>(1, state),
-            std::make_unique<FakeStandbyController>(ha::PromotionContext{})));
-    EXPECT_EQ(state->monitor_start_calls, 1);
-    EXPECT_EQ(state->release_calls, 1);
-
-    const auto health = HttpGet(admin_port, "/health");
-    EXPECT_EQ(health.status, 200);
-    EXPECT_NE(health.body.find("\"service_ready\":false"), std::string::npos);
-    admin.Stop();
-}
-
-TEST_F(HighAvailabilityTest,
-       RestoreFailureReleasesLeadershipAndKeepsServiceUnavailable) {
-    for (const bool overlap : {false, true}) {
-        SCOPED_TRACE(overlap ? "overlapping descriptors"
-                             : "descriptor size mismatch");
-        auto state = std::make_shared<FakeLeaderCoordinator::State>();
-        state->release_result = ErrorCode::ETCD_OPERATION_ERROR;
-        auto config = MakeSupervisorConfig();
-        const int admin_port = getFreeTcpPort();
-        MasterAdminServer admin(static_cast<uint16_t>(admin_port), false,
-                                "127.0.0.1");
-        ASSERT_TRUE(admin.Start());
-
-        EXPECT_EQ(-1, ha::RunSupervisorLoopForTesting(
-                          MakeEtcdBackendSpec("unused"), config, admin,
-                          std::make_unique<FakeLeaderCoordinator>(1, state),
-                          std::make_unique<FakeStandbyController>(
-                              MakeInvalidPromotionContext(overlap))));
-        EXPECT_EQ(state->release_calls, 1);
-
-        const auto health = HttpGet(admin_port, "/health");
-        EXPECT_EQ(health.status, 200);
-        EXPECT_NE(health.body.find("\"ha_state\":\"recovering\""),
-                  std::string::npos);
-        EXPECT_NE(health.body.find("\"service_ready\":false"),
-                  std::string::npos);
-        EXPECT_EQ(HttpGet(admin_port, "/get_all_keys").status, 503);
-        admin.Stop();
-    }
-}
-
 #ifdef STORE_USE_ETCD
+
+TEST_F(HighAvailabilityTest, HaWithoutOplogRestoresEmptyContextAndServes) {
+    if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
+        GTEST_SKIP() << *skip_reason;
+    }
+
+    const auto ports = getFreeTcpPorts(2);
+    ASSERT_EQ(ports.size(), 2);
+    const std::string cluster_id =
+        "ha-without-oplog-supervisor-" + std::to_string(getpid());
+    SupervisorChildProcess child(ports[0], ports[1], cluster_id);
+    ASSERT_TRUE(child.Start());
+    ASSERT_TRUE(WaitForServing(child, ports[1], std::chrono::seconds(20)));
+
+    EXPECT_EQ(HttpGet(ports[1], "/get_all_keys").status, 200);
+}
 
 TEST_F(HighAvailabilityTest, EtcdBasicOperations) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
@@ -1132,6 +1055,12 @@ TEST_F(HighAvailabilityTest, OpLogPersistenceInterfaces) {
 int main(int argc, char** argv) {
     // Initialize Google's flags library
     gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+    if (mooncake::testing::FLAGS_ha_supervisor_child) {
+        google::InitGoogleLogging("HighAvailabilitySupervisorChild");
+        FLAGS_logtostderr = 1;
+        return mooncake::testing::RunSupervisorChild();
+    }
 
     // Initialize Google Test
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Description

Gate HA serving on successful standby restoration and release leadership on all promotion-phase failures.

An elected candidate is allowed to serve only after:

1. standby final catch-up and promotion/export succeed;
2. the complete `PromotionContext`, including a valid empty context, is restored and validated;
3. leadership is revalidated immediately before serving.

If promotion or restoration fails, the candidate remains unavailable, its service delegate is not exposed, and leadership is released. A leadership-release failure does not make the candidate serviceable.

The previous behavior logged restoration errors and continued serving from empty or partially restored metadata. This was a correctness bug rather than a supported availability fallback: the in-memory state could disagree with the durable OpLog and make later recovery unsafe. This PR intentionally changes that observable failure behavior to fail closed.

Mooncake does not automatically discard recovery data after an error. The deployment guide documents the explicit recovery path for deployments that accept cache loss: stop all processes using the old `cluster_id` and start a new empty cluster with a previously unused `cluster_id`.

This branch is rebased onto current `main` and includes #3566. The combined HA-without-OpLog path is covered end to end in the real supervisor:

`CreateStandbyController()` -> `NoopStandbyController` -> empty `PromotionContext` -> restore gate -> `service_ready=true`.

The test starts a real `MasterServiceSupervisor` in a child process and observes `/health` and `/get_all_keys`; production code has no test-only injection path or public testing API.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] Breaking change
- [x] Documentation update

## How Has This Been Tested?

**Build and test commands:**

```bash
cmake -S . -B build-r02-latest \
  -DSTORE_USE_ETCD=ON \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo

cmake --build build-r02-latest \
  --target high_availability_test \
           master_service_ha_test \
           hot_standby_snapshot_bootstrap_test \
  -j32

LSAN_OPTIONS=detect_leaks=0 \
  build-r02-latest/mooncake-store/tests/high_availability_test \
  --etcd_endpoints=127.0.0.1:22379

LSAN_OPTIONS=detect_leaks=0 \
  build-r02-latest/mooncake-store/tests/hot_standby_snapshot_bootstrap_test

LSAN_OPTIONS=detect_leaks=0 \
  build-r02-latest/mooncake-store/tests/master_service_ha_test \
  --gtest_filter='MasterServiceHATest.RestoreRejectsDescriptorSizeMismatch:MasterServiceHATest.RestoreRejectsOverlappingMemoryDescriptors:MasterServiceHATest.RestoreRejectsDfsMode'

pre-commit run --files \
  docs/source/design/store/mooncake-store.md \
  docs/source/deployment/mooncake-store-deployment-guide.md \
  mooncake-store/src/ha/leadership/master_service_supervisor.cpp \
  mooncake-store/tests/ha/leadership/high_availability_test.cpp
```

**Test results:**

- [x] Fresh current-`main` build succeeds.
- [x] Full `high_availability_test` passes (14/14) against isolated local etcd.
- [x] Full `hot_standby_snapshot_bootstrap_test` passes (7/7).
- [x] Focused restore rejection tests pass (3/3).
- [x] Pre-commit checks pass.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted the changed C++ code using pre-commit.
- [x] I have run pre-commit on the files changed in this PR and all hooks pass.
- [x] I have updated the HA design and deployment documentation.
- [x] I have added tests to prove my changes are effective.

## AI Assistance Disclosure

- [x] AI tools were used.

AI assistance was used for code inspection, implementation, test construction, documentation, rebase validation, and verification. The human submitter must review and understand every changed line.
