### PR TITLE
[Store] Support NVMe KV commands over NVMe-oF

### DIFF
--- a/mooncake-store/include/nvme_kv_executor.h
+++ b/mooncake-store/include/nvme_kv_executor.h
@@ -133,4 +133,11 @@ NvmeKvExecutorResult CreateNvmeKvIoctlExecutor(std::string device_path,
                                                uint32_t queue_depth,
                                                uint32_t runtime_transfer_limit);
 
+#if defined(USE_NOF) && defined(MOONCAKE_HAVE_SPDK_NVME_KV)
+NvmeKvExecutorResult CreateNvmeKvSpdkExecutor(std::string transport_id,
+                                              uint32_t nsid,
+                                              uint32_t queue_depth,
+                                              uint32_t runtime_transfer_limit);
+#endif
+
 }  // namespace mooncake

--- a/mooncake-store/include/nvme_kv_executor_util.h
+++ b/mooncake-store/include/nvme_kv_executor_util.h
@@ -75,6 +75,8 @@ std::string NvmeKvTransportIdWithNsid(const std::string &configured_path,
 NvmeKvPackedKeyFields PackNvmeKvPhysicalKey(
     const NvmeKvCommandExecutor::PhysicalKey &key);
 ErrorCode MapNvmeKvStatus(uint32_t status, bool is_write);
+ErrorCode MapNvmeKvCompletionStatus(uint32_t status_code_type,
+                                    uint32_t status_code, bool is_write);
 ErrorCode MapNvmeKvTransportError(int err, bool is_write);
 bool IsNvmeKvControlFlowError(ErrorCode error);
 

--- a/mooncake-store/include/nvme_kv_executor_util.h
+++ b/mooncake-store/include/nvme_kv_executor_util.h
@@ -30,6 +30,16 @@ constexpr uint8_t kNvmeKvStoreOpcode = 0x01;
 constexpr uint8_t kNvmeKvRetrieveOpcode = 0x02;
 constexpr uint8_t kNvmeKvDeleteOpcode = 0x10;
 
+enum class NvmeKvDevicePathType {
+    kBlockNamespace,
+    kGenericCharacter,
+};
+
+struct NvmeKvResolvedDevicePath {
+    std::string path;
+    uint32_t nsid = 1;
+};
+
 struct NvmeKvFreeDeleter {
     void operator()(void *ptr) const { std::free(ptr); }
 };
@@ -57,6 +67,11 @@ NvmeKvCommandExecutor::Capabilities BuildNvmeKvCapabilities(
     uint32_t runtime_transfer_limit);
 std::string NvmeKvPhysicalKeyToHex(
     const NvmeKvCommandExecutor::PhysicalKey &key);
+tl::expected<NvmeKvResolvedDevicePath, ErrorCode> ResolveNvmeKvDevicePath(
+    const std::string &configured_path, NvmeKvDevicePathType type,
+    uint32_t configured_nsid);
+std::string NvmeKvTransportIdWithNsid(const std::string &configured_path,
+                                      uint32_t configured_nsid);
 NvmeKvPackedKeyFields PackNvmeKvPhysicalKey(
     const NvmeKvCommandExecutor::PhysicalKey &key);
 ErrorCode MapNvmeKvStatus(uint32_t status, bool is_write);

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -41,6 +41,8 @@ class SpdkWrapper {
     int64_t NvmePollProcessCompletion(nof_seg_handle *seg,
                                       uint32_t complete_per_seg);
 
+    void AbortNofSegment(nof_seg_handle *seg);
+
     /** @brief Open a NoF segment. */
     nof_seg_handle *OpenNofSegment(const std::string &tr_str);
 
@@ -53,6 +55,9 @@ class SpdkWrapper {
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
 #ifdef MOONCAKE_HAVE_SPDK_NVME_KV
+    nof_seg_handle *OpenNofKvSegment(const std::string &tr_str);
+    void CloseNofKvSegment(nof_seg_handle *seg);
+
     bool IsKvNamespace(const nof_seg_handle *seg_handle);
 
     int SubmitKvStore(const nof_seg_handle *seg_handle, const void *key,
@@ -68,6 +73,8 @@ class SpdkWrapper {
 #endif
 
    private:
+    nof_seg_handle *OpenNofSegment(const std::string &tr_str, bool shared);
+
     struct ProbeBuffer {
         void *ptr{nullptr};
         uint32_t size{0};

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -52,6 +52,20 @@ class SpdkWrapper {
 
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
+#ifdef MOONCAKE_HAVE_SPDK_NVME_KV
+    bool IsKvNamespace(const nof_seg_handle *seg_handle);
+
+    int SubmitKvStore(const nof_seg_handle *seg_handle, const void *key,
+                      uint8_t key_len, const void *value, uint32_t value_len,
+                      uint8_t options, spdk_nvme_cmd_cb cb_fn, void *cb_ctx);
+
+    int SubmitKvRetrieve(const nof_seg_handle *seg_handle, const void *key,
+                         uint8_t key_len, void *value, uint32_t value_len,
+                         uint8_t options, spdk_nvme_cmd_cb cb_fn, void *cb_ctx);
+
+    int SubmitKvDelete(const nof_seg_handle *seg_handle, const void *key,
+                       uint8_t key_len, spdk_nvme_cmd_cb cb_fn, void *cb_ctx);
+#endif
 
    private:
     struct ProbeBuffer {

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -219,7 +219,10 @@ int main() {
     set(MOONCAKE_HAVE_NVME_URING_CMD ON)
     message(STATUS "io_uring: NVMe uring command support enabled")
   else()
-    message(STATUS "io_uring: NVMe uring command support unavailable, NVMe KV io_uring executor disabled")
+    message(
+      STATUS
+        "io_uring: NVMe uring command support unavailable, NVMe KV io_uring executor disabled"
+    )
   endif()
 else()
   message(STATUS "io_uring: Disabled (liburing not found)")
@@ -273,72 +276,95 @@ if(USE_NOF)
   if(SPDK_USE_PKG_CONFIG)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(SPDK REQUIRED IMPORTED_TARGET spdk_nvme spdk_env_dpdk)
+    pkg_check_modules(SPDK_SYSLIBS REQUIRED IMPORTED_TARGET spdk_syslibs)
+    set(_SPDK_LIBRARY_SUFFIXES_SAVE ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".so")
+    unset(SPDK_NVME_SHARED_LIBRARY CACHE)
+    find_library(
+      SPDK_NVME_SHARED_LIBRARY
+      NAMES spdk_nvme
+      HINTS ${SPDK_LIBRARY_DIRS})
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ${_SPDK_LIBRARY_SUFFIXES_SAVE})
+    if(NOT SPDK_NVME_SHARED_LIBRARY)
+      message(
+        FATAL_ERROR
+          "SPDK_USE_PKG_CONFIG requires shared SPDK libraries; use the manual SPDK_LIB_DIR/DPDK_LIB_DIR mode for static linking"
+      )
+    endif()
     set(SPDK_INCLUDE_DIR ${SPDK_INCLUDE_DIRS})
     set(DPDK_INCLUDE_DIR ${SPDK_INCLUDE_DIRS})
-    set(SPDK_STATIC_LIBS PkgConfig::SPDK)
+    set(SPDK_STATIC_LIBS -Wl,--no-as-needed PkgConfig::SPDK -Wl,--as-needed
+                         PkgConfig::SPDK_SYSLIBS)
   else()
     set(SPDK_STATIC_LIBS
-      -Wl,--whole-archive
-      ${SPDK_LIB_DIR}/libspdk_event.a
-      ${SPDK_LIB_DIR}/libspdk_rdma.a
-      ${SPDK_LIB_DIR}/libspdk_nvme.a
-      ${SPDK_LIB_DIR}/libspdk_sock_posix.a
-      -Wl,--no-whole-archive
-      ${SPDK_LIB_DIR}/libspdk_vfio_user.a
-      ${SPDK_LIB_DIR}/libspdk_dma.a
-      ${SPDK_LIB_DIR}/libspdk_init.a
-      ${SPDK_LIB_DIR}/libspdk_env_dpdk.a
-      ${SPDK_LIB_DIR}/libspdk_log.a
-      ${SPDK_LIB_DIR}/libspdk_util.a
-      ${SPDK_LIB_DIR}/libspdk_blob.a
-      ${SPDK_LIB_DIR}/libspdk_blobfs.a
-      ${SPDK_LIB_DIR}/libspdk_bdev.a
-      ${SPDK_LIB_DIR}/libspdk_conf.a
-      ${SPDK_LIB_DIR}/libspdk_json.a
-      ${SPDK_LIB_DIR}/libspdk_jsonrpc.a
-      ${SPDK_LIB_DIR}/libspdk_sock.a
-      ${SPDK_LIB_DIR}/libspdk_thread.a
-      ${SPDK_LIB_DIR}/libspdk_trace.a
-      ${SPDK_LIB_DIR}/libspdk_vmd.a
-      ${SPDK_LIB_DIR}/libspdk_rpc.a
-      ${DPDK_LIB_DIR}/librte_eal.a
-      ${DPDK_LIB_DIR}/librte_mempool.a
-      ${DPDK_LIB_DIR}/librte_ring.a
-      ${DPDK_LIB_DIR}/librte_bus_pci.a
-      ${DPDK_LIB_DIR}/librte_pci.a
-      ${DPDK_LIB_DIR}/librte_timer.a
-      ${DPDK_LIB_DIR}/librte_telemetry.a
-      ${DPDK_LIB_DIR}/librte_kvargs.a
-      ${DPDK_LIB_DIR}/librte_mbuf.a
-      -Wl,--whole-archive
-      ${DPDK_LIB_DIR}/librte_mempool_ring.a
-      -Wl,--no-whole-archive
-      ${DPDK_LIB_DIR}/librte_power.a
-      ${DPDK_LIB_DIR}/librte_ethdev.a
-      ${DPDK_LIB_DIR}/librte_net.a
-      ${DPDK_LIB_DIR}/librte_vhost.a
-      ${DPDK_LIB_DIR}/librte_cryptodev.a
-      ${DPDK_LIB_DIR}/librte_hash.a
-      ${DPDK_LIB_DIR}/librte_rcu.a
-      pthread
-      dl
-      numa
-      rt
-      m
-      uuid
-      crypto
-      aio
-      z
-      isal
-      elf
-      ibverbs
-      rdmacm
-      ssl
-      bsd)
+        -Wl,--whole-archive
+        ${SPDK_LIB_DIR}/libspdk_event.a
+        ${SPDK_LIB_DIR}/libspdk_rdma.a
+        ${SPDK_LIB_DIR}/libspdk_nvme.a
+        ${SPDK_LIB_DIR}/libspdk_sock_posix.a
+        -Wl,--no-whole-archive
+        ${SPDK_LIB_DIR}/libspdk_vfio_user.a
+        ${SPDK_LIB_DIR}/libspdk_dma.a
+        ${SPDK_LIB_DIR}/libspdk_init.a
+        ${SPDK_LIB_DIR}/libspdk_env_dpdk.a
+        ${SPDK_LIB_DIR}/libspdk_log.a
+        ${SPDK_LIB_DIR}/libspdk_util.a
+        ${SPDK_LIB_DIR}/libspdk_blob.a
+        ${SPDK_LIB_DIR}/libspdk_blobfs.a
+        ${SPDK_LIB_DIR}/libspdk_bdev.a
+        ${SPDK_LIB_DIR}/libspdk_conf.a
+        ${SPDK_LIB_DIR}/libspdk_json.a
+        ${SPDK_LIB_DIR}/libspdk_jsonrpc.a
+        ${SPDK_LIB_DIR}/libspdk_sock.a
+        ${SPDK_LIB_DIR}/libspdk_thread.a
+        ${SPDK_LIB_DIR}/libspdk_trace.a
+        ${SPDK_LIB_DIR}/libspdk_vmd.a
+        ${SPDK_LIB_DIR}/libspdk_rpc.a
+        ${DPDK_LIB_DIR}/librte_eal.a
+        ${DPDK_LIB_DIR}/librte_mempool.a
+        ${DPDK_LIB_DIR}/librte_ring.a
+        ${DPDK_LIB_DIR}/librte_bus_pci.a
+        ${DPDK_LIB_DIR}/librte_pci.a
+        ${DPDK_LIB_DIR}/librte_timer.a
+        ${DPDK_LIB_DIR}/librte_telemetry.a
+        ${DPDK_LIB_DIR}/librte_kvargs.a
+        ${DPDK_LIB_DIR}/librte_mbuf.a
+        -Wl,--whole-archive
+        ${DPDK_LIB_DIR}/librte_mempool_ring.a
+        -Wl,--no-whole-archive
+        ${DPDK_LIB_DIR}/librte_power.a
+        ${DPDK_LIB_DIR}/librte_ethdev.a
+        ${DPDK_LIB_DIR}/librte_net.a
+        ${DPDK_LIB_DIR}/librte_vhost.a
+        ${DPDK_LIB_DIR}/librte_cryptodev.a
+        ${DPDK_LIB_DIR}/librte_hash.a
+        ${DPDK_LIB_DIR}/librte_rcu.a
+        pthread
+        dl
+        numa
+        rt
+        m
+        uuid
+        crypto
+        aio
+        z
+        isal
+        elf
+        ibverbs
+        rdmacm
+        ssl
+        bsd)
   endif()
 
   set(MOONCAKE_HAVE_SPDK_NVME_KV OFF)
-  if(EXISTS "${SPDK_INCLUDE_DIR}/spdk/nvme_kv.h")
+  unset(SPDK_NVME_KV_INCLUDE_DIR CACHE)
+  find_path(
+    SPDK_NVME_KV_INCLUDE_DIR
+    NAMES spdk/nvme_kv.h
+    HINTS ${SPDK_INCLUDE_DIR} ${DPDK_INCLUDE_DIR})
+  if(SPDK_NVME_KV_INCLUDE_DIR)
+    list(APPEND SPDK_INCLUDE_DIR ${SPDK_NVME_KV_INCLUDE_DIR})
+    list(REMOVE_DUPLICATES SPDK_INCLUDE_DIR)
     set(MOONCAKE_HAVE_SPDK_NVME_KV ON)
     list(APPEND MOONCAKE_STORE_SOURCES nvme_kv_executor_spdk.cpp)
     message(STATUS "SPDK NVMe KV typed API enabled")
@@ -353,8 +379,7 @@ if(BUILD_UNIT_TESTS)
                              PRIVATE MOONCAKE_ENABLE_NVME_KV_TEST_STUB=1)
 endif()
 if(MOONCAKE_HAVE_SPDK_NVME_KV)
-  target_compile_definitions(mooncake_store
-                             PRIVATE MOONCAKE_HAVE_SPDK_NVME_KV=1)
+  target_compile_definitions(mooncake_store PUBLIC MOONCAKE_HAVE_SPDK_NVME_KV=1)
 endif()
 if(KV_EVENTS_ZMQ_FOUND)
   target_compile_definitions(mooncake_store PRIVATE MOONCAKE_ENABLE_KV_EVENTS=1)
@@ -401,7 +426,8 @@ if(URING_LIB AND URING_INCLUDE)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_include_directories(mooncake_store PRIVATE ${URING_INCLUDE})
   if(MOONCAKE_HAVE_NVME_URING_CMD)
-    target_compile_definitions(mooncake_store PRIVATE MOONCAKE_HAVE_NVME_URING_CMD=1)
+    target_compile_definitions(mooncake_store
+                               PRIVATE MOONCAKE_HAVE_NVME_URING_CMD=1)
   endif()
 endif()
 
@@ -525,8 +551,8 @@ endif()
 install(TARGETS mooncake_master mooncake_client DESTINATION bin)
 
 # ---------------------------------------------------------------------------
-# Optional: a self-contained libmooncake_store.so exporting only the store_c.h
-# C ABI, for consumers that dlopen the store (e.g. the Rust crate's `dlopen`
+# Optional: a self-contained libmooncake_store.so exporting only the store_c.h C
+# ABI, for consumers that dlopen the store (e.g. the Rust crate's `dlopen`
 # feature). Whole-archives the static mooncake_store + asio_static (objects are
 # -fPIC, see mooncake-common/common.cmake) and localizes everything else via the
 # version script; only system/toolkit libs (and the Go etcd/k8s backends when
@@ -536,15 +562,13 @@ if(WITH_STORE_C_SHARED)
   # ELF/GNU-ld features (--whole-archive, --as-needed, version script, $ORIGIN);
   # supported by GNU ld, gold, and lld. Linux only.
   if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    message(
-      FATAL_ERROR
-        "WITH_STORE_C_SHARED currently supports Linux/ELF only "
-        "(got CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}).")
+    message(FATAL_ERROR "WITH_STORE_C_SHARED currently supports Linux/ELF only "
+                        "(got CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}).")
   endif()
 
-  # We whole-archive mooncake_store and reuse its name, so require it to be static
-  # (add_library(mooncake_store) follows BUILD_SHARED_LIBS, which some backends
-  # force ON).
+  # We whole-archive mooncake_store and reuse its name, so require it to be
+  # static (add_library(mooncake_store) follows BUILD_SHARED_LIBS, which some
+  # backends force ON).
   get_target_property(_mooncake_store_type mooncake_store TYPE)
   if(NOT _mooncake_store_type STREQUAL "STATIC_LIBRARY")
     message(

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -245,20 +245,39 @@ if(USE_NOF)
   add_subdirectory(spdk)
   list(APPEND MOONCAKE_STORE_SOURCES ${SPDK_WRAPPER_SOURCES})
 
+  set(SPDK_PREFIX_HINT
+      "$ENV{SPDK_PREFIX}"
+      CACHE PATH "SPDK installation prefix")
+  if(SPDK_PREFIX_HINT)
+    set(_SPDK_DEFAULT_INCLUDE_DIR "${SPDK_PREFIX_HINT}/include")
+    set(_SPDK_DEFAULT_LIB_DIR "${SPDK_PREFIX_HINT}/lib")
+  else()
+    set(_SPDK_DEFAULT_INCLUDE_DIR "/usr/local/include")
+    set(_SPDK_DEFAULT_LIB_DIR "/usr/local/lib")
+  endif()
+  option(SPDK_USE_PKG_CONFIG "Resolve SPDK libraries through pkg-config" OFF)
+
   set(SPDK_INCLUDE_DIR
-      "/usr/local/include"
+      "${_SPDK_DEFAULT_INCLUDE_DIR}"
       CACHE PATH "SPDK include directory")
   set(DPDK_INCLUDE_DIR
-      "/usr/local/include"
+      "${_SPDK_DEFAULT_INCLUDE_DIR}"
       CACHE PATH "DPDK include directory")
   set(SPDK_LIB_DIR
-      "/usr/local/lib"
+      "${_SPDK_DEFAULT_LIB_DIR}"
       CACHE PATH "SPDK static library directory")
   set(DPDK_LIB_DIR
-      "/usr/local/lib"
+      "${_SPDK_DEFAULT_LIB_DIR}"
       CACHE PATH "DPDK static library directory")
 
-  set(SPDK_STATIC_LIBS
+  if(SPDK_USE_PKG_CONFIG)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(SPDK REQUIRED IMPORTED_TARGET spdk_nvme spdk_env_dpdk)
+    set(SPDK_INCLUDE_DIR ${SPDK_INCLUDE_DIRS})
+    set(DPDK_INCLUDE_DIR ${SPDK_INCLUDE_DIRS})
+    set(SPDK_STATIC_LIBS PkgConfig::SPDK)
+  else()
+    set(SPDK_STATIC_LIBS
       -Wl,--whole-archive
       ${SPDK_LIB_DIR}/libspdk_event.a
       ${SPDK_LIB_DIR}/libspdk_rdma.a
@@ -316,6 +335,14 @@ if(USE_NOF)
       rdmacm
       ssl
       bsd)
+  endif()
+
+  set(MOONCAKE_HAVE_SPDK_NVME_KV OFF)
+  if(EXISTS "${SPDK_INCLUDE_DIR}/spdk/nvme_kv.h")
+    set(MOONCAKE_HAVE_SPDK_NVME_KV ON)
+    list(APPEND MOONCAKE_STORE_SOURCES nvme_kv_executor_spdk.cpp)
+    message(STATUS "SPDK NVMe KV typed API enabled")
+  endif()
 endif()
 
 # The cache_allocator library
@@ -324,6 +351,10 @@ add_library(mooncake_store ${MOONCAKE_STORE_SOURCES})
 if(BUILD_UNIT_TESTS)
   target_compile_definitions(mooncake_store
                              PRIVATE MOONCAKE_ENABLE_NVME_KV_TEST_STUB=1)
+endif()
+if(MOONCAKE_HAVE_SPDK_NVME_KV)
+  target_compile_definitions(mooncake_store
+                             PRIVATE MOONCAKE_HAVE_SPDK_NVME_KV=1)
 endif()
 if(KV_EVENTS_ZMQ_FOUND)
   target_compile_definitions(mooncake_store PRIVATE MOONCAKE_ENABLE_KV_EVENTS=1)

--- a/mooncake-store/src/nvme_kv_connector.cpp
+++ b/mooncake-store/src/nvme_kv_connector.cpp
@@ -27,6 +27,7 @@ enum class RuntimeTransport {
     kAuto,
     kIoUring,
     kIoctl,
+    kSpdk,
 };
 
 const char *RuntimeTransportName(RuntimeTransport transport) {
@@ -37,6 +38,8 @@ const char *RuntimeTransportName(RuntimeTransport transport) {
             return "io_uring";
         case RuntimeTransport::kIoctl:
             return "ioctl";
+        case RuntimeTransport::kSpdk:
+            return "spdk";
     }
     return "unknown";
 }
@@ -51,6 +54,10 @@ tl::expected<RuntimeTransport, ErrorCode> ParseRuntimeTransport() {
     }
     if (transport == "ioctl") {
         return RuntimeTransport::kIoctl;
+    }
+    if (transport == "spdk" || transport == "spdk_nof" ||
+        transport == "nof_spdk") {
+        return RuntimeTransport::kSpdk;
     }
     LOG(ERROR) << "Unknown MOONCAKE_NVME_KV_TRANSPORT: " << transport;
     return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -110,6 +117,15 @@ tl::expected<void, ErrorCode> NvmeKvConnector::InitRealExecutor() {
             case RuntimeTransport::kIoctl:
                 return CreateNvmeKvIoctlExecutor(device_path, nsid, queue_depth,
                                                  runtime_transfer_limit);
+            case RuntimeTransport::kSpdk:
+#if defined(USE_NOF) && defined(MOONCAKE_HAVE_SPDK_NVME_KV)
+                return CreateNvmeKvSpdkExecutor(device_path, nsid, queue_depth,
+                                                runtime_transfer_limit);
+#else
+                LOG(ERROR) << "SPDK NVMe KV executor requires USE_NOF and SPDK "
+                           << "26.05+ typed KV API support";
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+#endif
             case RuntimeTransport::kAuto:
                 break;
         }

--- a/mooncake-store/src/nvme_kv_executor_io_uring.cpp
+++ b/mooncake-store/src/nvme_kv_executor_io_uring.cpp
@@ -44,35 +44,14 @@ bool CanSubmitCallerBufferDirectly(std::string_view value,
 }
 
 bool IsCharacterDevice(const std::filesystem::path& path) {
-    struct stat st{};
+    struct stat st {};
     return ::stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode);
-}
-
-std::string ResolveIoUringDevicePath(const std::string& device_path) {
-    const std::filesystem::path path(device_path);
-    if (IsCharacterDevice(path)) {
-        return device_path;
-    }
-
-    const std::string filename = path.filename().string();
-    if (filename.rfind("nvme", 0) != 0) {
-        return device_path;
-    }
-    const std::filesystem::path generic_path =
-        path.parent_path() / ("ng" + filename.substr(4));
-    if (IsCharacterDevice(generic_path)) {
-        LOG(INFO) << "[NvmeKvIoUringExecutor] using NVMe generic char device "
-                  << generic_path << " for namespace block device "
-                  << device_path;
-        return generic_path.string();
-    }
-    return device_path;
 }
 
 class SharedNvmeUringRing {
    public:
     struct BatchCommand {
-        struct nvme_uring_cmd cmd{};
+        struct nvme_uring_cmd cmd {};
         bool is_write = false;
         size_t context_index = 0;
         uint32_t observed_result = 0;
@@ -383,8 +362,13 @@ class NvmeKvIoUringExecutor : public NvmeKvCommandExecutor {
           capabilities_(capabilities) {}
 
     tl::expected<void, ErrorCode> Init() {
-        const std::string io_uring_device_path =
-            ResolveIoUringDevicePath(device_path_);
+        auto resolved_path = ResolveNvmeKvDevicePath(
+            device_path_, NvmeKvDevicePathType::kGenericCharacter, nsid_);
+        if (!resolved_path.has_value()) {
+            return tl::make_unexpected(resolved_path.error());
+        }
+        const std::string io_uring_device_path = resolved_path->path;
+        nsid_ = resolved_path->nsid;
         if (!IsCharacterDevice(io_uring_device_path)) {
             LOG(WARNING) << "[NvmeKvIoUringExecutor] io_uring requires an NVMe "
                             "generic character device, configured path="

--- a/mooncake-store/src/nvme_kv_executor_io_uring.cpp
+++ b/mooncake-store/src/nvme_kv_executor_io_uring.cpp
@@ -44,14 +44,14 @@ bool CanSubmitCallerBufferDirectly(std::string_view value,
 }
 
 bool IsCharacterDevice(const std::filesystem::path& path) {
-    struct stat st {};
+    struct stat st{};
     return ::stat(path.c_str(), &st) == 0 && S_ISCHR(st.st_mode);
 }
 
 class SharedNvmeUringRing {
    public:
     struct BatchCommand {
-        struct nvme_uring_cmd cmd {};
+        struct nvme_uring_cmd cmd{};
         bool is_write = false;
         size_t context_index = 0;
         uint32_t observed_result = 0;

--- a/mooncake-store/src/nvme_kv_executor_ioctl.cpp
+++ b/mooncake-store/src/nvme_kv_executor_ioctl.cpp
@@ -28,6 +28,13 @@ class NvmeKvIoctlExecutor : public NvmeKvCommandExecutor {
           capabilities_(capabilities) {}
 
     tl::expected<void, ErrorCode> Init() {
+        auto resolved_path = ResolveNvmeKvDevicePath(
+            device_path_, NvmeKvDevicePathType::kBlockNamespace, nsid_);
+        if (!resolved_path.has_value()) {
+            return tl::make_unexpected(resolved_path.error());
+        }
+        device_path_ = resolved_path->path;
+        nsid_ = resolved_path->nsid;
         fd_ = ::open(device_path_.c_str(), O_RDWR | O_CLOEXEC);
         if (fd_ < 0) {
             LOG(ERROR) << "[NvmeKvIoctlExecutor] open failed for "

--- a/mooncake-store/src/nvme_kv_executor_spdk.cpp
+++ b/mooncake-store/src/nvme_kv_executor_spdk.cpp
@@ -11,12 +11,14 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cerrno>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <string>
-#include <string_view>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -30,23 +32,27 @@ struct SpdkDmaBufferDeleter {
     void operator()(void *ptr) const { SpdkWrapper::GetInstance().Free(ptr); }
 };
 
-using SpdkDmaBuffer = std::unique_ptr<void, SpdkDmaBufferDeleter>;
+using SpdkDmaBuffer = std::shared_ptr<void>;
 
-struct CompletionContext {
+struct CompletionState {
     std::atomic<bool> done{false};
-    bool submitted = false;
-    bool reported = false;
-    bool is_write = false;
-    uint32_t status = 0;
+    uint32_t status_code_type = 0;
+    uint32_t status_code = 0;
+    uint32_t result = 0;
+};
+
+struct CompletionCallbackContext {
+    std::shared_ptr<CompletionState> completion;
+    std::shared_ptr<void> keep_alive;
 };
 
 void KvCommandComplete(void *ctx, const struct spdk_nvme_cpl *cpl) {
-    auto *completion = static_cast<CompletionContext *>(ctx);
-    if (spdk_nvme_cpl_is_error(cpl)) {
-        completion->status = cpl->status.sc;
-    } else {
-        completion->status = 0;
-    }
+    std::unique_ptr<CompletionCallbackContext> callback_context(
+        static_cast<CompletionCallbackContext *>(ctx));
+    auto &completion = callback_context->completion;
+    completion->status_code_type = cpl->status.sct;
+    completion->status_code = cpl->status.sc;
+    completion->result = cpl->cdw0;
     completion->done.store(true, std::memory_order_release);
 }
 
@@ -55,15 +61,6 @@ ErrorCode MapSpdkSubmitError(int ret, bool is_write) {
         return ErrorCode::OK;
     }
     return MapNvmeKvTransportError(ret < 0 ? -ret : ret, is_write);
-}
-
-bool CanUseCallerBuffer(std::string_view value, uint32_t submission_bytes) {
-    if (value.empty() || value.size() != submission_bytes) {
-        return false;
-    }
-    const size_t alignment = std::max<size_t>(
-        kDefaultNvmeKvTransferAlignmentBytes, NvmeKvTransferAlignmentBytes());
-    return reinterpret_cast<uintptr_t>(value.data()) % alignment == 0;
 }
 
 }  // namespace
@@ -75,6 +72,8 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
         : wrapper_(wrapper),
           segment_(segment),
           capabilities_(std::move(capabilities)) {}
+
+    ~NvmeKvSpdkExecutor() override { wrapper_.CloseNofKvSegment(segment_); }
 
     tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
                                         std::string value) override {
@@ -107,11 +106,6 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                 continue;
             }
             submit_sizes[index] = submission_bytes;
-            if (CanUseCallerBuffer(request.value, submission_bytes)) {
-                submit_buffers[index] = request.value.data();
-                continue;
-            }
-
             void *buffer = wrapper_.Alloc(submission_bytes,
                                           NvmeKvTransferAlignmentBytes());
             if (buffer == nullptr) {
@@ -126,16 +120,15 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                 std::memset(static_cast<char *>(buffer) + request.value.size(),
                             0, submission_bytes - request.value.size());
             }
-            dma_buffers[index].reset(buffer);
+            dma_buffers[index] = SpdkDmaBuffer(buffer, SpdkDmaBufferDeleter());
             submit_buffers[index] = buffer;
         }
 
         SubmitBatch(
             requests.size(), true,
-            [&](size_t index, CompletionContext *ctx) {
-                if (submit_buffers[index] == nullptr) {
-                    return false;
-                }
+            [&](size_t index) { return submit_buffers[index] != nullptr; },
+            [&](size_t index, CompletionCallbackContext *ctx) {
+                ctx->keep_alive = dma_buffers[index];
                 const int ret = wrapper_.SubmitKvStore(
                     segment_, requests[index].key.data(),
                     static_cast<uint8_t>(requests[index].key.size()),
@@ -149,7 +142,7 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                 }
                 return true;
             },
-            [&](size_t index, ErrorCode error) {
+            [&](size_t index, ErrorCode error, uint32_t) {
                 if (error == ErrorCode::OK) {
                     requests[index].result = {};
                 } else {
@@ -243,19 +236,18 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
         tl::expected<void, ErrorCode> result =
             tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         SubmitBatch(
-            1, false,
-            [&](size_t, CompletionContext *ctx) {
+            1, true, [](size_t) { return true; },
+            [&](size_t, CompletionCallbackContext *ctx) {
                 const int ret = wrapper_.SubmitKvDelete(
                     segment_, key.data(), static_cast<uint8_t>(key.size()),
                     KvCommandComplete, ctx);
                 if (ret != 0) {
-                    result =
-                        tl::make_unexpected(MapSpdkSubmitError(ret, false));
+                    result = tl::make_unexpected(MapSpdkSubmitError(ret, true));
                     return false;
                 }
                 return true;
             },
-            [&](size_t, ErrorCode error) {
+            [&](size_t, ErrorCode error, uint32_t) {
                 if (error == ErrorCode::OK) {
                     result = {};
                 } else {
@@ -270,25 +262,85 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
     }
 
    private:
-    template <typename SubmitFn, typename CompleteFn>
-    void SubmitBatch(size_t count, bool is_write, SubmitFn submit,
-                     CompleteFn complete) const {
-        std::vector<CompletionContext> contexts(count);
+    template <typename ReadyFn, typename SubmitFn, typename CompleteFn>
+    void SubmitBatch(size_t count, bool is_write, ReadyFn ready,
+                     SubmitFn submit, CompleteFn complete) const {
+        struct BatchContext {
+            std::shared_ptr<CompletionState> completion =
+                std::make_shared<CompletionState>();
+            bool submitted = false;
+            bool reported = false;
+        };
+
+        std::vector<BatchContext> contexts(count);
         size_t next = 0;
         size_t completed = 0;
         size_t inflight = 0;
         const size_t queue_depth =
             std::max<uint32_t>(1, capabilities_.queue_depth);
+        const uint32_t timeout_ms = ParseNvmeKvU32EnvOr(
+            "MOONCAKE_NVME_KV_SPDK_COMPLETION_TIMEOUT_MS", 30000);
+        auto last_progress = std::chrono::steady_clock::now();
 
-        std::lock_guard<std::mutex> lock(qpair_mutex_);
+        for (size_t index = 0; index < count; ++index) {
+            if (!ready(index)) {
+                contexts[index].reported = true;
+                ++completed;
+            }
+        }
+
+        const auto fail_pending = [&](ErrorCode error) {
+            for (size_t index = 0; index < count; ++index) {
+                auto &ctx = contexts[index];
+                if (ctx.reported) {
+                    continue;
+                }
+                ctx.reported = true;
+                complete(index, error, 0);
+            }
+        };
+        const auto drain_completed = [&]() {
+            size_t observed = 0;
+            for (size_t index = 0; index < count; ++index) {
+                auto &ctx = contexts[index];
+                if (!ctx.submitted || ctx.reported ||
+                    !ctx.completion->done.load(std::memory_order_acquire)) {
+                    continue;
+                }
+                ctx.reported = true;
+                --inflight;
+                ++completed;
+                ++observed;
+                complete(index,
+                         MapNvmeKvCompletionStatus(
+                             ctx.completion->status_code_type,
+                             ctx.completion->status_code, is_write),
+                         ctx.completion->result);
+            }
+            return observed;
+        };
+
+        std::lock_guard<std::mutex> batch_lock(batch_mutex_);
         while (completed < count) {
             while (next < count && inflight < queue_depth) {
                 auto &ctx = contexts[next];
-                ctx.is_write = is_write;
-                if (!submit(next, &ctx)) {
-                    if (ctx.done.load(std::memory_order_acquire)) {
-                        complete(next, MapNvmeKvStatus(ctx.status, is_write));
-                    }
+                if (ctx.reported) {
+                    ++next;
+                    continue;
+                }
+                auto *callback_context =
+                    new (std::nothrow) CompletionCallbackContext{
+                        .completion = ctx.completion, .keep_alive = {}};
+                if (callback_context == nullptr) {
+                    ctx.reported = true;
+                    complete(next, ErrorCode::BUFFER_OVERFLOW, 0);
+                    ++completed;
+                    ++next;
+                    continue;
+                }
+                if (!submit(next, callback_context)) {
+                    delete callback_context;
+                    ctx.reported = true;
                     ++completed;
                     ++next;
                     continue;
@@ -296,6 +348,7 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                 ctx.submitted = true;
                 ++inflight;
                 ++next;
+                last_progress = std::chrono::steady_clock::now();
             }
 
             if (inflight == 0) {
@@ -303,24 +356,31 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
             }
             const int rc = static_cast<int>(
                 wrapper_.NvmePollProcessCompletion(segment_, 0));
+            const size_t observed = drain_completed();
             if (rc < 0) {
                 LOG(ERROR) << "SPDK NVMe KV completion polling failed: " << rc;
-            }
-
-            size_t observed = 0;
-            for (size_t index = 0; index < count; ++index) {
-                auto &ctx = contexts[index];
-                if (!ctx.submitted || ctx.reported ||
-                    !ctx.done.load(std::memory_order_acquire)) {
-                    continue;
+                wrapper_.AbortNofSegment(segment_);
+                drain_completed();
+                if (completed < count) {
+                    fail_pending(MapNvmeKvTransportError(-rc, is_write));
+                    return;
                 }
-                ctx.reported = true;
-                --inflight;
-                ++completed;
-                ++observed;
-                complete(index, ctx.status == 0
-                                    ? ErrorCode::OK
-                                    : MapNvmeKvStatus(ctx.status, is_write));
+                break;
+            }
+            if (completed == count) {
+                break;
+            }
+            if (observed != 0) {
+                last_progress = std::chrono::steady_clock::now();
+            } else if (timeout_ms != 0 &&
+                       std::chrono::steady_clock::now() - last_progress >=
+                           std::chrono::milliseconds(timeout_ms)) {
+                LOG(ERROR) << "SPDK NVMe KV completion timed out after "
+                           << timeout_ms << " ms";
+                wrapper_.AbortNofSegment(segment_);
+                drain_completed();
+                fail_pending(MapNvmeKvTransportError(ETIMEDOUT, is_write));
+                return;
             }
             if (observed == 0) {
                 std::this_thread::yield();
@@ -352,16 +412,15 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                     tl::make_unexpected(ErrorCode::BUFFER_OVERFLOW);
                 continue;
             }
-            dma_buffers[index].reset(buffer);
+            dma_buffers[index] = SpdkDmaBuffer(buffer, SpdkDmaBufferDeleter());
             request_bytes[index] = bytes;
         }
 
         SubmitBatch(
             requests.size(), false,
-            [&](size_t index, CompletionContext *ctx) {
-                if (dma_buffers[index] == nullptr) {
-                    return false;
-                }
+            [&](size_t index) { return dma_buffers[index] != nullptr; },
+            [&](size_t index, CompletionCallbackContext *ctx) {
+                ctx->keep_alive = dma_buffers[index];
                 const int ret = wrapper_.SubmitKvRetrieve(
                     segment_, requests[index].key.data(),
                     static_cast<uint8_t>(requests[index].key.size()),
@@ -374,26 +433,31 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
                 }
                 return true;
             },
-            [&](size_t index, ErrorCode error) {
+            [&](size_t index, ErrorCode error, uint32_t reported_size) {
                 if (error != ErrorCode::OK) {
                     requests[index].result = tl::make_unexpected(error);
                     return;
                 }
                 const uint32_t value_size = ResolveNvmeKvRetrievedValueSize(
                     static_cast<const char *>(dma_buffers[index].get()),
-                    request_bytes[index],
-                    capabilities_.effective_max_value_size,
+                    reported_size, capabilities_.effective_max_value_size,
                     requests[index].size_hint);
-                if (value_size == 0 || value_size > request_bytes[index]) {
+                if (value_size == 0) {
                     requests[index].result =
                         tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
                     return;
                 }
+                if (value_size > request_bytes[index]) {
+                    requests[index].result = tl::make_unexpected(
+                        value_size > capabilities_.effective_max_value_size
+                            ? ErrorCode::BUFFER_OVERFLOW
+                            : ErrorCode::INVALID_PARAMS);
+                    return;
+                }
                 RetrievedBuffer buffer;
-                void *owned = dma_buffers[index].release();
-                buffer.owner =
-                    std::shared_ptr<void>(owned, SpdkDmaBufferDeleter());
-                buffer.data = static_cast<const char *>(owned);
+                buffer.owner = dma_buffers[index];
+                buffer.data =
+                    static_cast<const char *>(dma_buffers[index].get());
                 buffer.size = value_size;
                 requests[index].result = std::move(buffer);
             });
@@ -402,7 +466,7 @@ class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
     SpdkWrapper &wrapper_;
     nof_seg_handle *segment_ = nullptr;
     Capabilities capabilities_;
-    mutable std::mutex qpair_mutex_;
+    mutable std::mutex batch_mutex_;
 };
 
 NvmeKvExecutorResult CreateNvmeKvSpdkExecutor(std::string transport_id,
@@ -415,7 +479,7 @@ NvmeKvExecutorResult CreateNvmeKvSpdkExecutor(std::string transport_id,
     }
     const std::string effective_transport_id =
         NvmeKvTransportIdWithNsid(transport_id, nsid);
-    auto *segment = wrapper.OpenNofSegment(effective_transport_id);
+    auto *segment = wrapper.OpenNofKvSegment(effective_transport_id);
     if (segment == nullptr) {
         LOG(ERROR) << "Failed to open SPDK NVMe-oF segment: "
                    << effective_transport_id;
@@ -424,6 +488,7 @@ NvmeKvExecutorResult CreateNvmeKvSpdkExecutor(std::string transport_id,
     if (!wrapper.IsKvNamespace(segment)) {
         LOG(ERROR) << "SPDK NVMe-oF namespace is not an NVMe KV namespace: "
                    << effective_transport_id;
+        wrapper.CloseNofKvSegment(segment);
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     auto capabilities = BuildNvmeKvCapabilities(

--- a/mooncake-store/src/nvme_kv_executor_spdk.cpp
+++ b/mooncake-store/src/nvme_kv_executor_spdk.cpp
@@ -1,0 +1,437 @@
+#include "nvme_kv_executor.h"
+
+#if defined(USE_NOF) && defined(MOONCAKE_HAVE_SPDK_NVME_KV)
+
+#include "nvme_kv_executor_util.h"
+#include "nvme_kv_object_layout.h"
+#include "spdk/spdk_wrapper.h"
+
+#include <spdk/nvme.h>
+#include <spdk/nvme_spec.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <glog/logging.h>
+
+namespace mooncake {
+namespace {
+
+struct SpdkDmaBufferDeleter {
+    void operator()(void *ptr) const { SpdkWrapper::GetInstance().Free(ptr); }
+};
+
+using SpdkDmaBuffer = std::unique_ptr<void, SpdkDmaBufferDeleter>;
+
+struct CompletionContext {
+    std::atomic<bool> done{false};
+    bool submitted = false;
+    bool reported = false;
+    bool is_write = false;
+    uint32_t status = 0;
+};
+
+void KvCommandComplete(void *ctx, const struct spdk_nvme_cpl *cpl) {
+    auto *completion = static_cast<CompletionContext *>(ctx);
+    if (spdk_nvme_cpl_is_error(cpl)) {
+        completion->status = cpl->status.sc;
+    } else {
+        completion->status = 0;
+    }
+    completion->done.store(true, std::memory_order_release);
+}
+
+ErrorCode MapSpdkSubmitError(int ret, bool is_write) {
+    if (ret == 0) {
+        return ErrorCode::OK;
+    }
+    return MapNvmeKvTransportError(ret < 0 ? -ret : ret, is_write);
+}
+
+bool CanUseCallerBuffer(std::string_view value, uint32_t submission_bytes) {
+    if (value.empty() || value.size() != submission_bytes) {
+        return false;
+    }
+    const size_t alignment = std::max<size_t>(
+        kDefaultNvmeKvTransferAlignmentBytes, NvmeKvTransferAlignmentBytes());
+    return reinterpret_cast<uintptr_t>(value.data()) % alignment == 0;
+}
+
+}  // namespace
+
+class NvmeKvSpdkExecutor : public NvmeKvCommandExecutor {
+   public:
+    NvmeKvSpdkExecutor(SpdkWrapper &wrapper, nof_seg_handle *segment,
+                       Capabilities capabilities)
+        : wrapper_(wrapper),
+          segment_(segment),
+          capabilities_(std::move(capabilities)) {}
+
+    tl::expected<void, ErrorCode> Store(const PhysicalKey &key,
+                                        std::string value) override {
+        std::vector<StoreRequest> requests;
+        requests.push_back(StoreRequest{key, value});
+        StoreBatch(requests);
+        return requests.front().result;
+    }
+
+    void StoreBatch(std::vector<StoreRequest> &requests) override {
+        if (requests.empty()) {
+            return;
+        }
+
+        std::vector<SpdkDmaBuffer> dma_buffers(requests.size());
+        std::vector<const void *> submit_buffers(requests.size(), nullptr);
+        std::vector<uint32_t> submit_sizes(requests.size(), 0);
+
+        for (size_t index = 0; index < requests.size(); ++index) {
+            auto &request = requests[index];
+            if (request.value.size() > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            const uint32_t submission_bytes = ResolveNvmeKvStoreSubmissionBytes(
+                static_cast<uint32_t>(request.value.size()));
+            if (submission_bytes == 0 ||
+                submission_bytes > capabilities_.effective_max_value_size) {
+                request.result = tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            submit_sizes[index] = submission_bytes;
+            if (CanUseCallerBuffer(request.value, submission_bytes)) {
+                submit_buffers[index] = request.value.data();
+                continue;
+            }
+
+            void *buffer = wrapper_.Alloc(submission_bytes,
+                                          NvmeKvTransferAlignmentBytes());
+            if (buffer == nullptr) {
+                request.result =
+                    tl::make_unexpected(ErrorCode::BUFFER_OVERFLOW);
+                continue;
+            }
+            if (!request.value.empty()) {
+                std::memcpy(buffer, request.value.data(), request.value.size());
+            }
+            if (submission_bytes > request.value.size()) {
+                std::memset(static_cast<char *>(buffer) + request.value.size(),
+                            0, submission_bytes - request.value.size());
+            }
+            dma_buffers[index].reset(buffer);
+            submit_buffers[index] = buffer;
+        }
+
+        SubmitBatch(
+            requests.size(), true,
+            [&](size_t index, CompletionContext *ctx) {
+                if (submit_buffers[index] == nullptr) {
+                    return false;
+                }
+                const int ret = wrapper_.SubmitKvStore(
+                    segment_, requests[index].key.data(),
+                    static_cast<uint8_t>(requests[index].key.size()),
+                    submit_buffers[index], submit_sizes[index],
+                    SPDK_NVME_KV_STORE_OPT_DONT_STORE_IF_KEY_EXISTS,
+                    KvCommandComplete, ctx);
+                if (ret != 0) {
+                    requests[index].result =
+                        tl::make_unexpected(MapSpdkSubmitError(ret, true));
+                    return false;
+                }
+                return true;
+            },
+            [&](size_t index, ErrorCode error) {
+                if (error == ErrorCode::OK) {
+                    requests[index].result = {};
+                } else {
+                    requests[index].result = tl::make_unexpected(error);
+                }
+            });
+    }
+
+    tl::expected<std::string, ErrorCode> Retrieve(
+        const PhysicalKey &key, uint32_t size_hint = 0) const override {
+        std::vector<RetrieveBufferRequest> requests;
+        RetrieveBufferRequest request;
+        request.key = key;
+        request.size_hint = size_hint;
+        requests.push_back(std::move(request));
+        RetrieveBufferBatch(requests);
+        auto &result = requests.front().result;
+        if (!result) {
+            return tl::make_unexpected(result.error());
+        }
+        return result.value().ToString();
+    }
+
+    void RetrieveBufferBatch(
+        std::vector<RetrieveBufferRequest> &requests) const override {
+        RetrieveBufferBatchOnce(requests, false);
+
+        std::vector<size_t> retry_indexes;
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const uint32_t request_bytes = ResolveNvmeKvInitialRetrieveBytes(
+                requests[index].size_hint,
+                capabilities_.effective_max_value_size);
+            if (!requests[index].result &&
+                ShouldRetryNvmeKvRetrieveWithMaxBuffer(
+                    requests[index].result.error(), requests[index].size_hint,
+                    request_bytes, capabilities_.effective_max_value_size)) {
+                retry_indexes.push_back(index);
+            }
+        }
+        if (retry_indexes.empty()) {
+            return;
+        }
+
+        std::vector<RetrieveBufferRequest> retries;
+        retries.reserve(retry_indexes.size());
+        for (size_t index : retry_indexes) {
+            RetrieveBufferRequest retry;
+            retry.key = requests[index].key;
+            retry.size_hint = capabilities_.effective_max_value_size;
+            retries.push_back(std::move(retry));
+        }
+        RetrieveBufferBatchOnce(retries, true);
+        for (size_t index = 0; index < retry_indexes.size(); ++index) {
+            requests[retry_indexes[index]].result =
+                std::move(retries[index].result);
+        }
+    }
+
+    void RetrieveIntoBatch(
+        std::vector<RetrieveIntoRequest> &requests) const override {
+        std::vector<RetrieveBufferRequest> buffer_requests;
+        buffer_requests.reserve(requests.size());
+        for (const auto &request : requests) {
+            RetrieveBufferRequest buffer_request;
+            buffer_request.key = request.key;
+            buffer_request.size_hint = request.size;
+            buffer_requests.push_back(std::move(buffer_request));
+        }
+
+        RetrieveBufferBatch(buffer_requests);
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const auto &buffer_result = buffer_requests[index].result;
+            if (!buffer_result) {
+                requests[index].result =
+                    tl::make_unexpected(buffer_result.error());
+                continue;
+            }
+            const auto &buffer = buffer_result.value();
+            if (requests[index].data == nullptr ||
+                buffer.size != requests[index].size) {
+                requests[index].result =
+                    tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                continue;
+            }
+            std::memcpy(requests[index].data, buffer.data, buffer.size);
+            requests[index].result = buffer.size;
+        }
+    }
+
+    tl::expected<void, ErrorCode> Delete(const PhysicalKey &key) override {
+        tl::expected<void, ErrorCode> result =
+            tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        SubmitBatch(
+            1, false,
+            [&](size_t, CompletionContext *ctx) {
+                const int ret = wrapper_.SubmitKvDelete(
+                    segment_, key.data(), static_cast<uint8_t>(key.size()),
+                    KvCommandComplete, ctx);
+                if (ret != 0) {
+                    result =
+                        tl::make_unexpected(MapSpdkSubmitError(ret, false));
+                    return false;
+                }
+                return true;
+            },
+            [&](size_t, ErrorCode error) {
+                if (error == ErrorCode::OK) {
+                    result = {};
+                } else {
+                    result = tl::make_unexpected(error);
+                }
+            });
+        return result;
+    }
+
+    const Capabilities &GetCapabilities() const override {
+        return capabilities_;
+    }
+
+   private:
+    template <typename SubmitFn, typename CompleteFn>
+    void SubmitBatch(size_t count, bool is_write, SubmitFn submit,
+                     CompleteFn complete) const {
+        std::vector<CompletionContext> contexts(count);
+        size_t next = 0;
+        size_t completed = 0;
+        size_t inflight = 0;
+        const size_t queue_depth =
+            std::max<uint32_t>(1, capabilities_.queue_depth);
+
+        std::lock_guard<std::mutex> lock(qpair_mutex_);
+        while (completed < count) {
+            while (next < count && inflight < queue_depth) {
+                auto &ctx = contexts[next];
+                ctx.is_write = is_write;
+                if (!submit(next, &ctx)) {
+                    if (ctx.done.load(std::memory_order_acquire)) {
+                        complete(next, MapNvmeKvStatus(ctx.status, is_write));
+                    }
+                    ++completed;
+                    ++next;
+                    continue;
+                }
+                ctx.submitted = true;
+                ++inflight;
+                ++next;
+            }
+
+            if (inflight == 0) {
+                continue;
+            }
+            const int rc = static_cast<int>(
+                wrapper_.NvmePollProcessCompletion(segment_, 0));
+            if (rc < 0) {
+                LOG(ERROR) << "SPDK NVMe KV completion polling failed: " << rc;
+            }
+
+            size_t observed = 0;
+            for (size_t index = 0; index < count; ++index) {
+                auto &ctx = contexts[index];
+                if (!ctx.submitted || ctx.reported ||
+                    !ctx.done.load(std::memory_order_acquire)) {
+                    continue;
+                }
+                ctx.reported = true;
+                --inflight;
+                ++completed;
+                ++observed;
+                complete(index, ctx.status == 0
+                                    ? ErrorCode::OK
+                                    : MapNvmeKvStatus(ctx.status, is_write));
+            }
+            if (observed == 0) {
+                std::this_thread::yield();
+            }
+        }
+    }
+
+    void RetrieveBufferBatchOnce(std::vector<RetrieveBufferRequest> &requests,
+                                 bool force_effective_max_value_size) const {
+        std::vector<SpdkDmaBuffer> dma_buffers(requests.size());
+        std::vector<uint32_t> request_bytes(requests.size(), 0);
+
+        for (size_t index = 0; index < requests.size(); ++index) {
+            const uint32_t bytes =
+                force_effective_max_value_size
+                    ? capabilities_.effective_max_value_size
+                    : ResolveNvmeKvInitialRetrieveBytes(
+                          requests[index].size_hint,
+                          capabilities_.effective_max_value_size);
+            if (bytes == 0 || bytes > capabilities_.effective_max_value_size) {
+                requests[index].result =
+                    tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                continue;
+            }
+            void *buffer =
+                wrapper_.Alloc(bytes, NvmeKvTransferAlignmentBytes());
+            if (buffer == nullptr) {
+                requests[index].result =
+                    tl::make_unexpected(ErrorCode::BUFFER_OVERFLOW);
+                continue;
+            }
+            dma_buffers[index].reset(buffer);
+            request_bytes[index] = bytes;
+        }
+
+        SubmitBatch(
+            requests.size(), false,
+            [&](size_t index, CompletionContext *ctx) {
+                if (dma_buffers[index] == nullptr) {
+                    return false;
+                }
+                const int ret = wrapper_.SubmitKvRetrieve(
+                    segment_, requests[index].key.data(),
+                    static_cast<uint8_t>(requests[index].key.size()),
+                    dma_buffers[index].get(), request_bytes[index], 0,
+                    KvCommandComplete, ctx);
+                if (ret != 0) {
+                    requests[index].result =
+                        tl::make_unexpected(MapSpdkSubmitError(ret, false));
+                    return false;
+                }
+                return true;
+            },
+            [&](size_t index, ErrorCode error) {
+                if (error != ErrorCode::OK) {
+                    requests[index].result = tl::make_unexpected(error);
+                    return;
+                }
+                const uint32_t value_size = ResolveNvmeKvRetrievedValueSize(
+                    static_cast<const char *>(dma_buffers[index].get()),
+                    request_bytes[index],
+                    capabilities_.effective_max_value_size,
+                    requests[index].size_hint);
+                if (value_size == 0 || value_size > request_bytes[index]) {
+                    requests[index].result =
+                        tl::make_unexpected(ErrorCode::FILE_READ_FAIL);
+                    return;
+                }
+                RetrievedBuffer buffer;
+                void *owned = dma_buffers[index].release();
+                buffer.owner =
+                    std::shared_ptr<void>(owned, SpdkDmaBufferDeleter());
+                buffer.data = static_cast<const char *>(owned);
+                buffer.size = value_size;
+                requests[index].result = std::move(buffer);
+            });
+    }
+
+    SpdkWrapper &wrapper_;
+    nof_seg_handle *segment_ = nullptr;
+    Capabilities capabilities_;
+    mutable std::mutex qpair_mutex_;
+};
+
+NvmeKvExecutorResult CreateNvmeKvSpdkExecutor(std::string transport_id,
+                                              uint32_t nsid,
+                                              uint32_t queue_depth,
+                                              uint32_t runtime_transfer_limit) {
+    auto &wrapper = SpdkWrapper::GetInstance();
+    if (!wrapper.InitializeEnv()) {
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+    const std::string effective_transport_id =
+        NvmeKvTransportIdWithNsid(transport_id, nsid);
+    auto *segment = wrapper.OpenNofSegment(effective_transport_id);
+    if (segment == nullptr) {
+        LOG(ERROR) << "Failed to open SPDK NVMe-oF segment: "
+                   << effective_transport_id;
+        return tl::make_unexpected(ErrorCode::FILE_OPEN_FAIL);
+    }
+    if (!wrapper.IsKvNamespace(segment)) {
+        LOG(ERROR) << "SPDK NVMe-oF namespace is not an NVMe KV namespace: "
+                   << effective_transport_id;
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    auto capabilities = BuildNvmeKvCapabilities(
+        kDefaultNvmeKvQueueDepth, queue_depth, runtime_transfer_limit);
+    return std::make_unique<NvmeKvSpdkExecutor>(wrapper, segment,
+                                                std::move(capabilities));
+}
+
+}  // namespace mooncake
+
+#endif

--- a/mooncake-store/src/nvme_kv_executor_util.cpp
+++ b/mooncake-store/src/nvme_kv_executor_util.cpp
@@ -4,8 +4,16 @@
 #include <algorithm>
 #include <cerrno>
 #include <cstdlib>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <limits>
+#include <optional>
+#include <sstream>
+#include <unordered_map>
+
+#include <glog/logging.h>
 
 namespace mooncake {
 namespace {
@@ -19,6 +27,12 @@ constexpr uint32_t kNvmeKvStatusInvalidKeySize = 0x86;
 constexpr uint32_t kNvmeKvStatusKeyNotFound = 0x87;
 constexpr uint32_t kNvmeKvStatusUnrecoveredRead = 0x88;
 constexpr uint32_t kNvmeKvStatusKeyExists = 0x89;
+constexpr char kNvmeKvSysfsRootEnv[] = "MOONCAKE_NVME_KV_SYSFS_ROOT";
+constexpr char kNvmeKvDevRootEnv[] = "MOONCAKE_NVME_KV_DEV_ROOT";
+constexpr char kDefaultNvmeKvSysfsRoot[] = "/sys/class/nvme";
+constexpr char kDefaultNvmeKvDevRoot[] = "/dev";
+
+using EndpointFields = std::unordered_map<std::string, std::string>;
 
 uint32_t ReadLe32(const uint8_t *p) {
     return static_cast<uint32_t>(p[0]) | (static_cast<uint32_t>(p[1]) << 8) |
@@ -26,17 +40,252 @@ uint32_t ReadLe32(const uint8_t *p) {
            (static_cast<uint32_t>(p[3]) << 24);
 }
 
+std::string Trim(std::string value) {
+    const auto is_space = [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    };
+    value.erase(value.begin(),
+                std::find_if(value.begin(), value.end(),
+                             [&](char ch) { return !is_space(ch); }));
+    value.erase(std::find_if(value.rbegin(), value.rend(),
+                             [&](char ch) { return !is_space(ch); })
+                    .base(),
+                value.end());
+    return value;
+}
+
+std::string ToLower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return std::tolower(ch); });
+    return value;
+}
+
+std::string GetEnvOrDefault(const char *name, const char *fallback) {
+    const char *value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') return fallback;
+    return value;
+}
+
+bool FileExists(const std::filesystem::path &path) {
+    std::error_code ec;
+    return std::filesystem::exists(path, ec);
+}
+
+std::optional<std::string> ReadFirstLine(const std::filesystem::path &path) {
+    std::ifstream stream(path);
+    if (!stream.is_open()) return std::nullopt;
+    std::string line;
+    if (!std::getline(stream, line)) return std::nullopt;
+    return Trim(line);
+}
+
+EndpointFields ParseFields(const std::string &text) {
+    EndpointFields fields;
+    std::string normalized = text;
+    std::replace(normalized.begin(), normalized.end(), ',', ' ');
+
+    std::istringstream stream(normalized);
+    std::string token;
+    while (stream >> token) {
+        auto separator = token.find('=');
+        if (separator == std::string::npos) separator = token.find(':');
+        if (separator == std::string::npos || separator == 0) continue;
+
+        std::string key = ToLower(Trim(token.substr(0, separator)));
+        std::string value = Trim(token.substr(separator + 1));
+        if (!key.empty() && !value.empty()) fields[key] = value;
+    }
+    return fields;
+}
+
+bool LooksLikeNofEndpoint(const EndpointFields &fields) {
+    return fields.find("traddr") != fields.end() &&
+           fields.find("subnqn") != fields.end();
+}
+
+bool HasNamespaceIdField(const EndpointFields &fields) {
+    return fields.find("ns") != fields.end() ||
+           fields.find("nsid") != fields.end();
+}
+
+std::optional<uint32_t> ParseNamespaceId(const EndpointFields &fields) {
+    auto it = fields.find("ns");
+    if (it == fields.end()) it = fields.find("nsid");
+    if (it == fields.end()) return std::nullopt;
+
+    char *end_ptr = nullptr;
+    errno = 0;
+    const unsigned long value = std::strtoul(it->second.c_str(), &end_ptr, 10);
+    if (errno != 0 || end_ptr == it->second.c_str() || *end_ptr != '\0' ||
+        value == 0 || value > std::numeric_limits<uint32_t>::max()) {
+        return std::nullopt;
+    }
+    return static_cast<uint32_t>(value);
+}
+
+bool FieldEquals(const EndpointFields &expected, const EndpointFields &actual,
+                 const char *key, bool case_insensitive) {
+    const auto expected_it = expected.find(key);
+    if (expected_it == expected.end()) return true;
+
+    const auto actual_it = actual.find(key);
+    if (actual_it == actual.end()) return false;
+    if (case_insensitive) {
+        return ToLower(expected_it->second) == ToLower(actual_it->second);
+    }
+    return expected_it->second == actual_it->second;
+}
+
+bool AddressMatches(const EndpointFields &endpoint,
+                    const EndpointFields &address) {
+    return FieldEquals(endpoint, address, "traddr", false) &&
+           FieldEquals(endpoint, address, "trsvcid", false) &&
+           FieldEquals(endpoint, address, "host_traddr", false) &&
+           FieldEquals(endpoint, address, "host_iface", false) &&
+           FieldEquals(endpoint, address, "trtype", true) &&
+           FieldEquals(endpoint, address, "adrfam", true);
+}
+
+std::optional<std::string> NamespaceDeviceName(
+    const std::filesystem::path &controller_path, uint32_t expected_nsid) {
+    std::error_code ec;
+    for (std::filesystem::directory_iterator it(controller_path, ec), end;
+         !ec && it != end; it.increment(ec)) {
+        const std::string name = it->path().filename().string();
+        if (name.rfind("nvme", 0) != 0 ||
+            name.find('n', 4) == std::string::npos) {
+            continue;
+        }
+
+        auto nsid = ReadFirstLine(it->path() / "nsid");
+        if (!nsid.has_value()) continue;
+
+        char *end_ptr = nullptr;
+        errno = 0;
+        const unsigned long value = std::strtoul(nsid->c_str(), &end_ptr, 10);
+        if (errno != 0 || end_ptr == nsid->c_str() || *end_ptr != '\0' ||
+            value != expected_nsid) {
+            continue;
+        }
+        return name;
+    }
+    return std::nullopt;
+}
+
+std::optional<NvmeKvResolvedDevicePath> ResolveNofEndpoint(
+    const EndpointFields &endpoint, NvmeKvDevicePathType type,
+    uint32_t configured_nsid) {
+    const std::filesystem::path sysfs_root =
+        GetEnvOrDefault(kNvmeKvSysfsRootEnv, kDefaultNvmeKvSysfsRoot);
+    const std::filesystem::path dev_root =
+        GetEnvOrDefault(kNvmeKvDevRootEnv, kDefaultNvmeKvDevRoot);
+    const auto parsed_nsid = ParseNamespaceId(endpoint);
+    if (!parsed_nsid.has_value() && HasNamespaceIdField(endpoint)) {
+        return std::nullopt;
+    }
+    const uint32_t effective_nsid = parsed_nsid.value_or(configured_nsid);
+    if (effective_nsid == 0) return std::nullopt;
+
+    std::error_code ec;
+    for (std::filesystem::directory_iterator it(sysfs_root, ec), end;
+         !ec && it != end; it.increment(ec)) {
+        const std::filesystem::path controller_path = it->path();
+        const std::string controller_name = controller_path.filename().string();
+        if (controller_name.rfind("nvme", 0) != 0) continue;
+
+        auto subsysnqn = ReadFirstLine(controller_path / "subsysnqn");
+        if (!subsysnqn.has_value() || *subsysnqn != endpoint.at("subnqn")) {
+            continue;
+        }
+
+        auto address = ReadFirstLine(controller_path / "address");
+        if (!address.has_value() ||
+            !AddressMatches(endpoint, ParseFields(*address))) {
+            continue;
+        }
+
+        auto namespace_name =
+            NamespaceDeviceName(controller_path, effective_nsid);
+        if (!namespace_name.has_value()) continue;
+
+        std::string device_name = *namespace_name;
+        if (type == NvmeKvDevicePathType::kGenericCharacter) {
+            device_name = "ng" + device_name.substr(4);
+        }
+        const std::filesystem::path device_path = dev_root / device_name;
+        if (FileExists(device_path)) {
+            return NvmeKvResolvedDevicePath{device_path.string(),
+                                            effective_nsid};
+        }
+    }
+    return std::nullopt;
+}
+
+std::string ResolveGenericCharacterDevicePath(const std::string &device_path) {
+    const std::filesystem::path path(device_path);
+    const std::string filename = path.filename().string();
+    if (filename.rfind("ng", 0) == 0) return device_path;
+    if (filename.rfind("nvme", 0) != 0) return device_path;
+
+    const std::filesystem::path generic_path =
+        path.parent_path() / ("ng" + filename.substr(4));
+    if (FileExists(generic_path)) {
+        LOG(INFO) << "[NvmeKvExecutor] using NVMe generic char device "
+                  << generic_path << " for namespace block device "
+                  << device_path;
+        return generic_path.string();
+    }
+    return device_path;
+}
+
 }  // namespace
+
+std::string NvmeKvTransportIdWithNsid(const std::string &configured_path,
+                                      uint32_t configured_nsid) {
+    const auto fields = ParseFields(configured_path);
+    if (!LooksLikeNofEndpoint(fields) || HasNamespaceIdField(fields)) {
+        return configured_path;
+    }
+    if (configured_nsid == 0) {
+        return configured_path;
+    }
+
+    std::ostringstream stream;
+    stream << configured_path << " ns:" << configured_nsid;
+    return stream.str();
+}
+
+tl::expected<NvmeKvResolvedDevicePath, ErrorCode> ResolveNvmeKvDevicePath(
+    const std::string &configured_path, NvmeKvDevicePathType type,
+    uint32_t configured_nsid) {
+    const auto fields = ParseFields(configured_path);
+    if (LooksLikeNofEndpoint(fields)) {
+        auto resolved = ResolveNofEndpoint(fields, type, configured_nsid);
+        if (!resolved.has_value()) {
+            LOG(ERROR) << "[NvmeKvExecutor] failed to resolve NVMe-oF endpoint "
+                       << "to a local NVMe device: " << configured_path;
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+        return resolved.value();
+    }
+
+    if (type == NvmeKvDevicePathType::kGenericCharacter) {
+        return NvmeKvResolvedDevicePath{
+            ResolveGenericCharacterDevicePath(configured_path),
+            configured_nsid};
+    }
+    return NvmeKvResolvedDevicePath{configured_path, configured_nsid};
+}
 
 uint32_t ParseNvmeKvU32EnvOr(const char *name, uint32_t fallback) {
     const char *value = std::getenv(name);
     if (value == nullptr || value[0] == '\0') {
         return fallback;
     }
-    char *end = nullptr;
+    char *end_ptr = nullptr;
     errno = 0;
-    unsigned long parsed = std::strtoul(value, &end, 0);
-    if (errno != 0 || end == value || *end != '\0' ||
+    unsigned long parsed = std::strtoul(value, &end_ptr, 0);
+    if (errno != 0 || end_ptr == value || *end_ptr != '\0' ||
         parsed > std::numeric_limits<uint32_t>::max()) {
         return fallback;
     }

--- a/mooncake-store/src/nvme_kv_executor_util.cpp
+++ b/mooncake-store/src/nvme_kv_executor_util.cpp
@@ -27,6 +27,7 @@ constexpr uint32_t kNvmeKvStatusInvalidKeySize = 0x86;
 constexpr uint32_t kNvmeKvStatusKeyNotFound = 0x87;
 constexpr uint32_t kNvmeKvStatusUnrecoveredRead = 0x88;
 constexpr uint32_t kNvmeKvStatusKeyExists = 0x89;
+constexpr uint32_t kNvmeStatusCodeTypeGeneric = 0x0;
 constexpr char kNvmeKvSysfsRootEnv[] = "MOONCAKE_NVME_KV_SYSFS_ROOT";
 constexpr char kNvmeKvDevRootEnv[] = "MOONCAKE_NVME_KV_DEV_ROOT";
 constexpr char kDefaultNvmeKvSysfsRoot[] = "/sys/class/nvme";
@@ -436,6 +437,17 @@ ErrorCode MapNvmeKvStatus(uint32_t status, bool is_write) {
             return is_write ? ErrorCode::FILE_WRITE_FAIL
                             : ErrorCode::FILE_READ_FAIL;
     }
+}
+
+ErrorCode MapNvmeKvCompletionStatus(uint32_t status_code_type,
+                                    uint32_t status_code, bool is_write) {
+    if (status_code_type == kNvmeStatusCodeTypeGeneric) {
+        if (status_code == 0) {
+            return ErrorCode::OK;
+        }
+        return MapNvmeKvStatus(status_code, is_write);
+    }
+    return is_write ? ErrorCode::FILE_WRITE_FAIL : ErrorCode::FILE_READ_FAIL;
 }
 
 ErrorCode MapNvmeKvTransportError(int err, bool is_write) {

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -3,6 +3,10 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#ifdef MOONCAKE_HAVE_SPDK_NVME_KV
+#include <spdk/nvme_kv.h>
+#include <spdk/nvme_spec.h>
+#endif
 #include <cstring>
 #include <cstdlib>
 #include <thread>
@@ -389,6 +393,53 @@ int SpdkWrapper::SubmitRequest(const nof_seg_handle *seg_handle, void *ptr,
     }
     return -1;
 }
+
+#ifdef MOONCAKE_HAVE_SPDK_NVME_KV
+bool SpdkWrapper::IsKvNamespace(const nof_seg_handle *seg_handle) {
+    if (!seg_handle || !seg_handle->ns) {
+        return false;
+    }
+    return spdk_nvme_ns_get_csi(seg_handle->ns) == SPDK_NVME_CSI_KV &&
+           spdk_nvme_kv_ns_get_data(seg_handle->ns) != nullptr;
+}
+
+int SpdkWrapper::SubmitKvStore(const nof_seg_handle *seg_handle,
+                               const void *key, uint8_t key_len,
+                               const void *value, uint32_t value_len,
+                               uint8_t options, spdk_nvme_cmd_cb cb_fn,
+                               void *cb_ctx) {
+    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
+        key_len == 0 || !value || value_len == 0) {
+        return -EINVAL;
+    }
+    return spdk_nvme_kv_store(seg_handle->ns, seg_handle->qpair, key, key_len,
+                              value, value_len, cb_fn, cb_ctx, options);
+}
+
+int SpdkWrapper::SubmitKvRetrieve(const nof_seg_handle *seg_handle,
+                                  const void *key, uint8_t key_len, void *value,
+                                  uint32_t value_len, uint8_t options,
+                                  spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
+    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
+        key_len == 0 || !value || value_len == 0) {
+        return -EINVAL;
+    }
+    return spdk_nvme_kv_retrieve(seg_handle->ns, seg_handle->qpair, key,
+                                 key_len, value, value_len, cb_fn, cb_ctx,
+                                 options);
+}
+
+int SpdkWrapper::SubmitKvDelete(const nof_seg_handle *seg_handle,
+                                const void *key, uint8_t key_len,
+                                spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
+    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
+        key_len == 0) {
+        return -EINVAL;
+    }
+    return spdk_nvme_kv_delete(seg_handle->ns, seg_handle->qpair, key, key_len,
+                               cb_fn, cb_ctx);
+}
+#endif
 
 SpdkWrapper::ProbeBuffer *SpdkWrapper::GetOrCreateProbeBuffer(
     const std::string &tr_str, uint32_t block_size, std::string *error_reason) {

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -1,5 +1,6 @@
 #include <glog/logging.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <chrono>
@@ -87,8 +88,11 @@ void ApplyCtrlrOptsFromEnv(struct spdk_nvme_ctrlr_opts *opts) {
 }  // namespace
 
 struct nof_seg_handle {
-    struct spdk_nvme_qpair *qpair;
-    struct spdk_nvme_ns *ns;
+    struct spdk_nvme_qpair *qpair = nullptr;
+    struct spdk_nvme_ns *ns = nullptr;
+    struct ctrlr_info *owner = nullptr;
+    mutable std::mutex io_mutex;
+    std::atomic<bool> failed{false};
 };
 
 struct tr_info {
@@ -100,6 +104,7 @@ struct tr_info {
 struct ctrlr_info {
     struct spdk_nvme_ctrlr *ctrlr;
     std::map<uint32_t, std::unique_ptr<nof_seg_handle>> ns_seg;
+    std::vector<std::unique_ptr<nof_seg_handle>> dedicated_ns_seg;
     std::mutex ns_mutex;
 };
 
@@ -146,6 +151,13 @@ void SpdkWrapper::Cleanup() {
                     // Free all qpairs and segment handles
                     for (auto &[_, seg] : info->ns_seg) {
                         if (seg && seg->qpair) {
+                            std::lock_guard<std::mutex> io_lock(seg->io_mutex);
+                            spdk_nvme_ctrlr_free_io_qpair(seg->qpair);
+                        }
+                    }
+                    for (auto &seg : info->dedicated_ns_seg) {
+                        if (seg && seg->qpair) {
+                            std::lock_guard<std::mutex> io_lock(seg->io_mutex);
                             spdk_nvme_ctrlr_free_io_qpair(seg->qpair);
                         }
                     }
@@ -237,7 +249,27 @@ void SpdkWrapper::RecycleProbeRequestContext(ProbeRequestContext *ctx) {
 
 int64_t SpdkWrapper::NvmePollProcessCompletion(nof_seg_handle *seg,
                                                uint32_t complete_per_seg) {
+    if (!seg) {
+        return -EINVAL;
+    }
+    std::lock_guard<std::mutex> lock(seg->io_mutex);
+    if (seg->failed.load(std::memory_order_acquire) || !seg->qpair) {
+        return -ENXIO;
+    }
     return spdk_nvme_qpair_process_completions(seg->qpair, complete_per_seg);
+}
+
+void SpdkWrapper::AbortNofSegment(nof_seg_handle *seg) {
+    if (!seg) {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(seg->io_mutex);
+    seg->failed.store(true, std::memory_order_release);
+    if (seg->qpair) {
+        auto *qpair = seg->qpair;
+        seg->qpair = nullptr;
+        spdk_nvme_ctrlr_free_io_qpair(qpair);
+    }
 }
 
 int SpdkWrapper::ParseTransPortStr(const std::string &tr_str, tr_info *info) {
@@ -307,6 +339,38 @@ int SpdkWrapper::ConnectController(const struct spdk_nvme_transport_id *trid,
 }
 
 nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str) {
+    return OpenNofSegment(tr_str, true);
+}
+
+#ifdef MOONCAKE_HAVE_SPDK_NVME_KV
+nof_seg_handle *SpdkWrapper::OpenNofKvSegment(const std::string &tr_str) {
+    return OpenNofSegment(tr_str, false);
+}
+
+void SpdkWrapper::CloseNofKvSegment(nof_seg_handle *seg) {
+    if (!seg || !seg->owner) {
+        return;
+    }
+    auto *owner = seg->owner;
+    std::unique_ptr<nof_seg_handle> owned_seg;
+    {
+        std::lock_guard<std::mutex> lock(owner->ns_mutex);
+        auto &segments = owner->dedicated_ns_seg;
+        auto it =
+            std::find_if(segments.begin(), segments.end(),
+                         [&](const auto &entry) { return entry.get() == seg; });
+        if (it == segments.end()) {
+            return;
+        }
+        owned_seg = std::move(*it);
+        segments.erase(it);
+    }
+    AbortNofSegment(owned_seg.get());
+}
+#endif
+
+nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str,
+                                            bool shared) {
     tr_info tr;
     int ret = ParseTransPortStr(tr_str, &tr);
     if (ret != 0) {
@@ -338,9 +402,11 @@ nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str) {
     {
         auto &ns_seg = info->ns_seg;
         std::lock_guard<std::mutex> lock(info->ns_mutex);
-        auto ns_it = ns_seg.find(tr.ns);
-        if (ns_it != ns_seg.end()) {
-            return ns_it->second.get();
+        if (shared) {
+            auto ns_it = ns_seg.find(tr.ns);
+            if (ns_it != ns_seg.end()) {
+                return ns_it->second.get();
+            }
         }
 
         if (spdk_nvme_ctrlr_is_active_ns(info->ctrlr, tr.ns)) {
@@ -359,8 +425,13 @@ nof_seg_handle *SpdkWrapper::OpenNofSegment(const std::string &tr_str) {
         auto new_seg = std::make_unique<nof_seg_handle>();
         new_seg->qpair = qpair;
         new_seg->ns = ns;
+        new_seg->owner = info;
         seg_handle = new_seg.get();
-        ns_seg[tr.ns] = std::move(new_seg);
+        if (shared) {
+            ns_seg[tr.ns] = std::move(new_seg);
+        } else {
+            info->dedicated_ns_seg.push_back(std::move(new_seg));
+        }
     }
 
     return seg_handle;
@@ -377,9 +448,14 @@ uint32_t SpdkWrapper::GetBlockSize(const nof_seg_handle *seg_handle) {
 int SpdkWrapper::SubmitRequest(const nof_seg_handle *seg_handle, void *ptr,
                                uint64_t lba, uint32_t lba_count, int op,
                                spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
-    if (!seg_handle || !ptr || !lba_count || !seg_handle->qpair ||
-        !seg_handle->ns) {
-        return -1;
+    if (!seg_handle || !ptr || !lba_count || !seg_handle->ns) {
+        return -EINVAL;
+    }
+
+    std::lock_guard<std::mutex> lock(seg_handle->io_mutex);
+    if (seg_handle->failed.load(std::memory_order_acquire) ||
+        !seg_handle->qpair) {
+        return -ENXIO;
     }
 
     struct spdk_nvme_qpair *qpair = seg_handle->qpair;
@@ -408,9 +484,14 @@ int SpdkWrapper::SubmitKvStore(const nof_seg_handle *seg_handle,
                                const void *value, uint32_t value_len,
                                uint8_t options, spdk_nvme_cmd_cb cb_fn,
                                void *cb_ctx) {
-    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
-        key_len == 0 || !value || value_len == 0) {
+    if (!seg_handle || !seg_handle->ns || !key || key_len == 0 || !value ||
+        value_len == 0) {
         return -EINVAL;
+    }
+    std::lock_guard<std::mutex> lock(seg_handle->io_mutex);
+    if (seg_handle->failed.load(std::memory_order_acquire) ||
+        !seg_handle->qpair) {
+        return -ENXIO;
     }
     return spdk_nvme_kv_store(seg_handle->ns, seg_handle->qpair, key, key_len,
                               value, value_len, cb_fn, cb_ctx, options);
@@ -420,9 +501,14 @@ int SpdkWrapper::SubmitKvRetrieve(const nof_seg_handle *seg_handle,
                                   const void *key, uint8_t key_len, void *value,
                                   uint32_t value_len, uint8_t options,
                                   spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
-    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
-        key_len == 0 || !value || value_len == 0) {
+    if (!seg_handle || !seg_handle->ns || !key || key_len == 0 || !value ||
+        value_len == 0) {
         return -EINVAL;
+    }
+    std::lock_guard<std::mutex> lock(seg_handle->io_mutex);
+    if (seg_handle->failed.load(std::memory_order_acquire) ||
+        !seg_handle->qpair) {
+        return -ENXIO;
     }
     return spdk_nvme_kv_retrieve(seg_handle->ns, seg_handle->qpair, key,
                                  key_len, value, value_len, cb_fn, cb_ctx,
@@ -432,9 +518,13 @@ int SpdkWrapper::SubmitKvRetrieve(const nof_seg_handle *seg_handle,
 int SpdkWrapper::SubmitKvDelete(const nof_seg_handle *seg_handle,
                                 const void *key, uint8_t key_len,
                                 spdk_nvme_cmd_cb cb_fn, void *cb_ctx) {
-    if (!seg_handle || !seg_handle->qpair || !seg_handle->ns || !key ||
-        key_len == 0) {
+    if (!seg_handle || !seg_handle->ns || !key || key_len == 0) {
         return -EINVAL;
+    }
+    std::lock_guard<std::mutex> lock(seg_handle->io_mutex);
+    if (seg_handle->failed.load(std::memory_order_acquire) ||
+        !seg_handle->qpair) {
+        return -ENXIO;
     }
     return spdk_nvme_kv_delete(seg_handle->ns, seg_handle->qpair, key, key_len,
                                cb_fn, cb_ctx);

--- a/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
+++ b/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -61,7 +62,130 @@ class NvmeKvStorageBackendTest : public ::testing::Test {
     std::string data_path_;
 };
 
+void WriteFile(const fs::path &path, const std::string &contents) {
+    std::ofstream stream(path);
+    ASSERT_TRUE(stream.is_open());
+    stream << contents;
+}
+
 }  // namespace
+
+TEST_F(NvmeKvStorageBackendTest, ResolvesNofEndpointToKernelDevices) {
+    const fs::path sysfs_root = fs::path(data_path_) / "sys" / "class" / "nvme";
+    const fs::path dev_root = fs::path(data_path_) / "dev";
+    const fs::path controller_path = sysfs_root / "nvme7";
+    const fs::path namespace_path = controller_path / "nvme7n3";
+    ASSERT_TRUE(fs::create_directories(namespace_path));
+    ASSERT_TRUE(fs::create_directories(dev_root));
+
+    WriteFile(controller_path / "address",
+              "trtype=rdma,traddr=192.168.65.56,trsvcid=4420,adrfam=ipv4\n");
+    WriteFile(controller_path / "subsysnqn", "nqn.2016-06.io.spdk:cnode1\n");
+    WriteFile(namespace_path / "nsid", "3\n");
+    WriteFile(dev_root / "nvme7n3", "");
+    WriteFile(dev_root / "ng7n3", "");
+
+    const std::string sysfs_root_string = sysfs_root.string();
+    const std::string dev_root_string = dev_root.string();
+    EnvVarGuard sysfs_guard("MOONCAKE_NVME_KV_SYSFS_ROOT",
+                            sysfs_root_string.c_str());
+    EnvVarGuard dev_guard("MOONCAKE_NVME_KV_DEV_ROOT", dev_root_string.c_str());
+
+    const std::string endpoint =
+        "traddr:192.168.65.56 trsvcid:4420 "
+        "subnqn:nqn.2016-06.io.spdk:cnode1 trtype:RDMA adrfam:IPv4 ns:3";
+
+    auto block_path = ResolveNvmeKvDevicePath(
+        endpoint, NvmeKvDevicePathType::kBlockNamespace, 1);
+    ASSERT_TRUE(block_path.has_value());
+    EXPECT_EQ((dev_root / "nvme7n3").string(), block_path->path);
+    EXPECT_EQ(3, block_path->nsid);
+
+    auto generic_path = ResolveNvmeKvDevicePath(
+        endpoint, NvmeKvDevicePathType::kGenericCharacter, 1);
+    ASSERT_TRUE(generic_path.has_value());
+    EXPECT_EQ((dev_root / "ng7n3").string(), generic_path->path);
+    EXPECT_EQ(3, generic_path->nsid);
+
+    const std::string equals_endpoint =
+        "traddr=192.168.65.56 trsvcid=4420 "
+        "subnqn=nqn.2016-06.io.spdk:cnode1 trtype=rdma adrfam=ipv4 nsid=3";
+    auto equals_path = ResolveNvmeKvDevicePath(
+        equals_endpoint, NvmeKvDevicePathType::kGenericCharacter, 1);
+    ASSERT_TRUE(equals_path.has_value());
+    EXPECT_EQ((dev_root / "ng7n3").string(), equals_path->path);
+    EXPECT_EQ(3, equals_path->nsid);
+}
+
+TEST_F(NvmeKvStorageBackendTest, UsesConfiguredNsidWhenEndpointOmitsNsid) {
+    const fs::path sysfs_root = fs::path(data_path_) / "sys" / "class" / "nvme";
+    const fs::path dev_root = fs::path(data_path_) / "dev";
+    const fs::path controller_path = sysfs_root / "nvme7";
+    const fs::path namespace_path = controller_path / "nvme7n3";
+    ASSERT_TRUE(fs::create_directories(namespace_path));
+    ASSERT_TRUE(fs::create_directories(dev_root));
+
+    WriteFile(controller_path / "address",
+              "trtype=rdma,traddr=192.168.65.56,trsvcid=4420,adrfam=ipv4\n");
+    WriteFile(controller_path / "subsysnqn", "nqn.2016-06.io.spdk:cnode1\n");
+    WriteFile(namespace_path / "nsid", "3\n");
+    WriteFile(dev_root / "ng7n3", "");
+
+    const std::string sysfs_root_string = sysfs_root.string();
+    const std::string dev_root_string = dev_root.string();
+    EnvVarGuard sysfs_guard("MOONCAKE_NVME_KV_SYSFS_ROOT",
+                            sysfs_root_string.c_str());
+    EnvVarGuard dev_guard("MOONCAKE_NVME_KV_DEV_ROOT", dev_root_string.c_str());
+
+    auto path = ResolveNvmeKvDevicePath(
+        "traddr:192.168.65.56 subnqn:nqn.2016-06.io.spdk:cnode1",
+        NvmeKvDevicePathType::kGenericCharacter, 3);
+    ASSERT_TRUE(path.has_value());
+    EXPECT_EQ((dev_root / "ng7n3").string(), path->path);
+    EXPECT_EQ(3, path->nsid);
+}
+
+TEST_F(NvmeKvStorageBackendTest, RejectsInvalidNofNamespaceId) {
+    const fs::path sysfs_root = fs::path(data_path_) / "sys" / "class" / "nvme";
+    const fs::path dev_root = fs::path(data_path_) / "dev";
+    const fs::path controller_path = sysfs_root / "nvme7";
+    const fs::path namespace_path = controller_path / "nvme7n3";
+    ASSERT_TRUE(fs::create_directories(namespace_path));
+    ASSERT_TRUE(fs::create_directories(dev_root));
+
+    WriteFile(controller_path / "address",
+              "trtype=rdma,traddr=192.168.65.56,trsvcid=4420,adrfam=ipv4\n");
+    WriteFile(controller_path / "subsysnqn", "nqn.2016-06.io.spdk:cnode1\n");
+    WriteFile(namespace_path / "nsid", "3\n");
+    WriteFile(dev_root / "ng7n3", "");
+
+    const std::string sysfs_root_string = sysfs_root.string();
+    const std::string dev_root_string = dev_root.string();
+    EnvVarGuard sysfs_guard("MOONCAKE_NVME_KV_SYSFS_ROOT",
+                            sysfs_root_string.c_str());
+    EnvVarGuard dev_guard("MOONCAKE_NVME_KV_DEV_ROOT", dev_root_string.c_str());
+
+    auto path = ResolveNvmeKvDevicePath(
+        "traddr:192.168.65.56 subnqn:nqn.2016-06.io.spdk:cnode1 ns:bad",
+        NvmeKvDevicePathType::kGenericCharacter, 1);
+    ASSERT_FALSE(path.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, path.error());
+}
+
+TEST_F(NvmeKvStorageBackendTest, RejectsUnmatchedNofEndpoint) {
+    const fs::path sysfs_root =
+        fs::path(data_path_) / "empty-sys" / "class" / "nvme";
+    ASSERT_TRUE(fs::create_directories(sysfs_root));
+    const std::string sysfs_root_string = sysfs_root.string();
+    EnvVarGuard sysfs_guard("MOONCAKE_NVME_KV_SYSFS_ROOT",
+                            sysfs_root_string.c_str());
+
+    auto path = ResolveNvmeKvDevicePath(
+        "traddr:192.168.65.57 subnqn:nqn.2016-06.io.spdk:cnode1",
+        NvmeKvDevicePathType::kGenericCharacter, 1);
+    ASSERT_FALSE(path.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, path.error());
+}
 
 TEST_F(NvmeKvStorageBackendTest, PhysicalKeyPackingEncodesCommandSet) {
     NvmeKvCommandExecutor::PhysicalKey key{};

--- a/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
+++ b/mooncake-store/tests/nvme_kv_storage_backend_test.cpp
@@ -250,6 +250,18 @@ TEST_F(NvmeKvStorageBackendTest, StatusMappingHandlesKvSpecificStatusCodes) {
         kDefaultNvmeKvRuntimeTransferLimit));
 }
 
+TEST_F(NvmeKvStorageBackendTest, CompletionStatusPreservesStatusCodeType) {
+    EXPECT_EQ(MapNvmeKvCompletionStatus(0, 0, false), ErrorCode::OK);
+    EXPECT_EQ(MapNvmeKvCompletionStatus(0, 0x87, false),
+              ErrorCode::OBJECT_NOT_FOUND);
+    EXPECT_EQ(MapNvmeKvCompletionStatus(3, 0, false),
+              ErrorCode::FILE_READ_FAIL);
+    EXPECT_EQ(MapNvmeKvCompletionStatus(3, 0, true),
+              ErrorCode::FILE_WRITE_FAIL);
+    EXPECT_EQ(MapNvmeKvCompletionStatus(1, 0x87, false),
+              ErrorCode::FILE_READ_FAIL);
+}
+
 TEST_F(NvmeKvStorageBackendTest, BackendLoadsKnownObjectsFromDevice) {
     EnvVarGuard driver_guard("MOONCAKE_NVME_KV_DRIVER", "stub");
 


### PR DESCRIPTION
## What this PR does

This PR lets the NVMe KV backend issue KV commands over NVMe-oF.

It keeps the existing NVMe KV executor model and adds two NVMe-oF access paths:

- Kernel NVMe-oF endpoint resolution:
  - ioctl uses the resolved namespace block device, such as `/dev/nvmeXnY`.
  - io_uring uses the matching NVMe generic character device, such as `/dev/ngXnY`.
  - local device paths continue to work as before.
- SPDK NVMe-oF KV executor:
  - enabled when Mooncake is built with `USE_NOF=ON` and SPDK provides the typed KV API from `spdk/nvme_kv.h`.
  - selected with `MOONCAKE_NVME_KV_TRANSPORT=spdk`, `spdk_nof`, or `nof_spdk`.
  - uses `spdk_nvme_kv_store`, `spdk_nvme_kv_retrieve`, and `spdk_nvme_kv_delete` rather than raw command passthrough.

## Implementation

- Add a shared resolver for NVMe-oF endpoint strings to local kernel NVMe device nodes.
- Support endpoint fields such as `traddr`, `trsvcid`, `subnqn`, `trtype`, `adrfam`, `host_traddr`, `host_iface`, `ns`, and `nsid`.
- Reuse the existing ioctl and io_uring NVMe KV executors after kernel device resolution.
- Add an SPDK typed KV executor for NVMe-oF KV namespaces.
- Reuse the existing NVMe KV backend layout, key codec, checksum, and batching logic.
- Add unit tests for endpoint resolution and namespace ID handling.

## Test plan

- `git diff --check --ignore-submodules=all`
- `cmake --build build-nof-cmd --target nvme_kv_storage_backend_test -j16`
- `./mooncake-store/tests/nvme_kv_storage_backend_test`
- `cmake -S . -B build-nof-spdk-typed -DWITH_STORE=ON -DWITH_STORE_RUST=OFF -DWITH_STORE_GO=OFF -DWITH_P2P_STORE=OFF -DUSE_NOF=ON -DSPDK_USE_PKG_CONFIG=ON -DFETCHCONTENT_FULLY_DISCONNECTED=ON`
- `cmake --build build-nof-spdk-typed --target mooncake_store -j16`
- `cmake --build build-nof-spdk-typed --target nvme_kv_storage_backend_test -j16`
- `./mooncake-store/tests/nvme_kv_storage_backend_test`