### PR TITLE
  feat(store): dedicated heartbeat RPC server to prevent head-of-line blocking

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1197,7 +1197,8 @@ PYBIND11_MODULE(store, m) {
                const py::object& engine = py::none(),
                const std::string& runtime_config = "",
                bool enable_metric_collection = true,
-               uint64_t metric_report_interval_seconds = 60) {
+               uint64_t metric_report_interval_seconds = 60,
+               uint16_t heartbeat_rpc_port = 0) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -1222,6 +1223,7 @@ PYBIND11_MODULE(store, m) {
                     p2p_key_lease_scan_interval_ms, p2p_transfer_direction_mode,
                     runtime_config, enable_metric_collection,
                     metric_report_interval_seconds);
+                config.heartbeat_rpc_port = heartbeat_rpc_port;
 
                 auto ret = real_client->setup(config);
                 return ret;
@@ -1246,6 +1248,7 @@ PYBIND11_MODULE(store, m) {
             py::arg("engine") = py::none(), py::arg("runtime_config") = "",
             py::arg("enable_metric_collection") = true,
             py::arg("metric_report_interval_seconds") = 60,
+            py::arg("heartbeat_rpc_port") = 0,
             "Setup the store in P2P architecture.")
         .def(
             "setup",
@@ -1261,7 +1264,8 @@ PYBIND11_MODULE(store, m) {
                bool enable_http_server = true,
                const std::string& runtime_config = "",
                bool enable_metric_collection = true,
-               uint64_t metric_report_interval_seconds = 60) {
+               uint64_t metric_report_interval_seconds = 60,
+               uint16_t heartbeat_rpc_port = 0) {
                 auto real_client = self.init_real_client();
                 std::shared_ptr<mooncake::TransferEngine> transfer_engine =
                     nullptr;
@@ -1280,6 +1284,7 @@ PYBIND11_MODULE(store, m) {
                         http_port, enable_http_server, {}, 50052,
                         runtime_config, enable_metric_collection,
                         metric_report_interval_seconds);
+                config.heartbeat_rpc_port = heartbeat_rpc_port;
 
                 auto ret = real_client->setup(config);
                 return ret;
@@ -1292,7 +1297,8 @@ PYBIND11_MODULE(store, m) {
             py::arg("enable_http_server") = true,
             py::arg("runtime_config") = "",
             py::arg("enable_metric_collection") = true,
-            py::arg("metric_report_interval_seconds") = 60)
+            py::arg("metric_report_interval_seconds") = 60,
+            py::arg("heartbeat_rpc_port") = 0)
         .def(
             "setup",
             [](MooncakeStorePyWrapper& self, const py::dict& config_dict) {
@@ -1321,7 +1327,9 @@ PYBIND11_MODULE(store, m) {
             "  protocol: Transfer protocol (default 'tcp').\n"
             "  rdma_devices: RDMA device list.\n"
             "  master_server_addr: Master server address.\n"
-            "  ipc_socket_path: IPC socket path.")
+            "  ipc_socket_path: IPC socket path.\n"
+            "  heartbeat_rpc_port: Dedicated heartbeat RPC port on the master "
+            "(0 = disabled, default 0).")
         .def(
             "setup_p2p_real_client",
             [](MooncakeStorePyWrapper& self, const py::dict& config_dict) {
@@ -1365,7 +1373,9 @@ PYBIND11_MODULE(store, m) {
             "  async_max_batch_size: Async route max batch size (default "
             "2000).\n"
             "  async_route_queue_size: Async route queue size (default 0).\n"
-            "  ipc_socket_path: IPC socket path.")
+            "  ipc_socket_path: IPC socket path.\n"
+            "  heartbeat_rpc_port: Dedicated heartbeat RPC port on the master "
+            "(0 = disabled, default 0).")
         .def(
             "setup_dummy",
             [](MooncakeStorePyWrapper& self, size_t mem_pool_size,

--- a/mooncake-store/benchmarks/master_bench.cpp
+++ b/mooncake-store/benchmarks/master_bench.cpp
@@ -64,6 +64,18 @@ class SegmentClient {
                                         master_server + ", ec=" + toString(ec));
         }
 
+        // Register client with master before mounting segments.
+        // Required since the refactored MountSegment checks ClientManager for
+        // the client_id (commit 48d3a47c).
+        mooncake::RegisterClientRequest reg_req;
+        reg_req.client_id = client_id_;
+        reg_req.deployment_mode = mooncake::DeploymentMode::CENTRALIZATION;
+        auto reg_ec = master_client_.RegisterClient(reg_req);
+        if (!reg_ec.has_value()) {
+            throw std::runtime_error("Failed to register client " + name +
+                                     ", ec=" + toString(reg_ec.error()));
+        }
+
         segment_.id = mooncake::generate_uuid();
         segment_.name = name;
         segment_.size = segment_size;

--- a/mooncake-store/include/centralized_rpc_service.h
+++ b/mooncake-store/include/centralized_rpc_service.h
@@ -102,6 +102,7 @@ class WrappedCentralizedMasterService final : public WrappedMasterService {
 
 void RegisterCentralizedRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedCentralizedMasterService& wrapped_master_service);
+    mooncake::WrappedCentralizedMasterService& wrapped_master_service,
+    bool include_heartbeat = true);
 
 }  // namespace mooncake

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -313,6 +313,9 @@ class ClientConfigBuilder {
             get_config_size(config, DictCommon::kMetricReportIntervalSeconds,
                             DictCommon::kDefaultMetricReportIntervalSeconds);
         RedisDiscoveryConfig redis_config = get_redis_discovery_config(config);
+        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(get_config_size(
+            config, DictCommon::kHeartbeatRpcPort,
+            DictCommon::kDefaultHeartbeatRpcPort));
 
         return build_centralized_real_client(
             local_hostname, metadata_server, protocol, rdma_devices,
@@ -321,7 +324,8 @@ class ClientConfigBuilder {
             enable_metric_collection, metric_report_interval_seconds,
             redis_config.cluster_id, redis_config.password,
             redis_config.db_index, redis_config.master_view_ttl_sec,
-            redis_config.heartbeat_interval_sec, redis_config.username);
+            redis_config.heartbeat_interval_sec, redis_config.username,
+            heartbeat_rpc_port);
     }
 
     static P2PClientConfig build_p2p_real_client(
@@ -466,6 +470,9 @@ class ClientConfigBuilder {
             get_config_size(config, DictCommon::kMetricReportIntervalSeconds,
                             DictCommon::kDefaultMetricReportIntervalSeconds);
         RedisDiscoveryConfig redis_config = get_redis_discovery_config(config);
+        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(get_config_size(
+            config, DictCommon::kHeartbeatRpcPort,
+            DictCommon::kDefaultHeartbeatRpcPort));
 
         return build_p2p_real_client(
             local_hostname, metadata_server, protocol, rdma_devices,
@@ -478,7 +485,8 @@ class ClientConfigBuilder {
             metric_report_interval_seconds, redis_config.cluster_id,
             redis_config.password, redis_config.db_index,
             redis_config.master_view_ttl_sec,
-            redis_config.heartbeat_interval_sec, redis_config.username);
+            redis_config.heartbeat_interval_sec, redis_config.username,
+            heartbeat_rpc_port);
     }
 
    private:
@@ -515,6 +523,7 @@ class ClientConfigBuilder {
             "metric_report_interval_seconds";
         static constexpr const char* kEnableMetricCollection =
             "enable_metric_collection";
+        static constexpr const char* kHeartbeatRpcPort = "heartbeat_rpc_port";
         // Defaults
         static constexpr size_t kDefaultLocalBufferSize = 1024 * 1024 * 16;
         static constexpr const char* kDefaultProtocol = "tcp";
@@ -522,6 +531,7 @@ class ClientConfigBuilder {
             "127.0.0.1:50051";
         static constexpr uint64_t kDefaultMetricReportIntervalSeconds = 60;
         static constexpr bool kDefaultEnableMetricCollection = true;
+        static constexpr uint16_t kDefaultHeartbeatRpcPort = 0;
         // Limits
         static constexpr size_t kMinSegmentSize = 1024;
         static constexpr size_t kMaxSegmentSize = 1024ULL * 1024 * 1024 * 1024;

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -313,9 +313,9 @@ class ClientConfigBuilder {
             get_config_size(config, DictCommon::kMetricReportIntervalSeconds,
                             DictCommon::kDefaultMetricReportIntervalSeconds);
         RedisDiscoveryConfig redis_config = get_redis_discovery_config(config);
-        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(get_config_size(
-            config, DictCommon::kHeartbeatRpcPort,
-            DictCommon::kDefaultHeartbeatRpcPort));
+        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(
+            get_config_size(config, DictCommon::kHeartbeatRpcPort,
+                            DictCommon::kDefaultHeartbeatRpcPort));
 
         return build_centralized_real_client(
             local_hostname, metadata_server, protocol, rdma_devices,
@@ -470,9 +470,9 @@ class ClientConfigBuilder {
             get_config_size(config, DictCommon::kMetricReportIntervalSeconds,
                             DictCommon::kDefaultMetricReportIntervalSeconds);
         RedisDiscoveryConfig redis_config = get_redis_discovery_config(config);
-        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(get_config_size(
-            config, DictCommon::kHeartbeatRpcPort,
-            DictCommon::kDefaultHeartbeatRpcPort));
+        uint16_t heartbeat_rpc_port = static_cast<uint16_t>(
+            get_config_size(config, DictCommon::kHeartbeatRpcPort,
+                            DictCommon::kDefaultHeartbeatRpcPort));
 
         return build_p2p_real_client(
             local_hostname, metadata_server, protocol, rdma_devices,

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -87,6 +87,12 @@ struct RealClientConfigBase {
     // 3. "redis://IP:Port" for Redis-based HA mode
     std::string master_server_entry = "127.0.0.1:50051";
 
+    // Port of the master's dedicated heartbeat RPC server. When > 0,
+    // heartbeats are sent to <master host>:heartbeat_rpc_port instead of the
+    // main RPC port, so they are not head-of-line-blocked by heavy metadata
+    // RPCs. Must match the master's --heartbeat_rpc_port. 0 = legacy behavior.
+    uint16_t heartbeat_rpc_port = 0;
+
     // Size of the local buffer (0 to skip).
     // For the case which separately deploys real client and dummy client,
     // the `local_buffer_size` could be 0, which means the local buffer is

--- a/mooncake-store/include/client_config_builder.h
+++ b/mooncake-store/include/client_config_builder.h
@@ -259,7 +259,8 @@ class ClientConfigBuilder {
         const std::string& redis_cluster_id = DEFAULT_CLUSTER_ID,
         const std::string& redis_password = "", int redis_db_index = 0,
         int redis_master_view_ttl_sec = 4, int redis_heartbeat_interval_sec = 1,
-        const std::string& redis_username = "") {
+        const std::string& redis_username = "",
+        uint16_t heartbeat_rpc_port = 0) {
         CentralizedClientConfig config;
         fill_real_client_config_base(
             config, local_hostname, metadata_connstring, protocol, rdma_devices,
@@ -274,6 +275,7 @@ class ClientConfigBuilder {
         config.global_segment_size = global_segment_size;
         config.enable_offload = enable_offload;
         config.local_rpc_port = local_rpc_port;
+        config.heartbeat_rpc_port = heartbeat_rpc_port;
         return config;
     }
 
@@ -352,7 +354,8 @@ class ClientConfigBuilder {
         const std::string& redis_cluster_id = DEFAULT_CLUSTER_ID,
         const std::string& redis_password = "", int redis_db_index = 0,
         int redis_master_view_ttl_sec = 4, int redis_heartbeat_interval_sec = 1,
-        const std::string& redis_username = "") {
+        const std::string& redis_username = "",
+        uint16_t heartbeat_rpc_port = 0) {
         P2PClientConfig config;
         fill_real_client_config_base(
             config, local_hostname, metadata_connstring, protocol, rdma_devices,
@@ -400,6 +403,7 @@ class ClientConfigBuilder {
         config.transfer_direction_mode =
             parse_p2p_transfer_direction_mode(p2p_transfer_direction_mode);
 
+        config.heartbeat_rpc_port = heartbeat_rpc_port;
         return config;
     }
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -45,6 +45,15 @@ class MasterClient {
         const std::string& master_addr = kDefaultMasterAddress);
 
     /**
+     * @brief Configures a dedicated heartbeat server port.
+     * When > 0, Heartbeat is sent to host:heartbeat_rpc_port (derived from the
+     * current master address at Connect time) instead of the main RPC port, so
+     * heartbeats are not head-of-line-blocked by heavy metadata RPCs. Must be
+     * set before Connect. 0 = legacy behavior (heartbeat on main pool).
+     */
+    void SetHeartbeatRpcPort(uint16_t port) { heartbeat_rpc_port_ = port; }
+
+    /**
      * @brief Checks if an object exists
      * @param object_key Key to query
      * @return tl::expected<bool, ErrorCode> indicating exist or not
@@ -214,8 +223,15 @@ class MasterClient {
     template <auto ServiceMethod, typename ReturnType, typename... Args>
     [[nodiscard]] async_simple::coro::Lazy<tl::expected<ReturnType, ErrorCode>>
     invoke_rpc_async(Args&&... args) {
-        auto pool = client_accessor_.GetClientPool();
+        return invoke_rpc_async_with_pool<ServiceMethod, ReturnType>(
+            client_accessor_.GetClientPool(), std::forward<Args>(args)...);
+    }
 
+    template <auto ServiceMethod, typename ReturnType, typename... Args>
+    [[nodiscard]] async_simple::coro::Lazy<tl::expected<ReturnType, ErrorCode>>
+    invoke_rpc_async_with_pool(
+        std::shared_ptr<coro_io::client_pool<coro_rpc::coro_rpc_client>> pool,
+        Args&&... args) {
         // Increment RPC counter
         if (metrics_) {
             metrics_->rpc_count.inc({RpcNameTraits<ServiceMethod>::value});
@@ -253,6 +269,14 @@ class MasterClient {
         return async_simple::coro::syncAwait(
             invoke_rpc_async<ServiceMethod, ReturnType>(
                 std::forward<Args>(args)...));
+    }
+
+    template <auto ServiceMethod, typename ReturnType, typename... Args>
+    [[nodiscard]] tl::expected<ReturnType, ErrorCode> invoke_rpc_via(
+        RpcClientAccessor& accessor, Args&&... args) {
+        return async_simple::coro::syncAwait(
+            invoke_rpc_async_with_pool<ServiceMethod, ReturnType>(
+                accessor.GetClientPool(), std::forward<Args>(args)...));
     }
 
     /**
@@ -343,6 +367,11 @@ class MasterClient {
 
    protected:
     RpcClientAccessor client_accessor_;
+    // Dedicated pool for Heartbeat. When heartbeat_rpc_port_ > 0 it points at
+    // the master's dedicated heartbeat server (host:heartbeat_rpc_port_); when
+    // 0 it mirrors client_accessor_ so heartbeats ride the main pool (legacy).
+    RpcClientAccessor heartbeat_accessor_;
+    uint16_t heartbeat_rpc_port_ = 0;
 
     // The client identification.
     const UUID client_id_;

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -271,14 +271,6 @@ class MasterClient {
                 std::forward<Args>(args)...));
     }
 
-    template <auto ServiceMethod, typename ReturnType, typename... Args>
-    [[nodiscard]] tl::expected<ReturnType, ErrorCode> invoke_rpc_via(
-        RpcClientAccessor& accessor, Args&&... args) {
-        return async_simple::coro::syncAwait(
-            invoke_rpc_async_with_pool<ServiceMethod, ReturnType>(
-                accessor.GetClientPool(), std::forward<Args>(args)...));
-    }
-
     /**
      * @brief Generic RPC invocation helper for batch operations
      * @tparam ServiceMethod Pointer to WrappedMasterService member function
@@ -364,6 +356,13 @@ class MasterClient {
         std::shared_ptr<coro_io::client_pool<coro_rpc::coro_rpc_client>>
             client_pool_;
     };
+    template <auto ServiceMethod, typename ReturnType, typename... Args>
+    [[nodiscard]] tl::expected<ReturnType, ErrorCode> invoke_rpc_via(
+        RpcClientAccessor& accessor, Args&&... args) {
+        return async_simple::coro::syncAwait(
+            invoke_rpc_async_with_pool<ServiceMethod, ReturnType>(
+                accessor.GetClientPool(), std::forward<Args>(args)...));
+    }
 
    protected:
     RpcClientAccessor client_accessor_;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -23,16 +23,9 @@ struct MasterConfig {
     // Dedicated heartbeat RPC server. When heartbeat_rpc_port > 0, Heartbeat is
     // served by a separate coro_rpc_server with its own thread pool so that
     // heavy metadata RPCs cannot head-of-line-block heartbeats. 0 = disabled,
-    // heartbeat is served on the main RPC server (legacy behavior).
+    // heartbeat is served on the main RPC server as a legacy fallback.
     uint32_t heartbeat_rpc_port = 0;
     uint32_t heartbeat_rpc_thread_num = 1;
-    // Transitional dual-mode flag for smooth rollout. When true (and
-    // heartbeat_rpc_port > 0), Heartbeat is ALSO kept registered on the main
-    // RPC server, so legacy clients (heartbeat_rpc_port=0) and migrated clients
-    // (heartbeat_rpc_port=P) both work during the upgrade. Set to false once
-    // all clients are migrated to drop heartbeat from the main server. No
-    // effect when heartbeat_rpc_port == 0.
-    bool heartbeat_keep_on_main = false;
 
     uint64_t default_kv_lease_ttl;
     uint64_t default_kv_soft_pin_ttl;
@@ -138,9 +131,6 @@ class MasterServiceSupervisorConfig {
     // Dedicated heartbeat RPC server (0 = disabled, serve on main server).
     uint32_t heartbeat_rpc_port = 0;
     uint32_t heartbeat_rpc_thread_num = 1;
-    // Transitional dual-mode: also keep Heartbeat on the main server during
-    // rollout (see MasterConfig::heartbeat_keep_on_main).
-    bool heartbeat_keep_on_main = false;
     std::string etcd_endpoints = "0.0.0.0:2379";
     std::string local_hostname = "0.0.0.0:50051";
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -210,7 +200,6 @@ class MasterServiceSupervisorConfig {
         rpc_enable_tcp_no_delay = config.rpc_enable_tcp_no_delay;
         heartbeat_rpc_port = config.heartbeat_rpc_port;
         heartbeat_rpc_thread_num = config.heartbeat_rpc_thread_num;
-        heartbeat_keep_on_main = config.heartbeat_keep_on_main;
         etcd_endpoints = config.etcd_endpoints;
         local_hostname = rpc_address + ":" + std::to_string(rpc_port);
         cluster_id = config.cluster_id;
@@ -912,7 +901,6 @@ struct InProcMasterConfig {
     // only honored when explicitly requested via Start).
     std::optional<int> heartbeat_rpc_port;
     std::optional<uint32_t> heartbeat_rpc_thread_num;
-    std::optional<bool> heartbeat_keep_on_main;
 };
 
 // Builder class for InProcMasterConfig
@@ -929,7 +917,6 @@ class InProcMasterConfigBuilder {
     std::optional<int64_t> client_crashed_ttl_sec_ = std::nullopt;
     std::optional<int> heartbeat_rpc_port_ = std::nullopt;
     std::optional<uint32_t> heartbeat_rpc_thread_num_ = std::nullopt;
-    std::optional<bool> heartbeat_keep_on_main_ = std::nullopt;
 
    public:
     InProcMasterConfigBuilder() = default;
@@ -989,8 +976,8 @@ class InProcMasterConfigBuilder {
         return *this;
     }
 
-    InProcMasterConfigBuilder& set_heartbeat_keep_on_main(bool keep) {
-        heartbeat_keep_on_main_ = keep;
+    InProcMasterConfigBuilder& set_heartbeat_rpc_thread_num(uint32_t num) {
+        heartbeat_rpc_thread_num_ = num;
         return *this;
     }
 
@@ -1011,7 +998,6 @@ inline InProcMasterConfig InProcMasterConfigBuilder::build() const {
     config.client_crashed_ttl_sec = client_crashed_ttl_sec_;
     config.heartbeat_rpc_port = heartbeat_rpc_port_;
     config.heartbeat_rpc_thread_num = heartbeat_rpc_thread_num_;
-    config.heartbeat_keep_on_main = heartbeat_keep_on_main_;
     return config;
 }
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -343,6 +343,10 @@ class WrappedMasterServiceConfig {
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
     bool enable_metric_reporting = true;
     uint16_t http_port = 9003;
+    // Dedicated heartbeat RPC server port (0 = legacy: Heartbeat served on the
+    // main server). Exposed to clients via HeartbeatServiceReady so they can
+    // detect a client/master heartbeat-routing mismatch at Connect time.
+    uint32_t heartbeat_rpc_port = 0;
     double eviction_ratio = DEFAULT_EVICTION_RATIO;
     double eviction_high_watermark_ratio =
         DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
@@ -396,6 +400,7 @@ class WrappedMasterServiceConfig {
             config.allow_evict_soft_pinned_objects;
         enable_metric_reporting = config.enable_metric_reporting;
         http_port = static_cast<uint16_t>(config.metrics_port);
+        heartbeat_rpc_port = config.heartbeat_rpc_port;
         eviction_ratio = config.eviction_ratio;
         eviction_high_watermark_ratio = config.eviction_high_watermark_ratio;
         view_version = view_version_param;
@@ -454,6 +459,7 @@ class WrappedMasterServiceConfig {
             config.allow_evict_soft_pinned_objects;
         enable_metric_reporting = config.enable_metric_reporting;
         http_port = static_cast<uint16_t>(config.metrics_port);
+        heartbeat_rpc_port = config.heartbeat_rpc_port;
         eviction_ratio = config.eviction_ratio;
         eviction_high_watermark_ratio = config.eviction_high_watermark_ratio;
         view_version = view_version_param;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -976,11 +976,6 @@ class InProcMasterConfigBuilder {
         return *this;
     }
 
-    InProcMasterConfigBuilder& set_heartbeat_rpc_thread_num(uint32_t num) {
-        heartbeat_rpc_thread_num_ = num;
-        return *this;
-    }
-
     InProcMasterConfig build() const;
 };
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -20,6 +20,13 @@ struct MasterConfig {
     int32_t rpc_conn_timeout_seconds;
     bool rpc_enable_tcp_no_delay;
 
+    // Dedicated heartbeat RPC server. When heartbeat_rpc_port > 0, Heartbeat is
+    // served by a separate coro_rpc_server with its own thread pool so that
+    // heavy metadata RPCs cannot head-of-line-block heartbeats. 0 = disabled,
+    // heartbeat is served on the main RPC server (legacy behavior).
+    uint32_t heartbeat_rpc_port = 0;
+    uint32_t heartbeat_rpc_thread_num = 1;
+
     uint64_t default_kv_lease_ttl;
     uint64_t default_kv_soft_pin_ttl;
     bool allow_evict_soft_pinned_objects;
@@ -121,6 +128,9 @@ class MasterServiceSupervisorConfig {
     std::chrono::steady_clock::duration rpc_conn_timeout = std::chrono::seconds(
         0);  // Client connection timeout. 0 = no timeout (infinite)
     bool rpc_enable_tcp_no_delay = true;
+    // Dedicated heartbeat RPC server (0 = disabled, serve on main server).
+    uint32_t heartbeat_rpc_port = 0;
+    uint32_t heartbeat_rpc_thread_num = 1;
     std::string etcd_endpoints = "0.0.0.0:2379";
     std::string local_hostname = "0.0.0.0:50051";
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -188,6 +198,8 @@ class MasterServiceSupervisorConfig {
         rpc_conn_timeout =
             std::chrono::seconds(config.rpc_conn_timeout_seconds);
         rpc_enable_tcp_no_delay = config.rpc_enable_tcp_no_delay;
+        heartbeat_rpc_port = config.heartbeat_rpc_port;
+        heartbeat_rpc_thread_num = config.heartbeat_rpc_thread_num;
         etcd_endpoints = config.etcd_endpoints;
         local_hostname = rpc_address + ":" + std::to_string(rpc_port);
         cluster_id = config.cluster_id;

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -897,6 +897,10 @@ struct InProcMasterConfig {
     std::optional<size_t> cxl_size;
     std::optional<int64_t> client_live_ttl_sec;
     std::optional<int64_t> client_crashed_ttl_sec;
+    // Dedicated heartbeat RPC server port (>0 enables; nullopt => free port
+    // only honored when explicitly requested via Start).
+    std::optional<int> heartbeat_rpc_port;
+    std::optional<uint32_t> heartbeat_rpc_thread_num;
 };
 
 // Builder class for InProcMasterConfig
@@ -911,6 +915,8 @@ class InProcMasterConfigBuilder {
     std::optional<size_t> cxl_size_ = std::nullopt;
     std::optional<int64_t> client_live_ttl_sec_ = std::nullopt;
     std::optional<int64_t> client_crashed_ttl_sec_ = std::nullopt;
+    std::optional<int> heartbeat_rpc_port_ = std::nullopt;
+    std::optional<uint32_t> heartbeat_rpc_thread_num_ = std::nullopt;
 
    public:
     InProcMasterConfigBuilder() = default;
@@ -960,6 +966,16 @@ class InProcMasterConfigBuilder {
         return *this;
     }
 
+    InProcMasterConfigBuilder& set_heartbeat_rpc_port(int port) {
+        heartbeat_rpc_port_ = port;
+        return *this;
+    }
+
+    InProcMasterConfigBuilder& set_heartbeat_rpc_thread_num(uint32_t num) {
+        heartbeat_rpc_thread_num_ = num;
+        return *this;
+    }
+
     InProcMasterConfig build() const;
 };
 
@@ -975,6 +991,8 @@ inline InProcMasterConfig InProcMasterConfigBuilder::build() const {
     config.cxl_size = cxl_size_;
     config.client_live_ttl_sec = client_live_ttl_sec_;
     config.client_crashed_ttl_sec = client_crashed_ttl_sec_;
+    config.heartbeat_rpc_port = heartbeat_rpc_port_;
+    config.heartbeat_rpc_thread_num = heartbeat_rpc_thread_num_;
     return config;
 }
 

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -26,6 +26,13 @@ struct MasterConfig {
     // heartbeat is served on the main RPC server (legacy behavior).
     uint32_t heartbeat_rpc_port = 0;
     uint32_t heartbeat_rpc_thread_num = 1;
+    // Transitional dual-mode flag for smooth rollout. When true (and
+    // heartbeat_rpc_port > 0), Heartbeat is ALSO kept registered on the main
+    // RPC server, so legacy clients (heartbeat_rpc_port=0) and migrated clients
+    // (heartbeat_rpc_port=P) both work during the upgrade. Set to false once
+    // all clients are migrated to drop heartbeat from the main server. No
+    // effect when heartbeat_rpc_port == 0.
+    bool heartbeat_keep_on_main = false;
 
     uint64_t default_kv_lease_ttl;
     uint64_t default_kv_soft_pin_ttl;
@@ -131,6 +138,9 @@ class MasterServiceSupervisorConfig {
     // Dedicated heartbeat RPC server (0 = disabled, serve on main server).
     uint32_t heartbeat_rpc_port = 0;
     uint32_t heartbeat_rpc_thread_num = 1;
+    // Transitional dual-mode: also keep Heartbeat on the main server during
+    // rollout (see MasterConfig::heartbeat_keep_on_main).
+    bool heartbeat_keep_on_main = false;
     std::string etcd_endpoints = "0.0.0.0:2379";
     std::string local_hostname = "0.0.0.0:50051";
     std::string cluster_id = DEFAULT_CLUSTER_ID;
@@ -200,6 +210,7 @@ class MasterServiceSupervisorConfig {
         rpc_enable_tcp_no_delay = config.rpc_enable_tcp_no_delay;
         heartbeat_rpc_port = config.heartbeat_rpc_port;
         heartbeat_rpc_thread_num = config.heartbeat_rpc_thread_num;
+        heartbeat_keep_on_main = config.heartbeat_keep_on_main;
         etcd_endpoints = config.etcd_endpoints;
         local_hostname = rpc_address + ":" + std::to_string(rpc_port);
         cluster_id = config.cluster_id;
@@ -901,6 +912,7 @@ struct InProcMasterConfig {
     // only honored when explicitly requested via Start).
     std::optional<int> heartbeat_rpc_port;
     std::optional<uint32_t> heartbeat_rpc_thread_num;
+    std::optional<bool> heartbeat_keep_on_main;
 };
 
 // Builder class for InProcMasterConfig
@@ -917,6 +929,7 @@ class InProcMasterConfigBuilder {
     std::optional<int64_t> client_crashed_ttl_sec_ = std::nullopt;
     std::optional<int> heartbeat_rpc_port_ = std::nullopt;
     std::optional<uint32_t> heartbeat_rpc_thread_num_ = std::nullopt;
+    std::optional<bool> heartbeat_keep_on_main_ = std::nullopt;
 
    public:
     InProcMasterConfigBuilder() = default;
@@ -976,6 +989,11 @@ class InProcMasterConfigBuilder {
         return *this;
     }
 
+    InProcMasterConfigBuilder& set_heartbeat_keep_on_main(bool keep) {
+        heartbeat_keep_on_main_ = keep;
+        return *this;
+    }
+
     InProcMasterConfig build() const;
 };
 
@@ -993,6 +1011,7 @@ inline InProcMasterConfig InProcMasterConfigBuilder::build() const {
     config.client_crashed_ttl_sec = client_crashed_ttl_sec_;
     config.heartbeat_rpc_port = heartbeat_rpc_port_;
     config.heartbeat_rpc_thread_num = heartbeat_rpc_thread_num_;
+    config.heartbeat_keep_on_main = heartbeat_keep_on_main_;
     return config;
 }
 

--- a/mooncake-store/include/p2p_rpc_service.h
+++ b/mooncake-store/include/p2p_rpc_service.h
@@ -42,6 +42,7 @@ class WrappedP2PMasterService final : public WrappedMasterService {
 
 void RegisterP2PRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedP2PMasterService& wrapped_master_service);
+    mooncake::WrappedP2PMasterService& wrapped_master_service,
+    bool include_heartbeat = true);
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -96,6 +96,14 @@ class WrappedMasterService {
 };
 
 void RegisterRpcService(coro_rpc::coro_rpc_server& server,
-                        mooncake::WrappedMasterService& wrapped_master_service);
+                        mooncake::WrappedMasterService& wrapped_master_service,
+                        bool include_heartbeat = true);
+
+// Registers only the Heartbeat handler on a dedicated heartbeat server. Used
+// by the priority-scheduling path to serve heartbeats on a separate
+// coro_rpc_server so heavy RPCs cannot head-of-line-block them.
+void RegisterHeartbeatRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedMasterService& wrapped_master_service);
 
 }  // namespace mooncake

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -83,6 +83,11 @@ class WrappedMasterService {
 
     tl::expected<std::string, ErrorCode> ServiceReady();
 
+    // Reports the master's heartbeat routing (dedicated port vs legacy main
+    // server) so clients can detect a heartbeat-port mismatch at Connect time.
+    tl::expected<HeartbeatServiceReadyResponse, ErrorCode>
+    HeartbeatServiceReady();
+
    protected:
     void init_http_server();
     virtual MasterService& GetMasterService() = 0;
@@ -93,6 +98,9 @@ class WrappedMasterService {
     std::thread metric_report_thread_;
     coro_http::coro_http_server http_server_;
     std::atomic<bool> metric_report_running_;
+    // Dedicated heartbeat RPC server port configured on this master
+    // (0 = legacy: Heartbeat served on the main server).
+    uint32_t heartbeat_rpc_port_ = 0;
 };
 
 void RegisterRpcService(coro_rpc::coro_rpc_server& server,

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -123,6 +123,21 @@ struct HeartbeatResponse {
 YLT_REFL(HeartbeatResponse, status, view_version, task_results);
 
 /**
+ * @brief Response for HeartbeatServiceReady.
+ *
+ * Reports the master's heartbeat routing so a client can detect a
+ * client/master heartbeat-port mismatch at Connect time:
+ *   heartbeat_rpc_port > 0 -> master serves Heartbeat on a dedicated server
+ *                             (Heartbeat is NOT on the main server)
+ *   heartbeat_rpc_port == 0 -> master serves Heartbeat on the main server
+ *                              (legacy fallback)
+ */
+struct HeartbeatServiceReadyResponse {
+    uint32_t heartbeat_rpc_port = 0;
+};
+YLT_REFL(HeartbeatServiceReadyResponse, heartbeat_rpc_port);
+
+/**
  * @brief Response structure for the DummyClient ping RPC (RealClient::ping).
  */
 struct DummyHeartbeatResponse {

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -173,6 +173,8 @@ enum class ErrorCode : int32_t {
 
     // RPC errors (Range: -900 to -999)
     RPC_FAIL = -900,  ///< RPC operation failed.
+    HEARTBEAT_RPC_UNREACHABLE =
+        -901,  ///< Dedicated heartbeat RPC server unreachable.
 
     // High availability errors (Range: -1000 to -1099)
     ETCD_OPERATION_ERROR = -1000,   ///< etcd operation failed.

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -175,6 +175,9 @@ enum class ErrorCode : int32_t {
     RPC_FAIL = -900,  ///< RPC operation failed.
     HEARTBEAT_RPC_UNREACHABLE =
         -901,  ///< Dedicated heartbeat RPC server unreachable.
+    HEARTBEAT_ROUTING_MISMATCH =
+        -902,  ///< Client/master heartbeat routing mismatch (one side
+               ///< dedicated, the other legacy).
 
     // High availability errors (Range: -1000 to -1099)
     ETCD_OPERATION_ERROR = -1000,   ///< etcd operation failed.

--- a/mooncake-store/src/centralized_client_service.cpp
+++ b/mooncake-store/src/centralized_client_service.cpp
@@ -102,6 +102,7 @@ ErrorCode CentralizedClientService::Init(
     const CentralizedClientConfig& config) {
     auto master_server_entry = config.master_server_entry;
     master_server_entry_ = master_server_entry;
+    master_client_.SetHeartbeatRpcPort(config.heartbeat_rpc_port);
     SetMasterDiscoveryConfig(config);
 
     ErrorCode err = ConnectToMaster(master_server_entry);

--- a/mooncake-store/src/centralized_rpc_service.cpp
+++ b/mooncake-store/src/centralized_rpc_service.cpp
@@ -624,8 +624,9 @@ WrappedCentralizedMasterService::NotifyOffloadSuccess(
 
 void RegisterCentralizedRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedCentralizedMasterService& wrapped_master_service) {
-    RegisterRpcService(server, wrapped_master_service);
+    mooncake::WrappedCentralizedMasterService& wrapped_master_service,
+    bool include_heartbeat) {
+    RegisterRpcService(server, wrapped_master_service, include_heartbeat);
     server.register_handler<
         &mooncake::WrappedCentralizedMasterService::BatchReplicaClear>(
         &wrapped_master_service);

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -365,8 +365,9 @@ int MasterServiceSupervisor::Start() {
                     WrappedMasterServiceConfig(config_, view_version));
             wrapped_master_service->init();
             RegisterCentralizedRpcService(
-                server, static_cast<WrappedCentralizedMasterService&>(
-                            *wrapped_master_service),
+                server,
+                static_cast<WrappedCentralizedMasterService&>(
+                    *wrapped_master_service),
                 /*include_heartbeat=*/main_includes_heartbeat);
         } else {
             auto p2p_wrapped_service =
@@ -388,8 +389,9 @@ int MasterServiceSupervisor::Start() {
                     return -1;
                 }
             }
-            RegisterP2PRpcService(server, *p2p_wrapped_service,
-                                  /*include_heartbeat=*/main_includes_heartbeat);
+            RegisterP2PRpcService(
+                server, *p2p_wrapped_service,
+                /*include_heartbeat=*/main_includes_heartbeat);
             wrapped_master_service = std::move(p2p_wrapped_service);
         }
 #ifdef STORE_USE_REDIS

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -3,6 +3,7 @@
 #include "centralized_rpc_service.h"
 #include "ha/oplog/p2p_hot_standby_service.h"
 #include "p2p_rpc_service.h"
+#include "rpc_service.h"
 #include "utils.h"
 #ifdef STORE_USE_REDIS
 #include "redis_master_view_helper.h"
@@ -347,6 +348,12 @@ int MasterServiceSupervisor::Start() {
         }
 
         LOG(INFO) << "Starting master service...";
+        // When a dedicated heartbeat port is configured, Heartbeat is served on
+        // a separate coro_rpc_server so heavy metadata RPCs cannot
+        // head-of-line-block heartbeats. The heartbeat server runs plain TCP
+        // (no init_ibv) to avoid contending for IB resources with the main
+        // server.
+        const bool dedicated_heartbeat = config_.heartbeat_rpc_port > 0;
         std::unique_ptr<WrappedMasterService> wrapped_master_service;
         if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {
             wrapped_master_service =
@@ -355,7 +362,8 @@ int MasterServiceSupervisor::Start() {
             wrapped_master_service->init();
             RegisterCentralizedRpcService(
                 server, static_cast<WrappedCentralizedMasterService&>(
-                            *wrapped_master_service));
+                            *wrapped_master_service),
+                /*include_heartbeat=*/!dedicated_heartbeat);
         } else {
             auto p2p_wrapped_service =
                 std::make_unique<WrappedP2PMasterService>(
@@ -376,7 +384,8 @@ int MasterServiceSupervisor::Start() {
                     return -1;
                 }
             }
-            RegisterP2PRpcService(server, *p2p_wrapped_service);
+            RegisterP2PRpcService(server, *p2p_wrapped_service,
+                                  /*include_heartbeat=*/!dedicated_heartbeat);
             wrapped_master_service = std::move(p2p_wrapped_service);
         }
 #ifdef STORE_USE_REDIS
@@ -386,11 +395,35 @@ int MasterServiceSupervisor::Start() {
 #endif
         // Metric reporting is now handled by WrappedMasterService.
 
+        // Start the dedicated heartbeat server alongside the main server. It
+        // shares the wrapped_master_service, so it must be stopped before that
+        // service object is destroyed (below, after the main server stops).
+        std::optional<coro_rpc::coro_rpc_server> heartbeat_server;
+        if (dedicated_heartbeat) {
+            heartbeat_server.emplace(
+                std::max<size_t>(1, config_.heartbeat_rpc_thread_num),
+                config_.heartbeat_rpc_port, config_.rpc_address,
+                config_.rpc_conn_timeout, config_.rpc_enable_tcp_no_delay);
+            RegisterHeartbeatRpcService(*heartbeat_server,
+                                        *wrapped_master_service);
+            LOG(INFO) << "Starting dedicated heartbeat RPC server on port "
+                      << config_.heartbeat_rpc_port;
+            auto heartbeat_ec = heartbeat_server->async_start();
+            if (heartbeat_ec.hasResult()) {
+                LOG(ERROR) << "Failed to start heartbeat RPC server: "
+                           << heartbeat_ec.result().value();
+                mv_helper->CancelKeepAlive(lease_id);
+                keep_leader_thread.join();
+                return -1;
+            }
+        }
+
         async_simple::Future<coro_rpc::err_code> ec =
             server.async_start();  // won't block here
         if (ec.hasResult()) {
             LOG(ERROR) << "Failed to start master service: "
                        << ec.result().value();
+            heartbeat_server.reset();
             mv_helper->CancelKeepAlive(lease_id);
             keep_leader_thread.join();
             return -1;
@@ -398,6 +431,9 @@ int MasterServiceSupervisor::Start() {
         // Block until the server is stopped
         auto server_err = std::move(ec).get();
         LOG(ERROR) << "Master service stopped: " << server_err;
+        // Stop the heartbeat server before wrapped_master_service (declared
+        // above) is destroyed at the end of this loop iteration.
+        heartbeat_server.reset();
 
         // If the server is closed due to internal errors, we need to manually
         // stop keep leader alive.

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -352,12 +352,11 @@ int MasterServiceSupervisor::Start() {
         // a separate coro_rpc_server so heavy metadata RPCs cannot
         // head-of-line-block heartbeats. The heartbeat server runs plain TCP
         // (no init_ibv) to avoid contending for IB resources with the main
-        // server.
+        // server. The main server serves Heartbeat only as a legacy fallback
+        // when no dedicated heartbeat port is configured (heartbeat_rpc_port
+        // == 0).
         const bool dedicated_heartbeat = config_.heartbeat_rpc_port > 0;
-        // In dual mode (heartbeat_keep_on_main), keep Heartbeat on the main
-        // server too so legacy clients keep working during migration.
-        const bool main_includes_heartbeat =
-            !dedicated_heartbeat || config_.heartbeat_keep_on_main;
+        const bool main_includes_heartbeat = !dedicated_heartbeat;
         std::unique_ptr<WrappedMasterService> wrapped_master_service;
         if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {
             wrapped_master_service =

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -354,6 +354,10 @@ int MasterServiceSupervisor::Start() {
         // (no init_ibv) to avoid contending for IB resources with the main
         // server.
         const bool dedicated_heartbeat = config_.heartbeat_rpc_port > 0;
+        // In dual mode (heartbeat_keep_on_main), keep Heartbeat on the main
+        // server too so legacy clients keep working during migration.
+        const bool main_includes_heartbeat =
+            !dedicated_heartbeat || config_.heartbeat_keep_on_main;
         std::unique_ptr<WrappedMasterService> wrapped_master_service;
         if (config_.deployment_mode == DeploymentMode::CENTRALIZATION) {
             wrapped_master_service =
@@ -363,7 +367,7 @@ int MasterServiceSupervisor::Start() {
             RegisterCentralizedRpcService(
                 server, static_cast<WrappedCentralizedMasterService&>(
                             *wrapped_master_service),
-                /*include_heartbeat=*/!dedicated_heartbeat);
+                /*include_heartbeat=*/main_includes_heartbeat);
         } else {
             auto p2p_wrapped_service =
                 std::make_unique<WrappedP2PMasterService>(
@@ -385,7 +389,7 @@ int MasterServiceSupervisor::Start() {
                 }
             }
             RegisterP2PRpcService(server, *p2p_wrapped_service,
-                                  /*include_heartbeat=*/!dedicated_heartbeat);
+                                  /*include_heartbeat=*/main_includes_heartbeat);
             wrapped_master_service = std::move(p2p_wrapped_service);
         }
 #ifdef STORE_USE_REDIS

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -59,15 +59,9 @@ DEFINE_bool(rpc_enable_tcp_no_delay, true,
             "Enable TCP_NODELAY for RPC connections");
 DEFINE_uint32(heartbeat_rpc_port, 0,
               "Port for a dedicated heartbeat RPC server (0 = disabled, "
-              "heartbeat served on the main RPC server)");
+              "heartbeat served on the main RPC server as a legacy fallback)");
 DEFINE_uint32(heartbeat_rpc_thread_num, 1,
               "Thread count for the dedicated heartbeat RPC server");
-DEFINE_bool(heartbeat_keep_on_main, false,
-            "Dual-mode rollout flag. When true and heartbeat_rpc_port > 0, "
-            "Heartbeat is ALSO kept on the main RPC server so legacy clients "
-            "(heartbeat_rpc_port=0) keep working during migration. Set false "
-            "once all clients are migrated. No effect when "
-            "heartbeat_rpc_port == 0.");
 DEFINE_validator(eviction_ratio, [](const char* flagname, double value) {
     if (value < 0.0 || value > 1.0) {
         LOG(FATAL) << "Eviction ratio must be between 0.0 and 1.0";
@@ -211,9 +205,6 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("heartbeat_rpc_thread_num",
                              &master_config.heartbeat_rpc_thread_num,
                              FLAGS_heartbeat_rpc_thread_num);
-    default_config.GetBool("heartbeat_keep_on_main",
-                           &master_config.heartbeat_keep_on_main,
-                           FLAGS_heartbeat_keep_on_main);
     default_config.GetUInt64("default_kv_lease_ttl",
                              &master_config.default_kv_lease_ttl,
                              FLAGS_default_kv_lease_ttl);
@@ -425,11 +416,6 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.heartbeat_rpc_thread_num = FLAGS_heartbeat_rpc_thread_num;
-    }
-    if ((google::GetCommandLineFlagInfo("heartbeat_keep_on_main", &info) &&
-         !info.is_default) ||
-        !conf_set) {
-        master_config.heartbeat_keep_on_main = FLAGS_heartbeat_keep_on_main;
     }
     if ((google::GetCommandLineFlagInfo("enable_metric_reporting", &info) &&
          !info.is_default) ||
@@ -864,7 +850,6 @@ int main(int argc, char* argv[]) {
         << ", heartbeat_rpc_port=" << master_config.heartbeat_rpc_port
         << ", heartbeat_rpc_thread_num="
         << master_config.heartbeat_rpc_thread_num
-        << ", heartbeat_keep_on_main=" << master_config.heartbeat_keep_on_main
         << ", rpc protocol=" << protocol
         << ", cluster_id=" << master_config.cluster_id
         << ", root_fs_dir=" << master_config.root_fs_dir
@@ -939,12 +924,11 @@ int main(int argc, char* argv[]) {
         // separate coro_rpc_server with its own thread pool so heavy metadata
         // RPCs on the main server cannot head-of-line-block heartbeats. The
         // heartbeat server always runs plain TCP (no init_ibv) to avoid
-        // contending for IB resources with the main server.
+        // contending for IB resources with the main server. The main server
+        // serves Heartbeat only as a legacy fallback when no dedicated
+        // heartbeat port is configured (heartbeat_rpc_port == 0).
         const bool dedicated_heartbeat = master_config.heartbeat_rpc_port > 0;
-        // In dual mode (heartbeat_keep_on_main), keep Heartbeat on the main
-        // server too so legacy clients keep working during migration.
-        const bool main_includes_heartbeat =
-            !dedicated_heartbeat || master_config.heartbeat_keep_on_main;
+        const bool main_includes_heartbeat = !dedicated_heartbeat;
         std::optional<coro_rpc::coro_rpc_server> heartbeat_server;
         if (dedicated_heartbeat) {
             heartbeat_server.emplace(

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -416,6 +416,21 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
         !conf_set) {
         master_config.rpc_enable_tcp_no_delay = FLAGS_rpc_enable_tcp_no_delay;
     }
+    if ((google::GetCommandLineFlagInfo("heartbeat_rpc_port", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.heartbeat_rpc_port = FLAGS_heartbeat_rpc_port;
+    }
+    if ((google::GetCommandLineFlagInfo("heartbeat_rpc_thread_num", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.heartbeat_rpc_thread_num = FLAGS_heartbeat_rpc_thread_num;
+    }
+    if ((google::GetCommandLineFlagInfo("heartbeat_keep_on_main", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.heartbeat_keep_on_main = FLAGS_heartbeat_keep_on_main;
+    }
     if ((google::GetCommandLineFlagInfo("enable_metric_reporting", &info) &&
          !info.is_default) ||
         !conf_set) {
@@ -846,6 +861,10 @@ int main(int argc, char* argv[]) {
         << ", rpc_conn_timeout_seconds="
         << master_config.rpc_conn_timeout_seconds
         << ", rpc_enable_tcp_no_delay=" << master_config.rpc_enable_tcp_no_delay
+        << ", heartbeat_rpc_port=" << master_config.heartbeat_rpc_port
+        << ", heartbeat_rpc_thread_num="
+        << master_config.heartbeat_rpc_thread_num
+        << ", heartbeat_keep_on_main=" << master_config.heartbeat_keep_on_main
         << ", rpc protocol=" << protocol
         << ", cluster_id=" << master_config.cluster_id
         << ", root_fs_dir=" << master_config.root_fs_dir

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -940,8 +940,7 @@ int main(int argc, char* argv[]) {
         // RPCs on the main server cannot head-of-line-block heartbeats. The
         // heartbeat server always runs plain TCP (no init_ibv) to avoid
         // contending for IB resources with the main server.
-        const bool dedicated_heartbeat =
-            master_config.heartbeat_rpc_port > 0;
+        const bool dedicated_heartbeat = master_config.heartbeat_rpc_port > 0;
         // In dual mode (heartbeat_keep_on_main), keep Heartbeat on the main
         // server too so legacy clients keep working during migration.
         const bool main_includes_heartbeat =
@@ -967,8 +966,9 @@ int main(int argc, char* argv[]) {
             master_service->init();
 
             mooncake::RegisterCentralizedRpcService(
-                server, static_cast<mooncake::WrappedCentralizedMasterService&>(
-                            *master_service),
+                server,
+                static_cast<mooncake::WrappedCentralizedMasterService&>(
+                    *master_service),
                 /*include_heartbeat=*/main_includes_heartbeat);
         } else {
             master_service =
@@ -978,8 +978,9 @@ int main(int argc, char* argv[]) {
             master_service->init();
 
             mooncake::RegisterP2PRpcService(
-                server, static_cast<mooncake::WrappedP2PMasterService&>(
-                            *master_service),
+                server,
+                static_cast<mooncake::WrappedP2PMasterService&>(
+                    *master_service),
                 /*include_heartbeat=*/main_includes_heartbeat);
         }
 

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -62,6 +62,12 @@ DEFINE_uint32(heartbeat_rpc_port, 0,
               "heartbeat served on the main RPC server)");
 DEFINE_uint32(heartbeat_rpc_thread_num, 1,
               "Thread count for the dedicated heartbeat RPC server");
+DEFINE_bool(heartbeat_keep_on_main, false,
+            "Dual-mode rollout flag. When true and heartbeat_rpc_port > 0, "
+            "Heartbeat is ALSO kept on the main RPC server so legacy clients "
+            "(heartbeat_rpc_port=0) keep working during migration. Set false "
+            "once all clients are migrated. No effect when "
+            "heartbeat_rpc_port == 0.");
 DEFINE_validator(eviction_ratio, [](const char* flagname, double value) {
     if (value < 0.0 || value > 1.0) {
         LOG(FATAL) << "Eviction ratio must be between 0.0 and 1.0";
@@ -205,6 +211,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetUInt32("heartbeat_rpc_thread_num",
                              &master_config.heartbeat_rpc_thread_num,
                              FLAGS_heartbeat_rpc_thread_num);
+    default_config.GetBool("heartbeat_keep_on_main",
+                           &master_config.heartbeat_keep_on_main,
+                           FLAGS_heartbeat_keep_on_main);
     default_config.GetUInt64("default_kv_lease_ttl",
                              &master_config.default_kv_lease_ttl,
                              FLAGS_default_kv_lease_ttl);
@@ -914,6 +923,10 @@ int main(int argc, char* argv[]) {
         // contending for IB resources with the main server.
         const bool dedicated_heartbeat =
             master_config.heartbeat_rpc_port > 0;
+        // In dual mode (heartbeat_keep_on_main), keep Heartbeat on the main
+        // server too so legacy clients keep working during migration.
+        const bool main_includes_heartbeat =
+            !dedicated_heartbeat || master_config.heartbeat_keep_on_main;
         std::optional<coro_rpc::coro_rpc_server> heartbeat_server;
         if (dedicated_heartbeat) {
             heartbeat_server.emplace(
@@ -937,7 +950,7 @@ int main(int argc, char* argv[]) {
             mooncake::RegisterCentralizedRpcService(
                 server, static_cast<mooncake::WrappedCentralizedMasterService&>(
                             *master_service),
-                /*include_heartbeat=*/!dedicated_heartbeat);
+                /*include_heartbeat=*/main_includes_heartbeat);
         } else {
             master_service =
                 std::make_unique<mooncake::WrappedP2PMasterService>(
@@ -948,7 +961,7 @@ int main(int argc, char* argv[]) {
             mooncake::RegisterP2PRpcService(
                 server, static_cast<mooncake::WrappedP2PMasterService&>(
                             *master_service),
-                /*include_heartbeat=*/!dedicated_heartbeat);
+                /*include_heartbeat=*/main_includes_heartbeat);
         }
 
         if (dedicated_heartbeat) {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -4,6 +4,7 @@
 #include <chrono>  // For std::chrono
 #include <csignal>
 #include <memory>  // For std::unique_ptr
+#include <optional>
 #include <thread>  // For std::thread
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 #include <ylt/easylog/record.hpp>
@@ -13,6 +14,7 @@
 #include "http_metadata_server.h"
 #include "centralized_rpc_service.h"
 #include "p2p_rpc_service.h"
+#include "rpc_service.h"
 #include "types.h"
 
 #include "master_config.h"
@@ -55,6 +57,11 @@ DEFINE_int32(rpc_conn_timeout_seconds, 0,
              "Connection timeout in seconds (0 = no timeout)");
 DEFINE_bool(rpc_enable_tcp_no_delay, true,
             "Enable TCP_NODELAY for RPC connections");
+DEFINE_uint32(heartbeat_rpc_port, 0,
+              "Port for a dedicated heartbeat RPC server (0 = disabled, "
+              "heartbeat served on the main RPC server)");
+DEFINE_uint32(heartbeat_rpc_thread_num, 1,
+              "Thread count for the dedicated heartbeat RPC server");
 DEFINE_validator(eviction_ratio, [](const char* flagname, double value) {
     if (value < 0.0 || value > 1.0) {
         LOG(FATAL) << "Eviction ratio must be between 0.0 and 1.0";
@@ -192,6 +199,12 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetBool("rpc_enable_tcp_no_delay",
                            &master_config.rpc_enable_tcp_no_delay,
                            FLAGS_rpc_enable_tcp_no_delay);
+    default_config.GetUInt32("heartbeat_rpc_port",
+                             &master_config.heartbeat_rpc_port,
+                             FLAGS_heartbeat_rpc_port);
+    default_config.GetUInt32("heartbeat_rpc_thread_num",
+                             &master_config.heartbeat_rpc_thread_num,
+                             FLAGS_heartbeat_rpc_thread_num);
     default_config.GetUInt64("default_kv_lease_ttl",
                              &master_config.default_kv_lease_ttl,
                              FLAGS_default_kv_lease_ttl);
@@ -894,6 +907,22 @@ int main(int argc, char* argv[]) {
             server.init_ibv();
         }
 
+        // When a dedicated heartbeat port is configured, serve Heartbeat on a
+        // separate coro_rpc_server with its own thread pool so heavy metadata
+        // RPCs on the main server cannot head-of-line-block heartbeats. The
+        // heartbeat server always runs plain TCP (no init_ibv) to avoid
+        // contending for IB resources with the main server.
+        const bool dedicated_heartbeat =
+            master_config.heartbeat_rpc_port > 0;
+        std::optional<coro_rpc::coro_rpc_server> heartbeat_server;
+        if (dedicated_heartbeat) {
+            heartbeat_server.emplace(
+                std::max<uint32_t>(1u, master_config.heartbeat_rpc_thread_num),
+                master_config.heartbeat_rpc_port, master_config.rpc_address,
+                std::chrono::seconds(master_config.rpc_conn_timeout_seconds),
+                master_config.rpc_enable_tcp_no_delay);
+        }
+
         // Declare service object outside if block to ensure it lives until
         // server.start() completes
         std::unique_ptr<mooncake::WrappedMasterService> master_service;
@@ -907,7 +936,8 @@ int main(int argc, char* argv[]) {
 
             mooncake::RegisterCentralizedRpcService(
                 server, static_cast<mooncake::WrappedCentralizedMasterService&>(
-                            *master_service));
+                            *master_service),
+                /*include_heartbeat=*/!dedicated_heartbeat);
         } else {
             master_service =
                 std::make_unique<mooncake::WrappedP2PMasterService>(
@@ -917,7 +947,21 @@ int main(int argc, char* argv[]) {
 
             mooncake::RegisterP2PRpcService(
                 server, static_cast<mooncake::WrappedP2PMasterService&>(
-                            *master_service));
+                            *master_service),
+                /*include_heartbeat=*/!dedicated_heartbeat);
+        }
+
+        if (dedicated_heartbeat) {
+            mooncake::RegisterHeartbeatRpcService(*heartbeat_server,
+                                                  *master_service);
+            LOG(INFO) << "Starting dedicated heartbeat RPC server on port "
+                      << master_config.heartbeat_rpc_port;
+            auto heartbeat_ec = heartbeat_server->async_start();
+            if (heartbeat_ec.hasResult()) {
+                LOG(ERROR) << "Failed to start heartbeat RPC server: "
+                           << heartbeat_ec.result().value();
+                return -1;
+            }
         }
         return server.start();
     }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -307,8 +307,9 @@ tl::expected<HeartbeatResponse, ErrorCode> MasterClient::Heartbeat(
 
     // Send via the dedicated heartbeat accessor (separate pool that targets the
     // master's heartbeat server when configured, else the main pool).
-    auto result = invoke_rpc_via<&WrappedMasterService::Heartbeat,
-                                 HeartbeatResponse>(heartbeat_accessor_, req);
+    auto result =
+        invoke_rpc_via<&WrappedMasterService::Heartbeat, HeartbeatResponse>(
+            heartbeat_accessor_, req);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -167,6 +167,15 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
         auto hb_result =
             invoke_rpc_via<&WrappedMasterService::ServiceReady, std::string>(
                 heartbeat_accessor_);
+        if (!hb_result.has_value() && is_same_addr) {
+            // Stale heartbeat connection pool might still exist (mirrors the
+            // main-pool retry above). Retrying once forces the pool to
+            // re-establish a new connection before declaring the heartbeat
+            // server unreachable. Skipped when !is_same_addr because a fresh
+            // pool was just obtained — a failure there is a real mismatch.
+            hb_result = invoke_rpc_via<&WrappedMasterService::ServiceReady,
+                                       std::string>(heartbeat_accessor_);
+        }
         if (!hb_result.has_value()) {
             LOG(ERROR) << "Dedicated heartbeat RPC server unreachable at"
                        << " heartbeat_rpc_port=" << heartbeat_rpc_port_

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -158,6 +158,26 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_VERSION);
         return ErrorCode::INVALID_VERSION;
     }
+    // When a dedicated heartbeat port is configured, verify the master
+    // actually opened it. A failure here means the client expects a dedicated
+    // heartbeat server the master never started (heartbeat_rpc_port > 0 on the
+    // client, but the master runs with the legacy fallback) — fail fast instead
+    // of letting heartbeats silently starve and the client get reaped.
+    if (heartbeat_rpc_port_ > 0) {
+        auto hb_result =
+            invoke_rpc_via<&WrappedMasterService::ServiceReady, std::string>(
+                heartbeat_accessor_);
+        if (!hb_result.has_value()) {
+            LOG(ERROR) << "Dedicated heartbeat RPC server unreachable at"
+                       << " heartbeat_rpc_port=" << heartbeat_rpc_port_
+                       << " (master may not have enabled it): error_code="
+                       << hb_result.error();
+            timer.LogResponse("error_code=",
+                              ErrorCode::HEARTBEAT_RPC_UNREACHABLE);
+            client_addr_param_.clear();
+            return ErrorCode::HEARTBEAT_RPC_UNREACHABLE;
+        }
+    }
     timer.LogResponse("error_code=", ErrorCode::OK);
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -103,6 +103,11 @@ struct RpcNameTraits<&WrappedMasterService::ServiceReady> {
     static constexpr const char* value = "ServiceReady";
 };
 
+template <>
+struct RpcNameTraits<&WrappedMasterService::HeartbeatServiceReady> {
+    static constexpr const char* value = "HeartbeatServiceReady";
+};
+
 ErrorCode MasterClient::Connect(const std::string& master_addr) {
     ScopedVLogTimer timer(1, "MasterClient::Connect");
     timer.LogRequest("master_addr=", master_addr);
@@ -158,29 +163,50 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
         timer.LogResponse("error_code=", ErrorCode::INVALID_VERSION);
         return ErrorCode::INVALID_VERSION;
     }
-    // When a dedicated heartbeat port is configured, verify the master
-    // actually opened it. A failure here means the client expects a dedicated
-    // heartbeat server the master never started (heartbeat_rpc_port > 0 on the
-    // client, but the master runs with the legacy fallback) — fail fast instead
-    // of letting heartbeats silently starve and the client get reaped.
-    if (heartbeat_rpc_port_ > 0) {
+    // Ask the master how it routes heartbeats, then verify it matches the
+    // client's expectation. Catches both mismatch directions at startup:
+    //   - client expects a dedicated heartbeat server the master never opened
+    //   - client is legacy but the master dropped Heartbeat from the main
+    //     server in favor of a dedicated port
+    // Either direction would otherwise silently starve heartbeats until the
+    // client gets reaped (client_live_ttl expiry, segment reclaim).
+    auto hb_ready = invoke_rpc<&WrappedMasterService::HeartbeatServiceReady,
+                               HeartbeatServiceReadyResponse>();
+    if (!hb_ready.has_value()) {
+        LOG(ERROR) << "HeartbeatServiceReady probe failed: error_code="
+                   << hb_ready.error()
+                   << " (master may predate this RPC; upgrade master first)";
+        timer.LogResponse("error_code=", hb_ready.error());
+        client_addr_param_.clear();
+        return hb_ready.error();
+    }
+    const bool client_dedicated = heartbeat_rpc_port_ > 0;
+    const bool master_dedicated = hb_ready->heartbeat_rpc_port > 0;
+    if (client_dedicated != master_dedicated) {
+        LOG(ERROR) << "Heartbeat routing mismatch: client_hb_port="
+                   << heartbeat_rpc_port_
+                   << " master_hb_port=" << hb_ready->heartbeat_rpc_port
+                   << " (one side is dedicated, the other is legacy)";
+        timer.LogResponse("error_code=", ErrorCode::HEARTBEAT_ROUTING_MISMATCH);
+        client_addr_param_.clear();
+        return ErrorCode::HEARTBEAT_ROUTING_MISMATCH;
+    }
+    // Both sides dedicated: confirm the dedicated heartbeat server is actually
+    // reachable (catches a configured-but-dead dedicated server). Mirrors the
+    // main-pool stale-connection retry above when reconnecting to the same
+    // address.
+    if (client_dedicated) {
         auto hb_result =
             invoke_rpc_via<&WrappedMasterService::ServiceReady, std::string>(
                 heartbeat_accessor_);
         if (!hb_result.has_value() && is_same_addr) {
-            // Stale heartbeat connection pool might still exist (mirrors the
-            // main-pool retry above). Retrying once forces the pool to
-            // re-establish a new connection before declaring the heartbeat
-            // server unreachable. Skipped when !is_same_addr because a fresh
-            // pool was just obtained — a failure there is a real mismatch.
             hb_result = invoke_rpc_via<&WrappedMasterService::ServiceReady,
                                        std::string>(heartbeat_accessor_);
         }
         if (!hb_result.has_value()) {
             LOG(ERROR) << "Dedicated heartbeat RPC server unreachable at"
                        << " heartbeat_rpc_port=" << heartbeat_rpc_port_
-                       << " (master may not have enabled it): error_code="
-                       << hb_result.error();
+                       << ": error_code=" << hb_result.error();
             timer.LogResponse("error_code=",
                               ErrorCode::HEARTBEAT_RPC_UNREACHABLE);
             client_addr_param_.clear();

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -115,6 +115,23 @@ ErrorCode MasterClient::Connect(const std::string& master_addr) {
         auto client_pool = client_pools_->at(master_addr);
         client_accessor_.SetClientPool(client_pool);
         client_addr_param_ = master_addr;
+        // Route heartbeats to the dedicated heartbeat server when configured.
+        // The heartbeat endpoint is the same host as the master with the
+        // dedicated heartbeat port, so it follows the leader automatically on
+        // HA failover. When no dedicated port is set, heartbeats use the main
+        // pool (legacy behavior).
+        if (heartbeat_rpc_port_ > 0) {
+            auto colon = master_addr.rfind(':');
+            std::string host = (colon == std::string::npos)
+                                   ? master_addr
+                                   : master_addr.substr(0, colon);
+            std::string heartbeat_addr =
+                host + ":" + std::to_string(heartbeat_rpc_port_);
+            heartbeat_accessor_.SetClientPool(
+                client_pools_->at(heartbeat_addr));
+        } else {
+            heartbeat_accessor_.SetClientPool(client_pool);
+        }
     }
     // The client pool does not have native connection check method, so we need
     // to use custom ServiceReady API.
@@ -288,8 +305,10 @@ tl::expected<HeartbeatResponse, ErrorCode> MasterClient::Heartbeat(
     ScopedVLogTimer timer(1, "MasterClient::Heartbeat");
     timer.LogRequest("client_id=", client_id_);
 
-    auto result =
-        invoke_rpc<&WrappedMasterService::Heartbeat, HeartbeatResponse>(req);
+    // Send via the dedicated heartbeat accessor (separate pool that targets the
+    // master's heartbeat server when configured, else the main pool).
+    auto result = invoke_rpc_via<&WrappedMasterService::Heartbeat,
+                                 HeartbeatResponse>(heartbeat_accessor_, req);
     timer.LogResponseExpected(result);
     return result;
 }

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -150,6 +150,7 @@ P2PClientService::~P2PClientService() {
 ErrorCode P2PClientService::Init(const P2PClientConfig& config) {
     client_rpc_port_ = config.client_rpc_port;
     transfer_direction_mode_ = config.transfer_direction_mode;
+    master_client_.SetHeartbeatRpcPort(config.heartbeat_rpc_port);
     // Saved so a later re-registration (after UnregisterClient) can restart
     // the heartbeat with the same master entry.
     master_server_entry_ = config.master_server_entry;

--- a/mooncake-store/src/p2p_rpc_service.cpp
+++ b/mooncake-store/src/p2p_rpc_service.cpp
@@ -15,8 +15,9 @@ void WrappedP2PMasterService::init_http_handlers() {
 
 void RegisterP2PRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedP2PMasterService& wrapped_master_service) {
-    RegisterRpcService(server, wrapped_master_service);
+    mooncake::WrappedP2PMasterService& wrapped_master_service,
+    bool include_heartbeat) {
+    RegisterRpcService(server, wrapped_master_service, include_heartbeat);
     server.register_handler<&mooncake::WrappedP2PMasterService::GetWriteRoute>(
         &wrapped_master_service);
     server.register_handler<

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -28,6 +28,12 @@ DEFINE_int32(redis_master_view_ttl_sec, 4,
              "Redis master view TTL for redis:// master discovery");
 DEFINE_int32(redis_heartbeat_interval_sec, 1,
              "Redis heartbeat interval for redis:// master discovery");
+DEFINE_uint32(
+    heartbeat_rpc_port, 0,
+    "Port of the master's dedicated heartbeat RPC server. When > 0, "
+    "heartbeats are sent to <master host>:heartbeat_rpc_port instead of "
+    "the main RPC port so heavy metadata RPCs cannot head-of-line-block "
+    "them. Must match the master's --heartbeat_rpc_port. 0 = disabled.");
 DEFINE_string(global_segment_size, "4 GB", "Size of global segment");
 DEFINE_int32(threads, 1, "Number of rpc threads for dummy client");
 DEFINE_bool(enable_offload, false, "Enable offload availability");
@@ -159,7 +165,8 @@ int main(int argc, char* argv[]) {
                 FLAGS_metric_report_interval_seconds, FLAGS_redis_cluster_id,
                 FLAGS_redis_password, FLAGS_redis_db_index,
                 FLAGS_redis_master_view_ttl_sec,
-                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username);
+                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username,
+                static_cast<uint16_t>(FLAGS_heartbeat_rpc_port));
         } else {
             if (FLAGS_deployment_mode != "Centralization") {
                 LOG(WARNING)
@@ -180,7 +187,8 @@ int main(int argc, char* argv[]) {
                 FLAGS_metric_report_interval_seconds, FLAGS_redis_cluster_id,
                 FLAGS_redis_password, FLAGS_redis_db_index,
                 FLAGS_redis_master_view_ttl_sec,
-                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username);
+                FLAGS_redis_heartbeat_interval_sec, FLAGS_redis_username,
+                static_cast<uint16_t>(FLAGS_heartbeat_rpc_port));
         }
     }();
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -517,6 +517,11 @@ void RegisterHeartbeatRpcService(
     mooncake::WrappedMasterService& wrapped_master_service) {
     server.register_handler<&mooncake::WrappedMasterService::Heartbeat>(
         &wrapped_master_service);
+    // ServiceReady gives clients a lightweight, side-effect-free probe to
+    // verify the dedicated heartbeat server is actually listening (used by
+    // MasterClient::Connect to fail fast on a client/master port mismatch).
+    server.register_handler<&mooncake::WrappedMasterService::ServiceReady>(
+        &wrapped_master_service);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -473,7 +473,8 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
 
 void RegisterRpcService(
     coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedMasterService& wrapped_master_service) {
+    mooncake::WrappedMasterService& wrapped_master_service,
+    bool include_heartbeat) {
     server.register_handler<&mooncake::WrappedMasterService::ExistKey>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchQueryIp>(
@@ -496,8 +497,10 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::Heartbeat>(
-        &wrapped_master_service);
+    if (include_heartbeat) {
+        server.register_handler<&mooncake::WrappedMasterService::Heartbeat>(
+            &wrapped_master_service);
+    }
     server.register_handler<&mooncake::WrappedMasterService::QueryClientStatus>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::RegisterClient>(
@@ -507,6 +510,13 @@ void RegisterRpcService(
     server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ServiceReady>(
+        &wrapped_master_service);
+}
+
+void RegisterHeartbeatRpcService(
+    coro_rpc::coro_rpc_server& server,
+    mooncake::WrappedMasterService& wrapped_master_service) {
+    server.register_handler<&mooncake::WrappedMasterService::Heartbeat>(
         &wrapped_master_service);
 }
 

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -471,10 +471,9 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
     return GetMooncakeStoreVersion();
 }
 
-void RegisterRpcService(
-    coro_rpc::coro_rpc_server& server,
-    mooncake::WrappedMasterService& wrapped_master_service,
-    bool include_heartbeat) {
+void RegisterRpcService(coro_rpc::coro_rpc_server& server,
+                        mooncake::WrappedMasterService& wrapped_master_service,
+                        bool include_heartbeat) {
     server.register_handler<&mooncake::WrappedMasterService::ExistKey>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchQueryIp>(

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -25,7 +25,8 @@ namespace mooncake {
 WrappedMasterService::WrappedMasterService(
     const WrappedMasterServiceConfig& config)
     : http_server_(4, config.http_port),
-      metric_report_running_(config.enable_metric_reporting) {}
+      metric_report_running_(config.enable_metric_reporting),
+      heartbeat_rpc_port_(config.heartbeat_rpc_port) {}
 
 void WrappedMasterService::init() {
     init_http_server();
@@ -471,6 +472,13 @@ tl::expected<std::string, ErrorCode> WrappedMasterService::ServiceReady() {
     return GetMooncakeStoreVersion();
 }
 
+tl::expected<HeartbeatServiceReadyResponse, ErrorCode>
+WrappedMasterService::HeartbeatServiceReady() {
+    HeartbeatServiceReadyResponse response;
+    response.heartbeat_rpc_port = heartbeat_rpc_port_;
+    return response;
+}
+
 void RegisterRpcService(coro_rpc::coro_rpc_server& server,
                         mooncake::WrappedMasterService& wrapped_master_service,
                         bool include_heartbeat) {
@@ -509,6 +517,12 @@ void RegisterRpcService(coro_rpc::coro_rpc_server& server,
     server.register_handler<&mooncake::WrappedMasterService::BatchExistKey>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ServiceReady>(
+        &wrapped_master_service);
+    // HeartbeatServiceReady is always on the main server so legacy clients
+    // (which only talk to the main server) can discover the master's heartbeat
+    // routing and fail fast on a client/master port mismatch at Connect time.
+    server.register_handler<
+        &mooncake::WrappedMasterService::HeartbeatServiceReady>(
         &wrapped_master_service);
 }
 

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -44,6 +44,7 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::TRANSFER_FAIL, "TRANSFER_FAIL"},
         {ErrorCode::RPC_FAIL, "RPC_FAIL"},
         {ErrorCode::HEARTBEAT_RPC_UNREACHABLE, "HEARTBEAT_RPC_UNREACHABLE"},
+        {ErrorCode::HEARTBEAT_ROUTING_MISMATCH, "HEARTBEAT_ROUTING_MISMATCH"},
         {ErrorCode::ETCD_OPERATION_ERROR, "ETCD_OPERATION_ERROR"},
         {ErrorCode::ETCD_KEY_NOT_EXIST, "ETCD_KEY_NOT_EXIST"},
         {ErrorCode::ETCD_TRANSACTION_FAIL, "ETCD_TRANSACTION_FAIL"},

--- a/mooncake-store/src/types.cpp
+++ b/mooncake-store/src/types.cpp
@@ -43,6 +43,7 @@ const std::string& toString(ErrorCode errorCode) noexcept {
         {ErrorCode::REPLICA_IS_PROCESSING, "REPLICA_IS_PROCESSING"},
         {ErrorCode::TRANSFER_FAIL, "TRANSFER_FAIL"},
         {ErrorCode::RPC_FAIL, "RPC_FAIL"},
+        {ErrorCode::HEARTBEAT_RPC_UNREACHABLE, "HEARTBEAT_RPC_UNREACHABLE"},
         {ErrorCode::ETCD_OPERATION_ERROR, "ETCD_OPERATION_ERROR"},
         {ErrorCode::ETCD_KEY_NOT_EXIST, "ETCD_KEY_NOT_EXIST"},
         {ErrorCode::ETCD_TRANSACTION_FAIL, "ETCD_TRANSACTION_FAIL"},

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_store_test(client_metrics_aggregator_test client_metrics_aggregator_test.cpp
 add_store_test(client_http_metrics_test client_http_metrics_test.cpp)
 add_store_test(serializer_test serializer_test.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
+add_store_test(heartbeat_dedicated_port_test heartbeat_dedicated_port_test.cpp)
 add_store_test(real_client_remount_test real_client_remount_test.cpp)
 add_store_test(shm_helper_test shm_helper_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -113,5 +113,37 @@ TEST(HeartbeatDedicatedPortDisabledTest,
     master.Stop();
 }
 
+// Dual-mode (heartbeat_keep_on_main=true): during migration the master serves
+// Heartbeat on BOTH the dedicated port and the main port, so legacy clients
+// (heartbeat_rpc_port=0) and migrated clients (heartbeat_rpc_port=P) both work.
+TEST(HeartbeatDedicatedPortDualModeTest, HeartbeatServedOnBothPorts) {
+    const int heartbeat_port = getFreeTcpPort();
+    InProcMaster master;
+    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder()
+                                 .set_heartbeat_rpc_port(heartbeat_port)
+                                 .set_heartbeat_keep_on_main(true)
+                                 .build()))
+        << "Failed to start InProcMaster in dual mode";
+
+    // Migrated client -> dedicated port: succeeds.
+    UUID migrated_id = generate_uuid();
+    CentralizedMasterClient migrated(migrated_id);
+    migrated.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port));
+    ASSERT_EQ(migrated.Connect(master.master_address()), ErrorCode::OK);
+    auto hb_dedicated = migrated.Heartbeat(MakeHeartbeatRequest(migrated_id));
+    EXPECT_TRUE(hb_dedicated.has_value())
+        << "Heartbeat via the dedicated port should succeed in dual mode";
+
+    // Legacy client -> main port: also succeeds (dual mode keeps it on main).
+    UUID legacy_id = generate_uuid();
+    CentralizedMasterClient legacy(legacy_id);  // heartbeat_rpc_port_ == 0
+    ASSERT_EQ(legacy.Connect(master.master_address()), ErrorCode::OK);
+    auto hb_main = legacy.Heartbeat(MakeHeartbeatRequest(legacy_id));
+    EXPECT_TRUE(hb_main.has_value())
+        << "Heartbeat via the main port should still succeed in dual mode";
+
+    master.Stop();
+}
+
 }  // namespace testing
 }  // namespace mooncake

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -10,19 +10,20 @@
 //
 // Coverage:
 //   1. Heartbeat reaches the dedicated port and succeeds.
-//   2. Heartbeat is NOT registered on the main port when the dedicated server
-//      is enabled.
+//   2. Reverse mismatch: legacy client vs dedicated master -> Connect fails
+//      fast with HEARTBEAT_ROUTING_MISMATCH.
+//   2b. Dedicated-port value mismatch (both dedicated, different ports) ->
+//       Connect fails fast with HEARTBEAT_RPC_UNREACHABLE at the reachability
+//       probe.
 //   3. Non-heartbeat RPCs still work via the main port.
 //   4. With the dedicated server disabled (port=0), Heartbeat is served on the
 //      main port as the legacy fallback.
-//   5. Client/master port mismatch (client expects a dedicated heartbeat
-//      server the master never opened) fails fast at Connect with
-//      HEARTBEAT_RPC_UNREACHABLE.
+//   5. Forward mismatch: dedicated client vs legacy master -> Connect fails
+//      fast with HEARTBEAT_ROUTING_MISMATCH.
 //   6. Reconnect after a master restart (same ports) rebuilds the stale main
 //      AND heartbeat connection pools via the is_same_addr retry instead of
 //      spuriously failing.
-//   7. The HEARTBEAT_RPC_UNREACHABLE error code round-trips through
-//      toString/fromInt.
+//   7. The heartbeat fail-fast error codes round-trip through toString/fromInt.
 //
 // Tests 1-6 are parameterized over CENTRALIZED and P2P: both modes share
 // RegisterHeartbeatRpcService, WrappedMasterService::ServiceReady and
@@ -152,9 +153,10 @@ class HeartbeatDedicatedPortTest : public ::testing::TestWithParam<TestMode> {
 
 // 1. Client configured with the dedicated port sends Heartbeat there and it
 // succeeds (the dedicated server has the Heartbeat handler registered). This
-// also implicitly proves ServiceReady is registered on the dedicated port:
-// Connect probes the heartbeat endpoint with ServiceReady and would fail
-// (HEARTBEAT_RPC_UNREACHABLE) otherwise.
+// also implicitly proves both that HeartbeatServiceReady is registered on the
+// main server (Connect queries it for the master's heartbeat port) and that
+// ServiceReady is registered on the dedicated server (Connect's reachability
+// probe would otherwise return HEARTBEAT_RPC_UNREACHABLE).
 TEST_P(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
     UUID client_id = generate_uuid();
     auto client = MakeClient(mode_, client_id);
@@ -166,18 +168,37 @@ TEST_P(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
         << "Heartbeat should succeed via the dedicated heartbeat port";
 }
 
-// 2. When the dedicated server is enabled, the main server must NOT have the
-// Heartbeat handler. A client that forces heartbeat_rpc_port=0 sends Heartbeat
-// to the main port and must fail.
-TEST_P(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
+// 2. Reverse mismatch: the master runs a dedicated heartbeat server, but the
+// client is legacy (heartbeat_rpc_port=0). Connect must fail fast with
+// HEARTBEAT_ROUTING_MISMATCH — otherwise the client would route heartbeats to
+// the main server, which dropped the Heartbeat handler when the dedicated
+// server was enabled, and silently starve.
+TEST_P(HeartbeatDedicatedPortTest,
+       LegacyClientAgainstDedicatedMasterFailsConnect) {
     UUID client_id = generate_uuid();
     auto client = MakeClient(mode_, client_id);  // heartbeat_rpc_port_ == 0
-    ASSERT_EQ(client->Connect(master_->master_address()), ErrorCode::OK);
+    EXPECT_EQ(client->Connect(master_->master_address()),
+              ErrorCode::HEARTBEAT_ROUTING_MISMATCH)
+        << "A legacy client must fail fast against a dedicated-port master "
+        << "instead of routing heartbeats to a main server that no longer "
+        << "serves Heartbeat";
+}
 
-    auto hb = client->Heartbeat(MakeHeartbeatRequest(client_id));
-    EXPECT_FALSE(hb.has_value())
-        << "Heartbeat must not be served on the main port when a dedicated "
-        << "heartbeat server is enabled";
+// 2b. Dedicated-port value mismatch: both sides are dedicated, but the client
+// points at a different dedicated port than the master opened. This is not a
+// routing-mode mismatch (both report dedicated), so it falls through to the
+// dedicated-server reachability probe and fails with HEARTBEAT_RPC_UNREACHABLE.
+TEST_P(HeartbeatDedicatedPortTest, DedicatedPortValueMismatchFailsConnect) {
+    int wrong_port = getFreeTcpPort();
+    ASSERT_NE(wrong_port, master_->heartbeat_rpc_port());
+    UUID client_id = generate_uuid();
+    auto client = MakeClient(mode_, client_id);
+    client->SetHeartbeatRpcPort(PortOf(wrong_port));
+
+    EXPECT_EQ(client->Connect(master_->master_address()),
+              ErrorCode::HEARTBEAT_RPC_UNREACHABLE)
+        << "A client pointed at the wrong dedicated port must fail fast at the "
+        << "reachability probe rather than silently failing heartbeats";
 }
 
 // 3. Non-heartbeat RPCs still reach the main port and succeed, proving the
@@ -225,23 +246,22 @@ TEST_P(HeartbeatLegacyMasterTest, HeartbeatServedOnMainPortWhenDisabled) {
         << "server is disabled (legacy fallback)";
 }
 
-// 5. Mismatch: the master is started WITHOUT a dedicated heartbeat port
-// (legacy fallback), but the client is configured with a heartbeat port
-// pointing at a port the master never opened. Connect must fail fast with
-// HEARTBEAT_RPC_UNREACHABLE instead of appearing to succeed and then silently
-// starving heartbeats.
+// 5. Forward mismatch: the master is started WITHOUT a dedicated heartbeat
+// port (legacy fallback), but the client is configured with a heartbeat port
+// (dedicated). Connect must fail fast with HEARTBEAT_ROUTING_MISMATCH instead
+// of appearing to succeed and then silently starving heartbeats.
 TEST_P(HeartbeatLegacyMasterTest, HeartbeatPortMismatchFailsConnect) {
-    // Client believes there is a dedicated heartbeat server on this free port;
-    // the master never opened it (this is a fresh is_same_addr=false Connect).
+    // Client believes it is dedicated; the master reports legacy (port=0) via
+    // HeartbeatServiceReady, so the routing-mode comparison catches it.
     int phantom_port = getFreeTcpPort();
     UUID client_id = generate_uuid();
     auto client = MakeClient(mode_, client_id);
     client->SetHeartbeatRpcPort(PortOf(phantom_port));
 
     EXPECT_EQ(client->Connect(master_->master_address()),
-              ErrorCode::HEARTBEAT_RPC_UNREACHABLE)
-        << "Connect must fail fast when the client's heartbeat_rpc_port does "
-        << "not match a dedicated heartbeat server the master actually opened";
+              ErrorCode::HEARTBEAT_ROUTING_MISMATCH)
+        << "Connect must fail fast when the client is dedicated but the master "
+        << "runs in legacy heartbeat mode";
 }
 
 // ---------------------------------------------------------------------------
@@ -307,13 +327,17 @@ INSTANTIATE_TEST_SUITE_P(AllModes, HeartbeatDedicatedPortReconnectTest,
 // ---------------------------------------------------------------------------
 // Error code serialization (mode-independent).
 // ---------------------------------------------------------------------------
-// 7. The HEARTBEAT_RPC_UNREACHABLE error code added for the fail-fast path
-// round-trips through toString/fromInt.
-TEST(HeartbeatErrorCodeTest, HeartbeatRpcUnreachableRoundTrip) {
+// 7. The heartbeat fail-fast error codes round-trip through toString/fromInt.
+TEST(HeartbeatErrorCodeTest, HeartbeatErrorCodesRoundTrip) {
     EXPECT_EQ(toString(ErrorCode::HEARTBEAT_RPC_UNREACHABLE),
               "HEARTBEAT_RPC_UNREACHABLE");
     EXPECT_EQ(fromInt(toInt(ErrorCode::HEARTBEAT_RPC_UNREACHABLE)),
               ErrorCode::HEARTBEAT_RPC_UNREACHABLE);
+
+    EXPECT_EQ(toString(ErrorCode::HEARTBEAT_ROUTING_MISMATCH),
+              "HEARTBEAT_ROUTING_MISMATCH");
+    EXPECT_EQ(fromInt(toInt(ErrorCode::HEARTBEAT_ROUTING_MISMATCH)),
+              ErrorCode::HEARTBEAT_ROUTING_MISMATCH);
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -15,15 +15,38 @@
 //   3. Non-heartbeat RPCs still work via the main port.
 //   4. With the dedicated server disabled (port=0), Heartbeat is served on the
 //      main port as the legacy fallback.
+//   5. Client/master port mismatch (client expects a dedicated heartbeat
+//      server the master never opened) fails fast at Connect with
+//      HEARTBEAT_RPC_UNREACHABLE.
+//   6. Reconnect after a master restart (same ports) rebuilds the stale main
+//      AND heartbeat connection pools via the is_same_addr retry instead of
+//      spuriously failing.
+//   7. The HEARTBEAT_RPC_UNREACHABLE error code round-trips through
+//      toString/fromInt.
+//
+// Tests 1-6 are parameterized over CENTRALIZED and P2P: both modes share
+// RegisterHeartbeatRpcService, WrappedMasterService::ServiceReady and
+// MasterClient::Connect, so the behavior is expected to be identical; the
+// parameterization guards against P2P's extra registration path
+// (RegisterP2PRpcService) breaking the dedicated-port routing.
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
+#include <memory>
+#include <optional>
 #include <string>
+#include <thread>
+#include <utility>
+#include <variant>
 
 #include "centralized_master_client.h"
+#include "master_client.h"
 #include "master_config.h"
+#include "p2p_master_client.h"
 #include "rpc_types.h"
+#include "test_p2p_server_helpers.h"
 #include "test_server_helpers.h"
 #include "types.h"
 #include "utils.h"
@@ -32,27 +55,99 @@ namespace mooncake {
 namespace testing {
 
 namespace {
+
+enum class TestMode { CENTRALIZED, P2P };
+
+inline std::ostream& operator<<(std::ostream& os, TestMode mode) {
+    return os << (mode == TestMode::CENTRALIZED ? "CENTRALIZED" : "P2P");
+}
+
 // Build a HeartbeatRequest for the given client id (no tasks, lightweight).
 HeartbeatRequest MakeHeartbeatRequest(const UUID& client_id) {
     HeartbeatRequest req;
     req.client_id = client_id;
     return req;
 }
+
+// Lightweight in-process master (Centralized or P2P) that can be started with
+// or without a dedicated heartbeat port, and restarted on the same ports to
+// simulate a master restart.
+class HeartbeatTestMaster {
+   public:
+    explicit HeartbeatTestMaster(TestMode mode) : mode_(mode) {
+        if (mode_ == TestMode::CENTRALIZED) {
+            master_ = std::make_unique<InProcMaster>();
+        } else {
+            master_ = std::make_unique<InProcP2PMaster>();
+        }
+    }
+
+    // Start the master. When `dedicated` is true a dedicated heartbeat server
+    // is opened (on a fresh free port, or `hb_port` if given). `rpc_port` and
+    // `hb_port` let a restart pin the same ports the previous instance used.
+    bool Start(bool dedicated, std::optional<int> rpc_port = std::nullopt,
+               std::optional<int> hb_port = std::nullopt) {
+        InProcMasterConfigBuilder builder;
+        rpc_port_ = rpc_port.value_or(getFreeTcpPort());
+        builder.set_rpc_port(rpc_port_);
+        if (dedicated) {
+            heartbeat_rpc_port_ = hb_port.value_or(getFreeTcpPort());
+            builder.set_heartbeat_rpc_port(heartbeat_rpc_port_);
+        } else {
+            heartbeat_rpc_port_ = 0;
+        }
+        return std::visit([&](auto& m) { return m->Start(builder.build()); },
+                          master_);
+    }
+
+    void Stop() {
+        std::visit([](auto& m) { m->Stop(); }, master_);
+    }
+
+    int rpc_port() const { return rpc_port_; }
+    int heartbeat_rpc_port() const { return heartbeat_rpc_port_; }
+    std::string master_address() const {
+        return std::visit([](const auto& m) { return m->master_address(); },
+                          master_);
+    }
+
+   private:
+    TestMode mode_;
+    std::variant<std::unique_ptr<InProcMaster>,
+                 std::unique_ptr<InProcP2PMaster>>
+        master_;
+    int rpc_port_ = 0;
+    int heartbeat_rpc_port_ = 0;
+};
+
+// Build the master client matching the deployment mode. Both clients inherit
+// SetHeartbeatRpcPort/Connect/Heartbeat from MasterClient.
+std::unique_ptr<MasterClient> MakeClient(TestMode mode, const UUID& client_id) {
+    if (mode == TestMode::CENTRALIZED) {
+        return std::make_unique<CentralizedMasterClient>(client_id);
+    }
+    return std::make_unique<P2PMasterClient>(client_id);
+}
+
+constexpr uint16_t PortOf(int port) { return static_cast<uint16_t>(port); }
+
 }  // namespace
 
-class HeartbeatDedicatedPortTest : public ::testing::Test {
+// ---------------------------------------------------------------------------
+// Dedicated heartbeat server enabled.
+// ---------------------------------------------------------------------------
+class HeartbeatDedicatedPortTest : public ::testing::TestWithParam<TestMode> {
    protected:
     void SetUp() override {
-        heartbeat_port_ = getFreeTcpPort();
-        ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
-                                      .set_heartbeat_rpc_port(heartbeat_port_)
-                                      .build()))
+        mode_ = GetParam();
+        master_ = std::make_unique<HeartbeatTestMaster>(mode_);
+        ASSERT_TRUE(master_->Start(/*dedicated=*/true))
             << "Failed to start InProcMaster with dedicated heartbeat port";
     }
-    void TearDown() override { master_.Stop(); }
+    void TearDown() override { master_->Stop(); }
 
-    InProcMaster master_;
-    int heartbeat_port_ = 0;
+    TestMode mode_;
+    std::unique_ptr<HeartbeatTestMaster> master_;
 };
 
 // 1. Client configured with the dedicated port sends Heartbeat there and it
@@ -60,13 +155,13 @@ class HeartbeatDedicatedPortTest : public ::testing::Test {
 // also implicitly proves ServiceReady is registered on the dedicated port:
 // Connect probes the heartbeat endpoint with ServiceReady and would fail
 // (HEARTBEAT_RPC_UNREACHABLE) otherwise.
-TEST_F(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
+TEST_P(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
     UUID client_id = generate_uuid();
-    CentralizedMasterClient client(client_id);
-    client.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port_));
-    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+    auto client = MakeClient(mode_, client_id);
+    client->SetHeartbeatRpcPort(PortOf(master_->heartbeat_rpc_port()));
+    ASSERT_EQ(client->Connect(master_->master_address()), ErrorCode::OK);
 
-    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    auto hb = client->Heartbeat(MakeHeartbeatRequest(client_id));
     EXPECT_TRUE(hb.has_value())
         << "Heartbeat should succeed via the dedicated heartbeat port";
 }
@@ -74,12 +169,12 @@ TEST_F(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
 // 2. When the dedicated server is enabled, the main server must NOT have the
 // Heartbeat handler. A client that forces heartbeat_rpc_port=0 sends Heartbeat
 // to the main port and must fail.
-TEST_F(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
+TEST_P(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
     UUID client_id = generate_uuid();
-    CentralizedMasterClient client(client_id);  // heartbeat_rpc_port_ == 0
-    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+    auto client = MakeClient(mode_, client_id);  // heartbeat_rpc_port_ == 0
+    ASSERT_EQ(client->Connect(master_->master_address()), ErrorCode::OK);
 
-    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    auto hb = client->Heartbeat(MakeHeartbeatRequest(client_id));
     EXPECT_FALSE(hb.has_value())
         << "Heartbeat must not be served on the main port when a dedicated "
         << "heartbeat server is enabled";
@@ -88,36 +183,46 @@ TEST_F(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
 // 3. Non-heartbeat RPCs still reach the main port and succeed, proving the
 // main server still serves the rest of the API (Connect already exercises
 // ServiceReady internally; ExistKey covers a data-path RPC).
-TEST_F(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
+TEST_P(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
     UUID client_id = generate_uuid();
-    CentralizedMasterClient client(client_id);
-    client.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port_));
-    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+    auto client = MakeClient(mode_, client_id);
+    client->SetHeartbeatRpcPort(PortOf(master_->heartbeat_rpc_port()));
+    ASSERT_EQ(client->Connect(master_->master_address()), ErrorCode::OK);
 
-    auto exists = client.ExistKey("nonexistent_key_for_heartbeat_test");
+    auto exists = client->ExistKey("nonexistent_key_for_heartbeat_test");
     EXPECT_TRUE(exists.has_value())
         << "ExistKey should reach the main port and succeed";
 }
 
+// ---------------------------------------------------------------------------
+// Legacy fallback (no dedicated heartbeat server).
+// ---------------------------------------------------------------------------
+class HeartbeatLegacyMasterTest : public ::testing::TestWithParam<TestMode> {
+   protected:
+    void SetUp() override {
+        mode_ = GetParam();
+        master_ = std::make_unique<HeartbeatTestMaster>(mode_);
+        ASSERT_TRUE(master_->Start(/*dedicated=*/false))
+            << "Failed to start InProcMaster (legacy, no dedicated port)";
+    }
+    void TearDown() override { master_->Stop(); }
+
+    TestMode mode_;
+    std::unique_ptr<HeartbeatTestMaster> master_;
+};
+
 // 4. With no dedicated heartbeat server configured (port=0, default), the
 // master falls back to serving Heartbeat on the main RPC server, so a client
 // without a heartbeat port succeeds.
-TEST(HeartbeatDedicatedPortDisabledTest,
-     HeartbeatServedOnMainPortWhenDisabled) {
-    InProcMaster master;
-    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
-        << "Failed to start InProcMaster";
-
+TEST_P(HeartbeatLegacyMasterTest, HeartbeatServedOnMainPortWhenDisabled) {
     UUID client_id = generate_uuid();
-    CentralizedMasterClient client(client_id);  // heartbeat_rpc_port_ == 0
-    ASSERT_EQ(client.Connect(master.master_address()), ErrorCode::OK);
+    auto client = MakeClient(mode_, client_id);  // heartbeat_rpc_port_ == 0
+    ASSERT_EQ(client->Connect(master_->master_address()), ErrorCode::OK);
 
-    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    auto hb = client->Heartbeat(MakeHeartbeatRequest(client_id));
     EXPECT_TRUE(hb.has_value())
         << "Heartbeat should succeed on the main port when the dedicated "
         << "server is disabled (legacy fallback)";
-
-    master.Stop();
 }
 
 // 5. Mismatch: the master is started WITHOUT a dedicated heartbeat port
@@ -125,24 +230,90 @@ TEST(HeartbeatDedicatedPortDisabledTest,
 // pointing at a port the master never opened. Connect must fail fast with
 // HEARTBEAT_RPC_UNREACHABLE instead of appearing to succeed and then silently
 // starving heartbeats.
-TEST(HeartbeatDedicatedPortDisabledTest, HeartbeatPortMismatchFailsConnect) {
-    InProcMaster master;
-    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
-        << "Failed to start InProcMaster (no dedicated heartbeat port)";
-
+TEST_P(HeartbeatLegacyMasterTest, HeartbeatPortMismatchFailsConnect) {
     // Client believes there is a dedicated heartbeat server on this free port;
-    // the master never opened it.
+    // the master never opened it (this is a fresh is_same_addr=false Connect).
     int phantom_port = getFreeTcpPort();
     UUID client_id = generate_uuid();
-    CentralizedMasterClient client(client_id);
-    client.SetHeartbeatRpcPort(static_cast<uint16_t>(phantom_port));
+    auto client = MakeClient(mode_, client_id);
+    client->SetHeartbeatRpcPort(PortOf(phantom_port));
 
-    EXPECT_EQ(client.Connect(master.master_address()),
+    EXPECT_EQ(client->Connect(master_->master_address()),
               ErrorCode::HEARTBEAT_RPC_UNREACHABLE)
         << "Connect must fail fast when the client's heartbeat_rpc_port does "
         << "not match a dedicated heartbeat server the master actually opened";
+}
 
-    master.Stop();
+// ---------------------------------------------------------------------------
+// Reconnect after master restart (stale connection pool rebuild).
+// ---------------------------------------------------------------------------
+class HeartbeatDedicatedPortReconnectTest
+    : public ::testing::TestWithParam<TestMode> {
+   protected:
+    void SetUp() override {
+        mode_ = GetParam();
+        master_ = std::make_unique<HeartbeatTestMaster>(mode_);
+    }
+    void TearDown() override { master_->Stop(); }
+
+    TestMode mode_;
+    std::unique_ptr<HeartbeatTestMaster> master_;
+};
+
+// 6. After a successful Connect, restarting the master on the same ports
+// invalidates the pooled main AND heartbeat connections. Reconnecting to the
+// same address (is_same_addr=true) must take the one-shot stale-pool retry on
+// BOTH probes and succeed. A missing heartbeat retry would surface here as a
+// spurious HEARTBEAT_RPC_UNREACHABLE despite the heartbeat server being up.
+TEST_P(HeartbeatDedicatedPortReconnectTest,
+       ReconnectAfterMasterRestartRebuildsStalePools) {
+    ASSERT_TRUE(master_->Start(/*dedicated=*/true));
+    int rpc_port = master_->rpc_port();
+    int hb_port = master_->heartbeat_rpc_port();
+    std::string addr = master_->master_address();
+
+    UUID client_id = generate_uuid();
+    auto client = MakeClient(mode_, client_id);
+    client->SetHeartbeatRpcPort(PortOf(hb_port));
+    ASSERT_EQ(client->Connect(addr), ErrorCode::OK);
+
+    // Restart on the same ports -> both pooled connections go stale.
+    master_->Stop();
+    // Give the OS a moment to release the listening sockets before rebind.
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    ASSERT_TRUE(master_->Start(/*dedicated=*/true, rpc_port, hb_port));
+
+    // Same address -> is_same_addr=true -> stale-pool retry path.
+    EXPECT_EQ(client->Connect(addr), ErrorCode::OK)
+        << "Reconnect to the same address should rebuild stale pools via the "
+        << "is_same_addr retry, not fail with HEARTBEAT_RPC_UNREACHABLE";
+
+    // Heartbeats must still land on the restarted dedicated heartbeat server.
+    auto hb = client->Heartbeat(MakeHeartbeatRequest(client_id));
+    EXPECT_TRUE(hb.has_value())
+        << "Heartbeat should succeed via the dedicated port after reconnect";
+}
+
+INSTANTIATE_TEST_SUITE_P(AllModes, HeartbeatDedicatedPortTest,
+                         ::testing::Values(TestMode::CENTRALIZED,
+                                           TestMode::P2P));
+INSTANTIATE_TEST_SUITE_P(AllModes, HeartbeatLegacyMasterTest,
+                         ::testing::Values(TestMode::CENTRALIZED,
+                                           TestMode::P2P));
+INSTANTIATE_TEST_SUITE_P(AllModes, HeartbeatDedicatedPortReconnectTest,
+                         ::testing::Values(TestMode::CENTRALIZED,
+                                           TestMode::P2P));
+
+// ---------------------------------------------------------------------------
+// Error code serialization (mode-independent).
+// ---------------------------------------------------------------------------
+// 7. The HEARTBEAT_RPC_UNREACHABLE error code added for the fail-fast path
+// round-trips through toString/fromInt.
+TEST(HeartbeatErrorCodeTest, HeartbeatRpcUnreachableRoundTrip) {
+    EXPECT_EQ(toString(ErrorCode::HEARTBEAT_RPC_UNREACHABLE),
+              "HEARTBEAT_RPC_UNREACHABLE");
+    EXPECT_EQ(fromInt(toInt(ErrorCode::HEARTBEAT_RPC_UNREACHABLE)),
+              ErrorCode::HEARTBEAT_RPC_UNREACHABLE);
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -1,0 +1,117 @@
+// Functional/routing tests for the dedicated heartbeat RPC server.
+//
+// When the master is started with a dedicated heartbeat port, Heartbeat is
+// served on a separate coro_rpc_server and removed from the main server, so
+// heavy metadata RPCs cannot head-of-line-block heartbeats. These tests verify
+// the routing (deterministic); the actual isolation-under-load property is a
+// perf concern covered separately.
+//
+// Coverage:
+//   1. Heartbeat reaches the dedicated port and succeeds.
+//   2. Heartbeat is NOT registered on the main port (include_heartbeat=false).
+//   3. Non-heartbeat RPCs still work via the main port.
+//   4. With the dedicated server disabled (port=0), Heartbeat is served on the
+//      main port (legacy behavior).
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+
+#include "centralized_master_client.h"
+#include "master_config.h"
+#include "rpc_types.h"
+#include "test_server_helpers.h"
+#include "types.h"
+#include "utils.h"
+
+namespace mooncake {
+namespace testing {
+
+namespace {
+// Build a HeartbeatRequest for the given client id (no tasks, lightweight).
+HeartbeatRequest MakeHeartbeatRequest(const UUID& client_id) {
+    HeartbeatRequest req;
+    req.client_id = client_id;
+    return req;
+}
+}  // namespace
+
+class HeartbeatDedicatedPortTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        heartbeat_port_ = getFreeTcpPort();
+        ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
+                                       .set_heartbeat_rpc_port(heartbeat_port_)
+                                       .build()))
+            << "Failed to start InProcMaster with dedicated heartbeat port";
+    }
+    void TearDown() override { master_.Stop(); }
+
+    InProcMaster master_;
+    int heartbeat_port_ = 0;
+};
+
+// 1. Client configured with the dedicated port sends Heartbeat there and it
+// succeeds (the dedicated server has the Heartbeat handler registered).
+TEST_F(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
+    UUID client_id = generate_uuid();
+    CentralizedMasterClient client(client_id);
+    client.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port_));
+    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+
+    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    EXPECT_TRUE(hb.has_value())
+        << "Heartbeat should succeed via the dedicated heartbeat port";
+}
+
+// 2. When the dedicated server is enabled, the main server must NOT have the
+// Heartbeat handler (include_heartbeat=false). A client that forces
+// heartbeat_rpc_port=0 sends Heartbeat to the main port and must fail.
+TEST_F(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
+    UUID client_id = generate_uuid();
+    CentralizedMasterClient client(client_id);  // heartbeat_rpc_port_ == 0
+    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+
+    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    EXPECT_FALSE(hb.has_value())
+        << "Heartbeat must not be served on the main port when a dedicated "
+        << "heartbeat server is enabled";
+}
+
+// 3. Non-heartbeat RPCs (ServiceReady) still reach the main port and succeed,
+// proving the main server still serves the rest of the API.
+TEST_F(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
+    UUID client_id = generate_uuid();
+    CentralizedMasterClient client(client_id);
+    client.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port_));
+    ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+
+    auto ready = client.ServiceReady();
+    EXPECT_TRUE(ready.has_value())
+        << "ServiceReady should reach the main port and succeed";
+}
+
+// 4. With no dedicated heartbeat server configured (port=0, default), the
+// master registers Heartbeat on the main server (legacy behavior) and a client
+// without a heartbeat port succeeds.
+TEST(HeartbeatDedicatedPortDisabledTest,
+     HeartbeatServedOnMainPortWhenDisabled) {
+    InProcMaster master;
+    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
+        << "Failed to start InProcMaster";
+
+    UUID client_id = generate_uuid();
+    CentralizedMasterClient client(client_id);  // heartbeat_rpc_port_ == 0
+    ASSERT_EQ(client.Connect(master.master_address()), ErrorCode::OK);
+
+    auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
+    EXPECT_TRUE(hb.has_value())
+        << "Heartbeat should succeed on the main port when the dedicated "
+        << "server is disabled (legacy behavior)";
+
+    master.Stop();
+}
+
+}  // namespace testing
+}  // namespace mooncake

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -2,16 +2,19 @@
 //
 // When the master is started with a dedicated heartbeat port, Heartbeat is
 // served on a separate coro_rpc_server and removed from the main server, so
-// heavy metadata RPCs cannot head-of-line-block heartbeats. These tests verify
-// the routing (deterministic); the actual isolation-under-load property is a
-// perf concern covered separately.
+// heavy metadata RPCs cannot head-of-line-block heartbeats. When no dedicated
+// port is configured (heartbeat_rpc_port == 0), Heartbeat is served on the
+// main server as a legacy fallback. These tests verify the routing
+// (deterministic); the actual isolation-under-load property is a perf concern
+// covered separately.
 //
 // Coverage:
 //   1. Heartbeat reaches the dedicated port and succeeds.
-//   2. Heartbeat is NOT registered on the main port (include_heartbeat=false).
+//   2. Heartbeat is NOT registered on the main port when the dedicated server
+//      is enabled.
 //   3. Non-heartbeat RPCs still work via the main port.
 //   4. With the dedicated server disabled (port=0), Heartbeat is served on the
-//      main port (legacy behavior).
+//      main port as the legacy fallback.
 
 #include <gtest/gtest.h>
 
@@ -66,8 +69,8 @@ TEST_F(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
 }
 
 // 2. When the dedicated server is enabled, the main server must NOT have the
-// Heartbeat handler (include_heartbeat=false). A client that forces
-// heartbeat_rpc_port=0 sends Heartbeat to the main port and must fail.
+// Heartbeat handler. A client that forces heartbeat_rpc_port=0 sends Heartbeat
+// to the main port and must fail.
 TEST_F(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
     UUID client_id = generate_uuid();
     CentralizedMasterClient client(client_id);  // heartbeat_rpc_port_ == 0
@@ -94,10 +97,9 @@ TEST_F(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
 }
 
 // 4. With no dedicated heartbeat server configured (port=0, default), the
-// master registers Heartbeat on the main server (legacy behavior) and a client
+// master falls back to serving Heartbeat on the main RPC server, so a client
 // without a heartbeat port succeeds.
-TEST(HeartbeatDedicatedPortDisabledTest,
-     HeartbeatServedOnMainPortWhenDisabled) {
+TEST(HeartbeatDedicatedPortDisabledTest, HeartbeatServedOnMainPortWhenDisabled) {
     InProcMaster master;
     ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
         << "Failed to start InProcMaster";
@@ -109,39 +111,7 @@ TEST(HeartbeatDedicatedPortDisabledTest,
     auto hb = client.Heartbeat(MakeHeartbeatRequest(client_id));
     EXPECT_TRUE(hb.has_value())
         << "Heartbeat should succeed on the main port when the dedicated "
-        << "server is disabled (legacy behavior)";
-
-    master.Stop();
-}
-
-// Dual-mode (heartbeat_keep_on_main=true): during migration the master serves
-// Heartbeat on BOTH the dedicated port and the main port, so legacy clients
-// (heartbeat_rpc_port=0) and migrated clients (heartbeat_rpc_port=P) both work.
-TEST(HeartbeatDedicatedPortDualModeTest, HeartbeatServedOnBothPorts) {
-    const int heartbeat_port = getFreeTcpPort();
-    InProcMaster master;
-    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder()
-                                 .set_heartbeat_rpc_port(heartbeat_port)
-                                 .set_heartbeat_keep_on_main(true)
-                                 .build()))
-        << "Failed to start InProcMaster in dual mode";
-
-    // Migrated client -> dedicated port: succeeds.
-    UUID migrated_id = generate_uuid();
-    CentralizedMasterClient migrated(migrated_id);
-    migrated.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port));
-    ASSERT_EQ(migrated.Connect(master.master_address()), ErrorCode::OK);
-    auto hb_dedicated = migrated.Heartbeat(MakeHeartbeatRequest(migrated_id));
-    EXPECT_TRUE(hb_dedicated.has_value())
-        << "Heartbeat via the dedicated port should succeed in dual mode";
-
-    // Legacy client -> main port: also succeeds (dual mode keeps it on main).
-    UUID legacy_id = generate_uuid();
-    CentralizedMasterClient legacy(legacy_id);  // heartbeat_rpc_port_ == 0
-    ASSERT_EQ(legacy.Connect(master.master_address()), ErrorCode::OK);
-    auto hb_main = legacy.Heartbeat(MakeHeartbeatRequest(legacy_id));
-    EXPECT_TRUE(hb_main.has_value())
-        << "Heartbeat via the main port should still succeed in dual mode";
+        << "server is disabled (legacy fallback)";
 
     master.Stop();
 }

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -79,17 +79,18 @@ TEST_F(HeartbeatDedicatedPortTest, HeartbeatNotRegisteredOnMainPort) {
         << "heartbeat server is enabled";
 }
 
-// 3. Non-heartbeat RPCs (ServiceReady) still reach the main port and succeed,
-// proving the main server still serves the rest of the API.
+// 3. Non-heartbeat RPCs still reach the main port and succeed, proving the
+// main server still serves the rest of the API (Connect already exercises
+// ServiceReady internally; ExistKey covers a data-path RPC).
 TEST_F(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
     UUID client_id = generate_uuid();
     CentralizedMasterClient client(client_id);
     client.SetHeartbeatRpcPort(static_cast<uint16_t>(heartbeat_port_));
     ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
 
-    auto ready = client.ServiceReady();
-    EXPECT_TRUE(ready.has_value())
-        << "ServiceReady should reach the main port and succeed";
+    auto exists = client.ExistKey("nonexistent_key_for_heartbeat_test");
+    EXPECT_TRUE(exists.has_value())
+        << "ExistKey should reach the main port and succeed";
 }
 
 // 4. With no dedicated heartbeat server configured (port=0, default), the

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -99,7 +99,8 @@ TEST_F(HeartbeatDedicatedPortTest, NonHeartbeatRpcStillServedOnMainPort) {
 // 4. With no dedicated heartbeat server configured (port=0, default), the
 // master falls back to serving Heartbeat on the main RPC server, so a client
 // without a heartbeat port succeeds.
-TEST(HeartbeatDedicatedPortDisabledTest, HeartbeatServedOnMainPortWhenDisabled) {
+TEST(HeartbeatDedicatedPortDisabledTest,
+     HeartbeatServedOnMainPortWhenDisabled) {
     InProcMaster master;
     ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
         << "Failed to start InProcMaster";

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -42,8 +42,8 @@ class HeartbeatDedicatedPortTest : public ::testing::Test {
     void SetUp() override {
         heartbeat_port_ = getFreeTcpPort();
         ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
-                                       .set_heartbeat_rpc_port(heartbeat_port_)
-                                       .build()))
+                                      .set_heartbeat_rpc_port(heartbeat_port_)
+                                      .build()))
             << "Failed to start InProcMaster with dedicated heartbeat port";
     }
     void TearDown() override { master_.Stop(); }

--- a/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
+++ b/mooncake-store/tests/heartbeat_dedicated_port_test.cpp
@@ -56,7 +56,10 @@ class HeartbeatDedicatedPortTest : public ::testing::Test {
 };
 
 // 1. Client configured with the dedicated port sends Heartbeat there and it
-// succeeds (the dedicated server has the Heartbeat handler registered).
+// succeeds (the dedicated server has the Heartbeat handler registered). This
+// also implicitly proves ServiceReady is registered on the dedicated port:
+// Connect probes the heartbeat endpoint with ServiceReady and would fail
+// (HEARTBEAT_RPC_UNREACHABLE) otherwise.
 TEST_F(HeartbeatDedicatedPortTest, HeartbeatRoutedToDedicatedPort) {
     UUID client_id = generate_uuid();
     CentralizedMasterClient client(client_id);
@@ -113,6 +116,31 @@ TEST(HeartbeatDedicatedPortDisabledTest,
     EXPECT_TRUE(hb.has_value())
         << "Heartbeat should succeed on the main port when the dedicated "
         << "server is disabled (legacy fallback)";
+
+    master.Stop();
+}
+
+// 5. Mismatch: the master is started WITHOUT a dedicated heartbeat port
+// (legacy fallback), but the client is configured with a heartbeat port
+// pointing at a port the master never opened. Connect must fail fast with
+// HEARTBEAT_RPC_UNREACHABLE instead of appearing to succeed and then silently
+// starving heartbeats.
+TEST(HeartbeatDedicatedPortDisabledTest, HeartbeatPortMismatchFailsConnect) {
+    InProcMaster master;
+    ASSERT_TRUE(master.Start(InProcMasterConfigBuilder().build()))
+        << "Failed to start InProcMaster (no dedicated heartbeat port)";
+
+    // Client believes there is a dedicated heartbeat server on this free port;
+    // the master never opened it.
+    int phantom_port = getFreeTcpPort();
+    UUID client_id = generate_uuid();
+    CentralizedMasterClient client(client_id);
+    client.SetHeartbeatRpcPort(static_cast<uint16_t>(phantom_port));
+
+    EXPECT_EQ(client.Connect(master.master_address()),
+              ErrorCode::HEARTBEAT_RPC_UNREACHABLE)
+        << "Connect must fail fast when the client's heartbeat_rpc_port does "
+        << "not match a dedicated heartbeat server the master actually opened";
 
     master.Stop();
 }

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -73,10 +73,7 @@ class InProcP2PMaster {
             const bool dedicated_heartbeat =
                 config.heartbeat_rpc_port.has_value() &&
                 config.heartbeat_rpc_port.value() > 0;
-            const bool keep_on_main =
-                config.heartbeat_keep_on_main.value_or(false);
-            const bool main_includes_heartbeat =
-                !dedicated_heartbeat || keep_on_main;
+            const bool main_includes_heartbeat = !dedicated_heartbeat;
             RegisterP2PRpcService(
                 *server_, *wrapped_,
                 /*include_heartbeat=*/main_includes_heartbeat);

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -77,8 +77,9 @@ class InProcP2PMaster {
                 config.heartbeat_keep_on_main.value_or(false);
             const bool main_includes_heartbeat =
                 !dedicated_heartbeat || keep_on_main;
-            RegisterP2PRpcService(*server_, *wrapped_,
-                                  /*include_heartbeat=*/main_includes_heartbeat);
+            RegisterP2PRpcService(
+                *server_, *wrapped_,
+                /*include_heartbeat=*/main_includes_heartbeat);
             if (dedicated_heartbeat) {
                 heartbeat_rpc_port_ = config.heartbeat_rpc_port.value();
                 uint32_t hb_threads =

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -73,8 +73,12 @@ class InProcP2PMaster {
             const bool dedicated_heartbeat =
                 config.heartbeat_rpc_port.has_value() &&
                 config.heartbeat_rpc_port.value() > 0;
+            const bool keep_on_main =
+                config.heartbeat_keep_on_main.value_or(false);
+            const bool main_includes_heartbeat =
+                !dedicated_heartbeat || keep_on_main;
             RegisterP2PRpcService(*server_, *wrapped_,
-                                  /*include_heartbeat=*/!dedicated_heartbeat);
+                                  /*include_heartbeat=*/main_includes_heartbeat);
             if (dedicated_heartbeat) {
                 heartbeat_rpc_port_ = config.heartbeat_rpc_port.value();
                 uint32_t hb_threads =

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -48,6 +48,7 @@ class InProcP2PMaster {
             wms_cfg.eviction_high_watermark_ratio =
                 DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
             wms_cfg.view_version = 0;
+            wms_cfg.heartbeat_rpc_port = config.heartbeat_rpc_port.value_or(0);
             wms_cfg.enable_ha = false;
             wms_cfg.cluster_id = DEFAULT_CLUSTER_ID;
             wms_cfg.root_fs_dir = DEFAULT_ROOT_FS_DIR;

--- a/mooncake-store/tests/test_p2p_server_helpers.h
+++ b/mooncake-store/tests/test_p2p_server_helpers.h
@@ -11,6 +11,7 @@
 
 #include "master_config.h"
 #include "p2p_rpc_service.h"
+#include "rpc_service.h"
 #include "types.h"
 #include "utils.h"
 
@@ -69,11 +70,34 @@ class InProcP2PMaster {
 
             wrapped_ = std::make_unique<WrappedP2PMasterService>(wms_cfg);
             wrapped_->init();
-            RegisterP2PRpcService(*server_, *wrapped_);
+            const bool dedicated_heartbeat =
+                config.heartbeat_rpc_port.has_value() &&
+                config.heartbeat_rpc_port.value() > 0;
+            RegisterP2PRpcService(*server_, *wrapped_,
+                                  /*include_heartbeat=*/!dedicated_heartbeat);
+            if (dedicated_heartbeat) {
+                heartbeat_rpc_port_ = config.heartbeat_rpc_port.value();
+                uint32_t hb_threads =
+                    config.heartbeat_rpc_thread_num.has_value()
+                        ? config.heartbeat_rpc_thread_num.value()
+                        : 1u;
+                if (hb_threads == 0) hb_threads = 1;
+                heartbeat_server_ = std::make_unique<coro_rpc::coro_rpc_server>(
+                    /*thread_num=*/hb_threads, /*port=*/heartbeat_rpc_port_,
+                    /*address=*/"0.0.0.0", std::chrono::seconds(0),
+                    /*tcp_no_delay=*/true);
+                RegisterHeartbeatRpcService(*heartbeat_server_, *wrapped_);
+            }
 
             auto ec = server_->async_start();
             if (ec.hasResult()) {
                 return false;
+            }
+            if (heartbeat_server_) {
+                auto hb_ec = heartbeat_server_->async_start();
+                if (hb_ec.hasResult()) {
+                    return false;
+                }
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
             return true;
@@ -83,6 +107,10 @@ class InProcP2PMaster {
     }
 
     void Stop() {
+        if (heartbeat_server_) {
+            heartbeat_server_->stop();
+            heartbeat_server_.reset();
+        }
         if (server_) {
             server_->stop();
             server_.reset();
@@ -91,6 +119,7 @@ class InProcP2PMaster {
     }
 
     int rpc_port() const { return rpc_port_; }
+    int heartbeat_rpc_port() const { return heartbeat_rpc_port_; }
     std::string master_address() const {
         return std::string("127.0.0.1:") + std::to_string(rpc_port_);
     }
@@ -98,8 +127,10 @@ class InProcP2PMaster {
 
    private:
     std::unique_ptr<coro_rpc::coro_rpc_server> server_;
+    std::unique_ptr<coro_rpc::coro_rpc_server> heartbeat_server_;
     std::unique_ptr<WrappedP2PMasterService> wrapped_;
     int rpc_port_ = 0;
+    int heartbeat_rpc_port_ = 0;
 };
 
 }  // namespace testing

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -12,6 +12,7 @@
 #include "http_metadata_server.h"
 #include "master_config.h"
 #include "centralized_rpc_service.h"
+#include "rpc_service.h"
 #include "types.h"
 #include "utils.h"
 #include <ylt/util/tl/expected.hpp>
@@ -122,11 +123,38 @@ class InProcMaster {
             wrapped_ =
                 std::make_unique<WrappedCentralizedMasterService>(wms_cfg);
             wrapped_->init();
-            RegisterCentralizedRpcService(*server_, *wrapped_);
+            // When a dedicated heartbeat port is configured, serve Heartbeat on
+            // a separate coro_rpc_server (plain TCP) and drop it from the main
+            // server, mirroring production (master.cpp).
+            const bool dedicated_heartbeat =
+                config.heartbeat_rpc_port.has_value() &&
+                config.heartbeat_rpc_port.value() > 0;
+            RegisterCentralizedRpcService(
+                *server_, *wrapped_,
+                /*include_heartbeat=*/!dedicated_heartbeat);
+            if (dedicated_heartbeat) {
+                heartbeat_rpc_port_ = config.heartbeat_rpc_port.value();
+                uint32_t hb_threads =
+                    config.heartbeat_rpc_thread_num.has_value()
+                        ? config.heartbeat_rpc_thread_num.value()
+                        : 1u;
+                if (hb_threads == 0) hb_threads = 1;
+                heartbeat_server_ = std::make_unique<coro_rpc::coro_rpc_server>(
+                    /*thread_num=*/hb_threads, /*port=*/heartbeat_rpc_port_,
+                    /*address=*/"0.0.0.0", std::chrono::seconds(0),
+                    /*tcp_no_delay=*/true);
+                RegisterHeartbeatRpcService(*heartbeat_server_, *wrapped_);
+            }
 
             auto ec = server_->async_start();
             if (ec.hasResult()) {
                 return false;
+            }
+            if (heartbeat_server_) {
+                auto hb_ec = heartbeat_server_->async_start();
+                if (hb_ec.hasResult()) {
+                    return false;
+                }
             }
             // Allow server to bind
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
@@ -137,6 +165,10 @@ class InProcMaster {
     }
 
     void Stop() {
+        if (heartbeat_server_) {
+            heartbeat_server_->stop();
+            heartbeat_server_.reset();
+        }
         if (server_) {
             server_->stop();
             server_.reset();
@@ -150,6 +182,7 @@ class InProcMaster {
 
     // Accessors
     int rpc_port() const { return rpc_port_; }
+    int heartbeat_rpc_port() const { return heartbeat_rpc_port_; }
     int http_metrics_port() const { return http_metrics_port_; }
     int http_metadata_port() const { return http_metadata_port_; }
     std::string master_address() const {
@@ -169,9 +202,11 @@ class InProcMaster {
 
    private:
     std::unique_ptr<coro_rpc::coro_rpc_server> server_;
+    std::unique_ptr<coro_rpc::coro_rpc_server> heartbeat_server_;
     std::unique_ptr<WrappedCentralizedMasterService> wrapped_;
     std::unique_ptr<HttpMetadataServer> meta_server_;
     int rpc_port_ = 0;
+    int heartbeat_rpc_port_ = 0;
     int http_metrics_port_ = 0;
     int http_metadata_port_ = 0;
 };

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -124,16 +124,12 @@ class InProcMaster {
                 std::make_unique<WrappedCentralizedMasterService>(wms_cfg);
             wrapped_->init();
             // When a dedicated heartbeat port is configured, serve Heartbeat on
-            // a separate coro_rpc_server (plain TCP). In dual mode
-            // (heartbeat_keep_on_main) Heartbeat is also kept on the main
-            // server so legacy clients keep working during migration.
+            // a separate coro_rpc_server (plain TCP). Otherwise Heartbeat is
+            // served on the main server as the legacy fallback.
             const bool dedicated_heartbeat =
                 config.heartbeat_rpc_port.has_value() &&
                 config.heartbeat_rpc_port.value() > 0;
-            const bool keep_on_main =
-                config.heartbeat_keep_on_main.value_or(false);
-            const bool main_includes_heartbeat =
-                !dedicated_heartbeat || keep_on_main;
+            const bool main_includes_heartbeat = !dedicated_heartbeat;
             RegisterCentralizedRpcService(
                 *server_, *wrapped_,
                 /*include_heartbeat=*/main_includes_heartbeat);

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -81,6 +81,7 @@ class InProcMaster {
             wms_cfg.eviction_high_watermark_ratio =
                 DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
             wms_cfg.view_version = 0;
+            wms_cfg.heartbeat_rpc_port = config.heartbeat_rpc_port.value_or(0);
             wms_cfg.root_fs_dir = DEFAULT_ROOT_FS_DIR;
             wms_cfg.memory_allocator = BufferAllocatorType::OFFSET;
 

--- a/mooncake-store/tests/test_server_helpers.h
+++ b/mooncake-store/tests/test_server_helpers.h
@@ -124,14 +124,19 @@ class InProcMaster {
                 std::make_unique<WrappedCentralizedMasterService>(wms_cfg);
             wrapped_->init();
             // When a dedicated heartbeat port is configured, serve Heartbeat on
-            // a separate coro_rpc_server (plain TCP) and drop it from the main
-            // server, mirroring production (master.cpp).
+            // a separate coro_rpc_server (plain TCP). In dual mode
+            // (heartbeat_keep_on_main) Heartbeat is also kept on the main
+            // server so legacy clients keep working during migration.
             const bool dedicated_heartbeat =
                 config.heartbeat_rpc_port.has_value() &&
                 config.heartbeat_rpc_port.value() > 0;
+            const bool keep_on_main =
+                config.heartbeat_keep_on_main.value_or(false);
+            const bool main_includes_heartbeat =
+                !dedicated_heartbeat || keep_on_main;
             RegisterCentralizedRpcService(
                 *server_, *wrapped_,
-                /*include_heartbeat=*/!dedicated_heartbeat);
+                /*include_heartbeat=*/main_includes_heartbeat);
             if (dedicated_heartbeat) {
                 heartbeat_rpc_port_ = config.heartbeat_rpc_port.value();
                 uint32_t hb_threads =

--- a/mooncake-wheel/mooncake/mooncake_config.py
+++ b/mooncake-wheel/mooncake/mooncake_config.py
@@ -115,6 +115,7 @@ class MooncakeConfig:
     protocol: str
     device_name: Optional[str]
     master_server_address: str
+    heartbeat_rpc_port: int = 0
 
     @staticmethod
     def from_file(file_path: str) -> 'MooncakeConfig':
@@ -141,6 +142,7 @@ class MooncakeConfig:
             protocol=config.get("protocol", "tcp"),
             device_name=config.get("device_name", ""),
             master_server_address=config.get("master_server_address"),
+            heartbeat_rpc_port=int(config.get("heartbeat_rpc_port", 0)),
         )
 
     @staticmethod
@@ -167,5 +169,6 @@ class MooncakeConfig:
                 protocol=os.getenv("MOONCAKE_PROTOCOL", "tcp"),
                 device_name=os.getenv("MOONCAKE_DEVICE", ""),
                 master_server_address=os.getenv("MOONCAKE_MASTER"),
+                heartbeat_rpc_port=int(os.getenv("MOONCAKE_HEARTBEAT_RPC_PORT", "0")),
             )
         return MooncakeConfig.from_file(config_file_path)

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -113,7 +113,8 @@ class MooncakeStoreService:
                     self.config.local_buffer_size,
                     self.config.protocol,
                     self.config.device_name,
-                    self.config.master_server_address
+                    self.config.master_server_address,
+                    heartbeat_rpc_port=self.config.heartbeat_rpc_port,
                 )
 
                 if ret != 0:

--- a/mooncake-wheel/tests/test_mooncake_config.py
+++ b/mooncake-wheel/tests/test_mooncake_config.py
@@ -118,5 +118,30 @@ class TestMooncakeConfig(unittest.TestCase):
             MooncakeConfig.load_from_env()
         self.assertIn("Neither the environment variable 'MOONCAKE_CONFIG_PATH' nor 'MOONCAKE_MASTER' is set.", str(cm.exception))
 
+    def test_heartbeat_rpc_port_default_and_from_file(self):
+        """heartbeat_rpc_port defaults to 0 and is read from config file."""
+        # Default when absent.
+        self.write_config(self.valid_config)
+        config = MooncakeConfig.from_file(self.config_file)
+        self.assertEqual(config.heartbeat_rpc_port, 0)
+
+        # Read when present.
+        cfg = self.valid_config.copy()
+        cfg["heartbeat_rpc_port"] = 50099
+        self.write_config(cfg)
+        config = MooncakeConfig.from_file(self.config_file)
+        self.assertEqual(config.heartbeat_rpc_port, 50099)
+
+    def test_heartbeat_rpc_port_from_env(self):
+        """heartbeat_rpc_port is read from MOONCAKE_HEARTBEAT_RPC_PORT."""
+        os.environ['MOONCAKE_MASTER'] = self.valid_config["master_server_address"]
+        os.environ['MOONCAKE_HEARTBEAT_RPC_PORT'] = '50099'
+        try:
+            config = MooncakeConfig.load_from_env()
+            self.assertEqual(config.heartbeat_rpc_port, 50099)
+        finally:
+            del os.environ['MOONCAKE_MASTER']
+            del os.environ['MOONCAKE_HEARTBEAT_RPC_PORT']
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description

  **Summary**

  Add an optional dedicated heartbeat RPC server to the Mooncake Store master, so heartbeat requests are no longer head-of-line-blocked by heavy metadata RPCs on the main server.

  When --heartbeat_rpc_port is set (> 0), the master spins up a separate coro_rpc_server (plain TCP, no IB) that only serves Heartbeat. The client routes heartbeat traffic to <master_host>:heartbeat_rpc_port while all other RPCs continue to use the main server.

  **Smooth migration with dual-mode**

  A --heartbeat_keep_on_main flag allows Heartbeat to be registered on both the dedicated and main servers simultaneously. This lets legacy clients (unaware of the new port) and migrated clients coexist during rollout. Set false once all clients are migrated to drop Heartbeat from the main server.

  **Key changes**

  - Master: serve Heartbeat on a dedicated coro_rpc_server when configured
  - Client: route Heartbeat to the dedicated port via a separate connection pool
  - Config plumbing: expose heartbeat_rpc_port through CLI flags, config dict, Python bindings, and environment variable (MOONCAKE_HEARTBEAT_RPC_PORT)
  - Dual-mode: heartbeat_keep_on_main keeps Heartbeat on the main server too during migration
  - Tests: verify routing (dedicated port, main port, dual-mode, and legacy fallback)

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
ctest -R 'master_service_test|non_ha_reconnect_test|ha_integration_test|client_integration_test'
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

### Manual tests

Firstly, start master with dedicate heartbeat rpc server with command:
```bash
  mooncake_master \
    --rpc_port=50051 \
    --rpc_thread_num=1 \
    --client_ttl=3 \
    --heartbeat_rpc_port=50099 \
    --heartbeat_keep_on_main \
    --heartbeat_rpc_thread_num=1 \
    --enable_http_metadata_server \
    --http_metadata_server_port=8080 &> master.log
```
Then, start real_client with dedicate heartbeat rpc port: 
```bash
  GLOG_v=1 /usr/local/bin/mooncake_client \
    --host=127.0.0.1 \
    --master_server_address=127.0.0.1:50051 \
    --metadata_server=http://127.0.0.1:8080/metadata \
    --protocol=tcp \
    --http_port=19002 \
    --heartbeat_rpc_port=50099 \
    --global_segment_size=16MB \
    --port=50052 &> heartbeat.log
```
Finally, running `master_bench` to flood `mooncake_master`: 
```bash
for i in $(seq 24); do
  echo client $i started
/home/local/workspace/augusto.yjh/kvpool/Mooncake/build/mooncake-store/benchmarks/master_bench \
    --master_server=127.0.0.1:50051 \
    --num_clients 16 \
    --num_threads=4 \
    --operation=BatchPut \
    --duration=120 &> bench.log &
done
wait
```
From the log of `mooncake_master`, we can see that there're many client disconnection log lines. 
<img width="2650" height="726" alt="image" src="https://github.com/user-attachments/assets/f556422d-1b63-49e1-93c3-873d772cbd1d" />

And `mooncake_client` that uses dedicate heartbeat rpc port is not disconnected.
<img width="2826" height="338" alt="image" src="https://github.com/user-attachments/assets/ca1264de-08d6-49e4-8894-33cd1eab3517" />

Logs of `mooncake_client` show that, with dedicate heartbeat rpc port, its heartbeat rpc is not blocked by rps from `master_bench` instances. 
 
<img width="1484" height="360" alt="image" src="https://github.com/user-attachments/assets/336fbc28-abbe-4fa6-a112-f121f0c424bb" />


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)
claude code with deepseek v4 pro