### PR TITLE
[Bugfix][TransferEngine] Register HIP IPC memory at allocation granularity

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -217,6 +217,13 @@ class TransferMetadata {
 
     int removeLocalMemoryBuffer(void *addr, bool update_metadata);
 
+    // Removes the buffer at addr only when pred accepts the entry, so
+    // transports sharing an address in the local buffer list remove only
+    // their own entries.
+    int removeLocalMemoryBuffer(
+        void *addr, const std::function<bool(const BufferDesc &)> &pred,
+        bool update_metadata);
+
     int addLocalSegment(SegmentID segment_id, const std::string &segment_name,
                         std::shared_ptr<SegmentDesc> &&desc);
 

--- a/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
@@ -91,7 +91,9 @@ class HipTransport : public Transport {
     bool use_fabric_mem_;
 
     std::mutex register_mutex_;
-    // Sub-ranges of one hipMalloc block share a single IPC registration.
+    // Registered sub-range address → its hipMalloc base; base → live alias
+    // count. One IPC registration per base, removed by the last unregister.
+    std::unordered_map<uint64_t, uint64_t> registered_addr_to_base_;
     std::unordered_map<uint64_t, size_t> registered_base_refs_;
 
     // Stream and event pools for async operations

--- a/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <unordered_set>
 #include <vector>
 #include <utility>
 
@@ -90,6 +91,7 @@ class HipTransport : public Transport {
     bool use_fabric_mem_;
 
     std::mutex register_mutex_;
+    std::unordered_set<uint64_t> registered_base_addrs_;
 
     // Stream and event pools for async operations
     StreamPool stream_pool_;

--- a/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_set>
+#include <unordered_map>
 #include <vector>
 #include <utility>
 
@@ -91,7 +91,8 @@ class HipTransport : public Transport {
     bool use_fabric_mem_;
 
     std::mutex register_mutex_;
-    std::unordered_set<uint64_t> registered_base_addrs_;
+    // Sub-ranges of one hipMalloc block share a single IPC registration.
+    std::unordered_map<uint64_t, size_t> registered_base_refs_;
 
     // Stream and event pools for async operations
     StreamPool stream_pool_;

--- a/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
+++ b/mooncake-transfer-engine/include/transport/hip_transport/hip_transport.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <utility>
 
@@ -95,6 +96,10 @@ class HipTransport : public Transport {
     // count. One IPC registration per base, removed by the last unregister.
     std::unordered_map<uint64_t, uint64_t> registered_addr_to_base_;
     std::unordered_map<uint64_t, size_t> registered_base_refs_;
+    // Addresses registerLocalMemory deliberately skipped (e.g. host memory
+    // left to other transports), distinguishing them from never-registered
+    // ones at unregister time.
+    std::unordered_set<uint64_t> skipped_addrs_;
 
     // Stream and event pools for async operations
     StreamPool stream_pool_;

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -1332,6 +1332,13 @@ int TransferMetadata::addLocalMemoryBuffer(const BufferDesc &buffer_desc,
 
 int TransferMetadata::removeLocalMemoryBuffer(void *addr,
                                               bool update_metadata) {
+    return removeLocalMemoryBuffer(
+        addr, [](const BufferDesc &) { return true; }, update_metadata);
+}
+
+int TransferMetadata::removeLocalMemoryBuffer(
+    void *addr, const std::function<bool(const BufferDesc &)> &pred,
+    bool update_metadata) {
     bool addr_exist = false;
     {
         RWSpinlock::WriteGuard guard(segment_lock_);
@@ -1341,12 +1348,13 @@ int TransferMetadata::removeLocalMemoryBuffer(void *addr,
         segment_desc = new_segment_desc;
         for (auto iter = segment_desc->buffers.begin();
              iter != segment_desc->buffers.end(); ++iter) {
-            if (iter->addr == (uint64_t)addr
+            if ((iter->addr == (uint64_t)addr
 #ifdef USE_CXL
-                ||
-                (iter->offset + segment_desc->cxl_base_addr) == (uint64_t)addr
+                 ||
+                 (iter->offset + segment_desc->cxl_base_addr) == (uint64_t)addr
 #endif
-            ) {
+                 ) &&
+                pred(*iter)) {
                 segment_desc->buffers.erase(iter);
                 addr_exist = true;
                 break;

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -697,8 +697,10 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
             return -1;
         }
 
-        // Skip if this hipMalloc block is already registered
-        if (registered_base_addrs_.count((uint64_t)base_ptr)) {
+        // Count aliases so the registration outlives every sub-range but one
+        auto it = registered_base_refs_.find((uint64_t)base_ptr);
+        if (it != registered_base_refs_.end()) {
+            it->second++;
             return 0;
         }
 
@@ -721,7 +723,7 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
 #endif
         int rc = metadata_->addLocalMemoryBuffer(desc, true);
         if (rc == 0) {
-            registered_base_addrs_.insert((uint64_t)base_ptr);
+            registered_base_refs_[(uint64_t)base_ptr] = 1;
         }
         return rc;
     }
@@ -788,8 +790,11 @@ int HipTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
                          << "); memory may already be freed, using the "
                          << "provided address";
         }
+        // Keep the registration alive until the last sub-range releases it
         std::lock_guard<std::mutex> lock(register_mutex_);
-        registered_base_addrs_.erase((uint64_t)key_ptr);
+        auto it = registered_base_refs_.find((uint64_t)key_ptr);
+        if (it != registered_base_refs_.end() && --it->second > 0) return 0;
+        registered_base_refs_.erase((uint64_t)key_ptr);
     }
     return metadata_->removeLocalMemoryBuffer(key_ptr, update_metadata);
 }

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -697,8 +697,13 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
             return -1;
         }
 
-        // Count aliases so the registration outlives every sub-range but one
-        auto it = registered_base_refs_.find((uint64_t)base_ptr);
+        // Re-registering the same address is idempotent; a new sub-range of
+        // an already exported allocation just takes another reference.
+        uint64_t base = (uint64_t)base_ptr;
+        if (!registered_addr_to_base_.emplace((uint64_t)addr, base).second) {
+            return 0;
+        }
+        auto it = registered_base_refs_.find(base);
         if (it != registered_base_refs_.end()) {
             it->second++;
             return 0;
@@ -708,6 +713,7 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         hipIpcMemHandle_t handle;
         if (!checkHip(hipIpcGetMemHandle(&handle, base_ptr),
                       "HipTransport: hipIpcGetMemHandle failed")) {
+            registered_addr_to_base_.erase((uint64_t)addr);
             return -1;
         }
 
@@ -723,7 +729,9 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
 #endif
         int rc = metadata_->addLocalMemoryBuffer(desc, true);
         if (rc == 0) {
-            registered_base_refs_[(uint64_t)base_ptr] = 1;
+            registered_base_refs_[base] = 1;
+        } else {
+            registered_addr_to_base_.erase((uint64_t)addr);
         }
         return rc;
     }
@@ -775,28 +783,33 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
 }
 
 int HipTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
-    void* key_ptr = addr;
     if (!use_fabric_mem_) {
-        void* base_ptr = nullptr;
-        size_t alloc_size = 0;
-        hipError_t result = hipMemGetAddressRange(
-            (hipDeviceptr_t*)&base_ptr, &alloc_size, (hipDeviceptr_t)addr);
-        if (result == hipSuccess) {
-            key_ptr = base_ptr;
-        } else {
-            (void)hipGetLastError();
-            LOG(WARNING) << "HipTransport: hipMemGetAddressRange failed for "
-                         << addr << " during unregister (error " << result
-                         << "); memory may already be freed, using the "
-                         << "provided address";
-        }
-        // Keep the registration alive until the last sub-range releases it
+        // Hold register_mutex_ through the metadata removal, mirroring the
+        // register path, so a concurrent register of another sub-range cannot
+        // republish the buffer in between.
         std::lock_guard<std::mutex> lock(register_mutex_);
-        auto it = registered_base_refs_.find((uint64_t)key_ptr);
-        if (it != registered_base_refs_.end() && --it->second > 0) return 0;
-        registered_base_refs_.erase((uint64_t)key_ptr);
+        auto alias_it = registered_addr_to_base_.find((uint64_t)addr);
+        if (alias_it != registered_addr_to_base_.end()) {
+            uint64_t base = alias_it->second;
+            registered_addr_to_base_.erase(alias_it);
+            // Both maps are updated in pairs under this mutex, so the base
+            // always has a refcount entry here. Only the last alias removes
+            // the shared registration.
+            if (--registered_base_refs_[base] > 0) return 0;
+            registered_base_refs_.erase(base);
+            return metadata_->removeLocalMemoryBuffer((void*)base,
+                                                      update_metadata);
+        }
+        // Not registered here (host memory owned by another transport, or
+        // already unregistered). The caller's address may still equal the
+        // base of a registration whose aliases are live (slab-level cleanup
+        // passing the allocation base); that registration is only removable
+        // through its aliases above.
+        if (registered_base_refs_.count((uint64_t)addr)) {
+            return ERR_ADDRESS_NOT_REGISTERED;
+        }
     }
-    return metadata_->removeLocalMemoryBuffer(key_ptr, update_metadata);
+    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
 }
 
 int HipTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -683,9 +683,28 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
             return 0;
         }
 
+        // Resolve the true hipMalloc base address. Framework caching
+        // allocators (PyTorch, etc.) sub-allocate tensors within larger
+        // hipMalloc segments. hipIpcGetMemHandle always returns a handle for
+        // the entire segment, so we must register at segment granularity or
+        // relocateSharedMemoryAddress() maps every sub-range back onto the
+        // segment base and the peer silently reads the wrong bytes.
+        void* base_ptr = nullptr;
+        size_t alloc_size = 0;
+        if (!checkHip(hipMemGetAddressRange((hipDeviceptr_t*)&base_ptr,
+                                            &alloc_size, (hipDeviceptr_t)addr),
+                      "HipTransport: hipMemGetAddressRange failed")) {
+            return -1;
+        }
+
+        // Skip if this hipMalloc block is already registered
+        if (registered_base_addrs_.count((uint64_t)base_ptr)) {
+            return 0;
+        }
+
         // Get IPC handle
         hipIpcMemHandle_t handle;
-        if (!checkHip(hipIpcGetMemHandle(&handle, addr),
+        if (!checkHip(hipIpcGetMemHandle(&handle, base_ptr),
                       "HipTransport: hipIpcGetMemHandle failed")) {
             return -1;
         }
@@ -693,14 +712,18 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         // Register buffer with metadata
         (void)remote_accessible;
         BufferDesc desc;
-        desc.addr = (uint64_t)addr;
-        desc.length = length;
+        desc.addr = (uint64_t)base_ptr;
+        desc.length = alloc_size;
         desc.name = location;
         desc.shm_name = serializeBinaryData(&handle, sizeof(hipIpcMemHandle_t));
 #ifdef ENABLE_MULTI_PROTOCOL
         desc.protocol = "hip";
 #endif
-        return metadata_->addLocalMemoryBuffer(desc, true);
+        int rc = metadata_->addLocalMemoryBuffer(desc, true);
+        if (rc == 0) {
+            registered_base_addrs_.insert((uint64_t)base_ptr);
+        }
+        return rc;
     }
 
     // Fabric memory registration
@@ -750,7 +773,25 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
 }
 
 int HipTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
-    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    void* key_ptr = addr;
+    if (!use_fabric_mem_) {
+        void* base_ptr = nullptr;
+        size_t alloc_size = 0;
+        hipError_t result = hipMemGetAddressRange(
+            (hipDeviceptr_t*)&base_ptr, &alloc_size, (hipDeviceptr_t)addr);
+        if (result == hipSuccess) {
+            key_ptr = base_ptr;
+        } else {
+            (void)hipGetLastError();
+            LOG(WARNING) << "HipTransport: hipMemGetAddressRange failed for "
+                         << addr << " during unregister (error " << result
+                         << "); memory may already be freed, using the "
+                         << "provided address";
+        }
+        std::lock_guard<std::mutex> lock(register_mutex_);
+        registered_base_addrs_.erase((uint64_t)key_ptr);
+    }
+    return metadata_->removeLocalMemoryBuffer(key_ptr, update_metadata);
 }
 
 int HipTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,

--- a/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/hip_transport/hip_transport.cpp
@@ -652,6 +652,22 @@ Status HipTransport::submitTransferTask(
     return Status::OK();
 }
 
+namespace {
+
+// Matches the descs this transport published into the shared local buffer
+// list. Under multi-protocol the protocol field is authoritative; without it,
+// the serialized IPC/fabric handle is the discriminator (only GPU-IPC
+// transports fill shm_name, and they never coexist with HIP in one build).
+bool isOwnDesc(const TransferMetadata::BufferDesc& desc) {
+#ifdef ENABLE_MULTI_PROTOCOL
+    return desc.protocol == "hip";
+#else
+    return !desc.shm_name.empty();
+#endif
+}
+
+}  // namespace
+
 int HipTransport::registerLocalMemory(void* addr, size_t length,
                                       const std::string& location,
                                       bool remote_accessible,
@@ -680,6 +696,7 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
                 LOG(INFO) << "HipTransport: skipping non-device memory " << addr
                           << ", leaving it to other transports";
             }
+            skipped_addrs_.insert((uint64_t)addr);
             return 0;
         }
 
@@ -731,6 +748,10 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         if (rc == 0) {
             registered_base_refs_[base] = 1;
         } else {
+            // addLocalMemoryBuffer appends the desc before publishing it;
+            // drop the leftover so a failed registration leaves nothing
+            // behind for a later rollback or unregister to miss.
+            metadata_->removeLocalMemoryBuffer((void*)base, isOwnDesc, false);
             registered_addr_to_base_.erase((uint64_t)addr);
         }
         return rc;
@@ -745,6 +766,7 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
             LOG(WARNING) << "Memory region " << addr
                          << " is not allocated by hipMemCreate, "
                          << "but it can be used as local buffer";
+            skipped_addrs_.insert((uint64_t)addr);
             return 0;
         }
 
@@ -761,15 +783,38 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
             real_size = (length + granularity - 1) & ~(granularity - 1);
         }
 
