### PR TITLE
[TransferEngine] Identify TCP peers by incarnation ID

### DIFF
--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -132,6 +132,12 @@ class TransferMetadata {
         // READ responses (#2086); absent/1 = legacy unacknowledged framing.
         int tcp_proto_version{1};
 
+        // Opaque identity for one TCP server incarnation. It stays stable
+        // for the lifetime of a TCP transport instance and changes after a
+        // restart. Missing/empty means a legacy peer with no incarnation
+        // identity support.
+        std::string tcp_instance_id;
+
         // In dual-NIC setups (MC_RDMA_BIND_ADDRESS), the RDMA-reachable
         // address may differ from the TCP-routable segment name.  When
         // non-empty, NIC paths are constructed using this value instead

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -134,8 +134,9 @@ class TransferMetadata {
 
         // Opaque identity for one TCP server incarnation. It stays stable
         // for the lifetime of a TCP transport instance and changes after a
-        // restart. Missing/empty means a legacy peer with no incarnation
-        // identity support.
+        // restart. A nonempty ID is 32 lowercase hexadecimal characters.
+        // Missing/empty means a legacy peer with no incarnation identity
+        // support.
         std::string tcp_instance_id;
 
         // In dual-NIC setups (MC_RDMA_BIND_ADDRESS), the RDMA-reachable

--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -109,6 +109,9 @@ class TcpTransport : public Transport {
     const char *getName() const override { return "tcp"; }
 
    private:
+    // Opaque identity generated once per transport lifetime and published in
+    // the local TCP segment descriptor.
+    std::string tcp_instance_id_;
     TcpContext *context_;
     std::atomic_bool running_;
     std::thread thread_;
@@ -118,16 +121,21 @@ class TcpTransport : public Transport {
     struct ConnectionKey {
         std::string host;
         uint16_t port;
+        std::string tcp_instance_id;
 
         bool operator==(const ConnectionKey &other) const {
-            return host == other.host && port == other.port;
+            return host == other.host && port == other.port &&
+                   tcp_instance_id == other.tcp_instance_id;
         }
     };
 
     struct ConnectionKeyHash {
         std::size_t operator()(const ConnectionKey &key) const {
-            return std::hash<std::string>()(key.host) ^
-                   (std::hash<uint16_t>()(key.port) << 1);
+            const auto host_hash = std::hash<std::string>()(key.host);
+            const auto port_hash = std::hash<uint16_t>()(key.port);
+            const auto instance_hash =
+                std::hash<std::string>()(key.tcp_instance_id);
+            return host_hash ^ (port_hash << 1) ^ (instance_hash << 2);
         }
     };
 

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -380,6 +380,9 @@ static int encodeMultiProtocolSegmentDesc(
     }
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
     segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
+    if (!desc.tcp_instance_id.empty()) {
+        segmentJSON["tcp_instance_id"] = desc.tcp_instance_id;
+    }
     segmentJSON["timestamp"] = getCurrentDateTime();
 
     return 0;
@@ -426,6 +429,9 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     }
     segmentJSON["tcp_data_port"] = desc.tcp_data_port;
     segmentJSON["tcp_proto_version"] = desc.tcp_proto_version;
+    if (!desc.tcp_instance_id.empty()) {
+        segmentJSON["tcp_instance_id"] = desc.tcp_instance_id;
+    }
     segmentJSON["timestamp"] = getCurrentDateTime();
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
@@ -644,6 +650,10 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
                                   : 1;
+    if (segmentJSON.isMember("tcp_instance_id") &&
+        segmentJSON["tcp_instance_id"].isString()) {
+        desc->tcp_instance_id = segmentJSON["tcp_instance_id"].asString();
+    }
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))
@@ -813,6 +823,10 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
                                   : 1;
+    if (segmentJSON.isMember("tcp_instance_id") &&
+        segmentJSON["tcp_instance_id"].isString()) {
+        desc->tcp_instance_id = segmentJSON["tcp_instance_id"].asString();
+    }
     if (segmentJSON.isMember("timestamp"))
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))
@@ -1169,6 +1183,7 @@ bool TransferMetadata::SegmentDesc::operator==(const SegmentDesc &other) const {
            rank_info == other.rank_info &&
            tcp_data_host == other.tcp_data_host &&
            tcp_data_port == other.tcp_data_port &&
+           tcp_instance_id == other.tcp_instance_id &&
            rdma_server_name == other.rdma_server_name;
 }
 

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -650,8 +650,7 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
                                   : 1;
