### PR TITLE
[Bugfix][Store] Fix standby snapshot compile regressions

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
@@ -34,6 +34,9 @@ class OpLogBatchStandbyReader {
                             OpLogApplier& applier);
 
     OpLogBatchStandbyPollResult PollOnce(size_t max_batches = 1024);
+    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const {
+        return storage_.ReadProducerView(producer_view_version);
+    }
     std::optional<DurablePrefix> GetLastAppliedDurablePrefix() const {
         return last_applied_durable_prefix_;
     }

--- a/mooncake-store/include/ha/oplog/oplog_batch_storage.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_storage.h
@@ -16,6 +16,7 @@ class OpLogBatchStorage {
     ErrorCode InitDurablePrefix(DurablePrefix& prefix);
     ErrorCode ClaimProducerView(ViewVersionId producer_view_version);
     ErrorCode ValidateProducerView(ViewVersionId producer_view_version) const;
+    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
     ErrorCode ReadDurablePrefix(DurablePrefix& prefix);
     ErrorCode WriteBatchAndAdvancePrefix(const OpLogBatchRecord& batch,
                                          const DurablePrefix& expected_prefix);
@@ -28,7 +29,6 @@ class OpLogBatchStorage {
 
    private:
     bool IsValidClusterId() const;
-    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
     ErrorCode WriteBatchAndAdvancePrefixImpl(
         const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix,
         const ViewVersionId* producer_view_version);

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -155,6 +155,9 @@ ErrorCode OpLogBatchStorage::ReadDurablePrefix(DurablePrefix& prefix) {
 
 ErrorCode OpLogBatchStorage::ReadProducerView(
     ViewVersionId& producer_view_version) const {
+    if (!IsValidClusterId()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
     std::string value;
     ErrorCode err = backend_.Get(BuildProducerViewKey(cluster_id_), value);
     if (err != ErrorCode::OK) {

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -705,15 +705,20 @@ void HotStandbyService::HandleSnapshotCaptureRequest(
 
     state->requested = false;
     auto applied_prefix = batch_standby_reader_->GetLastAppliedDurablePrefix();
+    ViewVersionId producer_view_version = 0;
+    const ErrorCode producer_view_error =
+        batch_standby_reader_->ReadProducerView(producer_view_version);
     const uint64_t expected = oplog_applier_->GetExpectedSequenceId();
     const bool consistent =
         result.error == ErrorCode::OK && result.durable_prefix_present &&
+        (producer_view_error == ErrorCode::OK ||
+         producer_view_error == ErrorCode::ETCD_KEY_NOT_EXIST) &&
         applied_prefix && *applied_prefix == result.durable_prefix &&
         expected > 0 && expected - 1 == applied_prefix->last_seq;
     if (consistent && IsRunning() && metadata_store_) {
         BatchOpLogSnapshotCapture capture(
             applied_prefix->last_seq, applied_prefix->batch_id,
-            applied_prefix->producer_view_version,
+            producer_view_version,
             oplog_applier_->GetSegmentRegistry().GetAllSegments(),
             metadata_store_->BeginSnapshotTraversal(), state->generation,
             state);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3043,16 +3043,6 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
                 << tenant_id.value() << ", key=" << user_key;
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-        if (entry.metadata.last_sequence_id > initial_oplog_sequence_id) {
-            LOG(ERROR) << "RestoreFromStandbySnapshot: object cursor "
-                       << entry.metadata.last_sequence_id
-                       << " exceeds snapshot cursor "
-                       << initial_oplog_sequence_id
-                       << ", tenant=" << tenant_id.value()
-                       << ", key=" << user_key;
-            return tl::make_unexpected(ErrorCode::INVALID_VERSION);
-        }
-
         const auto shard_idx = entry.metadata.group_id.empty()
                                    ? getShardIndex(tenant_id, user_key)
                                    : getShardIndex(entry.metadata.group_id);

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -983,21 +983,6 @@ TEST_F(MasterServiceHATest, RestoreRejectsDescriptorsBeyondSegmentCapacity) {
     EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
 }
 
-TEST_F(MasterServiceHATest, RestoreRejectsObjectCursorBeyondSnapshot) {
-    MasterService service(
-        MasterServiceConfig::builder().set_enable_ha(false).build());
-
-    const std::string endpoint = "standby_cursor_segment";
-    auto object = MakeStandbyObject("standby_cursor_key", endpoint);
-    object.metadata.last_sequence_id = 8;
-
-    auto result = service.RestoreFromStandbySnapshot(
-        {object}, 7, {MakeStandbyMemorySegment(endpoint)});
-
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::INVALID_VERSION);
-}
-
 TEST_F(MasterServiceHATest, RestoreRejectsDfsMode) {
     MasterService service(
         MasterServiceConfig::builder().set_enable_ha(false).build());

--- a/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
@@ -256,9 +256,7 @@ TEST(OpLogBatchStandbyReaderTest, FullPageContinuesOnNextPoll) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 3,
-                                               .last_seq = 3,
-                                               .producer_view_version = 7})));
+                          EncodeDurablePrefix({.batch_id = 3, .last_seq = 3})));
     for (uint64_t id = 1; id <= 3; ++id) {
         ASSERT_EQ(ErrorCode::OK,
                   backend.Put(BuildBatchRecordKey("clusterA", id),
@@ -282,16 +280,13 @@ TEST(OpLogBatchStandbyReaderTest, FullPageContinuesOnNextPoll) {
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(3u, applied_prefix->batch_id);
     EXPECT_EQ(3u, applied_prefix->last_seq);
-    EXPECT_EQ(7u, applied_prefix->producer_view_version);
 }
 
 TEST(OpLogBatchStandbyReaderTest, ReportsValidZeroBoundaryAsComplete) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 0,
-                                               .last_seq = 0,
-                                               .producer_view_version = 7})));
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     MockMetadataStore metadata_store;
     OpLogApplier applier(&metadata_store, "clusterA");
     OpLogBatchStandbyReader reader("clusterA", backend, applier);
@@ -301,7 +296,6 @@ TEST(OpLogBatchStandbyReaderTest, ReportsValidZeroBoundaryAsComplete) {
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(0u, applied_prefix->batch_id);
     EXPECT_EQ(0u, applied_prefix->last_seq);
-    EXPECT_EQ(7u, applied_prefix->producer_view_version);
 }
 
 TEST(OpLogBatchStandbyReaderTest, RejectsPrefixPointingIntoBatch) {
@@ -327,9 +321,7 @@ TEST(OpLogBatchStandbyReaderTest, AppliesExpandedEntriesInSequenceOrder) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 2,
-                                               .last_seq = 3,
-                                               .producer_view_version = 9})));
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 3})));
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildBatchRecordKey("clusterA", 1),
                           EncodeOpLogBatchRecord(MakeBatch(1, 1, 1))));