+        // Sub-ranges of one allocation share its page-granular registration.
+        // Track aliases and reference-count them like the IPC path so an
+        // unregister cannot consume another alias's registration. The
+        // shareable handle for the page is exported only once, so drop the
+        // retained allocation handle on these fast paths.
+        uint64_t page = (uint64_t)real_addr;
+        if (!registered_addr_to_base_.emplace((uint64_t)addr, page).second) {
+            (void)hipMemRelease(handle);
+            return 0;
+        }
+        auto refs_it = registered_base_refs_.find(page);
+        if (refs_it != registered_base_refs_.end()) {
+            refs_it->second++;
+            (void)hipMemRelease(handle);
+            return 0;
+        }
+
         // Export shareable handle
         hipxFabricHandle export_handle_raw = {};
         if (!checkHip(
                 hipMemExportToShareableHandle(&export_handle_raw, handle,
                                               HIPX_MEM_HANDLE_TYPE_FABRIC, 0),
                 "HipTransport: hipMemExportToShareableHandle failed")) {
+            registered_addr_to_base_.erase((uint64_t)addr);
+            (void)hipMemRelease(handle);
             return -1;
         }
         export_handle_raw.pid = getpid();
+        // The shareable handle keeps the allocation alive on its own; drop
+        // the reference taken above so registrations do not accumulate
+        // retains over the process lifetime.
+        (void)hipMemRelease(handle);
 
         (void)remote_accessible;
         BufferDesc desc;
