### PR TITLE
[TransferEngine] Enable TCP connection pool by default

### DIFF
--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -112,7 +112,7 @@ class TcpTransport : public Transport {
     TcpContext *context_;
     std::atomic_bool running_;
     std::thread thread_;
-    bool enable_connection_pool_ = false;
+    bool enable_connection_pool_ = true;
 
     // Client-side bounded work queues and fixed connection lanes.
     struct ConnectionKey {


### PR DESCRIPTION
## Description

Enable the TCP connection pool by default for TCP transport. Close #3540

Without `MC_TCP_ENABLE_CONNECTION_POOL` enabled, services that rely on sustained TCP transfers can fail to start or quickly run into socket/ephemeral-port exhaustion. This change makes the pooled connection path the default while preserving the existing rollback behavior:

- `MC_TCP_ENABLE_CONNECTION_POOL` unset: connection pool enabled
- `MC_TCP_ENABLE_CONNECTION_POOL=1/true/yes`: connection pool enabled
- `MC_TCP_ENABLE_CONNECTION_POOL=0/false/no`: connection pool disabled

Docs were updated to reflect the new default and the explicit disable values.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target tcp_write_visibility_test

env -u MC_TCP_ENABLE_CONNECTION_POOL \
  build/mooncake-transfer-engine/tests/tcp_write_visibility_test \
  --gtest_color=no --gtest_brief=1
```

**Test results:**
- [x] Build passed for `tcp_write_visibility_test`
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to make the scoped code/docs update and run local build/test checks. Human review is still required for all changed lines.