### PR TITLE
[Store] Skip full metadata scan in ReMountSegment when unneeded (#3517)  

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1105,7 +1105,13 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
         bool ambiguous_endpoint = false;
         bool unsupported_cxl = false;
         std::unordered_set<ObjectMetadata*> affected_objects;
-        for (size_t shard_index = 0; shard_index < kNumShards; ++shard_index) {
+        bool any_standby_kept_alive = std::any_of(
+            segments.begin(), segments.end(), [this](const Segment& segment) {
+                return standby_accounted_memory_bytes_.contains(segment.name);
+            });
+        for (size_t shard_index = 0;
+             any_standby_kept_alive && shard_index < kNumShards;
+             ++shard_index) {
             MetadataShardAccessorRW shard(this, shard_index);
             for (auto& [tenant_id, tenant] : shard->tenants) {
                 (void)tenant_id;


### PR DESCRIPTION
## Description

ReMountSegment unconditionally scans all kNumShards metadata shards under
exclusive client_mutex_/snapshot_mutex_ locks to reconcile
DummyBufferAllocator-backed placeholder replicas left over from standby
snapshot restoration. This scan is only meaningful when the segment being
remounted still has unreconciled replicas tracked in
standby_accounted_memory_bytes_ (i.e. it was restored via
RestoreFromStandby after a leader promotion and hasn't been reclaimed by a
real client remount yet).

For segments that never went through standby restoration — most notably a
newly mounted segment during scale-up, whose first ReMountSegment call is
triggered by Ping() returning NEED_REMOUNT right after MountSegment() — the
scan still runs anyway and walks every tenant/key/replica across the full
metadata store while holding locks that PutStart/BatchPutStart also need,
causing them to stall for minutes under load.

This PR guards the scan with `any_standby_kept_alive`, short-circuiting the
loop whenever none of the segments being remounted has an entry in
`standby_accounted_memory_bytes_`. Behavior for the necessary case (post
leader-promotion reconciliation) is unchanged.

Fixes #3517

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other