### PR TITLE
[TENT] Route RDMA slices by QP pool

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -175,6 +175,11 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index,
                      const std::function<void(RdmaSlice*)>& on_post = {});
 
+    int selectQpOwnerWorker(const std::string& qp_pool, int candidate,
+                            size_t num_workers);
+
+    bool qpPoolRoutingEnabled();
+
     int submitRecvImmDataRequest(int qp_index, uint64_t id);
 
     // Pop `slice` and every slice queued before it on the same QP, giving
@@ -196,10 +201,6 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     int setupOneQP(int qp_index, const std::string& peer_gid, uint16_t peer_lid,
                    uint32_t peer_qp_num, int local_gid_index,
                    std::string* reply_msg = nullptr);
-
-    // Returns the pool segment owning qp_index, or nullptr when no pools are
-    // configured (the default single-pool case). Read-only after construct().
-    const QpPoolSegment* poolForQp(int qp_index) const;
 
     bool reserveQuota(int qp_index, int num_entries);
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/params.h
@@ -94,6 +94,15 @@ struct QpPoolLayout {
     bool valid = false;  // false = invalid config (non-positive total).
 };
 
+struct QpLinkLayerQos {
+    uint8_t service_level = 0;
+    uint8_t traffic_class = 0;
+};
+
+inline bool isValidQpPoolQosValue(int value, int max_value) {
+    return value == -1 || (value >= 0 && value <= max_value);
+}
+
 // Pure resolver used by RdmaEndPoint::construct(). Kept free-standing (no RDMA
 // handles) so the layout math can be unit-tested. Empty `pools` reproduces the
 // historical single homogeneous run of `qp_mul_factor` data QPs (segments left
@@ -124,6 +133,28 @@ inline QpPoolLayout computeQpPoolSegments(
     }
     layout.valid = layout.total_qp > 0;
     return layout;
