### PR TITLE
[TransferEngine] Fix TCP endpoint refresh correctness

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -121,7 +121,12 @@ class TransferMetadata {
         // this is for ascend
         RankInfoDesc rank_info;
 
-        int tcp_data_port;
+        // TCP data-plane endpoint. Keeping the routable host beside the port
+        // makes one SegmentDesc an immutable endpoint snapshot for clients.
+        // Older descriptors may omit tcp_data_host; getSegmentDesc() fills it
+        // once from legacy RPC metadata before caching the descriptor.
+        std::string tcp_data_host;
+        int tcp_data_port{0};
         // TCP data-plane protocol version advertised by this segment's
         // server. v2 adds acknowledged WRITE framing and status-prefixed
         // READ responses (#2086); absent/1 = legacy unacknowledged framing.
@@ -261,6 +266,10 @@ class TransferMetadata {
     void dumpMetadataContentUnlocked();
 
    private:
+    std::shared_ptr<SegmentDesc> getSegmentDescInternal(
+        const std::string &segment_name, bool force_rpc_update);
+    int getRpcMetaEntryInternal(const std::string &server_name,
+                                RpcMetaDesc &desc, bool force_update);
     int encodeSegmentDesc(const SegmentDesc &desc, Json::Value &segmentJSON);
     std::shared_ptr<TransferMetadata::SegmentDesc> decodeSegmentDesc(
         Json::Value &segmentJSON, const std::string &segment_name);

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -217,6 +217,7 @@ class TcpTransport : public Transport {
         asio::io_context::executor_type executor;
     };
 
+    struct ConnectionLaneState;
     struct PeerConnectionGroup;
 
     struct ConnectionLane {
@@ -273,6 +274,9 @@ class TcpTransport : public Transport {
         std::shared_ptr<asio::steady_timer> retry_timer;
         uint64_t retry_epoch = 0;
         uint64_t connect_failure_log_count = 0;
+        bool retiring = false;
+        bool retirement_scheduled = false;
+        std::weak_ptr<ConnectionLaneState> owner_state;
         std::shared_ptr<FailureCounters> failure_counters;
     };
 
@@ -286,6 +290,8 @@ class TcpTransport : public Transport {
         std::unordered_map<ConnectionKey, std::shared_ptr<PeerConnectionGroup>,
                            ConnectionKeyHash>
             groups;
+        std::unordered_map<std::string, ConnectionKey> current_key_by_peer;
+        std::vector<std::shared_ptr<PeerConnectionGroup>> retiring_groups;
         std::weak_ptr<ConnectionLaneRuntime> runtime;
         std::shared_ptr<FailureCounters> failure_counters =
             std::make_shared<FailureCounters>();
@@ -300,10 +306,18 @@ class TcpTransport : public Transport {
 
     std::shared_ptr<asio::ip::tcp::socket> getConnection(
         const std::string &host, uint16_t port);
-    void enqueuePooledTransfer(const ConnectionKey &key, TcpWorkItem work);
+    void enqueuePooledTransfer(const std::string &logical_peer,
+                               const ConnectionKey &key, TcpWorkItem work);
     static uint64_t requestGroupPumpLocked(PeerConnectionGroup &group);
     static void postGroupPump(const std::shared_ptr<PeerConnectionGroup> &group,
                               uint64_t pump_epoch);
+    static bool requestGroupRetirementLocked(PeerConnectionGroup &group);
+    static void postGroupRetirement(
+        const std::shared_ptr<PeerConnectionGroup> &group);
+    static void scheduleGroupRetirement(
+        const std::shared_ptr<PeerConnectionGroup> &group);
+    static void runGroupRetirement(
+        const std::shared_ptr<PeerConnectionGroup> &group);
     static void runGroupPump(const std::shared_ptr<PeerConnectionGroup> &group,
                              uint64_t pump_epoch);
     static void startLaneConnect(

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -375,6 +375,9 @@ static int encodeMultiProtocolSegmentDesc(
     }
     segmentJSON["buffers"] = buffersJSON;
     segmentJSON["protocol"] = protocolJSON;
+    if (!desc.tcp_data_host.empty()) {
+        segmentJSON["tcp_data_host"] = desc.tcp_data_host;
+    }
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
     segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
     segmentJSON["timestamp"] = getCurrentDateTime();
@@ -418,6 +421,9 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
 
     segmentJSON["name"] = desc.name;
     segmentJSON["protocol"] = desc.protocol;
+    if (!desc.tcp_data_host.empty()) {
+        segmentJSON["tcp_data_host"] = desc.tcp_data_host;
+    }
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
     segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
     segmentJSON["timestamp"] = getCurrentDateTime();
@@ -628,6 +634,10 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
                                const std::string &segment_name) {
     auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
     desc->name = segmentJSON["name"].asString();
+    if (segmentJSON.isMember("tcp_data_host") &&
+        segmentJSON["tcp_data_host"].isString()) {
+        desc->tcp_data_host = segmentJSON["tcp_data_host"].asString();
+    }
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
@@ -793,6 +803,10 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     auto desc = std::make_shared<SegmentDesc>();
     desc->name = segmentJSON["name"].asString();
     desc->protocol = segmentJSON["protocol"].asString();
+    if (segmentJSON.isMember("tcp_data_host") &&
+        segmentJSON["tcp_data_host"].isString()) {
+        desc->tcp_data_host = segmentJSON["tcp_data_host"].asString();
+    }
     desc->tcp_data_port = segmentJSON["tcp_data_port"].asInt();
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
@@ -1062,6 +1076,12 @@ int TransferMetadata::receivePeerMetadata(const Json::Value &peer_json,
 
 std::shared_ptr<TransferMetadata::SegmentDesc> TransferMetadata::getSegmentDesc(
     const std::string &segment_name) {
+    return getSegmentDescInternal(segment_name, false);
+}
+
+std::shared_ptr<TransferMetadata::SegmentDesc>
+TransferMetadata::getSegmentDescInternal(const std::string &segment_name,
+                                         bool force_rpc_update) {
     Json::Value peer_json;
 
     if (p2p_handshake_mode_) {
@@ -1097,6 +1117,21 @@ std::shared_ptr<TransferMetadata::SegmentDesc> TransferMetadata::getSegmentDesc(
 
     auto result = decodeSegmentDesc(peer_json, segment_name);
 
+    // Compatibility for descriptors published before tcp_data_host was part
+    // of SegmentDesc. Freeze the legacy RPC location into this descriptor
+    // before it enters the segment cache, so startTransfer() still consumes a
+    // single local snapshot. New publishers carry host and port atomically in
+    // the descriptor and do not take this fallback path.
+    if (result && result->tcp_data_host.empty() && result->tcp_data_port > 0) {
+        RpcMetaDesc rpc_meta;
+        if (getRpcMetaEntryInternal(segment_name, rpc_meta, force_rpc_update)) {
+            LOG(ERROR) << "Failed to resolve legacy TCP data host for segment "
+                       << segment_name;
+            return nullptr;
+        }
+        result->tcp_data_host = rpc_meta.ip_or_host_name;
+    }
+
     // In P2P mode with dual-NIC setups (MC_RDMA_BIND_ADDRESS), the peer's
     // segment descriptor may contain an rdma_server_name that differs from
     // the TCP-routable segment_name. Cache the mapping so subsequent
@@ -1129,6 +1164,7 @@ bool TransferMetadata::SegmentDesc::operator==(const SegmentDesc &other) const {
            buffers == other.buffers && nvmeof_buffers == other.nvmeof_buffers &&
            cxl_name == other.cxl_name && cxl_base_addr == other.cxl_base_addr &&
            rank_info == other.rank_info &&
+           tcp_data_host == other.tcp_data_host &&
            tcp_data_port == other.tcp_data_port &&
            rdma_server_name == other.rdma_server_name;
 }
@@ -1157,7 +1193,7 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
     // Fetch updates without holding lock (may involve network I/O)
     std::vector<std::pair<std::string, std::shared_ptr<SegmentDesc>>> updates;
     for (const auto &name : names_to_sync) {
-        auto segment_desc = getSegmentDesc(name);
+        auto segment_desc = getSegmentDescInternal(name, true);
         if (segment_desc) {
             updates.emplace_back(name, segment_desc);
             ++fetched_count;
@@ -1473,7 +1509,13 @@ int TransferMetadata::rePublishRpcMetaEntry(const std::string &server_name) {
 
 int TransferMetadata::getRpcMetaEntry(const std::string &server_name,
                                       RpcMetaDesc &desc) {
-    {
+    return getRpcMetaEntryInternal(server_name, desc, false);
+}
+
+int TransferMetadata::getRpcMetaEntryInternal(const std::string &server_name,
+                                              RpcMetaDesc &desc,
+                                              bool force_update) {
+    if (!force_update) {
         RWSpinlock::ReadGuard guard(rpc_meta_lock_);
         if (rpc_meta_map_.count(server_name)) {
             desc = rpc_meta_map_[server_name];

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1167,6 +1167,19 @@ int TransferMetadata::syncSegmentCache(const std::string &segment_name) {
         }
     }
 
+    // RPC locations are cached independently from segment descriptors under
+    // the same logical segment name. Invalidate only successfully refreshed
+    // names before publishing their new descriptors so a subsequent lookup
+    // reloads the authoritative RPC host instead of pairing new segment
+    // metadata with a stale cached location.
+    {
+        RWSpinlock::WriteGuard guard(rpc_meta_lock_);
+        for (const auto &[name, desc] : updates) {
+            (void)desc;
+            rpc_meta_map_.erase(name);
+        }
+    }
+
     {
         // Apply updates with write lock
         RWSpinlock::WriteGuard guard(segment_lock_);

--- a/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata_dump.cpp
@@ -22,6 +22,10 @@ void TransferMetadata::SegmentDesc::dump() const {
         LOG(INFO) << "  rdma server name: " << rdma_server_name;
     }
     LOG(INFO) << "  protocol: " << protocol;
+    if (!tcp_data_host.empty()) {
+        LOG(INFO) << "  tcp data endpoint: " << tcp_data_host << ":"
+                  << tcp_data_port;
+    }
     LOG(INFO) << "  topology: " << topology.toString();
     LOG(INFO) << "  devices: ";
     for (auto& device : devices) {

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -703,7 +703,7 @@ void TcpTransport::startTransfer(Slice* slice,
     // disabled. Fixed lanes provide the same serial socket reuse without
     // reviving the old unbounded dynamic pool.
     if (enable_connection_pool_ || reuse_connection) {
-        enqueuePooledTransfer(key, std::move(work));
+        enqueuePooledTransfer(desc->name, key, std::move(work));
         return;
     }
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -57,6 +57,7 @@ using LaneAdmissionHandlerHook = void (*)() noexcept;
 using LaneObserverHook = void (*)(int, size_t, uint64_t, size_t, bool) noexcept;
 using LaneFailureReasonHook = void (*)(int) noexcept;
 using SessionProgressHook = int (*)(int, bool) noexcept;
+using StartTransferMetadataHook = void (*)() noexcept;
 
 std::mutex lane_test_hook_mutex;
 LaneConnectHandlerHook lane_connect_handler_hook = nullptr;
@@ -66,6 +67,7 @@ LaneAdmissionHandlerHook lane_admission_handler_hook = nullptr;
 LaneObserverHook lane_observer_hook = nullptr;
 LaneFailureReasonHook lane_failure_reason_hook = nullptr;
 SessionProgressHook session_progress_hook = nullptr;
+StartTransferMetadataHook start_transfer_metadata_hook = nullptr;
 
 enum LaneTestEvent {
     kLaneQueueAdmitted = 1,
@@ -167,6 +169,15 @@ int invokeSessionProgressHook(int event, bool detail) noexcept {
     }
     return hook ? hook(event, detail) : kSessionProgressNoAction;
 }
+
+void invokeStartTransferMetadataHook() noexcept {
+    StartTransferMetadataHook hook;
+    {
+        std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+        hook = start_transfer_metadata_hook;
+    }
+    if (hook) hook();
+}
 }  // namespace
 
 void tcpTransportSetLaneConnectHandlerHookForTest(
@@ -208,6 +219,12 @@ void tcpTransportSetSessionProgressHookForTest(
     SessionProgressHook hook) noexcept {
     std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
     session_progress_hook = hook;
+}
+
+void tcpTransportSetStartTransferMetadataHookForTest(
+    StartTransferMetadataHook hook) noexcept {
+    std::lock_guard<std::mutex> lock(lane_test_hook_mutex);
+    start_transfer_metadata_hook = hook;
 }
 
 bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept {
@@ -395,6 +412,7 @@ int TcpTransport::allocateLocalSegmentID(int tcp_data_port) {
 #else
     desc->protocol = "tcp";
 #endif
+    desc->tcp_data_host = metadata_->localRpcMeta().ip_or_host_name;
     desc->tcp_data_port = tcp_data_port;
     // Advertise acknowledged framing (#2086); initiators fall back to v1
     // against descriptors that do not carry the field.
@@ -677,10 +695,13 @@ void TcpTransport::startTransfer(Slice* slice,
         return;
     }
 
-    TransferMetadata::RpcMetaDesc meta_entry;
-    if (metadata_->getRpcMetaEntry(desc->name, meta_entry)) {
-        LOG(ERROR) << "TcpTransport::startTransfer failed to get RPC meta "
-                      "entry for segment name: "
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    invokeStartTransferMetadataHook();
+#endif
+
+    if (desc->tcp_data_host.empty()) {
+        LOG(ERROR) << "TcpTransport::startTransfer found no TCP data host for "
+                      "segment name: "
                    << desc->name;
         finish(TransferStatusEnum::FAILED);
         return;
@@ -694,7 +715,7 @@ void TcpTransport::startTransfer(Slice* slice,
         return;
     }
 
-    const ConnectionKey key{meta_entry.ip_or_host_name,
+    const ConnectionKey key{desc->tcp_data_host,
                             static_cast<uint16_t>(desc->tcp_data_port)};
     const bool use_v2 = desc->tcp_proto_version >= 2 && !forceLegacyTcpProto();
     TcpWorkItem work(slice, use_v2, std::move(continuation));

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
@@ -365,7 +365,123 @@ uint64_t TcpTransport::requestGroupPumpLocked(PeerConnectionGroup& group) {
     return group.pump_epoch;
 }
 
-void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
+bool TcpTransport::requestGroupRetirementLocked(PeerConnectionGroup& group) {
+    if (!group.retiring || group.retirement_scheduled ||
+        group.state != GroupState::OPEN) {
+        return false;
+    }
+    group.retirement_scheduled = true;
+    return true;
+}
+
+void TcpTransport::postGroupRetirement(
+    const std::shared_ptr<PeerConnectionGroup>& group) {
+    try {
+        asio::post(group->executor, [group] { runGroupRetirement(group); });
+    } catch (...) {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        group->retirement_scheduled = false;
+    }
+}
+
+void TcpTransport::scheduleGroupRetirement(
+    const std::shared_ptr<PeerConnectionGroup>& group) {
+    bool scheduled = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        scheduled = requestGroupRetirementLocked(*group);
+    }
+    if (scheduled) postGroupRetirement(group);
+}
+
+void TcpTransport::runGroupRetirement(
+    const std::shared_ptr<PeerConnectionGroup>& group) {
+    std::shared_ptr<asio::steady_timer> retry_timer;
+    std::shared_ptr<asio::steady_timer> admission_timer;
+    std::array<std::shared_ptr<ClientSession>, kMaxTcpLanesPerPeer> sessions;
+    std::array<std::shared_ptr<asio::ip::tcp::resolver>, kMaxTcpLanesPerPeer>
+        resolvers;
+    std::array<std::shared_ptr<asio::ip::tcp::socket>, kMaxTcpLanesPerPeer>
+        sockets;
+    size_t session_count = 0;
+    size_t resolver_count = 0;
+    size_t socket_count = 0;
+    uint64_t pump_epoch = 0;
+    bool retired = false;
+    {
+        std::lock_guard<std::mutex> lock(group->mutex);
+        group->retirement_scheduled = false;
+        if (!group->retiring || group->state != GroupState::OPEN) return;
+
+        if (!group->queue.empty() || !group->pending_admissions.empty()) {
+            pump_epoch = requestGroupPumpLocked(*group);
+        } else {
+            const bool owned_work = std::any_of(
+                group->lanes.begin(), group->lanes.end(), [](const auto& lane) {
+                    return lane->state == LaneState::BUSY ||
+                           lane->state == LaneState::COMPLETING ||
+                           lane->current.has_value();
+                });
+            if (owned_work) return;
+
+            group->state = GroupState::CLOSING;
+            group->pump_scheduled = false;
+            ++group->pump_epoch;
+            ++group->retry_epoch;
+            if (group->retry_epoch == 0) ++group->retry_epoch;
+            ++group->admission_epoch;
+            if (group->admission_epoch == 0) ++group->admission_epoch;
+            retry_timer = std::move(group->retry_timer);
+            admission_timer = std::move(group->admission_timer);
+            for (const auto& lane : group->lanes) {
+                ++lane->operation_epoch;
+                if (lane->operation_epoch == 0) ++lane->operation_epoch;
+                if (lane->session)
+                    sessions[session_count++] = std::move(lane->session);
+                if (lane->resolver)
+                    resolvers[resolver_count++] = std::move(lane->resolver);
+                if (lane->socket)
+                    sockets[socket_count++] = std::move(lane->socket);
+                lane->connect_stage = LaneConnectStage::NONE;
+                lane->state = LaneState::CLOSED;
+            }
+            group->probes_in_flight = 0;
+            group->state = GroupState::CLOSED;
+            retired = true;
+        }
+    }
+
+    if (pump_epoch != 0) {
+        postGroupPump(group, pump_epoch);
+        return;
+    }
+    if (!retired) return;
+
+    for (size_t i = 0; i < session_count; ++i)
+        if (sessions[i]) sessions[i]->cancel();
+    for (size_t i = 0; i < resolver_count; ++i) {
+        const auto& resolver = resolvers[i];
+        if (!resolver) continue;
+        try {
+            resolver->cancel();
+        } catch (...) {
+        }
+    }
+    for (size_t i = 0; i < socket_count; ++i) closeSocketNoThrow(sockets[i]);
+    cancelTimerNoThrow(retry_timer);
+    cancelTimerNoThrow(admission_timer);
+
+    if (auto state = group->owner_state.lock()) {
+        std::lock_guard<std::mutex> state_lock(state->mutex);
+        auto it = std::find(state->retiring_groups.begin(),
+                            state->retiring_groups.end(), group);
+        if (it != state->retiring_groups.end())
+            state->retiring_groups.erase(it);
+    }
+}
+
+void TcpTransport::enqueuePooledTransfer(const std::string& logical_peer,
+                                         const ConnectionKey& key,
                                          TcpWorkItem work) {
     const auto state = lane_state_;
     std::shared_ptr<PeerConnectionGroup> group;
@@ -373,6 +489,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
     std::deque<TcpWorkItem> expired;
     std::deque<TcpWorkItem> runtime_failed;
     std::shared_ptr<asio::steady_timer> timer_to_cancel;
+    std::shared_ptr<PeerConnectionGroup> retiring_group;
     WorkFailureReason rejection_reason = WorkFailureReason::QUEUE_FULL;
     uint64_t pump_epoch = 0;
     [[maybe_unused]] size_t promoted = 0;
@@ -381,6 +498,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
     [[maybe_unused]] bool pending_admission = false;
     [[maybe_unused]] bool hard_rejection = false;
     bool timer_armed = false;
+    bool retirement_scheduled = false;
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
     size_t queue_depth = 0;
     uint64_t queued_bytes = 0;
@@ -398,6 +516,33 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
                 rejected.emplace(std::move(work));
                 rejection_reason = WorkFailureReason::RUNTIME_UNAVAILABLE;
             } else {
+                auto current_it = state->current_key_by_peer.find(logical_peer);
+                if (current_it == state->current_key_by_peer.end()) {
+                    state->current_key_by_peer.emplace(logical_peer, key);
+                } else if (!(current_it->second == key)) {
+                    const ConnectionKey old_key = current_it->second;
+                    current_it->second = key;
+                    const bool old_key_still_current =
+                        std::any_of(state->current_key_by_peer.begin(),
+                                    state->current_key_by_peer.end(),
+                                    [&old_key](const auto& entry) {
+                                        return entry.second == old_key;
+                                    });
+                    if (!old_key_still_current) {
+                        auto old_group_it = state->groups.find(old_key);
+                        if (old_group_it != state->groups.end()) {
+                            retiring_group = old_group_it->second;
+                            state->retiring_groups.push_back(retiring_group);
+                            state->groups.erase(old_group_it);
+                            std::lock_guard<std::mutex> old_group_lock(
+                                retiring_group->mutex);
+                            retiring_group->retiring = true;
+                            retirement_scheduled =
+                                requestGroupRetirementLocked(*retiring_group);
+                        }
+                    }
+                }
+
                 auto group_it = state->groups.find(key);
                 if (group_it == state->groups.end()) {
                     group = std::make_shared<PeerConnectionGroup>(
@@ -413,6 +558,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
                     auto [inserted_it, inserted] =
                         state->groups.emplace(key, group);
                     if (!inserted) group = inserted_it->second;
+                    group->owner_state = state;
                 } else {
                     group = group_it->second;
                 }
@@ -474,6 +620,7 @@ void TcpTransport::enqueuePooledTransfer(const ConnectionKey& key,
     }
 
     cancelTimerNoThrow(timer_to_cancel);
+    if (retirement_scheduled) postGroupRetirement(retiring_group);
 #ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
     if (rejected) {
         invokeLaneObserverHook(kLaneQueueRejected, queue_depth, queued_bytes,
@@ -537,6 +684,7 @@ void TcpTransport::postGroupPump(
                    << ":" << group->key.port
                    << (error && *error ? ". Error: " : "")
                    << (error && *error ? error : "");
+        scheduleGroupRetirement(group);
     };
 
     try {
@@ -721,6 +869,7 @@ void TcpTransport::runGroupPump(
                   WorkFailureReason::RUNTIME_UNAVAILABLE,
                   group->failure_counters);
     if (followup_pump_epoch != 0) postGroupPump(group, followup_pump_epoch);
+    scheduleGroupRetirement(group);
 }
 
 void TcpTransport::startLaneConnect(
@@ -868,6 +1017,7 @@ void TcpTransport::handleLaneConnected(
     } else if (pump_epoch != 0) {
         postGroupPump(group, pump_epoch);
     }
+    scheduleGroupRetirement(group);
 }
 
 void TcpTransport::handleLaneConnectFailure(
@@ -958,6 +1108,7 @@ void TcpTransport::handleLaneConnectFailure(
                   WorkFailureReason::RUNTIME_UNAVAILABLE,
                   group->failure_counters);
     if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+    scheduleGroupRetirement(group);
 }
 
 void TcpTransport::startLaneSession(
@@ -1117,6 +1268,7 @@ void TcpTransport::handleLaneTerminal(
                            active_sockets, false);
 #endif
     if (pump_epoch != 0) postGroupPump(group, pump_epoch);
+    scheduleGroupRetirement(group);
 }
 
 void TcpTransport::completeTerminalAction(TerminalAction action) noexcept {
@@ -1216,8 +1368,10 @@ void TcpTransport::shutdownConnectionLanes() {
         std::lock_guard<std::mutex> state_lock(state->mutex);
         if (state->shutting_down) return;
         state->shutting_down = true;
-        groups.reserve(state->groups.size());
+        groups.reserve(state->groups.size() + state->retiring_groups.size());
         for (const auto& entry : state->groups) groups.push_back(entry.second);
+        for (const auto& group : state->retiring_groups)
+            groups.push_back(group);
     }
 
     for (const auto& group : groups) {
@@ -1379,6 +1533,8 @@ void TcpTransport::shutdownConnectionLanes() {
     {
         std::lock_guard<std::mutex> state_lock(state->mutex);
         state->groups.clear();
+        state->current_key_by_peer.clear();
+        state->retiring_groups.clear();
         state->runtime.reset();
     }
     groups.clear();

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -30,12 +30,14 @@
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
+#include <json/json.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
 #include <cstdlib>
@@ -43,8 +45,10 @@
 #include <future>
 #include <memory>
 #include <mutex>
+#include <sstream>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "transfer_engine.h"
@@ -546,6 +550,213 @@ struct TestSessionHeader {
 static_assert(sizeof(TestSessionHeader) == 24,
               "legacy TCP header ABI changed unexpectedly");
 
+// Small in-process implementation of the HTTP metadata key/value contract.
+// It lets refresh tests update the authoritative store first and then exercise
+// TransferEngine::syncSegmentCache(), rather than mutating the cached
+// SegmentDesc returned by getSegmentDescByID().
+class LocalHttpMetadataServer {
+   public:
+    LocalHttpMetadataServer() {
+        listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
+        if (listen_fd_ < 0) return;
+        int one = 1;
+        if (setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &one,
+                       sizeof(one)) != 0)
+            return;
+
+        sockaddr_in addr{};
+        addr.sin_family = AF_INET;
+        addr.sin_port = 0;
+        addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
+                 sizeof(addr)) != 0)
+            return;
+        if (listen(listen_fd_, 16) != 0) return;
+
+        socklen_t len = sizeof(addr);
+        if (getsockname(listen_fd_, reinterpret_cast<sockaddr*>(&addr), &len) !=
+            0)
+            return;
+        port_ = ntohs(addr.sin_port);
+        ok_ = true;
+        thread_ = std::thread([this] { serve(); });
+    }
+
+    ~LocalHttpMetadataServer() {
+        stopped_.store(true, std::memory_order_release);
+        if (listen_fd_ >= 0) (void)shutdown(listen_fd_, SHUT_RDWR);
+        if (thread_.joinable()) thread_.join();
+        if (listen_fd_ >= 0) close(listen_fd_);
+    }
+
+    bool ok() const { return ok_; }
+    std::string uri() const {
+        return "http://127.0.0.1:" + std::to_string(port_) + "/metadata";
+    }
+
+    bool rewriteStoredRpcHost(const std::string& server_name,
+                              const std::string& new_host) {
+        std::lock_guard<std::mutex> lock(values_mutex_);
+        size_t rewritten = 0;
+        for (auto& [key, encoded] : values_) {
+            if (key != "mooncake/rpc_meta/" + server_name) continue;
+            Json::CharReaderBuilder reader_builder;
+            Json::Value value;
+            std::string errors;
+            std::unique_ptr<Json::CharReader> reader(
+                reader_builder.newCharReader());
+            if (!reader->parse(encoded.data(), encoded.data() + encoded.size(),
+                               &value, &errors) ||
+                !value.isMember("ip_or_host_name")) {
+                continue;
+            }
+            value["ip_or_host_name"] = new_host;
+            Json::StreamWriterBuilder writer_builder;
+            writer_builder["indentation"] = "";
+            encoded = Json::writeString(writer_builder, value);
+            ++rewritten;
+        }
+        return rewritten == 1;
+    }
+
+   private:
+    static std::string decodeUrlComponent(const std::string& value) {
+        auto hexDigit = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return -1;
+        };
+        std::string decoded;
+        decoded.reserve(value.size());
+        for (size_t i = 0; i < value.size(); ++i) {
+            if (value[i] == '%' && i + 2 < value.size()) {
+                const int high = hexDigit(value[i + 1]);
+                const int low = hexDigit(value[i + 2]);
+                if (high >= 0 && low >= 0) {
+                    decoded.push_back(static_cast<char>((high << 4) | low));
+                    i += 2;
+                    continue;
+                }
+            }
+            decoded.push_back(value[i] == '+' ? ' ' : value[i]);
+        }
+        return decoded;
+    }
+
+    static bool sendExact(int fd, const std::string& value) {
+        size_t offset = 0;
+        while (offset < value.size()) {
+            const ssize_t n = send(fd, value.data() + offset,
+                                   value.size() - offset, MSG_NOSIGNAL);
+            if (n <= 0) return false;
+            offset += static_cast<size_t>(n);
+        }
+        return true;
+    }
+
+    static bool readRequest(int fd, std::string& request) {
+        constexpr size_t kMaximumRequestSize = 1 << 20;
+        char buffer[4096];
+        size_t header_end = std::string::npos;
+        while ((header_end = request.find("\r\n\r\n")) == std::string::npos) {
+            const ssize_t n = recv(fd, buffer, sizeof(buffer), 0);
+            if (n <= 0) return false;
+            request.append(buffer, static_cast<size_t>(n));
+            if (request.size() > kMaximumRequestSize) return false;
+        }
+
+        size_t content_length = 0;
+        std::istringstream headers(request.substr(0, header_end));
+        std::string line;
+        std::getline(headers, line);
+        while (std::getline(headers, line)) {
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            std::string lower = line;
+            std::transform(lower.begin(), lower.end(), lower.begin(),
+                           [](unsigned char c) { return std::tolower(c); });
+            constexpr char kContentLength[] = "content-length:";
+            if (lower.rfind(kContentLength, 0) == 0) {
+                content_length =
+                    std::stoull(line.substr(sizeof(kContentLength) - 1));
+            }
+        }
+
+        const size_t complete_size = header_end + 4 + content_length;
+        while (request.size() < complete_size) {
+            const ssize_t n = recv(fd, buffer, sizeof(buffer), 0);
+            if (n <= 0) return false;
+            request.append(buffer, static_cast<size_t>(n));
+            if (request.size() > kMaximumRequestSize) return false;
+        }
+        return true;
+    }
+
+    void handle(int fd) {
+        std::string request;
+        if (!readRequest(fd, request)) return;
+
+        const size_t request_line_end = request.find("\r\n");
+        if (request_line_end == std::string::npos) return;
+        std::istringstream request_line(request.substr(0, request_line_end));
+        std::string method;
+        std::string target;
+        std::string version;
+        request_line >> method >> target >> version;
+        (void)version;
+        const size_t key_pos = target.find("?key=");
+        if (key_pos == std::string::npos) return;
+        const std::string key = decodeUrlComponent(target.substr(key_pos + 5));
+
+        std::string body = "{}";
+        int status = 200;
+        if (method == "PUT") {
+            const size_t header_end = request.find("\r\n\r\n");
+            const std::string value = request.substr(header_end + 4);
+            std::lock_guard<std::mutex> lock(values_mutex_);
+            values_[key] = value;
+        } else if (method == "GET") {
+            std::lock_guard<std::mutex> lock(values_mutex_);
+            auto it = values_.find(key);
+            if (it == values_.end()) {
+                status = 404;
+            } else {
+                body = it->second;
+            }
+        } else if (method == "DELETE") {
+            std::lock_guard<std::mutex> lock(values_mutex_);
+            values_.erase(key);
+        } else {
+            status = 405;
+        }
+
+        const std::string response =
+            "HTTP/1.1 " + std::to_string(status) +
+            (status == 200 ? " OK\r\n" : " Error\r\n") +
+            "Content-Type: application/json\r\nContent-Length: " +
+            std::to_string(body.size()) + "\r\nConnection: close\r\n\r\n" +
+            body;
+        (void)sendExact(fd, response);
+    }
+
+    void serve() {
+        while (!stopped_.load(std::memory_order_acquire)) {
+            const int fd = accept(listen_fd_, nullptr, nullptr);
+            if (fd < 0) break;
+            handle(fd);
+            close(fd);
+        }
+    }
+
+    int listen_fd_ = -1;
+    uint16_t port_ = 0;
+    bool ok_ = false;
+    std::thread thread_;
+    std::atomic<bool> stopped_{false};
+    std::mutex values_mutex_;
+    std::unordered_map<std::string, std::string> values_;
+};
+
 // Minimal legacy-server behavior for a flagged WRITE: v1 does not recognize
 // opcode 0x81 as WRITE, so it treats the request as READ and streams payload
 // bytes without consuming the initiator's body. A sequential v2 client then
@@ -781,6 +992,11 @@ class HoldingWriteServer {
     std::atomic<int> max_accepted_count_{0};
 };
 
+// Reads a complete request header and optionally a fixed prefix of the WRITE
+// payload, then stops consuming. The receive window is kept deliberately
+// small so a large request cannot finish in the initiator's kernel buffers.
+// Condition variables expose protocol events; wall-clock time is used only by
+// the test's bounded no-progress watchdog.
 class PayloadStallingWriteServer {
    public:
     explicit PayloadStallingWriteServer(size_t payload_prefix_to_read)
@@ -988,6 +1204,15 @@ class ReusingWriteServer {
     bool ok() const { return ok_; }
     uint16_t port() const { return port_; }
     int acceptedCount() const { return accepted_count_.load(); }
+    int activeAcceptedCount() const {
+        std::lock_guard<std::mutex> lock(connection_mutex_);
+        return static_cast<int>(accepted_fds_.size());
+    }
+    bool waitForNoActiveConnections(std::chrono::milliseconds timeout) const {
+        std::unique_lock<std::mutex> lock(connection_mutex_);
+        return connection_cv_.wait_for(
+            lock, timeout, [this] { return accepted_fds_.empty(); });
+    }
 
     bool waitForRequests(int count, std::chrono::seconds timeout) const {
         const auto deadline = std::chrono::steady_clock::now() + timeout;
@@ -1106,6 +1331,7 @@ class ReusingWriteServer {
             auto it = std::find(accepted_fds_.begin(), accepted_fds_.end(), fd);
             if (it != accepted_fds_.end()) accepted_fds_.erase(it);
         }
+        connection_cv_.notify_all();
         close(fd);
     }
 
@@ -1128,7 +1354,8 @@ class ReusingWriteServer {
     uint16_t port_ = 0;
     bool ok_ = false;
     std::thread accept_thread_;
-    std::mutex connection_mutex_;
+    mutable std::mutex connection_mutex_;
+    mutable std::condition_variable connection_cv_;
     mutable std::mutex request_mutex_;
     std::vector<int> accepted_fds_;
     std::vector<std::thread> connection_threads_;
@@ -1156,7 +1383,8 @@ struct EngineHandle {
     bool ok = false;  // ASSERT_* in a helper only aborts the helper
 
     void init(const std::string& metadata_server,
-              const std::string& server_name, size_t pool_size) {
+              const std::string& server_name, size_t pool_size,
+              const std::string& remote_segment_name = {}) {
         // Exercise the pooled-connection path (default off): connection
         // reuse vs. discard-on-unclean-exchange is part of the contract
         // under test.
@@ -1177,9 +1405,12 @@ struct EngineHandle {
         // that is the engine-reported ip:port; against a real metadata
         // service (CI runs one at http://...) it is the requested
         // server_name, matching how production callers open segments.
-        std::string segment_name = (metadata_server == P2PHANDSHAKE)
-                                       ? engine->getLocalIpAndPort()
-                                       : server_name;
+        std::string segment_name = remote_segment_name;
+        if (segment_name.empty()) {
+            segment_name = (metadata_server == P2PHANDSHAKE)
+                               ? engine->getLocalIpAndPort()
+                               : server_name;
+        }
         segment_id = engine->openSegment(segment_name);
         auto desc = engine->getMetadata()->getSegmentDescByID(segment_id);
         ASSERT_NE(desc, nullptr);
@@ -1194,6 +1425,30 @@ void pointTcpSegmentAt(EngineHandle& handle, uint16_t port) {
     ASSERT_NE(desc, nullptr);
     desc->tcp_data_port = port;
     desc->tcp_proto_version = 2;
+}
+
+std::string publishAndRefreshTcpEndpoint(EngineHandle& handle,
+                                         Transport::SegmentID segment_id,
+                                         uint16_t port) {
+    auto metadata = handle.engine->getMetadata();
+    auto current = metadata->getSegmentDescByID(segment_id);
+    EXPECT_NE(current, nullptr);
+    if (!current) return {};
+    auto authoritative = *current;
+    authoritative.tcp_data_port = port;
+    authoritative.tcp_proto_version = 2;
+    EXPECT_EQ(metadata->updateSegmentDesc(current->name, authoritative), 0);
+    EXPECT_EQ(handle.engine->syncSegmentCache(current->name), 0);
+    auto refreshed = metadata->getSegmentDescByID(segment_id);
+    EXPECT_NE(refreshed, nullptr);
+    if (refreshed) {
+        EXPECT_EQ(refreshed->tcp_data_port, port);
+    }
+    return current->name;
+}
+
+std::string publishAndRefreshTcpEndpoint(EngineHandle& handle, uint16_t port) {
+    return publishAndRefreshTcpEndpoint(handle, handle.segment_id, port);
 }
 
 TransferRequest makeWriteRequest(const EngineHandle& handle, size_t length,
@@ -3430,4 +3685,278 @@ TEST(TcpWriteVisibilityTest, ShutdownWithArmedProgressDeadlineCompletesOnce) {
     reclaimBatchDescAfterEngineShutdownForTest(batch_id);
     fake_peer.release();
 }
+
+TEST(TcpWriteVisibilityTest, EndpointRefreshRoutesNewWorkToNewTcpEndpoint) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a;
+    ReusingWriteServer endpoint_b;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer = "127.0.0.2:18041";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18141", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_a.port()), logical_peer);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint_a.waitForRequests(1, std::chrono::seconds(5)));
+
+    const auto refreshed_logical_peer =
+        publishAndRefreshTcpEndpoint(h, endpoint_b.port());
+    ASSERT_EQ(refreshed_logical_peer, logical_peer);
+
+    EXPECT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    EXPECT_TRUE(endpoint_b.waitForRequests(1, std::chrono::seconds(5)))
+        << "new work did not observe endpoint B after explicit metadata "
+           "refresh";
+    EXPECT_EQ(endpoint_a.acceptedCount(), 1)
+        << "endpoint visibility is a separate observation from old-group "
+           "retirement";
+}
+
+TEST(TcpWriteVisibilityTest, EndpointRefreshRetiresOldTcpGroup) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a;
+    ReusingWriteServer endpoint_b;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer = "127.0.0.2:18042";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18142", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_a.port()), logical_peer);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint_a.waitForRequests(1, std::chrono::seconds(5)));
+    ASSERT_EQ(endpoint_a.activeAcceptedCount(), 1);
+
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_b.port()), logical_peer);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint_b.waitForRequests(1, std::chrono::seconds(5)));
+
+    EXPECT_TRUE(
+        endpoint_a.waitForNoActiveConnections(std::chrono::milliseconds(500)))
+        << "RED: endpoint B is visible, but the idle group/socket for old "
+           "endpoint A is never retired";
+}
+
+TEST(TcpWriteVisibilityTest, SharedEndpointOnePeerMovesDoesNotRetireOtherPeer) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a;
+    ReusingWriteServer endpoint_b;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer_x = "127.0.0.2:18046";
+    const std::string logical_peer_y = "127.0.0.2:18047";
+    EngineHandle target_x;
+    target_x.init(metadata_server.uri(), logical_peer_x, 64 * 1024);
+    ASSERT_TRUE(target_x.ok);
+    EngineHandle target_y;
+    target_y.init(metadata_server.uri(), logical_peer_y, 64 * 1024);
+    ASSERT_TRUE(target_y.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18146", 64 * 1024, logical_peer_x);
+    ASSERT_TRUE(h.ok);
+    const auto segment_y = h.engine->openSegment(logical_peer_y);
+    ASSERT_NE(h.engine->getMetadata()->getSegmentDescByID(segment_y), nullptr);
+
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, h.segment_id, endpoint_a.port()),
+              logical_peer_x);
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, segment_y, endpoint_a.port()),
+              logical_peer_y);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    auto peer_y_request = makeWriteRequest(h, 1);
+    peer_y_request.target_id = segment_y;
+    ASSERT_EQ(runOne(h.engine.get(), peer_y_request),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint_a.waitForRequests(2, std::chrono::seconds(5)));
+    ASSERT_EQ(endpoint_a.acceptedCount(), 1);
+
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, h.segment_id, endpoint_b.port()),
+              logical_peer_x);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint_b.waitForRequests(1, std::chrono::seconds(5)));
+
+    EXPECT_EQ(endpoint_a.activeAcceptedCount(), 1)
+        << "moving peer X must not retire endpoint A while peer Y still maps "
+           "to it";
+    ASSERT_EQ(runOne(h.engine.get(), peer_y_request),
+              TransferStatusEnum::COMPLETED);
+    EXPECT_TRUE(endpoint_a.waitForRequests(3, std::chrono::seconds(5)));
+    EXPECT_EQ(endpoint_a.acceptedCount(), 1)
+        << "peer Y should retain and reuse the shared endpoint-A group";
+}
+
+TEST(TcpWriteVisibilityTest, EndpointChangesAtoBtoCWithoutLeakingOldGroups) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a;
+    ReusingWriteServer endpoint_b;
+    ReusingWriteServer endpoint_c;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+    ASSERT_TRUE(endpoint_c.ok());
+
+    const std::string logical_peer = "127.0.0.2:18048";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18148", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+
+    for (const auto* endpoint : {&endpoint_a, &endpoint_b, &endpoint_c}) {
+        ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint->port()),
+                  logical_peer);
+        ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+                  TransferStatusEnum::COMPLETED);
+        ASSERT_TRUE(endpoint->waitForRequests(1, std::chrono::seconds(5)));
+    }
+
+    EXPECT_TRUE(endpoint_a.waitForNoActiveConnections(std::chrono::seconds(5)));
+    EXPECT_TRUE(endpoint_b.waitForNoActiveConnections(std::chrono::seconds(5)));
+    EXPECT_EQ(endpoint_c.activeAcceptedCount(), 1);
+    EXPECT_EQ(endpoint_a.acceptedCount(), 1);
+    EXPECT_EQ(endpoint_b.acceptedCount(), 1);
+    EXPECT_EQ(endpoint_c.acceptedCount(), 1);
+}
+
+TEST(TcpWriteVisibilityTest, EndpointRetirementRacesWithBusyCompletion) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a(/*hold_first_ack=*/true);
+    ReusingWriteServer endpoint_b;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer = "127.0.0.2:18049";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18149", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_a.port()), logical_peer);
+
+    const auto busy_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(
+        h.engine->submitTransfer(busy_batch, {makeWriteRequest(h, 1)}).ok());
+    ASSERT_TRUE(endpoint_a.waitForFirstRequest(std::chrono::seconds(5)));
+
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_b.port()), logical_peer);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(endpoint_a.activeAcceptedCount(), 1)
+        << "a retiring group must retain a BUSY session until completion";
+
+    endpoint_a.releaseFirstAck();
+    TransferStatusEnum status = TransferStatusEnum::WAITING;
+    ASSERT_TRUE(waitForTaskTerminal(h.engine.get(), busy_batch,
+                                    std::chrono::seconds(5), &status));
+    EXPECT_EQ(status, TransferStatusEnum::COMPLETED);
+    expectEverySliceCompletedExactlyOnce(busy_batch);
+    EXPECT_TRUE(endpoint_a.waitForNoActiveConnections(std::chrono::seconds(5)));
+    EXPECT_TRUE(h.engine->freeBatchID(busy_batch).ok());
+}
+
+TEST(TcpWriteVisibilityTest, EndpointRetirementRacesWithShutdown) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a(/*hold_first_ack=*/true);
+    ReusingWriteServer endpoint_b;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer = "127.0.0.2:18050";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18150", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_a.port()), logical_peer);
+
+    const auto busy_batch = h.engine->allocateBatchID(1);
+    ASSERT_TRUE(
+        h.engine->submitTransfer(busy_batch, {makeWriteRequest(h, 1)}).ok());
+    ASSERT_TRUE(endpoint_a.waitForFirstRequest(std::chrono::seconds(5)));
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, endpoint_b.port()), logical_peer);
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+
+    auto engine = std::move(h.engine);
+    auto destruction =
+        std::async(std::launch::async,
+                   [engine = std::move(engine)]() mutable { engine.reset(); });
+    ASSERT_EQ(destruction.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    destruction.get();
+    endpoint_a.releaseFirstAck();
+
+    expectEverySliceCompletedExactlyOnceAfterShutdown(busy_batch);
+    reclaimBatchDescAfterEngineShutdownForTest(busy_batch);
+}
+
+TEST(TcpWriteVisibilityTest, RpcMetadataRefreshInvalidatesCachedHost) {
+    LocalHttpMetadataServer metadata_server;
+    ASSERT_TRUE(metadata_server.ok());
+
+    const std::string logical_peer = "127.0.0.2:18043";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18143", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    auto metadata = h.engine->getMetadata();
+    auto segment = metadata->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(segment, nullptr);
+    ASSERT_EQ(segment->name, logical_peer);
+
+    TransferMetadata::RpcMetaDesc initial_rpc;
+    ASSERT_EQ(metadata->getRpcMetaEntry(logical_peer, initial_rpc), 0);
+    const std::string endpoint_b_host = "198.51.100.29";
+    ASSERT_NE(initial_rpc.ip_or_host_name, endpoint_b_host);
+    ASSERT_TRUE(
+        metadata_server.rewriteStoredRpcHost(logical_peer, endpoint_b_host));
+
+    auto authoritative = *segment;
+    authoritative.tcp_data_port =
+        segment->tcp_data_port == 65534 ? 65533 : 65534;
+    ASSERT_EQ(metadata->updateSegmentDesc(logical_peer, authoritative), 0);
+    ASSERT_EQ(h.engine->syncSegmentCache(logical_peer), 0);
+    auto refreshed_segment = metadata->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(refreshed_segment, nullptr);
+    ASSERT_EQ(refreshed_segment->tcp_data_port, authoritative.tcp_data_port);
+
+    TransferMetadata::RpcMetaDesc refreshed_rpc;
+    ASSERT_EQ(metadata->getRpcMetaEntry(logical_peer, refreshed_rpc), 0);
+    EXPECT_EQ(refreshed_rpc.ip_or_host_name, endpoint_b_host)
+        << "RED: segment metadata refreshed, but getRpcMetaEntry() retained "
+           "the independently cached host "
+        << initial_rpc.ip_or_host_name;
+}
+
 #endif

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -70,6 +70,8 @@ void tcpTransportSetLaneFailureReasonHookForTest(
     void (*hook)(int) noexcept) noexcept;
 void tcpTransportSetSessionProgressHookForTest(
     int (*hook)(int, bool) noexcept) noexcept;
+void tcpTransportSetStartTransferMetadataHookForTest(
+    void (*hook)() noexcept) noexcept;
 bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept;
 }  // namespace mooncake
 #endif
@@ -179,6 +181,8 @@ std::atomic<bool> session_timeout_commit_entered{false};
 std::atomic<bool> session_timeout_commit_had_write_in_flight{false};
 std::atomic<bool> hold_session_timeout_commit{false};
 std::atomic<bool> release_session_timeout_commit{false};
+std::atomic<bool> start_transfer_metadata_hook_entered{false};
+std::atomic<bool> release_start_transfer_metadata_hook{false};
 
 template <typename Predicate, typename Rep, typename Period>
 bool waitForPredicate(Predicate&& predicate,
@@ -412,6 +416,43 @@ int observeSessionProgress(int event, bool detail) noexcept {
     return session_progress_action.exchange(kSessionProgressNoAction,
                                             std::memory_order_acq_rel);
 }
+
+void blockStartTransferAfterMetadataLookup() noexcept {
+    start_transfer_metadata_hook_entered.store(true, std::memory_order_release);
+    while (
+        !release_start_transfer_metadata_hook.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+class ScopedStartTransferMetadataHook {
+   public:
+    ScopedStartTransferMetadataHook() {
+        start_transfer_metadata_hook_entered.store(false,
+                                                   std::memory_order_release);
+        release_start_transfer_metadata_hook.store(false,
+                                                   std::memory_order_release);
+        tcpTransportSetStartTransferMetadataHookForTest(
+            blockStartTransferAfterMetadataLookup);
+    }
+
+    ~ScopedStartTransferMetadataHook() { reset(); }
+
+    void release() noexcept {
+        release_start_transfer_metadata_hook.store(true,
+                                                   std::memory_order_release);
+    }
+
+    void reset() noexcept {
+        if (!active_) return;
+        release();
+        tcpTransportSetStartTransferMetadataHookForTest(nullptr);
+        active_ = false;
+    }
+
+   private:
+    bool active_ = true;
+};
 
 class ScopedLaneHooks {
    public:
@@ -1172,7 +1213,8 @@ class UnavailableTcpPeer {
 // multiple request/ack exchanges on each one.
 class ReusingWriteServer {
    public:
-    explicit ReusingWriteServer(bool hold_first_ack = false)
+    explicit ReusingWriteServer(bool hold_first_ack = false,
+                                const char* bind_address = nullptr)
         : hold_first_ack_(hold_first_ack) {
         listen_fd_ = socket(AF_INET, SOCK_STREAM, 0);
         if (listen_fd_ < 0) return;
@@ -1184,7 +1226,11 @@ class ReusingWriteServer {
         sockaddr_in addr{};
         addr.sin_family = AF_INET;
         addr.sin_port = 0;
-        addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        if (bind_address) {
+            if (inet_pton(AF_INET, bind_address, &addr.sin_addr) != 1) return;
+        } else {
+            addr.sin_addr.s_addr = htonl(INADDR_ANY);
+        }
         if (bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr),
                  sizeof(addr)) != 0)
             return;
@@ -1429,12 +1475,14 @@ void pointTcpSegmentAt(EngineHandle& handle, uint16_t port) {
 
 std::string publishAndRefreshTcpEndpoint(EngineHandle& handle,
                                          Transport::SegmentID segment_id,
-                                         uint16_t port) {
+                                         uint16_t port,
+                                         const std::string& host = {}) {
     auto metadata = handle.engine->getMetadata();
     auto current = metadata->getSegmentDescByID(segment_id);
     EXPECT_NE(current, nullptr);
     if (!current) return {};
     auto authoritative = *current;
+    if (!host.empty()) authoritative.tcp_data_host = host;
     authoritative.tcp_data_port = port;
     authoritative.tcp_proto_version = 2;
     EXPECT_EQ(metadata->updateSegmentDesc(current->name, authoritative), 0);
@@ -1442,6 +1490,9 @@ std::string publishAndRefreshTcpEndpoint(EngineHandle& handle,
     auto refreshed = metadata->getSegmentDescByID(segment_id);
     EXPECT_NE(refreshed, nullptr);
     if (refreshed) {
+        if (!host.empty()) {
+            EXPECT_EQ(refreshed->tcp_data_host, host);
+        }
         EXPECT_EQ(refreshed->tcp_data_port, port);
     }
     return current->name;
@@ -3721,6 +3772,70 @@ TEST(TcpWriteVisibilityTest, EndpointRefreshRoutesNewWorkToNewTcpEndpoint) {
            "retirement";
 }
 
+TEST(TcpWriteVisibilityTest,
+     ConcurrentEndpointRefreshNeverCombinesHostAndPortSnapshots) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint_a(false, "127.0.0.1");
+    ReusingWriteServer endpoint_b(false, "127.0.0.2");
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint_a.ok());
+    ASSERT_TRUE(endpoint_b.ok());
+
+    const std::string logical_peer = "127.0.0.2:18051";
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18151", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+    ASSERT_TRUE(
+        metadata_server.rewriteStoredRpcHost(logical_peer, "127.0.0.1"));
+    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, h.segment_id, endpoint_a.port(),
+                                           "127.0.0.1"),
+              logical_peer);
+
+    // Declare the future first so the hook's destructor releases a blocked
+    // submitter before the future is destroyed on any fatal assertion path.
+    std::future<TransferStatusEnum> transfer;
+    ScopedStartTransferMetadataHook hook;
+    transfer = std::async(std::launch::async, [&] {
+        return runOne(h.engine.get(), makeWriteRequest(h, 1));
+    });
+    ASSERT_TRUE(waitForPredicate(
+        [] {
+            return start_transfer_metadata_hook_entered.load(
+                std::memory_order_acquire);
+        },
+        std::chrono::seconds(5)));
+
+    auto metadata = h.engine->getMetadata();
+    auto old_snapshot = metadata->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(old_snapshot, nullptr);
+    auto authoritative = *old_snapshot;
+    authoritative.tcp_data_host = "127.0.0.2";
+    authoritative.tcp_data_port = endpoint_b.port();
+    ASSERT_TRUE(
+        metadata_server.rewriteStoredRpcHost(logical_peer, "127.0.0.2"));
+    ASSERT_EQ(metadata->updateSegmentDesc(logical_peer, authoritative), 0);
+    ASSERT_EQ(h.engine->syncSegmentCache(logical_peer), 0);
+
+    hook.release();
+    ASSERT_EQ(transfer.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    EXPECT_EQ(transfer.get(), TransferStatusEnum::COMPLETED)
+        << "a transfer that captured endpoint A before refresh must not use "
+           "the new host with endpoint A's old port";
+    EXPECT_TRUE(endpoint_a.waitForRequests(1, std::chrono::seconds(5)));
+
+    hook.reset();
+    EXPECT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    EXPECT_TRUE(endpoint_b.waitForRequests(1, std::chrono::seconds(5)));
+    EXPECT_EQ(endpoint_a.acceptedCount(), 1);
+    EXPECT_EQ(endpoint_b.acceptedCount(), 1);
+}
+
 TEST(TcpWriteVisibilityTest, EndpointRefreshRetiresOldTcpGroup) {
     ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
     LocalHttpMetadataServer metadata_server;
@@ -3943,12 +4058,17 @@ TEST(TcpWriteVisibilityTest, RpcMetadataRefreshInvalidatesCachedHost) {
         metadata_server.rewriteStoredRpcHost(logical_peer, endpoint_b_host));
 
     auto authoritative = *segment;
+    // Model a peer that predates tcp_data_host publication. Refresh must
+    // resolve the authoritative RPC host once and freeze it into the local
+    // SegmentDesc snapshot before startTransfer can consume it.
+    authoritative.tcp_data_host.clear();
     authoritative.tcp_data_port =
         segment->tcp_data_port == 65534 ? 65533 : 65534;
     ASSERT_EQ(metadata->updateSegmentDesc(logical_peer, authoritative), 0);
     ASSERT_EQ(h.engine->syncSegmentCache(logical_peer), 0);
     auto refreshed_segment = metadata->getSegmentDescByID(h.segment_id);
     ASSERT_NE(refreshed_segment, nullptr);
+    ASSERT_EQ(refreshed_segment->tcp_data_host, endpoint_b_host);
     ASSERT_EQ(refreshed_segment->tcp_data_port, authoritative.tcp_data_port);
 
     TransferMetadata::RpcMetaDesc refreshed_rpc;


### PR DESCRIPTION
## Description

This PR fixes two TCP endpoint-refresh correctness gaps in Transfer Engine.

First, after `syncSegmentCache()` successfully refreshes a logical segment, the corresponding cached RPC host entry is invalidated so the next `getRpcMetaEntry()` lookup reloads the authoritative host instead of returning stale metadata.

Second, TCP lane pooling now tracks the current `ConnectionKey` for each logical peer. When a logical peer moves to a different endpoint, the old endpoint group stops accepting new work for that peer, retains ownership of already accepted work, and retires only after queued, pending, and busy work has completed.

Idle sockets, timers, resolvers, and late callbacks are cleaned up using the existing group state and `operation_epoch` rules.

The retirement check also preserves a shared endpoint when another logical peer still maps to the same `{host, port}`.

Related to #2930.

## Module

- Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Deterministic coverage includes:

- refreshed metadata routes new work to the new TCP endpoint;
- stale RPC host cache is invalidated after explicit metadata refresh;
- an old endpoint group retires after a logical peer moves to a new endpoint;
- one logical peer moving away from a shared endpoint does not retire the group while another peer still uses it;
- sequential A → B → C endpoint changes retire stale groups correctly;
- endpoint retirement racing with busy completion preserves exactly-once ownership;
- endpoint retirement racing with shutdown preserves accepted work and cleanup semantics.

Final local validation:

- Normal `tcp_write_visibility_test`: 36/36 passed.
- Targeted ASan/LSan/UBSan: 7/7 passed with leak detection enabled and no sanitizer report.
- `clang-format --dry-run --Werror`: passed.
- `git diff --check upstream/main..HEAD`: passed.

Targeted tests were also exercised under TSan instrumentation during development. Test assertions passed, but TSan still reported existing project baseline races in `Transport::Slice` status access.

No new TSan report pointed to endpoint-retirement ownership, `retiring_groups`, group mutex state, or `operation_epoch`.

This is not claimed as a clean TSan pass.

`pre-commit` was unavailable in the current local environment, so it is not claimed as passed.

## Scope and limitations

This PR does not solve:

- same host/port G1 → G2 generation detection;
- concurrent stale-descriptor publication without metadata generation;
- a global peer-group bound;
- byte-based queue bounds;
- the existing transfer-status synchronization race;
- multi-rail behavior;
- TENT TCP behavior.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] The changed C++ files pass `clang-format --dry-run --Werror`.
- [x] I have added tests to prove the changes are effective.
- [x] Documentation is not required for this scoped correctness fix.
- [ ] `pre-commit` passed locally — unavailable in the current environment.

## AI Assistance Disclosure

- [x] AI tools were used.

Codex assisted with implementation review, deterministic test design, local validation, and preparation of the PR description. The human submitter remains responsible for reviewing and understanding every changed line.