@@ -349,7 +341,6 @@ TEST(OpLogBatchStandbyReaderTest, AppliesExpandedEntriesInSequenceOrder) {
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(2u, applied_prefix->batch_id);
     EXPECT_EQ(3u, applied_prefix->last_seq);
-    EXPECT_EQ(9u, applied_prefix->producer_view_version);
 }
 
 TEST(OpLogBatchStandbyReaderTest, AcceptsFirstBatchAfterSnapshotBaseline) {

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -352,6 +352,9 @@ TEST(OpLogBatchStorageTest, RejectsInvalidClusterId) {
 
     DurablePrefix prefix;
     EXPECT_EQ(ErrorCode::INVALID_PARAMS, storage.InitDurablePrefix(prefix));
+    ViewVersionId producer_view = 0;
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              storage.ReadProducerView(producer_view));
 }
 
 TEST(OpLogBatchStorageTest, RereadsDurablePrefixWhenCreateIfAbsentLosesRace) {

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -560,11 +560,12 @@ TEST_F(HotStandbyServiceTest,
             EncodeOpLogBatchRecord(MakeCaptureBatch(
                 1, 1, OpType::SEGMENT_MOUNT, mount.segment_name,
                 std::string(mount_payload.begin(), mount_payload.end())))));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
     ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 1,
-                                                .last_seq = 1,
-                                                .producer_view_version = 7})));
+              backend->Put(BuildProducerViewKey(cluster_id_), "7"));
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
     service_ = std::make_unique<HotStandbyService>(config_);
@@ -597,11 +598,10 @@ TEST_F(HotStandbyServiceTest,
     ASSERT_EQ(ErrorCode::OK,
               backend->Put(BuildBatchRecordKey(cluster_id_, 2),
                            EncodeOpLogBatchRecord(MakeCaptureBatch(2, 2))));
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 2,
-                                                .last_seq = 2,
-                                                .producer_view_version = 7})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     EXPECT_EQ(1u, service_->GetLatestAppliedSequenceId());
 
@@ -615,11 +615,10 @@ TEST_F(HotStandbyServiceTest,
 
 TEST_F(HotStandbyServiceTest, PromotionCancelsActiveSnapshotCapture) {
     auto backend = std::make_shared<FakeCaptureHaKvBackend>();
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0,
-                                                .last_seq = 0,
-                                                .producer_view_version = 7})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
     service_ = std::make_unique<HotStandbyService>(config_);
@@ -636,11 +635,10 @@ TEST_F(HotStandbyServiceTest, PromotionCancelsActiveSnapshotCapture) {
 
 TEST_F(HotStandbyServiceTest, SnapshotCaptureRejectsInconsistentSequence) {
     auto backend = std::make_shared<FakeCaptureHaKvBackend>();
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0,
-                                                .last_seq = 0,
-                                                .producer_view_version = 7})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     config_.enable_snapshot_bootstrap = true;
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;


### PR DESCRIPTION
## Description

Fix the main-branch compile regressions caused by hidden conflicts between #3326, #3354, and #3384.

- Remove the stale per-object `last_sequence_id` validation introduced by #3354. #3326 removed this field and now uses a complete-batch cursor for snapshot consistency.
- Read the snapshot producer view from `/oplog/<cluster>/producer_view`, matching the storage layout introduced by #3384, instead of the removed `DurablePrefix::producer_view_version`.
- Treat a missing producer-view key as legacy view `0`; reject other backend read failures.
- Update the affected tests to use the standalone producer-view key and cover invalid cluster IDs.

## Module

- [x] Mooncake Store

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Built the affected targets:

```bash
cmake --build build --target \
  mooncake_store \
  oplog_batch_storage_test \
  oplog_batch_standby_reader_test \
  hot_standby_service_test \
  master_service_ha_test -j32
```

Test results:

- `oplog_batch_storage_test`: 50/50 passed
- `oplog_batch_standby_reader_test`: 21/21 passed
- `master_service_ha_test`: 82/82 passed
- `hot_standby_service_test`: 32 passed, 15 skipped because they require a real etcd environment
- PR-scoped pre-commit hooks passed

The EFA build configuration was not reproduced locally because libfabric is unavailable in the local environment.

## Checklist

- [x] I have reviewed all changed lines.
- [x] The changes are formatted and pass pre-commit checks.
- [x] Relevant unit tests have been updated and pass.
- [x] Documentation changes are not required for this internal build fix.
- [x] An RFC is not required because the change is under 500 lines.

## AI Assistance Disclosure

- [x] AI tools were used.

OpenAI Codex assisted with CI log analysis, cross-PR conflict diagnosis, implementation, and verification. The human submitter has reviewed every changed line and is responsible for understanding and defending the change.