@@ -778,38 +823,54 @@ int HipTransport::registerLocalMemory(void* addr, size_t length,
         desc.name = location;
         desc.shm_name = serializeBinaryData((const void*)&export_handle_raw,
                                             sizeof(hipxFabricHandle));
-        return metadata_->addLocalMemoryBuffer(desc, true);
+#ifdef ENABLE_MULTI_PROTOCOL
+        desc.protocol = "hip";
+#endif
+        int rc = metadata_->addLocalMemoryBuffer(desc, true);
+        if (rc == 0) {
+            registered_base_refs_[page] = 1;
+        } else {
+            // addLocalMemoryBuffer appends the desc before publishing it;
+            // drop the leftover so a failed registration leaves nothing
+            // behind for a later rollback or unregister to miss.
+            metadata_->removeLocalMemoryBuffer(real_addr, isOwnDesc, false);
+            registered_addr_to_base_.erase((uint64_t)addr);
+        }
+        return rc;
     }
 }
 
 int HipTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
-    if (!use_fabric_mem_) {
-        // Hold register_mutex_ through the metadata removal, mirroring the
-        // register path, so a concurrent register of another sub-range cannot
-        // republish the buffer in between.
-        std::lock_guard<std::mutex> lock(register_mutex_);
-        auto alias_it = registered_addr_to_base_.find((uint64_t)addr);
-        if (alias_it != registered_addr_to_base_.end()) {
-            uint64_t base = alias_it->second;
-            registered_addr_to_base_.erase(alias_it);
-            // Both maps are updated in pairs under this mutex, so the base
-            // always has a refcount entry here. Only the last alias removes
-            // the shared registration.
-            if (--registered_base_refs_[base] > 0) return 0;
-            registered_base_refs_.erase(base);
-            return metadata_->removeLocalMemoryBuffer((void*)base,
-                                                      update_metadata);
-        }
-        // Not registered here (host memory owned by another transport, or
-        // already unregistered). The caller's address may still equal the
-        // base of a registration whose aliases are live (slab-level cleanup
-        // passing the allocation base); that registration is only removable
-        // through its aliases above.
+    // Hold register_mutex_ through the metadata removal, mirroring the
+    // register path, so a concurrent register of another sub-range cannot
+    // republish the buffer in between.
+    std::lock_guard<std::mutex> lock(register_mutex_);
+    auto alias_it = registered_addr_to_base_.find((uint64_t)addr);
+    if (alias_it == registered_addr_to_base_.end()) {
+        // The address is not one we registered. If it equals a live base or
+        // page, slab-level cleanup must not drop the shared registration
+        // while its aliases are still alive.
         if (registered_base_refs_.count((uint64_t)addr)) {
             return ERR_ADDRESS_NOT_REGISTERED;
         }
+        // Skipped registrations belong to another transport; addresses we
+        // never saw are invalid or repeated unregisters.
+        if (skipped_addrs_.erase((uint64_t)addr) > 0) {
+            return 0;
+        }
+        return ERR_ADDRESS_NOT_REGISTERED;
     }
-    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    uint64_t base = alias_it->second;
+    registered_addr_to_base_.erase(alias_it);
+    skipped_addrs_.erase((uint64_t)addr);
+    // Both maps are updated in pairs under this mutex, so the base always
+    // has a refcount entry here. Only the last alias removes the shared
+    // registration, whether it is keyed by IPC allocation base or fabric
+    // physical page.
+    if (--registered_base_refs_[base] > 0) return 0;
+    registered_base_refs_.erase(base);
+    return metadata_->removeLocalMemoryBuffer((void*)base, isOwnDesc,
+                                              update_metadata);
 }
 
 int HipTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -40,6 +40,22 @@
 
 namespace mooncake {
 
+namespace {
+
+// Mirrors the ownership test the submit path already uses (see the
+// buffer.protocol checks below): descs published by this transport, plus
+// legacy descs with no protocol field. Without this, RDMA's removal can
+// erase a same-address desc belonging to HIP/nvlink, which now filter.
+bool isOwnRdmaDesc(const TransferMetadata::BufferDesc &desc) {
+#ifdef ENABLE_MULTI_PROTOCOL
+    return desc.protocol.empty() || desc.protocol == "rdma";
+#else
+    return true;
+#endif
+}
+
+}  // namespace
+
 static bool MCIbRelaxedOrderingEnabled = false;
 static int MCIbRelaxedOrderingMode = 2;
 
@@ -372,7 +388,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
         size_t n = std::min(committed, chunks.size());
         for (size_t ri = 0; ri < n; ++ri) {
             int rc = metadata_->removeLocalMemoryBuffer(
-                chunks[ri].first, /*update_metadata=*/false);
+                chunks[ri].first, isOwnRdmaDesc, /*update_metadata=*/false);
             if (rc)
                 LOG(WARNING) << "Rollback: failed to remove metadata for chunk "
                                 "at "
@@ -565,7 +581,8 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
         // chunk); publish once after all removals, below.
         for (uint64_t ca : chunk_addrs) {
             int rc = metadata_->removeLocalMemoryBuffer(
-                reinterpret_cast<void *>(ca), /*update_metadata=*/false);
+                reinterpret_cast<void *>(ca), isOwnRdmaDesc,
+                /*update_metadata=*/false);
             if (rc && !first_err) first_err = rc;
         }
 
