### PR TITLE
[TENT] Reduce copies in the TCP data path (sendData/onRecvData)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -64,9 +64,9 @@ class CoroRpcAgent {
     using Function = std::function<void(const std::string_view & /* request */,
                                         std::string & /* response */)>;
 
-    // Handlers run on the server io_context thread pool (rpcServerThreads(),
-    // 1 by default), so a blocking one stalls every connection sharing its
-    // thread, not just its own.
+    // Handlers run on the server io_context thread pool (the threads
+    // argument of start(), 1 by default), so a blocking one stalls every
+    // connection sharing its thread, not just its own.
     //
     // offload=false (default): inline, no thread hop. Right for anything that
     // returns promptly.
@@ -77,7 +77,11 @@ class CoroRpcAgent {
     Status registerFunction(int func_id, const Function &func,
                             bool offload = false);
 
-    Status start(uint16_t &port, bool ipv6 = false);
+    // threads: number of io_context worker threads (default 1, the
+    // historical behavior). The TCP data-path handlers do full-payload
+    // blocking copies inline, so a single thread caps TCP throughput;
+    // sourced from the rpc_server_threads config key.
+    Status start(uint16_t &port, bool ipv6 = false, size_t threads = 1);
 
     Status stop();
 
@@ -111,10 +115,6 @@ class CoroRpcAgent {
     std::unordered_map<int, Handler> func_map_;
 
     std::atomic<bool> running_{false};
-    // RPC server worker threads, overridable via MC_TENT_RPC_THREADS
-    // (default 1). The TCP data-path handlers do full-payload blocking
-    // copies inline, so a single thread caps TCP throughput.
-    static size_t rpcServerThreads();
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -88,6 +88,11 @@ class CoroRpcAgent {
     Status call(const std::string &server_addr, int func_id,
                 const std::string_view &request, std::string &response);
 
+    // Same as call(), but moves the request into the coroutine instead of
+    // copying it, for large payloads.
+    Status callOwned(const std::string &server_addr, int func_id,
+                     std::string request, std::string &response);
+
     using AsyncCallback = std::function<void(Status, std::string)>;
     void callAsync(const std::string &server_addr, int func_id,
                    const std::string &request, AsyncCallback callback);

--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -64,8 +64,9 @@ class CoroRpcAgent {
     using Function = std::function<void(const std::string_view & /* request */,
                                         std::string & /* response */)>;
 
-    // Handlers run on the single io_context (kRpcThreads), so a blocking one
-    // stalls every connection, not just its own.
+    // Handlers run on the server io_context thread pool (rpcServerThreads(),
+    // 1 by default), so a blocking one stalls every connection sharing its
+    // thread, not just its own.
     //
     // offload=false (default): inline, no thread hop. Right for anything that
     // returns promptly.
@@ -110,7 +111,10 @@ class CoroRpcAgent {
     std::unordered_map<int, Handler> func_map_;
 
     std::atomic<bool> running_{false};
-    constexpr static size_t kRpcThreads = 1;
+    // RPC server worker threads, overridable via MC_TENT_RPC_THREADS
+    // (default 1). The TCP data-path handlers do full-payload blocking
+    // copies inline, so a single thread caps TCP throughput.
+    static size_t rpcServerThreads();
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -133,7 +133,7 @@ class ControlService {
 
     void setNotifyCallback(const OnNotify& callback);
 
-    Status start(uint16_t& port, bool ipv6_ = false);
+    Status start(uint16_t& port, bool ipv6_ = false, size_t threads = 1);
 
    private:
     void onGetSegmentDesc(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -179,6 +179,10 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     // MC_CUSTOM_TOPO_JSON works under MC_USE_TENT. Inline
     // topology/priority_matrix in MC_TENT_CONF still takes precedence.
     setConfig(config, "MC_CUSTOM_TOPO_JSON", "topology/custom_json_path");
+    // TENT RPC server io_context threads. The TCP data-path handlers do
+    // full-payload blocking copies inline, so deployments pushing bulk data
+    // over the TENT TCP transport raise this above the default of 1.
+    setConfig(config, "MC_TENT_RPC_THREADS", "rpc_server_threads");
     return status;
 }
 

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -16,6 +16,8 @@
 #include <glog/logging.h>
 #include <async_simple/executors/SimpleExecutor.h>
 
+#include <cstdlib>
+
 #include "transfer_engine_rpc_client_io_context.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/random.h"
@@ -85,6 +87,30 @@ struct ClientLease {
 
 CoroRpcAgent::CoroRpcAgent() = default;
 
+size_t CoroRpcAgent::rpcServerThreads() {
+    static const size_t val = [] {
+        const char* env = std::getenv("MC_TENT_RPC_THREADS");
+        if (env) {
+            try {
+                int v = std::stoi(env);
+                if (v > 0) {
+                    LOG(INFO) << "CoroRpcAgent: RPC server threads set to " << v
+                              << " via MC_TENT_RPC_THREADS";
+                    return static_cast<size_t>(v);
+                }
+                LOG(WARNING)
+                    << "Ignore non-positive MC_TENT_RPC_THREADS value: " << env
+                    << ", using default 1";
+            } catch (const std::exception& e) {
+                LOG(WARNING) << "Invalid MC_TENT_RPC_THREADS value: " << env
+                             << ". Error: " << e.what() << ", using default 1";
+            }
+        }
+        return size_t(1);
+    }();
+    return val;
+}
+
 CoroRpcAgent::~CoroRpcAgent() { stop(); }
 
 Status CoroRpcAgent::registerFunction(int func_id, const Function& func,
@@ -106,7 +132,7 @@ Status CoroRpcAgent::start(uint16_t& port, bool ipv6) {
         try {
             if (port == 0)
                 port = kStartPort + SimpleRandom::Get().next(kPortRange);
-            server_ = new coro_rpc::coro_rpc_server(kRpcThreads, port,
+            server_ = new coro_rpc::coro_rpc_server(rpcServerThreads(), port,
                                                     ipv6 ? "::" : "0.0.0.0");
             server_->register_handler<&CoroRpcAgent::process>(this);
             server_->async_start();

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -225,8 +225,11 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
         co_return std::make_pair(Status::RpcServiceError(msg + LOC_MARK), "");
     }
 
-    std::string response{lease->get_resp_attachment()};
-    lease->release_resp_attachment();
+    // The internal buffer is padded for small attachments; trim the moved
+    // string to the real attachment length from the view.
+    const size_t len = lease->get_resp_attachment().size();
+    std::string response = lease->release_resp_attachment();
+    response.resize(len);
 
     co_return std::make_pair(Status::OK(), std::move(response));
 }

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -16,8 +16,6 @@
 #include <glog/logging.h>
 #include <async_simple/executors/SimpleExecutor.h>
 
-#include <cstdlib>
-
 #include "transfer_engine_rpc_client_io_context.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/random.h"
@@ -87,30 +85,6 @@ struct ClientLease {
 
 CoroRpcAgent::CoroRpcAgent() = default;
 
-size_t CoroRpcAgent::rpcServerThreads() {
-    static const size_t val = [] {
-        const char* env = std::getenv("MC_TENT_RPC_THREADS");
-        if (env) {
-            try {
-                int v = std::stoi(env);
-                if (v > 0) {
-                    LOG(INFO) << "CoroRpcAgent: RPC server threads set to " << v
-                              << " via MC_TENT_RPC_THREADS";
-                    return static_cast<size_t>(v);
-                }
-                LOG(WARNING)
-                    << "Ignore non-positive MC_TENT_RPC_THREADS value: " << env
-                    << ", using default 1";
-            } catch (const std::exception& e) {
-                LOG(WARNING) << "Invalid MC_TENT_RPC_THREADS value: " << env
-                             << ". Error: " << e.what() << ", using default 1";
-            }
-        }
-        return size_t(1);
-    }();
-    return val;
-}
-
 CoroRpcAgent::~CoroRpcAgent() { stop(); }
 
 Status CoroRpcAgent::registerFunction(int func_id, const Function& func,
@@ -121,18 +95,20 @@ Status CoroRpcAgent::registerFunction(int func_id, const Function& func,
     return Status::OK();
 }
 
-Status CoroRpcAgent::start(uint16_t& port, bool ipv6) {
+Status CoroRpcAgent::start(uint16_t& port, bool ipv6, size_t threads) {
     const static uint16_t kStartPort = 15000;
     const static uint16_t kPortRange = 2000;
     const static int kMaxRetry = 10;
     if (running_)
         return Status::InvalidArgument("RPC server already started" LOC_MARK);
     easylog::set_min_severity(easylog::Severity::FATAL);
+    if (threads > 1)
+        LOG(INFO) << "CoroRpcAgent: RPC server threads set to " << threads;
     for (int retry = 0; retry < kMaxRetry; ++retry) {
         try {
             if (port == 0)
                 port = kStartPort + SimpleRandom::Get().next(kPortRange);
-            server_ = new coro_rpc::coro_rpc_server(rpcServerThreads(), port,
+            server_ = new coro_rpc::coro_rpc_server(threads, port,
                                                     ipv6 ? "::" : "0.0.0.0");
             server_->register_handler<&CoroRpcAgent::process>(this);
             server_->async_start();

--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -243,6 +243,17 @@ Status CoroRpcAgent::call(const std::string& server_addr, int func_id,
     return status;
 }
 
+Status CoroRpcAgent::callOwned(const std::string& server_addr, int func_id,
+                               std::string request, std::string& response) {
+    auto [status, resp] = async_simple::coro::syncAwait(
+        callCoroutine(server_addr, func_id, std::move(request)));
+
+    if (status.ok()) {
+        response = std::move(resp);
+    }
+    return status;
+}
+
 void CoroRpcAgent::callAsync(const std::string& server_addr, int func_id,
                              const std::string& request,
                              AsyncCallback callback) {

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -321,8 +321,8 @@ void ControlService::finishNotifyCallback() {
     notify_cb_cv_.notify_all();
 }
 
-Status ControlService::start(uint16_t& port, bool ipv6_) {
-    return rpc_server_->start(port, ipv6_);
+Status ControlService::start(uint16_t& port, bool ipv6_, size_t threads) {
+    return rpc_server_->start(port, ipv6_, threads);
 }
 
 void ControlService::onGetSegmentDesc(const std::string_view& request,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -72,12 +72,23 @@ Status ControlClient::bootstrap(const std::string& server_addr,
 Status ControlClient::sendData(const std::string& server_addr,
                                uint64_t peer_mem_addr, void* local_mem_addr,
                                size_t length) {
-    std::string request, response;
+    std::string response;
     XferDataDesc desc{htole64(peer_mem_addr), htole64(length)};
-    request.resize(sizeof(XferDataDesc) + length);
-    memcpy(&request[0], &desc, sizeof(desc));
-    Platform::getLoader().copy(&request[sizeof(desc)], local_mem_addr, length);
-    auto status = tl_rpc_agent.call(server_addr, SendData, request, response);
+    std::string request;
+    request.reserve(sizeof(XferDataDesc) + length);
+    request.resize(sizeof(XferDataDesc));
+    memcpy(request.data(), &desc, sizeof(desc));
+    auto& loader = Platform::getLoader();
+    if (loader.getMemoryType(local_mem_addr) == MTYPE_CPU) {
+        // Single copy into the RPC attachment; avoids the resize() zero-fill
+        // and the extra copy in call().
+        request.append(reinterpret_cast<const char*>(local_mem_addr), length);
+    } else {
+        request.resize(sizeof(XferDataDesc) + length);
+        loader.copy(request.data() + sizeof(desc), local_mem_addr, length);
+    }
+    auto status = tl_rpc_agent.callOwned(server_addr, SendData,
+                                         std::move(request), response);
     if (!status.ok()) return status;
     if (!response.empty()) return Status::RpcServiceError(response);
     return Status::OK();
@@ -422,9 +433,15 @@ void ControlService::onRecvData(const std::string_view& request,
     }
 
     if (local_desc->findBuffer(peer_mem_addr, length)) {
-        response.resize(length);
-        Platform::getLoader().copy(response.data(), (void*)peer_mem_addr,
-                                   length);
+        auto& loader = Platform::getLoader();
+        if (loader.getMemoryType((void*)peer_mem_addr) == MTYPE_CPU) {
+            // assign() skips the resize() zero-fill pass.
+            response.assign(reinterpret_cast<const char*>(peer_mem_addr),
+                            length);
+        } else {
+            response.resize(length);
+            loader.copy(response.data(), (void*)peer_mem_addr, length);
+        }
     } else {
         response = "RecvData failed: target address not in registered buffer";
     }

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -147,6 +147,47 @@ Status getRpcServerPortFromConfig(const Config& config, uint16_t default_value,
         "rpc_server_port must be an integer or integer string" LOC_MARK);
 }
 
+Status getRpcServerThreadsFromConfig(const Config& config, size_t default_value,
+                                     size_t& threads) {
+    constexpr const char* kKey = "rpc_server_threads";
+    constexpr long long kMinThreads = 1;
+    constexpr long long kMaxThreads = 1024;
+    auto validate = [&](long long value, const std::string& source) -> Status {
+        if (value < kMinThreads || value > kMaxThreads) {
+            return Status::InvalidArgument(
+                "Invalid rpc_server_threads '" + source +
+                "', expected value in range [1, " +
+                std::to_string(kMaxThreads) + "]" LOC_MARK);
+        }
+        threads = static_cast<size_t>(value);
+        return Status::OK();
+    };
+    if (!config.contains(kKey)) {
+        threads = default_value;
+        return Status::OK();
+    }
+
+    json raw_value = config.get<json>(kKey, json());
+    if (raw_value.is_number_integer() || raw_value.is_number_unsigned()) {
+        long long numeric_value = raw_value.get<long long>();
+        return validate(numeric_value, std::to_string(numeric_value));
+    }
+    if (raw_value.is_string()) {
+        auto string_value = raw_value.get<std::string>();
+        auto parsed_value = tryParseConfigIntString(string_value);
+        if (!parsed_value.has_value()) {
+            return Status::InvalidArgument(
+                "Invalid rpc_server_threads '" + string_value +
+                "', expected integer in range [1, " +
+                std::to_string(kMaxThreads) + "]" LOC_MARK);
+        }
+        return validate(*parsed_value, string_value);
+    }
+
+    return Status::InvalidArgument(
+        "rpc_server_threads must be an integer or integer string" LOC_MARK);
+}
+
 PreservedTentConfigOverrides captureExplicitTransferEngineConfig(
     const Config& config) {
     PreservedTentConfigOverrides preserved;
@@ -288,6 +329,8 @@ Status TransferEngineImpl::construct() {
     hostname_ = conf_->get("rpc_server_hostname", "");
     local_segment_name_ = conf_->get("local_segment_name", "");
     CHECK_STATUS(getRpcServerPortFromConfig(*conf_, 0, port_));
+    size_t rpc_server_threads = 1;
+    CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, 1, rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
     max_failover_attempts_ = conf_->get("max_failover_attempts", 3);
     enable_auto_failover_on_poll_ =
@@ -336,7 +379,7 @@ Status TransferEngineImpl::construct() {
     metadata_ =
         std::make_shared<ControlService>(metadata_type, metadata_servers, this);
 
-    CHECK_STATUS(metadata_->start(port_, ipv6_));
+    CHECK_STATUS(metadata_->start(port_, ipv6_, rpc_server_threads));
 
     if (metadata_type == "p2p")
         local_segment_name_ = buildIpAddrWithPort(hostname_, port_, ipv6_);

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -159,6 +159,21 @@ target_include_directories(tent_tcp_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_tcp_transport_test COMMAND tent_tcp_transport_test)
 
+add_executable(tent_tcp_datapath_roundtrip_test
+               tcp_datapath_roundtrip_test.cpp)
+target_link_libraries(tent_tcp_datapath_roundtrip_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+target_include_directories(tent_tcp_datapath_roundtrip_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+# Each case runs in its own process: the test forks a server child, which
+# must happen before the client process initializes any engine state.
+add_test(NAME tent_tcp_datapath_roundtrip_test_single_threaded
+         COMMAND tent_tcp_datapath_roundtrip_test
+                 --gtest_filter=TcpDataPathRoundtripTest.WriteThenReadAcrossProcesses)
+add_test(NAME tent_tcp_datapath_roundtrip_test_multi_threaded_rpc
+         COMMAND tent_tcp_datapath_roundtrip_test
+                 --gtest_filter=TcpDataPathRoundtripTest.WriteThenReadAcrossProcessesMultiThreadedRpc)
+
 add_executable(tent_shm_transport_test shm_transport_test.cpp)
 target_link_libraries(tent_shm_transport_test PRIVATE gtest gtest_main
                                                       tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/tcp_datapath_roundtrip_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_datapath_roundtrip_test.cpp
@@ -1,0 +1,247 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// End-to-end payload integrity test for the TENT TCP data path: a forked
+// server process serves a registered DRAM buffer over loopback, the client
+// WRITEs a pattern into it and READs it back, comparing byte for byte. This
+// covers the SendData/RecvData RPC handlers (including the copy-reduction
+// paths in ControlClient/ControlService) on any machine, no RDMA required.
+
+#include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/common/types.h"
+#include "tent/transfer_engine.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr size_t kDataLength = 4 * 1024 * 1024;
+constexpr size_t kTaskCount = 8;
+constexpr size_t kStride = 8 * 1024 * 1024;
+constexpr size_t kBufferLength =
+    2 * kTaskCount * kStride;  // sources in first half, READ dests in second
+
+class ChildProcessGuard {
+   public:
+    ChildProcessGuard(pid_t pid, int stop_fd) : pid_(pid), stop_fd_(stop_fd) {}
+
+    ~ChildProcessGuard() {
+        if (pid_ <= 0) return;
+        close(stop_fd_);
+        (void)waitpid(pid_, nullptr, 0);
+    }
+
+    int finish() {
+        close(stop_fd_);
+        int status = 0;
+        (void)waitpid(pid_, &status, 0);
+        pid_ = -1;
+        stop_fd_ = -1;
+        return status;
+    }
+
+    int reap() {
+        int status = 0;
+        (void)waitpid(pid_, &status, 0);
+        close(stop_fd_);
+        pid_ = -1;
+        stop_fd_ = -1;
+        return status;
+    }
+
+   private:
+    pid_t pid_;
+    int stop_fd_;
+};
+
+std::shared_ptr<Config> makeTcpConfig(size_t rpc_server_threads) {
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("metadata_servers", "P2PHANDSHAKE");
+    config->set("transports/tcp/enable", true);
+    config->set("transports/rdma/enable", false);
+    config->set("transports/shm/enable", false);
+    config->set("rpc_server_threads", rpc_server_threads);
+    return config;
+}
+
+bool waitBatchDone(TransferEngine& engine, BatchID batch) {
+    TransferStatus status;
+    for (int i = 0; i < 10000; ++i) {
+        auto result = engine.getTransferStatus(batch, status);
+        if (!result.ok() || status.s == TransferStatusEnum::FAILED)
+            return false;
+        if (status.s == TransferStatusEnum::COMPLETED) return true;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+// Drives WRITE-then-READ of kTaskCount non-contiguous slices between two
+// forked processes and verifies the pattern survives the round trip.
+void runWriteThenReadAcrossProcesses(size_t rpc_server_threads) {
+    int ready_pipe[2];
+    int stop_pipe[2];
+    ASSERT_EQ(pipe(ready_pipe), 0);
+    ASSERT_EQ(pipe(stop_pipe), 0);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        close(ready_pipe[0]);
+        close(stop_pipe[1]);
+
+        TransferEngine server(makeTcpConfig(rpc_server_threads));
+        if (!server.available()) _exit(2);
+        std::vector<uint8_t> buffer(kBufferLength);
+        if (!server.registerLocalMemory(buffer.data(), buffer.size()).ok())
+            _exit(3);
+
+        const std::string segment = server.getSegmentName();
+        uint32_t length = static_cast<uint32_t>(segment.size());
+        if (write(ready_pipe[1], &length, sizeof(length)) != sizeof(length))
+            _exit(4);
+        if (write(ready_pipe[1], segment.data(), length) !=
+            static_cast<ssize_t>(length))
+            _exit(5);
+
+        char stop = 0;
+        const ssize_t stop_result = read(stop_pipe[0], &stop, 1);
+        (void)stop_result;
+        (void)server.unregisterLocalMemory(buffer.data(), buffer.size());
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(stop_pipe[0]);
+    ChildProcessGuard child_guard(child, stop_pipe[1]);
+
+    uint32_t segment_length = 0;
+    ssize_t received =
+        read(ready_pipe[0], &segment_length, sizeof(segment_length));
+    if (received != static_cast<ssize_t>(sizeof(segment_length))) {
+        const int status = child_guard.reap();
+        GTEST_SKIP() << "TCP server initialization failed, child status "
+                     << status;
+    }
+    std::string server_segment(segment_length, '\0');
+    ASSERT_EQ(read(ready_pipe[0], server_segment.data(), segment_length),
+              static_cast<ssize_t>(segment_length));
+
+    TransferEngine client(makeTcpConfig(rpc_server_threads));
+    ASSERT_TRUE(client.available());
+    std::vector<uint8_t> buffer(kBufferLength, 0);
+    for (size_t task = 0; task < kTaskCount; ++task) {
+        uint8_t* slice = buffer.data() + task * kStride;
+        for (size_t i = 0; i < kDataLength; ++i) {
+            slice[i] = static_cast<uint8_t>((task * 131 + i * 7) & 0xff);
+        }
+    }
+    ASSERT_TRUE(client.registerLocalMemory(buffer.data(), buffer.size()).ok());
+
+    SegmentID segment = 0;
+    Status result;
+    for (int i = 0; i < 100; ++i) {
+        result = client.openSegment(segment, server_segment);
+        if (result.ok()) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(result.ok()) << result.ToString();
+
+    SegmentInfo info;
+    ASSERT_TRUE(client.getSegmentInfo(segment, info).ok());
+    ASSERT_FALSE(info.buffers.empty());
+
+    // READ destination: a second region of the same registered buffer.
+    std::vector<Request> write_requests;
+    std::vector<Request> read_requests;
+    for (size_t task = 0; task < kTaskCount; ++task) {
+        Request write_request{};
+        write_request.opcode = Request::WRITE;
+        write_request.source = buffer.data() + task * kStride;
+        write_request.target_id = segment;
+        write_request.target_offset = info.buffers[0].base + task * kStride;
+        write_request.length = kDataLength;
+        write_request.transport_hint = TCP;
+        write_requests.push_back(write_request);
+
+        Request read_request{};
+        read_request.opcode = Request::READ;
+        read_request.source =
+            buffer.data() + kBufferLength / 2 + task * kDataLength;
+        read_request.target_id = segment;
+        read_request.target_offset = info.buffers[0].base + task * kStride;
+        read_request.length = kDataLength;
+        read_request.transport_hint = TCP;
+        read_requests.push_back(read_request);
+    }
+    // Patterned sources live in the first half (4MB of each 8MB stride);
+    // READ destinations occupy the second half. No overlap.
+
+    BatchID batch = client.allocateBatch(kTaskCount);
+    ASSERT_TRUE(client.submitTransfer(batch, write_requests).ok());
+    ASSERT_TRUE(waitBatchDone(client, batch));
+    ASSERT_TRUE(client.freeBatch(batch).ok());
+
+    batch = client.allocateBatch(kTaskCount);
+    ASSERT_TRUE(client.submitTransfer(batch, read_requests).ok());
+    ASSERT_TRUE(waitBatchDone(client, batch));
+    ASSERT_TRUE(client.freeBatch(batch).ok());
+
+    for (size_t task = 0; task < kTaskCount; ++task) {
+        const uint8_t* written = buffer.data() + task * kStride;
+        // Patterned sources occupy the first 4MB of each 8MB stride in the
+        // buffer's first half; READ destinations are packed contiguously
+        // into the second half, so they never overlap a source.
+        const uint8_t* read_back =
+            buffer.data() + kBufferLength / 2 + task * kDataLength;
+        EXPECT_EQ(std::memcmp(written, read_back, kDataLength), 0)
+            << "slice " << task << " mismatch";
+    }
+
+    EXPECT_TRUE(client.closeSegment(segment).ok());
+    EXPECT_TRUE(
+        client.unregisterLocalMemory(buffer.data(), buffer.size()).ok());
+
+    const int status = child_guard.finish();
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+TEST(TcpDataPathRoundtripTest, WriteThenReadAcrossProcesses) {
+    runWriteThenReadAcrossProcesses(1);
+}
+
+// Same round trip with a multi-threaded RPC server, as used by bulk-TCP
+// deployments (MC_TENT_RPC_THREADS / rpc_server_threads).
+TEST(TcpDataPathRoundtripTest, WriteThenReadAcrossProcessesMultiThreadedRpc) {
+    runWriteThenReadAcrossProcesses(4);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

The TENT TCP data path makes redundant full-payload passes over every request:

- `ControlClient::sendData` (CPU source): `resize()` zero-fills the whole request buffer, `Platform::copy` fills it, then `call()` copies the entire string again into `callCoroutine`'s by-value parameter — three full passes, two of them pure waste.
- `ControlService::onRecvData` (CPU source): `resize()` zero-fills the response before the copy.
- `callCoroutine` (client READ path): `get_resp_attachment()` copies the response out, then the internal buffer is discarded — `release_resp_attachment()` already returns it by value, so the copy is unnecessary.

Changes:

- Add `CoroRpcAgent::callOwned()`, which moves the request into the coroutine instead of copying it.
- `callCoroutine` takes the response via `std::string response = lease->release_resp_attachment();` — one more full pass removed per READ.
- `sendData` (CPU source): `reserve` + `append` builds the RPC attachment in a single copy and moves it into the call. GPU sources keep the `resize` + D2H staging copy.
- `onRecvData` (CPU source): `assign()` is a single copy with no zero-fill. GPU targets unchanged.

Also adds `tent_tcp_datapath_roundtrip_test` (modeled on `rdma_transport_test`'s `WriteThenReadAcrossProcesses`): a forked server serves a registered DRAM buffer over loopback, the client WRITEs 8 non-contiguous patterned slices and READs them back, full `memcmp`. Two ctest cases cover `rpc_server_threads=1` and `=4`, locking in the combination with #3535 on any machine without special hardware.

Stacked on top of #3535 (the RPC-threads change); the gains are only visible once the receiver is not pinned to a single thread.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Same two-node rig as #3535 (TENT TCP, 16 MB requests unless noted, `rpc_server_threads=8`):

| WRITE, conc=64 | threads only (base PR) | + this PR |
|---|---|---|
| DRAM->DRAM | 109.1 Gbps | 125.1 Gbps |
| CUDA->CUDA | 106.6 Gbps | 120.7 Gbps |
| DRAM, 64 MB requests | 30.3 Gbps | 48.1 Gbps |
| CUDA, 64 MB requests | 32.0 Gbps | 53.1 Gbps |

Automated: `ctest -R tcp_datapath` — both round-trip cases pass (single-threaded and multi-threaded RPC server).

Data correctness: WRITE+READ round-trip byte-compare against a GPU target (8x16MB, 32x1MB, 4x64MB) all pass.

**Test commands:**
```bash
ctest --test-dir build -R tent_tcp_datapath_roundtrip_test --output-on-failure
# plus the same cross-node bench as the base PR, before/after this patch
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (clang-format-20 unavailable in this environment; changed lines hand-aligned to the repo `.clang-format` style)
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code helped implement the change, run the cross-node benchmarks and prepare this PR; the submitter reviewed every changed line and can defend the change end-to-end.
