### PR TITLE
[Store] Support graceful segment unmount on standalone client shutdown

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -2,6 +2,7 @@
 #include <pybind11/stl.h>
 #include <numa.h>
 
+#include <chrono>
 #include <functional>
 #include <limits>
 #include <numeric>
@@ -2379,13 +2380,42 @@ PYBIND11_MODULE(store, m) {
             py::arg("keys"),
             "Check if multiple objects exist. Returns list of results: 1 if "
             "exists, 0 if not exists, -1 if error")
-        .def("close",
-             [](MooncakeStorePyWrapper &self) {
-                 if (!self.store_) return 0;
-                 int rc = self.store_->tearDownAll();
-                 self.store_.reset();
-                 return rc;
-             })
+        .def(
+            "close",
+            [](MooncakeStorePyWrapper &self, uint64_t grace_period_seconds) {
+                if (!self.store_) return 0;
+                CloseOptions options;
+                options.grace_period =
+                    std::chrono::seconds(grace_period_seconds);
+                // timeout is left at zero on purpose: the upper bound depends
+                // on the client's own confirmation schedule, so the client is
+                // the only party able to derive a value that can actually
+                // observe completion.
+                // Only RealClient owns segments, so it is the only one with a
+                // graceful phase; other clients tear down immediately.
+                auto real_client =
+                    std::dynamic_pointer_cast<RealClient>(self.store_);
+                int rc = 0;
+                {
+                    // Close() may wait for the grace period to elapse, so the
+                    // interpreter must not be blocked while it runs.
+                    py::gil_scoped_release release;
+                    if (real_client) {
+                        rc = static_cast<int>(
+                            to_py_ret(real_client->Close(options)));
+                    } else {
+                        rc = self.store_->tearDownAll();
+                    }
+                }
+                self.store_.reset();
+                return rc;
+            },
+            py::arg("grace_period_seconds") = 0,
+            "Close the store. With grace_period_seconds > 0 the master is "
+            "asked to stop allocating on this client's segments while they "
+            "stay readable, and the call waits for them to be released, so "
+            "peers holding segment information can finish their reads. Zero "
+            "(the default) tears down immediately.")
         .def("health_check", &MooncakeStorePyWrapper::health_check,
              "Health check for store connectivity. "
              "Returns 0 if healthy, 1 if not initialized/closed, "

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -385,6 +385,35 @@ class Client {
         std::function<void(const UUID&)> cleanup_callback = {});
 
     /**
+     * @brief Requests graceful unmount for all currently mounted segments.
+     *
+     * The master stops allocating on these segments but keeps the replicas
+     * readable, so remote reads keep working as long as this process stays
+     * alive and its memory registrations are held. This only initiates the
+     * operation; use WaitForGracefulUnmountAll() to await completion.
+     *
+     * @param grace_period_ms grace period announced to the master.
+     * @return number of segments for which graceful unmount was accepted.
+     *         Segments that failed stay mounted and are unmounted immediately
+     *         by ~Client() as the fallback path.
+     */
+    size_t GracefulUnmountAll(uint64_t grace_period_ms);
+
+    /**
+     * @brief Waits until every gracefully unmounting segment has been released.
+     *
+     * Event-driven: blocks on a condition variable that is notified whenever a
+     * segment is erased from the gracefully-unmounting set, so it returns as
+     * soon as the last one completes. The caller owns the timeout policy.
+     *
+     * @param deadline absolute deadline supplied by the caller.
+     * @return true if all segments were released, false on deadline expiry
+     *         (leftovers are handled by ~Client() and master-side expiry).
+     */
+    bool WaitForGracefulUnmountAll(
+        std::chrono::steady_clock::time_point deadline);
+
+    /**
      * @brief Registers memory buffer with TransferEngine for data transfer
      * @param addr Memory address to register
      * @param length Size of the memory region
@@ -918,6 +947,10 @@ class Client {
     std::unordered_map<UUID, std::function<void(const UUID&)>,
                        boost::hash<UUID>>
         graceful_unmount_cleanup_callbacks_;
+    // Notified (under mounted_segments_mutex_) whenever a segment leaves
+    // gracefully_unmounting_segments_, so WaitForGracefulUnmountAll() can
+    // return as soon as the set drains instead of polling.
+    std::condition_variable gracefully_unmounting_done_cv_;
 
     /**
      * @brief Internal helper to unmount a segment by iterator.

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -15,6 +15,7 @@
 #include <unordered_set>
 
 #include "client_metric.h"
+#include "deadline_scheduler.h"
 #include "ha/leadership/leader_coordinator.h"
 #include "master_client.h"
 #include "storage_backend.h"
@@ -36,6 +37,14 @@ class RealClient;
 
 std::optional<size_t> GetTransportRegistrationLimit(
     const std::string& protocol);
+
+// Client-side schedule used to confirm that the master released a gracefully
+// unmounting segment: a first check one interval after the announced grace
+// period, then up to kGracefulUnmountConfirmRetries further checks one interval
+// apart. Exposed so callers that need to bound a graceful wait can derive a
+// deadline from the same numbers instead of duplicating them.
+constexpr std::chrono::seconds kGracefulUnmountConfirmInterval{10};
+constexpr int kGracefulUnmountConfirmRetries = 3;
 
 /**
  * @brief Result of a query operation containing replica information and lease
@@ -959,13 +968,26 @@ class Client {
     tl::expected<void, ErrorCode> UnmountSegmentImpl(
         std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
 
+    // One pending confirmation. The scheduler owns the deadline, so this only
+    // carries the retry budget.
+    struct GracefulUnmountCheck {
+        UUID segment_id;
+        int retry_left;
+    };
+
+    // Schedules the first confirmation check for a gracefully unmounting
+    // segment. Deliberately does not occupy one task_thread_pool_ worker per
+    // segment: that pool has a small, fixed worker count, and a blocking timer
+    // per segment would serialize the deadlines of a bulk unmount and make the
+    // caller's timeout budget unpredictable.
     void StartGracefulUnmountTimer(const UUID& segment_id,
                                    uint64_t grace_period_ms);
-    void OnGracefulUnmountTimer(const UUID& segment_id, int retry_left);
-    bool WaitForGracefulUnmountDelay(std::chrono::milliseconds delay);
-    std::mutex graceful_unmount_timer_mutex_;
-    std::condition_variable graceful_unmount_timer_cv_;
-    bool graceful_unmount_timer_stopping_{false};
+
+    // Confirmation callback driven by graceful_unmount_scheduler_. Asks the
+    // master whether the segment is gone; on success unregisters its MR and
+    // completes the local bookkeeping, otherwise reschedules itself while
+    // retries remain.
+    void OnGracefulUnmountTimer(const GracefulUnmountCheck& check);
 
     // Configuration
     const std::string local_hostname_;
@@ -973,6 +995,13 @@ class Client {
     const std::string metadata_connstring_;
     const std::string protocol_;
     const bool object_checksum_enabled_;
+
+    // Single timer thread with a deadline heap, so every segment's confirmation
+    // schedule progresses concurrently regardless of how many are unmounting.
+    // Callbacks run with the scheduler mutex released, so they may take
+    // mounted_segments_mutex_. Declared after the members its callback reads so
+    // that ~Client() can Stop() it before they are destroyed.
+    DeadlineScheduler<GracefulUnmountCheck> graceful_unmount_scheduler_;
 
     // Client persistent thread pool for async operations
     // Pinned host memory pool for GPU D2H staging (must outlive

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -211,7 +211,9 @@ class ClientRequester {
 // Describes the shutdown state transition performed by RealClient::Close().
 //
 // Frontends (the standalone binary, the Python bindings, the C API) only supply
-// this configuration; the client owns the whole transition.
+// this configuration; the client owns the whole transition. Both fields are
+// signed, so both must be non-negative: Close() rejects a negative value with
+// INVALID_PARAMS instead of reinterpreting it as the default below.
 struct CloseOptions {
     // Grace period announced to the master. Zero (the default) unmounts
     // immediately and preserves the deterministic teardown semantics.
@@ -220,11 +222,12 @@ struct CloseOptions {
     // Hard upper bound for the graceful wait, counted from the moment Close()
     // starts waiting. Zero lets the client derive it, and that is what every
     // frontend passes: the bound depends on the client's own confirmation
-    // schedule (first check at grace_period + 10s, then up to three retries 10s
-    // apart), so the client is the only party able to compute a value that can
-    // actually observe completion. Exposed for in-process C++ callers that need
-    // to cap the wait themselves; a value below the derived bound makes the
-    // wait give up before the master can confirm anything.
+    // schedule (see kGracefulUnmountConfirmInterval /
+    // kGracefulUnmountConfirmRetries), so the client is the only party able to
+    // compute a value that can actually observe completion. Exposed for
+    // in-process C++ callers that need to cap the wait themselves; a value
+    // below the derived bound makes the wait give up before the master can
+    // confirm anything.
     std::chrono::milliseconds timeout{0};
 };
 

--- a/mooncake-store/include/pyclient.h
+++ b/mooncake-store/include/pyclient.h
@@ -208,6 +208,26 @@ class ClientRequester {
         const std::string &client_addr, Args &&...args);
 };
 
+// Describes the shutdown state transition performed by RealClient::Close().
+//
+// Frontends (the standalone binary, the Python bindings, the C API) only supply
+// this configuration; the client owns the whole transition.
+struct CloseOptions {
+    // Grace period announced to the master. Zero (the default) unmounts
+    // immediately and preserves the deterministic teardown semantics.
+    std::chrono::milliseconds grace_period{0};
+
+    // Hard upper bound for the graceful wait, counted from the moment Close()
+    // starts waiting. Zero lets the client derive it, and that is what every
+    // frontend passes: the bound depends on the client's own confirmation
+    // schedule (first check at grace_period + 10s, then up to three retries 10s
+    // apart), so the client is the only party able to compute a value that can
+    // actually observe completion. Exposed for in-process C++ callers that need
+    // to cap the wait themselves; a value below the derived bound makes the
+    // wait give up before the master can confirm anything.
+    std::chrono::milliseconds timeout{0};
+};
+
 // Python-specific wrapper class for client interface
 class PyClient {
    public:

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -1036,8 +1036,20 @@ class RealClient : public PyClient {
         const std::vector<std::vector<size_t>> &all_sizes,
         const std::vector<std::string> &keys, const UUID &client_id) const;
 
-    // Ensure cleanup executes at most once across multiple entry points
+    // Ensure cleanup executes at most once across multiple entry points, and
+    // marks the client as closing so that operations which would create new
+    // resources are rejected instead of racing the teardown.
     std::atomic<bool> closed_{false};
+
+    // True once Close()/tearDownAll() has entered the shutdown transition.
+    // Segment-creating entry points check this: a segment mounted after
+    // GracefulUnmountAll() took its snapshot would never be unmounted
+    // gracefully, and any resource created here can outlive client_.reset().
+    //
+    // Still needed even when a frontend stops its RPC server first: the IPC
+    // channel is only torn down by stop_ipc_server(), which runs after the
+    // graceful wait, so it stays reachable for the whole grace period.
+    bool IsClosing() const { return closed_.load(std::memory_order_acquire); }
 
     // Counts every LOCAL_DISK read served via peer offload-RPC.
     std::atomic<int64_t> offload_rpc_read_count_{0};

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -42,6 +42,15 @@ class ResourceTracker {
     // Get the singleton instance
     static ResourceTracker &getInstance();
 
+    // Opt out of the built-in sigwait consumer for SIGINT/SIGTERM/SIGHUP.
+    //
+    // Must be called before the first getInstance(). Processes that install
+    // their own handlers for these signals have to call this: POSIX leaves the
+    // behaviour unspecified when the same signal is consumed by a sigaction
+    // handler and by sigwait at the same time, so exactly one owner may exist.
+    // The atexit fallback is unaffected.
+    static void DisableSignalHandling();
+
     // Register a DistributedObjectStore instance for cleanup
     void registerInstance(const std::shared_ptr<PyClient> &instance);
 
@@ -344,6 +353,21 @@ class RealClient : public PyClient {
                                  bool force = false);
 
     int tearDownAll();
+
+    /**
+     * @brief Shuts the client down, running the whole transition exactly once.
+     *
+     * This is the single shutdown implementation shared by every frontend: it
+     * atomically enters the closing state, initiates graceful unmount for the
+     * mounted segments when a grace period is requested, waits for all pending
+     * unmounts (including any started earlier through UnmountSegmentById),
+     * falls back to the regular teardown on timeout, and then tears everything
+     * down.
+     *
+     * A default-constructed CloseOptions shuts down immediately, which is what
+     * destructors and the C API want; tearDownAll() is exactly that case.
+     */
+    tl::expected<void, ErrorCode> Close(const CloseOptions &options);
 
     int health_check() override;
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -517,6 +517,7 @@ Client::~Client() {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         mounted_segments_.clear();
         gracefully_unmounting_segments_.clear();
+        gracefully_unmounting_done_cv_.notify_all();
     }
 
     for (auto& entry : graceful_cleanup_callbacks) {
@@ -3587,6 +3588,57 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentById(
     return {};
 }
 
+size_t Client::GracefulUnmountAll(uint64_t grace_period_ms) {
+    // Snapshot the ids first: UnmountSegmentById takes mounted_segments_mutex_
+    // itself, so we must not hold it across the calls.
+    std::vector<UUID> segment_ids;
+    {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+        segment_ids.reserve(mounted_segments_.size());
+        for (const auto& [id, segment] : mounted_segments_) {
+            segment_ids.push_back(id);
+        }
+    }
+
+    size_t graceful_ok = 0;
+    for (const auto& id : segment_ids) {
+        auto result = UnmountSegmentById(id, grace_period_ms);
+        if (result.has_value()) {
+            graceful_ok++;
+        } else {
+            // Leave the failed segment mounted; ~Client() will unmount it
+            // immediately as the fallback path.
+            LOG(WARNING) << "Graceful unmount failed for segment "
+                         << UuidToString(id)
+                         << ", error=" << toString(result.error())
+                         << "; it will fall back to immediate unmount";
+        }
+    }
+    if (!segment_ids.empty()) {
+        LOG(INFO) << "Graceful unmount requested for " << graceful_ok << "/"
+                  << segment_ids.size()
+                  << " segments, grace_period_ms=" << grace_period_ms;
+    }
+    return graceful_ok;
+}
+
+bool Client::WaitForGracefulUnmountAll(
+    std::chrono::steady_clock::time_point deadline) {
+    std::unique_lock<std::mutex> lock(mounted_segments_mutex_);
+    const bool drained = gracefully_unmounting_done_cv_.wait_until(
+        lock, deadline,
+        [this]() { return gracefully_unmounting_segments_.empty(); });
+    if (drained) {
+        LOG(INFO) << "Graceful unmount of all segments completed";
+    } else {
+        LOG(WARNING) << "Graceful unmount deadline reached with "
+                     << gracefully_unmounting_segments_.size()
+                     << " segments still pending; leftovers are handled by "
+                        "~Client() and master-side client expiry";
+    }
+    return drained;
+}
+
 bool Client::WaitForGracefulUnmountDelay(std::chrono::milliseconds delay) {
     std::unique_lock<std::mutex> lock(graceful_unmount_timer_mutex_);
     return graceful_unmount_timer_cv_.wait_for(
@@ -3643,6 +3695,7 @@ void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
                         << rc;
                 }
                 gracefully_unmounting_segments_.erase(it);
+                gracefully_unmounting_done_cv_.notify_all();
             }
             auto callback_it =
                 graceful_unmount_cleanup_callbacks_.find(segment_id);

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -417,6 +417,9 @@ Client::Client(const std::string& local_hostname,
       metadata_connstring_(metadata_connstring),
       protocol_(protocol),
       object_checksum_enabled_(Environ::Get().GetStoreChecksumEnabled()),
+      graceful_unmount_scheduler_([this](const GracefulUnmountCheck& check) {
+          this->OnGracefulUnmountTimer(check);
+      }),
       pinned_buffer_pool_(std::make_unique<PinnedBufferPool>()),
       write_thread_pool_(2),
       task_thread_pool_(4) {
@@ -459,11 +462,10 @@ Client::~Client() {
         leader_monitor_thread_.join();
     }
 
-    {
-        std::lock_guard<std::mutex> lock(graceful_unmount_timer_mutex_);
-        graceful_unmount_timer_stopping_ = true;
-    }
-    graceful_unmount_timer_cv_.notify_all();
+    // Join the confirmation timer thread before tearing down segment state:
+    // its callback touches mounted_segments_ and the transfer engine, and the
+    // teardown below must be the single owner of whatever is left pending.
+    graceful_unmount_scheduler_.Stop();
 
     // Stop queued timer/task callbacks before tearing down segment state.
     task_running_ = false;
@@ -3639,25 +3641,20 @@ bool Client::WaitForGracefulUnmountAll(
     return drained;
 }
 
-bool Client::WaitForGracefulUnmountDelay(std::chrono::milliseconds delay) {
-    std::unique_lock<std::mutex> lock(graceful_unmount_timer_mutex_);
-    return graceful_unmount_timer_cv_.wait_for(
-        lock, delay, [this]() { return graceful_unmount_timer_stopping_; });
-}
-
 void Client::StartGracefulUnmountTimer(const UUID& segment_id,
                                        uint64_t grace_period_ms) {
-    auto delay =
-        std::chrono::milliseconds(grace_period_ms) + std::chrono::seconds(10);
-    task_thread_pool_.enqueue([this, segment_id, delay]() {
-        if (this->WaitForGracefulUnmountDelay(delay)) {
-            return;
-        }
-        this->OnGracefulUnmountTimer(segment_id, /*retry_left=*/3);
-    });
+    // One scheduler entry rather than one blocked worker, so N segments get N
+    // concurrent deadlines instead of being serialized by the pool width.
+    graceful_unmount_scheduler_.Schedule(
+        GracefulUnmountCheck{segment_id, kGracefulUnmountConfirmRetries},
+        std::chrono::steady_clock::now() +
+            std::chrono::milliseconds(grace_period_ms) +
+            kGracefulUnmountConfirmInterval);
 }
 
-void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
+void Client::OnGracefulUnmountTimer(const GracefulUnmountCheck& check) {
+    const UUID& segment_id = check.segment_id;
+
     // Query master to confirm the segment has been removed
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
@@ -3710,18 +3707,10 @@ void Client::OnGracefulUnmountTimer(const UUID& segment_id, int retry_left) {
         return;
     }
 
-    if (retry_left > 0) {
-        try {
-            task_thread_pool_.enqueue([this, segment_id, retry_left]() {
-                if (this->WaitForGracefulUnmountDelay(
-                        std::chrono::seconds(10))) {
-                    return;
-                }
-                this->OnGracefulUnmountTimer(segment_id, retry_left - 1);
-            });
-        } catch (const std::runtime_error& e) {
-            VLOG(1) << "Skip graceful unmount retry enqueue: " << e.what();
-        }
+    if (check.retry_left > 0) {
+        graceful_unmount_scheduler_.Schedule(
+            GracefulUnmountCheck{segment_id, check.retry_left - 1},
+            std::chrono::steady_clock::now() + kGracefulUnmountConfirmInterval);
     } else {
         LOG(WARNING) << "Graceful unmount cleanup timeout for segment "
                      << UuidToString(segment_id);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -64,6 +64,12 @@ namespace mooncake {
 namespace {
 constexpr std::chrono::seconds kIpcRequestRecvTimeout{5};
 
+// Time the client needs, on top of the announced grace period, to observe that
+// the master has released every segment: Client checks 10s after the period
+// elapses and then retries up to three times at 10s intervals, so 40s plus a
+// small margin. Used when CloseOptions::timeout is left unset.
+constexpr std::chrono::seconds kGracefulCloseConfirmationBudget{45};
+
 size_t DivideRoundUp(size_t value, size_t divisor) {
     return value / divisor + (value % divisor != 0);
 }
@@ -587,13 +593,28 @@ ResourceTracker &ResourceTracker::getInstance() {
     return *instance;
 }
 
+namespace {
+// Set by ResourceTracker::DisableSignalHandling() before the singleton is
+// constructed, when the surrounding process owns the termination signals.
+std::atomic<bool> g_resource_tracker_signals_disabled{false};
+}  // namespace
+
+void ResourceTracker::DisableSignalHandling() {
+    g_resource_tracker_signals_disabled.store(true, std::memory_order_release);
+}
+
 ResourceTracker::ResourceTracker() {
     // In embedded environments (e.g. Python), the host runtime owns signal
     // handling.  Blocking SIGINT with pthread_sigmask (done inside
     // startSignalThread) would prevent Python from raising KeyboardInterrupt,
     // causing the process to hang on Ctrl-C.  Detect Python at runtime via
     // dlsym so we don't need to include <Python.h> or change any public API.
-    if (!dlsym(RTLD_DEFAULT, "Py_IsInitialized")) {
+    //
+    // A process that installs its own handlers opts out explicitly, because a
+    // signal must have a single consumer: POSIX does not define the behaviour
+    // when sigaction and sigwait handle the same signal concurrently.
+    if (!g_resource_tracker_signals_disabled.load(std::memory_order_acquire) &&
+        !dlsym(RTLD_DEFAULT, "Py_IsInitialized")) {
         // Standalone C/C++ process – install our own signal handling.
         startSignalThread();
     }
@@ -1347,11 +1368,34 @@ int RealClient::initAll(const std::string &protocol_,
 }
 
 tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
+    // Immediate shutdown: the zero-grace-period case of Close().
+    return Close(CloseOptions{});
+}
+
+tl::expected<void, ErrorCode> RealClient::Close(const CloseOptions &options) {
     // Ensure cleanup executes once across destructor/close/signal paths
     bool expected = false;
     if (!closed_.compare_exchange_strong(expected, true,
                                          std::memory_order_acq_rel)) {
         return {};
+    }
+
+    // Graceful phase, before anything is torn down. The Client object owns the
+    // thread pool that drives the graceful-unmount timers and holds the memory
+    // registrations that keep remote reads working, so it has to stay alive for
+    // the whole wait, i.e. this must run before client_.reset() below.
+    if (options.grace_period > std::chrono::milliseconds::zero() && client_) {
+        client_->GracefulUnmountAll(options.grace_period.count());
+        // Waits for the entire pending set, so segments that a caller had
+        // already started unmounting with a grace period are covered as well.
+        // On expiry we simply continue: ~Client() releases whatever is left and
+        // the master still applies its own scheduler and client expiry.
+        const auto timeout =
+            options.timeout > std::chrono::milliseconds::zero()
+                ? options.timeout
+                : options.grace_period + kGracefulCloseConfirmationBudget;
+        client_->WaitForGracefulUnmountAll(std::chrono::steady_clock::now() +
+                                           timeout);
     }
 
     stop_ipc_server();

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -65,10 +65,14 @@ namespace {
 constexpr std::chrono::seconds kIpcRequestRecvTimeout{5};
 
 // Time the client needs, on top of the announced grace period, to observe that
-// the master has released every segment: Client checks 10s after the period
-// elapses and then retries up to three times at 10s intervals, so 40s plus a
-// small margin. Used when CloseOptions::timeout is left unset.
-constexpr std::chrono::seconds kGracefulCloseConfirmationBudget{45};
+// the master has released every segment. Derived from the client's own
+// confirmation schedule (first check one interval after the period elapses,
+// then kGracefulUnmountConfirmRetries retries one interval apart) plus one
+// interval of margin for the master round trips. Used when
+// CloseOptions::timeout is left unset. The schedule is driven by a single
+// aggregate task, so this bound holds for any number of segments.
+constexpr std::chrono::seconds kGracefulCloseConfirmationBudget =
+    kGracefulUnmountConfirmInterval * (kGracefulUnmountConfirmRetries + 2);
 
 size_t DivideRoundUp(size_t value, size_t divisor) {
     return value / divisor + (value % divisor != 0);
@@ -1373,6 +1377,19 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
 }
 
 tl::expected<void, ErrorCode> RealClient::Close(const CloseOptions &options) {
+    // Validate before entering the closing state: a rejected call must leave
+    // the client fully usable, so this has to happen before closed_ is set.
+    // Only exactly zero carries the documented immediate/derived semantics;
+    // CloseOptions uses signed durations, so a negative value is a caller bug
+    // rather than a request for the default.
+    if (options.grace_period < std::chrono::milliseconds::zero() ||
+        options.timeout < std::chrono::milliseconds::zero()) {
+        LOG(ERROR) << "Close() rejected negative CloseOptions: grace_period_ms="
+                   << options.grace_period.count()
+                   << ", timeout_ms=" << options.timeout.count();
+        return tl::unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
     // Ensure cleanup executes once across destructor/close/signal paths
     bool expected = false;
     if (!closed_.compare_exchange_strong(expected, true,
@@ -1719,6 +1736,11 @@ int RealClient::unmountSegment(const std::vector<std::string> &segment_ids,
 int RealClient::allocateAndMountSegment(
     size_t size, const std::string &protocol, const std::string &location,
     std::vector<std::string> &out_segment_ids, size_t *out_allocated_size) {
+    if (IsClosing()) {
+        LOG(WARNING) << "Rejecting allocateAndMountSegment: client is closing";
+        return -1;
+    }
+
     if (!client_) {
         LOG(ERROR) << "Client not initialized";
         return -1;
@@ -2390,6 +2412,11 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal(
 tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
     int fd, uint64_t dummy_base_addr, size_t shm_size, bool is_local_buffer,
     int32_t physical_device_id, const UUID &client_id) {
+    if (IsClosing()) {
+        LOG(WARNING) << "Rejecting map_shm: client is closing";
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+
     std::stringstream addr_stream;
     addr_stream << "0x" << std::hex << dummy_base_addr;
 
@@ -2512,6 +2539,10 @@ tl::expected<void, ErrorCode> RealClient::ascend_shm_internal(
     uint64_t dummy_base_addr, size_t vmm_size, bool is_local_buffer,
     const std::string &shareable_handle_bytes, int32_t device_id,
     const UUID &client_id) {
+    if (IsClosing()) {
+        LOG(WARNING) << "Rejecting ascend_shm: client is closing";
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
 #ifdef USE_ASCEND_DIRECT
     if (!client_) {
         LOG(ERROR) << "Client is not initialized";
@@ -2593,6 +2624,10 @@ tl::expected<void, ErrorCode> RealClient::ascend_ipc_shm_internal(
     uint64_t dummy_base_addr, size_t mem_size, bool is_local_buffer,
     const std::string &ipc_key_bytes, int32_t device_id,
     const UUID &client_id) {
+    if (IsClosing()) {
+        LOG(WARNING) << "Rejecting ascend_ipc_shm: client is closing";
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
 #ifdef USE_ASCEND_DIRECT
     constexpr size_t kIPCKeyLen = 65;
     if (!client_) {

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -174,6 +174,23 @@ int main(int argc, char *argv[]) {
             return;
         }
         LOG(INFO) << "Received signal " << sig << ", shutting down";
+
+        // Stop ingress before the graceful wait. Close() can block for the
+        // grace period plus the confirmation budget, and while the server is
+        // still serving, a handler could mount a segment that
+        // GracefulUnmountAll() has already snapshotted past, or still be
+        // running when Close() resets the client. stop() closes the acceptors,
+        // closes the live connections and joins the handler pool, so no handler
+        // is running by the time it returns.
+        //
+        // This does not shorten the grace period. What the grace period keeps
+        // alive is peers reading these segments directly through the transfer
+        // engine, which only needs the memory registrations and the master-side
+        // segment state that Close() holds; it does not go through this RPC
+        // port. The port only serves this host's own dummy clients, which are
+        // going away with the process anyway.
+        server.stop();
+
         CloseOptions options;
         options.grace_period =
             std::chrono::seconds(FLAGS_graceful_unmount_seconds);
@@ -182,7 +199,6 @@ int main(int argc, char *argv[]) {
             LOG(ERROR) << "Client shutdown reported an error: "
                        << toString(closed.error());
         }
-        server.stop();
     });
 
     std::thread signal_thread([&signal_io]() { signal_io.run(); });
@@ -192,8 +208,17 @@ int main(int argc, char *argv[]) {
 
     const auto rc = server.start();
 
-    signals.cancel();
+    // Safe to call from any thread, and it does not interrupt a handler that is
+    // already executing. If no signal arrived, this is what lets run() return
+    // instead of blocking on the pending async_wait; if one did, the handler
+    // keeps running Close() and this has no effect on it.
     signal_io.stop();
+
+    // The handler calls server.stop() first, so start() returns while Close()
+    // may still be running. This join is what actually waits for it, and it has
+    // to happen before client_inst goes out of scope. `signals` is deliberately
+    // left alone: asio's signal_set is not safe for concurrent access, and
+    // ~signal_set cancels any operation that is still pending.
     if (signal_thread.joinable()) {
         signal_thread.join();
     }

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -1,5 +1,9 @@
 #include <gflags/gflags.h>
 #include <csignal>
+#include <chrono>
+#include <thread>
+#include <asio/io_context.hpp>
+#include <asio/signal_set.hpp>
 #include <ylt/coro_rpc/coro_rpc_server.hpp>
 
 #include "client_service.h"
@@ -27,6 +31,14 @@ DEFINE_bool(start_offload_rpc_server, true,
             "(batch_get_offload_object / release_offload_buffer). "
             "Effective only when --enable_offload is true. "
             "Disable for a write-only owner.");
+DEFINE_uint32(graceful_unmount_seconds, 0,
+              "Grace period, in seconds, for unmounting segments on shutdown. "
+              "0 (default) unmounts immediately. When greater than zero, a "
+              "termination signal first asks the master to stop allocating on "
+              "this client's segments while keeping them readable, and the "
+              "process stays alive (holding its memory registrations) until "
+              "the master released them, so peers that already hold segment "
+              "information can finish their reads. Standalone client only.");
 DECLARE_bool(enable_http_server);
 DECLARE_int32(http_port);
 
@@ -104,6 +116,13 @@ void RegisterClientRpcService(coro_rpc::coro_rpc_server &server,
 }  // namespace mooncake
 
 int main(int argc, char *argv[]) {
+    // This binary owns SIGINT/SIGTERM/SIGHUP through the asio::signal_set
+    // below, so the shared tracker must not also run its sigwait consumer for
+    // them: POSIX leaves it unspecified which one receives a signal that is
+    // handled by sigaction and awaited by sigwait at the same time. Has to
+    // happen before the first getInstance().
+    mooncake::ResourceTracker::DisableSignalHandling();
+
     // Attention !!!
     // Initialization of ResourceTracker must be the most earliest.
     // Otherwise, the main thread will not apply signal mask before other
@@ -144,8 +163,39 @@ int main(int argc, char *argv[]) {
     coro_rpc::coro_rpc_server server(FLAGS_threads, FLAGS_port, rpc_bind_host);
     RegisterClientRpcService(server, *client_inst);
 
+    // This entry point only owns signal registration and configuration; the
+    // shutdown transition itself lives in RealClient::Close(), which every
+    // frontend shares. ResourceTracker's own consumer was disabled above, so
+    // asio is the single owner of these signals.
+    asio::io_context signal_io;
+    asio::signal_set signals(signal_io, SIGINT, SIGTERM, SIGHUP);
+    signals.async_wait([&](const asio::error_code &ec, int sig) {
+        if (ec) {
+            return;
+        }
+        LOG(INFO) << "Received signal " << sig << ", shutting down";
+        CloseOptions options;
+        options.grace_period =
+            std::chrono::seconds(FLAGS_graceful_unmount_seconds);
+        auto closed = client_inst->Close(options);
+        if (!closed) {
+            LOG(ERROR) << "Client shutdown reported an error: "
+                       << toString(closed.error());
+        }
+        server.stop();
+    });
+
+    std::thread signal_thread([&signal_io]() { signal_io.run(); });
+
     LOG(INFO) << "Starting real client service on " << rpc_bind_host << ":"
               << FLAGS_port;
 
-    return server.start();
+    const auto rc = server.start();
+
+    signals.cancel();
+    signal_io.stop();
+    if (signal_thread.joinable()) {
+        signal_thread.join();
+    }
+    return rc;
 }

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -21,6 +21,7 @@
 #include "allocator.h"
 #include "client_service.h"
 #include "pyclient.h"
+#include "real_client.h"
 #include "types.h"
 #include "utils.h"
 #include "test_server_helpers.h"
@@ -2085,7 +2086,54 @@ TEST_F(ClientIntegrationTest, GracefulUnmountAllCompletesWithoutPolling) {
     // moment the segment is released.
     EXPECT_LT(elapsed, std::chrono::seconds(45));
 
+    // Destroy the client before releasing the backing memory: the transfer
+    // engine MR is only unregistered when the unmount completes or the
+    // destructor runs, and it must never point at freed storage.
+    client.reset();
     free(test_buffer);
+}
+
+// The bulk close path must be correct for more segments than task_thread_pool_
+// has workers: the confirmation schedule is driven by a single aggregate task,
+// so every segment's deadline progresses concurrently instead of waiting for an
+// earlier segment's timer to release a worker.
+TEST_F(ClientIntegrationTest,
+       GracefulUnmountAllHandlesMoreSegmentsThanWorkers) {
+    auto client = CreateClient("127.0.0.1:17823");
+    ASSERT_NE(client, nullptr);
+
+    // More than the four workers of Client::task_thread_pool_.
+    constexpr size_t kSegmentCount = 6;
+    const size_t test_size = 16 * 1024 * 1024;  // 16 MB each
+    std::vector<void*> buffers;
+    for (size_t i = 0; i < kSegmentCount; ++i) {
+        void* buffer = allocate_buffer_allocator_memory(test_size);
+        ASSERT_NE(buffer, nullptr);
+        buffers.push_back(buffer);
+        auto mount_result =
+            client->MountSegmentAndGetId(buffer, test_size, FLAGS_protocol);
+        ASSERT_TRUE(mount_result.has_value())
+            << "MountSegmentAndGetId failed for segment " << i << ": "
+            << toString(mount_result.error());
+    }
+
+    const uint64_t grace_period_ms = 1000;
+    ASSERT_EQ(client->GracefulUnmountAll(grace_period_ms), kSegmentCount);
+
+    // Same bound Close() derives, so this asserts exactly the property the
+    // shutdown path relies on: it holds for any number of segments.
+    const auto start = std::chrono::steady_clock::now();
+    const auto deadline =
+        start + std::chrono::milliseconds(grace_period_ms) +
+        kGracefulUnmountConfirmInterval * (kGracefulUnmountConfirmRetries + 2);
+    const bool drained = client->WaitForGracefulUnmountAll(deadline);
+    EXPECT_TRUE(drained)
+        << "bulk graceful unmount did not complete within the derived timeout";
+
+    client.reset();
+    for (void* buffer : buffers) {
+        free(buffer);
+    }
 }
 
 // The caller owns the timeout policy: an already-elapsed deadline must return
@@ -2117,6 +2165,10 @@ TEST_F(ClientIntegrationTest, WaitForGracefulUnmountAllRespectsDeadline) {
     // No mounted segments remain, so this is a no-op that must not block.
     EXPECT_EQ(client->GracefulUnmountAll(grace_period_ms), 0u);
 
+    // The wait deliberately expired, so the segment is still pending and its
+    // transfer engine MR is still registered against test_buffer. Destroy the
+    // client first so the registration is released before the memory goes away.
+    client.reset();
     free(test_buffer);
 }
 
@@ -2126,6 +2178,30 @@ TEST_F(ClientIntegrationTest, CloseOptionsDefaultToImmediateShutdown) {
     CloseOptions options;
     EXPECT_EQ(options.grace_period, std::chrono::milliseconds::zero());
     EXPECT_EQ(options.timeout, std::chrono::milliseconds::zero());
+}
+
+// Both CloseOptions fields are signed. Only exactly zero means
+// "immediate"/"derive the timeout"; a negative value is a caller bug and must
+// be rejected without entering the closing state.
+TEST_F(ClientIntegrationTest, CloseRejectsNegativeOptions) {
+    auto real_client = RealClient::create();
+    ASSERT_NE(real_client, nullptr);
+
+    CloseOptions negative_grace;
+    negative_grace.grace_period = std::chrono::milliseconds(-1);
+    auto grace_result = real_client->Close(negative_grace);
+    ASSERT_FALSE(grace_result.has_value());
+    EXPECT_EQ(grace_result.error(), ErrorCode::INVALID_PARAMS);
+
+    CloseOptions negative_timeout;
+    negative_timeout.timeout = std::chrono::milliseconds(-1);
+    auto timeout_result = real_client->Close(negative_timeout);
+    ASSERT_FALSE(timeout_result.has_value());
+    EXPECT_EQ(timeout_result.error(), ErrorCode::INVALID_PARAMS);
+
+    // A rejected call must not have consumed the one-shot closing state, so a
+    // valid Close() still runs the transition.
+    EXPECT_TRUE(real_client->Close(CloseOptions{}).has_value());
 }
 
 }  // namespace testing

--- a/mooncake-store/tests/client_integration_test.cpp
+++ b/mooncake-store/tests/client_integration_test.cpp
@@ -20,6 +20,7 @@
 
 #include "allocator.h"
 #include "client_service.h"
+#include "pyclient.h"
 #include "types.h"
 #include "utils.h"
 #include "test_server_helpers.h"
@@ -2045,6 +2046,86 @@ TEST_F(ClientIntegrationTest, MountSegmentAndGetIdAndUnmountSegmentById) {
         << "UnmountSegment failed: " << toString(unmount2.error());
 
     free(test_buffer);
+}
+
+// Verifies the mechanism/policy split: GracefulUnmountAll() only initiates, and
+// WaitForGracefulUnmountAll() returns as soon as the last segment is released
+// rather than after a fixed polling interval.
+//
+// Uses a dedicated client so the suite-wide segment mounted by SetUpTestSuite()
+// is not affected: GracefulUnmountAll() acts on every segment the client has
+// mounted.
+TEST_F(ClientIntegrationTest, GracefulUnmountAllCompletesWithoutPolling) {
+    auto client = CreateClient("127.0.0.1:17821");
+    ASSERT_NE(client, nullptr);
+
+    const size_t test_size = 16 * 1024 * 1024;  // 16 MB
+    void* test_buffer = allocate_buffer_allocator_memory(test_size);
+    ASSERT_NE(test_buffer, nullptr);
+
+    auto mount_result =
+        client->MountSegmentAndGetId(test_buffer, test_size, FLAGS_protocol);
+    ASSERT_TRUE(mount_result.has_value())
+        << "MountSegmentAndGetId failed: " << toString(mount_result.error());
+
+    // A short grace period keeps the test fast; the client-side confirmation
+    // timer fires 10s after the announced period, so the deadline must exceed
+    // that for the wait to observe completion.
+    const uint64_t grace_period_ms = 1000;
+    const size_t requested = client->GracefulUnmountAll(grace_period_ms);
+    EXPECT_EQ(requested, 1u) << "expected the mounted segment to be accepted";
+
+    const auto start = std::chrono::steady_clock::now();
+    const bool drained =
+        client->WaitForGracefulUnmountAll(start + std::chrono::seconds(60));
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    EXPECT_TRUE(drained) << "graceful unmount did not complete before deadline";
+    // The wait is condition-variable driven, so it must not linger past the
+    // moment the segment is released.
+    EXPECT_LT(elapsed, std::chrono::seconds(45));
+
+    free(test_buffer);
+}
+
+// The caller owns the timeout policy: an already-elapsed deadline must return
+// false immediately instead of blocking. Also uses a dedicated client to avoid
+// touching the suite-wide segment.
+TEST_F(ClientIntegrationTest, WaitForGracefulUnmountAllRespectsDeadline) {
+    auto client = CreateClient("127.0.0.1:17822");
+    ASSERT_NE(client, nullptr);
+
+    const size_t test_size = 16 * 1024 * 1024;  // 16 MB
+    void* test_buffer = allocate_buffer_allocator_memory(test_size);
+    ASSERT_NE(test_buffer, nullptr);
+
+    auto mount_result =
+        client->MountSegmentAndGetId(test_buffer, test_size, FLAGS_protocol);
+    ASSERT_TRUE(mount_result.has_value())
+        << "MountSegmentAndGetId failed: " << toString(mount_result.error());
+
+    // A long grace period guarantees the segment is still pending below.
+    const uint64_t grace_period_ms = 60000;
+    ASSERT_EQ(client->GracefulUnmountAll(grace_period_ms), 1u);
+
+    const auto start = std::chrono::steady_clock::now();
+    EXPECT_FALSE(client->WaitForGracefulUnmountAll(start))
+        << "an expired deadline must not report completion";
+    EXPECT_LT(std::chrono::steady_clock::now() - start,
+              std::chrono::seconds(5));
+
+    // No mounted segments remain, so this is a no-op that must not block.
+    EXPECT_EQ(client->GracefulUnmountAll(grace_period_ms), 0u);
+
+    free(test_buffer);
+}
+
+// CloseOptions defaults must keep the immediate, deterministic shutdown that
+// destructors, the C API and plain tearDownAll() rely on.
+TEST_F(ClientIntegrationTest, CloseOptionsDefaultToImmediateShutdown) {
+    CloseOptions options;
+    EXPECT_EQ(options.grace_period, std::chrono::milliseconds::zero());
+    EXPECT_EQ(options.timeout, std::chrono::milliseconds::zero());
 }
 
 }  // namespace testing

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -83,12 +83,29 @@ class MooncakeStoreService:
     - protocol: Communication protocol (tcp or rdma).
     - device_name: The name of the device to use.
     - master_server_address: The address of the master server.
+
+    Shutdown policy (not part of the config file, see
+    --graceful-unmount-seconds):
+    - graceful_unmount_seconds: Grace period applied when stop() closes the
+      store. 0 unmounts immediately.
     """
 
-    def __init__(self, config_path: str = None, cli_config: dict = None):
+    def __init__(
+        self,
+        config_path: str = None,
+        cli_config: dict = None,
+        graceful_unmount_seconds: int = 0,
+    ):
         self.store = None
         self.config = None
         self._setup_logging()
+
+        # Shutdown policy owned by this process-facing wrapper and forwarded to
+        # store.close(); the client itself runs the whole transition. 0 keeps
+        # the previous immediate teardown.
+        if graceful_unmount_seconds < 0:
+            raise ValueError("graceful_unmount_seconds must not be negative")
+        self.graceful_unmount_seconds = graceful_unmount_seconds
 
         # State for /api/reconfigure (Prefill/Decode mode switch)
         self.current_mode = "prefill"  # "prefill" or "decode"
@@ -776,7 +793,15 @@ class MooncakeStoreService:
 
     async def stop(self):
         if self.store:
-            ret = self.store.close()
+            # Forward this process's shutdown policy; close() releases the GIL
+            # while the client waits for the master to release the segments.
+            grace_seconds = getattr(self, "graceful_unmount_seconds", 0)
+            if grace_seconds:
+                logging.info(
+                    "Closing Mooncake store with a %ss graceful unmount period",
+                    grace_seconds,
+                )
+            ret = self.store.close(grace_seconds)
             self.store = None
             if ret != 0:
                 logging.warning("Mooncake service close returned %s", ret)
@@ -810,6 +835,20 @@ def parse_arguments():
         default=60,
         required=False,
     )
+    parser.add_argument(
+        "--graceful-unmount-seconds",
+        type=int,
+        help=(
+            "Grace period, in seconds, for unmounting segments on shutdown "
+            "(default: 0, unmount immediately). When greater than zero, a "
+            "termination signal first asks the master to stop allocating on "
+            "this process's segments while keeping them readable, and the "
+            "process stays alive until the master released them, so peers that "
+            "already hold segment information can finish their reads."
+        ),
+        default=0,
+        required=False,
+    )
     return parser.parse_args()
 
 
@@ -825,7 +864,11 @@ async def main():
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")
 
-    service = MooncakeStoreService(args.config, cli_config)
+    service = MooncakeStoreService(
+        args.config,
+        cli_config,
+        graceful_unmount_seconds=args.graceful_unmount_seconds,
+    )
     shutdown_event = asyncio.Event()
     loop = asyncio.get_running_loop()
 


### PR DESCRIPTION
Standalone mooncake_client unmounted its segments immediately on exit, so peers holding segment info could fail subsequent get/put. Add an opt-in grace period via MC_GRACEFUL_UNMOUNT_SECONDS: on teardown, request graceful unmount for all mounted segments and keep the process and its memory registrations alive until they are released or a bounded timeout expires.

Also install a process-wide sigaction handler for SIGINT/SIGTERM/SIGHUP that forwards to the existing sigwait thread. pthread_sigmask only affects the calling thread, so a termination signal delivered to a thread that never inherited the block mask took the default action and killed the process before any cleanup ran.

MC_GRACEFUL_UNMOUNT_SECONDS=0 (default) keeps the previous behavior.

Try to fix #3551 

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
export MC_GRACEFUL_UNMOUNT_SECONDS=30
start mooncake_client 
pkill -TERM -f mooncake_client
```

1. See if there still put/load errors exist on others.
2. We can see the graceful shutdown log.

```
grep -E "Graceful unmount|Received signal" mooncake_client.log | tail -20
I0820 16:35:56.381542 82704 real_client.cpp:581] Received signal 15, cleaning up resources
I0820 16:35:56.384151 82704 client_service.cpp:2908] Graceful unmount requested for 1/1 segments, grace_period_ms=30000, now waiting for completion (max 75s)
I0820 16:36:37.605084 82704 client_service.cpp:2921] Graceful unmount of all segments completed
I0820 16:41:47.074059 96751 real_client.cpp:581] Received signal 15, cleaning up resources
I0820 16:41:47.076062 96751 client_service.cpp:2908] Graceful unmount requested for 1/1 segments, grace_period_ms=30000, now waiting for completion (max 75s)
I0820 16:42:29.476811 96751 client_service.cpp:2921] Graceful unmount of all segments completed
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)