@@ -616,7 +633,8 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
         return first_err;
     }
 
-    int rc = metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    int rc = metadata_->removeLocalMemoryBuffer(addr, isOwnRdmaDesc,
+                                                update_metadata);
     if (rc) return rc;
 
     // force_sequential is used by batch operations to avoid nested parallelism

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -389,7 +389,18 @@ int TcpTransport::registerLocalMemory(void* addr, size_t length,
 }
 
 int TcpTransport::unregisterLocalMemory(void* addr, bool update_metadata) {
-    return metadata_->removeLocalMemoryBuffer(addr, update_metadata);
+    // Remove only the descs this transport published. Under multi-protocol
+    // the protocol field is authoritative; otherwise ours are the entries
+    // without a serialized IPC handle.
+    static const std::function<bool(const BufferDesc&)> own_desc =
+        [](const BufferDesc& desc) {
+#ifdef ENABLE_MULTI_PROTOCOL
+            return desc.protocol == "tcp";
+#else
+            return desc.shm_name.empty();
+#endif
+        };
+    return metadata_->removeLocalMemoryBuffer(addr, own_desc, update_metadata);
 }
 
 int TcpTransport::registerLocalMemoryBatch(

--- a/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
+++ b/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
@@ -62,6 +62,11 @@ def _sink(meta, result):
     for view in views:
         value = int(view[0])
         observed.append(value if bool(torch.all(view == value)) else "mixed")
+
+    # Every sub-range holds a reference to the one shared IPC registration.
+    for view in views:
+        assert engine.unregister_memory(view.data_ptr()) == 0
+
     result.put(observed)
 
 

--- a/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
+++ b/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
@@ -32,42 +32,93 @@ def _sub_ranges_of_one_allocation():
     return [pool[i * NBYTES : (i + 1) * NBYTES] for i in range(BUFFERS)]
 
 
-def _source(meta, done):
-    views = _sub_ranges_of_one_allocation()
-    for view, value in zip(views, EXPECTED):
-        view.fill_(value)
-    torch.cuda.synchronize()
+def _source(meta, done, result):
+    try:
+        views = _sub_ranges_of_one_allocation()
+        for view, value in zip(views, EXPECTED):
+            view.fill_(value)
+        torch.cuda.synchronize()
 
-    engine = _engine()
-    for view in views:
-        assert engine.register_memory(view.data_ptr(), NBYTES) == 0
+        engine = _engine()
+        addresses = [view.data_ptr() for view in views]
+        rc = engine.batch_register_memory(addresses, [NBYTES] * BUFFERS)
+        assert rc == 0, f"batch_register_memory returned {rc}"
 
-    meta.put((f"127.0.0.1:{engine.get_rpc_port()}", [v.data_ptr() for v in views]))
-    done.get(timeout=TIMEOUT)
+        meta.put((f"127.0.0.1:{engine.get_rpc_port()}", addresses))
+        done.get(timeout=TIMEOUT)
+
+        # `views` is still alive, so this is last-alias teardown of the shared
+        # registration, not an unregister-after-free.
+        rc = engine.batch_unregister_memory(addresses)
+        assert rc == 0, f"batch_unregister_memory returned {rc}"
+        result.put(("source", None))
+    except Exception as e:  # noqa: BLE001
+        result.put(("source", str(e)))
 
 
 def _sink(meta, result):
-    segment, addresses = meta.get(timeout=TIMEOUT)
-    views = _sub_ranges_of_one_allocation()
+    try:
+        segment, addresses = meta.get(timeout=TIMEOUT)
+        views = _sub_ranges_of_one_allocation()
 
-    engine = _engine()
-    for view in views:
-        assert engine.register_memory(view.data_ptr(), NBYTES) == 0
-    for view, address in zip(views, addresses):
-        read = engine.transfer_sync_read(segment, view.data_ptr(), address, NBYTES)
-        assert read == 0, f"transfer_sync_read returned {read}"
-    torch.cuda.synchronize()
+        engine = _engine()
+        rc = engine.batch_register_memory(
+            [view.data_ptr() for view in views], [NBYTES] * BUFFERS
+        )
+        assert rc == 0, f"batch_register_memory returned {rc}"
+        for view, address in zip(views, addresses):
+            read = engine.transfer_sync_read(
+                segment, view.data_ptr(), address, NBYTES
+            )
+            assert read == 0, f"transfer_sync_read returned {read}"
+        torch.cuda.synchronize()
 
-    observed = []
-    for view in views:
-        value = int(view[0])
-        observed.append(value if bool(torch.all(view == value)) else "mixed")
+        observed = []
+        for view in views:
+            value = int(view[0])
+            observed.append(value if bool(torch.all(view == value)) else "mixed")
 
-    # Every sub-range holds a reference to the one shared IPC registration.
-    for view in views:
-        assert engine.unregister_memory(view.data_ptr()) == 0
+        # Report the payload before unregistering so a failure below surfaces
+        # as itself, not as a missing result.
+        result.put(("sink", observed))
+        rc = engine.batch_unregister_memory(
+            [view.data_ptr() for view in views]
+        )
+        assert rc == 0, f"batch_unregister_memory returned {rc}"
+        result.put(("sink", None))
+    except Exception as e:  # noqa: BLE001
+        result.put(("sink", str(e)))
 
-    result.put(observed)
+
+def _alias_lifecycle(result):
+    try:
+        torch.cuda.set_device(0)
+        # Offset into the allocation so no sub-range starts at its base.
+        pool = torch.zeros(
+            (BUFFERS + 1) * NBYTES, dtype=torch.uint8, device="cuda:0"
+        )
+        views = [
+            pool[(i + 1) * NBYTES : (i + 2) * NBYTES] for i in range(BUFFERS)
+        ]
+        engine = _engine()
+        addresses = [view.data_ptr() for view in views]
+
+        for address in addresses:
+            assert engine.register_memory(address, NBYTES) == 0
+
+        # A double unregister of one alias fails but must not consume
+        # another alias's reference on the shared registration.
+        assert engine.unregister_memory(addresses[0]) == 0
+        assert engine.unregister_memory(addresses[0]) != 0
+        for address in addresses[1:]:
+            assert engine.unregister_memory(address) == 0
+
+        # The last unregister removed the registration, so no alias of the
+        # allocation can be released again.
+        assert engine.unregister_memory(addresses[-1]) != 0
+        result.put(("alias", None))
+    except Exception as e:  # noqa: BLE001
+        result.put(("alias", str(e)))
 
 
 class TestTransferSubAllocationOnHip(unittest.TestCase):
@@ -81,12 +132,24 @@ class TestTransferSubAllocationOnHip(unittest.TestCase):
         # spawn: the children initialize HIP, which a forked process cannot do.
         ctx = mp.get_context("spawn")
         meta, done, result = ctx.Queue(), ctx.Queue(), ctx.Queue()
-        source = ctx.Process(target=_source, args=(meta, done))
+        source = ctx.Process(target=_source, args=(meta, done, result))
         sink = ctx.Process(target=_sink, args=(meta, result))
         source.start()
         sink.start()
+        observed = None
         try:
-            observed = result.get(timeout=TIMEOUT)
+            finished = set()
+            while len(finished) < 2:
+                who, payload = result.get(timeout=TIMEOUT)
+                if isinstance(payload, str):
+                    self.fail(f"{who} failed: {payload}")
+                if payload is not None:
+                    observed = payload
+                    # Transfers are done; let the source tear down its
+                    # registration while its tensors are still alive.
+                    done.put(True)
+                else:
+                    finished.add(who)
         except queue.Empty:
             self.fail(f"no result: source={source.exitcode} sink={sink.exitcode}")
         finally:
@@ -98,6 +161,24 @@ class TestTransferSubAllocationOnHip(unittest.TestCase):
                     process.join()
 
         self.assertEqual(observed, EXPECTED)
+
+    def test_alias_registration_lifecycle(self):
+        ctx = mp.get_context("spawn")
+        result = ctx.Queue()
+        child = ctx.Process(target=_alias_lifecycle, args=(result,))
+        child.start()
+        try:
+            _, payload = result.get(timeout=TIMEOUT)
+        except queue.Empty:
+            self.fail(f"no result: exitcode={child.exitcode}")
+        finally:
+            child.join(TIMEOUT)
+            if child.is_alive():
+                child.terminate()
+                child.join()
+
+        if payload is not None:
+            self.fail(f"alias failed: {payload}")
 
 
 if __name__ == "__main__":

--- a/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
+++ b/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
@@ -121,6 +121,34 @@ def _alias_lifecycle(result):
         result.put(("alias", str(e)))
 
 
+def _base_alias_lifecycle(result):
+    try:
+        torch.cuda.set_device(0)
+        # The first sub-range starts at the allocation base, so HIP's
+        # base-keyed entry and the caller-keyed entries published by the
+        # other transports share an address.
+        views = _sub_ranges_of_one_allocation()
+        engine = _engine()
+        addresses = [view.data_ptr() for view in views]
+
+        for address in addresses:
+            assert engine.register_memory(address, NBYTES) == 0
+
+        # A double unregister of the base-address view must fail without
+        # disturbing the entries the other aliases still hold (#3548 review:
+        # the transports used to delete each other's same-address entries).
+        assert engine.unregister_memory(addresses[0]) == 0
+        assert engine.unregister_memory(addresses[0]) != 0
+        for address in addresses[1:]:
+            assert engine.unregister_memory(address) == 0
+
+        # The registration is fully torn down; every alias now fails.
+        assert engine.unregister_memory(addresses[-1]) != 0
+        result.put(("base_alias", None))
+    except Exception as e:  # noqa: BLE001
+        result.put(("base_alias", str(e)))
+
+
 class TestTransferSubAllocationOnHip(unittest.TestCase):
     def setUp(self):
         if not torch.cuda.is_available():
@@ -179,6 +207,24 @@ class TestTransferSubAllocationOnHip(unittest.TestCase):
 
         if payload is not None:
             self.fail(f"alias failed: {payload}")
+
+    def test_base_address_view_double_unregister(self):
+        ctx = mp.get_context("spawn")
+        result = ctx.Queue()
+        child = ctx.Process(target=_base_alias_lifecycle, args=(result,))
+        child.start()
+        try:
+            _, payload = result.get(timeout=TIMEOUT)
+        except queue.Empty:
+            self.fail(f"no result: exitcode={child.exitcode}")
+        finally:
+            child.join(TIMEOUT)
+            if child.is_alive():
+                child.terminate()
+                child.join()
+
+        if payload is not None:
+            self.fail(f"base_alias failed: {payload}")
 
 
 if __name__ == "__main__":

--- a/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
+++ b/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
@@ -1,0 +1,99 @@
+"""Cross-process HIP IPC transfer of sub-allocated device buffers.
+
+hipIpcGetMemHandle exports the whole allocation, so a buffer registered as a
+sub-range of one must still read back its own bytes and not the bytes at the
+allocation base. Two processes are required: a loopback transfer inside a single
+process never opens an IPC handle.
+"""
+
+import multiprocessing as mp
+import queue
+import unittest
+
+import torch
+
+BUFFERS = 4
+NBYTES = 1024 * 1024
+EXPECTED = [i + 1 for i in range(BUFFERS)]
+TIMEOUT = 120
+
+
+def _engine():
+    from mooncake.engine import TransferEngine
+
+    engine = TransferEngine()
+    assert engine.initialize("127.0.0.1", "P2PHANDSHAKE", "hip", "") == 0
+    return engine
+
+
+def _sub_ranges_of_one_allocation():
+    torch.cuda.set_device(0)
+    pool = torch.zeros(BUFFERS * NBYTES, dtype=torch.uint8, device="cuda:0")
+    return [pool[i * NBYTES : (i + 1) * NBYTES] for i in range(BUFFERS)]
+
+
+def _source(meta, done):
+    views = _sub_ranges_of_one_allocation()
+    for view, value in zip(views, EXPECTED):
+        view.fill_(value)
+    torch.cuda.synchronize()
+
+    engine = _engine()
+    for view in views:
+        assert engine.register_memory(view.data_ptr(), NBYTES) == 0
+
+    meta.put((f"127.0.0.1:{engine.get_rpc_port()}", [v.data_ptr() for v in views]))
+    done.get(timeout=TIMEOUT)
+
+
+def _sink(meta, result):
+    segment, addresses = meta.get(timeout=TIMEOUT)
+    views = _sub_ranges_of_one_allocation()
+
+    engine = _engine()
+    for view in views:
+        assert engine.register_memory(view.data_ptr(), NBYTES) == 0
+    for view, address in zip(views, addresses):
+        read = engine.transfer_sync_read(segment, view.data_ptr(), address, NBYTES)
+        assert read == 0, f"transfer_sync_read returned {read}"
+    torch.cuda.synchronize()
+
+    observed = []
+    for view in views:
+        value = int(view[0])
+        observed.append(value if bool(torch.all(view == value)) else "mixed")
+    result.put(observed)
+
+
+class TestTransferSubAllocationOnHip(unittest.TestCase):
+    def setUp(self):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("ROCm device not available")
+        if not getattr(torch.version, "hip", None):
+            raise unittest.SkipTest("PyTorch is not built with HIP support")
+
+    def test_each_sub_range_reads_its_own_bytes(self):
+        # spawn: the children initialize HIP, which a forked process cannot do.
+        ctx = mp.get_context("spawn")
+        meta, done, result = ctx.Queue(), ctx.Queue(), ctx.Queue()
+        source = ctx.Process(target=_source, args=(meta, done))
+        sink = ctx.Process(target=_sink, args=(meta, result))
+        source.start()
+        sink.start()
+        try:
+            observed = result.get(timeout=TIMEOUT)
+        except queue.Empty:
+            self.fail(f"no result: source={source.exitcode} sink={sink.exitcode}")
+        finally:
+            done.put(True)
+            for process in (sink, source):
+                process.join(TIMEOUT)
+                if process.is_alive():
+                    process.terminate()
+                    process.join()
+
+        self.assertEqual(observed, EXPECTED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
+++ b/mooncake-wheel/tests/test_transfer_sub_allocation_on_hip.py
@@ -67,9 +67,7 @@ def _sink(meta, result):
         )
         assert rc == 0, f"batch_register_memory returned {rc}"
         for view, address in zip(views, addresses):
-            read = engine.transfer_sync_read(
-                segment, view.data_ptr(), address, NBYTES
-            )
+            read = engine.transfer_sync_read(segment, view.data_ptr(), address, NBYTES)
             assert read == 0, f"transfer_sync_read returned {read}"
         torch.cuda.synchronize()
 
@@ -81,9 +79,7 @@ def _sink(meta, result):
         # Report the payload before unregistering so a failure below surfaces
         # as itself, not as a missing result.
         result.put(("sink", observed))
-        rc = engine.batch_unregister_memory(
-            [view.data_ptr() for view in views]
-        )
+        rc = engine.batch_unregister_memory([view.data_ptr() for view in views])
         assert rc == 0, f"batch_unregister_memory returned {rc}"
         result.put(("sink", None))
     except Exception as e:  # noqa: BLE001
@@ -94,12 +90,8 @@ def _alias_lifecycle(result):
     try:
         torch.cuda.set_device(0)
         # Offset into the allocation so no sub-range starts at its base.
-        pool = torch.zeros(
-            (BUFFERS + 1) * NBYTES, dtype=torch.uint8, device="cuda:0"
-        )
-        views = [
-            pool[(i + 1) * NBYTES : (i + 2) * NBYTES] for i in range(BUFFERS)
-        ]
+        pool = torch.zeros((BUFFERS + 1) * NBYTES, dtype=torch.uint8, device="cuda:0")
+        views = [pool[(i + 1) * NBYTES : (i + 2) * NBYTES] for i in range(BUFFERS)]
         engine = _engine()
         addresses = [view.data_ptr() for view in views]
 


### PR DESCRIPTION
## Description

Fixes #3546.

`hipIpcGetMemHandle` always exports the entire `hipMalloc` allocation, but the
HIP IPC registration path recorded the caller's sub-range address as the buffer
base. The reader's relocation (`dest_addr - entry.addr + shm_addr`) therefore
collapsed every sub-range onto the allocation base, and each buffer silently
returned the first buffer's bytes with `rc=0`. Framework caching allocators
sub-allocate constantly, so any caller registering individual tensors out of one
allocation is affected — including `batch_register_memory`, which loops over the
same function.

The CUDA IPC paths had exactly this bug and it was fixed by registering the
allocation base instead of the requested range — #1622 for
`intranode_nvlink_transport` and #1831 for TENT. The HIP port was missed: its only
`hipMemGetAddressRange` calls are in the fabric-memory branch and in the free
logic, never in the IPC branch. This applies the same fix there: resolve the real
base with `hipMemGetAddressRange`, skip allocations already exported, take the IPC
handle for the base, record the whole allocation in `BufferDesc`, and key
unregistration off that base as well, matching
`IntraNodeNvlinkTransport::registerLocalMemory` and `unregisterLocalMemory`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [x] Python Wheel (`mooncake-wheel`) — regression test only
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

8× AMD Instinct MI308X (gfx942), ROCm 7.2.0, PyTorch 2.9.1
(`torch.version.hip == 7.2.26015-fc0010cf6a`), Python 3.10.9, built from `main` @
`f90ae69` with `-DUSE_HIP=ON -DCMAKE_HIP_ARCHITECTURES=gfx942`.

The reproducer in #3546 goes from `got [1, 1, 1, 1]` to `got [1, 2, 3, 4]`, and
flips back when the pre-fix `engine.so` is swapped in again.

**Test commands:**

```bash
cd mooncake-wheel/tests
python -m unittest -v test_transfer_sub_allocation_on_hip   # new
python -m unittest -v test_transfer_on_hip                  # existing, unaffected
```

**Test results:**

The new test is the reproducer from #3546 turned into a regression test. Against
the pre-fix build:

```
AssertionError: Lists differ: [1, 1, 1, 1] != [1, 2, 3, 4]
FAILED (failures=1)
```

Against the fixed build: `OK`. `test_transfer_on_hip.py` is `OK` on both, which is
why the new test is a separate two-process file: a loopback transfer never opens
an IPC handle, so it cannot observe the relocation.

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Note: the new test is hardware-gated with `unittest.SkipTest` and is not wired
into `scripts/run_tests.sh`, matching `test_transfer_on_hip.py` and
`test_transfer_on_cuda.py`, which are not listed there either. Let me know if you
would rather it lived somewhere CI can reach.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run `pre-commit run --all-files` and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue — n/a, 48 lines excluding tests

`pre-commit run --files` over the three changed files passes every hook, including
the clang-format 20 C/C++ hook. I did not run `--all-files`, since it rewrites
files unrelated to this change.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Qoder was used for the investigation, the patch and the test.