### PR TITLE
[Bugfix][TE] Log the RDMA port number as an integer, not a byte

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -209,7 +209,7 @@ int RdmaContext::construct(size_t num_cq_list, size_t num_comp_channels,
     }
     if (openRdmaDevice(device_name_, port, gid_index)) {
         LOG(ERROR) << "Failed to open device " << device_name_ << " on port "
-                   << port << " with GID " << gid_index;
+                   << static_cast<int>(port) << " with GID " << gid_index;
         return ERR_CONTEXT;
     }
 
@@ -1213,8 +1213,8 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ibv_port_attr attr;
         int ret = ibv_query_port(context, port, &attr);
         if (ret) {
-            LOG(ERROR) << "Failed to query port " << port << " on "
-                       << device_name << ": " << strerror(ret);
+            LOG(ERROR) << "Failed to query port " << static_cast<int>(port)
+                       << " on " << device_name << ": " << strerror(ret);
             int close_ret = ibv_close_device(context);
             if (close_ret) {
                 LOG(ERROR) << "ibv_close_device(" << device_name
@@ -1341,7 +1341,8 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         ret = ibv_query_port(context, port, &port_attr);
         if (ret) {
             LOG(WARNING) << "Failed to query port attributes on " << device_name
-                         << "/" << port << ": " << strerror(ret);
+                         << "/" << static_cast<int>(port) << ": "
+                         << strerror(ret);
             int close_ret = ibv_close_device(context);
             if (close_ret) {
                 LOG(ERROR) << "ibv_close_device(" << device_name
@@ -1360,34 +1361,37 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
                                          found_gid_index);
             if (gid_state != GidNetworkState::GID_NOT_FOUND) {
                 LOG(INFO) << "Find best gid index: " << found_gid_index
-                          << " on " << device_name << "/" << port
-                          << " (network state: "
+                          << " on " << device_name << "/"
+                          << static_cast<int>(port) << " (network state: "
                           << GidNetworkStateToString(gid_state) << ")";
                 gid_index = found_gid_index;
             } else {
                 LOG(WARNING) << "No suitable GID found on " << device_name
-                             << "/" << port;
+                             << "/" << static_cast<int>(port);
                 goto cleanup_context_and_devices;
             }
         } else {
             // Also check network state for user-specified GID
             bool has_ndev = !readGidNdev(device_name, port, gid_index).empty();
             if (!has_ndev) {
-                LOG(WARNING) << "User-specified GID index " << gid_index
-                             << " on " << device_name << "/" << port
-                             << " has no associated network device, "
-                             << "may not be optimal for RDMA operations";
+                LOG(WARNING)
+                    << "User-specified GID index " << gid_index << " on "
+                    << device_name << "/" << static_cast<int>(port)
+                    << " has no associated network device, "
+                    << "may not be optimal for RDMA operations";
             }
             LOG(INFO) << "Using user-specified GID index: " << gid_index
-                      << " on " << device_name << "/" << port << " ("
-                      << (has_ndev ? "with" : "without") << " network device)";
+                      << " on " << device_name << "/" << static_cast<int>(port)
+                      << " (" << (has_ndev ? "with" : "without")
+                      << " network device)";
         }
 
         // Continue with GID validation
         ret = ibv_query_gid(context, port, gid_index, &gid_);
         if (ret) {
             LOG(ERROR) << "Failed to query GID " << gid_index << " on "
-                       << device_name << "/" << port << ": " << strerror(ret);
+                       << device_name << "/" << static_cast<int>(port) << ": "
+                       << strerror(ret);
             goto cleanup_context_and_devices;
         }
 

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <glog/logging.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -174,6 +175,26 @@ TEST_F(RdmaContextConstructionTest, RejectsZeroCompletionChannelsBeforeSetup) {
                                   /*num_comp_channels=*/0),
               ERR_INVALID_ARGUMENT);
     EXPECT_FALSE(RdmaContextTestPeer::hasEndpointStore(*context_));
+}
+
+TEST_F(RdmaContextConstructionTest, LogsPortNumberAsIntegerNotCharacter) {
+    // `port` is a uint8_t; streaming it raw into glog renders the byte as a
+    // control character, so the operator sees "on port \x01" instead of the
+    // number they configured. The failure path for a missing device is enough
+    // to exercise the log line.
+    const bool saved_logtostderr = FLAGS_logtostderr;
+    FLAGS_logtostderr = true;
+    ::testing::internal::CaptureStderr();
+    EXPECT_EQ(context_->construct(/*num_cq_list=*/1,
+                                  /*num_comp_channels=*/1,
+                                  /*port=*/1,
+                                  /*gid_index=*/-1),
+              ERR_CONTEXT);
+    const std::string log = ::testing::internal::GetCapturedStderr();
+    FLAGS_logtostderr = saved_logtostderr;
+
+    EXPECT_NE(log.find("on port 1 with GID"), std::string::npos) << log;
+    EXPECT_EQ(log.find(std::string("on port \x01")), std::string::npos) << log;
 }
 
 TEST_F(RdmaContextConstructionTest,


### PR DESCRIPTION
Description
  `RdmaContext::construct()` / `openRdmaDevice()` streamed the `uint8_t port` straight into glog at eight sites, so the port rendered as an invisible control character (`Failed to query port  on mlx5_0`) instead of the number. Cast to `int` at each site (matching existing usage in the file); follow-up to #3381.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  Added `RdmaContextConstructionTest.LogsPortNumberAsIntegerNotCharacter`, which drives `construct()` with `port=1` on a nonexistent device and asserts the captured log contains `on port 1` and not `\x01`; it fails without the
  cast.

  **Test commands:**
  ```bash
  cmake --build build --target rdma_context_reprobe_test
  ./build/mooncake-transfer-engine/tests/rdma_context_reprobe_test

  Test results:
  - [x] Unit tests pass (8/8)
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue