### PR TITLE
[Store] Restore HA snapshot compatibility after producer-view split

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
@@ -26,6 +26,8 @@ struct OpLogBatchStandbyPollResult {
     bool durable_prefix_present{false};
     size_t applied_entries{0};
     DurablePrefix durable_prefix{};
+    // Producer view is stored independently from the durable prefix.
+    ViewVersionId producer_view_version{0};
 };
 
 class OpLogBatchStandbyReader {
@@ -37,6 +39,9 @@ class OpLogBatchStandbyReader {
     std::optional<DurablePrefix> GetLastAppliedDurablePrefix() const {
         return last_applied_durable_prefix_;
     }
+    std::optional<ViewVersionId> GetLastAppliedProducerViewVersion() const {
+        return last_applied_producer_view_version_;
+    }
 
    private:
     OpLogBatchStorage storage_;
@@ -44,6 +49,7 @@ class OpLogBatchStandbyReader {
     bool batch_format_seen_{false};
     std::optional<DurablePrefix> last_observed_prefix_;
     std::optional<DurablePrefix> last_applied_durable_prefix_;
+    std::optional<ViewVersionId> last_applied_producer_view_version_;
     std::optional<uint64_t> last_scanned_batch_last_seq_;
     uint64_t last_applied_batch_id_{0};
 };

--- a/mooncake-store/include/ha/oplog/oplog_batch_storage.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_storage.h
@@ -16,6 +16,7 @@ class OpLogBatchStorage {
     ErrorCode InitDurablePrefix(DurablePrefix& prefix);
     ErrorCode ClaimProducerView(ViewVersionId producer_view_version);
     ErrorCode ValidateProducerView(ViewVersionId producer_view_version) const;
+    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
     ErrorCode ReadDurablePrefix(DurablePrefix& prefix);
     ErrorCode WriteBatchAndAdvancePrefix(const OpLogBatchRecord& batch,
                                          const DurablePrefix& expected_prefix);
@@ -28,7 +29,6 @@ class OpLogBatchStorage {
 
    private:
     bool IsValidClusterId() const;
-    ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const;
     ErrorCode WriteBatchAndAdvancePrefixImpl(
         const OpLogBatchRecord& batch, const DurablePrefix& expected_prefix,
         const ViewVersionId* producer_view_version);

--- a/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
@@ -48,6 +48,18 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
     result.durable_prefix_present = true;
     result.durable_prefix = prefix;
 
+    ViewVersionId producer_view_version = 0;
+    err = storage_.ReadProducerView(producer_view_version);
+    if (err == ErrorCode::ETCD_KEY_NOT_EXIST) {
+        // A prefix written before producer-view fencing has no separate view.
+        // Keep the existing zero-value snapshot metadata for that layout.
+    } else if (err != ErrorCode::OK) {
+        SetPollError(result, err, IsRetryableBackendError(err));
+        return result;
+    } else {
+        result.producer_view_version = producer_view_version;
+    }
+
     if (last_observed_prefix_ &&
         (prefix.batch_id < last_observed_prefix_->batch_id ||
          prefix.last_seq < last_observed_prefix_->last_seq ||
@@ -63,8 +75,10 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
         last_observed_prefix_ = prefix;
         if (prefix.last_seq != 0) {
             SetPollError(result, ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, false);
-        } else if (applier_.GetExpectedSequenceId() == 1) {
+        } else if (applier_.GetExpectedSequenceId() == 1 &&
+                   !last_applied_durable_prefix_) {
             last_applied_durable_prefix_ = prefix;
+            last_applied_producer_view_version_ = result.producer_view_version;
         }
         return result;
     }
@@ -149,6 +163,7 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
         const uint64_t expected = applier_.GetExpectedSequenceId();
         if (expected > 0 && expected - 1 == prefix.last_seq) {
             last_applied_durable_prefix_ = prefix;
+            last_applied_producer_view_version_ = result.producer_view_version;
         }
     }
     return result;

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -705,15 +705,18 @@ void HotStandbyService::HandleSnapshotCaptureRequest(
 
     state->requested = false;
     auto applied_prefix = batch_standby_reader_->GetLastAppliedDurablePrefix();
+    auto applied_producer_view =
+        batch_standby_reader_->GetLastAppliedProducerViewVersion();
     const uint64_t expected = oplog_applier_->GetExpectedSequenceId();
-    const bool consistent =
-        result.error == ErrorCode::OK && result.durable_prefix_present &&
-        applied_prefix && *applied_prefix == result.durable_prefix &&
-        expected > 0 && expected - 1 == applied_prefix->last_seq;
+    const bool consistent = result.error == ErrorCode::OK &&
+                            result.durable_prefix_present && applied_prefix &&
+                            *applied_prefix == result.durable_prefix &&
+                            applied_producer_view && expected > 0 &&
+                            expected - 1 == applied_prefix->last_seq;
     if (consistent && IsRunning() && metadata_store_) {
         BatchOpLogSnapshotCapture capture(
             applied_prefix->last_seq, applied_prefix->batch_id,
-            applied_prefix->producer_view_version,
+            *applied_producer_view,
             oplog_applier_->GetSegmentRegistry().GetAllSegments(),
             metadata_store_->BeginSnapshotTraversal(), state->generation,
             state);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3043,16 +3043,6 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
                 << tenant_id.value() << ", key=" << user_key;
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-        if (entry.metadata.last_sequence_id > initial_oplog_sequence_id) {
-            LOG(ERROR) << "RestoreFromStandbySnapshot: object cursor "
-                       << entry.metadata.last_sequence_id
-                       << " exceeds snapshot cursor "
-                       << initial_oplog_sequence_id
-                       << ", tenant=" << tenant_id.value()
-                       << ", key=" << user_key;
-            return tl::make_unexpected(ErrorCode::INVALID_VERSION);
-        }
-
         const auto shard_idx = entry.metadata.group_id.empty()
                                    ? getShardIndex(tenant_id, user_key)
                                    : getShardIndex(entry.metadata.group_id);

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -983,21 +983,6 @@ TEST_F(MasterServiceHATest, RestoreRejectsDescriptorsBeyondSegmentCapacity) {
     EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
 }
 
-TEST_F(MasterServiceHATest, RestoreRejectsObjectCursorBeyondSnapshot) {
-    MasterService service(
-        MasterServiceConfig::builder().set_enable_ha(false).build());
-
-    const std::string endpoint = "standby_cursor_segment";
-    auto object = MakeStandbyObject("standby_cursor_key", endpoint);
-    object.metadata.last_sequence_id = 8;
-
-    auto result = service.RestoreFromStandbySnapshot(
-        {object}, 7, {MakeStandbyMemorySegment(endpoint)});
-
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::INVALID_VERSION);
-}
-
 TEST_F(MasterServiceHATest, RestoreRejectsDfsMode) {
     MasterService service(
         MasterServiceConfig::builder().set_enable_ha(false).build());

--- a/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
@@ -256,9 +256,9 @@ TEST(OpLogBatchStandbyReaderTest, FullPageContinuesOnNextPoll) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 3,
-                                               .last_seq = 3,
-                                               .producer_view_version = 7})));
+                          EncodeDurablePrefix({.batch_id = 3, .last_seq = 3})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "7"));
     for (uint64_t id = 1; id <= 3; ++id) {
         ASSERT_EQ(ErrorCode::OK,
                   backend.Put(BuildBatchRecordKey("clusterA", id),
@@ -282,26 +282,29 @@ TEST(OpLogBatchStandbyReaderTest, FullPageContinuesOnNextPoll) {
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(3u, applied_prefix->batch_id);
     EXPECT_EQ(3u, applied_prefix->last_seq);
-    EXPECT_EQ(7u, applied_prefix->producer_view_version);
+    ASSERT_TRUE(reader.GetLastAppliedProducerViewVersion().has_value());
+    EXPECT_EQ(7u, *reader.GetLastAppliedProducerViewVersion());
 }
 
 TEST(OpLogBatchStandbyReaderTest, ReportsValidZeroBoundaryAsComplete) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 0,
-                                               .last_seq = 0,
-                                               .producer_view_version = 7})));
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "7"));
     MockMetadataStore metadata_store;
     OpLogApplier applier(&metadata_store, "clusterA");
     OpLogBatchStandbyReader reader("clusterA", backend, applier);
 
-    ASSERT_EQ(ErrorCode::OK, reader.PollOnce().error);
+    auto result = reader.PollOnce();
+    ASSERT_EQ(ErrorCode::OK, result.error);
     auto applied_prefix = reader.GetLastAppliedDurablePrefix();
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(0u, applied_prefix->batch_id);
     EXPECT_EQ(0u, applied_prefix->last_seq);
-    EXPECT_EQ(7u, applied_prefix->producer_view_version);
+    ASSERT_TRUE(reader.GetLastAppliedProducerViewVersion().has_value());
+    EXPECT_EQ(7u, *reader.GetLastAppliedProducerViewVersion());
 }
 
 TEST(OpLogBatchStandbyReaderTest, RejectsPrefixPointingIntoBatch) {
@@ -327,9 +330,9 @@ TEST(OpLogBatchStandbyReaderTest, AppliesExpandedEntriesInSequenceOrder) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildDurablePrefixKey("clusterA"),
-                          EncodeDurablePrefix({.batch_id = 2,
-                                               .last_seq = 3,
-                                               .producer_view_version = 9})));
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 3})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "9"));
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(BuildBatchRecordKey("clusterA", 1),
                           EncodeOpLogBatchRecord(MakeBatch(1, 1, 1))));
@@ -349,7 +352,47 @@ TEST(OpLogBatchStandbyReaderTest, AppliesExpandedEntriesInSequenceOrder) {
     ASSERT_TRUE(applied_prefix.has_value());
     EXPECT_EQ(2u, applied_prefix->batch_id);
     EXPECT_EQ(3u, applied_prefix->last_seq);
-    EXPECT_EQ(9u, applied_prefix->producer_view_version);
+    ASSERT_TRUE(reader.GetLastAppliedProducerViewVersion().has_value());
+    EXPECT_EQ(9u, *reader.GetLastAppliedProducerViewVersion());
+}
+
+TEST(OpLogBatchStandbyReaderTest, KeepsAppliedViewWhenPrefixDoesNotAdvance) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "7"));
+    MockMetadataStore metadata_store;
+    OpLogApplier applier(&metadata_store, "clusterA");
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+
+    ASSERT_EQ(ErrorCode::OK, reader.PollOnce().error);
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "8"));
+    auto result = reader.PollOnce();
+
+    ASSERT_EQ(ErrorCode::OK, result.error);
+    EXPECT_EQ(8u, result.producer_view_version);
+    ASSERT_TRUE(reader.GetLastAppliedProducerViewVersion().has_value());
+    EXPECT_EQ(7u, *reader.GetLastAppliedProducerViewVersion());
+}
+
+TEST(OpLogBatchStandbyReaderTest, RejectsMalformedProducerView) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildProducerViewKey("clusterA"), "not-a-view"));
+    MockMetadataStore metadata_store;
+    OpLogApplier applier(&metadata_store, "clusterA");
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+
+    auto result = reader.PollOnce();
+
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, result.error);
+    EXPECT_EQ(OpLogBatchStandbyPollDisposition::FATAL, result.disposition);
 }
 
 TEST(OpLogBatchStandbyReaderTest, AcceptsFirstBatchAfterSnapshotBaseline) {

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -560,11 +560,12 @@ TEST_F(HotStandbyServiceTest,
             EncodeOpLogBatchRecord(MakeCaptureBatch(
                 1, 1, OpType::SEGMENT_MOUNT, mount.segment_name,
                 std::string(mount_payload.begin(), mount_payload.end())))));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
     ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 1,
