### PR TITLE
[Store] Clean replication resources when source disappears

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1535,7 +1535,7 @@ class MasterService {
         uint64_t pending_quota_charge_bytes{0};
         UUID dynamic_replication_lease_id{};
         uint64_t dynamic_replication_version_epoch{0};
-        bool durable_cleanup_pending{false};
+        uint64_t durable_cleanup_generation{0};
         bool source_removed{false};
     };
 
@@ -1882,7 +1882,8 @@ class MasterService {
         MetadataShardAccessorRW* shard);
     void FinalizeRemovedReplicasAfterDurable(
         const OpLogEntry& durable_entry,
-        const std::vector<ReplicaID>& replica_ids, QuotaEraseMode quota_mode);
+        const std::vector<ReplicaID>& replica_ids, QuotaEraseMode quota_mode,
+        uint64_t replication_cleanup_generation = 0);
     void FinalizeMetadataEraseAfterDurable(const OpLogEntry& durable_entry,
                                            QuotaEraseMode quota_mode);
     void FinalizeExpiredProcessingReplicasAfterDurable(
@@ -1893,7 +1894,8 @@ class MasterService {
         const std::vector<ReplicaID>& target_ids,
         const UUID& dynamic_replication_lease_id,
         uint64_t dynamic_replication_version_epoch,
-        const std::chrono::system_clock::time_point& ttl);
+        const std::chrono::system_clock::time_point& ttl,
+        uint64_t cleanup_generation);
     struct StaleHandleCleanupPlan {
         std::vector<ReplicaID> removed_ids;
         std::vector<Replica::Descriptor> remaining;
@@ -2074,8 +2076,8 @@ class MasterService {
         NO_THREAD_SAFETY_ANALYSIS;
     void CancelReplicationTaskForRemovedSource(
         TenantState& tenant_state, ObjectMetadata& metadata,
-        const std::vector<ReplicaID>& removed_replica_ids)
-        NO_THREAD_SAFETY_ANALYSIS;
+        const std::vector<ReplicaID>& removed_replica_ids,
+        uint64_t cleanup_generation = 0) NO_THREAD_SAFETY_ANALYSIS;
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
@@ -2432,6 +2434,7 @@ class MasterService {
     void ClientMonitorFunc();
     std::thread client_monitor_thread_;
     std::atomic<bool> client_monitor_running_{false};
+    std::atomic<uint64_t> next_replication_cleanup_generation_{1};
     static constexpr uint64_t kClientMonitorSleepMs =
         1000;  // 1000 ms sleep between client monitor checks
     // boost lockfree queue requires trivial assignment operator

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1536,6 +1536,7 @@ class MasterService {
         UUID dynamic_replication_lease_id{};
         uint64_t dynamic_replication_version_epoch{0};
         bool durable_cleanup_pending{false};
+        bool source_removed{false};
     };
 
     struct OffloadingTask {
@@ -2071,6 +2072,10 @@ class MasterService {
         TenantState& tenant_state, ObjectMetadata& metadata,
         const std::vector<ReplicaID>& removed_replica_ids)
         NO_THREAD_SAFETY_ANALYSIS;
+    void CancelReplicationTaskForRemovedSource(
+        TenantState& tenant_state, ObjectMetadata& metadata,
+        const std::vector<ReplicaID>& removed_replica_ids)
+        NO_THREAD_SAFETY_ANALYSIS;
 
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
@@ -2172,8 +2177,14 @@ class MasterService {
                             << ", bytes=" << before_charge - after_charge;
                     }
                 }
-                // If no valid replicas remain, delete the whole object.
-                if (!it_->second.IsValid()) {
+                // If no valid replicas remain, delete the whole object unless
+                // a cancelled replication task still preserves End/Revoke
+                // protocol semantics.
+                const bool preserve_cancelled_replication =
+                    replication_task_it_ !=
+                        tenant_state_->replication_tasks.end() &&
+                    replication_task_it_->second.source_removed;
+                if (!it_->second.IsValid() && !preserve_cancelled_replication) {
                     // NOTE: Erase() -> EraseMetadata() already removes the key
                     // from processing_keys (by key), so calling
                     // EraseFromProcessing() here would re-erase the same node

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1907,8 +1907,8 @@ class MasterService {
         const std::function<bool(const Replica&)>& is_stale) const;
     tl::expected<void, ErrorCode> PersistStaleHandleCleanupForHA(
         const std::string& why, const TenantId& tenant_id,
-        const std::string& key, ObjectMetadata& metadata,
-        const StaleHandleCleanupPlan& plan);
+        const std::string& key, TenantState& tenant_state,
+        ObjectMetadata& metadata, const StaleHandleCleanupPlan& plan);
     void RebuildGroupRoutingIndex();
     void GrantLeaseForGroup(const TenantState& tenant_state,
                             const std::string& key,
@@ -2160,6 +2160,8 @@ class MasterService {
                     },
                     &removed_replica_ids);
                 service_->CancelPromotionTaskForRemovedReplicas(
+                    *tenant_state_, it_->second, removed_replica_ids);
+                service_->CancelReplicationTaskForRemovedSource(
                     *tenant_state_, it_->second, removed_replica_ids);
                 const uint64_t after_charge =
                     service_->CompletedMemoryQuotaCharge(it_->second);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1802,7 +1802,7 @@ tl::expected<void, ErrorCode> MasterService::SettlePrimaryWriteQuotaIfReady(
 
 void MasterService::FinalizeRemovedReplicasAfterDurable(
     const OpLogEntry& durable_entry, const std::vector<ReplicaID>& replica_ids,
-    QuotaEraseMode quota_mode) {
+    QuotaEraseMode quota_mode, uint64_t replication_cleanup_generation) {
     if (replica_ids.empty()) {
         return;
     }
@@ -1820,6 +1820,15 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     auto metadata_it = tenant_state.metadata.find(durable_entry.object_key);
     if (metadata_it == tenant_state.metadata.end()) {
         return;
+    }
+    if (replication_cleanup_generation != 0) {
+        auto task_it =
+            tenant_state.replication_tasks.find(durable_entry.object_key);
+        if (task_it == tenant_state.replication_tasks.end() ||
+            task_it->second.durable_cleanup_generation !=
+                replication_cleanup_generation) {
+            return;
+        }
     }
 
     std::unordered_set<ReplicaID> ids(replica_ids.begin(), replica_ids.end());
@@ -1877,7 +1886,8 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
                                           erased_replica_ids);
     CancelReplicationTaskForRemovedSource(tenant_state, metadata,
-                                          erased_replica_ids);
+                                          erased_replica_ids,
+                                          replication_cleanup_generation);
     if (!metadata.IsValid()) {
         auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
         if (task_it != tenant_state.replication_tasks.end() &&
@@ -1954,7 +1964,8 @@ void MasterService::FinalizeExpiredReplicationTaskAfterDurable(
     const std::vector<ReplicaID>& target_ids,
     const UUID& dynamic_replication_lease_id,
     uint64_t dynamic_replication_version_epoch,
-    const std::chrono::system_clock::time_point& ttl) {
+    const std::chrono::system_clock::time_point& ttl,
+    uint64_t cleanup_generation) {
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     const TenantId tenant_id(durable_entry.tenant_id);
     MetadataAccessorRW accessor(this, MakeObjectIdentityForRequest(
@@ -1967,8 +1978,8 @@ void MasterService::FinalizeExpiredReplicationTaskAfterDurable(
         return;
     }
     auto& task = accessor.GetReplicationTask();
-    if (!task.durable_cleanup_pending || task.source_id != source_id ||
-        task.replica_ids != target_ids ||
+    if (task.durable_cleanup_generation != cleanup_generation ||
+        task.source_id != source_id || task.replica_ids != target_ids ||
         task.dynamic_replication_lease_id != dynamic_replication_lease_id ||
         task.dynamic_replication_version_epoch !=
             dynamic_replication_version_epoch) {
@@ -2061,39 +2072,49 @@ tl::expected<void, ErrorCode> MasterService::PersistStaleHandleCleanupForHA(
                               : SerializeMetadataForOpLogFromReplicaDescriptors(
                                     metadata, plan.remaining);
 
+    const std::unordered_set<ReplicaID> ids(plan.removed_ids.begin(),
+                                            plan.removed_ids.end());
+    auto task_it = tenant_state.replication_tasks.find(key);
+    const bool removes_replication_source =
+        task_it != tenant_state.replication_tasks.end() &&
+        ids.contains(task_it->second.source_id);
+    if (removes_replication_source &&
+        task_it->second.durable_cleanup_generation != 0) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+
     auto reservation = ReserveBatchOpLogSlot();
     if (!reservation) {
         return tl::make_unexpected(reservation.error());
     }
-    const std::unordered_set<ReplicaID> ids(plan.removed_ids.begin(),
-                                            plan.removed_ids.end());
-    auto task_it = tenant_state.replication_tasks.find(key);
-    const bool replication_source_pending =
-        task_it != tenant_state.replication_tasks.end() &&
-        ids.contains(task_it->second.source_id);
-    if (replication_source_pending) {
-        task_it->second.durable_cleanup_pending = true;
+    uint64_t cleanup_generation = 0;
+    if (removes_replication_source) {
+        cleanup_generation = next_replication_cleanup_generation_.fetch_add(
+            1, std::memory_order_relaxed);
+        task_it->second.durable_cleanup_generation = cleanup_generation;
     }
-    metadata.VisitReplicas(
-        [&ids](const Replica& replica) { return ids.contains(replica.id()); },
-        [](Replica& replica) { replica.mark_removed(); });
     auto result = AppendReservedOpLogWithDurableFinalize(
         std::move(reservation.value()), op_type, tenant_id.value(), key,
         payload,
-        [this,
-         removed_ids = plan.removed_ids](const OpLogEntry& durable_entry) {
+        [this, removed_ids = plan.removed_ids,
+         cleanup_generation](const OpLogEntry& durable_entry) {
             FinalizeRemovedReplicasAfterDurable(durable_entry, removed_ids,
-                                                QuotaEraseMode::kFull);
+                                                QuotaEraseMode::kFull,
+                                                cleanup_generation);
         });
     if (!result) {
-        if (replication_source_pending) {
-            task_it->second.durable_cleanup_pending = false;
+        if (removes_replication_source &&
+            task_it->second.durable_cleanup_generation == cleanup_generation) {
+            task_it->second.durable_cleanup_generation = 0;
         }
         LOG(WARNING) << why
                      << ": stale cleanup OpLog queue failed for key=" << key
                      << ", err=" << static_cast<int>(result.error());
         return tl::make_unexpected(result.error());
     }
+    metadata.VisitReplicas(
+        [&ids](const Replica& replica) { return ids.contains(replica.id()); },
+        [](Replica& replica) { replica.mark_removed(); });
     return {};
 }
 
@@ -5846,7 +5867,7 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
         LOG(ERROR) << "Ongoing replication task type is MOVE instead of COPY";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    if (task.durable_cleanup_pending) {
+    if (task.durable_cleanup_generation) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (task.dynamic_replication_lease_id != dynamic_replication_lease_id ||
@@ -6023,7 +6044,7 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
         LOG(ERROR) << "Ongoing replication task type is MOVE instead of COPY";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    if (task.durable_cleanup_pending) {
+    if (task.durable_cleanup_generation) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (task.dynamic_replication_lease_id != dynamic_replication_lease_id ||
@@ -6225,7 +6246,7 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    if (task.durable_cleanup_pending) {
+    if (task.durable_cleanup_generation) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (!object_exists && task.source_removed) {
@@ -6418,7 +6439,7 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
-    if (task.durable_cleanup_pending) {
+    if (task.durable_cleanup_generation) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (!object_exists && task.source_removed) {
@@ -6991,7 +7012,8 @@ void MasterService::CancelPromotionTaskForRemovedReplicas(
 
 void MasterService::CancelReplicationTaskForRemovedSource(
     TenantState& tenant_state, ObjectMetadata& metadata,
-    const std::vector<ReplicaID>& removed_replica_ids) {
+    const std::vector<ReplicaID>& removed_replica_ids,
+    uint64_t cleanup_generation) {
     if (removed_replica_ids.empty()) return;
 
     auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
@@ -7000,17 +7022,37 @@ void MasterService::CancelReplicationTaskForRemovedSource(
                   task_it->second.source_id) == removed_replica_ids.end()) {
         return;
     }
+    if ((cleanup_generation == 0 &&
+         task_it->second.durable_cleanup_generation != 0) ||
+        (cleanup_generation != 0 &&
+         task_it->second.durable_cleanup_generation != cleanup_generation)) {
+        return;
+    }
 
     const auto target_ids = task_it->second.replica_ids;
-    EraseReplicasWithCacheTotalAccounting(
+    auto target_replicas = PopReplicasWithCacheTotalAccounting(
         metadata, [&target_ids](const Replica& replica) {
             return std::find(target_ids.begin(), target_ids.end(),
                              replica.id()) != target_ids.end();
         });
+    std::vector<ReplicaID> erased_target_ids;
+    erased_target_ids.reserve(target_replicas.size());
+    for (const auto& replica : target_replicas) {
+        erased_target_ids.push_back(replica.id());
+    }
+    RecordDynamicReplicaRemoval(metadata, erased_target_ids);
+    ReleaseLocalDiskUsage(target_replicas);
+    FreeDfsReplicas(metadata.user_key, target_replicas);
+    if (!target_replicas.empty()) {
+        const auto ttl =
+            task_it->second.start_time + put_start_release_timeout_sec_;
+        std::lock_guard lock(discarded_replicas_mutex_);
+        discarded_replicas_.emplace_back(std::move(target_replicas), ttl);
+    }
     ReleaseTenantQuota(GetBoundTenantQuotaHandle(tenant_state),
                        task_it->second.pending_quota_charge_bytes);
     task_it->second.pending_quota_charge_bytes = 0;
-    task_it->second.durable_cleanup_pending = false;
+    task_it->second.durable_cleanup_generation = 0;
     task_it->second.source_removed = true;
     ClearDynamicReplicationStateForKey(tenant_state, metadata.user_key);
 }
@@ -9275,7 +9317,7 @@ void MasterService::DiscardExpiredProcessingReplicas(
 
             const auto ttl =
                 task_it->second.start_time + put_start_release_timeout_sec_;
-            if (ttl > now || task_it->second.durable_cleanup_pending) {
+            if (ttl > now || task_it->second.durable_cleanup_generation) {
                 task_it++;
                 continue;
             }
@@ -9298,7 +9340,10 @@ void MasterService::DiscardExpiredProcessingReplicas(
 
             if (had_complete_replica && enable_oplog_ &&
                 ordered_oplog_writer_) {
-                task_it->second.durable_cleanup_pending = true;
+                const uint64_t cleanup_generation =
+                    next_replication_cleanup_generation_.fetch_add(
+                        1, std::memory_order_relaxed);
+                task_it->second.durable_cleanup_generation = cleanup_generation;
                 tl::expected<OpLogEntry, ErrorCode> persist_result;
                 auto source_id = task_it->second.source_id;
                 auto target_ids = replica_ids;
@@ -9313,12 +9358,13 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         enable_oplog_
                             ? [this, source_id,
                                target_ids = std::move(target_ids),
-                               dynamic_lease_id, dynamic_version_epoch,
-                               ttl](const OpLogEntry& durable_entry) {
+                               dynamic_lease_id, dynamic_version_epoch, ttl,
+                               cleanup_generation](
+                                  const OpLogEntry& durable_entry) {
                                   FinalizeExpiredReplicationTaskAfterDurable(
                                       durable_entry, source_id, target_ids,
                                       dynamic_lease_id, dynamic_version_epoch,
-                                      ttl);
+                                      ttl, cleanup_generation);
                               }
                             : DurableFinalizeCallback{});
                 } else {
@@ -9330,12 +9376,13 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         enable_oplog_
                             ? [this, source_id,
                                target_ids = std::move(target_ids),
-                               dynamic_lease_id, dynamic_version_epoch,
-                               ttl](const OpLogEntry& durable_entry) {
+                               dynamic_lease_id, dynamic_version_epoch, ttl,
+                               cleanup_generation](
+                                  const OpLogEntry& durable_entry) {
                                   FinalizeExpiredReplicationTaskAfterDurable(
                                       durable_entry, source_id, target_ids,
                                       dynamic_lease_id, dynamic_version_epoch,
-                                      ttl);
+                                      ttl, cleanup_generation);
                               }
                             : DurableFinalizeCallback{});
                 }
@@ -9346,7 +9393,10 @@ void MasterService::DiscardExpiredProcessingReplicas(
                         << task_it->first
                         << ", err=" << static_cast<int>(persist_result.error())
                         << ", deferring discard";
-                    task_it->second.durable_cleanup_pending = false;
+                    if (task_it->second.durable_cleanup_generation ==
+                        cleanup_generation) {
+                        task_it->second.durable_cleanup_generation = 0;
+                    }
                     ++task_it;
                     continue;
                 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2048,7 +2048,8 @@ MasterService::BuildStaleHandleCleanupPlan(
 
 tl::expected<void, ErrorCode> MasterService::PersistStaleHandleCleanupForHA(
     const std::string& why, const TenantId& tenant_id, const std::string& key,
-    ObjectMetadata& metadata, const StaleHandleCleanupPlan& plan) {
+    TenantState& tenant_state, ObjectMetadata& metadata,
+    const StaleHandleCleanupPlan& plan) {
     if (plan.removed_ids.empty() || !enable_oplog_) {
         return {};
     }
@@ -2066,6 +2067,13 @@ tl::expected<void, ErrorCode> MasterService::PersistStaleHandleCleanupForHA(
     }
     const std::unordered_set<ReplicaID> ids(plan.removed_ids.begin(),
                                             plan.removed_ids.end());
+    auto task_it = tenant_state.replication_tasks.find(key);
+    const bool replication_source_pending =
+        task_it != tenant_state.replication_tasks.end() &&
+        ids.contains(task_it->second.source_id);
+    if (replication_source_pending) {
+        task_it->second.durable_cleanup_pending = true;
+    }
     metadata.VisitReplicas(
         [&ids](const Replica& replica) { return ids.contains(replica.id()); },
         [](Replica& replica) { replica.mark_removed(); });
@@ -2078,6 +2086,9 @@ tl::expected<void, ErrorCode> MasterService::PersistStaleHandleCleanupForHA(
                                                 QuotaEraseMode::kFull);
         });
     if (!result) {
+        if (replication_source_pending) {
+            task_it->second.durable_cleanup_pending = false;
+        }
         LOG(WARNING) << why
                      << ": stale cleanup OpLog queue failed for key=" << key
                      << ", err=" << static_cast<int>(result.error());
@@ -2535,7 +2546,8 @@ void MasterService::ClearStaleHandles(
                             auto persist_result =
                                 PersistStaleHandleCleanupForHA(
                                     "ClearStaleHandles", tenant_it->first,
-                                    it->first, it->second, cleanup_plan);
+                                    it->first, tenant_state, it->second,
+                                    cleanup_plan);
                             if (!persist_result) {
                                 ++it;
                                 continue;
@@ -4411,7 +4423,7 @@ auto MasterService::PutStart(const UUID& client_id, const std::string& key,
                 if (!cleanup_plan.removed_ids.empty()) {
                     auto persist_result = PersistStaleHandleCleanupForHA(
                         "PutStart(stale cleanup)", object_id.tenant_id, key,
-                        it->second, cleanup_plan);
+                        tenant_state, it->second, cleanup_plan);
                     if (!persist_result) {
                         return tl::make_unexpected(persist_result.error());
                     }
@@ -5079,7 +5091,7 @@ auto MasterService::UpsertStart(const UUID& client_id, const std::string& key,
                 if (!cleanup_plan.removed_ids.empty()) {
                     auto persist_result = PersistStaleHandleCleanupForHA(
                         "UpsertStart(stale cleanup)", object_id.tenant_id, key,
-                        it->second, cleanup_plan);
+                        tenant_state, it->second, cleanup_plan);
                     if (!persist_result) {
                         return tl::make_unexpected(persist_result.error());
                     }
@@ -6213,6 +6225,9 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
+    if (task.durable_cleanup_pending) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
     if (!object_exists && task.source_removed) {
         accessor.Erase();
         return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
@@ -6402,6 +6417,9 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     if (task.type != ReplicationTask::Type::MOVE) {
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (task.durable_cleanup_pending) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (!object_exists && task.source_removed) {
         accessor.Erase();
@@ -6843,7 +6861,7 @@ auto MasterService::BatchRemove(const std::vector<std::string>& keys,
             if (!cleanup_plan.removed_ids.empty()) {
                 auto persist_result = PersistStaleHandleCleanupForHA(
                     "BatchRemove(stale cleanup)", normalized_tenant, key,
-                    it->second, cleanup_plan);
+                    tenant_state, it->second, cleanup_plan);
                 if (!persist_result) {
                     results[original_idx] =
                         tl::make_unexpected(persist_result.error());

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1876,7 +1876,14 @@ void MasterService::FinalizeRemovedReplicasAfterDurable(
     }
     CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
                                           erased_replica_ids);
+    CancelReplicationTaskForRemovedSource(tenant_state, metadata,
+                                          erased_replica_ids);
     if (!metadata.IsValid()) {
+        auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
+        if (task_it != tenant_state.replication_tasks.end() &&
+            task_it->second.source_removed) {
+            return;
+        }
         EraseMetadata(tenant_state, metadata_it, tenant_id, quota_mode, &shard);
         if (tenant_state.Empty()) {
             shard->tenants.erase(tenant_it);
@@ -2545,6 +2552,13 @@ void MasterService::ClearStaleHandles(
                         ++it;
                     }
                 } else if (!it->second.IsValid()) {
+                    auto task_it = tenant_state.replication_tasks.find(
+                        it->second.user_key);
+                    if (task_it != tenant_state.replication_tasks.end() &&
+                        task_it->second.source_removed) {
+                        ++it;
+                        continue;
+                    }
                     if (enable_ha_) {
                         if (enable_oplog_) {
                             auto persist_result =
@@ -5797,7 +5811,8 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this,
                                 MakeObjectIdentityForRequest(key, tenant_id));
-    if (!accessor.Exists()) {
+    const bool object_exists = accessor.Exists();
+    if (!object_exists && !accessor.HasReplicationTask()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -5828,6 +5843,10 @@ tl::expected<void, ErrorCode> MasterService::CopyEnd(
         LOG(ERROR) << "key=" << key
                    << ", error=dynamic_replication_token_mismatch";
         return tl::make_unexpected(ErrorCode::INVALID_VERSION);
+    }
+    if (!object_exists && task.source_removed) {
+        accessor.Erase();
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
     }
 
     auto& metadata = accessor.Get();
@@ -5969,7 +5988,8 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this,
                                 MakeObjectIdentityForRequest(key, tenant_id));
-    if (!accessor.Exists()) {
+    const bool object_exists = accessor.Exists();
+    if (!object_exists && !accessor.HasReplicationTask()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -6000,6 +6020,10 @@ tl::expected<void, ErrorCode> MasterService::CopyRevoke(
         LOG(ERROR) << "key=" << key
                    << ", error=dynamic_replication_token_mismatch";
         return tl::make_unexpected(ErrorCode::INVALID_VERSION);
+    }
+    if (!object_exists && task.source_removed) {
+        accessor.Erase();
+        return {};
     }
 
     auto& metadata = accessor.Get();
@@ -6166,7 +6190,8 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this,
                                 MakeObjectIdentityForRequest(key, tenant_id));
-    if (!accessor.Exists()) {
+    const bool object_exists = accessor.Exists();
+    if (!object_exists && !accessor.HasReplicationTask()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -6187,6 +6212,10 @@ tl::expected<void, ErrorCode> MasterService::MoveEnd(
     if (task.type != ReplicationTask::Type::MOVE) {
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (!object_exists && task.source_removed) {
+        accessor.Erase();
+        return tl::make_unexpected(ErrorCode::REPLICA_IS_GONE);
     }
 
     auto& metadata = accessor.Get();
@@ -6351,7 +6380,8 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     MetadataAccessorRW accessor(this,
                                 MakeObjectIdentityForRequest(key, tenant_id));
-    if (!accessor.Exists()) {
+    const bool object_exists = accessor.Exists();
+    if (!object_exists && !accessor.HasReplicationTask()) {
         LOG(ERROR) << "key=" << key << ", error=object_not_found";
         return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
     }
@@ -6372,6 +6402,10 @@ tl::expected<void, ErrorCode> MasterService::MoveRevoke(
     if (task.type != ReplicationTask::Type::MOVE) {
         LOG(ERROR) << "Ongoing replication task type is COPY instead of MOVE";
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    if (!object_exists && task.source_removed) {
+        accessor.Erase();
+        return {};
     }
 
     auto& metadata = accessor.Get();
@@ -6937,6 +6971,32 @@ void MasterService::CancelPromotionTaskForRemovedReplicas(
                                        metadata.user_key);
 }
 
+void MasterService::CancelReplicationTaskForRemovedSource(
+    TenantState& tenant_state, ObjectMetadata& metadata,
+    const std::vector<ReplicaID>& removed_replica_ids) {
+    if (removed_replica_ids.empty()) return;
+
+    auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
+    if (task_it == tenant_state.replication_tasks.end() ||
+        std::find(removed_replica_ids.begin(), removed_replica_ids.end(),
+                  task_it->second.source_id) == removed_replica_ids.end()) {
+        return;
+    }
+
+    const auto target_ids = task_it->second.replica_ids;
+    EraseReplicasWithCacheTotalAccounting(
+        metadata, [&target_ids](const Replica& replica) {
+            return std::find(target_ids.begin(), target_ids.end(),
+                             replica.id()) != target_ids.end();
+        });
+    ReleaseTenantQuota(GetBoundTenantQuotaHandle(tenant_state),
+                       task_it->second.pending_quota_charge_bytes);
+    task_it->second.pending_quota_charge_bytes = 0;
+    task_it->second.durable_cleanup_pending = false;
+    task_it->second.source_removed = true;
+    ClearDynamicReplicationStateForKey(tenant_state, metadata.user_key);
+}
+
 bool MasterService::CleanupStaleHandles(
     TenantState& tenant_state, ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
@@ -6970,6 +7030,8 @@ bool MasterService::CleanupStaleHandles(
                                           &removed_replica_ids);
     CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
                                           removed_replica_ids);
+    CancelReplicationTaskForRemovedSource(tenant_state, metadata,
+                                          removed_replica_ids);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
     if (enable_multi_tenants_ && before_charge > after_charge) {
         auto release_result = metadata.quota_ledger.ReleaseCommitted(
@@ -6985,8 +7047,11 @@ bool MasterService::CleanupStaleHandles(
         shard->OnDiskReplicaRemoved(had_completed_disk, metadata);
     }
 
-    // Return true if no valid replicas remain after cleanup
-    return !metadata.IsValid();
+    auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
+    const bool preserve_cancelled_task =
+        task_it != tenant_state.replication_tasks.end() &&
+        task_it->second.source_removed;
+    return !metadata.IsValid() && !preserve_cancelled_task;
 }
 
 void MasterService::FreeDfsReplicas(const std::string& key,

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -1088,6 +1088,39 @@ TEST_F(MasterServiceTenantQuotaTest,
                 200);
 }
 
+TEST_F(MasterServiceTenantQuotaTest, CopySourceCleanupAllowsDelayedRevoke) {
+    MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig config = MemoryConfig();
+    config.preferred_segment = "segment-a";
+    ASSERT_TRUE(
+        service
+            .PutStart(source_client, "key", TenantId("tenant-a"), 100, config)
+            .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    ASSERT_TRUE(service.CopyRevoke(source_client, "key", TenantId("tenant-a"))
+                    .has_value());
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
 TEST_F(MasterServiceTenantQuotaTest,
        MoveSourceCleanupReleasesTargetAndReservedQuota) {
     MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
@@ -1117,6 +1150,40 @@ TEST_F(MasterServiceTenantQuotaTest,
     ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
     ASSERT_TRUE(service.MoveRevoke(source_client, "key", TenantId("tenant-a"))
                     .has_value());
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, MoveSourceCleanupRejectsDelayedEnd) {
+    MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig config = MemoryConfig();
+    config.preferred_segment = "segment-a";
+    ASSERT_TRUE(
+        service
+            .PutStart(source_client, "key", TenantId("tenant-a"), 100, config)
+            .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .MoveStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", "segment-b")
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    auto move_end = service.MoveEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(move_end.has_value());
+    EXPECT_EQ(move_end.error(), ErrorCode::REPLICA_IS_GONE);
     EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
     PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
                 200);

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <future>
 #include <fstream>
@@ -18,10 +19,89 @@
 #include <unistd.h>
 
 #include "allocation_strategy.h"
+#include "ha/kv/ha_kv_backend.h"
 #include "tenant_quota_policy_store.h"
 #include "types.h"
 
 namespace mooncake::test {
+
+class BlockingQuotaOpLogBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard lock(kvs_mutex_);
+        auto it = kvs_.find(std::string(key));
+        if (it == kvs_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard lock(kvs_mutex_);
+        kvs_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view begin_key, std::string_view end_key,
+                    size_t limit, std::vector<KvPair>& kvs) override {
+        std::lock_guard lock(kvs_mutex_);
+        kvs.clear();
+        for (auto it = kvs_.lower_bound(std::string(begin_key));
+             it != kvs_.end() && it->first < end_key; ++it) {
+            kvs.push_back({.key = it->first, .value = it->second});
+            if (limit != 0 && kvs.size() >= limit) {
+                break;
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+
+    ErrorCode Txn(const KvTxn& txn) override {
+        {
+            std::unique_lock lock(block_mutex_);
+            block_cv_.wait(lock, [this] { return !blocked_; });
+        }
+        std::lock_guard lock(kvs_mutex_);
+        for (const auto& compare : txn.compares) {
+            auto it = kvs_.find(compare.key);
+            if (compare.kind == KvCompareKind::kKeyNotExists) {
+                if (it != kvs_.end()) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
+            } else if (it == kvs_.end() ||
+                       it->second != compare.expected_value) {
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+        }
+        for (const auto& put : txn.puts) {
+            kvs_[put.key] = put.value;
+        }
+        return ErrorCode::OK;
+    }
+
+    void BlockTransactions() {
+        std::lock_guard lock(block_mutex_);
+        blocked_ = true;
+    }
+
+    void AllowTransactions() {
+        {
+            std::lock_guard lock(block_mutex_);
+            blocked_ = false;
+        }
+        block_cv_.notify_all();
+    }
+
+   private:
+    std::mutex kvs_mutex_;
+    std::map<std::string, std::string> kvs_;
+    std::mutex block_mutex_;
+    std::condition_variable block_cv_;
+    bool blocked_{false};
+};
 
 class BlockingTenantQuotaPolicyStore final : public TenantQuotaPolicyStore {
    public:
@@ -136,7 +216,8 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
     }
 
     UUID MountSegment(MasterService& service, size_t size = 4096,
-                      std::string name = "quota_segment") {
+                      std::string name = "quota_segment",
+                      UUID* segment_id = nullptr) {
         Segment segment;
         segment.id = generate_uuid();
         segment.name = std::move(name);
@@ -148,6 +229,7 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         UUID client_id = generate_uuid();
         auto result = service.MountSegment(segment, client_id);
         EXPECT_TRUE(result.has_value()) << toString(result.error());
+        if (segment_id != nullptr) *segment_id = segment.id;
         return client_id;
     }
 
@@ -191,6 +273,27 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
         auto snapshot = service.GetTenantQuotaSnapshot(tenant_id);
         EXPECT_TRUE(snapshot.has_value());
         return *snapshot;
+    }
+
+    bool HasReplicationTask(MasterService& service, const TenantId& tenant_id,
+                            const std::string& key) {
+        const size_t shard_index =
+            service.getMetadataShardIndex(tenant_id, key);
+        MasterService::MetadataShardAccessorRO shard(&service, shard_index);
+        auto tenant_it = shard->tenants.find(tenant_id);
+        return tenant_it != shard->tenants.end() &&
+               tenant_it->second.replication_tasks.contains(key);
+    }
+
+    bool WaitForChargedBytes(MasterService& service, const TenantId& tenant_id,
+                             uint64_t expected) {
+        for (int attempt = 0; attempt < 200; ++attempt) {
+            if (Snapshot(service, tenant_id).charged_bytes == expected) {
+                return true;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        return false;
     }
 
     void ReloadTenantQuotaPolicyFromStore(MasterService& service) {
@@ -948,6 +1051,121 @@ TEST_F(MasterServiceTenantQuotaTest, MoveEndSettlesToFinalReplicaCharge) {
     ASSERT_TRUE(
         service.MoveEnd(client_id, "key", TenantId("tenant-a")).has_value());
     EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 100);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       CopySourceCleanupReleasesTargetAndReservedQuota) {
+    MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig config = MemoryConfig();
+    config.preferred_segment = "segment-a";
+    ASSERT_TRUE(
+        service
+            .PutStart(source_client, "key", TenantId("tenant-a"), 100, config)
+            .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    auto copy_end = service.CopyEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(copy_end.has_value());
+    EXPECT_EQ(copy_end.error(), ErrorCode::REPLICA_IS_GONE);
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       MoveSourceCleanupReleasesTargetAndReservedQuota) {
+    MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig config = MemoryConfig();
+    config.preferred_segment = "segment-a";
+    ASSERT_TRUE(
+        service
+            .PutStart(source_client, "key", TenantId("tenant-a"), 100, config)
+            .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .MoveStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", "segment-b")
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    ASSERT_TRUE(service.MoveRevoke(source_client, "key", TenantId("tenant-a"))
+                    .has_value());
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, CopySourceCleanupWaitsForOpLogDurability) {
+    auto config = MakeConfig({{TenantId("tenant-a"), 200}});
+    config.enable_ha = true;
+    config.enable_oplog = true;
+    config.cluster_id = "quota_copy_source_cleanup";
+    config.oplog_batch_max_entries = 16;
+    MasterService service(config);
+    auto backend = std::make_shared<BlockingQuotaOpLogBackend>();
+    ASSERT_EQ(service.SetBatchOpLogBackendForTesting(backend), ErrorCode::OK);
+
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig replicate_config = MemoryConfig();
+    replicate_config.preferred_segment = "segment-a";
+    ASSERT_TRUE(service
+                    .PutStart(source_client, "key", TenantId("tenant-a"), 100,
+                              replicate_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    backend->BlockTransactions();
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    backend->AllowTransactions();
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    auto copy_end = service.CopyEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(copy_end.has_value());
+    EXPECT_EQ(copy_end.error(), ErrorCode::REPLICA_IS_GONE);
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
 }
 
 TEST_F(MasterServiceTenantQuotaTest, DeletePolicyRequiresTenantWithoutObjects) {

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -391,6 +391,25 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
             entry, removed_ids, MasterService::QuotaEraseMode::kFull);
     }
 
+    void InvalidateSegmentAllocatorWithoutCleanup(MasterService& service,
+                                                  const UUID& segment_id) {
+        size_t ignored_capacity = 0;
+        auto segment_access = service.segment_manager_.getSegmentAccess();
+        ASSERT_EQ(
+            segment_access.PrepareUnmountSegment(segment_id, ignored_capacity),
+            ErrorCode::OK);
+    }
+
+    void TriggerMetadataAccessorCleanupForRemovedSource(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key) {
+        MasterService::MetadataAccessorRW accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        EXPECT_FALSE(accessor.Exists());
+        ASSERT_TRUE(accessor.HasReplicationTask());
+        EXPECT_TRUE(accessor.GetReplicationTask().source_removed);
+    }
+
     void AddCompletedDiskReplica(MasterService& service, const UUID& client_id,
                                  const std::string& key,
                                  const TenantId& tenant_id, uint64_t size) {
@@ -1225,8 +1244,116 @@ TEST_F(MasterServiceTenantQuotaTest, CopySourceCleanupWaitsForOpLogDurability) {
         service.UnmountSegment(source_segment_id, source_client).has_value());
     EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
 
+    auto blocked_copy_end =
+        service.CopyEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(blocked_copy_end.has_value());
+    EXPECT_EQ(blocked_copy_end.error(),
+              ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    auto blocked_copy_revoke =
+        service.CopyRevoke(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(blocked_copy_revoke.has_value());
+    EXPECT_EQ(blocked_copy_revoke.error(),
+              ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    EXPECT_TRUE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
     backend->AllowTransactions();
     ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    auto copy_end = service.CopyEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(copy_end.has_value());
+    EXPECT_EQ(copy_end.error(), ErrorCode::REPLICA_IS_GONE);
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest, MoveSourceCleanupWaitsForOpLogDurability) {
+    auto config = MakeConfig({{TenantId("tenant-a"), 200}});
+    config.enable_ha = true;
+    config.enable_oplog = true;
+    config.cluster_id = "quota_move_source_cleanup";
+    config.oplog_batch_max_entries = 16;
+    MasterService service(config);
+    auto backend = std::make_shared<BlockingQuotaOpLogBackend>();
+    ASSERT_EQ(service.SetBatchOpLogBackendForTesting(backend), ErrorCode::OK);
+
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig replicate_config = MemoryConfig();
+    replicate_config.preferred_segment = "segment-a";
+    ASSERT_TRUE(service
+                    .PutStart(source_client, "key", TenantId("tenant-a"), 100,
+                              replicate_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .MoveStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", "segment-b")
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    backend->BlockTransactions();
+    ASSERT_TRUE(
+        service.UnmountSegment(source_segment_id, source_client).has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    auto blocked_move_end =
+        service.MoveEnd(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(blocked_move_end.has_value());
+    EXPECT_EQ(blocked_move_end.error(),
+              ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    auto blocked_move_revoke =
+        service.MoveRevoke(source_client, "key", TenantId("tenant-a"));
+    ASSERT_FALSE(blocked_move_revoke.has_value());
+    EXPECT_EQ(blocked_move_revoke.error(),
+              ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    EXPECT_TRUE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    backend->AllowTransactions();
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    ASSERT_TRUE(service.MoveRevoke(source_client, "key", TenantId("tenant-a"))
+                    .has_value());
+    EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
+                200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       MetadataAccessorCleanupCancelsReplicationForRemovedSource) {
+    MasterService service(MakeConfig({{TenantId("tenant-a"), 200}}));
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+
+    ReplicateConfig replicate_config = MemoryConfig();
+    replicate_config.preferred_segment = "segment-a";
+    ASSERT_TRUE(service
+                    .PutStart(source_client, "key", TenantId("tenant-a"), 100,
+                              replicate_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 200);
+
+    InvalidateSegmentAllocatorWithoutCleanup(service, source_segment_id);
+    TriggerMetadataAccessorCleanupForRemovedSource(service,
+                                                   TenantId("tenant-a"), "key");
+    EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 0);
+
     auto copy_end = service.CopyEnd(source_client, "key", TenantId("tenant-a"));
     ASSERT_FALSE(copy_end.has_value());
     EXPECT_EQ(copy_end.error(), ErrorCode::REPLICA_IS_GONE);

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -20,10 +20,35 @@
 
 #include "allocation_strategy.h"
 #include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/ordered_oplog_writer.h"
 #include "tenant_quota_policy_store.h"
 #include "types.h"
 
 namespace mooncake::test {
+
+class RejectableCommitOpLogWriter final : public OrderedOpLogWriter {
+   public:
+    RejectableCommitOpLogWriter(
+        OrderedOpLogWriterConfig config, WriteBatchFn write_batch,
+        std::shared_ptr<std::atomic<bool>> reject_commit)
+        : OrderedOpLogWriter(std::move(config), std::move(write_batch)),
+          reject_commit_(std::move(reject_commit)) {}
+
+    tl::expected<PendingHandle, ErrorCode> Commit(
+        Reservation&& reservation, OpLogEntry entry,
+        DurableCallback callback) override {
+        if (reject_commit_->load(std::memory_order_relaxed)) {
+            Abort(std::move(reservation));
+            return tl::make_unexpected(
+                ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+        }
+        return OrderedOpLogWriter::Commit(
+            std::move(reservation), std::move(entry), std::move(callback));
+    }
+
+   private:
+    std::shared_ptr<std::atomic<bool>> reject_commit_;
+};
 
 class BlockingQuotaOpLogBackend final : public HaKvBackend {
    public:
@@ -294,6 +319,85 @@ class MasterServiceTenantQuotaTest : public ::testing::Test {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         return false;
+    }
+
+    uint64_t ReplicationCleanupGeneration(MasterService& service,
+                                          const TenantId& tenant_id,
+                                          const std::string& key) {
+        MasterService::MetadataAccessorRW accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        if (!accessor.HasReplicationTask()) {
+            return 0;
+        }
+        return accessor.GetReplicationTask().durable_cleanup_generation;
+    }
+
+    bool HasReplicaWithStatus(MasterService& service, const TenantId& tenant_id,
+                              const std::string& key, ReplicaStatus status) {
+        MasterService::MetadataAccessorRW accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        if (!accessor.Exists()) {
+            return false;
+        }
+        return accessor.Get().HasReplica([status](const Replica& replica) {
+            return replica.status() == status;
+        });
+    }
+
+    tl::expected<void, ErrorCode> PersistStaleCleanupForTest(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key) {
+        MasterService::MetadataAccessorRW accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        if (!accessor.Exists()) {
+            return tl::make_unexpected(ErrorCode::OBJECT_NOT_FOUND);
+        }
+        const std::unordered_set<UUID, boost::hash<UUID>> alive_clients;
+        auto plan =
+            service.BuildStaleHandleCleanupPlan(accessor.Get(), alive_clients);
+        return service.PersistStaleHandleCleanupForHA("test", tenant_id, key,
+                                                      accessor.GetTenantState(),
+                                                      accessor.Get(), plan);
+    }
+
+    void FinalizeExpiredReplicationWithGenerationForTest(
+        MasterService& service, const TenantId& tenant_id,
+        const std::string& key, uint64_t cleanup_generation) {
+        MasterService::ReplicationTask task;
+        {
+            MasterService::MetadataAccessorRW accessor(
+                &service, MasterService::ObjectIdentity{tenant_id, key});
+            ASSERT_TRUE(accessor.HasReplicationTask());
+            task = accessor.GetReplicationTask();
+        }
+        OpLogEntry entry;
+        entry.tenant_id = tenant_id.value();
+        entry.object_key = key;
+        service.FinalizeExpiredReplicationTaskAfterDurable(
+            entry, task.source_id, task.replica_ids,
+            task.dynamic_replication_lease_id,
+            task.dynamic_replication_version_epoch,
+            task.start_time + service.put_start_release_timeout_sec_,
+            cleanup_generation);
+    }
+
+    size_t DiscardedReplicaBatchCount(MasterService& service) {
+        std::lock_guard lock(service.discarded_replicas_mutex_);
+        return service.discarded_replicas_.size();
+    }
+
+    uint64_t DiscardedReplicaMemoryBytes(MasterService& service) {
+        std::lock_guard lock(service.discarded_replicas_mutex_);
+        uint64_t bytes = 0;
+        for (const auto& replicas : service.discarded_replicas_) {
+            bytes += replicas.memSize();
+        }
+        return bytes;
+    }
+
+    uint64_t ReleaseAllDiscardedReplicasForTest(MasterService& service) {
+        return service.ReleaseExpiredDiscardedReplicas(
+            std::chrono::system_clock::time_point::max());
     }
 
     void ReloadTenantQuotaPolicyFromStore(MasterService& service) {
@@ -1353,13 +1457,125 @@ TEST_F(MasterServiceTenantQuotaTest,
     TriggerMetadataAccessorCleanupForRemovedSource(service,
                                                    TenantId("tenant-a"), "key");
     EXPECT_EQ(Snapshot(service, TenantId("tenant-a")).charged_bytes, 0);
+    EXPECT_EQ(DiscardedReplicaBatchCount(service), 1);
+    EXPECT_EQ(DiscardedReplicaMemoryBytes(service), 100);
 
     auto copy_end = service.CopyEnd(source_client, "key", TenantId("tenant-a"));
     ASSERT_FALSE(copy_end.has_value());
     EXPECT_EQ(copy_end.error(), ErrorCode::REPLICA_IS_GONE);
     EXPECT_FALSE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+    EXPECT_EQ(ReleaseAllDiscardedReplicasForTest(service), 1);
+    EXPECT_EQ(DiscardedReplicaBatchCount(service), 0);
     PutComplete(service, source_client, "replacement", TenantId("tenant-a"),
                 200);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       ReplicationCleanupGenerationSerializesStaleAndTimeoutCleanup) {
+    auto config = MakeConfig({{TenantId("tenant-a"), 200}});
+    config.enable_ha = true;
+    config.enable_oplog = true;
+    config.cluster_id = "quota_cleanup_generation";
+    config.oplog_batch_max_entries = 16;
+    MasterService service(config);
+    auto backend = std::make_shared<BlockingQuotaOpLogBackend>();
+    ASSERT_EQ(service.SetBatchOpLogBackendForTesting(backend), ErrorCode::OK);
+
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+    ReplicateConfig replicate_config = MemoryConfig();
+    replicate_config.preferred_segment = "segment-a";
+    ASSERT_TRUE(service
+                    .PutStart(source_client, "key", TenantId("tenant-a"), 100,
+                              replicate_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+
+    InvalidateSegmentAllocatorWithoutCleanup(service, source_segment_id);
+    backend->BlockTransactions();
+    ASSERT_TRUE(PersistStaleCleanupForTest(service, TenantId("tenant-a"), "key")
+                    .has_value());
+    const uint64_t stale_generation =
+        ReplicationCleanupGeneration(service, TenantId("tenant-a"), "key");
+    ASSERT_NE(stale_generation, 0);
+
+    DiscardExpiredProcessingForTest(service, TenantId("tenant-a"), "key");
+    EXPECT_EQ(
+        ReplicationCleanupGeneration(service, TenantId("tenant-a"), "key"),
+        stale_generation);
+    FinalizeExpiredReplicationWithGenerationForTest(
+        service, TenantId("tenant-a"), "key", stale_generation + 1);
+    EXPECT_EQ(
+        ReplicationCleanupGeneration(service, TenantId("tenant-a"), "key"),
+        stale_generation);
+    EXPECT_TRUE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
+
+    backend->AllowTransactions();
+    ASSERT_TRUE(WaitForChargedBytes(service, TenantId("tenant-a"), 0));
+    EXPECT_EQ(
+        ReplicationCleanupGeneration(service, TenantId("tenant-a"), "key"), 0);
+}
+
+TEST_F(MasterServiceTenantQuotaTest,
+       StaleCleanupCommitFailureLeavesReplicaAndTaskUnchanged) {
+    auto config = MakeConfig({{TenantId("tenant-a"), 200}});
+    config.enable_ha = true;
+    config.enable_oplog = true;
+    config.cluster_id = "quota_cleanup_commit_failure";
+    config.oplog_batch_max_entries = 16;
+    MasterService service(config);
+    auto reject_commit = std::make_shared<std::atomic<bool>>(false);
+    service.SetBatchOpLogWriterFactoryForTesting(
+        [reject_commit](OrderedOpLogWriterConfig writer_config,
+                        OrderedOpLogWriter::WriteBatchFn write_batch) {
+            return std::make_unique<RejectableCommitOpLogWriter>(
+                std::move(writer_config), std::move(write_batch),
+                reject_commit);
+        });
+    auto backend = std::make_shared<BlockingQuotaOpLogBackend>();
+    ASSERT_EQ(service.SetBatchOpLogBackendForTesting(backend), ErrorCode::OK);
+
+    UUID source_segment_id;
+    UUID source_client =
+        MountSegment(service, 4096, "segment-a", &source_segment_id);
+    MountSegment(service, 4096, "segment-b");
+    ReplicateConfig replicate_config = MemoryConfig();
+    replicate_config.preferred_segment = "segment-a";
+    ASSERT_TRUE(service
+                    .PutStart(source_client, "key", TenantId("tenant-a"), 100,
+                              replicate_config)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .PutEnd(source_client, "key", TenantId("tenant-a"),
+                            ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service
+                    .CopyStart(source_client, "key", TenantId("tenant-a"),
+                               "segment-a", {"segment-b"})
+                    .has_value());
+
+    InvalidateSegmentAllocatorWithoutCleanup(service, source_segment_id);
+    reject_commit->store(true, std::memory_order_relaxed);
+    auto persist_result =
+        PersistStaleCleanupForTest(service, TenantId("tenant-a"), "key");
+    ASSERT_FALSE(persist_result.has_value());
+    EXPECT_EQ(persist_result.error(), ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    EXPECT_EQ(
+        ReplicationCleanupGeneration(service, TenantId("tenant-a"), "key"), 0);
+    EXPECT_TRUE(HasReplicaWithStatus(service, TenantId("tenant-a"), "key",
+                                     ReplicaStatus::COMPLETE));
+    EXPECT_FALSE(HasReplicaWithStatus(service, TenantId("tenant-a"), "key",
+                                      ReplicaStatus::REMOVED));
+    EXPECT_TRUE(HasReplicationTask(service, TenantId("tenant-a"), "key"));
 }
 
 TEST_F(MasterServiceTenantQuotaTest, DeletePolicyRequiresTenantWithoutObjects) {


### PR DESCRIPTION
## Description

Fixes #3401.

When the COMPLETE source replica of an in-flight Copy/Move task disappears during stale-handle cleanup, the master now:

- removes the task's PROCESSING target replicas;
- releases the task's reserved tenant quota;
- clears dynamic replication state;
- keeps a lightweight `source_removed` task tombstone so a concurrent or delayed `CopyEnd`/`MoveEnd` still returns `REPLICA_IS_GONE` and `CopyRevoke`/`MoveRevoke` keeps its existing success semantics;
- performs the same cleanup only after the stale-replica OpLog entry becomes durable in HA mode.

The tombstone is removed by the next End/Revoke request or by the existing replication-task timeout reaper.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
master_service_tenant_quota_test \
  --gtest_filter='MasterServiceTenantQuotaTest.CopySourceCleanupReleasesTargetAndReservedQuota:MasterServiceTenantQuotaTest.MoveSourceCleanupReleasesTargetAndReservedQuota:MasterServiceTenantQuotaTest.CopySourceCleanupWaitsForOpLogDurability'

master_service_test \
  --gtest_filter='MasterServiceTest.CopyEnd:MasterServiceTest.CopyRevoke:MasterServiceTest.MoveEnd:MasterServiceTest.MoveRevoke:MasterServiceTest.CopyInProgressDoesNotKeepUnmountedSourceVisible:MasterServiceTest.MoveInProgressDoesNotKeepUnmountedSourceVisible'

git diff --check
```

The regression tests were also compiled against unmodified `origin/main`; all three failed because quota remained charged until the replication timeout. With this change, all three pass.

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (HA OpLog durability path uses a blocking transactional test backend)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: internal lifecycle fix)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable

`./scripts/code_format.sh` requires clang-format 20, while the current development host provides clang-format 17. The touched files were formatted with the available formatter and `git diff --check` passes.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with the lifecycle analysis, implementation, HA durability review, and regression testing. The submitter reviewed the final change and test results.