### PR TITLE
[Store] Fix promotion-on-hit delivery starvation and retry loss

### DIFF
--- a/mooncake-store/include/local_ssd/manager.h
+++ b/mooncake-store/include/local_ssd/manager.h
@@ -29,6 +29,9 @@ class LocalSsdTaskMailbox {
     ErrorCode EnqueuePromotion(PromotionTaskItem task);
     std::vector<PromotionTaskItem> TakePromotions(size_t max_items);
     bool RemovePromotion(const TenantId& tenant_id, std::string_view key);
+    // Re-mark a queued promotion as most-recently-touched. No-op (returns
+    // false) when the key is not queued, e.g. already taken by a heartbeat.
+    bool TouchPromotion(const TenantId& tenant_id, std::string_view key);
 
     void RequestRemoveAll();
     bool ConsumeRemoveAll();
@@ -38,8 +41,17 @@ class LocalSsdTaskMailbox {
     bool enable_offloading_ GUARDED_BY(mutex_);
     std::unordered_map<std::string, OffloadTaskItem> pending_offloads_
         GUARDED_BY(mutex_);
-    std::unordered_map<std::string, PromotionTaskItem> pending_promotions_
+    // Dedup map + recency order. seq is monotone; enqueue, a duplicate
+    // enqueue, and TouchPromotion all re-mark the entry with a fresh seq, so
+    // TakePromotions can deliver the most-recently-touched key first instead
+    // of an arbitrary (hash-order) one.
+    struct PromotionEntry {
+        PromotionTaskItem task;
+        uint64_t seq;
+    };
+    std::unordered_map<std::string, PromotionEntry> pending_promotions_
         GUARDED_BY(mutex_);
+    uint64_t promotion_seq_ GUARDED_BY(mutex_){0};
     bool pending_remove_all_ GUARDED_BY(mutex_){false};
 
     friend class LocalSsdManager;
@@ -83,6 +95,8 @@ class LocalSsdManager {
         const UUID& client_id, size_t max_items);
     bool RemovePromotion(const UUID& client_id, const TenantId& tenant_id,
                          std::string_view key);
+    bool TouchPromotion(const UUID& client_id, const TenantId& tenant_id,
+                        std::string_view key);
 
     void RequestRemoveAll();
     void RequestRemoveAll(const std::vector<UUID>& clients);

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -311,6 +311,7 @@ class MasterMetricManager {
     void inc_promotion_completed_bytes(int64_t bytes);
     void inc_promotion_expired(int64_t val = 1);
     void inc_promotion_failed(int64_t val = 1);
+    void inc_promotion_execution_gave_up(int64_t val = 1);
     void inc_promotion_cancelled(int64_t val = 1);
     void inc_promotion_rejected_frequency(int64_t val = 1);
     void inc_promotion_rejected_watermark(int64_t val = 1);
@@ -336,6 +337,7 @@ class MasterMetricManager {
     int64_t get_promotion_completed_bytes();
     int64_t get_promotion_expired();
     int64_t get_promotion_failed();
+    int64_t get_promotion_execution_gave_up();
     int64_t get_promotion_cancelled();
     int64_t get_promotion_rejected_frequency();
     int64_t get_promotion_rejected_watermark();
@@ -695,6 +697,7 @@ class MasterMetricManager {
     ylt::metric::counter_t promotion_completed_bytes_;
     ylt::metric::counter_t promotion_expired_;
     ylt::metric::counter_t promotion_failed_;
+    ylt::metric::counter_t promotion_execution_gave_up_;
     ylt::metric::counter_t promotion_cancelled_;
     ylt::metric::counter_t promotion_rejected_frequency_;
     ylt::metric::counter_t promotion_rejected_watermark_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1530,6 +1530,7 @@ class MasterService {
         kWatermark,
         kQueueCap,
         kPushFailed,
+        kExecutionFailed,
     };
 
     struct PromotionCandidate {
@@ -2424,14 +2425,21 @@ class MasterService {
     std::atomic<uint64_t> promotion_candidate_count_{0};
     std::atomic<size_t> promotion_retry_cursor_{0};
     static constexpr size_t kPromotionCandidateLimit = 50000;
-    static constexpr uint32_t kPromotionCandidateMaxRetries = 8;
+    // Retry budget is sized to the condition it waits on: the watermark /
+    // queue-cap / push-failure gates clear on the client's offload heartbeat
+    // (10s-scale), not in milliseconds. The old budget (8 retries ≈ 2.3s)
+    // expired candidates long before their condition could clear, silently
+    // killing promotions whose only trigger was a one-off read. 64 retries
+    // with a 5s backoff cap spans ~5 minutes (≈ 30 heartbeat ticks); the TTL
+    // bounds how long an unread key can keep a slot.
+    static constexpr uint32_t kPromotionCandidateMaxRetries = 64;
     static constexpr size_t kPromotionRetryBatchSize = 128;
     static constexpr size_t kPromotionRetryShardBatch = 64;
-    static constexpr std::chrono::milliseconds kPromotionCandidateTtl{60000};
+    static constexpr std::chrono::milliseconds kPromotionCandidateTtl{300000};
     static constexpr std::chrono::milliseconds
         kPromotionCandidateInitialBackoff{10};
     static constexpr std::chrono::milliseconds kPromotionCandidateMaxBackoff{
-        1000};
+        5000};
 
     // Master-side frequency sketch. Constructed only when promotion_on_hit_ is
     // true. CountMinSketch is mutex-protected internally so we can call into it

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1542,6 +1542,12 @@ class MasterService {
             PromotionCandidateReason::kQueueCap};
         ErrorCode last_error{ErrorCode::OK};
         uint32_t retry_count{0};
+        // Execution failures in this admission chain (AllocStart / TE-write /
+        // SSD failures reported via NotifyPromotionFailure). Propagated into
+        // PromotionTask at admission so the bound survives the candidate's
+        // consumption; reset only when a genuinely new chain starts (fresh
+        // insert with 0, e.g. after a give-up or a success).
+        uint32_t execution_failures{0};
     };
 
     // NotifyPromotionSuccess should commit, so a concurrent Put on the
@@ -1568,6 +1574,13 @@ class MasterService {
         uint64_t pending_quota_charge_bytes{0};
         std::chrono::system_clock::time_point start_time;
         UUID holder_id;  // owner of source LOCAL_DISK; only Notifier allowed
+        // Execution failures so far in this admission chain. Read by
+        // NotifyPromotionFailure before the task is erased and re-recorded as
+        // execution_failures+1 until kMaxPromotionExecutionFailures. Note the
+        // asymmetry with PromotionCandidate::execution_failures: admission
+        // copies candidate -> task verbatim, failure re-record writes
+        // task+1 -> candidate.
+        uint32_t execution_failures{0};
     };
 
     static constexpr size_t kNumShards = 1024;  // Number of metadata shards
@@ -1977,7 +1990,8 @@ class MasterService {
     void RecordOrUpdateCandidate(TenantState& tenant_state,
                                  const std::string& key, uint8_t sketch_score,
                                  PromotionCandidateReason reason,
-                                 ErrorCode last_error);
+                                 ErrorCode last_error,
+                                 uint32_t execution_failures = 0);
     void EraseCandidate(TenantState& tenant_state, const std::string& key);
     void EraseCandidate(const ObjectIdentity& object_id);
     void DecrementCandidateCount();
@@ -2440,6 +2454,14 @@ class MasterService {
         kPromotionCandidateInitialBackoff{10};
     static constexpr std::chrono::milliseconds kPromotionCandidateMaxBackoff{
         5000};
+    // Bound on self-sustaining execution-failure cycles: a key whose
+    // promotion keeps failing at execution time (AllocStart under DRAM
+    // pressure, TE-write flake, SSD error) is re-recorded at most this many
+    // times. Bounds a persistently-failing ("poison") key to this many
+    // delivery slots (~this many heartbeat ticks, ~30s at the 10s default)
+    // before it stops re-queueing itself; genuine reads can still re-admit
+    // it afterwards with a fresh count.
+    static constexpr uint32_t kMaxPromotionExecutionFailures = 3;
 
     // Master-side frequency sketch. Constructed only when promotion_on_hit_ is
     // true. CountMinSketch is mutex-protected internally so we can call into it

--- a/mooncake-store/src/local_ssd/manager.cpp
+++ b/mooncake-store/src/local_ssd/manager.cpp
@@ -48,8 +48,13 @@ bool LocalSsdTaskMailbox::RemoveOffload(const TenantId& tenant_id,
 ErrorCode LocalSsdTaskMailbox::EnqueuePromotion(PromotionTaskItem task) {
     MutexLocker lock(&mutex_);
     auto index = TenantId(task.tenant_id).MakeScopedKey(task.key);
-    if (!pending_promotions_.emplace(std::move(index), std::move(task))
-             .second) {
+    const uint64_t seq = ++promotion_seq_;
+    auto [it, inserted] = pending_promotions_.emplace(
+        std::move(index), PromotionEntry{std::move(task), seq});
+    if (!inserted) {
+        // Already queued: keep the dedup contract but refresh recency, so a
+        // repeated admission moves ahead of stale entries.
+        it->second.seq = seq;
         return ErrorCode::OBJECT_ALREADY_EXISTS;
     }
     return ErrorCode::OK;
@@ -59,10 +64,25 @@ std::vector<PromotionTaskItem> LocalSsdTaskMailbox::TakePromotions(
     size_t max_items) {
     MutexLocker lock(&mutex_);
     std::vector<PromotionTaskItem> tasks;
-    tasks.reserve(std::min(max_items, pending_promotions_.size()));
-    while (!pending_promotions_.empty() && tasks.size() < max_items) {
-        auto node = pending_promotions_.extract(pending_promotions_.begin());
-        tasks.push_back(std::move(node.mapped()));
+    const size_t count = std::min(max_items, pending_promotions_.size());
+    if (count == 0) {
+        return tasks;
+    }
+    // Global recency order: rank every entry by seq and take the top
+    // |count|. Entries left behind stay recency-ordered for the next tick —
+    // a backlog larger than max_items never degrades to hash order.
+    std::vector<std::pair<uint64_t, std::string>> ranked;
+    ranked.reserve(pending_promotions_.size());
+    for (const auto& [scoped_key, entry] : pending_promotions_) {
+        ranked.emplace_back(entry.seq, scoped_key);
+    }
+    std::partial_sort(
+        ranked.begin(), ranked.begin() + count, ranked.end(),
+        [](const auto& a, const auto& b) { return a.first > b.first; });
+    tasks.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        auto node = pending_promotions_.extract(ranked[i].second);
+        tasks.push_back(std::move(node.mapped().task));
     }
     return tasks;
 }
@@ -71,6 +91,17 @@ bool LocalSsdTaskMailbox::RemovePromotion(const TenantId& tenant_id,
                                           std::string_view key) {
     MutexLocker lock(&mutex_);
     return pending_promotions_.erase(tenant_id.MakeScopedKey(key)) != 0;
+}
+
+bool LocalSsdTaskMailbox::TouchPromotion(const TenantId& tenant_id,
+                                         std::string_view key) {
+    MutexLocker lock(&mutex_);
+    auto it = pending_promotions_.find(tenant_id.MakeScopedKey(key));
+    if (it == pending_promotions_.end()) {
+        return false;
+    }
+    it->second.seq = ++promotion_seq_;
+    return true;
 }
 
 void LocalSsdTaskMailbox::RequestRemoveAll() {
@@ -271,6 +302,13 @@ LocalSsdManager::TakePromotions(const UUID& client_id, size_t max_items) {
         return tl::unexpected(ErrorCode::SEGMENT_NOT_FOUND);
     }
     return client->record->mailbox.TakePromotions(max_items);
+}
+
+bool LocalSsdManager::TouchPromotion(const UUID& client_id,
+                                     const TenantId& tenant_id,
+                                     std::string_view key) {
+    auto client = FindClient(client_id);
+    return client && client->record->mailbox.TouchPromotion(tenant_id, key);
 }
 
 bool LocalSsdManager::RemovePromotion(const UUID& client_id,

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -360,6 +360,11 @@ MasterMetricManager::MasterMetricManager()
           "master_promotion_failed_total",
           "Total promotion tasks aborted by holder via "
           "NotifyPromotionFailure (holder reported a downstream failure)"),
+      promotion_execution_gave_up_(
+          "master_promotion_execution_gave_up_total",
+          "Total promotion admission chains permanently abandoned after "
+          "kMaxPromotionExecutionFailures consecutive execution failures "
+          "(self-sustaining cycle stopped; reads can still re-admit)"),
       promotion_cancelled_(
           "master_promotion_cancelled_total",
           "Total promotion tasks removed because the prerequisite went "
@@ -504,6 +509,7 @@ void MasterMetricManager::update_metrics_for_zero_output() {
     promotion_completed_bytes_.inc(0);
     promotion_expired_.inc(0);
     promotion_failed_.inc(0);
+    promotion_execution_gave_up_.inc(0);
     promotion_cancelled_.inc(0);
     promotion_rejected_frequency_.inc(0);
     promotion_rejected_watermark_.inc(0);
@@ -1180,6 +1186,9 @@ void MasterMetricManager::inc_promotion_expired(int64_t val) {
 void MasterMetricManager::inc_promotion_failed(int64_t val) {
     promotion_failed_.inc(val);
 }
+void MasterMetricManager::inc_promotion_execution_gave_up(int64_t val) {
+    promotion_execution_gave_up_.inc(val);
+}
 void MasterMetricManager::inc_promotion_cancelled(int64_t val) {
     promotion_cancelled_.inc(val);
 }
@@ -1599,6 +1608,9 @@ int64_t MasterMetricManager::get_promotion_expired() {
 }
 int64_t MasterMetricManager::get_promotion_failed() {
     return promotion_failed_.value();
+}
+int64_t MasterMetricManager::get_promotion_execution_gave_up() {
+    return promotion_execution_gave_up_.value();
 }
 int64_t MasterMetricManager::get_promotion_cancelled() {
     return promotion_cancelled_.value();

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7506,12 +7506,16 @@ void MasterService::RecordOrUpdateCandidate(TenantState& tenant_state,
                                             const std::string& key,
                                             uint8_t sketch_score,
                                             PromotionCandidateReason reason,
-                                            ErrorCode last_error) {
+                                            ErrorCode last_error,
+                                            uint32_t execution_failures) {
     const auto now = std::chrono::steady_clock::now();
     auto it = tenant_state.promotion_candidates.find(key);
     if (it != tenant_state.promotion_candidates.end()) {
         // Update existing entry: refresh last_seen, reset
-        // retry_after/retry_count.
+        // retry_after/retry_count. execution_failures is intentionally NOT
+        // updated here: a read refresh is new demand signal and may extend
+        // the budget, but it must not erase the failure history of this
+        // admission chain.
         it->second.last_seen = now;
         it->second.last_reason = reason;
         it->second.last_error = last_error;
@@ -7545,7 +7549,8 @@ void MasterService::RecordOrUpdateCandidate(TenantState& tenant_state,
                                 .retry_after = now,
                                 .last_reason = reason,
                                 .last_error = last_error,
-                                .retry_count = 0});
+                                .retry_count = 0,
+                                .execution_failures = execution_failures});
     if (inserted) {
         MasterMetricManager::instance().inc_promotion_candidate_recorded();
         VLOG(1) << "promotion_candidate_recorded key=" << key;
@@ -8514,13 +8519,22 @@ MasterService::PromotionQueueResult MasterService::TryPushPromotionQueue(
 
     // Record the in-flight task. alloc_id is filled in by
     // PromotionAllocStart once the new MEMORY replica is staged.
+    // Propagate the execution-failure count across the candidate's
+    // consumption so NotifyPromotionFailure can bound self-sustaining
+    // execution-failure cycles; an absent candidate means a fresh chain (0).
+    uint32_t execution_failures = 0;
+    if (auto cit = tenant_state.promotion_candidates.find(key);
+        cit != tenant_state.promotion_candidates.end()) {
+        execution_failures = cit->second.execution_failures;
+    }
     EraseCandidate(tenant_state, key);
     tenant_state.promotion_tasks.emplace(
         key, PromotionTask{.source_id = source->id(),
                            .alloc_id = 0,
                            .object_size = object_size,
                            .start_time = std::chrono::system_clock::now(),
-                           .holder_id = holder_id});
+                           .holder_id = holder_id,
+                           .execution_failures = execution_failures});
     promotion_in_flight_.fetch_add(1, std::memory_order_relaxed);
     MasterMetricManager::instance().inc_promotion_in_flight();
     MasterMetricManager::instance().inc_promotion_admitted();
@@ -8827,6 +8841,9 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     ReleaseTenantQuota(
         GetBoundTenantQuotaHandle(tenant_state),
         std::exchange(task_it->second.pending_quota_charge_bytes, 0));
+    // Capture the chain's execution-failure count BEFORE erasing the task
+    // (the iterator is invalidated by the erase).
+    const uint32_t prior_failures = task_it->second.execution_failures;
     tenant_state.promotion_tasks.erase(task_it);
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     MasterMetricManager::instance().dec_promotion_in_flight();
@@ -8842,15 +8859,29 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     // (read-only), NOT increment(): an executor-side failure is not demand
     // signal, and bumping the sketch here would pollute the frequency signal
     // the admission gate relies on.
+    //
+    // The self-sustaining cycle is additionally bounded by
+    // kMaxPromotionExecutionFailures: without it, a persistently-failing key
+    // (e.g. a broken SSD file that still has a LOCAL_DISK replica) would
+    // re-record -> re-admit -> fail -> re-record forever, monopolizing
+    // delivery slots with no read demand. Once the bound is hit we stop
+    // re-recording — a genuine read can still re-admit the key (fresh chain).
     if (!metadata.HasReplica(&Replica::fn_is_memory_replica) &&
         metadata.HasReplica(&Replica::fn_is_local_disk_replica)) {
-        const auto admission_key =
-            object_id.tenant_id.MakeScopedKey(object_id.user_key);
-        const uint8_t freq =
-            promotion_sketch_ ? promotion_sketch_->count(admission_key) : 0;
-        RecordOrUpdateCandidate(tenant_state, object_id.user_key, freq,
-                                PromotionCandidateReason::kExecutionFailed,
-                                ErrorCode::OK);
+        if (prior_failures >= kMaxPromotionExecutionFailures) {
+            LOG(WARNING) << "promotion_execution_gave_up key="
+                         << object_id.user_key
+                         << " failures=" << prior_failures;
+            MasterMetricManager::instance().inc_promotion_execution_gave_up();
+        } else {
+            const auto admission_key =
+                object_id.tenant_id.MakeScopedKey(object_id.user_key);
+            const uint8_t freq =
+                promotion_sketch_ ? promotion_sketch_->count(admission_key) : 0;
+            RecordOrUpdateCandidate(tenant_state, object_id.user_key, freq,
+                                    PromotionCandidateReason::kExecutionFailed,
+                                    ErrorCode::OK, prior_failures + 1);
+        }
     }
 
     // Clear the holder's per-client promotion mailbox entry. Same

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -8435,6 +8435,13 @@ MasterService::PromotionQueueResult MasterService::TryPushPromotionQueue(
     // Dedup: don't queue twice if a promotion is already in flight or if a
     // MEMORY replica has appeared since GetReplicaList observed only-disk.
     if (tenant_state.promotion_tasks.count(key) > 0) {
+        // A read hit an already in-flight promotion: re-mark the queued
+        // entry's recency so the next heartbeat delivers it ahead of stale
+        // admissions. No-op if the heartbeat already took the entry (the
+        // promotion is executing) or the holder's mailbox is gone.
+        local_ssd_manager_.TouchPromotion(
+            tenant_state.promotion_tasks.at(key).holder_id, object_id.tenant_id,
+            key);
         EraseCandidate(tenant_state, key);
         return PromotionQueueResult::kAlreadyInFlight;
     }
@@ -8824,6 +8831,27 @@ auto MasterService::NotifyPromotionFailure(const UUID& client_id,
     promotion_in_flight_.fetch_sub(1, std::memory_order_relaxed);
     MasterMetricManager::instance().dec_promotion_in_flight();
     MasterMetricManager::instance().inc_promotion_failed();
+
+    // A transient execution failure (DRAM pressure at AllocStart, a TE write
+    // flake, SSD throttling) must not silently kill the promotion: re-record
+    // a retry candidate so the eviction-thread retry loop re-queues it with
+    // backoff. Bounded by kPromotionCandidateMaxRetries /
+    // kPromotionCandidateTtl, and the retry path erases the candidate on
+    // permanent conditions (not-found, memory-present, no-local-disk-source),
+    // so this cannot spin. Record the current estimate via count()
+    // (read-only), NOT increment(): an executor-side failure is not demand
+    // signal, and bumping the sketch here would pollute the frequency signal
+    // the admission gate relies on.
+    if (!metadata.HasReplica(&Replica::fn_is_memory_replica) &&
+        metadata.HasReplica(&Replica::fn_is_local_disk_replica)) {
+        const auto admission_key =
+            object_id.tenant_id.MakeScopedKey(object_id.user_key);
+        const uint8_t freq =
+            promotion_sketch_ ? promotion_sketch_->count(admission_key) : 0;
+        RecordOrUpdateCandidate(tenant_state, object_id.user_key, freq,
+                                PromotionCandidateReason::kExecutionFailed,
+                                ErrorCode::OK);
+    }
 
     // Clear the holder's per-client promotion mailbox entry. Same
     // best-effort cleanup pattern as NotifyPromotionSuccess — the

--- a/mooncake-store/tests/local_ssd/local_ssd_test.cpp
+++ b/mooncake-store/tests/local_ssd/local_ssd_test.cpp
@@ -65,6 +65,80 @@ TEST(LocalSsdTaskMailboxTest, PromotionsAreBatchedAndRemoveAllIsConsumed) {
     EXPECT_FALSE(mailbox.ConsumeRemoveAll());
 }
 
+TEST(LocalSsdTaskMailboxTest, PromotionsAreDeliveredByRecency) {
+    LocalSsdTaskMailbox mailbox(false);
+    ASSERT_TRUE(mailbox.EnqueuePromotion(Promotion("t", "a", 1)) ==
+                ErrorCode::OK);
+    ASSERT_TRUE(mailbox.EnqueuePromotion(Promotion("t", "b", 2)) ==
+                ErrorCode::OK);
+    ASSERT_TRUE(mailbox.EnqueuePromotion(Promotion("t", "c", 3)) ==
+                ErrorCode::OK);
+
+    // Without any touch, the most recent enqueue is delivered first.
+    auto first = mailbox.TakePromotions(1);
+    ASSERT_EQ(first.size(), 1);
+    EXPECT_EQ(first.front(), Promotion("t", "c", 3));
+
+    // A touch re-marks an older entry ahead of newer ones.
+    ASSERT_TRUE(mailbox.TouchPromotion(TenantId("t"), "a"));
+    auto second = mailbox.TakePromotions(1);
+    ASSERT_EQ(second.size(), 1);
+    EXPECT_EQ(second.front(), Promotion("t", "a", 1));
+
+    // A duplicate enqueue keeps the dedup contract but refreshes recency.
+    ASSERT_TRUE(mailbox.EnqueuePromotion(Promotion("t", "b", 2)) ==
+                ErrorCode::OBJECT_ALREADY_EXISTS);
+    auto third = mailbox.TakePromotions(1);
+    ASSERT_EQ(third.size(), 1);
+    EXPECT_EQ(third.front(), Promotion("t", "b", 2));
+
+    EXPECT_TRUE(mailbox.TakePromotions(10).empty());
+    EXPECT_FALSE(mailbox.TouchPromotion(TenantId("t"), "missing"));
+}
+
+TEST(LocalSsdTaskMailboxTest, TakePromotionsKeepsGlobalRecencyAcrossTicks) {
+    LocalSsdTaskMailbox mailbox(false);
+    for (const char* key : {"k1", "k2", "k3", "k4", "k5"}) {
+        ASSERT_TRUE(mailbox.EnqueuePromotion(Promotion("t", key, 1)) ==
+                    ErrorCode::OK);
+    }
+    ASSERT_TRUE(mailbox.TouchPromotion(TenantId("t"), "k2"));
+
+    // k2 (touched) first, then the newest enqueue. The batch limit must not
+    // degrade the remainder to hash order on the next tick.
+    auto batch = mailbox.TakePromotions(2);
+    ASSERT_EQ(batch.size(), 2);
+    EXPECT_EQ(batch[0], Promotion("t", "k2", 1));
+    EXPECT_EQ(batch[1], Promotion("t", "k5", 1));
+
+    auto rest = mailbox.TakePromotions(10);
+    ASSERT_EQ(rest.size(), 3);
+    EXPECT_EQ(rest[0], Promotion("t", "k4", 1));
+    EXPECT_EQ(rest[1], Promotion("t", "k3", 1));
+    EXPECT_EQ(rest[2], Promotion("t", "k1", 1));
+}
+
+TEST(LocalSsdManagerTest, TouchPromotionIsClientScoped) {
+    LocalSsdManager manager;
+    UUID client{7, 8};
+    UUID other{9, 10};
+    ASSERT_TRUE(manager.RegisterClient(client, false) == ErrorCode::OK);
+    ASSERT_TRUE(manager.RegisterClient(other, false) == ErrorCode::OK);
+    ASSERT_TRUE(manager.EnqueuePromotion(client, Promotion("t", "a", 1)) ==
+                ErrorCode::OK);
+    ASSERT_TRUE(manager.EnqueuePromotion(client, Promotion("t", "b", 2)) ==
+                ErrorCode::OK);
+
+    // Unknown clients and foreign clients cannot touch the entry.
+    EXPECT_FALSE(manager.TouchPromotion(UUID{11, 12}, TenantId("t"), "a"));
+    EXPECT_FALSE(manager.TouchPromotion(other, TenantId("t"), "a"));
+
+    ASSERT_TRUE(manager.TouchPromotion(client, TenantId("t"), "a"));
+    auto taken = manager.TakePromotions(client, 1);
+    ASSERT_EQ(taken->size(), 1);
+    EXPECT_EQ(taken->front(), Promotion("t", "a", 1));
+}
+
 TEST(LocalSsdManagerTest, ManagesRegistrationCapacityAndUsage) {
     LocalSsdManager manager;
     UUID client{1, 2};

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -59,6 +59,10 @@ class PromotionOnHitTest : public ::testing::Test {
         return service->CountCandidatesForTesting(tenant);
     }
 
+    static constexpr uint32_t MaxPromotionCandidateRetriesForTesting() {
+        return MasterService::kPromotionCandidateMaxRetries;
+    }
+
     static void ResetCandidateBackoffsForTesting(MasterService* service) {
         service->ResetCandidateBackoffsForTesting();
     }
@@ -1642,6 +1646,13 @@ TEST_F(PromotionOnHitTest, NotifyRejectsNonHolder) {
 // be silently dropped until reaper TTL if Notify-Failure didn't
 // fast-release. The TTL is set high enough here that any test pass
 // can be attributed to the explicit release, not to reaper expiry.
+//
+// Note: failure also re-records the failed key as a retry candidate
+// (transient execution errors are retried, not dropped). With queue_limit=1
+// the retried key and a fresh admission on another key race for the freed
+// slot; the assertions below accept either winner — what they must NOT
+// accept is an undeliverable heartbeat, which is what a saturated slot
+// would produce.
 TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     MasterServiceConfig config;
     config.enable_offload = true;
@@ -1668,6 +1679,7 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
 
     auto& mm = MasterMetricManager::instance();
     const int64_t failed_pre = mm.get_promotion_failed();
+    const int64_t recorded_pre = mm.get_promotion_candidate_recorded();
 
     // Admit + stage k_a. promotion_in_flight_ goes 0 -> 1.
     {
@@ -1694,6 +1706,12 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
         << "legitimate holder must succeed; error=" << failure.error();
     EXPECT_EQ(mm.get_promotion_failed() - failed_pre, 1)
         << "holder-reported failure must bump promotion_failed";
+    // The failure must also re-record a retry candidate for k_a (metric
+    // moves synchronously inside NotifyPromotionFailure; the background
+    // retry loop can only consume the candidate, never un-record it).
+    EXPECT_EQ(mm.get_promotion_candidate_recorded() - recorded_pre, 1)
+        << "NotifyPromotionFailure must re-record k_a as a retry candidate "
+        << "so transient execution errors are retried, not dropped";
 
     // The staged buffer must be freed back to the DRAM allocator. If
     // this fires, NotifyPromotionFailure did not pop the staged replica
@@ -1706,20 +1724,31 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
         << "to the allocator; otherwise it leaks until the object is "
         << "removed or evicted.";
 
-    // The slot must be freed: a second admission on a different key must
-    // succeed even though queue_limit=1. Without the failure-side
-    // decrement the cap would stay saturated until reaper TTL.
+    // The slot must be freed. Two outcomes prove it, and which one occurs
+    // depends on a benign race with the eviction thread's retry loop:
+    //   (a) k_b's read admits k_b while the freed slot is still open, or
+    //   (b) k_a — re-recorded as a retry candidate by the failure above —
+    //       is re-admitted first, so k_b is cap-rejected and becomes a
+    //       candidate itself.
+    // Either way the heartbeat must deliver exactly one task (queue_limit=1)
+    // and it must be one of the two keys; before the fast-release fix the
+    // slot would have stayed saturated and the heartbeat would be empty.
     {
         auto r = service->GetReplicaList("k_b", TenantId::Default());
         ASSERT_TRUE(r.has_value());
     }
     auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
     ASSERT_TRUE(heartbeat.has_value());
-    EXPECT_EQ(CountPromotionTask(*heartbeat, "k_b"), 1u)
-        << "k_b admission must succeed after k_a's failure released the "
-        << "slot. If this fires, NotifyPromotionFailure did not decrement "
-        << "promotion_in_flight_, and transient client-side errors "
-        << "would saturate the queue limit for the full reaper TTL.";
+    ASSERT_EQ(heartbeat->size(), 1u)
+        << "after k_a's failure released the slot, exactly one promotion "
+        << "must be deliverable (queue_limit=1); an empty result means "
+        << "NotifyPromotionFailure did not decrement promotion_in_flight_, "
+        << "and transient client-side errors would saturate the queue "
+        << "limit for the full reaper TTL";
+    const std::string& winner = heartbeat->front().key;
+    EXPECT_TRUE(winner == "k_a" || winner == "k_b")
+        << "delivered task must be the retried k_a or the newly admitted "
+        << "k_b, got: " << winner;
 
     // Idempotency: repeated failure notification on the same key must be
     // safe (return OK without underflowing the counter).
@@ -1728,6 +1757,65 @@ TEST_F(PromotionOnHitTest, NotifyFailureReleasesStateImmediately) {
     EXPECT_TRUE(failure_again.has_value())
         << "Repeated NotifyPromotionFailure should be idempotent (return "
         << "OK on already-released task), not error.";
+
+    service->RemoveAll();
+}
+
+// NotifyPromotionFailure must re-record a retry candidate for the failed
+// key so transient execution errors (DRAM pressure at AllocStart, TE write
+// flake, SSD throttle) are retried by the eviction-thread retry loop rather
+// than silently dropped. The re-admission can be driven by the background
+// retry loop or by an explicit scan — the final state is identical either
+// way: candidate consumed, key re-queued for the holder.
+TEST_F(PromotionOnHitTest, NotifyFailureRecordsCandidateAndRetries) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_a", 1024,
+                                       seg.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t recorded_pre = mm.get_promotion_candidate_recorded();
+
+    {
+        auto r = service->GetReplicaList("k_a", TenantId::Default());
+        ASSERT_TRUE(r.has_value());
+    }
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_a",
+                                              TenantId::Default(), 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+
+    // Holder reports failure after a successful AllocStart (simulating an
+    // SSD read error / TE write flake past the staging point).
+    auto failure = service->NotifyPromotionFailure(seg.client_id, "k_a",
+                                                   TenantId::Default());
+    ASSERT_TRUE(failure.has_value());
+    EXPECT_EQ(mm.get_promotion_candidate_recorded() - recorded_pre, 1)
+        << "NotifyPromotionFailure must re-record a retry candidate";
+
+    // Whether the eviction thread's retry loop or this explicit scan wins
+    // the race to re-admit, the resulting state is identical: the candidate
+    // is consumed and k_a is queued again for the holder.
+    ResetCandidateBackoffsForTesting(service.get());
+    RunPromotionCandidateRetryForTesting(service.get());
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 1u)
+        << "k_a must be re-admitted after its transient failure";
+    EXPECT_EQ(
+        CountPromotionCandidatesForTesting(service.get(), TenantId::Default()),
+        0u)
+        << "the re-admitted candidate must be consumed";
+
+    auto heartbeat = service->PromotionObjectHeartbeat(seg.client_id);
+    ASSERT_TRUE(heartbeat.has_value());
+    ASSERT_EQ(heartbeat->size(), 1u);
+    EXPECT_EQ(heartbeat->front().key, "k_a");
 
     service->RemoveAll();
 }
@@ -2736,9 +2824,17 @@ TEST_F(PromotionOnHitTest, RetryCandidate_CapRejectedThenQueuedOnRetry) {
         CountPromotionCandidatesForTesting(service.get(), TenantId::Default()),
         1u);
 
-    auto failed = service->NotifyPromotionFailure(seg.client_id, "k_busy",
-                                                  TenantId::Default());
-    ASSERT_TRUE(failed.has_value());
+    // Release the slot via a *successful* promotion of k_busy. Using
+    // NotifyPromotionFailure here would change the candidate set: failure
+    // deliberately re-records a retry candidate for the failed key
+    // (transient execution errors are retried, not dropped), so k_busy
+    // would then compete with k_retry for the freed slot.
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_busy",
+                                              TenantId::Default(), 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+    auto done = service->NotifyPromotionSuccess(seg.client_id, "k_busy",
+                                                TenantId::Default());
+    ASSERT_TRUE(done.has_value());
     ASSERT_EQ(GetPromotionInFlightForTesting(service.get()), 0u);
 
     ResetCandidateBackoffsForTesting(service.get());
@@ -2824,8 +2920,10 @@ TEST_F(PromotionOnHitTest, RetryCandidate_ExhaustedAfterMaxRetries) {
 
     // Drive retries; each scan increments retry_count until exhausted.
     // Reset backoff timestamps before each scan so wall-clock time doesn't
-    // gate retries and the loop completes without sleeping.
-    for (int i = 0; i <= 10; ++i) {
+    // gate retries and the loop completes without sleeping. The scan count
+    // is derived from kPromotionCandidateMaxRetries (one scan to reach the
+    // limit, one more to observe it and erase).
+    for (uint32_t i = 0; i <= MaxPromotionCandidateRetriesForTesting(); ++i) {
         ResetCandidateBackoffsForTesting(service.get());
         RunPromotionCandidateRetryForTesting(service.get());
     }

--- a/mooncake-store/tests/promotion_on_hit_test.cpp
+++ b/mooncake-store/tests/promotion_on_hit_test.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <thread>
 #include <vector>
@@ -63,6 +64,10 @@ class PromotionOnHitTest : public ::testing::Test {
         return MasterService::kPromotionCandidateMaxRetries;
     }
 
+    static constexpr uint32_t MaxPromotionExecutionFailuresForTesting() {
+        return MasterService::kMaxPromotionExecutionFailures;
+    }
+
     static void ResetCandidateBackoffsForTesting(MasterService* service) {
         service->ResetCandidateBackoffsForTesting();
     }
@@ -99,6 +104,24 @@ class PromotionOnHitTest : public ::testing::Test {
         const auto* tenant_state = accessor.GetTenantState();
         return tenant_state != nullptr &&
                tenant_state->promotion_tasks.contains(key);
+    }
+
+    // std::nullopt when the key has no in-flight promotion task.
+    static std::optional<uint32_t> GetPromotionTaskExecutionFailuresForTesting(
+        MasterService* service, const TenantId& tenant_id,
+        const std::string& key) {
+        MasterService::MetadataAccessorRO accessor(
+            service, MasterService::ObjectIdentity{.tenant_id = tenant_id,
+                                                   .user_key = key});
+        const auto* tenant_state = accessor.GetTenantState();
+        if (tenant_state == nullptr) {
+            return std::nullopt;
+        }
+        auto it = tenant_state->promotion_tasks.find(key);
+        if (it == tenant_state->promotion_tasks.end()) {
+            return std::nullopt;
+        }
+        return it->second.execution_failures;
     }
 
     static bool PromotionAdmissionBlockedByPrimaryWriteForTesting(
@@ -1816,6 +1839,101 @@ TEST_F(PromotionOnHitTest, NotifyFailureRecordsCandidateAndRetries) {
     ASSERT_TRUE(heartbeat.has_value());
     ASSERT_EQ(heartbeat->size(), 1u);
     EXPECT_EQ(heartbeat->front().key, "k_a");
+
+    service->RemoveAll();
+}
+
+// A persistently-failing key (e.g. a broken SSD file that still has a
+// LOCAL_DISK replica) must not re-record -> re-admit -> fail -> re-record
+// forever: each NotifyPromotionFailure re-records with execution_failures+1
+// (propagated candidate -> task at admission), and once the chain reaches
+// kMaxPromotionExecutionFailures the failure stops re-recording. The
+// give-up kills only the self-sustaining cycle — a genuine read afterwards
+// re-admits with a fresh count.
+TEST_F(PromotionOnHitTest, NotifyFailureGivesUpAfterMaxExecutionFailures) {
+    MasterServiceConfig config;
+    config.enable_offload = true;
+    config.promotion_on_hit = true;
+    config.promotion_admission_threshold = 1;
+    config.default_kv_lease_ttl = 5000;
+    config.put_start_release_timeout_sec = 300;
+    auto service = std::make_unique<MasterService>(config);
+
+    constexpr size_t seg_size = 1024 * 1024 * 16;
+    auto seg = PrepareSegment(*service, "seg_a", kDefaultSegmentBase, seg_size);
+    ASSERT_TRUE(InjectLocalDiskReplica(*service, seg.client_id, "k_a", 1024,
+                                       seg.segment_name));
+
+    auto& mm = MasterMetricManager::instance();
+    const int64_t recorded_pre = mm.get_promotion_candidate_recorded();
+    const int64_t gave_up_pre = mm.get_promotion_execution_gave_up();
+
+    // First admission is driven by a real read (fresh chain, count 0).
+    {
+        auto r = service->GetReplicaList("k_a", TenantId::Default());
+        ASSERT_TRUE(r.has_value());
+    }
+
+    // Fail kMaxPromotionExecutionFailures times. Each failure must re-record
+    // with an incremented count, and each re-admission must show the count
+    // propagated across the candidate's consumption. The background eviction
+    // thread may win the re-admission race against the explicit retry call —
+    // assertions only target the resulting terminal state, which is
+    // identical under both interleavings.
+    for (uint32_t i = 1; i <= MaxPromotionExecutionFailuresForTesting(); ++i) {
+        ASSERT_EQ(GetPromotionInFlightForTesting(service.get()), 1u)
+            << "chain must be in-flight at iteration " << i;
+        EXPECT_EQ(GetPromotionTaskExecutionFailuresForTesting(
+                      service.get(), TenantId::Default(), "k_a"),
+                  std::optional<uint32_t>(i - 1))
+            << "execution_failures must propagate candidate -> task";
+        auto alloc = service->PromotionAllocStart(
+            seg.client_id, "k_a", TenantId::Default(), 1024, {});
+        ASSERT_TRUE(alloc.has_value());
+        auto failure = service->NotifyPromotionFailure(seg.client_id, "k_a",
+                                                       TenantId::Default());
+        ASSERT_TRUE(failure.has_value());
+        EXPECT_EQ(mm.get_promotion_candidate_recorded() - recorded_pre,
+                  static_cast<int64_t>(i))
+            << "failure " << i << " must re-record (still below the bound)";
+        ResetCandidateBackoffsForTesting(service.get());
+        RunPromotionCandidateRetryForTesting(service.get());
+    }
+
+    // The next failure hits the bound: no re-record, no re-admission.
+    ASSERT_EQ(GetPromotionInFlightForTesting(service.get()), 1u);
+    EXPECT_EQ(
+        GetPromotionTaskExecutionFailuresForTesting(service.get(),
+                                                    TenantId::Default(), "k_a"),
+        std::optional<uint32_t>(MaxPromotionExecutionFailuresForTesting()));
+    auto alloc = service->PromotionAllocStart(seg.client_id, "k_a",
+                                              TenantId::Default(), 1024, {});
+    ASSERT_TRUE(alloc.has_value());
+    auto failure = service->NotifyPromotionFailure(seg.client_id, "k_a",
+                                                   TenantId::Default());
+    ASSERT_TRUE(failure.has_value());
+    EXPECT_EQ(mm.get_promotion_candidate_recorded() - recorded_pre,
+              static_cast<int64_t>(MaxPromotionExecutionFailuresForTesting()))
+        << "the bound-crossing failure must NOT re-record";
+    EXPECT_EQ(mm.get_promotion_execution_gave_up() - gave_up_pre, 1)
+        << "give-up must bump promotion_execution_gave_up";
+    EXPECT_EQ(
+        CountPromotionCandidatesForTesting(service.get(), TenantId::Default()),
+        0u);
+    EXPECT_EQ(RunPromotionCandidateRetryForTesting(service.get()), 0u);
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 0u)
+        << "the self-sustaining cycle must be dead";
+
+    // Give-up kills only the self-sustaining cycle: a genuine read re-admits
+    // with a fresh chain (count 0).
+    {
+        auto r = service->GetReplicaList("k_a", TenantId::Default());
+        ASSERT_TRUE(r.has_value());
+    }
+    EXPECT_EQ(GetPromotionInFlightForTesting(service.get()), 1u);
+    EXPECT_EQ(GetPromotionTaskExecutionFailuresForTesting(
+                  service.get(), TenantId::Default(), "k_a"),
+              std::optional<uint32_t>(0u));
 
     service->RemoveAll();
 }

--- a/mooncake-wheel/tests/test_promotion_on_hit.py
+++ b/mooncake-wheel/tests/test_promotion_on_hit.py
@@ -9,10 +9,13 @@ next heartbeat tick stages a fresh MEMORY replica.
 Test scenario:
   1. Push enough data to overflow DRAM, so eviction + offload turns warm
      keys into LOCAL_DISK-only objects.
-  2. Identify one such key from the replica descriptors.
+  2. Identify one such key from the replica descriptors (condition-polled,
+     not a fixed sleep).
   3. Read it repeatedly to clear ``promotion_admission_threshold``.
-  4. Wait long enough for one master heartbeat (which queues the task) plus
-     one FileStorage heartbeat (which executes it).
+  4. Poll single-key ``batch_get_replica_desc`` until the key regains a
+     MEMORY replica; each poll re-fires the promotion gate for that key,
+     so the wait is condition-based and self-healing rather than a bet on
+     the heartbeat phase.
   5. Assert the key now also has a MEMORY replica.
 
 Prerequisites:
@@ -22,10 +25,17 @@ Prerequisites:
       ``--promotion_on_hit=true``
       ``--promotion_admission_threshold=1``  (any positive int; we send
           enough reads to clear up to 4)
+      ``--promotion_max_per_heartbeat=16``  (raise the delivery cap so a
+          burst of admissions from the phase-2 batch query drains within
+          the wait window instead of starving individual keys at the
+          default 1-per-heartbeat)
       ``--root_fs_dir=<dir>``  (so the master tells the client to init
           its FileStorage; without this, no offload heartbeat runs and
           no LOCAL_DISK replicas are ever created)
   - ``MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=<dir>`` set on the client side.
+  - ``MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=2`` recommended on the
+    client (pins the master/client clock phase; the 10s default makes the
+    wait windows racy against offload draining).
   - ``MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10`` and
     ``MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760`` on the client.
     The default bucket-flush thresholds (500 keys / 256 MB) are too high
@@ -52,8 +62,9 @@ default_kv_lease_ttl = int(
 SEGMENT_SIZE = int(os.getenv("SEGMENT_SIZE_BYTES", str(32 * 1024 * 1024)))
 LOCAL_BUFFER_SIZE = int(os.getenv("LOCAL_BUFFER_SIZE_BYTES", str(64 * 1024 * 1024)))
 
-# Wait window for a full master+client heartbeat round-trip. The default
-# heartbeat interval is 10s on both sides, so 25s is comfortably > 2 ticks.
+# Timeout ceiling for the condition polls below (not a fixed sleep). CI runs
+# the client offload heartbeat at 2s (MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_
+# SECONDS); 25s leaves ample room even at the 10s default interval.
 PROMOTION_WAIT_SECONDS = int(os.getenv("PROMOTION_WAIT_SECONDS", "25"))
 
 
@@ -99,6 +110,28 @@ def _replica_types(descs, key):
         else:
             tags.append("UNKNOWN")
     return tags
+
+
+def wait_until(cond, timeout_s, interval=1.0, desc=""):
+    """Poll ``cond()`` (which returns (ok, detail)) until ok or timeout.
+
+    Returns the detail on success; raises AssertionError on timeout with the
+    last observed detail. Polling beats fixed sleeps here for two reasons:
+    the wait adapts to however long the offload/promotion heartbeat actually
+    takes on a loaded CI runner, and — for the promotion waits below — every
+    poll is a single-key ``batch_get_replica_desc``, which re-fires the
+    master's promotion gate for that key (re-admitting it if the task was
+    never queued or was dropped after a transient failure)."""
+    t0 = time.monotonic()
+    while True:
+        ok, detail = cond()
+        if ok:
+            return detail
+        if time.monotonic() - t0 >= timeout_s:
+            raise AssertionError(
+                f"timeout ({timeout_s}s) waiting for {desc}; last={detail}"
+            )
+        time.sleep(interval)
 
 
 class TestPromotionOnHit(unittest.TestCase):
@@ -153,33 +186,37 @@ class TestPromotionOnHit(unittest.TestCase):
                 len(reference), 0, "No PUTs succeeded — cannot run promotion test"
             )
 
-            # Phase 2: wait long enough for offload heartbeat to flush the
-            # evicted keys to LOCAL_DISK.
-            time.sleep(PROMOTION_WAIT_SECONDS)
+            # Phase 2: poll until the offload heartbeat has flushed at least
+            # one evicted key to a LOCAL_DISK-only state (instead of betting
+            # on a fixed sleep matching the heartbeat phase).
+            def _find_cold_key():
+                descs = self.store.batch_get_replica_desc(list(reference.keys()))
+                type_hist = {}
+                found = None
+                for key in reference.keys():
+                    types = _replica_types(descs, key)
+                    hist_key = ",".join(sorted(set(types)))
+                    type_hist[hist_key] = type_hist.get(hist_key, 0) + 1
+                    if (
+                        found is None
+                        and types
+                        and all("MEMORY" not in t for t in types)
+                        and any("LOCAL_DISK" in t for t in types)
+                    ):
+                        found = key
+                return (found is not None), (found, type_hist)
 
-            descs = self.store.batch_get_replica_desc(list(reference.keys()))
-            type_hist = {}
-            cold_key = None
-            for key in reference.keys():
-                types = _replica_types(descs, key)
-                hist_key = ",".join(sorted(set(types)))
-                type_hist[hist_key] = type_hist.get(hist_key, 0) + 1
-                if (
-                    cold_key is None
-                    and types
-                    and all("MEMORY" not in t for t in types)
-                    and any("LOCAL_DISK" in t for t in types)
-                ):
-                    cold_key = key
-            print(f"replica-type histogram after phase 2: {type_hist}")
-
-            self.assertIsNotNone(
-                cold_key,
-                "No LOCAL_DISK-only key found after eviction — is "
-                "offload_on_evict=true and the segment small enough to "
-                "overflow? master config / SEGMENT_SIZE_BYTES env may need "
-                "tuning. Histogram above shows the actual replica state.",
+            cold_key, type_hist = wait_until(
+                _find_cold_key,
+                PROMOTION_WAIT_SECONDS,
+                desc=(
+                    "a LOCAL_DISK-only key after eviction — is "
+                    "offload_on_evict=true and the segment small enough to "
+                    "overflow? master config / SEGMENT_SIZE_BYTES env may "
+                    "need tuning"
+                ),
             )
+            print(f"replica-type histogram after phase 2: {type_hist}")
 
             # Phase 3: clear the admission threshold via per-key reads.
             # ``store.get`` goes through ``Client::Query`` → master's
@@ -203,21 +240,28 @@ class TestPromotionOnHit(unittest.TestCase):
                     f"read path is broken — promotion cannot be tested.",
                 )
 
-            # Phase 4: wait for the master to enqueue the promotion task and
-            # for the client's next FileStorage heartbeat to execute it.
-            time.sleep(PROMOTION_WAIT_SECONDS)
+            # Phase 4: poll until the promotion lands. Each poll is a
+            # single-key batch_get_replica_desc, which re-fires the master's
+            # promotion gate for cold_key only — re-admitting it if the task
+            # was never queued or was dropped after a transient failure —
+            # so polling doubles as a self-healing re-trigger rather than a
+            # passive wait.
+            def _promoted():
+                descs = self.store.batch_get_replica_desc([cold_key])
+                types = _replica_types(descs, cold_key)
+                return ("MEMORY" in types), types
 
-            descs_after = self.store.batch_get_replica_desc([cold_key])
-            types_after = _replica_types(descs_after, cold_key)
-            print(f"replica types for {cold_key} after promotion: {types_after}")
-            self.assertTrue(
-                "MEMORY" in types_after,
-                f"Expected a MEMORY replica for {cold_key} after promotion, "
-                f"got types={types_after}. Either promotion_on_hit is not "
-                f"enabled in the master, the admission threshold was not "
-                f"cleared, or the heartbeat tick did not fire within "
-                f"{PROMOTION_WAIT_SECONDS}s.",
+            types_after = wait_until(
+                _promoted,
+                PROMOTION_WAIT_SECONDS,
+                desc=(
+                    f"MEMORY replica for {cold_key} after promotion "
+                    f"(check master metrics promotion_admitted / "
+                    f"promotion_rejected_watermark / promotion_completed "
+                    f"and the client's 'ProcessPromotionTasks pulled' log)"
+                ),
             )
+            print(f"replica types for {cold_key} after promotion: {types_after}")
 
             # Phase 5: post-promotion bytes-back AND prove MEMORY was the
             # replica actually served. SelectBestReplica should prefer the
@@ -397,18 +441,27 @@ class BenchPromotionLatency(unittest.TestCase):
 
             time.sleep(PROMOTION_WAIT_SECONDS)
 
-            descs = self.store.batch_get_replica_desc(list(reference.keys()))
-            cold_key = None
-            for key in reference.keys():
-                types = _replica_types(descs, key)
-                if (
-                    cold_key is None
-                    and types
-                    and all("MEMORY" not in t for t in types)
-                    and any("LOCAL_DISK" in t for t in types)
-                ):
-                    cold_key = key
-            self.assertIsNotNone(cold_key, "no LOCAL_DISK-only key after eviction")
+            def _find_cold_key():
+                descs = self.store.batch_get_replica_desc(list(reference.keys()))
+                found = None
+                for key in reference.keys():
+                    types = _replica_types(descs, key)
+                    if (
+                        found is None
+                        and types
+                        and all("MEMORY" not in t for t in types)
+                        and any("LOCAL_DISK" in t for t in types)
+                    ):
+                        found = key
+                return (found is not None), found
+
+            # Keep the initial fixed wait (the pre-promotion read loop below
+            # wants a quiet system), then poll for the cold key.
+            cold_key = wait_until(
+                _find_cold_key,
+                PROMOTION_WAIT_SECONDS,
+                desc="no LOCAL_DISK-only key after eviction",
+            )
 
             # Pre-promotion: timed LOCAL_DISK reads, bail when a read
             # serves from MEMORY (= worker raced the loop).
@@ -439,11 +492,18 @@ class BenchPromotionLatency(unittest.TestCase):
                 "lower LATENCY_SAMPLES.",
             )
 
-            # Wait for promotion to complete.
-            time.sleep(PROMOTION_WAIT_SECONDS)
-            descs_after = self.store.batch_get_replica_desc([cold_key])
-            types_after = _replica_types(descs_after, cold_key)
-            self.assertIn("MEMORY", types_after)
+            # Wait for promotion to complete (poll; each poll re-fires the
+            # promotion gate for cold_key, doubling as a re-trigger).
+            def _promoted():
+                descs_after = self.store.batch_get_replica_desc([cold_key])
+                types_after = _replica_types(descs_after, cold_key)
+                return ("MEMORY" in types_after), types_after
+
+            wait_until(
+                _promoted,
+                PROMOTION_WAIT_SECONDS,
+                desc=f"MEMORY replica for {cold_key} after promotion",
+            )
 
             # Post-promotion: timed MEMORY reads; the counter must stay
             # put (otherwise at least one read still hit LOCAL_DISK).

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -185,21 +185,30 @@ if [ -n "$TEST_PROMOTION_ON_HIT" ]; then
     # deterministic. --root_fs_dir is required so the master returns a non-
     # empty fsdir from GetStorageConfig, which is the trigger that initializes
     # the client's FileStorage (and therefore the offload heartbeat).
+    # promotion_max_per_heartbeat=16 raises the delivery cap so a burst of
+    # admissions (the phase-2 batch query promotes every LOCAL_DISK-only key)
+    # drains within the test's wait window instead of starving individual keys
+    # at the default 1-per-heartbeat.
     mooncake_master \
         --default_kv_lease_ttl=500 \
         --root_fs_dir=$TEST_ROOT_DIR \
         --enable_offload=true \
         --offload_on_evict=true \
         --promotion_on_hit=true \
-        --promotion_admission_threshold=1 &
+        --promotion_admission_threshold=1 \
+        --promotion_max_per_heartbeat=16 &
     MASTER_PID=$!
     sleep 1
     # Lower bucket-flush thresholds so the test workload (~64 MB) actually
     # writes to disk rather than sitting in the bucket backend's ungrouped
-    # pool until the default 500-key / 256-MB bucket fills.
+    # pool until the default 500-key / 256-MB bucket fills. The 2s offload
+    # heartbeat (default 10s) pins the master/client clock phase so offload
+    # draining and promotion delivery complete well inside the test's wait
+    # windows.
     MC_METADATA_SERVER=http://127.0.0.1:8080/metadata \
         DEFAULT_KV_LEASE_TTL=500 \
         MOONCAKE_OFFLOAD_FILE_STORAGE_PATH=$TEST_ROOT_DIR \
+        MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=2 \
         MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT=10 \
         MOONCAKE_OFFLOAD_BUCKET_SIZE_LIMIT_BYTES=10485760 \
         python test_promotion_on_hit.py


### PR DESCRIPTION
## Description

Fixes the nightly `test_promotion_after_repeated_hits` flake ([run 32276229813](https://github.com/kvcache-ai/Mooncake/actions/runs/32276229813/job/96162038864)).

**Problem.** The test overflows a 32MB segment, waits for offload to turn some keys LOCAL_DISK-only, reads one `cold_key` to clear `promotion_admission_threshold=1`, then asserts a MEMORY replica appears. It flakes because the promotion path races three independent clocks (10ms eviction / 10s client heartbeat / 25s test sleep):

1. A read-only `batch_get_replica_desc` (the test's own phase-2 introspection) admits *every* LOCAL_DISK-only key, flooding the promotion mailbox.
2. The mailbox is an `unordered_map` and each heartbeat delivers only `promotion_max_per_heartbeat=1`, hash-arbitrary — so the target key is starved.
3. A watermark-rejected candidate gets 8 retries (~2.3s) before permanent deletion, while the condition it waits on (offload draining `used_ratio`) is 10–30s scale.
4. `NotifyPromotionFailure` (and `PromotionAllocStart` failing with `NO_AVAILABLE_HANDLE`) drops the task without re-recording a candidate — every delivery gets exactly one chance.

**Fix.**

- `local_ssd/manager`: deliver promotions in **recency order** — a monotonic `seq` is refreshed on enqueue, duplicate enqueue, and a new `TouchPromotion` (called when a read hits an already in-flight key). `TakePromotions` ranks by `seq` desc, so the most-recently-read key is delivered first regardless of the hash order of the map.
- `master_service`: re-record a retry candidate in `NotifyPromotionFailure` for transient execution failures (using `CountMinSketch::count()`, read-only, so the executor-side failure does not pollute the frequency signal). The re-record is bounded by a per-chain `execution_failures` counter propagated candidate → task at admission (`kMaxPromotionExecutionFailures = 3`): without it a persistently-failing key (e.g. a broken SSD file that still has a LOCAL_DISK replica) would re-record → re-admit → fail → re-record *forever*, because admission consumes the candidate, so every re-record is a fresh insert and the retry budget / TTL never apply. On give-up only the self-sustaining cycle stops — a genuine read can still re-admit the key with a fresh count. Give-ups are observable via the new `master_promotion_execution_gave_up_total` counter.
- Retry budget rescaled to the heartbeat timescale: `kPromotionCandidateMaxRetries` 8→64, max backoff 1s→5s, TTL 60s→300s, so candidates survive long enough for their gate to actually clear.
- `test_promotion_on_hit.py`: replace fixed `time.sleep(25)` with condition polling (`wait_until`); each poll is a single-key `batch_get_replica_desc`, which re-fires the promotion gate — the wait becomes self-healing instead of a bet on the phase.
- `scripts/run_tests.sh`: pin the clock phase with `--promotion_max_per_heartbeat=16` and `MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS=2`.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
# unit tests (mailbox recency, failure re-record, retry budget)
cmake --build build --target local_ssd_test promotion_on_hit_test && \
    ctest --test-dir build -R "local_ssd|promotion_on_hit" --output-on-failure

# nightly e2e
TEST_PROMOTION_ON_HIT=1 bash scripts/run_tests.sh
```

**Test results:**

- [x] Unit tests pass — added: mailbox recency delivery / cross-tick order / client-scoped touch, `NotifyFailureRecordsCandidateAndRetries`, `NotifyFailureGivesUpAfterMaxExecutionFailures`, retry-budget exhaustion follows `kPromotionCandidateMaxRetries`.
- [x] Integration tests pass — e2e `test_promotion_on_hit.py` **5/5** against a branch-built `mooncake_master` (fresh master + fresh storage dir per run, CI-identical flags, ~40s/run; cold keys varied across runs — poh_1/2/4/11 — all promoted; histograms consistently showed ~5 LOCAL_DISK-only keys whose admission burst drains via `promotion_max_per_heartbeat=16`). Note for local repro: the wheel's `store.so` must be built from the same commit as the master — an older installed wheel fails `MountSegment` with `invalid rpc arg` (RPC struct mismatch), which is an environment issue, not a test failure.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used — assisted analysis and code review of the mechanism (root-cause tracing of the three-clock race and the mailbox/retry/failure semantics). The human submitter reviewed every changed line.