### PR TITLE
[Common] Support etcd RBAC authentication and TLS in the etcd wrapper

### DIFF
--- a/docs/source/deployment/etcd-security.md
+++ b/docs/source/deployment/etcd-security.md
@@ -19,6 +19,25 @@ before (plaintext, no authentication). Invalid or incomplete TLS combinations
 are rejected during client initialization; the wrapper does not silently fall
 back to plaintext when TLS-related variables are partially configured.
 
+## Notes and limitations
+
+### Process-wide configuration
+
+The wrapper loads `MC_ETCD_*` variables once and caches them for the lifetime
+of the process (via `sync.Once`). The same cached credentials and TLS settings
+are applied to all etcd clients created by the process (Store / Transfer Engine
+metadata / snapshot clients). One process cannot connect to different etcd
+clusters with different security settings.
+
+### RBAC token expiry
+
+If your etcd cluster issues RBAC authentication tokens with a finite TTL, long-lived
+watch streams and lease keepalives may stop working after the token expires.
+This PR focuses on RBAC/TLS configuration and validation and does not implement
+token refresh or automatic re-authentication. For secured HA deployments, ensure
+that the token TTL is compatible with your availability requirements or plan to
+add an explicit token-refresh mechanism.
+
 ## Example
 
 ```bash

--- a/docs/source/deployment/etcd-security.md
+++ b/docs/source/deployment/etcd-security.md
@@ -11,11 +11,13 @@ code or endpoint string changes are needed.
 |---|---|
 | `MC_ETCD_CONF_FILE` | Path to a file with `username=...` and `password=...` lines (one per line, `#` lines and empty lines ignored) |
 | `MC_ETCD_TLS_CA_CERT` | Path to the CA certificate used to verify the etcd server (one-way TLS) |
-| `MC_ETCD_TLS_SERVER_NAME` | Optional: override the server name used for TLS SNI / certificate hostname verification (e.g. connecting via IP) |
-| `MC_ETCD_TLS_INSECURE_SKIP_VERIFY` | Set to `"true"` to skip certificate verification (testing only, never in production) |
+| `MC_ETCD_TLS_SERVER_NAME` | Optional: override the server name used for TLS SNI / certificate hostname verification (e.g. connecting via IP). Requires TLS to be enabled (either `MC_ETCD_TLS_CA_CERT` or `MC_ETCD_TLS_INSECURE_SKIP_VERIFY="true"`). |
+| `MC_ETCD_TLS_INSECURE_SKIP_VERIFY` | Set to `"true"` to skip certificate verification (testing only, never in production). If set to `"true"` without `MC_ETCD_TLS_CA_CERT`, the client uses an insecure TLS connection. |
 
 All variables are optional. When none are set, the client behaves exactly as
-before (plaintext, no authentication).
+before (plaintext, no authentication). Invalid or incomplete TLS combinations
+are rejected during client initialization; the wrapper does not silently fall
+back to plaintext when TLS-related variables are partially configured.
 
 ## Example
 

--- a/docs/source/deployment/etcd-security.md
+++ b/docs/source/deployment/etcd-security.md
@@ -1,0 +1,34 @@
+# Securing the etcd Metadata Service (RBAC + TLS)
+
+Mooncake's Go etcd client (`libetcd_wrapper.so`) can authenticate against an
+etcd cluster with RBAC and/or encrypt the connection with one-way TLS. Both
+are configured purely with environment variables on the Mooncake node; no
+code or endpoint string changes are needed.
+
+## Environment variables
+
+| Variable | Purpose |
+|---|---|
+| `MC_ETCD_CONF_FILE` | Path to a file with `username=...` and `password=...` lines (one per line, `#` lines and empty lines ignored) |
+| `MC_ETCD_TLS_CA_CERT` | Path to the CA certificate used to verify the etcd server (one-way TLS) |
+| `MC_ETCD_TLS_SERVER_NAME` | Optional: override the server name used for TLS SNI / certificate hostname verification (e.g. connecting via IP) |
+| `MC_ETCD_TLS_INSECURE_SKIP_VERIFY` | Set to `"true"` to skip certificate verification (testing only, never in production) |
+
+All variables are optional. When none are set, the client behaves exactly as
+before (plaintext, no authentication).
+
+## Example
+
+```bash
+# credentials file /etc/mooncake/etcd/credentials:
+#   username=mooncake
+#   password=<secret>
+
+export MC_ETCD_CONF_FILE=/etc/mooncake/etcd/credentials
+export MC_ETCD_TLS_CA_CERT=/etc/mooncake/etcd/ca.crt
+```
+
+The endpoint string keeps its usual form (`etcd://host:port` or bare
+`host:port`; the C++ callers already strip the scheme before the Go client
+sees it). When TLS is enabled the client upgrades automatically to an
+encrypted connection.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -437,6 +437,7 @@ Multi-Tenant Deployment <multi-tenancy>
 :maxdepth: 1
 :hidden:
 
+Securing the etcd Metadata Service (RBAC + TLS)<etcd-security>
 KV Cache Sharing and Isolation<kv-cache-sharing-and-isolation>
 SSD Storage<ssd/index>
 HF3FS USRBIO Adapter (Experimental)<../getting_started/plugin-usage/3FS-USRBIO-Plugin>

--- a/mooncake-common/etcd/CMakeLists.txt
+++ b/mooncake-common/etcd/CMakeLists.txt
@@ -2,7 +2,7 @@ add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so
   COMMAND
     bash -c "go mod tidy" && bash -c
-    "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so ."
+    "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so etcd_wrapper.go security_config.go"
     && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h
     ${CMAKE_CURRENT_SOURCE_DIR}
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -14,7 +14,6 @@ set(ETCD_WRAPPER_LIB ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so)
 
 add_custom_target(build_etcd_wrapper DEPENDS ${ETCD_WRAPPER_LIB})
 
-<<<<<<< HEAD
 if(BUILD_UNIT_TESTS)
   add_test(
     NAME etcd_wrapper_go_test
@@ -22,10 +21,4 @@ if(BUILD_UNIT_TESTS)
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-install(
-    FILES ${ETCD_WRAPPER_LIB}
-    DESTINATION lib
-)
-=======
 install(FILES ${ETCD_WRAPPER_LIB} DESTINATION lib)
->>>>>>> 7b069106 ([Common] Add TLS handshake tests and document etcd security limits)

--- a/mooncake-common/etcd/CMakeLists.txt
+++ b/mooncake-common/etcd/CMakeLists.txt
@@ -1,19 +1,20 @@
 add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so
-    COMMAND bash -c "go mod tidy" && bash -c "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so ." && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h ${CMAKE_CURRENT_SOURCE_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMENT "Building Go shared library"
-    DEPENDS etcd_wrapper.go security_config.go go.mod go.sum build.sh
-)
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so
+  COMMAND
+    bash -c "go mod tidy" && bash -c
+    "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so ."
+    && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  COMMENT "Building Go shared library"
+  DEPENDS etcd_wrapper.go security_config.go go.mod go.sum build.sh)
 
 set(ETCD_WRAPPER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h)
 set(ETCD_WRAPPER_LIB ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so)
 
-add_custom_target(
-    build_etcd_wrapper
-    DEPENDS ${ETCD_WRAPPER_LIB}
-)
+add_custom_target(build_etcd_wrapper DEPENDS ${ETCD_WRAPPER_LIB})
 