-                                                .last_seq = 1,
-                                                .producer_view_version = 7})));
+              backend->Put(BuildProducerViewKey(cluster_id_), "7"));
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
     service_ = std::make_unique<HotStandbyService>(config_);
@@ -597,11 +598,10 @@ TEST_F(HotStandbyServiceTest,
     ASSERT_EQ(ErrorCode::OK,
               backend->Put(BuildBatchRecordKey(cluster_id_, 2),
                            EncodeOpLogBatchRecord(MakeCaptureBatch(2, 2))));
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 2,
-                                                .last_seq = 2,
-                                                .producer_view_version = 7})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
     std::this_thread::sleep_for(std::chrono::milliseconds(20));
     EXPECT_EQ(1u, service_->GetLatestAppliedSequenceId());
 
@@ -615,11 +615,12 @@ TEST_F(HotStandbyServiceTest,
 
 TEST_F(HotStandbyServiceTest, PromotionCancelsActiveSnapshotCapture) {
     auto backend = std::make_shared<FakeCaptureHaKvBackend>();
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0,
-                                                .last_seq = 0,
-                                                .producer_view_version = 7})));
+              backend->Put(BuildProducerViewKey(cluster_id_), "7"));
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
     service_ = std::make_unique<HotStandbyService>(config_);
