### PR TITLE
fix(store): allow P2P client HA re-register

### DIFF
--- a/mooncake-store/src/p2p_master_service.cpp
+++ b/mooncake-store/src/p2p_master_service.cpp
@@ -57,20 +57,32 @@ auto P2PMasterService::RegisterClient(const RegisterClientRequest& req)
         return tl::make_unexpected(ErrorCode::ILLEGAL_CLIENT);
     }
 
-    if (GetClientManager().GetClient(req.client_id)) {
-        LOG(WARNING) << "RegisterClient(P2P): client already exists"
-                     << ", client_id=" << req.client_id;
-        return tl::make_unexpected(ErrorCode::CLIENT_ALREADY_EXISTS);
-    }
-
     if (!req.ip_address || !req.rpc_port) {
         LOG(ERROR) << "RegisterClient(P2P): missing endpoint"
                    << ", client_id=" << req.client_id;
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
+    auto make_idempotent_response = [&]() {
+        RegisterClientResponse response;
+        response.view_version = view_version_;
+        LOG(INFO) << "RegisterClient(P2P): client already registered, "
+                     "treating as idempotent re-register"
+                  << ", client_id=" << req.client_id
+                  << ", view_version=" << response.view_version;
+        return response;
+    };
+
+    if (GetClientManager().GetClient(req.client_id)) {
+        return make_idempotent_response();
+    }
+
     auto result = MasterService::RegisterClient(req);
     if (!result.has_value()) {
+        if (result.error() == ErrorCode::CLIENT_ALREADY_EXISTS &&
+            GetClientManager().GetClient(req.client_id)) {
+            return make_idempotent_response();
+        }
         LOG(ERROR) << "RegisterClient(P2P): failed"
                    << ", client_id=" << req.client_id
                    << ", error=" << result.error();

--- a/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
@@ -220,6 +220,28 @@ TEST_F(P2PRecordOplogTest, RegisterClientRecordsOplog) {
     EXPECT_EQ(payload.segments[0].name, segment.name);
 }
 
+TEST_F(P2PRecordOplogTest, DuplicateRegisterClientDoesNotRecordOplog) {
+    P2PMasterService service(MakeConfig());
+    const UUID client_id{1, 1};
+    const UUID segment_id{2, 2};
+    RegisterClient(service, client_id, MakeSegment(segment_id));
+
+    RegisterClientRequest req;
+    req.client_id = client_id;
+    req.ip_address = "127.0.0.1";
+    req.rpc_port = 50051;
+    req.segments = {MakeSegment({3, 3})};
+    req.deployment_mode = DeploymentMode::P2P;
+
+    auto duplicate_result = service.RegisterClient(req);
+    ASSERT_TRUE(duplicate_result.has_value())
+        << toString(duplicate_result.error());
+
+    auto* manager = service.GetOpLogManager();
+    ASSERT_NE(manager, nullptr);
+    EXPECT_EQ(manager->GetLastSequenceId(), 1);
+}
+
 TEST_F(P2PRecordOplogTest, RegisterClientRejectsMissingEndpoint) {
     P2PMasterService service(MakeConfig());
     const UUID segment_id{2, 2};

--- a/mooncake-store/tests/ha_integration_test.cpp
+++ b/mooncake-store/tests/ha_integration_test.cpp
@@ -139,7 +139,7 @@ class HAIntegrationTest : public ::testing::Test {
             << "Expected DEGRADED state after MASTER_UNREACHABLE";
     }
 
-    static bool RegisterOrAlreadyRestored(
+    static bool RegisterClientForRecovery(
         std::shared_ptr<P2PClientService>& client, ErrorCode& error) {
         auto reg = client->RegisterClient();
         if (reg.has_value()) {
@@ -147,7 +147,7 @@ class HAIntegrationTest : public ::testing::Test {
             return true;
         }
         error = reg.error();
-        return error == ErrorCode::CLIENT_ALREADY_EXISTS;
+        return false;
     }
 
     static void ForceRecover(std::shared_ptr<P2PClientService>& client) {
@@ -573,20 +573,13 @@ TEST_F(HAIntegrationTest, MasterRestartRecovery) {
         if (attempt == 9) FAIL() << "Reconnect client2 failed after retries";
     }
 
-    // Re-register clients with the restarted master. After P2P master metadata
-    // restore is enabled, background HA recovery can race with this manual
-    // re-register and restore the same client first. In that case
-    // CLIENT_ALREADY_EXISTS means the restarted master already has the client,
-    // which is acceptable for this recovery test.
-    //
-    // TODO: Split client registration into strict user-initiated register and
-    // HA recovery register, so this idempotent "already restored" case is
-    // modeled by a dedicated recovery API instead of test-side interpretation.
+    // Re-register clients with the restarted master. Duplicate P2P
+    // registration is handled as an idempotent HA re-register by the master.
     ErrorCode reg1_error = ErrorCode::OK;
-    ASSERT_TRUE(RegisterOrAlreadyRestored(client1_, reg1_error))
+    ASSERT_TRUE(RegisterClientForRecovery(client1_, reg1_error))
         << "Re-register client1 failed: " << static_cast<int>(reg1_error);
     ErrorCode reg2_error = ErrorCode::OK;
-    ASSERT_TRUE(RegisterOrAlreadyRestored(client2_, reg2_error))
+    ASSERT_TRUE(RegisterClientForRecovery(client2_, reg2_error))
         << "Re-register client2 failed: " << static_cast<int>(reg2_error);
 
     // Recovery: DEGRADED → SYNCING → FULL

--- a/mooncake-store/tests/p2p_master_service_test.cpp
+++ b/mooncake-store/tests/p2p_master_service_test.cpp
@@ -109,14 +109,20 @@ TEST_F(P2PMasterServiceTest, RegisterClientDuplicate) {
     auto client_id = generate_uuid();
     RegisterP2PClient(*service, client_id, {seg}, "127.0.0.1", 50051);
 
-    // Try registering the same client_id again
+    // HA re-registering the same client_id is idempotent.
     RegisterClientRequest req;
     req.client_id = client_id;
     req.segments = {MakeP2PSegment("seg2")};
     req.deployment_mode = DeploymentMode::P2P;
+    req.ip_address = "127.0.0.1";
+    req.rpc_port = 50051;
     auto res = service->RegisterClient(req);
-    EXPECT_FALSE(res.has_value());
-    EXPECT_EQ(ErrorCode::CLIENT_ALREADY_EXISTS, res.error());
+    ASSERT_TRUE(res.has_value()) << res.error();
+
+    // Duplicate registration does not merge new segment metadata.
+    auto seg_res = service->QuerySegments("seg2");
+    EXPECT_FALSE(seg_res.has_value());
+    EXPECT_EQ(ErrorCode::SEGMENT_NOT_FOUND, seg_res.error());
 }
 
 // ============================================================

--- a/mooncake-store/tests/p2p_register_concurrency_test.cpp
+++ b/mooncake-store/tests/p2p_register_concurrency_test.cpp
@@ -135,12 +135,9 @@ TEST_F(P2PRegisterConcurrencyTest, ConcurrentRegisterNoCrash) {
     go.store(true, std::memory_order_release);
     for (auto& t : threads) t.join();
 
-    // Registers serialize on registration_mutex_, so exactly one re-registers
-    // the client (HTTP 200); the rest hit the master with the same client_id
-    // and get CLIENT_ALREADY_EXISTS -> non-200. The point of the test is no
-    // crash and a consistent terminal state, not that every concurrent register
-    // succeeds.
-    EXPECT_EQ(ok_count.load(), 1);
+    // The first request creates the client; later requests may observe the
+    // existing client and complete as idempotent re-registers.
+    EXPECT_GE(ok_count.load(), 1);
     ASSERT_TRUE(WaitFor([&] { return client->heartbeat_running_.load(); }));
     EXPECT_TRUE(client->registered_.load());
 
@@ -242,16 +239,14 @@ TEST_F(P2PRegisterConcurrencyTest, RegisterFromLocalOnlyRecovers) {
     client->Stop();
 }
 
-// A redundant /register while already registered (master returns
-// CLIENT_ALREADY_EXISTS) must not crash nor change state.
+// A redundant /register while already registered must not crash nor change
+// state.
 TEST_F(P2PRegisterConcurrencyTest, DuplicateRegisterIsNoop) {
     auto client = CreateClient();
     ASSERT_TRUE(WaitFor([&] { return client->registered_.load(); }));
     const bool hb_before = client->heartbeat_running_.load();
 
-    // Status is expected non-200 (ALREADY_EXISTS); we only care that state
-    // holds.
-    HttpPost(Url(client, "/register"));
+    EXPECT_EQ(HttpPost(Url(client, "/register")), 200);
     EXPECT_TRUE(client->registered_.load());
     EXPECT_EQ(client->heartbeat_running_.load(), hb_before);
 


### PR DESCRIPTION
## Description

  Allow P2P client `RegisterClient` to behave as an idempotent HA re-register when the client already exists on the master.

  Changes include:
  - Return success for duplicate P2P `RegisterClient` requests instead of `CLIENT_ALREADY_EXISTS`.
  - Preserve existing client metadata on duplicate register; the duplicate request does not merge new segment metadata.
  - Avoid recording a second `REGISTER_CLIENT` OpLog entry for duplicate register.
  - Treat concurrent register lost-race as idempotent success when the client is already present.
  - Update HA and register concurrency tests to use the new master-side semantics.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Reshard (`mooncake-reshard`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  docker exec -w /workspace/.claude/worktrees/p2p-register-reregister-v21 mooncake-dev clang-format-20 -i mooncake-store/src/p2p_master_service.cpp mooncake-store/tests/p2p_master_service_test.cpp mooncake-store/tests/ha/oplog/p2p_record_oplog_test.cpp
  mooncake-store/tests/p2p_register_concurrency_test.cpp mooncake-store/tests/ha_integration_test.cpp
  docker exec -w /workspace/.claude/worktrees/p2p-register-reregister-v21 mooncake-dev cmake -S . -B build-v21 -DSTORE_USE_REDIS=ON -DBUILD_UNIT_TESTS=ON
  docker exec -w /workspace/.claude/worktrees/p2p-register-reregister-v21 mooncake-dev cmake --build build-v21 --target p2p_master_service_test p2p_oplog_test p2p_register_concurrency_test ha_integration_test -j3
  docker exec -w /workspace/.claude/worktrees/p2p-register-reregister-v21 mooncake-dev ctest --test-dir build-v21 -R '^(p2p_master_service_test|p2p_oplog_test|p2p_register_concurrency_test)$' --output-on-failure
  docker exec -w /workspace/.claude/worktrees/p2p-register-reregister-v21 mooncake-dev ctest --test-dir build-v21 -R '^ha_integration_test$' --output-on-failure
```
  Test results:

  - [x] Unit tests pass
  - [x] Integration tests pass
  - [x] Manual testing done

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to inspect the registration and OpLog paths, update the implementation and tests, and run local validation. The human submitter is responsible for reviewing and defending the changes.