### PR TITLE
[Bugfix][TENT] Keep lazyFreeBatch sweeping past a batch it cannot reclaim

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -112,6 +112,12 @@ class TentMetrics {
     // distinguishable from genuine MLU samples in the histogram above.
     void recordDeadlineInfeasible(TransportType tp);
 
+    // Record a batch abandoned by lazyFreeBatch after repeated failed reclaim
+    // attempts. Such a batch stays on the freelist without further retries and
+    // is only reclaimed at engine teardown, so a nonzero value means resources
+    // are parked until shutdown and the last reclaim error is in the log.
+    void recordBatchQuarantined();
+
     enum class Stage {
         QueueWait,
         Dispatch,
@@ -224,6 +230,12 @@ class TentMetrics {
         "tent_deadline_infeasible_total",
         "Transfers whose deadline was already in the past at submit",
         kTransportLabel};
+    // Label-less: quarantine is a batch-lifecycle event, not a per-transport
+    // one (a batch may hold SubBatches on several transports).
+    ylt::metric::counter_t quarantined_batches_total_{
+        "tent_quarantined_batches_total",
+        "Batches abandoned by lazyFreeBatch after repeated failed reclaim "
+        "attempts; reclaimed only at engine teardown"};
 
     // Histograms - paired with their bucket boundaries in a single vector so
     // the two cannot drift out of sync (ylt histogram doesn't expose its
@@ -457,6 +469,14 @@ class ScopedLatencyRecorder {
         }                                                                      \
     } while (0)
 
+#define TENT_RECORD_BATCH_QUARANTINED()                   \
+    do {                                                  \
+        if (::mooncake::tent::TentMetrics::isEnabled()) { \
+            ::mooncake::tent::TentMetrics::instance()     \
+                .recordBatchQuarantined();                \
+        }                                                 \
+    } while (0)
+
 #define TENT_SCOPED_READ_LATENCY(tp, bytes)                               \
     ::mooncake::tent::ScopedLatencyRecorder _tent_latency_recorder_(      \
         ::mooncake::tent::ScopedLatencyRecorder::OperationType::Read, tp, \
@@ -491,6 +511,7 @@ class ScopedLatencyRecorder {
 #define TENT_RECORD_READ_FAILED(tp) ((void)0)
 #define TENT_RECORD_WRITE_FAILED(tp) ((void)0)
 #define TENT_RECORD_TRANSPORT_FAILOVER(from, to) ((void)0)
+#define TENT_RECORD_BATCH_QUARANTINED() ((void)0)
 #define TENT_SCOPED_READ_LATENCY(tp, bytes) ((void)0)
 #define TENT_SCOPED_WRITE_LATENCY(tp, bytes) ((void)0)
 #define TENT_RECORD_STAGE_LATENCY(stage, tp, latency_us) ((void)0)

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -221,6 +221,7 @@ void TentMetrics::registerMetrics() {
         &transport_attempts_total_,
         &transport_attempt_failures_total_,
         &deadline_infeasible_total_,
+        &quarantined_batches_total_,
     };
 
     // Register the N=1 per-transport histograms with their bucket boundaries
@@ -293,6 +294,12 @@ void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
         return;
     deadline_infeasible_total_.inc(
         std::array<std::string, 1>{transportTypeName(tp)});
+}
+
+void TentMetrics::recordBatchQuarantined() {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    quarantined_batches_total_.inc();
 }
 
 void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
@@ -607,6 +614,8 @@ std::string TentMetrics::getJsonMetrics() {
             sumCounterValues(&transport_attempt_failures_total_);
         root[deadline_infeasible_total_.str_name()] =
             sumCounterValues(&deadline_infeasible_total_);
+        root[quarantined_batches_total_.str_name()] =
+            static_cast<int64_t>(quarantined_batches_total_.value());
 
         // Histograms: sum bucket counts across all transport labels. The
         // templated helper also reads back the parallel sum counter so the
@@ -679,7 +688,9 @@ std::string TentMetrics::getSummaryString() {
         << "Write: " << formatBytes(write_bytes) << " ("
         << static_cast<uint64_t>(write_reqs) << " reqs, "
         << static_cast<uint64_t>(write_fails) << " fails) | "
-        << "Failovers: " << static_cast<uint64_t>(failovers);
+        << "Failovers: " << static_cast<uint64_t>(failovers)
+        << " | Quarantined batches: "
+        << static_cast<uint64_t>(quarantined_batches_total_.value());
 
     return oss.str();
 }
@@ -708,6 +719,7 @@ void TentMetrics::recordTransportAttemptFinished(TransportType, Request::OpCode,
                                                  TransferStatusEnum, double) {}
 void TentMetrics::recordDeadlineMLU(TransportType, double) {}
 void TentMetrics::recordDeadlineInfeasible(TransportType) {}
+void TentMetrics::recordBatchQuarantined() {}
 void TentMetrics::recordStageLatency(Stage, TransportType, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {

--- a/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/progress_worker.cpp
@@ -96,6 +96,9 @@ void ProgressWorker::runner() {
                 queued_.erase(batch_id);
             }
         }
+        // lazyFreeBatch reports the first batch it could not reclaim and logs
+        // the skip itself (rate-limited); the worker only sweeps, so the
+        // status is intentionally dropped at these call sites.
         if (queue_ready) {
             (void)impl_->progressRuntimeQueue();
             (void)impl_->lazyFreeBatch();

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -834,6 +834,15 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
 
 Status TransferEngineImpl::lazyFreeBatch() {
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    // freelist is insertion-ordered. A batch that cannot be reclaimed on this
+    // pass (poll error, queue owners not yet terminal) must not stop the sweep:
+    // returning early would strand every batch queued behind it, and a
+    // permanent error would strand them for good. Skip it, keep going, and
+    // report the first error once the pass is complete. Most callers drop the
+    // returned status (the ProgressWorker sweeps on every step), so the skip is
+    // also logged here, rate-limited, or a permanently stuck batch would be
+    // re-polled forever without a trace.
+    Status first_error = Status::OK();
     for (auto it = batch_set_.freelist.begin();
          it != batch_set_.freelist.end();) {
         auto& batch = *it;
@@ -842,13 +851,23 @@ Status TransferEngineImpl::lazyFreeBatch() {
             continue;
         }
         TransferStatus overall_status;
-        CHECK_STATUS(getTransferStatus((BatchID)batch, overall_status));
-        if (overall_status.s == PENDING) {
+        auto status = getTransferStatus((BatchID)batch, overall_status);
+        if (status.ok() && overall_status.s == PENDING) {
             it++;
             continue;
         }
-        if (runtime_queue_config_.enabled && batch->queue_token != 0) {
-            CHECK_STATUS(retireQueueForBatch(batch));
+        if (status.ok() && runtime_queue_config_.enabled &&
+            batch->queue_token != 0) {
+            status = retireQueueForBatch(batch);
+        }
+        if (!status.ok()) {
+            LOG_EVERY_N(WARNING, 100)
+                << "lazyFreeBatch: batch " << batch
+                << " cannot be reclaimed yet, left in freelist: "
+                << status.ToString();
+            if (first_error.ok()) first_error = status;
+            it++;
+            continue;
         }
         for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
             auto& transport = transport_list_[type];
@@ -860,7 +879,7 @@ Status TransferEngineImpl::lazyFreeBatch() {
         Slab<Batch>::Get().deallocate(batch);
         it = batch_set_.freelist.erase(it);
     }
-    return Status::OK();
+    return first_error;
 }
 
 Status TransferEngineImpl::retainBatch(BatchID batch_id, Batch*& batch) {

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -48,6 +48,12 @@ namespace tent {
 namespace {
 constexpr uint8_t kRedisMaxDbIndex = 255;
 constexpr uint8_t kRedisDefaultDbIndex = 0;
+
+// After this many consecutive failed reclaim attempts, lazyFreeBatch stops
+// retrying a batch (see Batch::reclaim_abandoned). Transient errors heal in a
+// pass or two and a healthy-but-inflight batch reports PENDING (which resets
+// the counter), so only a permanently failing poll or queue retire gets here.
+constexpr size_t kMaxReclaimAttempts = 4096;
 }  // namespace
 
 struct Batch {
@@ -61,6 +67,13 @@ struct Batch {
     size_t runtime_refs{0};
     bool free_requested{false};
     uint64_t queue_token{0};
+    // Consecutive lazyFreeBatch passes that failed to reclaim this batch
+    // (poll error or queue retire error). Reset when a pass observes the
+    // batch healthy (PENDING). At kMaxReclaimAttempts the batch is marked
+    // reclaim_abandoned: the sweep stops retrying (and warning) and leaves
+    // it for deconstruct(), which reclaims the freelist unconditionally.
+    size_t reclaim_failures{0};
+    bool reclaim_abandoned{false};
 
     struct SubmitHook {
         size_t start_task_id{0};
@@ -846,13 +859,14 @@ Status TransferEngineImpl::lazyFreeBatch() {
     for (auto it = batch_set_.freelist.begin();
          it != batch_set_.freelist.end();) {
         auto& batch = *it;
-        if (batch->runtime_refs > 0) {
+        if (batch->runtime_refs > 0 || batch->reclaim_abandoned) {
             it++;
             continue;
         }
         TransferStatus overall_status;
         auto status = getTransferStatus((BatchID)batch, overall_status);
         if (status.ok() && overall_status.s == PENDING) {
+            batch->reclaim_failures = 0;
             it++;
             continue;
         }
@@ -861,10 +875,21 @@ Status TransferEngineImpl::lazyFreeBatch() {
             status = retireQueueForBatch(batch);
         }
         if (!status.ok()) {
-            LOG_EVERY_N(WARNING, 100)
-                << "lazyFreeBatch: batch " << batch
-                << " cannot be reclaimed yet, left in freelist: "
-                << status.ToString();
+            if (++batch->reclaim_failures >= kMaxReclaimAttempts) {
+                batch->reclaim_abandoned = true;
+                TENT_RECORD_BATCH_QUARANTINED();
+                LOG(ERROR) << "lazyFreeBatch: batch " << batch << " failed "
+                           << batch->reclaim_failures
+                           << " consecutive reclaim attempts; giving up until "
+                              "engine teardown reclaims it unconditionally. "
+                              "Last error: "
+                           << status.ToString();
+            } else {
+                LOG_EVERY_N(WARNING, 100)
+                    << "lazyFreeBatch: batch " << batch
+                    << " cannot be reclaimed yet, left in freelist: "
+                    << status.ToString();
+            }
             if (first_error.ok()) first_error = status;
             it++;
             continue;

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -710,6 +710,73 @@ TEST_F(MetricsRecordingTest, InfeasibleDeadlineRecordsSeparateCounter) {
 }
 
 // ---------------------------------------------------------------------------
+// A batch whose reclaim fails permanently is quarantined by lazyFreeBatch
+// after kMaxReclaimAttempts (4096) consecutive failures, and that event is
+// counted in tent_quarantined_batches_total. Drives the real sweep path.
+// ---------------------------------------------------------------------------
+
+// FakeTransport whose poll fails permanently once poisoned.
+class PoisonedPollFakeTransport : public FakeTransport {
+   public:
+    explicit PoisonedPollFakeTransport(TransportType type)
+        : FakeTransport(type) {}
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        if (poisoned.load(std::memory_order_acquire)) {
+            return Status::InternalError(
+                "injected permanent poll failure" LOC_MARK);
+        }
+        return FakeTransport::getTransferStatus(batch, task_id, status);
+    }
+
+    std::atomic<bool> poisoned{false};
+};
+
+TEST_F(MetricsRecordingTest, QuarantinedBatchIncrementsCounter) {
+    constexpr size_t kMaxReclaimAttempts = 4096;  // mirrors the impl constant
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<PoisonedPollFakeTransport>(RDMA);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xAB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    BatchID batch = engine.allocateBatch(1);
+    ASSERT_NE(batch, (BatchID)0);
+    ASSERT_TRUE(
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)}).ok());
+    fake->poisoned.store(true, std::memory_order_release);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    // Each freeBatch call on an already free-requested batch runs one sweep.
+    ASSERT_TRUE(engine.freeBatch(batch).ok());
+    for (size_t i = 0; i + 1 < kMaxReclaimAttempts; ++i) {
+        (void)engine.freeBatch(batch);
+    }
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(after.counter("tent_quarantined_batches_total") -
+                  before.counter("tent_quarantined_batches_total"),
+              1)
+        << "quarantining a batch must increment "
+           "tent_quarantined_batches_total exactly once";
+    // Prometheus endpoint carries the series too.
+    EXPECT_EQ(after.series("tent_quarantined_batches_total") -
+                  before.series("tent_quarantined_batches_total"),
+              1);
+
+    // Unpoison so teardown drains cleanly; the batch itself is reclaimed by
+    // the engine destructor regardless.
+    fake->poisoned.store(false, std::memory_order_release);
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+// ---------------------------------------------------------------------------
 // A transfer whose deadline is in the future records a genuine MLU sample
 // into the histogram (feasible or missed, but real).
 // ---------------------------------------------------------------------------

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1160,6 +1160,100 @@ TEST(ProxyManager, DestructorWaitsForDeferredBatchBeforeFreeingStageMemory) {
         engine.unregisterLocalMemory(target.data(), target.size()).ok());
 }
 
+// ---------------------------------------------------------------------------
+// lazyFreeBatch head-of-line blocking. freelist is insertion-ordered; a batch
+// whose poll fails permanently must not stop every batch behind it from being
+// reclaimed.
+// ---------------------------------------------------------------------------
+
+// Polls succeed except for requests whose source is `poison_source`, which
+// fail permanently. Also counts freeSubBatch so a test can see reclamation.
+class PoisonedPollTransport : public FakeTransport {
+   public:
+    explicit PoisonedPollTransport(TransportType type) : FakeTransport(type) {}
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fb = static_cast<FakeSubBatch*>(batch);
+        if (task_id >= 0 && task_id < (int)fb->requests.size() &&
+            fb->requests[task_id].source ==
+                poison_source.load(std::memory_order_acquire)) {
+            return Status::InternalError(
+                "injected permanent poll failure" LOC_MARK);
+        }
+        return FakeTransport::getTransferStatus(batch, task_id, status);
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        free_sub_batch_calls.fetch_add(1, std::memory_order_relaxed);
+        return FakeTransport::freeSubBatch(batch);
+    }
+
+    std::atomic<const void*> poison_source{nullptr};
+    std::atomic<int> free_sub_batch_calls{0};
+};
+
+TEST(BatchLifecycle, FreeListSweepSkipsAStuckBatchInsteadOfStopping) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<PoisonedPollTransport>(RDMA);
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> stuck_buf(kBufLen, 0xA1);
+    std::vector<uint8_t> healthy_buf(kBufLen, 0xB2);
+    ASSERT_TRUE(engine.registerLocalMemory(stuck_buf.data(), kBufLen).ok());
+    ASSERT_TRUE(engine.registerLocalMemory(healthy_buf.data(), kBufLen).ok());
+
+    auto make_request = [&](std::vector<uint8_t>& buf) {
+        Request req;
+        req.opcode = Request::WRITE;
+        req.source = buf.data();
+        req.target_id = LOCAL_SEGMENT_ID;
+        req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+        req.length = kBufLen;
+        return req;
+    };
+
+    // Batch A polls with a permanent error, so lazyFreeBatch can neither
+    // reclaim it nor decide it is still pending.
+    BatchID stuck = engine.allocateBatch(1);
+    ASSERT_NE(stuck, (BatchID)0);
+    ASSERT_TRUE(engine.submitTransfer(stuck, {make_request(stuck_buf)}).ok());
+    fake_rdma->poison_source.store(stuck_buf.data(), std::memory_order_release);
+
+    // Batch B completes normally.
+    BatchID healthy = engine.allocateBatch(1);
+    ASSERT_NE(healthy, (BatchID)0);
+    ASSERT_TRUE(
+        engine.submitTransfer(healthy, {make_request(healthy_buf)}).ok());
+    TransferStatus status{};
+    ASSERT_TRUE(engine.getTransferStatus(healthy, status).ok());
+    ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+
+    // A enters the freelist first and stays there; B lands behind it.
+    EXPECT_TRUE(engine.freeBatch(stuck).ok());
+    EXPECT_TRUE(engine.freeBatch(healthy).ok());
+
+    // B must be reclaimed even though A, ahead of it, cannot be: its SubBatch
+    // is returned to the transport and its handle is no longer alive.
+    EXPECT_EQ(fake_rdma->free_sub_batch_calls.load(std::memory_order_acquire),
+              1)
+        << "the healthy batch behind the stuck one was never reclaimed";
+    TransferStatus after_free{};
+    EXPECT_FALSE(engine.getTransferStatus(healthy, after_free).ok())
+        << "a reclaimed batch handle must not stay alive";
+
+    // Unpoison so the stuck batch drains at teardown.
+    fake_rdma->poison_source.store(nullptr, std::memory_order_release);
+    EXPECT_TRUE(engine.unregisterLocalMemory(stuck_buf.data(), kBufLen).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(healthy_buf.data(), kBufLen).ok());
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1178,6 +1178,7 @@ class PoisonedPollTransport : public FakeTransport {
         if (task_id >= 0 && task_id < (int)fb->requests.size() &&
             fb->requests[task_id].source ==
                 poison_source.load(std::memory_order_acquire)) {
+            poisoned_polls.fetch_add(1, std::memory_order_relaxed);
             return Status::InternalError(
                 "injected permanent poll failure" LOC_MARK);
         }
@@ -1191,6 +1192,7 @@ class PoisonedPollTransport : public FakeTransport {
 
     std::atomic<const void*> poison_source{nullptr};
     std::atomic<int> free_sub_batch_calls{0};
+    std::atomic<int> poisoned_polls{0};
 };
 
 TEST(BatchLifecycle, FreeListSweepSkipsAStuckBatchInsteadOfStopping) {
@@ -1252,6 +1254,83 @@ TEST(BatchLifecycle, FreeListSweepSkipsAStuckBatchInsteadOfStopping) {
     fake_rdma->poison_source.store(nullptr, std::memory_order_release);
     EXPECT_TRUE(engine.unregisterLocalMemory(stuck_buf.data(), kBufLen).ok());
     EXPECT_TRUE(engine.unregisterLocalMemory(healthy_buf.data(), kBufLen).ok());
+}
+
+// A batch whose reclaim fails on every pass must eventually be parked: after
+// kMaxReclaimAttempts (4096) consecutive failures the sweep stops polling and
+// warning about it, later frees are unaffected, and engine teardown still
+// reclaims it unconditionally.
+TEST(BatchLifecycle, PermanentlyStuckBatchIsQuarantinedNotRetriedForever) {
+    constexpr size_t kMaxReclaimAttempts = 4096;  // mirrors the impl constant
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> stuck_buf(kBufLen, 0xA1);
+    std::vector<uint8_t> late_buf(kBufLen, 0xB2);
+    auto fake_rdma = std::make_shared<PoisonedPollTransport>(RDMA);
+
+    {
+        auto cfg = makeMinimalP2PConfig();
+        TransferEngineImpl engine(cfg);
+        ASSERT_TRUE(engine.available());
+        std::string seg = engine.getSegmentName();
+        ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+        engine.swapTransportForTest(RDMA, fake_rdma);
+        ASSERT_TRUE(engine.registerLocalMemory(stuck_buf.data(), kBufLen).ok());
+        ASSERT_TRUE(engine.registerLocalMemory(late_buf.data(), kBufLen).ok());
+
+        auto make_request = [&](std::vector<uint8_t>& buf) {
+            Request req;
+            req.opcode = Request::WRITE;
+            req.source = buf.data();
+            req.target_id = LOCAL_SEGMENT_ID;
+            req.target_offset = reinterpret_cast<uint64_t>(buf.data());
+            req.length = kBufLen;
+            return req;
+        };
+
+        BatchID stuck = engine.allocateBatch(1);
+        ASSERT_NE(stuck, (BatchID)0);
+        ASSERT_TRUE(
+            engine.submitTransfer(stuck, {make_request(stuck_buf)}).ok());
+        fake_rdma->poison_source.store(stuck_buf.data(),
+                                       std::memory_order_release);
+        ASSERT_TRUE(engine.freeBatch(stuck).ok());
+
+        // Drive sweeps past the quarantine threshold. Re-freeing an already
+        // free-requested batch runs one sweep per call and returns the sweep
+        // error while the batch is still being retried.
+        bool saw_error = false;
+        for (size_t i = 0; i + 1 < kMaxReclaimAttempts; ++i) {
+            saw_error |= !engine.freeBatch(stuck).ok();
+        }
+        EXPECT_TRUE(saw_error);
+
+        // Quarantined: further sweeps neither poll the batch nor report its
+        // error.
+        const int polls_at_quarantine =
+            fake_rdma->poisoned_polls.load(std::memory_order_acquire);
+        for (int i = 0; i < 100; ++i) {
+            EXPECT_TRUE(engine.freeBatch(stuck).ok());
+        }
+        EXPECT_EQ(fake_rdma->poisoned_polls.load(std::memory_order_acquire),
+                  polls_at_quarantine)
+            << "a quarantined batch must not be re-polled";
+
+        // Healthy batches are still reclaimed normally alongside it.
+        BatchID late = engine.allocateBatch(1);
+        ASSERT_NE(late, (BatchID)0);
+        ASSERT_TRUE(engine.submitTransfer(late, {make_request(late_buf)}).ok());
+        TransferStatus status{};
+        ASSERT_TRUE(engine.getTransferStatus(late, status).ok());
+        ASSERT_EQ(status.s, TransferStatusEnum::COMPLETED);
+        EXPECT_TRUE(engine.freeBatch(late).ok());
+        EXPECT_EQ(
+            fake_rdma->free_sub_batch_calls.load(std::memory_order_acquire), 1)
+            << "batches behind a quarantined one must still be reclaimed";
+    }  // engine teardown reclaims the quarantined batch unconditionally
+
+    EXPECT_EQ(fake_rdma->free_sub_batch_calls.load(std::memory_order_acquire),
+              2)
+        << "teardown must reclaim the quarantined batch";
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

  `lazyFreeBatch()` returned on the first `getTransferStatus` / `retireQueueForBatch` error, so a batch that could not be reclaimed stranded every batch queued behind it in the insertion-ordered `freelist`; a permanent error (e.g. a transport that keeps failing the poll) leaked those `Batch` slabs and SubBatches forever. Record the first error, skip that batch, finish the sweep, then return it.

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  Added `BatchLifecycle.FreeListSweepSkipsAStuckBatchInsteadOfStopping` (FakeTransport with a permanently failing poll on one batch); it fails on main and passes with the fix.

  **Test commands:**
  ```bash
  cmake --build build-tent --target tent_progress_worker_test
  ctest --test-dir build-tent/mooncake-transfer-engine/tent/tests --output-on-failure

  Test results:
  - [x] Unit tests pass (TENT ctest 38/38)
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue
  
  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)