### PR TITLE
[Bugfix][Store] Allow HA promotion without OpLog

### DIFF
--- a/mooncake-store/src/ha/standby_controller.cpp
+++ b/mooncake-store/src/ha/standby_controller.cpp
@@ -83,7 +83,7 @@ class NoopStandbyController final : public StandbyController {
 
     tl::expected<PromotionContext, ErrorCode> PromoteStandbyAndExport()
         override {
-        return tl::unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+        return PromotionContext{};
     }
 
     void UpdateObservedLeader(const std::optional<MasterView>&) override {}

--- a/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
@@ -186,6 +186,25 @@ TEST(StandbyControllerTest, OplogEnablementControlsReaderController) {
     EXPECT_EQ(ErrorCode::OK, unsupported->PromoteStandby());
 }
 
+TEST(StandbyControllerTest, HaWithoutOplogPromotesWithEmptyContext) {
+    ha::HABackendSpec spec{
+        .type = ha::HABackendType::ETCD,
+        .connstring = "http://localhost:2379",
+        .cluster_namespace = "ha-without-oplog-test",
+    };
+    MasterServiceSupervisorConfig config;
+    config.enable_oplog = false;
+
+    auto controller = ha::CreateStandbyController(spec, config);
+    ASSERT_EQ(ErrorCode::OK, controller->StartStandby(std::nullopt));
+
+    auto result = controller->PromoteStandbyAndExport();
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(0u, result->applied_seq_id);
+    EXPECT_TRUE(result->objects.empty());
+    EXPECT_TRUE(result->segments.empty());
+}
+
 TEST(StandbyControllerTest,
      PromoteStandbyAndExport_ReturnsErrorWhenNotStarted) {
     ha::HABackendSpec spec{


### PR DESCRIPTION
## Description

Allow HA mode to enter the serving state when OpLog and snapshot recovery are both disabled.

When `enable_ha=true` and `enable_oplog=false`, the HA supervisor uses `NoopStandbyController`. After acquiring leadership, the supervisor calls `PromoteStandbyAndExport()`, but the no-op implementation returned `UNAVAILABLE_IN_CURRENT_STATUS`. As a result, the elected leader could never enter the serving state.

The no-op controller now returns an empty `PromotionContext`, which represents that there is no standby metadata to restore. A regression test covers the HA-without-OpLog promotion path.

This addresses the HA-only startup regression reported in #2971.

This change is separate from #3497: that PR handles actual promotion and restore failures, while this PR fixes the expected-success path when no standby recovery capability is enabled.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target hot_standby_snapshot_bootstrap_test -j32

GTEST_FILTER=StandbyControllerTest.HaWithoutOplogPromotesWithEmptyContext \
  build/mooncake-store/tests/hot_standby_snapshot_bootstrap_test

build/mooncake-store/tests/hot_standby_snapshot_bootstrap_test

pre-commit run --files \
  mooncake-store/src/ha/standby_controller.cpp \
  mooncake-store/tests/ha/standby/hot_standby_snapshot_bootstrap_test.cpp
```

Manual HA startup was also verified against a local etcd instance with:

```bash
mooncake_master \
  --enable_ha=true \
  --enable_oplog=false \
  --ha_backend_type=etcd \
  --etcd_endpoints=127.0.0.1:23791
```

The master successfully acquired leadership and `/health` reported:

```json
{
  "status": "ok",
  "role": "leader",
  "ha_state": "serving",
  "service_ready": true
}
```

**Test results:**

- [x] Focused regression test passes
- [x] Full `hot_standby_snapshot_bootstrap_test` passes (7/7)
- [x] Manual HA startup without OpLog passes
- [x] Pre-commit checks pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using pre-commit
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not required for this narrowly scoped bug fix
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required for this 21-line bug fix

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with root-cause analysis, implementation, test construction, and local verification. The submitter is responsible for reviewing and understanding every changed line.