### PR TITLE
[Store] Shrink metadata maps after eviction cycles

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -105,6 +105,25 @@ namespace benchmarks {
 class BatchEvictBench;
 }  // namespace benchmarks
 
+// std::unordered_map/set never shrink their bucket array on erase, so a
+// container that once held millions of entries keeps its high-water bucket
+// memory (8 bytes per bucket) forever. ShrinkBucketsIfSparse rehashes a
+// container down to roughly twice its live size once the bucket array is
+// both large enough to matter and less than a quarter full. The bucket
+// floor avoids rehash churn on small containers; the 2x headroom keeps a
+// freshly shrunk container from growing again right away.
+// Rehashing invalidates iterators: callers must hold the lock guarding the
+// container and must not be iterating it.
+inline constexpr size_t kShrinkMinBucketCount = 1024;
+
+template <typename UnorderedContainer>
+void ShrinkBucketsIfSparse(UnorderedContainer& container) {
+    if (container.bucket_count() > kShrinkMinBucketCount &&
+        container.size() < container.bucket_count() / 4) {
+        container.rehash(container.size() * 2);
+    }
+}
+
 /*
  * @brief MasterService is the main class for the master server.
  * Lock order: To avoid deadlocks, the following lock order should be followed:

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <algorithm>
+#include <bitset>
 #include <cassert>
 #include <cctype>
 #include <cmath>
@@ -10428,6 +10429,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
     uint64_t total_freed_size = 0;
     std::vector<std::chrono::system_clock::time_point> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
+    // Shards that actually evicted this cycle; their metadata maps are
+    // shrink candidates once eviction finishes.
+    std::bitset<kNumShards> evicted_shards;
 
     // First pass: evict candidates with no soft pin
     if (!candidates.empty()) {
@@ -10491,6 +10495,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
                     evicted_count += evict_result.evicted_objects;
                     evicted_this_pass += evict_result.evicted_objects;
+                    if (evict_result.evicted_objects > 0) {
+                        evicted_shards.set(c.shard_idx);
+                    }
                 }
                 deferred_replicas.clear();
             }
@@ -10537,9 +10544,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
             // Evict via key lookup — avoid full metadata traversal
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
+                const size_t shard_idx = (start_idx + i) % kNumShards;
                 {
-                    MetadataShardAccessorRW shard(this,
-                                                  (start_idx + i) % kNumShards);
+                    MetadataShardAccessorRW shard(this, shard_idx);
                     for (auto tenant_it = shard->tenants.begin();
                          tenant_it != shard->tenants.end() &&
                          target_evict_num > 0;) {
@@ -10572,6 +10579,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 evicted_count += evict_result.evicted_objects;
                                 target_evict_num -=
                                     evict_result.evicted_objects;
+                                if (evict_result.evicted_objects > 0) {
+                                    evicted_shards.set(shard_idx);
+                                }
                             } else {
                                 ++it;
                             }
@@ -10597,9 +10607,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
             auto soft_target_timeout = soft_pin_objects[soft_pin_evict_num - 1];
 
             for (size_t i = 0; i < kNumShards && target_evict_num > 0; i++) {
+                const size_t shard_idx = (start_idx + i) % kNumShards;
                 {
-                    MetadataShardAccessorRW shard(this,
-                                                  (start_idx + i) % kNumShards);
+                    MetadataShardAccessorRW shard(this, shard_idx);
 
                     for (auto tenant_it = shard->tenants.begin();
                          tenant_it != shard->tenants.end() &&
@@ -10637,6 +10647,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
                                 evicted_count += evict_result.evicted_objects;
                                 target_evict_num -=
                                     evict_result.evicted_objects;
+                                if (evict_result.evicted_objects > 0) {
+                                    evicted_shards.set(shard_idx);
+                                }
                             } else {
                                 ++it;
                             }
@@ -10660,6 +10673,19 @@ void MasterService::BatchEvict(double evict_ratio_target,
                        << ", eviction_base=" << total_eviction_base
                        << ", evict_ratio_target=" << evict_ratio_target
                        << ", evict_ratio_lowerbound=" << evict_ratio_lowerbound;
+        }
+    }
+
+    // erase() never returns bucket memory, so a shard that once held far
+    // more keys than it does now would keep its high-water bucket array
+    // forever. Shrink the metadata maps of the shards that evicted this
+    // cycle. The shard lock is held, and the loop iterates `tenants`, not
+    // the map being rehashed, so no live iterator is invalidated.
+    for (size_t i = 0; i < kNumShards; i++) {
+        if (!evicted_shards.test(i)) continue;
+        MetadataShardAccessorRW shard(this, i);
+        for (auto& tenant : shard->tenants) {
+            ShrinkBucketsIfSparse(tenant.second.metadata);
         }
     }
 

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -143,6 +143,21 @@ class MasterServiceTest : public ::testing::Test {
         service.CleanupExpiredSoftPins(now);
     }
 
+    size_t MetadataShardIndex(MasterService& service, const std::string& key,
+                              const TenantId& tenant_id = TenantId::Default()) {
+        return service.getShardIndex(tenant_id, key);
+    }
+
+    size_t MetadataBucketCount(
+        MasterService& service, size_t shard_idx,
+        const TenantId& tenant_id = TenantId::Default()) {
+        MasterService::MetadataShardAccessorRO shard(&service, shard_idx);
+        const auto tenant_it = shard->tenants.find(tenant_id);
+        return tenant_it == shard->tenants.end()
+                   ? 0
+                   : tenant_it->second.metadata.bucket_count();
+    }
+
     void SetSoftPinDeadlineForTest(
         MasterService& service, const std::string& key,
         const std::chrono::system_clock::time_point& deadline,
@@ -4867,6 +4882,94 @@ TEST_F(MasterServiceTest, EvictObject) {
     ASSERT_GT(success_puts, 1024 * 16);
     std::this_thread::sleep_for(std::chrono::milliseconds(kv_lease_ttl));
     service_->RemoveAll();
+}
+
+TEST_F(MasterServiceTest, ShrinkBucketsIfSparseThresholds) {
+    // Small containers stay untouched regardless of sparsity: their bucket
+    // memory is negligible and rehash churn is not worth it.
+    std::unordered_map<std::string, int> small;
+    small.emplace("small_key", 0);
+    const size_t small_buckets = small.bucket_count();
+    ASSERT_LE(small_buckets, kShrinkMinBucketCount);
+    ShrinkBucketsIfSparse(small);
+    EXPECT_EQ(small.bucket_count(), small_buckets);
+
+    // Grow a map well past the bucket floor, then erase most entries: the
+    // bucket array keeps its high-water size until explicitly shrunk.
+    std::unordered_map<std::string, int> map;
+    for (size_t i = 0; i < 4 * kShrinkMinBucketCount; ++i) {
+        map.emplace("key" + std::to_string(i), 0);
+    }
+    const size_t high_water = map.bucket_count();
+    ASSERT_GT(high_water, kShrinkMinBucketCount);
+
+    // At exactly a quarter full there is nothing to shrink yet.
+    while (map.size() > high_water / 4) {
+        map.erase(map.begin());
+    }
+    ShrinkBucketsIfSparse(map);
+    EXPECT_EQ(map.bucket_count(), high_water);
+
+    // One more erase crosses the threshold and triggers the shrink.
+    map.erase(map.begin());
+    ShrinkBucketsIfSparse(map);
+    EXPECT_LT(map.bucket_count(), high_water);
+    EXPECT_GE(map.bucket_count(), map.size());
+}
+
+TEST_F(MasterServiceTest, BatchEvictShrinksSparseMetadataMaps) {
+    // Zero lease TTL so every committed object is immediately evictable.
+    auto service_config =
+        MasterServiceConfig::builder().set_default_kv_lease_ttl(0).build();
+    std::unique_ptr<MasterService> service_(new MasterService(service_config));
+    const UUID client_id = generate_uuid();
+    constexpr size_t buffer = 0x300000000;
+    constexpr size_t object_size = 1024;
+    constexpr size_t object_count = 2 * kShrinkMinBucketCount;
+    // Size the segment with ample headroom so the background eviction
+    // thread never fires; only the explicit call below evicts.
+    [[maybe_unused]] const auto context = PrepareSimpleSegment(
+        *service_, "test_segment", buffer, object_size * object_count * 16);
+
+    // Pick keys that all hash to one shard so its metadata map grows past
+    // the shrink floor; random keys would spread these objects thinly
+    // across all 1024 shards.
+    const size_t target_shard = MetadataShardIndex(*service_, "shrink_key_0");
+    std::vector<std::string> keys;
+    for (size_t i = 0; keys.size() < object_count; ++i) {
+        std::string key = "shrink_key_" + std::to_string(i);
+        if (MetadataShardIndex(*service_, key) != target_shard) continue;
+        keys.push_back(std::move(key));
+    }
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    for (const auto& key : keys) {
+        // Hard-pin the first object: it is excluded from eviction, so the
+        // tenant (and its metadata map) deterministically survives the
+        // full eviction below and the shrunk bucket count stays
+        // observable.
+        config.with_hard_pin = (&key == &keys.front());
+        ASSERT_TRUE(service_
+                        ->PutStart(client_id, key, TenantId::Default(),
+                                   object_size, config)
+                        .has_value());
+        ASSERT_TRUE(service_
+                        ->PutEnd(client_id, key, TenantId::Default(),
+                                 ReplicaType::MEMORY)
+                        .has_value());
+    }
+
+    const size_t buckets_before = MetadataBucketCount(*service_, target_shard);
+    ASSERT_GT(buckets_before, kShrinkMinBucketCount);
+
+    service_->RunBatchEvictForTesting(1.0, 1.0);
+
+    const size_t buckets_after = MetadataBucketCount(*service_, target_shard);
+    ASSERT_GT(buckets_after, 0u);
+    // Without the post-eviction shrink the bucket array would still sit at
+    // its high-water mark and this assertion would fail.
+    EXPECT_LT(buckets_after, buckets_before / 2);
 }
 
 TEST_F(MasterServiceTest, TryEvictLeasedObject) {


### PR DESCRIPTION
## Description

Contributes to #3452 (mooncake-master production OOM / RSS audit).

`std::unordered_map::erase` never reduces the bucket array. A metadata shard that once held millions of keys therefore keeps its high-water bucket memory (8 bytes/bucket) forever — `master_service.cpp` previously contained no `rehash()`/`shrink_to_fit()` call at all. After a 25M-object peak, even if eviction removes 90% of the entries, the bucket arrays stay at peak size.

This PR adds a conditional shrink after each `BatchEvict` cycle:

- **Condition**: `bucket_count() > kShrinkMinBucketCount (1024) && size() < bucket_count() / 4`. The bucket floor avoids rehash churn on small maps; the quarter threshold plus the 2x headroom (`rehash(size() * 2)`) keeps a freshly shrunk map from immediately growing again.
- **Scope**: `TenantState::metadata` (the dominant per-object map), only for shards that actually evicted in the current cycle. `BatchEvict` is already driven periodically, so no extra throttling is needed.
- **Lock & iterator safety**: the shrink runs while holding the shard lock via `MetadataShardAccessorRW`, in a dedicated pass after eviction finishes. The pass iterates `shard->tenants` — not the map being rehashed — so no live iterator is invalidated.

The shrink logic is a small reusable helper (`ShrinkBucketsIfSparse`) in `master_service.h`.

## Module

- [x] Mooncake Store

## Type of Change

- [x] Performance optimization

## Testing

- `ShrinkBucketsIfSparseThresholds`: unit test for the helper — small maps untouched, no shrink at exactly a quarter full, shrink once below.
- `BatchEvictShrinksSparseMetadataMaps`: discriminating service-level test — 2048 same-shard objects inserted (plus one hard-pinned survivor so the tenant deterministically outlives full eviction), then `BatchEvict`; asserts the shard's metadata `bucket_count` drops below half its high-water mark. Reverting the fix makes this assertion fail because the bucket array never shrinks.
- `clang-format --dry-run --Werror` clean on all touched files. Local machine cannot build mooncake-store (dependency set too large); compilation is verified by CI.

## AI Assistance Disclosure

AI-assisted (code drafted with an AI agent); the change has been human-reviewed line by line.