+}
+
+inline const QpPoolSegment* findQpPoolSegment(
+    const std::vector<QpPoolSegment>& segments, int qp_index) {
+    for (const auto& seg : segments) {
+        if (qp_index >= seg.begin && qp_index < seg.begin + seg.num_qp)
+            return &seg;
+    }
+    return nullptr;
+}
+
+inline QpLinkLayerQos resolveQpLinkLayerQos(
+    const std::vector<QpPoolSegment>& segments, int qp_index,
+    uint8_t default_service_level, uint8_t default_traffic_class) {
+    const QpPoolSegment* pool = findQpPoolSegment(segments, qp_index);
+    return QpLinkLayerQos{
+        (pool && pool->service_level >= 0)
+            ? static_cast<uint8_t>(pool->service_level)
+            : default_service_level,
+        (pool && pool->traffic_class >= 0)
+            ? static_cast<uint8_t>(pool->traffic_class)
+            : default_traffic_class};
 }
 
 // Pure QP router used by RdmaEndPoint::submitSlices (RFC #2568 step 3). Given

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/qp_pool_routing.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/qp_pool_routing.h
@@ -1,0 +1,98 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_QP_POOL_ROUTING_H
+#define TENT_QP_POOL_ROUTING_H
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "params.h"
+#include "slice.h"
+
+namespace mooncake {
+namespace tent {
+
+struct QpPoolRoute {
+    int qp_index = -1;
+    int worker_id = -1;
+};
+
+struct QpPoolSliceGroup {
+    std::string pool;
+    std::vector<RdmaSlice*> slices;
+};
+
+inline std::string rdmaSliceQpPoolName(const RdmaSlice* slice) {
+    return (slice && slice->task) ? slice->task->qp_pool : std::string();
+}
+
+inline int ownerWorkerForQpIndex(int qp_index, size_t num_workers,
+                                 int fallback_worker) {
+    if (qp_index < 0 || num_workers == 0) return fallback_worker;
+    return qp_index % static_cast<int>(num_workers);
+}
+
+inline QpPoolRoute selectQpPoolRoute(
+    const std::vector<QpPoolSegment>& segments, const std::string& qp_pool,
+    int candidate, int total_qp, size_t num_workers, int fallback_worker) {
+    if (total_qp <= 0) return QpPoolRoute{-1, fallback_worker};
+    if (candidate < 0) candidate = 0;
+    const int qp_index = selectQpInPool(segments, qp_pool, candidate, total_qp);
+    if (num_workers == 0) return QpPoolRoute{qp_index, fallback_worker};
+
+    const auto stable_route = [&](int worker_id) -> QpPoolRoute {
+        int routed_qp = selectQpInPool(segments, qp_pool, worker_id, total_qp);
+        int owner = ownerWorkerForQpIndex(routed_qp, num_workers,
+                                          fallback_worker);
+        return QpPoolRoute{routed_qp, owner == worker_id ? worker_id : -1};
+    };
+
+    int owner = ownerWorkerForQpIndex(qp_index, num_workers, fallback_worker);
+    if (owner >= 0 && owner < static_cast<int>(num_workers)) {
+        auto route = stable_route(owner);
+        if (route.worker_id == owner) return route;
+    }
+
+    for (size_t offset = 0; offset < num_workers; ++offset) {
+        int worker_id = static_cast<int>(
+            (static_cast<size_t>(candidate) + offset) % num_workers);
+        auto route = stable_route(worker_id);
+        if (route.worker_id == worker_id) return route;
+    }
+    return QpPoolRoute{qp_index, fallback_worker};
+}
+
+inline std::vector<QpPoolSliceGroup> groupSlicesByQpPool(
+    const std::vector<RdmaSlice*>& slices) {
+    std::vector<QpPoolSliceGroup> groups;
+    std::unordered_map<std::string, size_t> index_by_pool;
+
+    for (auto* slice : slices) {
+        auto pool = rdmaSliceQpPoolName(slice);
+        auto [it, inserted] = index_by_pool.emplace(pool, groups.size());
+        if (inserted) {
+            groups.push_back(QpPoolSliceGroup{pool, {}});
+        }
+        groups[it->second].slices.push_back(slice);
+    }
+    return groups;
+}
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_QP_POOL_ROUTING_H

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -35,6 +35,7 @@
 #include "tent/thirdparty/nlohmann/json.h"
 #include "tent/transport/rdma/context.h"
 #include "tent/transport/rdma/endpoint_store.h"
+#include "tent/transport/rdma/qp_pool_routing.h"
 
 namespace mooncake {
 namespace tent {
@@ -708,12 +709,19 @@ int RdmaEndPoint::resetConnection(const std::string& reason) {
     return 0;
 }
 
-const QpPoolSegment* RdmaEndPoint::poolForQp(int qp_index) const {
-    for (const auto& seg : qp_pool_segments_) {
-        if (qp_index >= seg.begin && qp_index < seg.begin + seg.num_qp)
-            return &seg;
-    }
-    return nullptr;
+int RdmaEndPoint::selectQpOwnerWorker(const std::string& qp_pool,
+                                      int candidate, size_t num_workers) {
+    RWSpinlock::ReadGuard guard(lock_);
+    if (qp_list_.empty()) return candidate;
+    return selectQpPoolRoute(qp_pool_segments_, qp_pool, candidate,
+                             static_cast<int>(qp_list_.size()), num_workers,
+                             candidate)
+        .worker_id;
+}
+
+bool RdmaEndPoint::qpPoolRoutingEnabled() {
+    RWSpinlock::ReadGuard guard(lock_);
+    return !qp_pool_segments_.empty();
 }
 
 int RdmaEndPoint::setupAllQPs(const std::string& peer_gid, uint16_t peer_lid,
@@ -947,15 +955,9 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
     // Resolve link-layer QoS for this QP. When it belongs to a pool that
     // overrides SL/TC, use the pool's values; otherwise fall back to the global
     // endpoint SL/TC (unchanged default behavior).
-    const QpPoolSegment* pool = poolForQp(qp_index);
-    const uint8_t qp_service_level =
-        (pool && pool->service_level >= 0)
-            ? static_cast<uint8_t>(pool->service_level)
-            : params_->service_level;
-    const uint8_t qp_traffic_class =
-        (pool && pool->traffic_class >= 0)
-            ? static_cast<uint8_t>(pool->traffic_class)
-            : params_->traffic_class;
+    const auto qos = resolveQpLinkLayerQos(
+        qp_pool_segments_, qp_index, params_->service_level,
+        params_->traffic_class);
 
     // RESET -> INIT
     ibv_qp_attr attr;
@@ -996,9 +998,9 @@ int RdmaEndPoint::setupOneQP(int qp_index, const std::string& peer_gid,
     attr.ah_attr.grh.sgid_index = local_gid_index;
     attr.ah_attr.grh.hop_limit = params_->hop_limit;
     attr.ah_attr.grh.flow_label = params_->flow_label;
-    attr.ah_attr.grh.traffic_class = qp_traffic_class;
+    attr.ah_attr.grh.traffic_class = qos.traffic_class;
     attr.ah_attr.dlid = peer_lid;
-    attr.ah_attr.sl = qp_service_level;
+    attr.ah_attr.sl = qos.service_level;
     attr.ah_attr.src_path_bits = params_->src_path_bits;
     attr.ah_attr.static_rate = params_->static_rate;
     attr.ah_attr.is_global = 1;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -224,6 +224,18 @@ static Status convertConfToRdmaParams(std::shared_ptr<Config> conf,
         }
         seg.service_level = pool_json.value("service_level", -1);
         seg.traffic_class = pool_json.value("traffic_class", -1);
+        auto validate_qos = [&](int value, int max_value,
+                                const char* field) -> Status {
+            if (isValidQpPoolQosValue(value, max_value)) return Status::OK();
+            std::stringstream ss;
+            ss << "Invalid RDMA qp_pool '" << seg.name << "' " << field << "="
+               << value << ", expected -1 or 0.." << max_value;
+            return Status::InvalidArgument(ss.str() + LOC_MARK);
+        };
+        status = validate_qos(seg.service_level, 15, "service_level");
+        if (!status.ok()) return status;
+        status = validate_qos(seg.traffic_class, 255, "traffic_class");
+        if (!status.ok()) return status;
         params->endpoint.qp_pools.push_back(std::move(seg));
     }
     if (!params->endpoint.qp_pools.empty()) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -26,10 +26,12 @@
 #include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_set>
 
 #include "tent/transport/rdma/bw_arbitration.h"
 #include "tent/transport/rdma/endpoint_store.h"
 #include "tent/transport/rdma/promotion_policy.h"
+#include "tent/transport/rdma/qp_pool_routing.h"
 #include "tent/transport/rdma/shared_quota.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/string_builder.h"
@@ -379,6 +381,7 @@ void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
     if (slice && slice->task) {
         priority = slice->priority;
     }
+    bool wake_worker = false;
     // This lane's queue and counter are about to account for the slice, so
     // move the count here before it is visible on the queue. With a shared
     // queue pair the lane re-queueing the slice is the one that polled the
@@ -393,14 +396,20 @@ void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
             slice->counted_lane.exchange(lane, std::memory_order_acq_rel);
         if (prev >= 0 && prev != lane && prev < (int)num_workers_)
             worker_context_[prev].inflight_slices.fetch_sub(1);
-        if (prev != lane) worker.inflight_slices.fetch_add(1);
+        if (prev != lane) wake_worker = !worker.inflight_slices.fetch_add(1);
     }
     // The worker must never block on its own queue (issue #3637): a full
-    // queue parks the slice in requeue_overflow and the next tick retries.
-    // Either way it stays counted as inflight, which keeps the worker from
-    // suspending while a parked flush is pending.
-    if (!worker.queues[priority].try_push(slice_list)) {
+    // local queue parks the slice in requeue_overflow and the next tick
+    // retries. A different worker is reached through the MPSC producer path
+    // and must not touch that worker's local overflow vector.
+    if (laneIndex(worker) != tl_wid) {
+        worker.queues[priority].push(slice_list);
+    } else if (!worker.queues[priority].try_push(slice_list)) {
         worker.requeue_overflow.emplace_back(priority, slice_list);
+    }
+    if (wake_worker) {
+        std::lock_guard<std::mutex> lock(worker.mutex);
+        if (worker.in_suspend) worker.cv.notify_all();
     }
 }
 
@@ -785,18 +794,8 @@ void Workers::asyncPostSend() {
                             getCurrentTimeInNano());
         }
 
-        // Everything a completion's poller must find is written before the
-        // work request can reach the wire: with a shared queue pair another
-        // lane may poll the completion before submitSlices returns, and a
-        // poller that finds no posted device on the slice would leave the
-        // device's backlog holding these bytes for good.
-        const uint64_t post_ts = getCurrentTimeInNano();
-        int num_submitted = endpoint->submitSlices(
-            slices, tl_wid,
-            [&](RdmaSlice* posted) { markPosted(worker, posted, post_ts); });
-        for (int id = 0; id < num_submitted; ++id) {
-            auto slice = slices[id];
-            if (!slice->failed) continue;
+        auto handle_rejected = [&](RdmaSlice* slice, uint64_t post_ts) {
+            if (!slice->failed) return;
             // Rejected by the hardware: it never went on the wire, so take
             // back what the hook put in place.
             worker.inflight_slice_set.erase(slice);
@@ -804,7 +803,7 @@ void Workers::asyncPostSend() {
             if (slice->task->cancel_requested.load(std::memory_order_acquire)) {
                 updateSliceStatus(slice, CANCELED);
                 discountFromOwner(worker, slice);
-                continue;
+                return;
             }
             slice->retry_count++;
             if (slice->retry_count >=
@@ -817,10 +816,67 @@ void Workers::asyncPostSend() {
             } else {
                 submitFromTick(worker, slice);
             }
+        };
+
+        const bool qp_pool_routing = endpoint->qpPoolRoutingEnabled();
+        if (qp_pool_routing) {
+            std::vector<RdmaSlice*> retained;
+            retained.reserve(slices.size());
+            for (auto* slice : slices) {
+                const int owner = endpoint->selectQpOwnerWorker(
+                    rdmaSliceQpPoolName(slice), tl_wid, num_workers_);
+                if (owner >= 0 && owner < static_cast<int>(num_workers_) &&
+                    owner != tl_wid) {
+                    submitFromTick(worker_context_[owner], slice);
+                } else {
+                    retained.push_back(slice);
+                }
+            }
+            slices.swap(retained);
+            if (slices.empty()) continue;
         }
 
-        if (num_submitted) {
-            slices.erase(slices.begin(), slices.begin() + num_submitted);
+        // Everything a completion's poller must find is written before the
+        // work request can reach the wire: with a shared queue pair another
+        // lane may poll the completion before submitSlices returns, and a
+        // poller that finds no posted device on the slice would leave the
+        // device's backlog holding these bytes for good.
+        if (!qp_pool_routing) {
+            const uint64_t post_ts = getCurrentTimeInNano();
+            int num_submitted = endpoint->submitSlices(
+                slices, tl_wid, [&](RdmaSlice* posted) {
+                    markPosted(worker, posted, post_ts);
+                });
+            for (int id = 0; id < num_submitted; ++id) {
+                handle_rejected(slices[id], post_ts);
+            }
+
+            if (num_submitted) {
+                slices.erase(slices.begin(), slices.begin() + num_submitted);
+            }
+            continue;
+        }
+
+        std::unordered_set<RdmaSlice*> submitted;
+        auto groups = groupSlicesByQpPool(slices);
+        for (auto& group : groups) {
+            const uint64_t post_ts = getCurrentTimeInNano();
+            int num_submitted = endpoint->submitSlices(
+                group.slices, tl_wid, [&](RdmaSlice* posted) {
+                    markPosted(worker, posted, post_ts);
+                });
+            for (int id = 0; id < num_submitted; ++id) {
+                auto* slice = group.slices[id];
+                handle_rejected(slice, post_ts);
+                submitted.insert(slice);
+            }
+        }
+        if (!submitted.empty()) {
+            slices.erase(std::remove_if(slices.begin(), slices.end(),
+                                        [&](RdmaSlice* slice) {
+                                            return submitted.count(slice) > 0;
+                                        }),
+                         slices.end());
         }
     }
 }

--- a/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/qp_pool_layout_test.cpp
@@ -19,14 +19,16 @@
 #include <gtest/gtest.h>
 
 #include "tent/transport/rdma/params.h"
+#include "tent/transport/rdma/qp_pool_routing.h"
 
 namespace mooncake {
 namespace tent {
 namespace {
 
 // Default path: no pools configured => a single homogeneous run of
-// qp_mul_factor QPs, no explicit segments (poolForQp will return nullptr and
-// callers fall back to the global SL/TC — byte-for-byte the prior behavior).
+// qp_mul_factor QPs, no explicit segments (findQpPoolSegment will return
+// nullptr and callers fall back to the global SL/TC — byte-for-byte the prior
+// behavior).
 TEST(QpPoolLayoutTest, EmptyPoolsKeepsFlatQpMulFactor) {
     auto layout = computeQpPoolSegments({}, 6);
     EXPECT_TRUE(layout.valid);
@@ -77,7 +79,7 @@ TEST(QpPoolLayoutTest, MultiplePoolsLayoutContiguousSegments) {
 }
 
 // Segments partition [0, total_qp): every QP index maps to exactly one pool,
-// mirroring RdmaEndPoint::poolForQp's linear scan.
+// mirroring findQpPoolSegment's linear scan.
 TEST(QpPoolLayoutTest, SegmentsPartitionAllQpIndices) {
     std::vector<QpPoolSegment> pools;
     QpPoolSegment a;
@@ -105,8 +107,69 @@ TEST(QpPoolLayoutTest, SegmentsPartitionAllQpIndices) {
     EXPECT_EQ(pool_of(2)->name, "a");
     ASSERT_NE(pool_of(3), nullptr);
     EXPECT_EQ(pool_of(3)->name, "b");
-    // Out of range => no pool (default single-pool fallback in poolForQp).
+    // Out of range => no pool (default single-pool fallback in QoS resolver).
     EXPECT_EQ(pool_of(4), nullptr);
+}
+
+TEST(QpPoolLayoutTest, PerPoolLinkLayerQosOverridesDefaults) {
+    auto layout = computeQpPoolSegments(
+        {{"latency", 2, 0, 3, 96}, {"bulk", 2, 0, 7, 128}}, 4);
+    ASSERT_TRUE(layout.valid);
+
+    auto latency0 = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/0, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(latency0.service_level, 3);
+    EXPECT_EQ(latency0.traffic_class, 96);
+
+    auto latency1 = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/1, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(latency1.service_level, 3);
+    EXPECT_EQ(latency1.traffic_class, 96);
+
+    auto bulk0 = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/2, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(bulk0.service_level, 7);
+    EXPECT_EQ(bulk0.traffic_class, 128);
+
+    auto bulk1 = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/3, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(bulk1.service_level, 7);
+    EXPECT_EQ(bulk1.traffic_class, 128);
+}
+
+TEST(QpPoolLayoutTest, MissingPoolQosFieldsFallBackIndependently) {
+    auto layout = computeQpPoolSegments(
+        {{"sl-only", 1, 0, 5, -1}, {"tc-only", 1, 0, -1, 144}}, 2);
+    ASSERT_TRUE(layout.valid);
+
+    auto sl_only = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/0, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(sl_only.service_level, 5);
+    EXPECT_EQ(sl_only.traffic_class, 2);
+
+    auto tc_only = resolveQpLinkLayerQos(
+        layout.segments, /*qp_index=*/1, /*default_service_level=*/1,
+        /*default_traffic_class=*/2);
+    EXPECT_EQ(tc_only.service_level, 1);
+    EXPECT_EQ(tc_only.traffic_class, 144);
+}
+
+TEST(QpPoolLayoutTest, QosValuesKeepSentinelAndRangeBounds) {
+    EXPECT_TRUE(isValidQpPoolQosValue(-1, 15));
+    EXPECT_TRUE(isValidQpPoolQosValue(0, 15));
+    EXPECT_TRUE(isValidQpPoolQosValue(15, 15));
+    EXPECT_FALSE(isValidQpPoolQosValue(-2, 15));
+    EXPECT_FALSE(isValidQpPoolQosValue(16, 15));
+
+    EXPECT_TRUE(isValidQpPoolQosValue(-1, 255));
+    EXPECT_TRUE(isValidQpPoolQosValue(0, 255));
+    EXPECT_TRUE(isValidQpPoolQosValue(255, 255));
+    EXPECT_FALSE(isValidQpPoolQosValue(256, 255));
 }
 
 // --- selectQpInPool: the step-3 router (slice pool -> QP index)
@@ -173,6 +236,77 @@ TEST(SelectQpInPoolTest, ResultAlwaysInRange) {
             EXPECT_LT(idx, 6);
         }
     }
+}
+
+TEST(QpPoolWorkerRoutingTest, NamedPoolSelectsOwningWorker) {
+    auto segs = twoPools();  // kv=[0,4), ctrl=[4,6)
+
+    auto ctrl_from_worker0 = selectQpPoolRoute(
+        segs, "ctrl", /*candidate=*/0, /*total_qp=*/6,
+        /*num_workers=*/6, /*fallback_worker=*/0);
+    EXPECT_EQ(ctrl_from_worker0.qp_index, 4);
+    EXPECT_EQ(ctrl_from_worker0.worker_id, 4);
+
+    auto ctrl_from_worker1 = selectQpPoolRoute(
+        segs, "ctrl", /*candidate=*/1, /*total_qp=*/6,
+        /*num_workers=*/6, /*fallback_worker=*/1);
+    EXPECT_EQ(ctrl_from_worker1.qp_index, 5);
+    EXPECT_EQ(ctrl_from_worker1.worker_id, 5);
+
+    auto kv_wrap = selectQpPoolRoute(segs, "kv", /*candidate=*/5,
+                                     /*total_qp=*/6, /*num_workers=*/6,
+                                     /*fallback_worker=*/5);
+    EXPECT_EQ(kv_wrap.qp_index, 1);
+    EXPECT_EQ(kv_wrap.worker_id, 1);
+
+    auto no_workers = selectQpPoolRoute(segs, "ctrl", /*candidate=*/0,
+                                        /*total_qp=*/6, /*num_workers=*/0,
+                                        /*fallback_worker=*/0);
+    EXPECT_EQ(no_workers.qp_index, 4);
+    EXPECT_EQ(no_workers.worker_id, 0);
+}
+
+TEST(QpPoolWorkerRoutingTest, FallsBackWhenNoStableOwnerExists) {
+    auto layout = computeQpPoolSegments({{"misaligned", 4, 0, -1, -1}}, 6);
+    ASSERT_TRUE(layout.valid);
+    layout.segments[0].begin = 1;
+
+    auto route = selectQpPoolRoute(
+        layout.segments, "misaligned", /*candidate=*/5, /*total_qp=*/6,
+        /*num_workers=*/6, /*fallback_worker=*/5);
+
+    EXPECT_EQ(route.qp_index, 2);
+    EXPECT_EQ(route.worker_id, 5);
+}
+
+TEST(QpPoolWorkerRoutingTest, MixedBatchGroupsSlicesByPool) {
+    RdmaTask kv_task{};
+    kv_task.qp_pool = "kv";
+    RdmaTask ctrl_task{};
+    ctrl_task.qp_pool = "ctrl";
+    RdmaTask default_task{};
+
+    RdmaSlice kv0{};
+    kv0.task = &kv_task;
+    RdmaSlice ctrl0{};
+    ctrl0.task = &ctrl_task;
+    RdmaSlice kv1{};
+    kv1.task = &kv_task;
+    RdmaSlice default0{};
+    default0.task = &default_task;
+    RdmaSlice ctrl1{};
+    ctrl1.task = &ctrl_task;
+
+    auto groups =
+        groupSlicesByQpPool({&kv0, &ctrl0, &kv1, &default0, &ctrl1});
+
+    ASSERT_EQ(groups.size(), static_cast<size_t>(3));
+    EXPECT_EQ(groups[0].pool, "kv");
+    EXPECT_EQ(groups[0].slices, (std::vector<RdmaSlice*>{&kv0, &kv1}));
+    EXPECT_EQ(groups[1].pool, "ctrl");
+    EXPECT_EQ(groups[1].slices, (std::vector<RdmaSlice*>{&ctrl0, &ctrl1}));
+    EXPECT_EQ(groups[2].pool, "");
+    EXPECT_EQ(groups[2].slices, (std::vector<RdmaSlice*>{&default0}));
 }
 
 // A pool with a non-positive num_qp would create an empty/negative QP span and


### PR DESCRIPTION
## Description

This PR fixes RDMA QP-pool routing so slices that request different `qp_pool`s are posted to the correct pool-specific QPs and therefore use the intended link-layer QoS parameters.

The change does three things:

1. Resolves per-QP link-layer QoS from the owning QP pool, so different pools can use different `service_level` / `traffic_class` values.
2. Routes slices to the worker that owns the QP selected for their requested pool.
3. Splits mixed-pool batches before `submitSlices()`, so a batch containing multiple `qp_pool`s does not inherit the first slice's pool.

For the traditional/default case where no QP pools are configured, the worker keeps the legacy single-submit path. The only added work on that path is checking whether QP-pool routing is enabled.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check

cmake --build build --target tent_xport_rdma tent_qp_pool_layout_test tent_rdma_transport_test -j$(nproc)

ctest --test-dir build -R 'tent_qp_pool_layout_test|tent_rdma_transport_test' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`tent_qp_pool_layout_test` covers:
- two QP pools with different `service_level` / `traffic_class`
- per-field fallback to endpoint defaults
- routing a named pool to its owning worker
- grouping mixed-pool slices before submit

`tent_rdma_transport_test` passed on a machine with mlx5 RDMA devices.

Note: `pre-commit run --files ...` could not be run because `pre-commit` is not installed in the current environment.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools were used to help isolate the patch, structure the implementation, add focused tests, and run local verification. The human submitter should review and understand every changed line before submitting.