### PR TITLE
[Bugfix][Store] Drop stale per-object last_sequence_id snapshot cursor check

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3043,15 +3043,6 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
                 << tenant_id.value() << ", key=" << user_key;
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
-        if (entry.metadata.last_sequence_id > initial_oplog_sequence_id) {
-            LOG(ERROR) << "RestoreFromStandbySnapshot: object cursor "
-                       << entry.metadata.last_sequence_id
-                       << " exceeds snapshot cursor "
-                       << initial_oplog_sequence_id
-                       << ", tenant=" << tenant_id.value()
-                       << ", key=" << user_key;
-            return tl::make_unexpected(ErrorCode::INVALID_VERSION);
-        }
 
         const auto shard_idx = entry.metadata.group_id.empty()
                                    ? getShardIndex(tenant_id, user_key)

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -983,21 +983,6 @@ TEST_F(MasterServiceHATest, RestoreRejectsDescriptorsBeyondSegmentCapacity) {
     EXPECT_EQ(result.error(), ErrorCode::INVALID_PARAMS);
 }
 
-TEST_F(MasterServiceHATest, RestoreRejectsObjectCursorBeyondSnapshot) {
-    MasterService service(
-        MasterServiceConfig::builder().set_enable_ha(false).build());
-
-    const std::string endpoint = "standby_cursor_segment";
-    auto object = MakeStandbyObject("standby_cursor_key", endpoint);
-    object.metadata.last_sequence_id = 8;
-
-    auto result = service.RestoreFromStandbySnapshot(
-        {object}, 7, {MakeStandbyMemorySegment(endpoint)});
-
-    ASSERT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::INVALID_VERSION);
-}
-
 TEST_F(MasterServiceHATest, RestoreRejectsDfsMode) {
     MasterService service(
         MasterServiceConfig::builder().set_enable_ha(false).build());


### PR DESCRIPTION
## Description

`main` currently fails to compile `mooncake_store` due to a merge-order race between two already-merged PRs:

- **#3354 ([Store] Return explicit standby restore errors)** added a per-object cursor check in `MasterService::RestoreFromStandbySnapshot`: `if (entry.metadata.last_sequence_id > initial_oplog_sequence_id) { ... return INVALID_VERSION; }`.
- **#3326 ([Store] Add bounded standby snapshot capture)** then removed `last_sequence_id` from `StandbyObjectMetadata` (and stopped populating it in `MetadataPayload::ToStandbyMetadata`) as part of bounded snapshot capture.

Each was green on its own branch, but together they leave `master_service.cpp` referencing a field that no longer exists:

```
mooncake-store/src/master_service.cpp:3046: error: 'const struct mooncake::StandbyObjectMetadata' has no member named 'last_sequence_id'
```

This blocks every full-repo build job (build-wheel, tent-ci, ...) on unrelated PRs.

## Fix
remove the now-unsupportable per-object cursor check and its obsolete test `RestoreRejectsObjectCursorBeyondSnapshot`. Re-adding the field is not the right fix — `ToStandbyMetadata` no longer populates it, so it would be a dead always-zero value; and bounded snapshot capture (#3326) already bounds captured objects to the snapshot cursor, so the per-object comparison is redundant by construction. `initial_oplog_sequence_id` is still used elsewhere in the function, so its signature is unchanged.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

Restores `mooncake_store` compilation on `main` (the build break above is gone). Grepped the tree to confirm no other references to the removed `StandbyObjectMetadata::last_sequence_id` remain, and the obsolete test that depended on it was removed.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (build-break fix; CI full-repo build validates)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped bisect the merge-order race between #3354 and #3326 and prepare the minimal fix. The human submitter has reviewed every changed line and can defend the change end-to-end.