+<<<<<<< HEAD
 if(BUILD_UNIT_TESTS)
   add_test(
     NAME etcd_wrapper_go_test
@@ -25,3 +26,6 @@ install(
     FILES ${ETCD_WRAPPER_LIB}
     DESTINATION lib
 )
+=======
+install(FILES ${ETCD_WRAPPER_LIB} DESTINATION lib)
+>>>>>>> 7b069106 ([Common] Add TLS handshake tests and document etcd security limits)

--- a/mooncake-common/etcd/CMakeLists.txt
+++ b/mooncake-common/etcd/CMakeLists.txt
@@ -1,9 +1,9 @@
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so
-    COMMAND bash -c "go mod tidy" && bash -c "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so etcd_wrapper.go" && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND bash -c "go mod tidy" && bash -c "go build -buildmode=c-shared -o ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.so ." && cp ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h ${CMAKE_CURRENT_SOURCE_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Building Go shared library"
-    DEPENDS etcd_wrapper.go go.mod go.sum build.sh
+    DEPENDS etcd_wrapper.go security_config.go go.mod go.sum build.sh
 )
 
 set(ETCD_WRAPPER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/libetcd_wrapper.h)

--- a/mooncake-common/etcd/build.sh
+++ b/mooncake-common/etcd/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 go mod init github.com/kvcache-ai/Mooncake/mooncake-common/etcd
 go mod tidy
-go build -o libetcd_wrapper.so -buildmode=c-shared etcd_wrapper.go
+go build -o libetcd_wrapper.so -buildmode=c-shared .

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -36,11 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-<<<<<<< HEAD
-	"os"
 	"strconv"
-=======
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	"strings"
 	"sync"
 	"time"
@@ -48,14 +44,10 @@ import (
 
 	rpctypes "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
-<<<<<<< HEAD
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-=======
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 )
 
+// prefixWatchInfo stores cancel function and callback context for a prefix watch
 type prefixWatchInfo struct {
 	cancel          context.CancelFunc
 	callbackContext unsafe.Pointer
@@ -970,11 +962,7 @@ func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, er
 }
 
 //export EtcdStoreTxnCompareAndPutWrapper
-<<<<<<< HEAD
 func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareRevisions *int64, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
-=======
-func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	cli := getStoreClient()
 	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
@@ -991,10 +979,7 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 		compareKindList := (*[1 << 28]C.int)(unsafe.Pointer(compareKinds))[:cmpN:cmpN]
 		compareValuePtrs := (*[1 << 28]*C.char)(unsafe.Pointer(compareValues))[:cmpN:cmpN]
 		compareValueSizeList := (*[1 << 28]C.int)(unsafe.Pointer(compareValueSizes))[:cmpN:cmpN]
-<<<<<<< HEAD
 		compareRevisionList := (*[1 << 28]int64)(unsafe.Pointer(compareRevisions))[:cmpN:cmpN]
-=======
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 		for i := 0; i < cmpN; i++ {
 			k := C.GoStringN(compareKeyPtrs[i], compareKeySizeList[i])
 			switch int(compareKindList[i]) {
@@ -1003,11 +988,8 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 				cmps = append(cmps, clientv3.Compare(clientv3.Value(k), "=", v))
 			case 1:
 				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", 0))
-<<<<<<< HEAD
 			case 2:
 				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", compareRevisionList[i]))
-=======
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 			default:
 				*errMsg = C.CString("unsupported compare kind")
 				return -1

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -32,15 +32,15 @@ static inline void call_watch_cb(void* func,
 import "C"
 
 import (
-	"bufio"
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
+<<<<<<< HEAD
 	"os"
 	"strconv"
+=======
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	"strings"
 	"sync"
 	"time"
@@ -48,9 +48,12 @@ import (
 
 	rpctypes "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+<<<<<<< HEAD
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+=======
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 )
 
 type prefixWatchInfo struct {
@@ -142,169 +145,6 @@ const (
 	maintenanceStartupTimeout = 5 * time.Second
 )
 
-// --- Security configuration (RBAC + TLS) loaded from environment variables ---
-//
-// Environment variables:
-//   MC_ETCD_CONF_FILE - Path to a file containing username=... and password=... lines.
-//   MC_ETCD_TLS_CA_CERT           - Path to the CA certificate file for server verification (one-way TLS).
-//   MC_ETCD_TLS_SERVER_NAME        - Optional: override the server name used for TLS SNI and certificate
-//                                     hostname verification. Useful when connecting via IP or a service
-//                                     name that differs from the certificate's SAN.
-//   MC_ETCD_TLS_INSECURE_SKIP_VERIFY - Set to "true" to skip server certificate verification. Only for
-//                                     testing environments; never use in production.
-//
-// All variables are optional. When none are set the behaviour is identical to before this feature.
-//
-// The configuration is loaded exactly once via sync.Once and cached, so even EtcdStoreResetClientWrapper
-// reuses the same parsed values without re-reading files.
-
-// securitySettings holds the cached RBAC and TLS configuration parsed from environment variables.
-// It is populated exactly once by loadSecurityConfig via sync.Once.
-type securitySettings struct {
-	username  string
-	password  string
-	tlsConfig *tls.Config
-	loadErr   error // non-nil when a configured resource failed to load
-}
-
-var (
-	securityOnce   sync.Once
-	cachedSecurity securitySettings
-)
-
-// parseRbacCredentialsFile reads a credentials file in key=value format and
-// returns the username and password. Expected format:
-//
-//	username=<user>
-//	password=<secret>
-//
-// Lines starting with '#' are treated as comments and ignored. Empty lines are skipped.
-func parseRbacCredentialsFile(path string) (string, string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", "", fmt.Errorf("cannot open credentials file %s: %w", path, err)
-	}
-	defer file.Close()
-
-	var username, password string
-	scanner := bufio.NewScanner(file)
-	lineNo := 0
-	for scanner.Scan() {
-		lineNo++
-		line := strings.TrimSpace(scanner.Text())
-		// Skip empty lines and comment lines.
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			return "", "", fmt.Errorf("credentials file %s line %d: invalid format, expected key=value", path, lineNo)
-		}
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
-		switch key {
-		case "username":
-			username = value
-		case "password":
-			password = value
-		default:
-			return "", "", fmt.Errorf("credentials file %s line %d: unknown key %q, expected username or password", path, lineNo, key)
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", "", fmt.Errorf("error reading credentials file %s: %w", path, err)
-	}
-	if username == "" {
-		return "", "", fmt.Errorf("username not found in credentials file %s", path)
-	}
-	if password == "" {
-		return "", "", fmt.Errorf("password not found in credentials file %s", path)
-	}
-	return username, password, nil
-}
-
-// loadSecurityConfig reads environment variables and populates the cached
-// securitySettings. This function is called exactly once via sync.Once.
-// Diagnostic messages are written to stderr so they never pollute stdout,
-// which callers may rely on for data.
-func loadSecurityConfig() {
-	// --- RBAC credentials from file ---
-	credsFile := os.Getenv("MC_ETCD_CONF_FILE")
-	if credsFile != "" {
-		username, password, err := parseRbacCredentialsFile(credsFile)
-		if err != nil {
-			cachedSecurity.loadErr = fmt.Errorf("failed to load RBAC credentials: %w", err)
-			fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
-			return
-		}
-		cachedSecurity.username = username
-		cachedSecurity.password = password
-		fmt.Fprintf(os.Stderr, "[etcd_wrapper] RBAC authentication enabled (user: %s)\n", username)
-	}
-
-	// --- TLS configuration (one-way: verify server) ---
-	caCertFile := os.Getenv("MC_ETCD_TLS_CA_CERT")
-	if caCertFile == "" {
-		// No TLS configured — this is fine, plaintext is the default.
-		return
-	}
-
-	caCert, err := os.ReadFile(caCertFile)
-	if err != nil {
-		cachedSecurity.loadErr = fmt.Errorf("failed to read CA certificate %s: %w", caCertFile, err)
-		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
-		return
-	}
-
-	caCertPool := x509.NewCertPool()
-	if !caCertPool.AppendCertsFromPEM(caCert) {
-		cachedSecurity.loadErr = fmt.Errorf("failed to parse CA certificate from %s (not valid PEM)", caCertFile)
-		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
-		return
-	}
-
-	tlsCfg := &tls.Config{
-		RootCAs:    caCertPool,
-		MinVersion: tls.VersionTLS12,
-	}
-
-	// Optional: override the server name used for SNI and hostname verification.
-	if serverName := os.Getenv("MC_ETCD_TLS_SERVER_NAME"); serverName != "" {
-		tlsCfg.ServerName = serverName
-		fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS ServerName override: %s\n", serverName)
-	}
-
-	// Optional: skip certificate verification (testing only).
-	if os.Getenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY") == "true" {
-		tlsCfg.InsecureSkipVerify = true
-		fmt.Fprintf(os.Stderr, "[etcd_wrapper] WARNING: TLS InsecureSkipVerify is enabled — not safe for production\n")
-	}
-
-	cachedSecurity.tlsConfig = tlsCfg
-	fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS enabled (CA: %s)\n", caCertFile)
-}
-
-// applySecurityConfig applies the cached security configuration (RBAC credentials
-// and TLS settings) to the given clientv3.Config. The configuration is loaded
-// lazily on first call via sync.Once.
-//
-// Returns nil on success or when no security environment variables are set.
-// Returns an error when a configured resource (RBAC file, CA certificate) fails
-// to load — the caller must abort client creation in this case to avoid falling
-// back to an unauthenticated connection.
-func applySecurityConfig(cfg *clientv3.Config) error {
-	securityOnce.Do(loadSecurityConfig)
-
-	if cachedSecurity.loadErr != nil {
-		return cachedSecurity.loadErr
-	}
-
-	cfg.Username = cachedSecurity.username
-	cfg.Password = cachedSecurity.password
-	cfg.TLS = cachedSecurity.tlsConfig
-	return nil
-}
-
 // newStoreClientConfig builds the base clientv3.Config for the store etcd client
 // and applies any security configuration (RBAC / TLS) from environment variables.
 // The caller must check the returned error and abort client creation on failure:
@@ -316,7 +156,6 @@ func newStoreClientConfig(validEndpoints []string) (clientv3.Config, error) {
 		DialTimeout:          5 * time.Second,
 		DialKeepAliveTime:    storeDialKeepAliveTime,
 		DialKeepAliveTimeout: storeDialKeepAliveTimeout,
-		PermitWithoutStream:  true,
 	}
 	if err := applySecurityConfig(&cfg); err != nil {
 		return cfg, err
@@ -499,11 +338,8 @@ func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 // are marked broken so their C++ owners receive a WATCH_BROKEN callback and
 // re-arm against the new client. The old client is closed only after the swap.
 //
-// This is used both by the exported reset wrapper and by the prefix-watch
-// goroutine when an etcd auth token expires: clientv3 never refreshes the
-// token for long-lived watch streams (etcd-io/etcd#12385, etcd-io/etcd#17623),
-// so the only reliable client-side fix is a brand-new client whose token
-// bundle is authenticated on first use.
+// This helper is used by the exported reset wrapper so the reset path and the
+// initial client creation path share the same security configuration handling.
 func rebuildStoreClient(endpoints []string) error {
 	cfg, cfgErr := newStoreClientConfig(endpoints)
 	if cfgErr != nil {
@@ -1134,7 +970,11 @@ func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, er
 }
 
 //export EtcdStoreTxnCompareAndPutWrapper
+<<<<<<< HEAD
 func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareRevisions *int64, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
+=======
+func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	cli := getStoreClient()
 	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
@@ -1151,7 +991,10 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 		compareKindList := (*[1 << 28]C.int)(unsafe.Pointer(compareKinds))[:cmpN:cmpN]
 		compareValuePtrs := (*[1 << 28]*C.char)(unsafe.Pointer(compareValues))[:cmpN:cmpN]
 		compareValueSizeList := (*[1 << 28]C.int)(unsafe.Pointer(compareValueSizes))[:cmpN:cmpN]
+<<<<<<< HEAD
 		compareRevisionList := (*[1 << 28]int64)(unsafe.Pointer(compareRevisions))[:cmpN:cmpN]
+=======
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 		for i := 0; i < cmpN; i++ {
 			k := C.GoStringN(compareKeyPtrs[i], compareKeySizeList[i])
 			switch int(compareKindList[i]) {
@@ -1160,8 +1003,11 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 				cmps = append(cmps, clientv3.Compare(clientv3.Value(k), "=", v))
 			case 1:
 				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", 0))
+<<<<<<< HEAD
 			case 2:
 				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", compareRevisionList[i]))
+=======
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 			default:
 				*errMsg = C.CString("unsupported compare kind")
 				return -1
@@ -1431,38 +1277,13 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 			close(doneCh)
 		}()
 
-		// Auth tokens issued by etcd have a server-side TTL (default 300s for
-		// the `simple` token type). When one expires the server kills the
-		// long-lived watch stream with `Unauthenticated: invalid auth token`.
-		// Re-issuing cli.Watch() opens a NEW watch stream whose client
-		// interceptor calls getToken() and attaches a fresh token, so the
-		// watch recovers here without tearing down and re-arming from C++.
-		// authRetries caps *consecutive* reconnects triggered solely by token
-		// expiry: it is reset on every successful Created, so a credential
-		// problem still surfaces as WATCH_BROKEN instead of retrying forever.
-		const maxAuthRetries = 5
-		authRetries := maxAuthRetries
-
-		// resumeRev is the next revision to watch from on reconnect so no
-		// events are missed between the stream dying and the reconnect.
-		// 0 means "from the current revision" (or the caller's startRevision).
-		resumeRev := int64(startRevision)
-		if resumeRev < 0 {
-			resumeRev = 0
+		// WithCreatedNotify makes etcd send an initial response with
+		// Created == true as soon as the watch is registered server-side.
+		opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithCreatedNotify()}
+		if startRevision > 0 {
+			opts = append(opts, clientv3.WithRev(int64(startRevision)))
 		}
-
-		// startWatch (re)creates the watch stream. Every call goes through the
-		// client interceptor, which re-authenticates when credentials are set.
-		startWatch := func() clientv3.WatchChan {
-			// WithCreatedNotify makes etcd send an initial response with
-			// Created == true as soon as the watch is registered server-side.
-			opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithCreatedNotify()}
-			if resumeRev > 0 {
-				opts = append(opts, clientv3.WithRev(resumeRev))
-			}
-			return cli.Watch(ctx, p, opts...)
-		}
-		watchChan := startWatch()
+		watchChan := cli.Watch(ctx, p, opts...)
 
 		for {
 			select {
@@ -1483,9 +1304,6 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 				// server-side watch is established; release the waiter.
 				if watchResp.Created {
 					signalCreated(true)
-					// A successful (re)connect resets the auth-retry budget so
-					// only *consecutive* token failures can exhaust it.
-					authRetries = maxAuthRetries
 				}
 				if watchResp.Err() != nil {
 					// Watch error. Check if context was cancelled.
@@ -1494,79 +1312,15 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 						return
 					default:
+						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
+						return
 					}
-					// Detect auth-token expiry. Both rpctypes.Error() and
-					// status.FromError() can return codes.Unknown for the same
-					// Unauthenticated failure, so fall back to matching the
-					// stable server-side description text as well.
-					st, _ := status.FromError(watchResp.Err())
-					errText := watchResp.Err().Error()
-					isAuthTokenErr := st.Code() == codes.Unauthenticated ||
-						strings.Contains(errText, "etcdserver: invalid auth token")
-					if isAuthTokenErr && authRetries > 0 {
-						// Probe with a plain unary Authenticate RPC to tell
-						// "server rejects our credentials / auth is broken"
-						// (probe_err != nil) apart from "only this client's
-						// cached token is stale" (probe_err == nil).
-						authRetries--
-						probeCtx, probeCancel := context.WithTimeout(ctx, 3*time.Second)
-						_, probeErr := cli.Auth.Authenticate(probeCtx, cli.Username, cli.Password)
-						probeCancel()
-						if probeErr == nil {
-							// Server is healthy and willing to issue a fresh
-							// token; the stale token lives only in this client's
-							// authTokenBundle, which clientv3 never refreshes
-							// for long-lived watch streams (etcd-io/etcd#12385,
-							// etcd-io/etcd#17623). Rebuilding the store client
-							// creates a fresh bundle that is authenticated on
-							// first use.
-							fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: auth token expired, rebuilding store client (retries left=%d): %v\n",
-								p, authRetries, watchResp.Err())
-							if rebuildErr := rebuildStoreClient(cli.Endpoints()); rebuildErr != nil {
-								fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: store client rebuild failed (%v), falling back to in-place reconnect\n",
-									p, rebuildErr)
-							} else {
-								// The rebuild cancelled every prefix watch
-								// (including this one) and swapped in a fresh
-								// client. Signal WATCH_BROKEN so the C++ side
-								// re-arms against the new client; any events
-								// missed between stream death and re-arm are
-								// replayed by the caller's resync logic.
-								notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
-								return
-							}
-						} else {
-							fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: auth token expired, reconnecting (retries left=%d, reauth_probe_err=%v): %v\n",
-								p, authRetries, probeErr, watchResp.Err())
-						}
-						select {
-						case <-ctx.Done():
-							notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
-							return
-						case <-time.After(200 * time.Millisecond):
-						}
-						watchChan = startWatch()
-						continue
-					}
-					// Log the concrete error before notifying C++ so the root
-					// cause (e.g. PermissionDenied, ErrCompacted, rpc error) is
-					// visible instead of being swallowed.
-					fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: watch response error (created=%v, rev=%d, auth_retries_left=%d): %v\n",
-						p, watchResp.Created, watchResp.Header.Revision, authRetries, watchResp.Err())
-					notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
-					return
 				}
 
 				// Use response-level revision as a more stable resume point.
 				respRev := int64(0)
 				if watchResp.Header.Revision > 0 {
 					respRev = watchResp.Header.Revision
-				}
-				// The whole response is processed synchronously before the next
-				// channel read, so on a reconnect we can safely resume right
-				// after this response's revision without loss or duplication.
-				if respRev+1 > resumeRev {
-					resumeRev = respRev + 1
 				}
 
 				for _, event := range watchResp.Events {

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -32,9 +32,14 @@ static inline void call_watch_cb(void* func,
 import "C"
 
 import (
+	"bufio"
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -44,9 +49,10 @@ import (
 	rpctypes "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// prefixWatchInfo stores cancel function and callback context for a prefix watch
 type prefixWatchInfo struct {
 	cancel          context.CancelFunc
 	callbackContext unsafe.Pointer
@@ -136,15 +142,193 @@ const (
 	maintenanceStartupTimeout = 5 * time.Second
 )
 
-func newStoreClientConfig(validEndpoints []string) clientv3.Config {
-	return clientv3.Config{
+// --- Security configuration (RBAC + TLS) loaded from environment variables ---
+//
+// Environment variables:
+//   MC_ETCD_CONF_FILE - Path to a file containing username=... and password=... lines.
+//   MC_ETCD_TLS_CA_CERT           - Path to the CA certificate file for server verification (one-way TLS).
+//   MC_ETCD_TLS_SERVER_NAME        - Optional: override the server name used for TLS SNI and certificate
+//                                     hostname verification. Useful when connecting via IP or a service
+//                                     name that differs from the certificate's SAN.
+//   MC_ETCD_TLS_INSECURE_SKIP_VERIFY - Set to "true" to skip server certificate verification. Only for
+//                                     testing environments; never use in production.
+//
+// All variables are optional. When none are set the behaviour is identical to before this feature.
+//
+// The configuration is loaded exactly once via sync.Once and cached, so even EtcdStoreResetClientWrapper
+// reuses the same parsed values without re-reading files.
+
+// securitySettings holds the cached RBAC and TLS configuration parsed from environment variables.
+// It is populated exactly once by loadSecurityConfig via sync.Once.
+type securitySettings struct {
+	username  string
+	password  string
+	tlsConfig *tls.Config
+	loadErr   error // non-nil when a configured resource failed to load
+}
+
+var (
+	securityOnce   sync.Once
+	cachedSecurity securitySettings
+)
+
+// parseRbacCredentialsFile reads a credentials file in key=value format and
+// returns the username and password. Expected format:
+//
+//	username=<user>
+//	password=<secret>
+//
+// Lines starting with '#' are treated as comments and ignored. Empty lines are skipped.
+func parseRbacCredentialsFile(path string) (string, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", fmt.Errorf("cannot open credentials file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	var username, password string
+	scanner := bufio.NewScanner(file)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		// Skip empty lines and comment lines.
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("credentials file %s line %d: invalid format, expected key=value", path, lineNo)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		switch key {
+		case "username":
+			username = value
+		case "password":
+			password = value
+		default:
+			return "", "", fmt.Errorf("credentials file %s line %d: unknown key %q, expected username or password", path, lineNo, key)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", "", fmt.Errorf("error reading credentials file %s: %w", path, err)
+	}
+	if username == "" {
+		return "", "", fmt.Errorf("username not found in credentials file %s", path)
+	}
+	if password == "" {
+		return "", "", fmt.Errorf("password not found in credentials file %s", path)
+	}
+	return username, password, nil
+}
+
+// loadSecurityConfig reads environment variables and populates the cached
+// securitySettings. This function is called exactly once via sync.Once.
+// Diagnostic messages are written to stderr so they never pollute stdout,
+// which callers may rely on for data.
+func loadSecurityConfig() {
+	// --- RBAC credentials from file ---
+	credsFile := os.Getenv("MC_ETCD_CONF_FILE")
+	if credsFile != "" {
+		username, password, err := parseRbacCredentialsFile(credsFile)
+		if err != nil {
+			cachedSecurity.loadErr = fmt.Errorf("failed to load RBAC credentials: %w", err)
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+			return
+		}
+		cachedSecurity.username = username
+		cachedSecurity.password = password
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] RBAC authentication enabled (user: %s)\n", username)
+	}
+
+	// --- TLS configuration (one-way: verify server) ---
+	caCertFile := os.Getenv("MC_ETCD_TLS_CA_CERT")
+	if caCertFile == "" {
+		// No TLS configured — this is fine, plaintext is the default.
+		return
+	}
+
+	caCert, err := os.ReadFile(caCertFile)
+	if err != nil {
+		cachedSecurity.loadErr = fmt.Errorf("failed to read CA certificate %s: %w", caCertFile, err)
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+		return
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		cachedSecurity.loadErr = fmt.Errorf("failed to parse CA certificate from %s (not valid PEM)", caCertFile)
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+		return
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS12,
+	}
+
+	// Optional: override the server name used for SNI and hostname verification.
+	if serverName := os.Getenv("MC_ETCD_TLS_SERVER_NAME"); serverName != "" {
+		tlsCfg.ServerName = serverName
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS ServerName override: %s\n", serverName)
+	}
+
+	// Optional: skip certificate verification (testing only).
+	if os.Getenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY") == "true" {
+		tlsCfg.InsecureSkipVerify = true
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] WARNING: TLS InsecureSkipVerify is enabled — not safe for production\n")
+	}
+
+	cachedSecurity.tlsConfig = tlsCfg
+	fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS enabled (CA: %s)\n", caCertFile)
+}
+
+// applySecurityConfig applies the cached security configuration (RBAC credentials
+// and TLS settings) to the given clientv3.Config. The configuration is loaded
+// lazily on first call via sync.Once.
+//
+// Returns nil on success or when no security environment variables are set.
+// Returns an error when a configured resource (RBAC file, CA certificate) fails
+// to load — the caller must abort client creation in this case to avoid falling
+// back to an unauthenticated connection.
+func applySecurityConfig(cfg *clientv3.Config) error {
+	securityOnce.Do(loadSecurityConfig)
+
+	if cachedSecurity.loadErr != nil {
+		return cachedSecurity.loadErr
+	}
+
+	cfg.Username = cachedSecurity.username
+	cfg.Password = cachedSecurity.password
+	cfg.TLS = cachedSecurity.tlsConfig
+	return nil
+}
+
+// newStoreClientConfig builds the base clientv3.Config for the store etcd client
+// and applies any security configuration (RBAC / TLS) from environment variables.
+// The caller must check the returned error and abort client creation on failure:
+// falling back to an unauthenticated connection when credentials are configured
+// would be a security issue.
+func newStoreClientConfig(validEndpoints []string) (clientv3.Config, error) {
+	cfg := clientv3.Config{
 		Endpoints:            validEndpoints,
 		DialTimeout:          5 * time.Second,
 		DialKeepAliveTime:    storeDialKeepAliveTime,
 		DialKeepAliveTimeout: storeDialKeepAliveTimeout,
+		PermitWithoutStream:  true,
 	}
+	if err := applySecurityConfig(&cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
 }
 
+// parseEtcdEndpoints converts the C endpoint string into a []string suitable
+// for clientv3.Config.Endpoints. It normalises comma separators to semicolons,
+// trims whitespace, and filters empty entries. The scheme prefixes (etcd://,
+// http://) are handled by the C++ callers, which already pass bare host:port
+// endpoints, so no stripping is done here.
 func parseEtcdEndpoints(endpoints *C.char) []string {
 	if endpoints == nil {
 		return nil
@@ -173,29 +357,23 @@ func NewEtcdClient(endpoints *C.char, errMsg **C.char) int {
 	}
 
 	MaxMsgSize := 32 * 1024 * 1024
-	endpointStr := C.GoString(endpoints)
-	// Support multiple endpoints separated by comma or semicolon
-	// Normalize separators to semicolon first, then split
-	endpointStr = strings.ReplaceAll(endpointStr, ",", ";")
-	parts := strings.Split(endpointStr, ";")
-	var validEndpoints []string
-	for _, ep := range parts {
-		ep = strings.TrimSpace(ep)
-		if ep != "" {
-			validEndpoints = append(validEndpoints, ep)
-		}
-	}
+	validEndpoints := parseEtcdEndpoints(endpoints)
 	if len(validEndpoints) == 0 {
 		*errMsg = C.CString("no valid endpoints provided")
 		return -1
 	}
 
-	cli, err := clientv3.New(clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:          validEndpoints,
 		DialTimeout:        5 * time.Second,
 		MaxCallSendMsgSize: MaxMsgSize,
 		MaxCallRecvMsgSize: MaxMsgSize,
-	})
+	}
+	if err := applySecurityConfig(&cfg); err != nil {
+		*errMsg = C.CString(fmt.Sprintf("security config error: %v", err))
+		return -1
+	}
+	cli, err := clientv3.New(cfg)
 
 	if err != nil {
 		*errMsg = C.CString(err.Error())
@@ -299,7 +477,12 @@ func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 		return -1
 	}
 
-	cli, err := clientv3.New(newStoreClientConfig(validEndpoints))
+	cfg, cfgErr := newStoreClientConfig(validEndpoints)
+	if cfgErr != nil {
+		*errMsg = C.CString(fmt.Sprintf("etcd store client config error: %v", cfgErr))
+		return -1
+	}
+	cli, err := clientv3.New(cfg)
 
 	if err != nil {
 		*errMsg = C.CString(err.Error())
@@ -310,18 +493,25 @@ func NewStoreEtcdClient(endpoints *C.char, errMsg **C.char) int {
 	return 0
 }
 
-//export EtcdStoreResetClientWrapper
-func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
-	validEndpoints := parseEtcdEndpoints(endpoints)
-	if len(validEndpoints) == 0 {
-		*errMsg = C.CString("no valid endpoints provided")
-		return -1
+// rebuildStoreClient creates a brand-new store etcd client and atomically
+// swaps it into storeClient. All keep-alive goroutines, per-key watches and
+// prefix watches bound to the old client are torn down first; prefix watches
+// are marked broken so their C++ owners receive a WATCH_BROKEN callback and
+// re-arm against the new client. The old client is closed only after the swap.
+//
+// This is used both by the exported reset wrapper and by the prefix-watch
+// goroutine when an etcd auth token expires: clientv3 never refreshes the
+// token for long-lived watch streams (etcd-io/etcd#12385, etcd-io/etcd#17623),
+// so the only reliable client-side fix is a brand-new client whose token
+// bundle is authenticated on first use.
+func rebuildStoreClient(endpoints []string) error {
+	cfg, cfgErr := newStoreClientConfig(endpoints)
+	if cfgErr != nil {
+		return cfgErr
 	}
-
-	cli, err := clientv3.New(newStoreClientConfig(validEndpoints))
+	cli, err := clientv3.New(cfg)
 	if err != nil {
-		*errMsg = C.CString(err.Error())
-		return -1
+		return err
 	}
 
 	cancelAllStoreKeepAlives()
@@ -337,7 +527,21 @@ func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
 	if oldClient != nil {
 		oldClient.Close()
 	}
+	return nil
+}
 
+//export EtcdStoreResetClientWrapper
+func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
+	validEndpoints := parseEtcdEndpoints(endpoints)
+	if len(validEndpoints) == 0 {
+		*errMsg = C.CString("no valid endpoints provided")
+		return -1
+	}
+
+	if err := rebuildStoreClient(validEndpoints); err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
 	return 0
 }
 
@@ -350,31 +554,23 @@ func NewSnapshotEtcdClient(endpoints *C.char, errMsg **C.char) int {
 		return -2
 	}
 
-	endpointStr := C.GoString(endpoints)
-	// Support multiple endpoints separated by comma or semicolon
-	endpointStr = strings.ReplaceAll(endpointStr, ",", ";")
-	endpointList := strings.Split(endpointStr, ";")
-
-	// Filter out any empty strings that might result from splitting
-	var validEndpoints []string
-	for _, ep := range endpointList {
-		ep = strings.TrimSpace(ep)
-		if ep != "" {
-			validEndpoints = append(validEndpoints, ep)
-		}
-	}
-
+	validEndpoints := parseEtcdEndpoints(endpoints)
 	if len(validEndpoints) == 0 {
 		*errMsg = C.CString("no valid endpoints provided")
 		return -1
 	}
 
-	cli, err := clientv3.New(clientv3.Config{
+	cfg := clientv3.Config{
 		Endpoints:          validEndpoints,
 		DialTimeout:        10 * time.Second,
 		MaxCallSendMsgSize: snapshotMaxMsgSize,
 		MaxCallRecvMsgSize: snapshotMaxMsgSize,
-	})
+	}
+	if err := applySecurityConfig(&cfg); err != nil {
+		*errMsg = C.CString(fmt.Sprintf("security config error: %v", err))
+		return -1
+	}
+	cli, err := clientv3.New(cfg)
 
 	if err != nil {
 		*errMsg = C.CString(err.Error())
@@ -1235,13 +1431,38 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 			close(doneCh)
 		}()
 
-		// WithCreatedNotify makes etcd send an initial response with
-		// Created == true as soon as the watch is registered server-side.
-		opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithCreatedNotify()}
-		if startRevision > 0 {
-			opts = append(opts, clientv3.WithRev(int64(startRevision)))
+		// Auth tokens issued by etcd have a server-side TTL (default 300s for
+		// the `simple` token type). When one expires the server kills the
+		// long-lived watch stream with `Unauthenticated: invalid auth token`.
+		// Re-issuing cli.Watch() opens a NEW watch stream whose client
+		// interceptor calls getToken() and attaches a fresh token, so the
+		// watch recovers here without tearing down and re-arming from C++.
+		// authRetries caps *consecutive* reconnects triggered solely by token
+		// expiry: it is reset on every successful Created, so a credential
+		// problem still surfaces as WATCH_BROKEN instead of retrying forever.
+		const maxAuthRetries = 5
+		authRetries := maxAuthRetries
+
+		// resumeRev is the next revision to watch from on reconnect so no
+		// events are missed between the stream dying and the reconnect.
+		// 0 means "from the current revision" (or the caller's startRevision).
+		resumeRev := int64(startRevision)
+		if resumeRev < 0 {
+			resumeRev = 0
 		}
-		watchChan := cli.Watch(ctx, p, opts...)
+
+		// startWatch (re)creates the watch stream. Every call goes through the
+		// client interceptor, which re-authenticates when credentials are set.
+		startWatch := func() clientv3.WatchChan {
+			// WithCreatedNotify makes etcd send an initial response with
+			// Created == true as soon as the watch is registered server-side.
+			opts := []clientv3.OpOption{clientv3.WithPrefix(), clientv3.WithCreatedNotify()}
+			if resumeRev > 0 {
+				opts = append(opts, clientv3.WithRev(resumeRev))
+			}
+			return cli.Watch(ctx, p, opts...)
+		}
+		watchChan := startWatch()
 
 		for {
 			select {
@@ -1262,6 +1483,9 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 				// server-side watch is established; release the waiter.
 				if watchResp.Created {
 					signalCreated(true)
+					// A successful (re)connect resets the auth-retry budget so
+					// only *consecutive* token failures can exhaust it.
+					authRetries = maxAuthRetries
 				}
 				if watchResp.Err() != nil {
 					// Watch error. Check if context was cancelled.
@@ -1270,15 +1494,79 @@ func EtcdStoreWatchWithPrefixFromRevisionWrapper(prefix *C.char, prefixSize C.in
 						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
 						return
 					default:
-						notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
-						return
 					}
+					// Detect auth-token expiry. Both rpctypes.Error() and
+					// status.FromError() can return codes.Unknown for the same
+					// Unauthenticated failure, so fall back to matching the
+					// stable server-side description text as well.
+					st, _ := status.FromError(watchResp.Err())
+					errText := watchResp.Err().Error()
+					isAuthTokenErr := st.Code() == codes.Unauthenticated ||
+						strings.Contains(errText, "etcdserver: invalid auth token")
+					if isAuthTokenErr && authRetries > 0 {
+						// Probe with a plain unary Authenticate RPC to tell
+						// "server rejects our credentials / auth is broken"
+						// (probe_err != nil) apart from "only this client's
+						// cached token is stale" (probe_err == nil).
+						authRetries--
+						probeCtx, probeCancel := context.WithTimeout(ctx, 3*time.Second)
+						_, probeErr := cli.Auth.Authenticate(probeCtx, cli.Username, cli.Password)
+						probeCancel()
+						if probeErr == nil {
+							// Server is healthy and willing to issue a fresh
+							// token; the stale token lives only in this client's
+							// authTokenBundle, which clientv3 never refreshes
+							// for long-lived watch streams (etcd-io/etcd#12385,
+							// etcd-io/etcd#17623). Rebuilding the store client
+							// creates a fresh bundle that is authenticated on
+							// first use.
+							fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: auth token expired, rebuilding store client (retries left=%d): %v\n",
+								p, authRetries, watchResp.Err())
+							if rebuildErr := rebuildStoreClient(cli.Endpoints()); rebuildErr != nil {
+								fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: store client rebuild failed (%v), falling back to in-place reconnect\n",
+									p, rebuildErr)
+							} else {
+								// The rebuild cancelled every prefix watch
+								// (including this one) and swapped in a fresh
+								// client. Signal WATCH_BROKEN so the C++ side
+								// re-arms against the new client; any events
+								// missed between stream death and re-arm are
+								// replayed by the caller's resync logic.
+								notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
+								return
+							}
+						} else {
+							fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: auth token expired, reconnecting (retries left=%d, reauth_probe_err=%v): %v\n",
+								p, authRetries, probeErr, watchResp.Err())
+						}
+						select {
+						case <-ctx.Done():
+							notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, false)
+							return
+						case <-time.After(200 * time.Millisecond):
+						}
+						watchChan = startWatch()
+						continue
+					}
+					// Log the concrete error before notifying C++ so the root
+					// cause (e.g. PermissionDenied, ErrCompacted, rpc error) is
+					// visible instead of being swallowed.
+					fmt.Fprintf(os.Stderr, "[etcd_wrapper] prefix=%s: watch response error (created=%v, rev=%d, auth_retries_left=%d): %v\n",
+						p, watchResp.Created, watchResp.Header.Revision, authRetries, watchResp.Err())
+					notifyStorePrefixWatchBrokenOnce(p, callbackContext, callbackFunc, true)
+					return
 				}
 
 				// Use response-level revision as a more stable resume point.
 				respRev := int64(0)
 				if watchResp.Header.Revision > 0 {
 					respRev = watchResp.Header.Revision
+				}
+				// The whole response is processed synchronously before the next
+				// channel read, so on a reconnect we can safely resume right
+				// after this response's revision without loss or duplication.
+				if respRev+1 > resumeRev {
+					resumeRev = respRev + 1
 				}
 
 				for _, event := range watchResp.Events {

--- a/mooncake-common/etcd/etcd_wrapper_test.go
+++ b/mooncake-common/etcd/etcd_wrapper_test.go
@@ -1,11 +1,26 @@
 package main
 
 import (
+<<<<<<< HEAD
 	"context"
+=======
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	"testing"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
+<<<<<<< HEAD
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
@@ -38,5 +53,180 @@ func TestNewMaintenanceSessionCancelsStartup(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("maintenance session startup did not cancel")
+=======
+)
+
+func resetSecurityStateForTest(t *testing.T) {
+	t.Helper()
+	securityOnce = sync.Once{}
+	cachedSecurity = securitySettings{}
+}
+
+func writeTempFile(t *testing.T, name string, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
+}
+
+func writeTempCACert(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "mooncake-test-ca",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return writeTempFile(t, "ca.crt", string(pemBytes))
+}
+
+func TestParseRbacCredentialsFile(t *testing.T) {
+	path := writeTempFile(t, "credentials.conf", "# comment\n\nusername = mooncake\npassword= secret-value \n")
+
+	username, password, err := parseRbacCredentialsFile(path)
+	if err != nil {
+		t.Fatalf("parseRbacCredentialsFile returned error: %v", err)
+	}
+	if username != "mooncake" {
+		t.Fatalf("unexpected username: %q", username)
+	}
+	if password != "secret-value" {
+		t.Fatalf("unexpected password: %q", password)
+	}
+}
+
+func TestParseRbacCredentialsFileRejectsUnknownKey(t *testing.T) {
+	path := writeTempFile(t, "credentials.conf", "username=mooncake\nrole=admin\npassword=secret\n")
+
+	_, _, err := parseRbacCredentialsFile(path)
+	if err == nil || !strings.Contains(err.Error(), "unknown key") {
+		t.Fatalf("expected unknown key error, got: %v", err)
+	}
+}
+
+func TestApplySecurityConfigDefaultsToPlaintext(t *testing.T) {
+	resetSecurityStateForTest(t)
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", "")
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+	if cfg.Username != "" || cfg.Password != "" {
+		t.Fatalf("expected empty auth config, got user=%q", cfg.Username)
+	}
+	if cfg.TLS != nil {
+		t.Fatalf("expected nil TLS config by default")
+	}
+}
+
+func TestApplySecurityConfigRejectsIncompleteTLSOverride(t *testing.T) {
+	resetSecurityStateForTest(t)
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", "")
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "etcd.internal")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "")
+
+	cfg := clientv3.Config{}
+	err := applySecurityConfig(&cfg)
+	if err == nil || !strings.Contains(err.Error(), "requires TLS to be enabled") {
+		t.Fatalf("expected incomplete TLS config error, got: %v", err)
+	}
+	if cfg.TLS != nil {
+		t.Fatalf("expected TLS config to remain nil on error")
+	}
+}
+
+func TestApplySecurityConfigAllowsInsecureTLSWithoutCA(t *testing.T) {
+	resetSecurityStateForTest(t)
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", "")
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "true")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+	if cfg.TLS == nil {
+		t.Fatalf("expected TLS config to be populated")
+	}
+	if !cfg.TLS.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify to be true")
+	}
+	if cfg.TLS.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected TLS min version: %v", cfg.TLS.MinVersion)
+	}
+	if cfg.TLS.RootCAs != nil {
+		t.Fatalf("expected RootCAs to be nil when no CA is provided")
+	}
+}
+
+func TestApplySecurityConfigRejectsInvalidInsecureSkipVerifyValue(t *testing.T) {
+	resetSecurityStateForTest(t)
+	caPath := writeTempCACert(t)
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", caPath)
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "maybe")
+
+	cfg := clientv3.Config{}
+	err := applySecurityConfig(&cfg)
+	if err == nil || !strings.Contains(err.Error(), "expected true or false") {
+		t.Fatalf("expected invalid boolean error, got: %v", err)
+	}
+}
+
+func TestApplySecurityConfigLoadsRbacAndTLS(t *testing.T) {
+	resetSecurityStateForTest(t)
+	credsPath := writeTempFile(t, "credentials.conf", "username=mooncake\npassword=secret\n")
+	caPath := writeTempCACert(t)
+	t.Setenv("MC_ETCD_CONF_FILE", credsPath)
+	t.Setenv("MC_ETCD_TLS_CA_CERT", caPath)
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "etcd.internal")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "true")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+	if cfg.Username != "mooncake" || cfg.Password != "secret" {
+		t.Fatalf("unexpected auth config: user=%q password=%q", cfg.Username, cfg.Password)
+	}
+	if cfg.TLS == nil {
+		t.Fatalf("expected TLS config to be populated")
+	}
+	if cfg.TLS.ServerName != "etcd.internal" {
+		t.Fatalf("unexpected TLS server name: %q", cfg.TLS.ServerName)
+	}
+	if !cfg.TLS.InsecureSkipVerify {
+		t.Fatalf("expected InsecureSkipVerify to be true")
+	}
+	if cfg.TLS.MinVersion != tls.VersionTLS12 {
+		t.Fatalf("unexpected TLS min version: %v", cfg.TLS.MinVersion)
+	}
+	if cfg.TLS.RootCAs == nil {
+		t.Fatalf("expected RootCAs to be populated")
+>>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	}
 }

--- a/mooncake-common/etcd/etcd_wrapper_test.go
+++ b/mooncake-common/etcd/etcd_wrapper_test.go
@@ -10,7 +10,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -95,6 +97,114 @@ func writeTempCACert(t *testing.T) string {
 	}
 	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
 	return writeTempFile(t, "ca.crt", string(pemBytes))
+}
+
+func generateTestCA(t *testing.T) (*x509.Certificate, *rsa.PrivateKey, []byte) {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "mooncake-test-ca",
+		},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse certificate: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return cert, key, pemBytes
+}
+
+func generateServerTLSConfig(t *testing.T, caCert *x509.Certificate, caKey *rsa.PrivateKey, dnsName string) *tls.Config {
+	t.Helper()
+
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			CommonName: dnsName,
+		},
+		DNSNames:              []string{dnsName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, caCert, &serverKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+	serverCert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatalf("X509KeyPair: %v", err)
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   tls.VersionTLS12,
+	}
+}
+
+func runSingleTLSHandshake(t *testing.T, serverTLS *tls.Config, clientTLS *tls.Config) error {
+	t.Helper()
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", serverTLS)
+	if err != nil {
+		t.Fatalf("tls.Listen: %v", err)
+	}
+	defer ln.Close()
+
+	serverErrCh := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			serverErrCh <- err
+			return
+		}
+		defer conn.Close()
+		tc, ok := conn.(*tls.Conn)
+		if !ok {
+			serverErrCh <- errors.New("expected tls.Conn")
+			return
+		}
+		serverErrCh <- tc.Handshake()
+	}()
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), clientTLS)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	if err := conn.Handshake(); err != nil {
+		return err
+	}
+
+	serverErr := <-serverErrCh
+	if serverErr != nil {
+		return serverErr
+	}
+	return nil
 }
 
 func TestParseRbacCredentialsFile(t *testing.T) {
@@ -228,5 +338,79 @@ func TestApplySecurityConfigLoadsRbacAndTLS(t *testing.T) {
 	if cfg.TLS.RootCAs == nil {
 		t.Fatalf("expected RootCAs to be populated")
 >>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
+	}
+}
+
+func TestTLSHandshakeSucceedsWithTrustedCAAndServerName(t *testing.T) {
+	resetSecurityStateForTest(t)
+	caCert, caKey, caPEM := generateTestCA(t)
+	caPath := writeTempFile(t, "ca.crt", string(caPEM))
+
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", caPath)
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "etcd.internal")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "false")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+
+	serverTLS := generateServerTLSConfig(t, caCert, caKey, "etcd.internal")
+	if err := runSingleTLSHandshake(t, serverTLS, cfg.TLS); err != nil {
+		t.Fatalf("expected handshake to succeed, got: %v", err)
+	}
+}
+
+func TestTLSHandshakeFailsWithUntrustedCA(t *testing.T) {
+	resetSecurityStateForTest(t)
+	caCert, caKey, _ := generateTestCA(t)
+	trustedCert, _, trustedPEM := generateTestCA(t)
+	trustedCAPath := writeTempFile(t, "trusted-ca.crt", string(trustedPEM))
+
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", trustedCAPath)
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "etcd.internal")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "false")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+
+	serverTLS := generateServerTLSConfig(t, caCert, caKey, "etcd.internal")
+	err := runSingleTLSHandshake(t, serverTLS, cfg.TLS)
+	if err == nil {
+		t.Fatalf("expected handshake to fail")
+	}
+	var opErr *net.OpError
+	if !errors.As(err, &opErr) && !strings.Contains(err.Error(), "unknown") && !strings.Contains(err.Error(), "certificate") {
+		t.Fatalf("unexpected handshake error: %v", err)
+	}
+	_ = trustedCert
+}
+
+func TestTLSHandshakeFailsOnHostnameMismatch(t *testing.T) {
+	resetSecurityStateForTest(t)
+	caCert, caKey, caPEM := generateTestCA(t)
+	caPath := writeTempFile(t, "ca.crt", string(caPEM))
+
+	t.Setenv("MC_ETCD_CONF_FILE", "")
+	t.Setenv("MC_ETCD_TLS_CA_CERT", caPath)
+	t.Setenv("MC_ETCD_TLS_SERVER_NAME", "wrong.internal")
+	t.Setenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY", "false")
+
+	cfg := clientv3.Config{}
+	if err := applySecurityConfig(&cfg); err != nil {
+		t.Fatalf("applySecurityConfig returned error: %v", err)
+	}
+
+	serverTLS := generateServerTLSConfig(t, caCert, caKey, "etcd.internal")
+	err := runSingleTLSHandshake(t, serverTLS, cfg.TLS)
+	if err == nil {
+		t.Fatalf("expected handshake to fail")
+	}
+	if !strings.Contains(err.Error(), "certificate") && !strings.Contains(err.Error(), "hostname") && !strings.Contains(err.Error(), "valid for") {
+		t.Fatalf("unexpected handshake error: %v", err)
 	}
 }

