### PR TITLE
[Store] Parallelize large shared-memory first touch

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1209,6 +1209,7 @@ Do not run binaries from before and after checksum support was introduced in the
 |----------|---------|-------------|
 | `MC_STORE_USE_HUGEPAGE` | unset | Set `1` to request HugeTLB-backed `mmap()` |
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `512MB`, `1GB` |
+| `MC_STORE_SHM_POPULATE_THREADS` | unset | Opt in to native parallel first-touch for memfd-backed shared-memory allocations. Valid values are `1`-`256`; unset keeps the existing `MAP_POPULATE` path |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
 

--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -3,6 +3,9 @@ add_executable(allocator_bench allocator_bench.cpp)
 target_link_libraries(allocator_bench PRIVATE cachelib_memory_allocator
                                               mooncake_store)
 
+add_executable(shm_helper_bench shm_helper_bench.cpp)
+target_link_libraries(shm_helper_bench PRIVATE mooncake_store glog::glog pthread)
+
 # Add focused OffsetAllocator concurrency benchmark
 add_executable(offset_allocator_concurrency_bench
                offset_allocator_concurrency_bench.cpp)

--- a/mooncake-store/benchmarks/README.md
+++ b/mooncake-store/benchmarks/README.md
@@ -2,6 +2,26 @@
 
 This directory contains benchmark tools for Mooncake Store internals.
 
+## Shared-Memory First-Touch Benchmark
+
+`shm_helper_bench` measures the allocation and initial page population time for
+memfd-backed shared memory. The default path uses the existing `MAP_POPULATE`
+behavior. Set `MC_STORE_SHM_POPULATE_THREADS` to opt in to native parallel
+first-touch and compare different thread counts on the target host:
+
+```bash
+cmake --build build --target shm_helper_bench -j$(nproc)
+./build/mooncake-store/benchmarks/shm_helper_bench 1024
+MC_STORE_SHM_POPULATE_THREADS=4 \
+  ./build/mooncake-store/benchmarks/shm_helper_bench 1024
+MC_STORE_SHM_POPULATE_THREADS=8 \
+  ./build/mooncake-store/benchmarks/shm_helper_bench 1024
+```
+
+Use the same allocation size and host configuration when comparing results.
+Large allocations can be limited by NUMA placement and memory bandwidth, so a
+higher thread count is not guaranteed to be faster.
+
 ## Allocation Strategy Benchmark
 
 `allocation_strategy_bench` evaluates Store allocation behavior across segment

