### PR TITLE
[TransferEngine] Split EFA transfers that straddle BufferDesc chunk boundaries

### DIFF
--- a/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/efa_transport/efa_transport.cpp
@@ -939,13 +939,102 @@ Status EfaTransport::submitTransfer(
     return submitTransferTask(task_list);
 }
 
+// Bytes from `address` to the end of the registered chunk that covers it, or 0
+// if no chunk does.  `last_buffer_idx` caches the previous hit so that slicing
+// one request across a seam does not rescan the buffer list per slice.
+//
+// registerLocalMemoryInternal() splits a buffer larger than
+// min(max_mr_size, per-NIC PTE budget) into several chunks and publishes one
+// BufferDesc per chunk, so what the caller registered as a single contiguous
+// range can be several MRs here -- on either side of the transfer.
+static uint64_t efaBytesUntilChunkEnd(
+    const TransferMetadata::SegmentDesc* segment_desc, uint64_t address,
+    bool require_remote_key, size_t& last_buffer_idx) {
+    if (!segment_desc || segment_desc->buffers.empty()) return 0;
+
+    auto is_valid_buffer = [&](const TransferMetadata::BufferDesc& buffer) {
+        const auto& keys = require_remote_key ? buffer.rkey : buffer.lkey;
+        if (keys.empty()) return false;
+        if (address < buffer.addr || address - buffer.addr >= buffer.length)
+            return false;
+        // A chunk under the disjoint per-NIC partition carries a zero key for
+        // every NIC it was not registered on (see the nic_assignments fan-out
+        // in registerLocalMemoryInternal).  All-zero means no NIC can serve it
+        // and selectDevice() will reject it, so capping a slice at such a chunk
+        // would only turn one miss into several.
+        for (auto key : keys)
+            if (key != 0) return true;
+        return false;
+    };
+
+    if (last_buffer_idx < segment_desc->buffers.size()) {
+        const auto& buffer = segment_desc->buffers[last_buffer_idx];
+        if (is_valid_buffer(buffer)) {
+            return buffer.length - (address - buffer.addr);
+        }
+    }
+
+    uint64_t max_remaining = 0;
+    for (size_t i = 0; i < segment_desc->buffers.size(); ++i) {
+        const auto& buffer = segment_desc->buffers[i];
+        if (is_valid_buffer(buffer)) {
+            uint64_t remaining = buffer.length - (address - buffer.addr);
+            if (remaining > max_remaining) {
+                max_remaining = remaining;
+                last_buffer_idx = i;
+            }
+        }
+    }
+    return max_remaining;
+}
+
+// Slice length for a request, capped at the nearest registration boundary.
+//
+// Unlike RDMA this deliberately does not cut at globalConfig().slice_size: EFA
+// posts one WR per slice and SRD handles multi-MB messages natively, so a
+// request that stays inside one chunk on both sides still becomes exactly one
+// slice, as before.  The one thing that does force a split is an MR boundary --
+// a single fi_write/fi_read carries one lkey and one rkey, so a slice may not
+// straddle two chunks on either side.
+struct EfaSliceLengthCalculator {
+    const Transport::TransferRequest& request;
+    const TransferMetadata::SegmentDesc* local_desc;
+    const TransferMetadata::SegmentDesc* target_desc;
+
+    size_t src_buffer_idx = 0;
+    size_t tgt_buffer_idx = 0;
+
+    inline size_t calculate(uint64_t offset) {
+        uint64_t slice_length = request.length - offset;
+
+        const uint64_t src_rem = efaBytesUntilChunkEnd(
+            local_desc, reinterpret_cast<uint64_t>(request.source) + offset,
+            false, src_buffer_idx);
+        if (src_rem > 0) slice_length = std::min(slice_length, src_rem);
+
+        const uint64_t tgt_rem = efaBytesUntilChunkEnd(
+            target_desc, request.target_offset + offset, true, tgt_buffer_idx);
+        if (tgt_rem > 0) slice_length = std::min(slice_length, tgt_rem);
+
+        return static_cast<size_t>(slice_length);
+    }
+};
+
 Status EfaTransport::submitTransferTask(
     const std::vector<TransferTask*>& task_list) {
     std::unordered_map<std::shared_ptr<EfaContext>, std::vector<Slice*>>
         slices_to_post;
+    std::unordered_map<SegmentID, std::shared_ptr<SegmentDesc>>
+        target_segment_descs;
     auto local_segment_desc = metadata_->getSegmentDescByID(LOCAL_SEGMENT_ID);
     assert(local_segment_desc.get());
     const int kMaxRetryCount = globalConfig().retry_cnt;
+
+    auto fail_unposted_slices = [&]() {
+        for (auto& entry : slices_to_post)
+            for (auto* slice : entry.second) slice->markFailed();
+        slices_to_post.clear();
+    };
 
     for (size_t index = 0; index < task_list.size(); ++index) {
         assert(task_list[index]);
@@ -955,7 +1044,24 @@ Status EfaTransport::submitTransferTask(
 
         if (request.length == 0) continue;
 
-        // Find which buffer and preferred device covers this request
+        // The slice length is capped against the peer's chunk boundaries too,
+        // so the target descriptor is needed here and not only in
+        // EfaContext::submitPostSend().  Cache it per target_id: a batch
+        // normally aims every request at the same segment.
+        auto target_desc_it = target_segment_descs.find(request.target_id);
+        if (target_desc_it == target_segment_descs.end()) {
+            target_desc_it =
+                target_segment_descs
+                    .emplace(request.target_id,
+                             metadata_->getSegmentDescByID(request.target_id))
+                    .first;
+        }
+        const auto& target_segment_desc = target_desc_it->second;
+
+        // Find which buffer and preferred device covers this request.  This can
+        // only succeed when the whole request fits in one local chunk, which is
+        // the common case; a request that straddles a seam falls through to the
+        // per-slice selection in the loop below.
         int request_buffer_id = -1, request_device_id = -1;
         if (selectDevice(local_segment_desc.get(), (uint64_t)request.source,
                          request.length, request_buffer_id,
@@ -963,53 +1069,40 @@ Status EfaTransport::submitTransferTask(
             request_buffer_id = -1;
             request_device_id = -1;
         }
+        // selectDevice() returns an index into the HCA space and validates it
+        // against buffer.rkey only, so bound it before indexing context_list_.
+        // Dropping to the retry path is the right recovery: it re-selects, and
+        // its own check covers context_list_ as well.
+        if (request_device_id >= 0 &&
+            (static_cast<size_t>(request_device_id) >= context_list_.size() ||
+             !context_list_[request_device_id] ||
+             !context_list_[request_device_id]->active())) {
+            request_buffer_id = -1;
+            request_device_id = -1;
+        }
 
-        if (request_buffer_id >= 0 && request_device_id >= 0) {
-            // One slice per request.  Round-robin NIC selection is
-            // handled by selectDevice above.
-            auto& context = context_list_[request_device_id];
-            if (!context || !context->active()) {
-                LOG(ERROR) << "EFA Device " << request_device_id
-                           << " is not active";
-                return Status::InvalidArgument(
-                    "EFA Device " + std::to_string(request_device_id) +
-                    " is not active");
-            }
+        EfaSliceLengthCalculator slice_calc{request, local_segment_desc.get(),
+                                            target_segment_desc.get()};
+        for (uint64_t offset = 0; offset < request.length;) {
+            size_t slice_length = slice_calc.calculate(offset);
+            // Neither side reported a covering chunk (nothing registered at
+            // this address): keep the old whole-request behavior and let the
+            // selection below produce the ERR_ADDRESS_NOT_REGISTERED.  A zero
+            // here would otherwise spin forever.
+            if (slice_length == 0) slice_length = request.length - offset;
 
-            Slice* slice = getSliceCache().allocate();
-            assert(slice);
-            slice->peer_nic_path.clear();
-            slice->rdma.dest_rkey = 0;
+            char* source_addr = (char*)request.source + offset;
 
-            slice->source_addr = (char*)request.source;
-            slice->length = request.length;
-            slice->opcode = request.opcode;
-            slice->rdma.dest_addr = request.target_offset;
-            slice->rdma.retry_cnt = request.advise_retry_cnt;
-            slice->rdma.max_retry_cnt = kMaxRetryCount;
-            slice->task = &task;
-            slice->target_id = request.target_id;
-            slice->status = Slice::PENDING;
-            slice->ts = 0;
-            task.slice_list.push_back(slice);
-
-            slice->rdma.source_lkey =
-                local_segment_desc->buffers[request_buffer_id]
-                    .lkey[request_device_id];
-            slices_to_post[context].push_back(slice);
-            __sync_fetch_and_add(&task.total_bytes, slice->length);
-            __sync_fetch_and_add(&task.slice_count, 1);
-        } else {
-            // FALLBACK: device not found via initial selectDevice.
-            // Try per-slice retry with increasing retry_cnt to find any
-            // available device (handles edge cases like multi-buffer spans).
-            int buffer_id = -1, device_id = -1;
+            // The whole-request selection covers every slice when it succeeded:
+            // it means one local chunk spans the entire request, and only the
+            // target side is forcing the split.
+            int buffer_id = request_buffer_id, device_id = request_device_id;
+            bool found_device = (buffer_id >= 0 && device_id >= 0);
             int retry_cnt = request.advise_retry_cnt;
-            bool found_device = false;
             while (retry_cnt < kMaxRetryCount && !found_device) {
                 if (selectDevice(local_segment_desc.get(),
-                                 (uint64_t)request.source, request.length,
-                                 buffer_id, device_id, retry_cnt++))
+                                 (uint64_t)source_addr, slice_length, buffer_id,
+                                 device_id, retry_cnt++))
                     continue;
                 if (device_id >= 0 &&
                     static_cast<size_t>(device_id) < context_list_.size() &&
@@ -1022,26 +1115,23 @@ Status EfaTransport::submitTransferTask(
             if (!found_device) {
                 LOG(ERROR) << "Memory region not registered by any active EFA "
                               "device(s): "
-                           << request.source;
-                for (auto& entry : slices_to_post)
-                    for (auto s : entry.second) s->markFailed();
+                           << (void*)source_addr;
+                fail_unposted_slices();
                 return Status::AddressNotRegistered(
                     "Memory region not registered by any active EFA "
                     "device(s): " +
-                    std::to_string(
-                        reinterpret_cast<uintptr_t>(request.source)));
+                    std::to_string(reinterpret_cast<uintptr_t>(source_addr)));
             }
 
-            // Found a device via retry — create single slice
             Slice* slice = getSliceCache().allocate();
             assert(slice);
             slice->peer_nic_path.clear();
             slice->rdma.dest_rkey = 0;
 
-            slice->source_addr = (char*)request.source;
-            slice->length = request.length;
+            slice->source_addr = source_addr;
+            slice->length = slice_length;
             slice->opcode = request.opcode;
-            slice->rdma.dest_addr = request.target_offset;
+            slice->rdma.dest_addr = request.target_offset + offset;
             slice->rdma.retry_cnt = request.advise_retry_cnt;
             slice->rdma.max_retry_cnt = kMaxRetryCount;
             slice->task = &task;
@@ -1050,12 +1140,13 @@ Status EfaTransport::submitTransferTask(
             slice->ts = 0;
             task.slice_list.push_back(slice);
 
-            auto& context = context_list_[device_id];
             slice->rdma.source_lkey =
                 local_segment_desc->buffers[buffer_id].lkey[device_id];
-            slices_to_post[context].push_back(slice);
+            slices_to_post[context_list_[device_id]].push_back(slice);
             __sync_fetch_and_add(&task.total_bytes, slice->length);
             __sync_fetch_and_add(&task.slice_count, 1);
+
+            offset += slice_length;
         }
     }
 

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -209,6 +209,12 @@ if(USE_EFA)
   target_link_libraries(efa_single_nic_large_mr_test
                         PUBLIC transfer_engine gflags::gflags glog::glog)
 
+  add_executable(efa_large_mr_test ${WORKSPACE}/efa_large_mr_test.cpp)
+  target_link_libraries(efa_large_mr_test PUBLIC transfer_engine gtest
+                                                 gtest_main)
+  # No add_test(): needs EFA hardware plus MC_MAX_MR_SIZE=67108864 in the
+  # environment, same as rdma_large_mr_test.
+
   add_executable(efa_transfer_test ${WORKSPACE}/efa_transfer_test.cpp)
   target_link_libraries(efa_transfer_test PUBLIC transfer_engine gflags::gflags
                                                  glog::glog)

--- a/mooncake-transfer-engine/tests/efa_large_mr_test.cpp
+++ b/mooncake-transfer-engine/tests/efa_large_mr_test.cpp
@@ -1,0 +1,237 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Regression test for issue #3501: a transfer that straddles a BufferDesc chunk
+// boundary must be split at that boundary instead of failing.
+//
+// EfaTransport::registerLocalMemoryInternal() already splits a buffer larger
+// than min(max_mr_size, per-NIC PTE budget) into several chunks and publishes
+// one BufferDesc per chunk (the EFA counterpart of #2644). Submission, however,
+// posted exactly one slice per request and EfaTransport::selectDevice() only
+// accepts a buffer that contains the WHOLE request, so any read/write crossing
+// a seam died with ERR_ADDRESS_NOT_REGISTERED (source side) or "Cannot select
+// device for dest_addr" (target side) -- which is why the Store had to keep
+// splitting EFA segments in GetTransportRegistrationLimit().
+//
+// This forces the condition at a small, hardware-independent size via
+// MC_MAX_MR_SIZE, then runs loopback transfers that cross the first seam.
+//
+// Needs EFA hardware, and MC_MAX_MR_SIZE must be set before the process starts
+// (globalConfig() reads it once):
+//
+//   MC_MAX_MR_SIZE=67108864 ./efa_large_mr_test
+//
+// Not registered with add_test() for that reason, same as rdma_large_mr_test.
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "config.h"
+#include "transfer_engine.h"
+#include "transport/transport.h"
+
+using namespace mooncake;
+
+namespace mooncake {
+
+// Small max_mr_size so the multi-chunk path is exercised without a multi-GB
+// allocation. 256 MiB / 64 MiB = 4 chunks.
+static constexpr size_t kMaxMrSize = 64ull << 20;
+static constexpr size_t kBufferSize = 256ull << 20;
+static constexpr size_t kExpectedChunks = kBufferSize / kMaxMrSize;
+static constexpr size_t kDataLength = 1ull << 20;
+
+class EFALargeMrTest : public ::testing::Test {
+   protected:
+    std::unique_ptr<TransferEngine> engine;
+    void *addr = nullptr;
+    SegmentID segment_id = 0;
+
+    void SetUp() override {
+        const char *env = std::getenv("MC_METADATA_SERVER");
+        std::string metadata_server = env ? env : "P2PHANDSHAKE";
+        env = std::getenv("MC_LOCAL_SERVER_NAME");
+        std::string local_server_name = env ? env : "127.0.0.1:12345";
+
+        ASSERT_EQ(globalConfig().max_mr_size, kMaxMrSize)
+            << "Launch this test process with MC_MAX_MR_SIZE=" << kMaxMrSize;
+
+        engine = std::make_unique<TransferEngine>(false);
+        // Manually discover the topology to populate the EFA device list, same
+        // pattern as efa_transport_test.
+        engine->getLocalTopology()->discover({});
+        auto hp = parseHostNameWithPort(local_server_name);
+        ASSERT_EQ(engine->init(metadata_server, local_server_name,
+                               hp.first.c_str(), hp.second),
+                  0);
+        ASSERT_NE(engine->installTransport("efa", nullptr), nullptr)
+            << "installTransport(\"efa\") failed -- EFA hardware required";
+
+        addr = numa_alloc_onnode(kBufferSize, 0);
+        ASSERT_NE(addr, nullptr);
+        ASSERT_EQ(engine->registerLocalMemory(addr, kBufferSize, "cpu:0"), 0);
+
+        segment_id = engine->openSegment(engine->getLocalIpAndPort());
+        auto desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+        ASSERT_NE(desc, nullptr);
+        // The premise of every case below: the registration really did split.
+        size_t chunks = 0;
+        for (const auto &buffer : desc->buffers) {
+            if (buffer.addr >= (uint64_t)addr &&
+                buffer.addr < (uint64_t)addr + kBufferSize) {
+                EXPECT_LE(buffer.length, kMaxMrSize);
+                ++chunks;
+            }
+        }
+        ASSERT_EQ(chunks, kExpectedChunks)
+            << "buffer was not auto-split into " << kExpectedChunks
+            << " chunks; the straddle cases below would be vacuous";
+    }
+
+    void TearDown() override {
+        if (engine && addr) engine->unregisterLocalMemory(addr);
+        if (addr) numa_free(addr, kBufferSize);
+    }
+
+    // Submit one request and poll to a terminal state.
+    TransferStatusEnum submitAndWait(void *source, uint64_t target_offset,
+                                     size_t length,
+                                     TransferRequest::OpCode opcode) {
+        auto batch_id = engine->allocateBatchID(1);
+        TransferRequest entry;
+        entry.opcode = opcode;
+        entry.length = length;
+        entry.source = (uint8_t *)source;
+        entry.target_id = segment_id;
+        entry.target_offset = target_offset;
+
+        Status s = engine->submitTransfer(batch_id, {entry});
+        if (!s.ok()) {
+            LOG(ERROR) << "submitTransfer failed: " << s.ToString();
+            engine->freeBatchID(batch_id);
+            return TransferStatusEnum::FAILED;
+        }
+
+        const int kMaxPollIterations = 10000000;
+        TransferStatus status;
+        status.s = TransferStatusEnum::WAITING;
+        for (int i = 0; i < kMaxPollIterations; ++i) {
+            if (!engine->getTransferStatus(batch_id, 0, status).ok()) {
+                engine->freeBatchID(batch_id);
+                return TransferStatusEnum::FAILED;
+            }
+            if (status.s != TransferStatusEnum::WAITING) break;
+        }
+        engine->freeBatchID(batch_id);
+        return status.s;
+    }
+
+    void fillSource(size_t offset) {
+        for (size_t i = 0; i < kDataLength; ++i)
+            *((char *)addr + offset + i) = (char)('a' + (lrand48() % 26));
+    }
+};
+
+// Baseline: the target lands past the first chunk but inside a single later
+// chunk. This already worked (each chunk is its own MR with its own key) and
+// guards against a regression in the non-straddling multi-chunk path.
+TEST_F(EFALargeMrTest, WritePastFirstChunk) {
+    const size_t kTargetOffset = kBufferSize - kDataLength;  // chunk 3
+    ASSERT_GT(kTargetOffset, kMaxMrSize);
+
+    fillSource(0);
+    memset((char *)addr + kTargetOffset, 0, kDataLength);
+
+    ASSERT_EQ(submitAndWait(addr, (uint64_t)addr + kTargetOffset, kDataLength,
+                            TransferRequest::WRITE),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_EQ(0, memcmp(addr, (char *)addr + kTargetOffset, kDataLength));
+}
+
+// The TARGET range straddles the seam between chunk 0 and chunk 1. Pre-fix the
+// peer-side selectDevice() in EfaContext::submitPostSend() finds no single
+// BufferDesc covering the whole range and the transfer is marked FAILED.
+TEST_F(EFALargeMrTest, WriteStraddlesChunkBoundary) {
+    const size_t kTargetOffset = kMaxMrSize - kDataLength / 2 + 1;
+    ASSERT_LT(kTargetOffset, kMaxMrSize);                // starts in chunk 0
+    ASSERT_GT(kTargetOffset + kDataLength, kMaxMrSize);  // ends in chunk 1
+
+    fillSource(0);
+    memset((char *)addr + kTargetOffset, 0, kDataLength);
+
+    ASSERT_EQ(submitAndWait(addr, (uint64_t)addr + kTargetOffset, kDataLength,
+                            TransferRequest::WRITE),
+              TransferStatusEnum::COMPLETED)
+        << "EFA WRITE straddling a chunk boundary failed -- the request was "
+           "not split at the seam (issue #3501)";
+    ASSERT_EQ(0, memcmp(addr, (char *)addr + kTargetOffset, kDataLength));
+}
+
+// The SOURCE range straddles the seam. Pre-fix EfaTransport::submitTransferTask
+// rejects the request outright with ERR_ADDRESS_NOT_REGISTERED.
+TEST_F(EFALargeMrTest, WriteWithSourceStraddlingChunkBoundary) {
+    const size_t kSourceOffset = kMaxMrSize - kDataLength / 2 + 1;
+    const size_t kTargetOffset = 2 * kMaxMrSize;
+
+    fillSource(kSourceOffset);
+    memset((char *)addr + kTargetOffset, 0, kDataLength);
+
+    ASSERT_EQ(submitAndWait((char *)addr + kSourceOffset,
+                            (uint64_t)addr + kTargetOffset, kDataLength,
+                            TransferRequest::WRITE),
+              TransferStatusEnum::COMPLETED)
+        << "EFA WRITE with a source straddling a chunk boundary failed "
+           "(issue #3501)";
+    ASSERT_EQ(0, memcmp((char *)addr + kSourceOffset,
+                        (char *)addr + kTargetOffset, kDataLength));
+}
+
+// Same seam, opposite direction: READ pulls from a remote range that straddles
+// the boundary into a local range that straddles the NEXT one, so both sides
+// have to be cut.
+TEST_F(EFALargeMrTest, ReadStraddlesChunkBoundaryOnBothSides) {
+    const size_t kRemoteOffset = kMaxMrSize - kDataLength / 2 + 1;
+    const size_t kLocalOffset = 2 * kMaxMrSize - kDataLength / 2 + 1;
+
+    fillSource(kRemoteOffset);
+    memset((char *)addr + kLocalOffset, 0, kDataLength);
+
+    ASSERT_EQ(submitAndWait((char *)addr + kLocalOffset,
+                            (uint64_t)addr + kRemoteOffset, kDataLength,
+                            TransferRequest::READ),
+              TransferStatusEnum::COMPLETED)
+        << "EFA READ straddling a chunk boundary failed (issue #3501)";
+    ASSERT_EQ(0, memcmp((char *)addr + kLocalOffset,
+                        (char *)addr + kRemoteOffset, kDataLength));
+}
+
+}  // namespace mooncake
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    // Once for the whole binary -- calling InitGoogleLogging() per-test in
+    // SetUp() aborts on the 2nd TEST_F.
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = 1;
+    ::testing::InitGoogleTest(&argc, argv);
+    int rc = RUN_ALL_TESTS();
+    google::ShutdownGoogleLogging();
+    return rc;
+}


### PR DESCRIPTION
## Description

Implements #3501 (child of #3500).

`EfaTransport::registerLocalMemoryInternal()` already splits a buffer larger than
`min(max_mr_size, per-NIC PTE budget)` into several chunks and publishes one
`BufferDesc` per chunk, but submission did not follow:

- `submitTransferTask()` posted exactly **one slice per request**, and
- `selectDevice()` only accepts a `BufferDesc` that contains the **whole**
  `request.length`.

So any read/write crossing a chunk seam failed with `ERR_ADDRESS_NOT_REGISTERED`
on the source side, or `Cannot select device for dest_addr` from
`EfaContext::submitPostSend()` on the target side — which is why
mooncake-store still has to split EFA segments in
`GetTransportRegistrationLimit()`.

**Fix (as prescribed in the issue):** mirror the RDMA transport — cap each
posted slice at the remaining bytes of *both* the source and the target
`BufferDesc`, and look up the lkey per sub-slice (the target rkey is already
resolved per slice inside `submitPostSend()`, so capping to one peer chunk fixes
that side automatically).

Notes on the deliberate differences from RDMA's `SliceLengthCalculator`:

- **No cut at `globalConfig().slice_size`.** EFA posts one WR per slice and SRD
  handles multi-MB messages natively (`MC_SLICE_SIZE` is a no-op on this
  transport), so a request that stays inside one chunk on both sides still
  becomes exactly one slice — behaviour and performance are unchanged for
  everything that works today.
- Chunks whose key vector is all zeros (a NIC the chunk was not registered on
  under the disjoint per-NIC partition) are skipped, so capping a slice never
  turns one miss into several.
- Slices already queued for other contexts are marked failed before returning an
  error, instead of being leaked.
- Drive-by: an out-of-range or inactive `advise_retry_cnt` device on the request
  no longer returns `InvalidArgument`; it falls back to per-slice device
  selection.

Follow-up (not in this PR): once this and the sibling issues land, EFA's
`GetTransportRegistrationLimit()` in mooncake-store can be relaxed.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Hardware: 2x `p5.48xlarge` (8x H100, 32x EFA NIC, libfabric 2.4.0amzn5.0,
CUDA 13.0.88). Both trees built with
`-DUSE_EFA=ON -DUSE_CUDA=ON -DBUILD_UNIT_TESTS=ON`. Every result below is
base-vs-PR on the same box, where "base" is `main` **carrying the same new test
file**, so the tests are shown red before green.

**Test commands:**
```bash
# 1. New regression test (needs EFA hardware; MC_MAX_MR_SIZE forces the split
#    at 64 MiB so a 256 MiB buffer becomes 4 chunks)
MC_MAX_MR_SIZE=67108864 ./mooncake-transfer-engine/tests/efa_large_mr_test

# 2. Existing EFA suite, default config
./mooncake-transfer-engine/tests/efa_transport_test

# 3. Cross-node wire path: block_size is deliberately not a divisor of
#    MC_MAX_MR_SIZE, so the request spanning byte 67108864 straddles the seam
#    on BOTH sides.  The target runs the UNPATCHED binary -- the fix is
#    initiator-side only and wire-compatible.
#  target (node B):
MC_MAX_MR_SIZE=67108864 ./transfer_engine_bench --mode=target \
  --metadata_server=P2PHANDSHAKE --local_server_name=<B>:12345 --protocol=efa \
  --gpu_id=-1 --block_size=1000000 --batch_size=32 --threads=4 \
  --buffer_size=128000000
#  initiator (node A):
MC_MAX_MR_SIZE=67108864 ./transfer_engine_bench --mode=initiator \
  --metadata_server=P2PHANDSHAKE --local_server_name=<A>:12346 \
  --segment_id=<B>:<listen_port> --protocol=efa --operation=write|read \
  --gpu_id=-1 --block_size=1000000 --batch_size=128 --threads=1 \
  --buffer_size=128000000 --duration=5
```

**Test results:**

1. `efa_large_mr_test` (4 cases: baseline past the first chunk, target
   straddling, source straddling, READ straddling on both sides)

| build | result |
|---|---|
| base (`main` + this test) | **1 passed, 3 FAILED** — `Cannot select device for dest_addr 0x…80001` (target side) and `Memory region not registered by any active EFA device(s)` (source side) |
| this PR | **4/4 passed** (8.6 s) |

2. `efa_transport_test`: **11/11 passed** on both builds (28.4 s vs 28.5 s) — no
   regression in the single-chunk path.

3. Cross-node, real `fi_write`/`fi_read` (not the same-process memcpy loopback):

| build | write | read |
|---|---|---|
| base | **aborted** at the straddling request (`AddressNotRegistered`) | **aborted** likewise |
| this PR | completes, 1651 batches in 5.00 s = 42.24 GB/s (≈3.03 ms per 128 MB batch) | 1473 batches in 5.00 s = 37.70 GB/s |

   (Single submission thread with 1 MB blocks, so these are throughput sanity
   numbers, not a peak-bandwidth measurement.)

4. Byte-exactness on the wire (extra local harness, not part of this PR — the
   in-repo gtest is single-process, where `tryLoopbackCopy()` short-circuits to
   `memcpy` and never touches an lkey/rkey; this complements it): a 4 MiB
   straddling WRITE + READ round-trip between the two nodes compares
   byte-for-byte, and a subsequent inner 1 MiB straddling WRITE lands exactly at
   the intended address with both guard regions around it bit-identical. Passes
   on this PR; the base build aborts before the first transfer.

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`efa_large_mr_test` is built but intentionally **not** registered with
`add_test()`, exactly like the existing `rdma_large_mr_test`, because it needs
EFA hardware and `MC_MAX_MR_SIZE` in the environment before process start.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`pre-commit run --files <the 3 files>` passes (clang-format 20.1.8). The
`cmake-format` hook additionally wants to reflow three pre-existing lines in
`mooncake-transfer-engine/tests/CMakeLists.txt` that this PR does not touch
(`shared_segment_test`'s `target_include_directories` and a comment above
`worker_pool_rail_state_test`); per `AGENTS.md` those unrelated edits were left
out.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used to implement the slicing helpers, write the new test, and
run the base-vs-PR hardware validation above. The submitter has reviewed every
changed line.