-    if (segmentJSON.isMember("tcp_instance_id") &&
-        segmentJSON["tcp_instance_id"].isString()) {
+    if (segmentJSON.isMember("tcp_instance_id")) {
         desc->tcp_instance_id = segmentJSON["tcp_instance_id"].asString();
     }
     if (segmentJSON.isMember("timestamp"))
@@ -778,6 +777,20 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
 std::shared_ptr<TransferMetadata::SegmentDesc>
 TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
                                     const std::string &segment_name) {
+    if (segmentJSON.isMember("tcp_instance_id")) {
+        const char *begin = nullptr;
+        const char *end = nullptr;
+        if (!segmentJSON["tcp_instance_id"].getString(&begin, &end) ||
+            (begin != end &&
+             (end - begin != 32 || !std::all_of(begin, end, [](char c) {
+                  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+              })))) {
+            LOG(WARNING) << "Invalid TCP instance ID in segment "
+                         << segment_name;
+            return nullptr;
+        }
+    }
+
 #ifdef ENABLE_MULTI_PROTOCOL
     // Check if this is a multi-protocol scenario (CXL+TCP or CXL+RDMA)
     bool is_multi_protocol = false;
@@ -823,8 +836,7 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
     desc->tcp_proto_version = segmentJSON.isMember("tcp_proto_version")
                                   ? segmentJSON["tcp_proto_version"].asInt()
                                   : 1;
-    if (segmentJSON.isMember("tcp_instance_id") &&
-        segmentJSON["tcp_instance_id"].isString()) {
+    if (segmentJSON.isMember("tcp_instance_id")) {
         desc->tcp_instance_id = segmentJSON["tcp_instance_id"].asString();
     }
     if (segmentJSON.isMember("timestamp"))

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -31,10 +31,13 @@
 #include <cstdlib>
 #include <deque>
 #include <functional>
+#include <iomanip>
 #include <limits>
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <random>
+#include <sstream>
 #include <type_traits>
 
 #include "common.h"
@@ -282,10 +285,27 @@ bool validateTcpAddress(const std::shared_ptr<TransferMetadata>& metadata,
     }
     return false;
 }
+
+std::string generateTcpInstanceId() {
+    std::random_device random_device;
+    std::array<std::uint32_t, 8> entropy{};
+    std::generate(entropy.begin(), entropy.end(),
+                  [&random_device] { return random_device(); });
+    std::seed_seq seed(entropy.begin(), entropy.end());
+    std::mt19937_64 generator(seed);
+    const uint64_t high = generator();
+    const uint64_t low = generator();
+
+    std::ostringstream result;
+    result << std::hex << std::setfill('0') << std::setw(16) << high
+           << std::setw(16) << low;
+    return result.str();
+}
 }  // namespace
 
 TcpTransport::TcpTransport()
