### PR TITLE
fix(store): link transfer_engine for ascend builds of mooncake_store_master

### DIFF
--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -453,6 +453,9 @@ endif()
 if(USE_UB)
   target_link_libraries(mooncake_store_master PRIVATE ub_allocator)
 endif()
+if(USE_ASCEND_DIRECT OR USE_UBSHMEM)
+  target_link_libraries(mooncake_store_master PRIVATE transfer_engine)
+endif()
 
 # Complete public Store library.
 add_library(


### PR DESCRIPTION
## Description

PR #3276 split `mooncake_store` into dedicated object libraries and made CMake target dependencies explicit, but the new `mooncake_store_master` static library lost the ascend link path:

- `mooncake-store/src/utils.cpp` compiled with `USE_ASCEND_DIRECT`/`USE_UBSHMEM` references `ascend_allocate_memory` / `ascend_free_memory` (declared in `mooncake-transfer-engine/include/ascend_allocator.h`, defined in `libascend_transport.so`, reachable via `transfer_engine`).
- `mooncake_store_master` only got `ub_allocator` for the `USE_UB` case; the ascend variants were not linked.

Result: ascend CI (`-DUSE_ASCEND_DIRECT=ON`) fails at link time since #3276:

```
libmooncake_store_master.a(utils.cpp.o): undefined reference to 
mooncake::ascend_allocate_memory(unsigned long, std::string const&)
mooncake::ascend_free_memory(std::string const&, void*)
```

This adds the missing link, mirroring what `mooncake_store_client_objects` already does (`PRIVATE transfer_engine`).

## Module

mooncake-store (build)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified the symbol path: caller `utils.cpp:158/577` -> definition `ascend_allocator.cpp` -> `libascend_transport.so` -> linked via `transfer_engine` (PUBLIC under `USE_ASCEND_DIRECT`, see `mooncake-transfer-engine/src/CMakeLists.txt:174-176`).
- Please confirm with the ascend CI workflow (`ci_ascend.yml`, `-DUSE_ASCEND_DIRECT=ON`) that `mooncake_master` links again.

## Regression

Introduced by #3276 (commit dc9d25f3).

Fixes the ascend nightly link failure.