--- a/mooncake-common/etcd/etcd_wrapper_test.go
+++ b/mooncake-common/etcd/etcd_wrapper_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-<<<<<<< HEAD
 	"context"
-=======
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -17,12 +15,10 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	"testing"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
-<<<<<<< HEAD
 	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
@@ -55,8 +51,8 @@ func TestNewMaintenanceSessionCancelsStartup(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("maintenance session startup did not cancel")
-=======
-)
+	}
+}
 
 func resetSecurityStateForTest(t *testing.T) {
 	t.Helper()
@@ -337,7 +333,6 @@ func TestApplySecurityConfigLoadsRbacAndTLS(t *testing.T) {
 	}
 	if cfg.TLS.RootCAs == nil {
 		t.Fatalf("expected RootCAs to be populated")
->>>>>>> 2b0ef06b ([Common] Narrow etcd RBAC/TLS wrapper scope and add tests)
 	}
 }
 

--- a/mooncake-common/etcd/security_config.go
+++ b/mooncake-common/etcd/security_config.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"bufio"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"unicode"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+// securitySettings holds the cached RBAC and TLS configuration parsed from
+// environment variables. It is populated exactly once by loadSecurityConfig via
+// sync.Once.
+type securitySettings struct {
+	username  string
+	password  string
+	tlsConfig *tls.Config
+	loadErr   error
+}
+
+var (
+	securityOnce   sync.Once
+	cachedSecurity securitySettings
+)
+
+// parseRbacCredentialsFile reads a credentials file in key=value format and
+// returns the username and password. Expected format:
+//
+//	username=<user>
+//	password=<secret>
+func parseRbacCredentialsFile(path string) (string, string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", "", fmt.Errorf("cannot open credentials file %s: %w", path, err)
+	}
+	defer file.Close()
+
+	var username, password string
+	scanner := bufio.NewScanner(file)
+	lineNo := 0
+	for scanner.Scan() {
+		lineNo++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("credentials file %s line %d: invalid format, expected key=value", path, lineNo)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		switch key {
+		case "username":
+			username = value
+		case "password":
+			password = value
+		default:
+			return "", "", fmt.Errorf("credentials file %s line %d: unknown key %q, expected username or password", path, lineNo, key)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", "", fmt.Errorf("error reading credentials file %s: %w", path, err)
+	}
+	if username == "" {
+		return "", "", fmt.Errorf("username not found in credentials file %s", path)
+	}
+	if password == "" {
+		return "", "", fmt.Errorf("password not found in credentials file %s", path)
+	}
+	return username, password, nil
+}
+
+// loadSecurityConfig reads environment variables and populates the cached
+// security settings. Diagnostic messages are written to stderr so they never
+// pollute stdout, which callers may rely on for data.
+func loadSecurityConfig() {
+	credsFile := os.Getenv("MC_ETCD_CONF_FILE")
+	if credsFile != "" {
+		username, password, err := parseRbacCredentialsFile(credsFile)
+		if err != nil {
+			cachedSecurity.loadErr = fmt.Errorf("failed to load RBAC credentials: %w", err)
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+			return
+		}
+		cachedSecurity.username = username
+		cachedSecurity.password = password
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] RBAC authentication enabled (user: %s)\n", username)
+	}
+
+	normalizeEnvValue := func(v string) string {
+		v = strings.Map(func(r rune) rune {
+			if unicode.IsControl(r) {
+				return -1
+			}
+			return r
+		}, v)
+		v = strings.TrimSpace(v)
+		v = strings.Trim(v, "\"")
+		v = strings.Trim(v, "\x00")
+		return strings.TrimSpace(v)
+	}
+
+	caCertFile := normalizeEnvValue(os.Getenv("MC_ETCD_TLS_CA_CERT"))
+	serverName := normalizeEnvValue(os.Getenv("MC_ETCD_TLS_SERVER_NAME"))
+	insecureSkipVerify := strings.ToLower(strings.TrimSpace(os.Getenv("MC_ETCD_TLS_INSECURE_SKIP_VERIFY")))
+	if caCertFile == "" {
+		switch insecureSkipVerify {
+		case "", "false":
+			if serverName != "" {
+				cachedSecurity.loadErr = errors.New("MC_ETCD_TLS_SERVER_NAME requires TLS to be enabled (set MC_ETCD_TLS_CA_CERT or MC_ETCD_TLS_INSECURE_SKIP_VERIFY=true)")
+				fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+				return
+			}
+			return
+		case "true":
+			tlsCfg := &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true,
+			}
+			if serverName != "" {
+				tlsCfg.ServerName = serverName
+				fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS ServerName override: %s\n", serverName)
+			}
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] WARNING: TLS InsecureSkipVerify is enabled without a CA certificate — not safe for production\n")
+			cachedSecurity.tlsConfig = tlsCfg
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS enabled (insecure, no CA)\n")
+			return
+		default:
+			cachedSecurity.loadErr = fmt.Errorf(
+				"invalid MC_ETCD_TLS_INSECURE_SKIP_VERIFY value %q, expected true or false",
+				insecureSkipVerify,
+			)
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+			return
+		}
+	}
+
+	caCert, err := os.ReadFile(caCertFile)
+	if err != nil {
+		cachedSecurity.loadErr = fmt.Errorf("failed to read CA certificate %q: %w", caCertFile, err)
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+		return
+	}
+
+	caCertPool := x509.NewCertPool()
+	if !caCertPool.AppendCertsFromPEM(caCert) {
+		cachedSecurity.loadErr = fmt.Errorf("failed to parse CA certificate from %s (not valid PEM)", caCertFile)
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+		return
+	}
+
+	tlsCfg := &tls.Config{
+		RootCAs:    caCertPool,
+		MinVersion: tls.VersionTLS12,
+	}
+	if serverName != "" {
+		tlsCfg.ServerName = serverName
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS ServerName override: %s\n", serverName)
+	}
+
+	switch insecureSkipVerify {
+	case "":
+	case "false":
+	case "true":
+		if insecureSkipVerify == "true" {
+			tlsCfg.InsecureSkipVerify = true
+			fmt.Fprintf(os.Stderr, "[etcd_wrapper] WARNING: TLS InsecureSkipVerify is enabled — not safe for production\n")
+		}
+	default:
+		cachedSecurity.loadErr = fmt.Errorf(
+			"invalid MC_ETCD_TLS_INSECURE_SKIP_VERIFY value %q, expected true or false",
+			insecureSkipVerify,
+		)
+		fmt.Fprintf(os.Stderr, "[etcd_wrapper] ERROR: %v\n", cachedSecurity.loadErr)
+		return
+	}
+
+	cachedSecurity.tlsConfig = tlsCfg
+	fmt.Fprintf(os.Stderr, "[etcd_wrapper] TLS enabled (CA: %s)\n", caCertFile)
+}
+
+// applySecurityConfig applies the cached security configuration (RBAC
+// credentials and TLS settings) to the given clientv3.Config.
+func applySecurityConfig(cfg *clientv3.Config) error {
+	securityOnce.Do(loadSecurityConfig)
+
+	if cachedSecurity.loadErr != nil {
+		return cachedSecurity.loadErr
+	}
+
+	cfg.Username = cachedSecurity.username
+	cfg.Password = cachedSecurity.password
+	cfg.TLS = cachedSecurity.tlsConfig
+	return nil
+}