@@ -636,11 +637,12 @@ TEST_F(HotStandbyServiceTest, PromotionCancelsActiveSnapshotCapture) {
 
 TEST_F(HotStandbyServiceTest, SnapshotCaptureRejectsInconsistentSequence) {
     auto backend = std::make_shared<FakeCaptureHaKvBackend>();
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0,
-                                                .last_seq = 0,
-                                                .producer_view_version = 7})));
+              backend->Put(BuildProducerViewKey(cluster_id_), "7"));
     config_.enable_snapshot_bootstrap = true;
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;


### PR DESCRIPTION
## Description

This fixes the HA snapshot consumers that were left on the pre-S03 data layout after the producer-view fencing change was merged.

- Reads the producer view from the independent `/oplog/<cluster>/producer_view` key instead of `DurablePrefix`.
- Keeps the producer view paired with the durable prefix when that prefix becomes fully applied, so later view changes cannot relabel an older snapshot boundary.
- Preserves zero producer-view metadata when the independent key is absent, which keeps prefixes written before producer-view fencing readable.
- Fails closed on malformed producer-view values and propagates backend errors through the existing standby poll disposition.
- Removes the obsolete per-object `last_sequence_id` restore check and its test because N02 now uses one global applied OpLog cursor.
- Updates the standby reader and snapshot-capture tests to use the S03 key layout.

This is a compatibility/build fix for the merged HA changes in #3326 and #3384. It does not add a new snapshot protocol or change the producer-view fencing contract. RFC #3167 remains the design reference.

The open N03 artifact-writer work in #3447 is separate: it consumes the capture object, while this patch repairs the capture object's existing producer-view source and the stale restore consumer before that work is rebased.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B /tmp/mooncake-ha-build -G Ninja \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF \
  -DWITH_TE=OFF \
  -DWITH_STORE_RUST=OFF \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo

cmake --build /tmp/mooncake-ha-build \
  --target mooncake_store \
  oplog_batch_standby_reader_test \
  hot_standby_service_test \
  master_service_ha_test -j32

LSAN_OPTIONS=detect_leaks=0 \
  /tmp/mooncake-ha-build/mooncake-store/tests/oplog_batch_standby_reader_test

clang-format-20 --dry-run --Werror \
  mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h \
  mooncake-store/include/ha/oplog/oplog_batch_storage.h \
  mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp \
  mooncake-store/src/hot_standby_service.cpp \
  mooncake-store/src/master_service.cpp \
  mooncake-store/tests/ha/master_service_ha_test.cpp \
  mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp \
  mooncake-store/tests/ha/standby/hot_standby_service_test.cpp

pre-commit run --files <all changed files>
```

**Test results:**

- [x] `mooncake_store` and the three HA test targets compile successfully with `-j32`.
- [x] `oplog_batch_standby_reader_test`: 23/23 passed, including detached producer-view lookup, malformed values, missing-key compatibility, and applied-prefix/view pairing.
- [x] `master_service_ha_test`: the 9 restore-focused tests pass.
- [x] clang-format check passed.
- [x] Pre-commit 4.6.0 passed on all changed files.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using clang-format 20 and the repository's C/C++ pre-commit hook
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: this restores internal HA build/runtime compatibility)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex helped review the HA data-layout change, implement the compatibility fix, update tests, and run verification.