--- a/mooncake-store/benchmarks/shm_helper_bench.cpp
+++ b/mooncake-store/benchmarks/shm_helper_bench.cpp
@@ -1,0 +1,39 @@
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "shm_helper.h"
+
+namespace {
+
+size_t parse_size_mb(const char *value) {
+    char *end = nullptr;
+    const unsigned long mb = std::strtoul(value, &end, 10);
+    if (end == value || *end != '\0' || mb == 0) {
+        throw std::invalid_argument("size_mb must be a positive integer");
+    }
+    return static_cast<size_t>(mb) * 1024 * 1024;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    const size_t size_bytes =
+        argc > 1 ? parse_size_mb(argv[1]) : 1024UL * 1024 * 1024;
+    const auto start = std::chrono::steady_clock::now();
+    void *buffer = mooncake::ShmHelper::getInstance()->allocate(size_bytes);
+    const auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start)
+            .count();
+
+    std::cout << "size_bytes=" << size_bytes << " elapsed_ms=" << elapsed_ms
+              << " threads="
+              << (std::getenv("MC_STORE_SHM_POPULATE_THREADS")
+                      ? std::getenv("MC_STORE_SHM_POPULATE_THREADS")
+                      : "default")
+              << std::endl;
+    return mooncake::ShmHelper::getInstance()->free(buffer);
+}

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -359,6 +359,16 @@ inline size_t align_up(size_t size, size_t alignment) {
 }
 
 /**
+ * @brief Fault in a fresh mmap mapping with parallel CPU writes.
+ *
+ * Touches one byte per page. A thread_count of zero selects the existing
+ * hardware-based default. Call this only for a newly allocated mapping whose
+ * contents may be zeroed.
+ */
+void populate_mmap_mapping(void* ptr, size_t total_size, size_t page_size,
+                           size_t thread_count = 0);
+
+/**
  * @brief Fault in a fresh HugeTLB mapping with parallel CPU writes.
  *
  * Touches one byte per configured hugepage. Call this only for a newly

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -1,5 +1,7 @@
 #include "shm_helper.h"
 
+#include <cerrno>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
@@ -20,6 +22,32 @@
 #endif
 
 namespace mooncake {
+
+namespace {
+
+constexpr char kPopulateThreadsEnv[] = "MC_STORE_SHM_POPULATE_THREADS";
+constexpr size_t kMaxPopulateThreads = 256;
+
+size_t get_populate_thread_count() {
+    const char* value = std::getenv(kPopulateThreadsEnv);
+    if (value == nullptr || *value == '\0') {
+        return 0;
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long parsed = std::strtoul(value, &end, 10);
+    if (errno != 0 || end == value || *end != '\0' || parsed == 0 ||
+        parsed > kMaxPopulateThreads) {
+        LOG(WARNING) << "Ignoring invalid " << kPopulateThreadsEnv << "="
+                     << value << "; expected an integer in [1, "
+                     << kMaxPopulateThreads << "]";
+        return 0;
+    }
+    return static_cast<size_t>(parsed);
+}
+
+}  // namespace
 
 std::mutex ShmHelper::shm_mutex_;
 
@@ -120,13 +148,42 @@ void* ShmHelper::allocate(size_t size) {
                                  std::string(strerror(errno)));
     }
 
-    void* base_addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-                           MAP_SHARED | MAP_POPULATE, fd, 0);
+    const size_t populate_threads = get_populate_thread_count();
+    const bool use_native_population = populate_threads > 0;
+    const int mmap_flags =
+        MAP_SHARED | (use_native_population ? 0 : MAP_POPULATE);
+    const auto populate_start = std::chrono::steady_clock::now();
+    void* base_addr =
+        mmap(nullptr, size, PROT_READ | PROT_WRITE, mmap_flags, fd, 0);
     if (base_addr == MAP_FAILED) {
         close(fd);
         throw std::runtime_error("Failed to map shared memory: " +
                                  std::string(strerror(errno)));
     }
+
+    if (use_native_population) {
+        const size_t page_size = use_hugepage_
+                                     ? get_hugepage_size_from_env()
+                                     : static_cast<size_t>(getpagesize());
+        try {
+            populate_mmap_mapping(base_addr, size, page_size, populate_threads);
+        } catch (...) {
+            munmap(base_addr, size);
+            close(fd);
+            throw;
+        }
+    }
+
+    const auto populate_elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - populate_start)
+            .count();
+    LOG(INFO) << "Shared memory allocation completed: size=" << size
+              << ", mode="
+              << (use_native_population ? "native_parallel_touch"
+                                        : "map_populate")
+              << ", threads=" << (use_native_population ? populate_threads : 1)
+              << ", elapsed_ms=" << populate_elapsed_ms;
 
     auto shm = std::make_shared<ShmSegment>();
     shm->fd = fd;

--- a/mooncake-store/src/utils.cpp
+++ b/mooncake-store/src/utils.cpp
@@ -187,7 +187,10 @@ static inline size_t mmap_map_size(size_t total_size, size_t hugepage_size) {
 
 namespace {
 
-size_t touch_thread_count(size_t page_count) {
+size_t touch_thread_count(size_t page_count, size_t requested_threads = 0) {
+    if (requested_threads > 0) {
+        return std::min(requested_threads, page_count);
+    }
     const unsigned int hardware_threads = std::thread::hardware_concurrency();
     const size_t available_threads =
         hardware_threads == 0 ? 1 : std::min<size_t>(hardware_threads, 16);
@@ -205,13 +208,15 @@ void touch_page_range(volatile char *data, size_t page_size, size_t begin_page,
     }
 }
 
-void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size) {
+void touch_mmap_pages(void *ptr, size_t map_size, size_t page_size,
+                      size_t requested_threads = 0) {
     if (ptr == nullptr || map_size == 0 || page_size == 0) {
         return;
     }
 
     const size_t page_count = (map_size + page_size - 1) / page_size;
-    const size_t num_threads = touch_thread_count(page_count);
+    const size_t num_threads =
+        touch_thread_count(page_count, requested_threads);
 
     auto *data = static_cast<volatile char *>(ptr);
     if (num_threads <= 1) {
@@ -285,14 +290,19 @@ void touch_numa_mmap_pages(void *ptr, size_t map_size, size_t page_size,
 
 }  // namespace
 
+void populate_mmap_mapping(void *ptr, size_t total_size, size_t page_size,
+                           size_t thread_count) {
+    touch_mmap_pages(ptr, total_size, page_size, thread_count);
+}
+
 void populate_hugetlb_mapping(void *ptr, size_t total_size) {
     const size_t hugepage_size = get_hugepage_size_from_env();
     if (ptr == nullptr || total_size == 0 || hugepage_size == 0) {
         return;
     }
 
-    touch_mmap_pages(ptr, mmap_map_size(total_size, hugepage_size),
-                     hugepage_size);
+    populate_mmap_mapping(ptr, mmap_map_size(total_size, hugepage_size),
+                          hugepage_size);
 }
 
 void populate_hugetlb_numa_mapping(void *ptr, size_t total_size,

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ function(add_ha_test name)
 endfunction()
 
 add_store_test(buffer_allocator_test buffer_allocator_test.cpp)
+add_store_test(shm_helper_test shm_helper_test.cpp)
 add_store_test(region_driver_test region_driver_test.cpp)
 add_store_test(replica_allocator_test replica_allocator_test.cpp)
 add_store_test(runtime_accelerator_test runtime_accelerator_test.cpp)

--- a/mooncake-store/tests/shm_helper_test.cpp
+++ b/mooncake-store/tests/shm_helper_test.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "shm_helper.h"
+
+namespace mooncake {
+
+TEST(ShmHelperTest, AllocatesAndFindsSegmentWithDefaultPath) {
+    unsetenv("MC_STORE_SHM_POPULATE_THREADS");
+    unsetenv("MC_STORE_USE_HUGEPAGE");
+    auto *helper = ShmHelper::getInstance();
+    void *buffer = helper->allocate(2 * 1024 * 1024);
+    ASSERT_NE(buffer, nullptr);
+    auto segment = helper->get_shm(buffer);
+    ASSERT_NE(segment, nullptr);
+    EXPECT_EQ(segment->base_addr, buffer);
+    EXPECT_EQ(segment->size, 2 * 1024 * 1024);
+    EXPECT_EQ(helper->free(buffer), 0);
+}
+
+TEST(ShmHelperTest, AllocatesWithParallelPopulationPath) {
+    setenv("MC_STORE_SHM_POPULATE_THREADS", "2", 1);
+    auto *helper = ShmHelper::getInstance();
+    void *buffer = helper->allocate(4 * 1024 * 1024);
+    ASSERT_NE(buffer, nullptr);
+    EXPECT_NE(helper->get_shm(buffer), nullptr);
+    EXPECT_EQ(helper->free(buffer), 0);
+    unsetenv("MC_STORE_SHM_POPULATE_THREADS");
+}
+
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Large regular shared-memory allocations in Mooncake Store currently rely on `MAP_POPULATE`, which performs page population on the caller thread. For multi-gigabyte memfd-backed buffers, this can make allocation latency unnecessarily sensitive to a single-threaded first-touch path.

This PR extends the Store's existing parallel mmap population worker to `ShmHelper`-backed allocations. It extracts a page-size-agnostic helper from the existing HugeTLB population path, then lets `ShmHelper` use it when `MC_STORE_SHM_POPULATE_THREADS` is set to a positive value (1–256).

The default `MAP_POPULATE` behavior remains unchanged. Existing HugeTLB, NUMA, transfer protocol, and public allocation behavior are preserved; no separate THP policy is introduced.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
env -u MC_STORE_SHM_POPULATE_THREADS ./shm_helper_bench 1024
MC_STORE_SHM_POPULATE_THREADS=1 ./shm_helper_bench 1024
MC_STORE_SHM_POPULATE_THREADS=4 ./shm_helper_bench 1024
MC_STORE_SHM_POPULATE_THREADS=8 ./shm_helper_bench 1024
```

**Test results:**
- Default `MAP_POPULATE` path: 416 ms for 1 GiB.
- Parallel first-touch, 1 thread: 492 ms for 1 GiB.
- Parallel first-touch, 4 threads: 179 ms for 1 GiB.
- Parallel first-touch, 8 threads: 138 ms for 1 GiB.
- The updated `utils.cpp` and `shm_helper.cpp` compile with the Store build flags.
- The benchmark executes successfully for the default and opt-in paths; the unit-test source passes compilation checks.
- clang-format 20 and `git diff --check` pass.
- [x] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using the project formatter
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI tools assisted with drafting and code review. The submitter reviewed the implementation and validation results.