-    : context_(nullptr),
+    : tcp_instance_id_(generateTcpInstanceId()),
+      context_(nullptr),
       running_(false),
       lane_state_(std::make_shared<ConnectionLaneState>()) {
     if (getenv("MC_TCP_ENABLE_CONNECTION_POOL") != nullptr) {
@@ -414,6 +434,7 @@ int TcpTransport::allocateLocalSegmentID(int tcp_data_port) {
 #endif
     desc->tcp_data_host = metadata_->localRpcMeta().ip_or_host_name;
     desc->tcp_data_port = tcp_data_port;
+    desc->tcp_instance_id = tcp_instance_id_;
     // Advertise acknowledged framing (#2086); initiators fall back to v1
     // against descriptors that do not carry the field.
     desc->tcp_proto_version = 2;
@@ -716,7 +737,8 @@ void TcpTransport::startTransfer(Slice* slice,
     }
 
     const ConnectionKey key{desc->tcp_data_host,
-                            static_cast<uint16_t>(desc->tcp_data_port)};
+                            static_cast<uint16_t>(desc->tcp_data_port),
+                            desc->tcp_instance_id};
     const bool use_v2 = desc->tcp_proto_version >= 2 && !forceLegacyTcpProto();
     TcpWorkItem work(slice, use_v2, std::move(continuation));
 

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -1502,6 +1502,32 @@ std::string publishAndRefreshTcpEndpoint(EngineHandle& handle, uint16_t port) {
     return publishAndRefreshTcpEndpoint(handle, handle.segment_id, port);
 }
 
+std::string publishAndRefreshTcpIncarnation(EngineHandle& handle,
+                                            Transport::SegmentID segment_id,
+                                            uint16_t port,
+                                            const std::string& instance_id) {
+    auto metadata = handle.engine->getMetadata();
+    auto current = metadata->getSegmentDescByID(segment_id);
+    EXPECT_NE(current, nullptr);
+    if (!current) return {};
+
+    auto authoritative = *current;
+    authoritative.tcp_data_port = port;
+    authoritative.tcp_proto_version = 2;
+    authoritative.tcp_instance_id = instance_id;
+
+    EXPECT_EQ(metadata->updateSegmentDesc(current->name, authoritative), 0);
+    EXPECT_EQ(handle.engine->syncSegmentCache(current->name), 0);
+
+    auto refreshed = metadata->getSegmentDescByID(segment_id);
+    EXPECT_NE(refreshed, nullptr);
+    if (refreshed) {
+        EXPECT_EQ(refreshed->tcp_data_port, port);
+        EXPECT_EQ(refreshed->tcp_instance_id, instance_id);
+    }
+    return current->name;
+}
+
 TransferRequest makeWriteRequest(const EngineHandle& handle, size_t length,
                                  uint64_t target_offset = 0) {
     TransferRequest request;
@@ -3737,6 +3763,115 @@ TEST(TcpWriteVisibilityTest, ShutdownWithArmedProgressDeadlineCompletesOnce) {
     fake_peer.release();
 }
 
+TEST(TcpWriteVisibilityTest, SameEndpointNewTcpInstanceRetiresOldGroup) {
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    LocalHttpMetadataServer metadata_server;
+    ReusingWriteServer endpoint;
+    ASSERT_TRUE(metadata_server.ok());
+    ASSERT_TRUE(endpoint.ok());
+
+    const std::string logical_peer = "127.0.0.2:18051";
+
+    EngineHandle target;
+    target.init(metadata_server.uri(), logical_peer, 64 * 1024);
+    ASSERT_TRUE(target.ok);
+
+    EngineHandle h;
+    h.init(metadata_server.uri(), "127.0.0.2:18151", 64 * 1024, logical_peer);
+    ASSERT_TRUE(h.ok);
+
+    // G1 uses endpoint A.
+    ASSERT_EQ(publishAndRefreshTcpIncarnation(h, h.segment_id, endpoint.port(),
+                                              "tcp-instance-g1"),
+              logical_peer);
+
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint.waitForRequests(1, std::chrono::seconds(5)));
+    ASSERT_EQ(endpoint.acceptedCount(), 1);
+    ASSERT_EQ(endpoint.activeAcceptedCount(), 1);
+
+    // Simulate a process restart. The TCP endpoint is deliberately unchanged;
+    // only the incarnation identity changes from G1 to G2.
+    ASSERT_EQ(publishAndRefreshTcpIncarnation(h, h.segment_id, endpoint.port(),
+                                              "tcp-instance-g2"),
+              logical_peer);
+
+    auto refreshed = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
+    ASSERT_NE(refreshed, nullptr);
+    ASSERT_EQ(refreshed->tcp_data_port, endpoint.port());
+    ASSERT_EQ(refreshed->tcp_instance_id, "tcp-instance-g2");
+
+    ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
+              TransferStatusEnum::COMPLETED);
+    ASSERT_TRUE(endpoint.waitForRequests(2, std::chrono::seconds(5)));
+
+    // A new incarnation must not reuse the idle connection established for
+    // G1. The instance ID is part of ConnectionKey, so this starts a fresh
+    // G2 connection even though host and port are unchanged.
+    ASSERT_TRUE(waitForPredicate([&] { return endpoint.acceptedCount() >= 2; },
+                                 std::chrono::milliseconds(500)))
+        << "RED: tcp_instance_id changed at the same host:port, but the "
+           "existing G1 connection group was still reused";
+
+    EXPECT_EQ(endpoint.acceptedCount(), 2);
+
+    // Once G2 owns the current connection, G1's old group must eventually
+    // drain and close rather than remaining pinned alongside it.
+    EXPECT_TRUE(
+        waitForPredicate([&] { return endpoint.activeAcceptedCount() == 1; },
+                         std::chrono::seconds(5)))
+        << "old G1 connection remained active after the G2 incarnation "
+           "became current";
+}
+
+TEST(TcpWriteVisibilityTest, LocalTcpInstanceIdIsNonEmptyAndStable) {
+    LocalHttpMetadataServer metadata_server;
+    ASSERT_TRUE(metadata_server.ok());
+
+    EngineHandle handle;
+    handle.init(metadata_server.uri(), "127.0.0.2:18171", 64 * 1024);
+    ASSERT_TRUE(handle.ok);
+
+    auto metadata = handle.engine->getMetadata();
+    auto before = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(before, nullptr);
+    ASSERT_FALSE(before->tcp_instance_id.empty());
+    EXPECT_EQ(before->tcp_instance_id.size(), 32U);
+    const std::string instance_id = before->tcp_instance_id;
+
+    // Re-publish through the normal local descriptor update path. The
+    // incarnation belongs to the TcpTransport, so memory publication must not
+    // replace it with a new value.
+    ASSERT_EQ(metadata->updateLocalSegmentDesc(), 0);
+    auto after = metadata->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(after, nullptr);
+    EXPECT_EQ(after->tcp_instance_id, instance_id);
+}
+
+TEST(TcpWriteVisibilityTest,
+     DistinctTcpTransportInstancesHaveDistinctInstanceIds) {
+    LocalHttpMetadataServer metadata_server;
+    ASSERT_TRUE(metadata_server.ok());
+
+    EngineHandle first;
+    first.init(metadata_server.uri(), "127.0.0.2:18181", 64 * 1024);
+    ASSERT_TRUE(first.ok);
+    EngineHandle second;
+    second.init(metadata_server.uri(), "127.0.0.2:18182", 64 * 1024);
+    ASSERT_TRUE(second.ok);
+
+    auto first_desc =
+        first.engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    auto second_desc =
+        second.engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(first_desc, nullptr);
+    ASSERT_NE(second_desc, nullptr);
+    ASSERT_FALSE(first_desc->tcp_instance_id.empty());
+    ASSERT_FALSE(second_desc->tcp_instance_id.empty());
+    EXPECT_NE(first_desc->tcp_instance_id, second_desc->tcp_instance_id);
+}
+
 TEST(TcpWriteVisibilityTest, EndpointRefreshRoutesNewWorkToNewTcpEndpoint) {
     ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
     LocalHttpMetadataServer metadata_server;
@@ -3892,9 +4027,20 @@ TEST(TcpWriteVisibilityTest, SharedEndpointOnePeerMovesDoesNotRetireOtherPeer) {
     const auto segment_y = h.engine->openSegment(logical_peer_y);
     ASSERT_NE(h.engine->getMetadata()->getSegmentDescByID(segment_y), nullptr);
 
-    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, h.segment_id, endpoint_a.port()),
-              logical_peer_x);
-    ASSERT_EQ(publishAndRefreshTcpEndpoint(h, segment_y, endpoint_a.port()),
+    // Both logical peers represent the same TCP server process. Keep their
+    // incarnation identity equal so they intentionally share one endpoint-A
+    // connection group.
+    auto target_x_local =
+        target_x.engine->getMetadata()->getSegmentDescByID(LOCAL_SEGMENT_ID);
+    ASSERT_NE(target_x_local, nullptr);
+    ASSERT_FALSE(target_x_local->tcp_instance_id.empty());
+
+    ASSERT_EQ(
+        publishAndRefreshTcpIncarnation(h, h.segment_id, endpoint_a.port(),
+                                        target_x_local->tcp_instance_id),
+        logical_peer_x);
+    ASSERT_EQ(publishAndRefreshTcpIncarnation(h, segment_y, endpoint_a.port(),
+                                              target_x_local->tcp_instance_id),
               logical_peer_y);
     ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
               TransferStatusEnum::COMPLETED);

--- a/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_write_visibility_test.cpp
@@ -3771,6 +3771,8 @@ TEST(TcpWriteVisibilityTest, SameEndpointNewTcpInstanceRetiresOldGroup) {
     ASSERT_TRUE(endpoint.ok());
 
     const std::string logical_peer = "127.0.0.2:18051";
+    const std::string first_id = "0123456789abcdef0123456789abcdef";
+    const std::string second_id = "fedcba9876543210fedcba9876543210";
 
     EngineHandle target;
     target.init(metadata_server.uri(), logical_peer, 64 * 1024);
@@ -3782,7 +3784,7 @@ TEST(TcpWriteVisibilityTest, SameEndpointNewTcpInstanceRetiresOldGroup) {
 
     // G1 uses endpoint A.
     ASSERT_EQ(publishAndRefreshTcpIncarnation(h, h.segment_id, endpoint.port(),
-                                              "tcp-instance-g1"),
+                                              first_id),
               logical_peer);
 
     ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
@@ -3794,13 +3796,13 @@ TEST(TcpWriteVisibilityTest, SameEndpointNewTcpInstanceRetiresOldGroup) {
     // Simulate a process restart. The TCP endpoint is deliberately unchanged;
     // only the incarnation identity changes from G1 to G2.
     ASSERT_EQ(publishAndRefreshTcpIncarnation(h, h.segment_id, endpoint.port(),
-                                              "tcp-instance-g2"),
+                                              second_id),
               logical_peer);
 
     auto refreshed = h.engine->getMetadata()->getSegmentDescByID(h.segment_id);
     ASSERT_NE(refreshed, nullptr);
     ASSERT_EQ(refreshed->tcp_data_port, endpoint.port());
-    ASSERT_EQ(refreshed->tcp_instance_id, "tcp-instance-g2");
+    ASSERT_EQ(refreshed->tcp_instance_id, second_id);
 
     ASSERT_EQ(runOne(h.engine.get(), makeWriteRequest(h, 1)),
               TransferStatusEnum::COMPLETED);

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -347,6 +347,42 @@ TEST(TransferMetadataPublicationTest, PreservesLocalOnlyBufferWithoutRkey) {
     EXPECT_TRUE(remote_desc->buffers[1].rkey.empty());
 }
 
+TEST(TransferMetadataCompatibilityTest,
+     LegacySegmentWithoutTcpInstanceIdDecodesEmpty) {
+    TransferMetadata server(P2PHANDSHAKE);
+    int sockfd = -1;
+    const uint16_t port = findAvailableTcpPort(sockfd);
+    ASSERT_GT(port, 0);
+    const std::string host = globalConfig().use_ipv6 ? "::1" : "127.0.0.1";
+    const std::string server_name =
+        maybeWrapIpV6(host) + ":" + std::to_string(port);
+
+    auto server_segment = makeRdmaSegmentDesc(server_name, 0x1000);
+    server_segment->tcp_data_port = port;
+    server_segment->tcp_proto_version = 1;
+    ASSERT_EQ(server.addLocalSegment(LOCAL_SEGMENT_ID, server_name,
+                                     std::move(server_segment)),
+              0);
+    TransferMetadata::RpcMetaDesc rpc;
+    rpc.ip_or_host_name = host;
+    rpc.rpc_port = port;
+    rpc.sockfd = sockfd;
+    ASSERT_EQ(server.addRpcMetaEntry(server_name, rpc), 0);
+
+    TransferMetadata client(P2PHANDSHAKE);
+    auto client_segment = std::make_shared<TransferMetadata::SegmentDesc>();
+    client_segment->name = "client";
+    client_segment->protocol = "rdma";
+    ASSERT_EQ(client.addLocalSegment(LOCAL_SEGMENT_ID, "client",
+                                     std::move(client_segment)),
+              0);
+
+    auto decoded = client.getSegmentDesc(server_name);
+    ASSERT_NE(decoded, nullptr);
+    EXPECT_TRUE(decoded->tcp_instance_id.empty());
+    EXPECT_EQ(decoded->tcp_proto_version, 1);
+}
+
 // A peer descriptor whose key vector is longer than its device list lets the
 // topology-selected device_id pass the rkey bound in selectPeerDevice() and
 // still index devices[] out of bounds. Such a descriptor must be rejected at

--- a/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
+++ b/mooncake-transfer-engine/tests/transfer_metadata_test.cpp
@@ -383,6 +383,63 @@ TEST(TransferMetadataCompatibilityTest,
     EXPECT_EQ(decoded->tcp_proto_version, 1);
 }
 
+TEST(TransferMetadataValidationTest, ValidatesTcpInstanceId) {
+    const struct {
+        Json::Value id;
+        bool valid;
+    } cases[] = {{"", true},
+                 {"0123456789abcdef0123456789abcdef", true},
+                 {std::string(31, 'a'), false},
+                 {std::string(33, 'a'), false},
+                 {std::string(32, 'g'), false},
+                 {std::string(32, 'A'), false},
+                 {42, false},
+                 {Json::Value(), false}};
+    std::vector<Json::Value> protocols = {"tcp"};
+#ifdef ENABLE_MULTI_PROTOCOL
+    Json::Value mixed(Json::arrayValue);
+    mixed.append("tcp");
+    mixed.append("cxl");
+    protocols.push_back(mixed);
+#endif
+    for (const auto& protocol : protocols) {
+        for (const auto& test_case : cases) {
+            SCOPED_TRACE(protocol.toStyledString() +
+                         test_case.id.toStyledString());
+            auto server = HandShakePlugin::Create(P2PHANDSHAKE);
+            ASSERT_NE(server, nullptr);
+            int sockfd = -1;
+            const uint16_t port = findAvailableTcpPort(sockfd);
+            ASSERT_GT(port, 0);
+            const std::string host =
+                globalConfig().use_ipv6 ? "::1" : "127.0.0.1";
+            const std::string name =
+                maybeWrapIpV6(host) + ":" + std::to_string(port);
+            Json::Value response;
+            response["name"] = name;
+            response["protocol"] = protocol;
+            response["tcp_instance_id"] = test_case.id;
+            server->registerOnMetadataCallBack(
+                [response](const Json::Value&, Json::Value& peer) {
+                    peer = response;
+                    return 0;
+                });
+            ASSERT_EQ(server->startDaemon(port, sockfd), 0);
+
+            TransferMetadata client(P2PHANDSHAKE);
+            ASSERT_EQ(
+                client.addLocalSegment(LOCAL_SEGMENT_ID, "client",
+                                       makeRdmaSegmentDesc("client", 0x1000)),
+                0);
+            auto decoded = client.getSegmentDesc(name);
+            ASSERT_EQ(decoded != nullptr, test_case.valid);
+            if (decoded) {
+                EXPECT_EQ(decoded->tcp_instance_id, test_case.id.asString());
+            }
+        }
+    }
+}
+
 // A peer descriptor whose key vector is longer than its device list lets the
 // topology-selected device_id pass the rkey bound in selectPeerDevice() and
 // still index devices[] out of bounds. Such a descriptor must be rejected at


### PR DESCRIPTION
## Description

This PR adds a TCP peer incarnation ID to distinguish different TCP server lifetimes that reuse the same host and port.

Previously, TCP connection groups were identified only by host and port. If a peer process restarted while keeping the same endpoint, the transport could not distinguish the old process instance from the new one and might reuse stale connection groups.

This change:
- adds an optional tcp_instance_id to SegmentDesc;
- generates one stable incarnation ID per TcpTransport lifetime;
- includes the ID in TCP ConnectionKey;
- reuses the existing endpoint refresh and connection-group retirement logic.

Legacy descriptors without tcp_instance_id remain compatible.

## Testing

Validated with:

- Same host/port peer restart regression test;
- TCP incarnation lifecycle tests;
- Endpoint refresh and retirement tests;
- Full tcp_write_visibility_test;
- ASan/LSan tcp_write_visibility_test.

Results:

- tcp_write_visibility_test: 39/39 passed
- ASan/LSan: 39/39 passed
- clang-format --dry-run --Werror: passed
- git diff --check: passed