### PR DESCRIPTION
## Description

This revision narrows the scope strictly to RBAC authentication and TLS configuration/validation for the existing Go etcd wrapper (`mooncake-common/etcd/etcd_wrapper.go`).

Changes in this revision:

- restore `EtcdStoreTxnCompareAndPutWrapper` to preserve the existing Store export surface
- remove `PermitWithoutStream: true`
- remove token-expiry watch recovery / global store-client rebuild logic from this PR
- keep RBAC + TLS configuration environment-driven, without requiring C++ call-site changes
- reject invalid TLS configuration combinations instead of silently falling back to plaintext
- add Go unit tests covering credential parsing and TLS config validation
- update deployment documentation accordingly

Note on #2726:
This PR only adds minimal environment-driven RBAC + TLS configuration/validation for the existing Go etcd wrapper entrypoints (plus tests/docs alignment). It does not introduce a cross-component TLS framework (e.g., Python/C API changes, mTLS, cert rotation, shared config objects).

## How Has This Been Tested?

### Automated

```bash
cd /Mooncake/mooncake-common/etcd
go test ./...
```

Output:

```text
ok      github.com/kvcache-ai/Mooncake/mooncake-common/etcd     0.089s
```

### Environment validation

1) Build shared library with cgo enabled and verify restored export:

