### PR TITLE
[Bugfix][Store] Fix partial-unmount snapshot test race

### DIFF
--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -1280,7 +1280,11 @@ TEST_F(MasterServiceSnapshotTest, UnmountSegmentImmediateCleanup) {
 }
 
 TEST_F(MasterServiceSnapshotTest, ReadableAfterPartialUnmountWithReplication) {
-    service_.reset(new MasterService());
+    auto service_config = MasterServiceConfig::builder()
+                              .set_enable_snapshot(true)
+                              .set_snapshot_object_store_type("local")
+                              .build();
+    service_.reset(new MasterService(service_config));
 
     // Mount two large segments
     constexpr size_t buffer1 = 0x300000000;


### PR DESCRIPTION
## Description

Addresses the C++ snapshot failure reported in #3539. The Python promotion failure from the same nightly run is outside the scope of this PR.

`ReadableAfterPartialUnmountWithReplication` constructed `MasterService` with the default configuration, which enables asynchronous segment cleanup. The snapshot test fixture persists service state immediately during teardown, so it could race with cleanup and attempt to serialize replica metadata whose allocator had already expired.

Configure this test to run with the local snapshot backend. Snapshot mode keeps segment cleanup synchronous, ensuring the metadata is consistent before teardown persists and restores it. Production behavior is unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Tested in the repository's Ubuntu 22.04 arm64 development container with a Debug + ASan/LSan build.

**Test commands:**

```bash
cmake -S /workspace -B /build/snapshot-debug -G Ninja \
  -DWITH_TE=ON \
  -DWITH_STORE=ON \
  -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF \
  -DUSE_HTTP=ON \
  -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF \
  -DENABLE_ASAN=ON \
  -DCMAKE_BUILD_TYPE=Debug \
  -DENABLE_DEBUG_SYMBOLS=OFF

cmake --build /build/snapshot-debug \
  --target master_service_test_for_snapshot

ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 \
GLOG_minloglevel=2 \
/build/snapshot-debug/mooncake-store/tests/master_service_test_for_snapshot \
  --gtest_filter=MasterServiceSnapshotTest.ReadableAfterPartialUnmountWithReplication \
  --gtest_repeat=100 \
  --gtest_break_on_failure \
  --gtest_brief=1

ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 \
GLOG_minloglevel=2 \
ctest --test-dir /build/snapshot-debug \
  -R '^master_service_test_for_snapshot$' \
  --output-on-failure
```

**Test results:**

- Before the change, the focused test reproduced the failure on iteration 3: `buffer.allocator_.expired,buffer_ptr:0x300000000`.
- After the change, the focused test passed 100/100 iterations under ASan/LSan.
- The complete `master_service_test_for_snapshot` suite passed all 69 Google Test cases (`209.69 sec`).
- No ASan or LSan errors were reported.

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

## Checklist



- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable; test-only change)
- [x] I have added tests to prove my changes are effective (updated the existing regression test)
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; 5-line change)

The non-formatting pre-commit hooks pass. The local formatting hook requires clang-format 20, which was not available in the test environment; clang-format 22.1.8 reports no formatting changes for the modified lines.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [ ] AI tools were used (specified below)