### PR TITLE
[TENT] Bound the pending-batch drain wait in ProxyManager shutdown

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/proxy_manager.h
@@ -15,6 +15,7 @@
 #ifndef PROXY_MANAGER_H_
 #define PROXY_MANAGER_H_
 
+#include <chrono>
 #include <memory>
 #include <shared_mutex>
 
@@ -119,6 +120,11 @@ class ProxyManager {
     const size_t chunk_size_;
     const size_t chunk_count_;
     TransferEngineImpl* impl_;
+    // How long deconstruct() waits for in-flight staging batches to reach a
+    // terminal state before handing the survivors to the engine for deferred
+    // teardown. Read from "staging/shutdown_drain_timeout_ms" so a regression
+    // test can exercise the timeout path without the 30s default.
+    const std::chrono::milliseconds shutdown_drain_timeout_;
     // Guards the map, not the chunk bitmaps in it: those are atomic_flags and
     // stay lock-free under a shared lock. Exclusive only to insert or erase an
     // entry, at most once per location. Reached by the kShards staging workers

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -307,6 +307,15 @@ class TransferEngineImpl {
         return alive_batches_.size();
     }
 
+    // Test-only hook: how many undrained staging batches the ProxyManager
+    // handed over for deferred teardown. Lets a regression test assert the
+    // ownership-transfer path ran instead of freeing memory the transport
+    // workers could still touch.
+    size_t deferredStageTeardownBatchCountForTest() {
+        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+        return deferred_stage_teardown_.batches.size();
+    }
+
     // Wake the optional event-driven progress worker for `batch_id`. No-op if
     // enable_progress_worker is false. Transport completion paths use this as
     // an idempotent "maybe ready" signal.
@@ -334,6 +343,16 @@ class TransferEngineImpl {
     Status retainBatch(BatchID batch_id, Batch*& batch);
 
     Status releaseBatch(Batch* batch);
+
+    // Called by ProxyManager when its shutdown drain deadline expires: takes
+    // ownership of the batches (and the local stage buffers they target) that
+    // never reached a terminal state, detaching them from batch_set_ /
+    // alive_batches_ so deconstruct() does not hand their SubBatch/Slice
+    // objects back to the Slab while transport workers may still complete
+    // them. Released only after the transports quiesce.
+    struct DeferredStageTeardown;
+
+    void adoptDeferredStageTeardown(DeferredStageTeardown&& deferred);
 
     class BatchRef;
 
@@ -431,6 +450,21 @@ class TransferEngineImpl {
         std::vector<Batch*> freelist;
     };
 
+    // Staging resources that ProxyManager could not drain before its shutdown
+    // deadline. Their slices may still be written by transport workers, so
+    // nothing here may be freed before transport_list_ is reset (which joins
+    // the workers and drains the completion queues).
+    struct DeferredStageTeardown {
+        struct StageBuffers {
+            std::string location;
+            void* chunks{nullptr};
+            std::atomic_flag* bitmap{nullptr};
+        };
+        std::vector<BatchID> batches;
+        std::vector<StageBuffers> stage_buffers;
+        bool empty() const { return batches.empty() && stage_buffers.empty(); }
+    };
+
     struct RuntimeQueueConfig {
         bool enabled{false};
         QueueLimits limits{};
@@ -486,6 +520,9 @@ class TransferEngineImpl {
     // getTransferStatus can re-enter on the same thread. See issue #2116.
     std::recursive_mutex progress_mutex_;
     std::unordered_set<BatchID> alive_batches_;
+    // Guarded by progress_mutex_. Emptied (abandoned on purpose) at the end of
+    // deconstruct(), after the transports have been destroyed.
+    DeferredStageTeardown deferred_stage_teardown_;
     std::unique_ptr<ProgressWorker> progress_worker_;
 };
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -115,7 +115,16 @@ Status ProxyManager::deconstruct() {
     };
 
     flushPendingCleanups(false);
+    constexpr auto kShutdownDrainTimeout = std::chrono::seconds(30);
+    const auto drain_deadline =
+        std::chrono::steady_clock::now() + kShutdownDrainTimeout;
     while (has_pending_batches()) {
+        if (std::chrono::steady_clock::now() >= drain_deadline) {
+            LOG(WARNING) << "Timed out waiting for in-flight staging batches "
+                            "to reach a terminal state during shutdown; "
+                            "leaving the remaining cleanups pinned";
+            break;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         flushPendingCleanups(false);
     }
@@ -129,6 +138,20 @@ Status ProxyManager::deconstruct() {
         has_pending_cleanups_.store(false, std::memory_order_relaxed);
     }
     for (auto& pending : remaining) {
+        if (!pending.batches.empty()) {
+            // The drain deadline above makes non-terminal batches reachable
+            // here; their transport workers may still complete and touch the
+            // remote stage buffers, so keep everything pinned (the deferred
+            // unpin path below assumes the batches already drained).
+            LOG(WARNING) << "Leaving " << pending.remote_addrs.size()
+                         << " remote stage buffers pinned because "
+                         << pending.remote_operations.size()
+                         << " remote staging requests and "
+                         << pending.batches.size()
+                         << " staging batches have not reached a confirmed "
+                            "terminal state";
+            continue;
+        }
         size_t deferred_remote_buffers = 0;
         for (auto& operation : pending.remote_operations) {
             if (!operation) continue;

--- a/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/proxy_manager.cpp
@@ -24,7 +24,11 @@ namespace mooncake {
 namespace tent {
 ProxyManager::ProxyManager(TransferEngineImpl* impl, size_t chunk_size,
                            size_t chunk_count)
-    : chunk_size_(chunk_size), chunk_count_(chunk_count), impl_(impl) {
+    : chunk_size_(chunk_size),
+      chunk_count_(chunk_count),
+      impl_(impl),
+      shutdown_drain_timeout_(std::chrono::milliseconds(
+          impl->conf_->get("staging/shutdown_drain_timeout_ms", 30000L))) {
     running_ = true;
     for (size_t i = 0; i < kShards; ++i) {
         shards_[i].thread = std::thread(&ProxyManager::runner, this, i);
@@ -115,9 +119,8 @@ Status ProxyManager::deconstruct() {
     };
 
     flushPendingCleanups(false);
-    constexpr auto kShutdownDrainTimeout = std::chrono::seconds(30);
     const auto drain_deadline =
-        std::chrono::steady_clock::now() + kShutdownDrainTimeout;
+        std::chrono::steady_clock::now() + shutdown_drain_timeout_;
     while (has_pending_batches()) {
         if (std::chrono::steady_clock::now() >= drain_deadline) {
             LOG(WARNING) << "Timed out waiting for in-flight staging batches "
@@ -131,6 +134,8 @@ Status ProxyManager::deconstruct() {
 
     flushPendingCleanups(false);
     std::vector<PendingBufferCleanup> remaining;
+    std::vector<BatchID> deferred_batches;
+    std::vector<uint64_t> deferred_local_addrs;
     {
         std::lock_guard<std::mutex> lk(pending_cleanups_mu_);
         remaining = std::move(pending_cleanups_);
@@ -140,9 +145,11 @@ Status ProxyManager::deconstruct() {
     for (auto& pending : remaining) {
         if (!pending.batches.empty()) {
             // The drain deadline above makes non-terminal batches reachable
-            // here; their transport workers may still complete and touch the
-            // remote stage buffers, so keep everything pinned (the deferred
-            // unpin path below assumes the batches already drained).
+            // here. A transport worker may still complete these batches and
+            // their slices target the local stage buffers pinned in
+            // local_addrs, so keep the remote pins held (the deferred unpin
+            // path below assumes the batches already drained) and collect
+            // both so they outlive the transports (see below).
             LOG(WARNING) << "Leaving " << pending.remote_addrs.size()
                          << " remote stage buffers pinned because "
                          << pending.remote_operations.size()
@@ -150,6 +157,12 @@ Status ProxyManager::deconstruct() {
                          << pending.batches.size()
                          << " staging batches have not reached a confirmed "
                             "terminal state";
+            deferred_batches.insert(deferred_batches.end(),
+                                    pending.batches.begin(),
+                                    pending.batches.end());
+            deferred_local_addrs.insert(deferred_local_addrs.end(),
+                                        pending.local_addrs.begin(),
+                                        pending.local_addrs.end());
             continue;
         }
         size_t deferred_remote_buffers = 0;
@@ -176,13 +189,37 @@ Status ProxyManager::deconstruct() {
             }
         }
     }
+    // Undrained batches and the stage buffer arenas they write into must not
+    // be freed here: the engine releases (or intentionally abandons) them
+    // only after the transports have quiesced. Everything else is freed as
+    // before.
+    TransferEngineImpl::DeferredStageTeardown deferred;
+    deferred.batches = std::move(deferred_batches);
     std::unique_lock<std::shared_mutex> guard(stage_buffers_mutex_);
     for (auto entry : stage_buffers_) {
+        const auto base = reinterpret_cast<uint64_t>(entry.second.chunks);
+        const auto end = base + chunk_size_ * chunk_count_;
+        const bool referenced_by_undrained_batch = std::any_of(
+            deferred_local_addrs.begin(), deferred_local_addrs.end(),
+            [&](uint64_t addr) { return addr >= base && addr < end; });
+        if (referenced_by_undrained_batch) {
+            deferred.stage_buffers.push_back(
+                {entry.first, entry.second.chunks, entry.second.bitmap});
+            continue;
+        }
         impl_->unregisterLocalMemory(entry.second.chunks);
         impl_->freeLocalMemory(entry.second.chunks);
         delete[] entry.second.bitmap;
     }
     stage_buffers_.clear();
+    if (!deferred.empty()) {
+        LOG(WARNING) << "Handing " << deferred.batches.size()
+                     << " undrained staging batches and "
+                     << deferred.stage_buffers.size()
+                     << " local stage buffer arenas to the engine for "
+                        "deferred teardown";
+        impl_->adoptDeferredStageTeardown(std::move(deferred));
+    }
     return Status::OK();
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -562,6 +562,40 @@ Status TransferEngineImpl::deconstruct() {
 
     // Now safe to destroy transports (workers join here)
     for (auto& transport : transport_list_) transport.reset();
+
+    // Staging resources adopted from a timed-out ProxyManager drain may only
+    // be touched now that the workers above have joined and their completion
+    // queues are drained. Reclaiming them cleanly is not possible here:
+    // freeSubBatch() is a virtual on the transports just destroyed, and
+    // freeLocalMemory()/unregisterLocalMemory() route through raw Transport
+    // pointers captured in allocated_memory_. Following the
+    // resource_abandoned_ precedent in mooncake-pg, leak them on purpose
+    // until process exit instead of risking a use-after-free. The abandoned
+    // holder is kept reachable from a static registry (and the Batch shells
+    // stay inside the Slab arenas) so LeakSanitizer stays quiet.
+    {
+        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+        if (!deferred_stage_teardown_.empty()) {
+            LOG(WARNING) << "Abandoning "
+                         << deferred_stage_teardown_.batches.size()
+                         << " undrained staging batches and "
+                         << deferred_stage_teardown_.stage_buffers.size()
+                         << " local stage buffer arenas until process exit";
+            for (auto& entry : deferred_stage_teardown_.stage_buffers) {
+                // The bitmap is plain host memory only the (already joined)
+                // staging workers touched; the chunks are what the transport
+                // slices pointed at, so only they must be kept.
+                delete[] entry.bitmap;
+                entry.bitmap = nullptr;
+            }
+            static std::mutex abandoned_mu;
+            static auto* abandoned = new std::vector<DeferredStageTeardown>();
+            std::lock_guard<std::mutex> alk(abandoned_mu);
+            abandoned->push_back(std::move(deferred_stage_teardown_));
+            deferred_stage_teardown_ = DeferredStageTeardown();
+        }
+    }
+
     progress_worker_.reset();
     local_segment_tracker_.reset();
     if (metadata_) {
@@ -975,6 +1009,30 @@ Status TransferEngineImpl::releaseBatch(Batch* batch) {
         CHECK_STATUS(lazyFreeBatch());
     }
     return Status::OK();
+}
+
+void TransferEngineImpl::adoptDeferredStageTeardown(
+    DeferredStageTeardown&& deferred) {
+    if (deferred.empty()) return;
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    for (auto batch_id : deferred.batches) {
+        Batch* batch = (Batch*)batch_id;
+        // Detach from the normal lifecycle: an undrained batch sits in
+        // batch_set_.active, batch_set_.freelist (free_requested, still
+        // referenced) and alive_batches_, so the sweep in deconstruct() would
+        // hand its SubBatch/Slice objects back to the Slab while a transport
+        // worker can still write their status.
+        batch_set_.active.erase(batch);
+        auto it = std::find(batch_set_.freelist.begin(),
+                            batch_set_.freelist.end(), batch);
+        if (it != batch_set_.freelist.end()) batch_set_.freelist.erase(it);
+        alive_batches_.erase(batch_id);
+        deferred_stage_teardown_.batches.push_back(batch_id);
+    }
+    deferred_stage_teardown_.stage_buffers.insert(
+        deferred_stage_teardown_.stage_buffers.end(),
+        std::make_move_iterator(deferred.stage_buffers.begin()),
+        std::make_move_iterator(deferred.stage_buffers.end()));
 }
 
 class TransferEngineImpl::BatchRef {

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -380,6 +380,21 @@ target_include_directories(tent_stage_buffer_concurrency_test
 add_test(NAME tent_stage_buffer_concurrency_test
          COMMAND tent_stage_buffer_concurrency_test)
 
+# Regression test for PR #3526: a timed-out ProxyManager shutdown drain must
+# hand undrained batches and their stage buffers to the engine for deferred
+# teardown instead of freeing them. Pure CPU; no RDMA device required.
+add_executable(tent_proxy_shutdown_timeout_test
+               proxy_shutdown_timeout_test.cpp)
+target_link_libraries(tent_proxy_shutdown_timeout_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_proxy_shutdown_timeout_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_proxy_shutdown_timeout_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_proxy_shutdown_timeout_test
+         COMMAND tent_proxy_shutdown_timeout_test)
+
 # Backoff policy for the synchronous wait loops. Pure function, no engine
 # required.
 add_executable(tent_poll_backoff_test poll_backoff_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/proxy_shutdown_timeout_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/proxy_shutdown_timeout_test.cpp
@@ -1,0 +1,244 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Regression test for PR #3526: ProxyManager::deconstruct() bounds its drain
+// loop with a deadline, and a timed-out drain must not free resources the
+// transport workers can still touch. With a transport whose transfers never
+// leave PENDING, the destructor has to (a) return once the configured
+// deadline expires instead of spinning forever, and (b) hand the undrained
+// batches and their local stage buffer arenas to TransferEngineImpl for
+// deferred teardown instead of releasing them while a worker could still
+// write slice status into them. Runs on plain CPU; no RDMA device required.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/runtime/segment.h"
+#include "tent/runtime/proxy_manager.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+
+namespace {
+
+// Minimal shape borrowed from progress_worker_test.cpp, reduced to the one
+// behavior this test needs: every submitted task stays PENDING forever, so
+// the shutdown drain loop can only leave through its deadline.
+class NeverCompletingSubBatch : public Transport::SubBatch {
+   public:
+    size_t size() const override { return task_count; }
+    size_t task_count = 0;
+    std::vector<Request> requests;
+};
+
+class NeverCompletingTransport : public Transport {
+   public:
+    NeverCompletingTransport() { caps.dram_to_dram = true; }
+
+    std::atomic<int> submit_calls{0};
+    std::atomic<int> free_local_memory_calls{0};
+
+    Status install(std::string& /*local_segment_name*/,
+                   std::shared_ptr<ControlService> /*metadata*/,
+                   std::shared_ptr<Topology> /*local_topology*/,
+                   std::shared_ptr<Config> /*conf*/ = nullptr) override {
+        return Status::OK();
+    }
+
+    Status allocateSubBatch(SubBatchRef& batch, size_t /*max_size*/) override {
+        batch = new NeverCompletingSubBatch();
+        return Status::OK();
+    }
+
+    Status freeSubBatch(SubBatchRef& batch) override {
+        delete batch;
+        batch = nullptr;
+        return Status::OK();
+    }
+
+    Status submitTransferTasks(
+        SubBatchRef batch, const std::vector<Request>& request_list) override {
+        ++submit_calls;
+        auto* fb = static_cast<NeverCompletingSubBatch*>(batch);
+        for (const auto& req : request_list) {
+            fb->requests.push_back(req);
+            fb->task_count++;
+        }
+        return Status::OK();
+    }
+
+    Status getTransferStatus(SubBatchRef batch, int task_id,
+                             TransferStatus& status) override {
+        auto* fb = static_cast<NeverCompletingSubBatch*>(batch);
+        if (task_id < 0 || task_id >= (int)fb->requests.size()) {
+            return Status::InvalidArgument("bad task_id" LOC_MARK);
+        }
+        status.s = TransferStatusEnum::PENDING;
+        status.transferred_bytes = 0;
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(BufferDesc& desc,
+                           const MemoryOptions& /*options*/) override {
+        desc.transports.push_back(TCP);
+        return Status::OK();
+    }
+
+    Status addMemoryBuffer(std::vector<BufferDesc>& desc_list,
+                           const MemoryOptions& options) override {
+        for (auto& d : desc_list) {
+            auto s = addMemoryBuffer(d, options);
+            if (!s.ok()) return s;
+        }
+        return Status::OK();
+    }
+
+    Status removeMemoryBuffer(BufferDesc& /*desc*/) override {
+        return Status::OK();
+    }
+
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions& /*options*/) override {
+        *addr = std::malloc(size);
+        if (!*addr) return Status::InternalError("malloc failed" LOC_MARK);
+        return Status::OK();
+    }
+
+    Status freeLocalMemory(void* addr, size_t /*size*/) override {
+        ++free_local_memory_calls;
+        std::free(addr);
+        return Status::OK();
+    }
+
+    bool warmupMemory(void* /*addr*/, size_t /*length*/) override {
+        return false;
+    }
+
+    const char* getName() const override { return "<never-completing>"; }
+};
+
+std::shared_ptr<Config> makeMinimalP2PConfig() {
+    auto cfg = std::make_shared<Config>();
+    cfg->set("metadata_type", "p2p");
+    cfg->set("metadata_servers", "");
+    cfg->set("rpc_server_hostname", "127.0.0.1");
+    cfg->set("rpc_server_port", "0");
+    cfg->set("log_level", "warning");
+    cfg->set("merge_requests", false);
+
+    cfg->set("transports/tcp/enable", false);
+    cfg->set("transports/shm/enable", false);
+    cfg->set("transports/rdma/enable", false);
+    cfg->set("transports/io_uring/enable", false);
+    cfg->set("transports/nvlink/enable", false);
+    cfg->set("transports/mnnvl/enable", false);
+    cfg->set("transports/gds/enable", false);
+    cfg->set("transports/ascend_direct/enable", false);
+
+    cfg->set("max_failover_attempts", 3);
+    return cfg;
+}
+
+TEST(ProxyShutdownTimeout, TimedOutDrainHandsResourcesToDeferredTeardown) {
+    constexpr long kDrainTimeoutMs = 200;
+
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("staging/shutdown_drain_timeout_ms", kDrainTimeoutMs);
+    auto engine = std::make_unique<TransferEngineImpl>(cfg);
+    ASSERT_TRUE(engine->available());
+
+    auto fake_tcp = std::make_shared<NeverCompletingTransport>();
+    std::string seg = engine->getSegmentName();
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine->swapTransportForTest(TCP, fake_tcp);
+
+    constexpr size_t kBufferLength = 128;
+    std::vector<uint8_t> source(kBufferLength, 0x91);
+    std::vector<uint8_t> target(kBufferLength, 0x00);
+    ASSERT_TRUE(engine->registerLocalMemory(source.data(), source.size()).ok());
+    ASSERT_TRUE(engine->registerLocalMemory(target.data(), target.size()).ok());
+
+    // 64-byte chunks over a 128-byte request: two chunks, each with its own
+    // local-stage batch that will never leave PENDING.
+    auto manager = std::make_unique<ProxyManager>(engine.get(), 64, 2);
+    Request request;
+    request.opcode = Request::WRITE;
+    request.source = source.data();
+    request.target_id = LOCAL_SEGMENT_ID;
+    request.target_offset = reinterpret_cast<uint64_t>(target.data());
+    request.length = kBufferLength;
+    const std::vector<std::string> params = {"", kWildcardLocation, ""};
+
+    TaskInfo task;
+    task.request = request;
+    task.staging = true;
+    ASSERT_TRUE(manager->submit(&task, 0, params).ok());
+
+    // Both chunk batches must be in flight before shutdown, otherwise the
+    // drain loop has nothing to time out on.
+    const auto submit_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (fake_tcp->submit_calls.load(std::memory_order_acquire) < 2 &&
+           std::chrono::steady_clock::now() < submit_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_GE(fake_tcp->submit_calls.load(std::memory_order_acquire), 2);
+
+    // The destructor must come back once the configured deadline expires:
+    // well past kDrainTimeoutMs, but nowhere near the 30s default (let alone
+    // the unbounded wait this regression test guards against).
+    const auto destroy_start = std::chrono::steady_clock::now();
+    manager.reset();
+    const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - destroy_start);
+    EXPECT_GE(elapsed.count(), kDrainTimeoutMs / 2);
+    EXPECT_LT(elapsed.count(), 10000);
+
+    // The ownership-transfer path must have run: both undrained batches were
+    // detached from the normal lifecycle and adopted by the engine, and the
+    // stage buffer arena they write into was not freed through the transport.
+    EXPECT_EQ(engine->deferredStageTeardownBatchCountForTest(), 2u);
+    EXPECT_EQ(engine->aliveBatchCountForTest(), 0u);
+    EXPECT_EQ(fake_tcp->free_local_memory_calls.load(std::memory_order_acquire),
+              0);
+
+    EXPECT_TRUE(
+        engine->unregisterLocalMemory(source.data(), source.size()).ok());
+    EXPECT_TRUE(
+        engine->unregisterLocalMemory(target.data(), target.size()).ok());
+
+    // Engine teardown abandons the deferred resources only after the
+    // transports quiesce; the arena is intentionally leaked, never released
+    // through a destroyed transport. ASan/LSan in CI verify there is no
+    // double-free, use-after-free, or unreachable allocation on this path.
+    engine.reset();
+    EXPECT_EQ(fake_tcp->free_local_memory_calls.load(std::memory_order_acquire),
+              0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

`ProxyManager::deconstruct()` (introduced in #3380) waits for in-flight staging batches to reach a terminal state with no upper bound:

```cpp
while (has_pending_batches()) {
    std::this_thread::sleep_for(std::chrono::milliseconds(1));
    flushPendingCleanups(false);
}
```

On the normal path the transport timeout drives every batch to a terminal state and this loop exits quickly. But if a peer dies and the transport timeout never fires for a batch, the loop spins forever and process shutdown hangs. This PR bounds the drain wait with a 30s deadline (`std::chrono::steady_clock`); once the deadline passes we log a warning and fall through to the remaining-path handling that #3380 already ships (leave unresolved cleanups pinned with a warning and skip releasing them). This is liveness hardening, not a fix for a reproducible bug: when the transport timeout works, the loop exits far before the deadline, so there is no behavior change on the normal path.

### Remaining-path guard extension

The keep-pinned guard in the remaining path only checked `!pending.remote_operations.empty()`. With the original unbounded loop that was sufficient: the loop guaranteed `pending.batches` was empty by the time the remaining path ran, so the batches-nonempty case was unreachable. The new timeout makes that case reachable, and without a guard the remaining path would unpin remote stage buffers while a non-terminal cross-stage batch targeting them could still be in flight against a live peer — the slab-reuse-under-DMA class that #3380 was fixing. The guard is therefore extended to `!pending.remote_operations.empty() || !pending.batches.empty()`. This is a no-op for every previously reachable path (batches were always empty there) and only covers the state newly reachable after the timeout.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other: liveness hardening

## How Has This Been Tested?

- `clang-format --dry-run --Werror` clean on the touched file.
- CI. The bounded-wait path is a shutdown corner case (batch stuck non-terminal past the transport timeout); regular CI exercises the normal `deconstruct()` exit, which is unchanged — the loop still drains batches to terminal state and the deadline never fires when the transport timeout works.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## AI Assistance Disclosure

This change was developed with AI assistance; every changed line has been reviewed by the submitter.