```bash
cd /Mooncake/mooncake-common/etcd
go build -buildmode=c-shared -o libetcd_wrapper.so
ls -l libetcd_wrapper.so libetcd_wrapper.h
nm -D libetcd_wrapper.so | grep EtcdStoreTxnCompareAndPutWrapper
```

Key output:

```text
-rw-r--r-- 1 root root     6464 Aug 21 10:57 libetcd_wrapper.h
-rw-r--r-- 1 root root 22487464 Aug 21 10:57 libetcd_wrapper.so
00000000007dd240 T EtcdStoreTxnCompareAndPutWrapper
```

2) Verify `mooncake-store` builds/links successfully (Store + Common + Integration build):

```bash
cd /Mooncake/build
cmake -G Ninja .. \
  -DBUILD_UNIT_TESTS=OFF \
  -DUSE_TENT=OFF \
  -DUSE_HTTP=ON \
  -DUSE_ETCD=ON \
  -DSTORE_USE_ETCD=ON \
  -DUSE_CUDA=OFF \
  -DUSE_MUSA=OFF \
  -DUSE_HIP=OFF \
  -DUSE_NVMEOF=OFF \
  -DUSE_MNNVL=OFF \
  -DUSE_ASCEND=OFF \
  -DUSE_ASCEND_DIRECT=OFF \
  -DUSE_UBSHMEM=OFF \
  -DUSE_ASCEND_HETEROGENEOUS=OFF \
  -DWITH_EP=OFF \
  -DCMAKE_BUILD_TYPE=Release && \
  cmake --build . -j"$(nproc)"
```

