### PR TITLE
[TransferEngine] Reuse TCP CUDA staging buffers across chunks

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cassert>
 #include <cctype>
 #include <chrono>
@@ -36,6 +37,7 @@
 #include <mutex>
 #include <optional>
 #include <type_traits>
+#include <vector>
 
 #include "common.h"
 #include "transfer_engine.h"
@@ -68,6 +70,20 @@ LaneObserverHook lane_observer_hook = nullptr;
 LaneFailureReasonHook lane_failure_reason_hook = nullptr;
 SessionProgressHook session_progress_hook = nullptr;
 StartTransferMetadataHook start_transfer_metadata_hook = nullptr;
+std::atomic<size_t> staging_buffer_allocation_count{0};
+std::atomic<size_t> staging_device_query_count{0};
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+void recordStagingBufferAllocationForTest() noexcept {
+    staging_buffer_allocation_count.fetch_add(1, std::memory_order_relaxed);
+}
+
+void recordStagingDeviceQueryForTest() noexcept {
+    staging_device_query_count.fetch_add(1, std::memory_order_relaxed);
+}
+#endif
 
 enum LaneTestEvent {
     kLaneQueueAdmitted = 1,
@@ -234,6 +250,19 @@ bool tcpTransportLaneTypesAreMoveOnlyForTest() noexcept {
            std::is_move_constructible<TcpTransport::TerminalAction>::value &&
            !std::is_copy_constructible<TcpTransport::TerminalAction>::value &&
            !std::is_copy_assignable<TcpTransport::TerminalAction>::value;
+}
+
+void tcpTransportResetStagingStatsForTest() noexcept {
+    staging_buffer_allocation_count.store(0, std::memory_order_relaxed);
+    staging_device_query_count.store(0, std::memory_order_relaxed);
+}
+
+size_t tcpTransportStagingBufferAllocationCountForTest() noexcept {
+    return staging_buffer_allocation_count.load(std::memory_order_relaxed);
+}
+
+size_t tcpTransportStagingDeviceQueryCountForTest() noexcept {
+    return staging_device_query_count.load(std::memory_order_relaxed);
 }
 #endif
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
@@ -55,12 +55,31 @@ struct SessionHeader {
 // Callers must call cudaSetDevice before any cudaMemcpy to avoid implicit
 // GPU 0 context creation.
 static int getCudaDeviceId(void* addr) {
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+    recordStagingDeviceQueryForTest();
+#endif
     cudaPointerAttributes attributes;
     auto status = cudaPointerGetAttributes(&attributes, addr);
     if (status != cudaSuccess) return -1;
     if (attributes.type == cudaMemoryTypeDevice) return attributes.device;
     return -1;
 }
+
+class TcpStagingBuffer {
+   public:
+    char* ensure(size_t size) {
+        if (buffer_.size() < size) {
+            buffer_.resize(size);
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+            recordStagingBufferAllocationForTest();
+#endif
+        }
+        return buffer_.data();
+    }
+
+   private:
+    std::vector<char> buffer_;
+};
 
 #ifdef USE_MACA
 static cudaError_t copyTcpCudaMemory(void* dst, const void* src, size_t size) {
@@ -137,6 +156,12 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
     char* local_buffer_;
     bool v2_ = false;
     uint64_t status_frame_;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+    int cuda_device_ = -1;
+    TcpStagingBuffer staging_buffer_;
+#endif
 
     void start() {
         total_transferred_bytes_ = 0;
@@ -191,6 +216,11 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                     if (v2_) sendStatus(kStatusAddrRejected, nullptr);
                     return;
                 }
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+                cuda_device_ = getCudaDeviceId(local_buffer_);
+#endif
                 if (opcode == (uint8_t)TransferRequest::WRITE) {
                     readBody();
                 } else if (v2_) {
@@ -216,15 +246,13 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-            cudaSetDevice(cuda_device);
+        if (cuda_device_ >= 0) {
+            dram_buffer = staging_buffer_.ensure(buffer_size);
+            cudaSetDevice(cuda_device_);
 #ifdef USE_MACA
             cudaError_t cuda_status = copyTcpCudaMemory(
                 dram_buffer, addr + total_transferred_bytes_, buffer_size);
@@ -237,7 +265,6 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                 LOG(ERROR) << "ServerSession::writeBody failed to copy from "
                               "CUDA memory. "
                            << "Error: " << cudaGetErrorString(cuda_status);
-                delete[] dram_buffer;
                 return;  // Connection will be closed
             }
         }
@@ -245,15 +272,8 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
 
         asio::async_write(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    delete[] dram_buffer;
-                }
-#endif
+            [this, addr, dram_buffer, self](const asio::error_code& ec,
+                                            std::size_t transferred_bytes) {
                 if (ec) {
                     LOG(ERROR)
                         << "ServerSession::writeBody failed. "
@@ -289,21 +309,19 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
+        if (cuda_device_ >= 0) {
+            dram_buffer = staging_buffer_.ensure(buffer_size);
         }
 #endif
 
         asio::async_read(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
+            [this, addr, dram_buffer, self](const asio::error_code& ec,
+                                            std::size_t transferred_bytes) {
                 if (ec) {
                     // If client closed connection (EOF), this is normal - don't
                     // log
@@ -316,15 +334,14 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << ". Error: " << ec.message()
                             << " (value: " << ec.value() << ")";
                     }
-                    if (cuda_device >= 0) delete[] dram_buffer;
                     return;  // Connection will be closed
                 }
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    cudaSetDevice(cuda_device);
+                if (cuda_device_ >= 0) {
+                    cudaSetDevice(cuda_device_);
 #ifdef USE_MACA
                     cudaError_t cuda_status =
                         copyTcpCudaMemory(addr + total_transferred_bytes_,
@@ -339,10 +356,8 @@ struct ServerSession : public std::enable_shared_from_this<ServerSession> {
                             << "ServerSession::readBody failed to copy to CUDA "
                                "memory. "
                             << "Error: " << cudaGetErrorString(cuda_status);
-                        delete[] dram_buffer;
                         return;  // Connection will be closed
                     }
-                    delete[] dram_buffer;
                 }
 #endif
                 total_transferred_bytes_ += transferred_bytes;
@@ -368,6 +383,12 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     char* local_buffer_;
     bool v2_;
     uint64_t status_frame_;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+    int cuda_device_ = -1;
+    TcpStagingBuffer staging_buffer_;
+#endif
     // v2 WRITE runs the body stream and the ack read concurrently (one
     // async op per direction; handlers serialize on the io thread). The
     // concurrent read lets a rejection — or a v1 server's bogus payload —
@@ -422,6 +443,11 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
     void initiate(void* buffer, uint64_t dest_addr, size_t size,
                   TransferRequest::OpCode opcode) {
         local_buffer_ = (char*)buffer;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
+    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
+    defined(USE_COREX)
+        cuda_device_ = getCudaDeviceId(local_buffer_);
+#endif
         header_.addr = htole64(dest_addr);
         header_.size = htole64(size);
         header_.opcode = (uint8_t)opcode | (v2_ ? kOpcodeV2Flag : 0);
@@ -734,21 +760,19 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
+        if (cuda_device_ >= 0) {
+            dram_buffer = staging_buffer_.ensure(buffer_size);
         }
 #endif
 
         asio::async_read(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
+            [this, addr, dram_buffer, self](const asio::error_code& ec,
+                                            std::size_t transferred_bytes) {
                 if (ec) {
                     LOG(ERROR)
                         << "ClientSession::readBody failed. "
@@ -756,11 +780,6 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                         << " using buffer " << static_cast<void*>(dram_buffer)
                         << ". Error: " << ec.message()
                         << " (value: " << ec.value() << ")";
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                    if (cuda_device >= 0) delete[] dram_buffer;
-#endif
                     finalize(TransferStatusEnum::FAILED, false);
                     return;
                 }
@@ -775,11 +794,6 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #endif
                 }
                 if (!progress_accepted) {
-#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
-    defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
-    defined(USE_COREX)
-                    if (cuda_device >= 0) delete[] dram_buffer;
-#endif
                     finalize(TransferStatusEnum::FAILED, false);
                     return;
                 }
@@ -787,8 +801,8 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-                if (cuda_device >= 0) {
-                    cudaSetDevice(cuda_device);
+                if (cuda_device_ >= 0) {
+                    cudaSetDevice(cuda_device_);
 #ifdef USE_MACA
                     cudaError_t cuda_status =
                         copyTcpCudaMemory(addr + total_transferred_bytes_,
@@ -803,11 +817,9 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                             << "ClientSession::readBody failed to copy to CUDA "
                                "memory. "
                             << "Error: " << cudaGetErrorString(cuda_status);
-                        delete[] dram_buffer;
                         finalize(TransferStatusEnum::FAILED, false);
                         return;
                     }
-                    delete[] dram_buffer;
                 }
 #endif
                 total_transferred_bytes_ += transferred_bytes;
@@ -849,15 +861,13 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         }
 
         char* dram_buffer = addr + total_transferred_bytes_;
-        int cuda_device = -1;
 
 #if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP) ||  \
     defined(USE_MLU) || defined(USE_MACA) || defined(USE_HYGON) || \
     defined(USE_COREX)
-        cuda_device = getCudaDeviceId(addr);
-        if (cuda_device >= 0) {
-            dram_buffer = new char[buffer_size];
-            cudaSetDevice(cuda_device);
+        if (cuda_device_ >= 0) {
+            dram_buffer = staging_buffer_.ensure(buffer_size);
+            cudaSetDevice(cuda_device_);
 #ifdef USE_MACA
             cudaError_t cuda_status = copyTcpCudaMemory(
                 dram_buffer, addr + total_transferred_bytes_, buffer_size);
@@ -870,7 +880,6 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
                 LOG(ERROR) << "ClientSession::writeBody failed to copy from "
                               "CUDA memory. "
                            << "Error: " << cudaGetErrorString(cuda_status);
-                delete[] dram_buffer;
                 abortWrite();
                 return;
             }
@@ -880,12 +889,9 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
         write_body_in_flight_ = true;
         asio::async_write(
             *socket_, asio::buffer(dram_buffer, buffer_size),
-            [this, addr, dram_buffer, cuda_device, self](
-                const asio::error_code& ec, std::size_t transferred_bytes) {
+            [this, addr, dram_buffer, self](const asio::error_code& ec,
+                                            std::size_t transferred_bytes) {
                 write_body_in_flight_ = false;
-                if (cuda_device >= 0) {
-                    delete[] dram_buffer;
-                }
                 if (ec) {
                     LOG(ERROR)
                         << "ClientSession::writeBody failed. "

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -50,8 +50,8 @@ add_test(NAME rdma_endpoint_state_test COMMAND rdma_endpoint_state_test)
 
 # Regression test for the reconnect storm of issue #3299: repeated local
 # completion faults toward one peer RNIC must pause that path instead of
-# re-handshaking it forever. The rail monitor is plain per-worker-pool state,
-# so this runs on every CI runner without an RDMA device.
+# re-handshaking it forever. The rail monitor is plain per-worker-pool state, so
+# this runs on every CI runner without an RDMA device.
 add_executable(worker_pool_rail_state_test
                ${WORKSPACE}/worker_pool_rail_state_test.cpp)
 target_link_libraries(worker_pool_rail_state_test PUBLIC transfer_engine gtest
@@ -165,6 +165,17 @@ if(USE_TCP)
   target_link_libraries(tcp_write_visibility_test PUBLIC transfer_engine gtest
                                                          gtest_main)
   add_test(NAME tcp_write_visibility_test COMMAND tcp_write_visibility_test)
+
+  if(USE_CUDA)
+    add_executable(tcp_cuda_staging_test ${WORKSPACE}/tcp_cuda_staging_test.cpp)
+    target_compile_definitions(tcp_cuda_staging_test
+                               PRIVATE MOONCAKE_TCP_TRANSPORT_TEST_HOOKS)
+    target_include_directories(tcp_cuda_staging_test
+                               PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_link_libraries(tcp_cuda_staging_test PUBLIC transfer_engine gtest
+                                                       gtest_main CUDA::cudart)
+    add_test(NAME tcp_cuda_staging_test COMMAND tcp_cuda_staging_test)
+  endif()
 endif()
 
 add_executable(tcp_address_validation_test

--- a/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "cuda_alike.h"
+#include "transfer_engine.h"
+
+#ifdef MOONCAKE_TCP_TRANSPORT_TEST_HOOKS
+namespace mooncake {
+void tcpTransportResetStagingStatsForTest() noexcept;
+size_t tcpTransportStagingBufferAllocationCountForTest() noexcept;
+size_t tcpTransportStagingDeviceQueryCountForTest() noexcept;
+}  // namespace mooncake
+#endif
+
+namespace {
+
+using namespace mooncake;
+
+class ScopedEnvVar {
+   public:
+    ScopedEnvVar(const char* name, const char* value) : name_(name) {
+        const char* current = std::getenv(name);
+        if (current) old_value_ = current;
+        setenv(name, value, 1);
+    }
+
+    ~ScopedEnvVar() {
+        if (old_value_)
+            setenv(name_.c_str(), old_value_->c_str(), 1);
+        else
+            unsetenv(name_.c_str());
+    }
+
+   private:
+    std::string name_;
+    std::optional<std::string> old_value_;
+};
+
+class DeviceBuffer {
+   public:
+    ~DeviceBuffer() {
+        if (data_) cudaFree(data_);
+    }
+
+    void** out() { return &data_; }
+    void* get() const { return data_; }
+
+   private:
+    void* data_ = nullptr;
+};
+
+TransferStatusEnum runOne(TransferEngine* engine,
+                          const TransferRequest& request) {
+    auto batch_id = engine->allocateBatchID(1);
+    if (!engine->submitTransfer(batch_id, {request}).ok())
+        return TransferStatusEnum::FAILED;
+
+    TransferStatus status;
+    status.s = TransferStatusEnum::WAITING;
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(15);
+    while (status.s != TransferStatusEnum::COMPLETED &&
+           status.s != TransferStatusEnum::FAILED &&
+           std::chrono::steady_clock::now() < deadline) {
+        if (!engine->getTransferStatus(batch_id, 0, status).ok()) {
+            status.s = TransferStatusEnum::FAILED;
+            break;
+        }
+        if (status.s == TransferStatusEnum::WAITING)
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    if (status.s == TransferStatusEnum::WAITING)
+        status.s = TransferStatusEnum::TIMEOUT;
+    (void)engine->freeBatchID(batch_id);
+    return status.s;
+}
+
+TEST(TcpCudaStagingTest, ReusesStagingAcrossChunksAndRequests) {
+    int device_count = 0;
+    cudaError_t cuda_status = cudaGetDeviceCount(&device_count);
+    if (cuda_status != cudaSuccess || device_count == 0) {
+        GTEST_SKIP() << "CUDA device unavailable";
+    }
+    ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+    ScopedEnvVar connection_pool("MC_TCP_ENABLE_CONNECTION_POOL", "1");
+    ScopedEnvVar lanes("MC_TCP_LANES_PER_PEER", "1");
+    ScopedEnvVar slice_size("MC_TCP_SLICE_SIZE", "65536");
+
+    constexpr size_t kChunkSize = 64 * 1024;
+    constexpr size_t kTransferSize = 8 * kChunkSize;
+    constexpr size_t kBufferSize = 3 * kTransferSize;
+
+    DeviceBuffer device_buffer;
+    ASSERT_EQ(cudaMalloc(device_buffer.out(), kBufferSize), cudaSuccess);
+    ASSERT_EQ(cudaMemset(device_buffer.get(), 0, kBufferSize), cudaSuccess);
+
+    std::vector<unsigned char> pattern(kTransferSize);
+    for (size_t i = 0; i < pattern.size(); ++i)
+        pattern[i] = static_cast<unsigned char>((i * 37 + 11) & 0xFF);
+    ASSERT_EQ(cudaMemcpy(device_buffer.get(), pattern.data(), pattern.size(),
+                         cudaMemcpyHostToDevice),
+              cudaSuccess);
+
+    auto engine = std::make_unique<TransferEngine>(false);
+    const std::string server_name = "127.0.0.2:17931";
+    const auto hostname_port = parseHostNameWithPort(server_name);
+    ASSERT_EQ(engine->init(P2PHANDSHAKE, server_name,
+                           hostname_port.first.c_str(), hostname_port.second),
+              0);
+    ASSERT_NE(engine->installTransport("tcp", nullptr), nullptr);
+    ASSERT_EQ(
+        engine->registerLocalMemory(device_buffer.get(), kBufferSize, "cuda:0"),
+        0);
+
+    const auto segment_id = engine->openSegment(engine->getLocalIpAndPort());
+    const auto segment_desc =
+        engine->getMetadata()->getSegmentDescByID(segment_id);
+    ASSERT_NE(segment_desc, nullptr);
+    ASSERT_FALSE(segment_desc->buffers.empty());
+    const uint64_t remote_base = segment_desc->buffers[0].addr;
+    auto* device_bytes = static_cast<unsigned char*>(device_buffer.get());
+
+    tcpTransportResetStagingStatsForTest();
+    TransferRequest write;
+    write.opcode = TransferRequest::WRITE;
+    write.length = kTransferSize;
+    write.source = device_bytes;
+    write.target_id = segment_id;
+    write.target_offset = remote_base + kTransferSize;
+    ASSERT_EQ(runOne(engine.get(), write), TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(tcpTransportStagingDeviceQueryCountForTest(), 2u);
+    EXPECT_EQ(tcpTransportStagingBufferAllocationCountForTest(), 2u);
+
+    std::vector<unsigned char> actual(kTransferSize);
+    ASSERT_EQ(cudaMemcpy(actual.data(), device_bytes + kTransferSize,
+                         actual.size(), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(actual, pattern);
+
+    tcpTransportResetStagingStatsForTest();
+    TransferRequest read;
+    read.opcode = TransferRequest::READ;
+    read.length = kTransferSize;
+    read.source = device_bytes + 2 * kTransferSize;
+    read.target_id = segment_id;
+    read.target_offset = remote_base + kTransferSize;
+    ASSERT_EQ(runOne(engine.get(), read), TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(tcpTransportStagingDeviceQueryCountForTest(), 2u);
+    // The client session is new; the persistent server session retains the
+    // staging allocation used by the preceding WRITE.
+    EXPECT_EQ(tcpTransportStagingBufferAllocationCountForTest(), 1u);
+
+    ASSERT_EQ(cudaMemcpy(actual.data(), device_bytes + 2 * kTransferSize,
+                         actual.size(), cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    EXPECT_EQ(actual, pattern);
+
+    EXPECT_EQ(engine->unregisterLocalMemory(device_buffer.get()), 0);
+    engine.reset();
+}
+
+}  // namespace

--- a/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
@@ -73,11 +73,11 @@ class DeviceBuffer {
 
 TransferStatusEnum runOne(TransferEngine* engine,
                           const TransferRequest& request) {
-auto batch_id = engine->allocateBatchID(1);
-if (!engine->submitTransfer(batch_id, {request}).ok()) {
-    (void)engine->freeBatchID(batch_id);
-    return TransferStatusEnum::FAILED;
-}
+    auto batch_id = engine->allocateBatchID(1);
+    if (!engine->submitTransfer(batch_id, {request}).ok()) {
+        (void)engine->freeBatchID(batch_id);
+        return TransferStatusEnum::FAILED;
+    }
     TransferStatus status;
     status.s = TransferStatusEnum::WAITING;
     const auto deadline =

--- a/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
+++ b/mooncake-transfer-engine/tests/tcp_cuda_staging_test.cpp
@@ -73,10 +73,11 @@ class DeviceBuffer {
 
 TransferStatusEnum runOne(TransferEngine* engine,
                           const TransferRequest& request) {
-    auto batch_id = engine->allocateBatchID(1);
-    if (!engine->submitTransfer(batch_id, {request}).ok())
-        return TransferStatusEnum::FAILED;
-
+auto batch_id = engine->allocateBatchID(1);
+if (!engine->submitTransfer(batch_id, {request}).ok()) {
+    (void)engine->freeBatchID(batch_id);
+    return TransferStatusEnum::FAILED;
+}
     TransferStatus status;
     status.s = TransferStatusEnum::WAITING;
     const auto deadline =


### PR DESCRIPTION
## Description

Refs #3446.

The classic Transfer Engine TCP accelerator path previously queried pointer attributes and allocated/freed a host staging buffer for every 64 KiB chunk in all four client/server READ/WRITE directions. A 512 KiB self-loop transfer
therefore performed 16 device queries and 16 staging allocations across both endpoints.

This change:

- caches accelerator device detection once per request;
- retains a growable, pageable host staging buffer in each TCP client/server session and reuses it across chunks;
- lets a persistent server session reuse its staging allocation across requests;
- adds a CUDA regression test covering multi-chunk READ and WRITE correctness, connection reuse, device-query counts, and staging-allocation counts.

For the same 512 KiB transfer, the first WRITE now performs two device queries and two staging-buffer growths across both endpoints. A following READ performs two device queries and only one new growth because the persistent server session reuses its existing buffer.

There is no wire-format, public API, configuration-default, or CPU data-path change. Pinned staging and copy/network double buffering remain separate future work in #3446.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Tested on Ubuntu with CUDA 13.0, driver 580.173.02, and two NVIDIA RTX 5090 GPUs. The initiator used physical GPU 0 and the target used physical GPU 1. The test path was GPU-to-host staging, TCP, then host staging-to-GPU; it does
not require RDMA or GPU peer-to-peer support.

**Test commands:**

```bash
# CUDA build and focused regression tests.
cmake -S . -B build-cuda \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DWITH_TE=ON \
  -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF \
  -DWITH_EP=OFF \
  -DUSE_CUDA=ON \
  -DUSE_TCP=ON \
  -DUSE_TENT=OFF \
  -DUSE_ETCD=OFF \
  -DUSE_REDIS=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=ON \
  -DBUILD_BENCHMARK=ON

cmake --build build-cuda \
  --target tcp_cuda_staging_test tcp_write_visibility_test \
           tcp_address_validation_test transfer_engine_bench \
  -j 24

build-cuda/mooncake-transfer-engine/tests/tcp_cuda_staging_test \
  --gtest_repeat=5 \
  --gtest_break_on_failure

MC_METADATA_SERVER=P2PHANDSHAKE \
MC_LOCAL_SERVER_NAME=127.0.0.2:17940 \
ctest --test-dir build-cuda \
  -R '^(tcp_cuda_staging_test|tcp_write_visibility_test|tcp_address_validation_test)$' \
  --output-on-failure

# CUDA-disabled build and focused TCP regressions.
cmake -S . -B build-cpu \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DWITH_TE=ON \
  -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF \
  -DWITH_EP=OFF \
  -DUSE_CUDA=OFF \
  -DUSE_TCP=ON \
  -DUSE_TENT=OFF \
  -DUSE_ETCD=OFF \
  -DUSE_REDIS=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=OFF

cmake --build build-cpu \
  --target tcp_write_visibility_test tcp_address_validation_test \
  -j 24

MC_METADATA_SERVER=P2PHANDSHAKE \
MC_LOCAL_SERVER_NAME=127.0.0.2:17940 \
ctest --test-dir build-cpu \
  -R '^(tcp_write_visibility_test|tcp_address_validation_test)$' \
  --output-on-failure
```

The two-GPU A/B benchmark used `transfer_engine_bench` with TCP connection pooling enabled, 1 MiB blocks, a 256 MiB VRAM buffer, batch size 32, four submission threads, and 10-second samples. Baseline and optimized binaries were built from the same `266a966b` source revision; only this patch differed.

**Test results:**

- The new CUDA multi-chunk correctness/counter test passed 5/5 consecutive iterations.
- CUDA focused CTest passed 3/3 tests in 38.51 seconds.
- The CUDA-disabled build completed without warnings from this change, and its focused CTest passed 2/2 tests in 35.84 seconds.
- Same-host dual-GPU WRITE throughput median increased from 0.88 GB/s to 1.29 GB/s (approximately +46.6%; samples were noisy).
- Same-host dual-GPU READ throughput median changed from 1.07 GB/s to 1.09 GB/s (approximately +1.9%, within run-to-run variation).
- `git diff --check`, clang-format 20.1.8, cmake-format, trailing-whitespace, end-of-file, merge-conflict, added-large-file, and codespell checks passed.

The legacy `tcp_transport_test` is not included in the passing CTest set. In `P2PHANDSHAKE` mode it connects to the configured fixed port 17940 while the engine advertises a dynamic RPC port. The unchanged `266a966b` baseline and
this patch both reproduce the same connection-refused/segmentation-fault failure.

- [x] Unit tests pass
- [x] Integration tests pass (CUDA TCP self-loop READ/WRITE)
- [x] Manual testing done (dual-GPU same-host TCP A/B benchmark)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable; no public behavior or
      configuration change)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; the
      patch is under 500 changed lines and references RFC #3446)

The code was formatted directly with clang-format 20.1.8, and the applicable
non-formatting pre-commit hooks listed above passed. The human submitter should
run the exact staged-file pre-commit workflow and complete the self-review
before submission.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [ ] AI tools were used (specified below)