### PR TITLE
[TENT] Canonicalize AMD GPU location prefix to hip: (keep rocm: as parse alias)

### DIFF
--- a/docs/source/api-reference/cpp/tent.md
+++ b/docs/source/api-reference/cpp/tent.md
@@ -121,6 +121,12 @@ TENT accepts the same classic Transfer Engine priority-matrix JSON format:
 }
 ```
 
+Keys must match discovered location names (`cpu:N`, `cuda:N`, `hip:N` on AMD).
+TENT accepts the legacy AMD prefix `rocm:N` when parsing matrices so existing
+configs keep working — such keys are canonicalized to `hip:N` on load, and
+specifying both `rocm:N` and `hip:N` for the same device is rejected as a
+conflict. Discovery and dumps emit `hip:N`, matching classic TE.
+
 Preferred HCAs map to topology rank 0; available/fallback HCAs map to rank 1.
 
 Configuration priority (highest first):
@@ -593,7 +599,7 @@ using Location = std::string;
 const static std::string kWildcardLocation = "*";
 ```
 
-Location strings identify device affinity: `"cpu:0"`, `"cuda:0"`, `"cuda:1"`, etc. Use `"*"` for automatic detection.
+Location strings identify device affinity: `"cpu:0"`, `"cuda:0"`, `"hip:0"`, etc. Use `"*"` for automatic detection. On AMD GPUs the canonical prefix is `hip:` (same as classic TE). The legacy TENT prefix `rocm:` is still accepted when parsing locations and custom NIC matrices.
 
 ### TransportType
 

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -142,7 +142,7 @@ static int resolveSegTypeParams(const std::string& seg_type,
         }
 #elif defined(USE_HIP)
     } else if (seg_type == "VRAM" || seg_type == "vram") {
-        device_prefix = "rocm";
+        device_prefix = "hip";
         int gpu_count = 0;
         hipGetDeviceCount(&gpu_count);
         start_idx = 0;
@@ -425,7 +425,8 @@ void TENTBenchRunner::pinThread(int thread_id) {
     if (location.type() == "cpu") {
         auto socket_id = location.index();
         bindToSocket(socket_id);
-    } else if (location.type() == "cuda" || location.type() == "rocm") {
+    } else if (location.type() == "cuda" ||
+               isAmdGpuLocationType(location.type())) {
         auto device_id = location.index();
         auto socket_id = getGpuDeviceNumaID(device_id);
         bindToSocket(socket_id);

--- a/mooncake-transfer-engine/tent/include/tent/platform/rocm.h
+++ b/mooncake-transfer-engine/tent/include/tent/platform/rocm.h
@@ -115,7 +115,7 @@ class RocmPlatform : public Platform {
     virtual const std::vector<RangeLocation> getLocation(
         void* start, size_t len, bool skip_prefault = false);
 
-    virtual const std::string type() const { return "rocm"; }
+    virtual const std::string type() const { return kAmdGpuLocationType; }
 
     Status getStreamFromPool(HIPStreamHandle& outHandle,
                              int deviceId = HIPStreamPool::kCurrentDevice);

--- a/mooncake-transfer-engine/tent/include/tent/runtime/amd_location.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/amd_location.h
@@ -1,0 +1,41 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Self-contained AMD GPU location-prefix helpers, shared by the TENT
+// runtime (topology.h) and the out-of-tree rocm device plugin, which
+// cannot pull in the full runtime headers.
+#ifndef TENT_RUNTIME_AMD_LOCATION_H
+#define TENT_RUNTIME_AMD_LOCATION_H
+
+#include <string>
+
+namespace mooncake {
+namespace tent {
+
+// Canonical AMD GPU location type — the component before ':' in location
+// strings such as "hip:0" (no trailing colon in the constant itself).
+// Matches classic TE GPU_PREFIX ("hip:") so location strings and custom NIC
+// matrices can be shared across backends.
+// "rocm" remains a parse-only alias for existing TENT configs.
+inline constexpr const char kAmdGpuLocationType[] = "hip";
+inline constexpr const char kAmdGpuLocationTypeAlias[] = "rocm";
+
+inline bool isAmdGpuLocationType(const std::string& type) {
+    return type == kAmdGpuLocationType || type == kAmdGpuLocationTypeAlias;
+}
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_RUNTIME_AMD_LOCATION_H

--- a/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/topology.h
@@ -31,6 +31,7 @@
 
 #include "tent/common/config.h"
 #include "tent/common/status.h"
+#include "tent/runtime/amd_location.h"
 namespace mooncake {
 namespace tent {
 class Platform;
@@ -158,6 +159,35 @@ class LocationParser {
     std::string type_;
     int index_;
 };
+
+// Canonical AMD GPU location prefix and alias handling live in
+// amd_location.h, shared with the rocm device plugin.
+
+inline std::string makeAmdGpuLocation(int device) {
+    return std::string(kAmdGpuLocationType) + ":" + std::to_string(device);
+}
+
+// Canonicalize the legacy AMD alias: "rocm:N" becomes "hip:N". All other
+// location strings (including malformed ones) are returned unchanged.
+// Applied where names enter or leave topology storage so entries stored
+// under a legacy matrix key remain reachable via canonical names.
+inline std::string canonicalizeLocation(const std::string& location) {
+    LocationParser parser(location);
+    if (isAmdGpuLocationType(parser.type()) && parser.index() >= 0) {
+        return makeAmdGpuLocation(parser.index());
+    }
+    return location;
+}
+
+inline Topology::MemType memTypeFromLocation(const std::string& location) {
+    LocationParser parser(location);
+    const auto type = parser.type();
+    if (type == "cpu") return Topology::MEM_HOST;
+    if (type == "cuda" || type == "gpu") return Topology::MEM_CUDA;
+    if (isAmdGpuLocationType(type)) return Topology::MEM_ROCM;
+    if (type == "ascend") return Topology::MEM_ASCEND;
+    return Topology::MEM_UNKNOWN;
+}
 
 struct RangeLocation {
     uint64_t start;

--- a/mooncake-transfer-engine/tent/plugins/rocm/rocm_plugin.cpp
+++ b/mooncake-transfer-engine/tent/plugins/rocm/rocm_plugin.cpp
@@ -13,12 +13,16 @@
 // limitations under the License.
 
 #include "tent/device_plugin.h"
+#include "tent/runtime/amd_location.h"
 
 #include <hip/hip_runtime.h>
 #include <string.h>
 #include <stdio.h>
 #include <string>
 #include <glog/logging.h>
+
+using mooncake::tent::isAmdGpuLocationType;
+using mooncake::tent::kAmdGpuLocationType;
 
 struct rocm_plugin_ctx_t {
     // reserved
@@ -73,7 +77,7 @@ static int rocm_destroy_plugin(void* handle) {
 static int rocm_alloc(void* ctx_, void** pptr, size_t size, const char* loc) {
     (void)ctx_;
     LocationParser location(loc);
-    if (location.type() != "rocm") return -1;
+    if (!isAmdGpuLocationType(location.type())) return -1;
     int hip_dev = 0;
     CHECK_HIP(hipGetDevice(&hip_dev));
     CHECK_HIP(hipSetDevice(location.index()));
@@ -109,7 +113,8 @@ static int rocm_query_location(void* ctx_, void* addr, size_t size,
     if (err != hipSuccess || attr.type != hipMemoryTypeDevice) return 0;
     buf[0].start = addr;
     buf[0].length = size;
-    snprintf(buf[0].location, LOCATION_LEN, "rocm:%d", attr.device);
+    snprintf(buf[0].location, LOCATION_LEN, "%s:%d", kAmdGpuLocationType,
+             attr.device);
     return 1;
 }
 
@@ -133,7 +138,7 @@ static int rocm_get_device_pci_bus_id(void* ctx_, int device_index,
 extern "C" int tent_register_device_plugin(device_plugin_t* out) {
     if (!out) return -1;
     memset(out, 0, sizeof(*out));
-    out->class_name = "rocm";
+    out->class_name = kAmdGpuLocationType;
     out->create_plugin = rocm_create_plugin;
     out->destroy_plugin = rocm_destroy_plugin;
     out->alloc = rocm_alloc;

--- a/mooncake-transfer-engine/tent/src/platform/cpu_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/cpu_allocator.cpp
@@ -22,9 +22,9 @@ namespace mooncake {
 namespace tent {
 Status CpuPlatform::allocate(void** pptr, size_t size, MemoryOptions& options) {
     LocationParser location(options.location);
-    if (location.type() == "cuda") {
+    if (location.type() == "cuda" || isAmdGpuLocationType(location.type())) {
         return Status::NotImplemented(
-            "CUDA not supported in cpu platform" LOC_MARK);
+            "GPU locations are not supported in cpu platform" LOC_MARK);
     }
     int socket_id = 0;
     if (location.type() == "cpu") socket_id = location.index();

--- a/mooncake-transfer-engine/tent/src/platform/rocm/rocm_allocator.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/rocm/rocm_allocator.cpp
@@ -25,7 +25,7 @@ namespace tent {
 Status RocmPlatform::allocate(void** pptr, size_t size,
                               MemoryOptions& options) {
     LocationParser location(options.location);
-    if (location.type() == "rocm") {
+    if (isAmdGpuLocationType(location.type())) {
         int hip_dev = 0;
         CHECK_HIP(hipGetDevice(&hip_dev));
         CHECK_HIP(hipSetDevice(location.index()));

--- a/mooncake-transfer-engine/tent/src/platform/rocm/rocm_probe.cpp
+++ b/mooncake-transfer-engine/tent/src/platform/rocm/rocm_probe.cpp
@@ -194,7 +194,7 @@ static void discoverRocmTopology(std::vector<Topology::NicEntry>& nic_list,
         }
 
         Topology::MemEntry entry;
-        entry.name = "rocm:" + std::to_string(i);
+        entry.name = makeAmdGpuLocation(i);
         entry.numa_node = numa_node;
         entry.pci_bus_id = pci_bus_id;
         entry.type = Topology::MEM_ROCM;
@@ -274,7 +274,7 @@ static inline std::string genCpuNodeName(int node) {
 }
 
 static inline std::string genRocmNodeName(int node) {
-    if (node >= 0) return "rocm:" + std::to_string(node);
+    if (node >= 0) return makeAmdGpuLocation(node);
     return kWildcardLocation;
 }
 

--- a/mooncake-transfer-engine/tent/src/runtime/memory_prober.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/memory_prober.cpp
@@ -93,6 +93,13 @@ Status MemoryProber::loadPlugins(const std::string& path) {
     return Status::OK();
 }
 
+static bool pluginHandlesLocationType(const char* class_name,
+                                      const std::string& type) {
+    if (!class_name) return false;
+    if (class_name == type) return true;
+    return isAmdGpuLocationType(class_name) && isAmdGpuLocationType(type);
+}
+
 void MemoryProber::unloadPlugins() {
     for (auto& p : plugins_) {
         if (p.iface.destroy_plugin && p.ctx) {
@@ -132,7 +139,9 @@ Status MemoryProber::alloc(void** pptr, size_t size, const std::string& loc) {
     }
 
     for (auto& p : plugins_) {
-        if (!(p.iface.class_name == type) || !p.iface.alloc) continue;
+        if (!pluginHandlesLocationType(p.iface.class_name, type) ||
+            !p.iface.alloc)
+            continue;
         int rc = p.iface.alloc(p.ctx, pptr, size, loc.c_str());
         if (rc == 0) {
             std::lock_guard<std::mutex> lock(mu_);
@@ -157,7 +166,9 @@ Status MemoryProber::free(void* ptr, size_t size) {
     }
 
     for (auto& p : plugins_) {
-        if (!(p.iface.class_name == type) || !p.iface.free) continue;
+        if (!pluginHandlesLocationType(p.iface.class_name, type) ||
+            !p.iface.free)
+            continue;
         int rc = p.iface.free(p.ctx, ptr, size);
         if (rc == 0) {
             memory_type_map_.erase(ptr);
@@ -364,7 +375,8 @@ void MemoryProber::probeDeviceMemory(
     MemoryProber::LoadedPlugin& plugin,
     const std::vector<Topology::NicEntry>& nic_list,
     std::vector<Topology::MemEntry>& mem_list) {
-    if (!plugin.iface.get_device_count || !plugin.iface.get_device_pci_bus_id) {
+    if (!plugin.iface.class_name || !plugin.iface.get_device_count ||
+        !plugin.iface.get_device_pci_bus_id) {
         return;
     }
     int device_count = plugin.iface.get_device_count(plugin.ctx);
@@ -386,11 +398,20 @@ void MemoryProber::probeDeviceMemory(
         }
 
         Topology::MemEntry entry;
-        entry.name =
-            std::string(plugin.iface.class_name) + ":" + std::to_string(i);
+        // Canonicalize the AMD alias so legacy plugins registering
+        // class_name "rocm" still emit the canonical "hip:N" names.
+        const bool is_amd = isAmdGpuLocationType(plugin.iface.class_name);
+        entry.name = (is_amd ? std::string(kAmdGpuLocationType)
+                             : std::string(plugin.iface.class_name)) +
+                     ":" + std::to_string(i);
         entry.numa_node = numa_node;
         entry.pci_bus_id = pci_bus_id;
-        entry.type = Topology::MEM_CUDA;
+        entry.type = memTypeFromLocation(entry.name);
+        if (entry.type == Topology::MEM_UNKNOWN) {
+            // Non-AMD device plugins historically defaulted to CUDA-class
+            // memory (e.g. npu). Keep that fallback.
+            entry.type = Topology::MEM_CUDA;
+        }
         if (distance_map.count(0)) {
             // Prefer NICs with distance 0 (e.g. same PCIe switch/RC)
             entry.device_list[0] = std::move(distance_map[0]);

--- a/mooncake-transfer-engine/tent/src/runtime/topology.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/topology.cpp
@@ -237,16 +237,6 @@ Status Topology::parse(const std::string& json_content) {
 
 namespace {
 
-Topology::MemType memTypeFromLocation(const std::string& location) {
-    LocationParser parser(location);
-    const auto type = parser.type();
-    if (type == "cpu") return Topology::MEM_HOST;
-    if (type == "cuda" || type == "gpu") return Topology::MEM_CUDA;
-    if (type == "rocm") return Topology::MEM_ROCM;
-    if (type == "ascend") return Topology::MEM_ASCEND;
-    return Topology::MEM_UNKNOWN;
-}
-
 Topology::NicID ensureNic(
     Topology& topo, const std::string& name,
     std::unordered_map<std::string, Topology::NicID>* ids) {
@@ -281,6 +271,9 @@ Status Topology::parsePriorityMatrix(const std::string& json_content) {
         std::vector<NicID> all_avail;
         std::unordered_set<NicID> seen_preferred;
         std::unordered_set<NicID> seen_avail;
+        // Canonical mem names, to reject configs that specify the same
+        // device twice via the "rocm:N" alias and the canonical "hip:N".
+        std::unordered_set<std::string> seen_mem_names;
 
         for (auto it = root.begin(); it != root.end(); ++it) {
             const auto& value = it.value();
@@ -292,7 +285,15 @@ Status Topology::parsePriorityMatrix(const std::string& json_content) {
             }
 
             MemEntry mem;
-            mem.name = it.key();
+            // Store canonical names: a legacy "rocm:N" key becomes "hip:N"
+            // so runtime lookups with canonical names match.
+            mem.name = canonicalizeLocation(it.key());
+            if (!seen_mem_names.insert(mem.name).second) {
+                return Status::MalformedJson(
+                    "duplicate location key \"" + mem.name +
+                    "\" (the rocm:N alias and hip:N key refer to the same "
+                    "device)" LOC_MARK);
+            }
             mem.pci_bus_id = "";
             mem.type = memTypeFromLocation(mem.name);
             mem.numa_node = -1;
@@ -431,8 +432,9 @@ const Topology::NicEntry* Topology::getNicEntry(const std::string& name) const {
 }
 
 const Topology::MemEntry* Topology::getMemEntry(const std::string& name) const {
+    const auto canonical = canonicalizeLocation(name);
     for (size_t i = 0; i < mem_list_.size(); ++i) {
-        if (mem_list_[i].name == name) return &mem_list_[i];
+        if (mem_list_[i].name == canonical) return &mem_list_[i];
     }
     return nullptr;
 }
@@ -445,8 +447,9 @@ Topology::NicID Topology::getNicId(const std::string& name) const {
 }
 
 Topology::MemID Topology::getMemId(const std::string& name) const {
+    const auto canonical = canonicalizeLocation(name);
     for (size_t i = 0; i < mem_list_.size(); ++i) {
-        if (mem_list_[i].name == name) return (MemID)i;
+        if (mem_list_[i].name == canonical) return (MemID)i;
     }
     return -1;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -954,7 +954,7 @@ static MemoryType getTypeEnum(const std::string& type) {
     if (type == "cpu" || type == "*") return MTYPE_CPU;
     if (type == "cuda") return MTYPE_CUDA;
     if (type == "npu") return MTYPE_CUDA;
-    if (type == "rocm") return MTYPE_ROCM;
+    if (isAmdGpuLocationType(type)) return MTYPE_ROCM;
     if (type == "tpu") return MTYPE_TPU;
     return MTYPE_UNKNOWN;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transport_selector.cpp
@@ -15,6 +15,7 @@
 #include "tent/runtime/transport_selector.h"
 #include "tent/runtime/transport.h"
 #include "tent/runtime/platform.h"
+#include "tent/runtime/topology.h"
 #include "tent/thirdparty/nlohmann/json.h"
 
 #include <algorithm>
@@ -374,8 +375,7 @@ bool TransportSelector::matchesMemoryPattern(const std::string& pattern,
             type_str = kMemoryTypeCuda;
             break;
         case MTYPE_ROCM:
-            type_str = "rocm";
-            break;
+            return isAmdGpuLocationType(pattern);
         case MTYPE_TPU:
             type_str = "tpu";
             break;

--- a/mooncake-transfer-engine/tent/tests/rocm_platform_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rocm_platform_test.cpp
@@ -98,7 +98,9 @@ class RocmPlatformTest : public ::testing::Test {
     std::shared_ptr<RocmPlatform> platform_;
 };
 
-TEST_F(RocmPlatformTest, TypeString) { EXPECT_EQ(platform_->type(), "rocm"); }
+TEST_F(RocmPlatformTest, TypeString) {
+    EXPECT_EQ(platform_->type(), kAmdGpuLocationType);
+}
 
 TEST_F(RocmPlatformTest, ProbeDiscoversMems) {
     std::vector<Topology::NicEntry> nics;
@@ -110,7 +112,7 @@ TEST_F(RocmPlatformTest, ProbeDiscoversMems) {
     for (const auto& m : mems) {
         if (m.type == Topology::MEM_ROCM) {
             found_rocm = true;
-            EXPECT_EQ(m.name.substr(0, 5), "rocm:");
+            EXPECT_EQ(m.name.substr(0, 4), "hip:");
         }
     }
     EXPECT_TRUE(found_rocm) << "probe() found no MEM_ROCM entries";
@@ -118,7 +120,7 @@ TEST_F(RocmPlatformTest, ProbeDiscoversMems) {
 
 TEST_F(RocmPlatformTest, AllocateAndFreeDeviceMemory) {
     MemoryOptions opts;
-    opts.location = "rocm:0";
+    opts.location = "hip:0";
     void* ptr = nullptr;
     constexpr size_t kSize = 1024 * 1024;  // 1 MiB
 
@@ -150,7 +152,7 @@ TEST_F(RocmPlatformTest, AllocateAndFreeCpuMemory) {
 
 TEST_F(RocmPlatformTest, CopyDeviceToDevice) {
     MemoryOptions opts;
-    opts.location = "rocm:0";
+    opts.location = "hip:0";
     constexpr size_t kSize = 256;
     void *src = nullptr, *dst = nullptr;
 
@@ -177,7 +179,7 @@ TEST_F(RocmPlatformTest, CopyDeviceToDevice) {
 
 TEST_F(RocmPlatformTest, CopyHostToDevice) {
     MemoryOptions dev_opts;
-    dev_opts.location = "rocm:0";
+    dev_opts.location = "hip:0";
     MemoryOptions cpu_opts;
     cpu_opts.location = "cpu:0";
     constexpr size_t kSize = 512;
@@ -204,14 +206,28 @@ TEST_F(RocmPlatformTest, CopyHostToDevice) {
 
 TEST_F(RocmPlatformTest, GetLocationDeviceMemory) {
     MemoryOptions opts;
-    opts.location = "rocm:0";
+    opts.location = "hip:0";
     constexpr size_t kSize = 4096;
     void* ptr = nullptr;
 
     ASSERT_TRUE(platform_->allocate(&ptr, kSize, opts).ok());
     auto locs = platform_->getLocation(ptr, kSize);
     ASSERT_FALSE(locs.empty());
-    EXPECT_EQ(locs[0].location, "rocm:0");
+    EXPECT_EQ(locs[0].location, "hip:0");
+    EXPECT_TRUE(platform_->free(ptr, kSize).ok());
+}
+
+TEST_F(RocmPlatformTest, LegacyRocmPrefixStillAllocates) {
+    MemoryOptions opts;
+    opts.location = "rocm:0";
+    constexpr size_t kSize = 4096;
+    void* ptr = nullptr;
+
+    ASSERT_TRUE(platform_->allocate(&ptr, kSize, opts).ok());
+    EXPECT_EQ(platform_->getMemoryType(ptr), MTYPE_ROCM);
+    auto locs = platform_->getLocation(ptr, kSize);
+    ASSERT_FALSE(locs.empty());
+    EXPECT_EQ(locs[0].location, "hip:0");
     EXPECT_TRUE(platform_->free(ptr, kSize).ok());
 }
 
@@ -231,7 +247,7 @@ TEST_F(RocmPlatformTest, AllocateOnSecondGpu) {
     if (getHipDeviceCount() < 2) GTEST_SKIP() << "Requires >= 2 AMD GPUs";
 
     MemoryOptions opts;
-    opts.location = "rocm:1";
+    opts.location = "hip:1";
     void* ptr = nullptr;
     constexpr size_t kSize = 1024;
 

--- a/mooncake-transfer-engine/tent/tests/topology_priority_matrix_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/topology_priority_matrix_test.cpp
@@ -109,6 +109,80 @@ TEST(TopologyPriorityMatrixTest, RejectsMalformedMatrixEntries) {
         topology.parsePriorityMatrix(R"({"cpu:0": [[1], ["mlx5_1"]]})").ok());
 }
 
+TEST(TopologyPriorityMatrixTest, AmdGpuLocationUsesHipPrefixAndRocmAlias) {
+    EXPECT_EQ(memTypeFromLocation("hip:0"), Topology::MEM_ROCM);
+    EXPECT_EQ(memTypeFromLocation("rocm:3"), Topology::MEM_ROCM);
+    EXPECT_EQ(makeAmdGpuLocation(2), "hip:2");
+    EXPECT_TRUE(isAmdGpuLocationType("hip"));
+    EXPECT_TRUE(isAmdGpuLocationType("rocm"));
+    EXPECT_FALSE(isAmdGpuLocationType("cuda"));
+    EXPECT_EQ(canonicalizeLocation("rocm:1"), "hip:1");
+    EXPECT_EQ(canonicalizeLocation("hip:1"), "hip:1");
+    EXPECT_EQ(canonicalizeLocation("cpu:0"), "cpu:0");
+
+    Topology topology;
+    ASSERT_TRUE(topology
+                    .parsePriorityMatrix(R"json({
+          "hip:0": [["mlx5_0"], ["mlx5_1"]],
+          "rocm:1": [["mlx5_1"], ["mlx5_0"]]
+        })json")
+                    .ok());
+
+    const auto* hip0 = topology.getMemEntry("hip:0");
+    ASSERT_NE(hip0, nullptr);
+    EXPECT_EQ(hip0->type, Topology::MEM_ROCM);
+
+    // The legacy "rocm:1" key is stored under its canonical name, and both
+    // the canonical and the legacy name resolve to the same entry.
+    const auto* rocm1 = topology.getMemEntry("rocm:1");
+    ASSERT_NE(rocm1, nullptr);
+    EXPECT_EQ(rocm1->name, "hip:1");
+    EXPECT_EQ(rocm1->type, Topology::MEM_ROCM);
+    EXPECT_EQ(topology.getMemEntry("hip:1"), rocm1);
+}
+
+// Regression test: a matrix configured with only the legacy "rocm:N" key
+// must be reachable via the canonical runtime name, so the configured NIC
+// priorities are not silently ignored by exact-name lookups.
+TEST(TopologyPriorityMatrixTest,
+     LegacyRocmMatrixKeyResolvesViaCanonicalHipName) {
+    Topology topology;
+    ASSERT_TRUE(topology
+                    .parsePriorityMatrix(R"json({
+          "rocm:0": [["mlx5_0"], ["mlx5_1"]]
+        })json")
+                    .ok());
+
+    // Stored under the canonical name only.
+    const auto* hip0 = topology.getMemEntry("hip:0");
+    ASSERT_NE(hip0, nullptr);
+    EXPECT_EQ(hip0->name, "hip:0");
+    EXPECT_EQ(hip0->type, Topology::MEM_ROCM);
+
+    // Exact-id lookups with the canonical name resolve to the entry and
+    // carry the configured per-GPU NIC priorities.
+    const auto mem_id = topology.getMemId("hip:0");
+    EXPECT_GE(mem_id, 0);
+    const auto* by_id = topology.getMemEntry(mem_id);
+    ASSERT_NE(by_id, nullptr);
+    ASSERT_EQ(by_id->device_list[0].size(), 1u);
+    EXPECT_EQ(topology.getNicName(by_id->device_list[0][0]), "mlx5_0");
+    ASSERT_EQ(by_id->device_list[1].size(), 1u);
+    EXPECT_EQ(topology.getNicName(by_id->device_list[1][0]), "mlx5_1");
+}
+
+TEST(TopologyPriorityMatrixTest, RejectsConflictingHipAndRocmKeys) {
+    Topology topology;
+    // "rocm:0" and "hip:0" refer to the same device; specifying both is a
+    // config error rather than a silent last-wins.
+    EXPECT_FALSE(topology
+                     .parsePriorityMatrix(R"json({
+          "hip:0": [["mlx5_0"], ["mlx5_1"]],
+          "rocm:0": [["mlx5_1"], ["mlx5_0"]]
+        })json")
+                     .ok());
+}
+
 TEST(TopologyPriorityMatrixTest, ParseCustomRoutesNativeFormat) {
     constexpr const char* kNative = R"json(
         {


### PR DESCRIPTION
## Description

Implements **Option A** from the RFC discussion in #3386, where
@amd-arozanov endorsed unifying on `hip:`:

> I like the option A. We already use USE_HIP in CMakeFiles for TE and TENT
> and "HIP" naming was initially introduced in TE before TENT. So, renaming
> rocm->hip sounds good to me.
>
> The only question is if we want to continue support "ROCM" as alias

This PR also answers that open question: **yes** — `rocm:` is kept as a
parse-only alias, so existing TENT configs, custom NIC priority matrices
(`MC_CUSTOM_TOPO_JSON`), and app location strings keep working unchanged.
Only discovery output changes (`rocm:N` → `hip:N`), aligning with classic
TE's `GPU_PREFIX` (`include/gpu_vendor/hip.h`).

**Context** (from #3386): on the same AMD/ROCm host, classic TE discovers
`hip:0..7` while TENT discovers `rocm:0..7`, so (1) custom NIC matrices
cannot be shared between backends, (2) app location strings like
`registerLocalMemory(..., "hip:0")` lose affinity under `MC_USE_TENT=1`,
(3) topology dumps look like different machines on identical hardware.

Resolutions for the RFC's reviewer questions:

| RFC question | Resolution |
|---|---|
| Match TE's vendor `GPU_PREFIX` (`hip:`)? | Yes — emit and canonical form is now `hip:` |
| Was `rocm:` intentional or historical? | Historical (HIP naming predates TENT, per review) |
| Deprecation window for `rocm:`? | Not needed — accepted indefinitely as parse-only alias; only emitted names change |
| Accept `hip` in `memTypeFromLocation`? | Yes — both `hip` and `rocm` map to `MEM_ROCM` |

What changed:

- Discovery and dumps now emit `hip:N` (ROCm probe, plugin `query_location`,
  `MemoryProber::probeDeviceMemory`).
- All parse paths accept both prefixes: allocators, plugin dispatch
  (`class_name` matching), `getTypeEnum`, `matchesMemoryPattern`,
  `memTypeFromLocation`.
- Shared helpers live in a new self-contained header
  `tent/runtime/amd_location.h` (`kAmdGpuLocationType`, alias constant,
  `isAmdGpuLocationType`), consumed by both the runtime and the out-of-tree
  rocm device plugin — single source of truth for the prefix.
- Out-of-tree plugins that still register `class_name = "rocm"` continue to
  dispatch correctly (the prober matches either name on both sides).
- Bonus fix: the CPU platform used to silently allocate DRAM on socket 0 for
  `rocm:N` locations; it now rejects all GPU locations with a clear error.
- Docs (`docs/source/api-reference/cpp/tent.md`) and the `tebench` TENT
  backend updated; `MemoryProber::listPlugins` now reports `hip`.

Compatibility notes (user-visible):

- Configs/matrices/apps using `rocm:N` keep working (parse-only alias).
- Anything that string-matches discovery output must switch to `hip:N`.

Closes #3386.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Refactor
- [ ] Breaking change *(parse paths accept both prefixes; only consumers that
      string-match emitted names are affected — flagged in case maintainers
      view that as breaking)*

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja -B build -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON \
      -DBUILD_EXAMPLES=OFF -DUSE_CUDA=OFF -DWITH_STORE=OFF -DCMAKE_BUILD_TYPE=Release
ninja -C build mooncake-transfer-engine/tent/tests/all
ctest --test-dir build/mooncake-transfer-engine/tent/tests -j --output-on-failure
```

**Test results:**
- [x] Unit tests pass — 38/38 host-side tent tests, including the new
      `TopologyPriorityMatrixTest.AmdGpuLocationUsesHipPrefixAndRocmAlias`
      (covers `memTypeFromLocation("hip:0"/"rocm:3")` → `MEM_ROCM`,
      `makeAmdGpuLocation`, mixed `hip:`/`rocm:` matrix keys) and the
      44-case `TransportSelectorTest` (MTYPE_ROCM pattern matching).
- [ ] **Device-side tests NOT run** — `tent_rocm_platform_test` (legacy
      `rocm:0` allocate → `getLocation` returns `hip:0`, probe names, D2D/H2D
      copies) requires an AMD GPU + ROCm toolchain, unavailable on the dev
      host used for this PR. Note `ci_rocm.yml` only builds the wheel and
      does not run it — reviewer with AMD hardware input welcome.
- [x] `rocm_plugin.cpp` syntax-verified against the new shared header with a
      stubbed HIP header (`g++ -fsyntax-only`); runtime compile of the plugin
      itself happens under `USE_HIP=ON` in the ROCm wheel CI.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed a RFC issue — *(149 insertions; RFC #3386 filed anyway)*

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

CodeBuddy (GLM) assisted with implementation review (first-principles /
minimal-change check), the `amd_location.h` deduplication refactor, running
the host-side test suite, and drafting this PR. All changed lines have been
reviewed by the human submitter, who can defend the change end-to-end.