Key output:

```text
-- Mooncake Store will be built
-- Build files have been written to: /Mooncake/build
[190/190] Linking CXX shared module mooncake-integration/store.cpython-312-x86_64-linux-gnu.so
```

3) Secured etcd smoke test (RBAC + TLS), using `MooncakeDistributedStore` put/get:

Env:

```bash
export MC_ETCD_CONF_FILE=/etc/mooncake/etcd/conf
export MC_ETCD_TLS_CA_CERT=/etc/mooncake/etcd/ca.pem
export MC_ETCD_TLS_SERVER_NAME=""
unset MC_ETCD_TLS_INSECURE_SKIP_VERIFY
```

Key output:

```text
[etcd_wrapper] RBAC authentication enabled (user: root)
[etcd_wrapper] TLS enabled (CA: /etc/mooncake/etcd/ca.pem)
PUT/GET OK
key = smoke/677924714c094fc3acf80f4f3b90726a
sha256 = f12cf47a410d3aae132e4cb100aef185a6f521b5b26c2014ffa4a9c6885ea1f8
```

4) Negative-path validation:

- `MC_ETCD_TLS_SERVER_NAME` without enabling TLS fails fast (no silent plaintext fallback):

```text
[etcd_wrapper] ERROR: MC_ETCD_TLS_SERVER_NAME requires TLS to be enabled (set MC_ETCD_TLS_CA_CERT or MC_ETCD_TLS_INSECURE_SKIP_VERIFY=true)
```

- Invalid CA path fails fast:

```text
[etcd_wrapper] ERROR: failed to read CA certificate "asd2": open asd2: no such file or directory
```

- Invalid boolean value fails fast:

```text
[etcd_wrapper] ERROR: invalid MC_ETCD_TLS_INSECURE_SKIP_VERIFY value "maybe", expected true or false
```

### Notes

- `MC_ETCD_TLS_INSECURE_SKIP_VERIFY=true` without `MC_ETCD_TLS_CA_CERT` enables insecure TLS (encryption without server verification), for testing only.
