### PR TITLE
[Bugfix][TransferEngine] Export the requested range for dma-buf registration under CUDA VMM (fixes #2511)

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -131,14 +131,18 @@ class RdmaContext {
     int registerMemoryRegion(void *addr, size_t length, int access,
                              const DmabufExport &exp);
 
-    // Exports a single dma_buf fd for the allocation backing addr. GPU device
+    // Exports a single dma_buf fd covering [addr, addr + length). GPU device
     // memory yields kDmabufReg with a live fd; host memory and the
     // nvidia-peermem path yield kHostReg with no fd. Any fd placed in out.fd
     // MUST be closed by the caller (via closeDmabufExport) AFTER every
     // registerMemoryRegion() call consuming it has returned — each successful
     // registration takes its own reference, so closing earlier would invalidate
     // the fd for the remaining NICs.
-    static int exportDmabuf(void *addr, DmabufExport &out);
+    // `length` is the length of the whole buffer the caller is going to
+    // register (chunked registrations derive their own offset from out.offset),
+    // and is used to guarantee the exported dma_buf really covers that range —
+    // see the VMM note in exportDmabuf().
+    static int exportDmabuf(void *addr, size_t length, DmabufExport &out);
 
     // Closes the fd held by a DmabufExport, if any. Idempotent.
     static void closeDmabufExport(DmabufExport &exp);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -477,14 +477,14 @@ int RdmaContext::exportDmabuf(void *addr, size_t length, DmabufExport &out) {
             exportOffset = (uintptr_t)addr - aligned;
             exportSize =
                 (exportOffset + length + page - 1) & ~(size_t)(page - 1);
-            LOG(INFO) << "dma_buf: reported allocation for " << (uintptr_t)addr
-                      << " (base=" << (uintptr_t)allocBase
-                      << " size=" << allocSize << ") does not cover length "
-                      << length << "; exporting the requested range instead"
-                      << " (base=" << (uintptr_t)exportBase
-                      << " size=" << exportSize
-                      << "). Expected for CUDA VMM allocations such as PyTorch"
-                         " expandable_segments.";
+            VLOG(1) << "dma_buf: reported allocation for " << (uintptr_t)addr
+                    << " (base=" << (uintptr_t)allocBase
+                    << " size=" << allocSize << ") does not cover length "
+                    << length << "; exporting the requested range instead"
+                    << " (base=" << (uintptr_t)exportBase
+                    << " size=" << exportSize
+                    << "). Expected for CUDA VMM allocations such as PyTorch"
+                       " expandable_segments.";
         }
 
         // flags must be 0: the PCIE-BAR1 mapping flag is rejected (error 801)

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -389,9 +389,10 @@ int RdmaContext::deconstruct() {
     return 0;
 }
 
-int RdmaContext::exportDmabuf(void *addr, DmabufExport &out) {
+int RdmaContext::exportDmabuf(void *addr, size_t length, DmabufExport &out) {
     out = DmabufExport{};
     (void)addr;  // unused on the host-only (#else) build
+    (void)length;
 #if defined(USE_MLU) || defined(USE_MACA) || defined(USE_CUDA) || \
     defined(USE_SUPA)
     // Decide host vs GPU without assuming the presence of nvidia-peermem. Host
@@ -446,17 +447,57 @@ int RdmaContext::exportDmabuf(void *addr, DmabufExport &out) {
         }
 
         int dmabuf_fd;
+        // cuMemGetAddressRange() only reports the mapping that contains addr.
+        // For memory allocated through the CUDA virtual memory management API
+        // (cuMemCreate + cuMemMap), as used by PyTorch's
+        // PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True, that mapping is a
+        // single growth chunk — 20 MiB by default, see c10's
+        // large_segment_size / large_segment_size_mb — even though the
+        // surrounding VA reservation is contiguous and orders of magnitude
+        // larger. Exporting only that chunk makes offset + length exceed the
+        // resulting dma_buf, and ibv_reg_dmabuf_mr() below then fails with
+        // EINVAL for every buffer larger than one chunk (Mooncake#2511).
+        //
+        // When the reported allocation does not cover the range the caller is
+        // about to register, export exactly [addr, addr + length) instead.
+        // cuMemGetHandleForAddressRange() accepts a range spanning several
+        // mappings as long as they are contiguously mapped, which is precisely
+        // the expandable-segment layout. The export base is page-aligned so
+        // that offset % page_size == iova % page_size, which
+        // ibv_reg_dmabuf_mr() requires.
+        CUdeviceptr exportBase = allocBase;
+        size_t exportSize = allocSize;
+        uint64_t exportOffset = (uintptr_t)addr - (uintptr_t)allocBase;
+        if (exportOffset + length > allocSize) {
+            const size_t page = (size_t)sysconf(_SC_PAGESIZE);
+            uintptr_t aligned = (uintptr_t)addr & ~(uintptr_t)(page - 1);
+            if (aligned < (uintptr_t)allocBase)
+                aligned = (uintptr_t)allocBase;
+            exportBase = (CUdeviceptr)aligned;
+            exportOffset = (uintptr_t)addr - aligned;
+            exportSize =
+                (exportOffset + length + page - 1) & ~(size_t)(page - 1);
+            LOG(INFO) << "dma_buf: reported allocation for " << (uintptr_t)addr
+                      << " (base=" << (uintptr_t)allocBase
+                      << " size=" << allocSize << ") does not cover length "
+                      << length << "; exporting the requested range instead"
+                      << " (base=" << (uintptr_t)exportBase
+                      << " size=" << exportSize
+                      << "). Expected for CUDA VMM allocations such as PyTorch"
+                         " expandable_segments.";
+        }
+
         // flags must be 0: the PCIE-BAR1 mapping flag is rejected (error 801)
         // on some GPU/driver combinations (e.g. B200).
         result = cuMemGetHandleForAddressRange(
-            &dmabuf_fd, allocBase, allocSize,
+            &dmabuf_fd, exportBase, exportSize,
             CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
         if (result != CUDA_SUCCESS) {
             const char *errStr;
             cuGetErrorString(result, &errStr);
             LOG(ERROR) << "Failed to retrieve dmabuf for " << (uintptr_t)addr
-                       << " base=" << (uintptr_t)allocBase
-                       << " size=" << allocSize << " cuda error=" << errStr;
+                       << " base=" << (uintptr_t)exportBase
+                       << " size=" << exportSize << " cuda error=" << errStr;
 #if defined(USE_CUDA) || defined(USE_SUPA)
             cuDevicePrimaryCtxRelease(cuDev);
 #endif
@@ -464,7 +505,7 @@ int RdmaContext::exportDmabuf(void *addr, DmabufExport &out) {
         }
         out.method = DmabufExport::Method::kDmabufReg;
         out.fd = dmabuf_fd;
-        out.offset = (uintptr_t)addr - (uintptr_t)allocBase;
+        out.offset = exportOffset;
 #if defined(USE_CUDA) || defined(USE_SUPA)
         cuDevicePrimaryCtxRelease(cuDev);
 #endif
@@ -599,7 +640,8 @@ int RdmaContext::registerMemoryRegionInternal(void *addr, size_t length,
     mrMeta.mr = ibv_reg_mr(pd_, addr, length, access);
 #endif
     if (!mrMeta.mr) {
-        PLOG(ERROR) << "Failed to register memory " << addr;
+        PLOG(ERROR) << "Failed to register memory " << addr << " length "
+                    << length << " dmabuf_offset " << exp.offset;
         return ERR_CONTEXT;
     }
     return 0;
@@ -625,7 +667,7 @@ int RdmaContext::registerMemoryRegion(void *addr, size_t length, int access) {
     // The shared-fd benefit only matters when a buffer is registered against
     // multiple NICs (see RdmaTransport::registerLocalMemoryInternal).
     DmabufExport exp;
-    int ret = exportDmabuf(addr, exp);
+    int ret = exportDmabuf(addr, length, exp);
     if (ret != 0) {
         return ret;
     }
@@ -651,7 +693,7 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
 int RdmaContext::preTouchMemory(void *addr, size_t length) {
     if (!pd_) return 0;  // placeholder context
     DmabufExport exp;
-    int ret = exportDmabuf(addr, exp);
+    int ret = exportDmabuf(addr, length, exp);
     if (ret != 0) {
         return ret;
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -471,8 +471,7 @@ int RdmaContext::exportDmabuf(void *addr, size_t length, DmabufExport &out) {
         if (exportOffset + length > allocSize) {
             const size_t page = (size_t)sysconf(_SC_PAGESIZE);
             uintptr_t aligned = (uintptr_t)addr & ~(uintptr_t)(page - 1);
-            if (aligned < (uintptr_t)allocBase)
-                aligned = (uintptr_t)allocBase;
+            if (aligned < (uintptr_t)allocBase) aligned = (uintptr_t)allocBase;
             exportBase = (CUdeviceptr)aligned;
             exportOffset = (uintptr_t)addr - aligned;
             exportSize =

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -337,7 +337,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     // the RAII guard below.
     DmabufExport dmabuf_exp;
     if (!context_list_.empty()) {
-        int eret = RdmaContext::exportDmabuf(addr, dmabuf_exp);
+        int eret = RdmaContext::exportDmabuf(addr, length, dmabuf_exp);
         if (eret != 0) {
             LOG(ERROR) << "Failed to export dma_buf for addr=" << addr;
             return eret;

--- a/mooncake-transfer-engine/tests/dmabuf_export_test.cpp
+++ b/mooncake-transfer-engine/tests/dmabuf_export_test.cpp
@@ -110,7 +110,7 @@ TEST(CloseDmabufExport, Idempotent) {
 TEST(ExportDmabuf, HostMemoryYieldsHostReg) {
     std::vector<char> buf(4096);
     DmabufExport exp;
-    int ret = RdmaContext::exportDmabuf(buf.data(), exp);
+    int ret = RdmaContext::exportDmabuf(buf.data(), buf.size(), exp);
     EXPECT_EQ(ret, 0);
     EXPECT_EQ(exp.method, DmabufExport::Method::kHostReg);
     EXPECT_EQ(exp.fd, -1);
@@ -122,7 +122,7 @@ TEST(ExportDmabuf, LargeHostBufferYieldsHostReg) {
     constexpr size_t kSize = 8ULL * 1024 * 1024;  // 8 MiB
     std::vector<char> buf(kSize);
     DmabufExport exp;
-    int ret = RdmaContext::exportDmabuf(buf.data(), exp);
+    int ret = RdmaContext::exportDmabuf(buf.data(), kSize, exp);
     EXPECT_EQ(ret, 0);
     EXPECT_EQ(exp.method, DmabufExport::Method::kHostReg);
     EXPECT_EQ(exp.fd, -1);
@@ -134,7 +134,7 @@ TEST(ExportDmabuf, MmapAnonymousYieldsHostReg) {
     ASSERT_NE(p, MAP_FAILED);
 
     DmabufExport exp;
-    int ret = RdmaContext::exportDmabuf(p, exp);
+    int ret = RdmaContext::exportDmabuf(p, 4096, exp);
     EXPECT_EQ(ret, 0);
     EXPECT_EQ(exp.method, DmabufExport::Method::kHostReg);
     EXPECT_EQ(exp.fd, -1);
@@ -145,7 +145,7 @@ TEST(ExportDmabuf, MmapAnonymousYieldsHostReg) {
 TEST(ExportDmabuf, StackAddressYieldsHostReg) {
     char stack_buf[128];
     DmabufExport exp;
-    int ret = RdmaContext::exportDmabuf(stack_buf, exp);
+    int ret = RdmaContext::exportDmabuf(stack_buf, sizeof(stack_buf), exp);
     EXPECT_EQ(ret, 0);
     EXPECT_EQ(exp.method, DmabufExport::Method::kHostReg);
     EXPECT_EQ(exp.fd, -1);


### PR DESCRIPTION
## Problem

With `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, PyTorch allocates the KV cache through the CUDA virtual memory management API (`cuMemCreate` + `cuMemMap`). `RdmaContext::exportDmabuf()` derives the dma-buf export range from `cuMemGetAddressRange()`, which for VMM memory reports **only the single mapping containing the pointer** — one expandable-segment growth chunk, 20 MiB by default (`c10/core/AllocatorConfig.h`, `large_segment_size_{20971520}`) — not the surrounding contiguous VA reservation.

The registration then asks for the whole buffer, so `offset + length` exceeds the exported dma-buf and `ibv_reg_dmabuf_mr()` fails with `EINVAL` for every buffer larger than one chunk. Captured from a real run, with the fd size read via `lseek(fd, 0, SEEK_END)`:

```
offset=8214528  length=1916853120  iova=0x12397fd5800  fd=240
dmabuf_size=20971520   offset+length=1925067648   -> FAIL errno=22 (Invalid argument)
```

Because the caller in SGLang does not abort on registration failure, the server starts up healthy and the problem only surfaces as `Failed to send kv chunk` on the first KV transfer. See #2511 for the original report and the analysis comment there.

## Fix

`exportDmabuf()` now takes the length the caller is going to register. When the range reported by `cuMemGetAddressRange()` cannot cover `[addr, addr + length)`, the dma-buf is exported for that range instead, with a page-aligned base:

```cpp
if (exportOffset + length > allocSize) {
    const size_t page = (size_t)sysconf(_SC_PAGESIZE);
    uintptr_t aligned = (uintptr_t)addr & ~(uintptr_t)(page - 1);
    if (aligned < (uintptr_t)allocBase) aligned = (uintptr_t)allocBase;
    exportBase = (CUdeviceptr)aligned;
    exportOffset = (uintptr_t)addr - aligned;
    exportSize = (exportOffset + length + page - 1) & ~(size_t)(page - 1);
}
```

`cuMemGetHandleForAddressRange()` accepts a range spanning several mappings as long as they are contiguously mapped, which is exactly the expandable-segment layout. This was verified with a standalone probe that maps 8 separate `cuMemCreate` handles into one reservation and registers the whole range successfully.

The failure log in `registerMemoryRegionInternal()` now also prints `length` and `dmabuf_offset`. The absence of those two numbers is the reason #2511 stayed undiagnosed for two months.

## Why this is low risk

1. **The new branch only runs where the current code always fails.** `exportOffset + length > allocSize` means the existing export cannot possibly satisfy the kernel's `offset + length <= size` check. For `cudaMalloc`-backed memory the reported allocation always covers the registration, so the behaviour introduced by #2035 and #2019 for caching-allocator sub-allocations is untouched.
2. **The page-aligned base preserves the kernel's page-offset rule.** `ibv_reg_dmabuf_mr()` requires `offset % page_size == iova % page_size`; aligning the base down to a page boundary makes `exportOffset % page == (uintptr_t)addr % page` by construction. `sysconf(_SC_PAGESIZE)` is used rather than a hardcoded 4096 so 64 KiB-page kernels are handled too.
3. **Chunked registration is unaffected.** `RdmaTransport::registerLocalMemoryInternal()` still adds `chunk_offset` to `out.offset` for each chunk, and the `length` passed to `exportDmabuf()` is the whole-buffer length, so the single exported dma-buf still covers every chunk.
4. **Shared-fd lifetime is unchanged.** Still one export per buffer, imported by every NIC, closed once by `closeDmabufExport()` (#2523).
5. **The `aligned < allocBase` clamp** guards against aligning below the allocation base, reachable only if `allocBase` itself is not page-aligned.

## Testing

Verified on SGLang PD disaggregation with prefill and decode on separate 8-GPU hosts, DeepSeek-V4-Pro, ConnectX-8 RoCE (`mlx5_bond_0..7`), torch 2.11.0+cu130, `WITH_NVIDIA_PEERMEM=0`, `MC_GID_INDEX=3`, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` at the default 20 MiB granularity. Everything except the export range is identical across rows:

| mooncake | export range | failed registrations per side | first request |
| --- | --- | --- | --- |
| 0.3.11.post1 | as shipped | 1944 (243 buffers × 8 ranks), all `EINVAL` | HTTP 500, `Failed to send kv chunk` |
| 0.3.12.post1 | as shipped | fails likewise, `EINVAL` on the same buffers | HTTP 500 |
| 0.3.11.post1 | corrected as in this PR | **0** | correct output, KV transferred correctly |

The 0.3.12.post1 row logs fewer error lines (16 per side) than 0.3.11.post1, but the two counts are not comparable: registration aborts and rolls back on the first failing chunk, so a differing number of attempts is reached. What matters is that both versions fail with `EINVAL` on the same large buffers and both return HTTP 500.

`max_total_num_tokens` in the fixed configuration stays within 0.26% of the `expandable_segments`-disabled baseline, so the fix costs no KV capacity.

**How this was validated.** Rebuilding the wheel on that cluster was not practical, so the behaviour was validated by interposing `ibv_reg_dmabuf_mr()` with an `LD_PRELOAD` library implementing the same range computation. The arithmetic is identical: for the failing 1.79 GiB buffer the interposing library logged `new offset = 2048, exported size = 1916858368`, and the code in this PR produces exactly those two numbers for the same inputs. That said, **this patch itself has not been compiled or run in-tree** — please let CI build it, and a maintainer with a VMM-capable setup may want to repeat the end-to-end check.

## Not covered

1. Non-CUDA backends (`USE_HIP_DMABUF`, MLU, MACA, SUPA) are untouched. If their address-range queries have the same VMM caveat, they need the same treatment.
2. Functional verification only; no load or long-running test was performed.
3. 64 KiB-page hosts were not tested. `sysconf(_SC_PAGESIZE)` is used on the assumption that it is the relevant granularity there (cf. sgl-project/sglang#23971).
4. Each GPU was pinned to a single NIC in this setup, so the multi-NIC shared-fd path was not exercised.