### PR TITLE
[CI] Serialize mmap_arena_fallback_test to curb coverage flake

### DIFF
--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -196,6 +196,12 @@ add_store_test(health_check_test health_check_test.cpp)
 add_store_test(http_metadata_server_test http_metadata_server_test.cpp)
 add_store_test(mmap_arena_test mmap_arena_test.cpp)
 add_store_test(mmap_arena_fallback_test mmap_arena_fallback_test.cpp)
+# mmap_arena_fallback_test exercises a large slice of utils.cpp/mmap_arena.cpp,
+# so under --coverage builds it produces heavy .gcda merge traffic at exit.
+# Running it in parallel with the rest of the suite intermittently trips
+# libgcov's file locking on CI: every gtest case passes yet the process exits
+# non-zero. Serialize it as mitigation; see the PR for the full analysis.
+set_tests_properties(mmap_arena_fallback_test PROPERTIES RUN_SERIAL TRUE)
 add_store_test(object_data_type_test object_data_type_test.cpp)
 add_subdirectory(e2e)
 


### PR DESCRIPTION
## Description

Mitigates a recurring CI flake in `mmap_arena_fallback_test` by running it serially (`RUN_SERIAL TRUE`). One-line CMake change, no test code touched.

### Symptom

- Under the coverage build with `ctest --parallel $(nproc)`, the test intermittently fails at the **suite level**: every gtest case prints `[ OK ]`, yet ctest reports the test as `Failed` (non-zero process exit).
- A plain re-run of the job passes. This has broken CI for several unrelated PRs in the past. Since #3482 the test runs in nightly, so the flake now produces recurring nightly red noise instead.

### Root cause hypothesis (suspected, ~70% confidence)

- CI builds with `CXXFLAGS=--coverage` and runs `ctest --parallel $(nproc)`, so 100+ test binaries share the same set of `.gcda` files.
- libgcov serializes `.gcda` merge writes at `atexit` using `fcntl` file locks. On GitHub Actions (overlayfs), this locking is unreliable under high concurrency; a failed merge can rewrite the process exit code.
- That matches the observed signature exactly: all cases pass, the process still exits non-zero, and a re-run (less contention) succeeds.
- `mmap_arena_fallback_test` exercises a wide slice of `utils.cpp` / `mmap_arena.cpp`, giving it unusually heavy `.gcda` write traffic at exit — a natural repeat offender.

No existing issue or open PR covers this; nobody appears to be working on it.

### Why `RUN_SERIAL`

- One line, zero risk to test semantics or coverage data collection — it only removes the concurrency window during this binary's gcov flush.
- If the flake ever recurs even when serialized, the escalation path is per-test `GCOV_PREFIX` isolation (separate `.gcda` directories per test), which is a larger change and not justified yet.

### Impact

- Only a marginal increase in total ctest wall time for coverage/nightly runs; no functional change.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other: CI flake mitigation

## How Has This Been Tested?

CMake-only change (test property). Verified `cmake-format --check` (v0.6.13, same as the pre-commit hook) passes on the modified file. Since the flake is intermittent and CI-environment-specific, effectiveness will be observed via nightly runs after merge.

**Test commands:**
```bash
cmake-format --check mooncake-store/tests/CMakeLists.txt
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used for the flake root-cause investigation and drafting this change; the submitter reviewed and stands behind the analysis and the one-line mitigation.