### PR TITLE
[Store] add key retention time metrics for client and cluster-level

### DIFF
--- a/mooncake-store/include/client_metrics_aggregator.h
+++ b/mooncake-store/include/client_metrics_aggregator.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <ylt/metric/gauge.hpp>
 
@@ -46,6 +47,10 @@ class ClientMetricsAggregator {
                               const DataMetricSnapshot& new_v,
                               CounterGroup& group);
 
+    // Recomputes retention aggregates from client_snapshots_.
+    // Callers must hold mutex_.
+    void RefreshRetentionAggregates();
+
     mutable std::mutex mutex_;
     // Per-client baseline for signed deltas; subtracted on client removal.
     std::unordered_map<UUID, ClientMetricSnapshot> client_snapshots_;
@@ -55,6 +60,14 @@ class ClientMetricsAggregator {
     CounterGroup remote_;  // per-op granularity
     ylt::metric::gauge_t remote_read_retries_;
     ylt::metric::gauge_t remote_write_retries_;
+
+    // Cluster-wide key retention. The bucket arrays hold the merged
+    // distributions (non-cumulative) over KeyRetentionMetric::LifetimeBuckets()
+    // and are rendered as histograms at serialize time.
+    ylt::metric::gauge_t key_live_count_;
+    ylt::metric::gauge_t key_removed_count_;
+    std::vector<int64_t> key_live_age_buckets_;
+    std::vector<int64_t> key_removed_age_buckets_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/heartbeat_type.h
+++ b/mooncake-store/include/heartbeat_type.h
@@ -67,6 +67,15 @@ struct RemoteDataMetricSnapshot {
 };
 YLT_REFL(RemoteDataMetricSnapshot, data, read_retries, write_retries);
 
+struct KeyRetentionSnapshot {
+    int64_t live_count = 0;
+    int64_t removed_total = 0;
+    std::vector<int64_t> live_age_buckets;  // approximate (birth cohorts)
+    std::vector<int64_t> removed_buckets;
+};
+YLT_REFL(KeyRetentionSnapshot, live_count, removed_total, live_age_buckets,
+         removed_buckets);
+
 // Metric snapshot carried by the SYNC_CLIENT_METRIC heartbeat task.
 // Granularity:
 // - total_request: request (batch) granularity; one BatchPut/BatchGet counts
@@ -77,8 +86,10 @@ struct ClientMetricSnapshot {
     DataMetricSnapshot total_request;
     DataMetricSnapshot local_request;
     RemoteDataMetricSnapshot remote_request;
+    KeyRetentionSnapshot key_retention;
 };
-YLT_REFL(ClientMetricSnapshot, total_request, local_request, remote_request);
+YLT_REFL(ClientMetricSnapshot, total_request, local_request, remote_request,
+         key_retention);
 
 /**
  * @brief Param for SYNC_CLIENT_METRIC task.

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -1,9 +1,12 @@
 #pragma once
 
 #include <array>
+#include <atomic>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <ylt/metric/gauge.hpp>
 
@@ -200,6 +203,78 @@ struct TierMetric {
     std::unordered_map<UUID, TierEntry> tiers_;
 };
 
+// record how long keys live on this client
+struct KeyRetentionMetric {
+   public:
+    explicit KeyRetentionMetric(
+        const std::string& prefix,
+        const std::map<std::string, std::string>& labels = {},
+        std::chrono::steady_clock::time_point anchor =
+            std::chrono::steady_clock::now());
+
+    // Data path hooks: lock-free, O(1).
+    void OnKeyCreated(std::chrono::steady_clock::time_point birth);
+    void OnKeyRemoved(std::chrono::steady_clock::time_point birth);
+
+    KeyRetentionSnapshot Snapshot();
+    void serialize(std::string& str);
+    std::string summary_metrics();
+
+    // Bucket boundaries (seconds) for lifetime / live-age distributions.
+    static const std::vector<double>& LifetimeBuckets();
+
+    // Interpolates the quantiles qs (each in (0,1], sorted ascending) from
+    // non-cumulative bucket counts in a single pass (histogram semantics:
+    // bucket j counts values <= boundaries[j]).
+    // Returns one value per q, in input order. Empty distribution -> zeros;
+    // quantiles in the open +Inf bucket resolve to the largest finite boundary.
+    static std::vector<int64_t> InterpolateQuantiles(
+        const std::vector<double>& boundaries,
+        const std::vector<int64_t>& bucket_counts,
+        const std::vector<double>& quantiles);
+
+    // Renders a classic-format Prometheus histogram from non-cumulative
+    // per-bucket counts over `boundaries` (implicit +Inf bucket last).
+    // Used for scrape-time distributions that cannot be expressed as
+    // cumulative observe() histograms (e.g. the current age of live keys).
+    // `_sum` is estimated from bucket midpoints (+Inf resolves to the
+    // largest finite boundary).
+    static void SerializeBucketHistogram(
+        std::string& str, const std::string& name, const std::string& help,
+        const std::map<std::string, std::string>& labels,
+        const std::vector<double>& boundaries,
+        const std::vector<int64_t>& bucket_counts);
+
+   private:
+    void CollectBuckets(std::vector<int64_t>& live_age_buckets,
+                        std::vector<int64_t>& removed_buckets);
+    std::vector<int64_t> BuildLiveAgeBuckets(int64_t t) const;
+    int64_t ToOffsetSeconds(std::chrono::steady_clock::time_point tp) const;
+    size_t CohortIndex(int64_t birth_offset_seconds) const;
+
+   private:
+    const std::chrono::steady_clock::time_point anchor_;
+    // Retained to render the scrape-time live-age histogram.
+    const std::string prefix_;
+    const std::map<std::string, std::string> labels_;
+
+    ylt::metric::gauge_t live_keys;
+    ylt::metric::counter_t removed_keys;
+    ylt::metric::histogram_t removed_age;
+
+    // Birth cohorts for the live-age distribution. cohorts_[i] counts
+    // live keys whose birth offset (seconds since anchor_) falls in
+    // [cohort_bounds_[i], cohort_bounds_[i+1]); the last slot extends to
+    // +inf (births beyond kCohortCoverageSeconds clamp into it).
+    // At scrape time a slot's keys are all estimated at "now - midpoint(slot)",
+    // so the error is at most one slot width.
+    // Example: a key born 100s after anchor lands in slot [81, 106);
+    // at t=1000s its age is estimated as 1000 - 93 = 907s (true: 900s).
+    static constexpr int64_t kCohortCoverageSeconds = 365 * 24 * 3600;
+    std::vector<int64_t> cohort_bounds_;
+    std::vector<std::atomic<int64_t>> cohorts_;
+};
+
 struct P2PClientMetric : public ClientMetric {
    public:
     // total_request is recorded at request (Batch) granularity:
@@ -215,6 +290,7 @@ struct P2PClientMetric : public ClientMetric {
     PeerRequestMetrics peer_request_metrics;
     // Per-tier storage metrics; initially empty. Shared with TieredBackend.
     std::shared_ptr<TierMetric> tier_metric;
+    std::shared_ptr<KeyRetentionMetric> key_retention;
 
    public:
     static std::unique_ptr<P2PClientMetric> Create(

--- a/mooncake-store/include/p2p_client_metric.h
+++ b/mooncake-store/include/p2p_client_metric.h
@@ -251,6 +251,8 @@ struct KeyRetentionMetric {
     std::vector<int64_t> BuildLiveAgeBuckets(int64_t t) const;
     int64_t ToOffsetSeconds(std::chrono::steady_clock::time_point tp) const;
     size_t CohortIndex(int64_t birth_offset_seconds) const;
+    // Geometric (~1.3x) birth-offset boundaries for the cohort counters.
+    static std::vector<int64_t> BuildCohortBounds();
 
    private:
     const std::chrono::steady_clock::time_point anchor_;

--- a/mooncake-store/include/tiered_cache/tiered_backend.h
+++ b/mooncake-store/include/tiered_cache/tiered_backend.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -19,9 +20,10 @@
 
 namespace mooncake {
 
-class TieredBackend;     // Forward declaration
-class IClientScheduler;  // Forward declaration
-struct TierMetric;       // Optional per-tier metrics sink (p2p_client_metric.h)
+class TieredBackend;        // Forward declaration
+class IClientScheduler;     // Forward declaration
+struct TierMetric;          // p2p_client_metric.h
+struct KeyRetentionMetric;  // p2p_client_metric.h
 
 /**
  * @struct TieredLocation
@@ -148,7 +150,8 @@ class TieredBackend {
         AddReplicaCallback add_replica_callback,
         RemoveReplicaCallback remove_replica_callback,
         SegmentSyncCallback segment_sync_callback,
-        std::shared_ptr<TierMetric> tier_metric = nullptr);
+        std::shared_ptr<TierMetric> tier_metric = nullptr,
+        std::shared_ptr<KeyRetentionMetric> retention_metric = nullptr);
 
     // --- Client-Centric Operations ---
     // All the following operations are designed for Client-Centric, Client
@@ -339,6 +342,7 @@ class TieredBackend {
         std::vector<std::pair<UUID, AllocationHandle>>
             replicas;          // tier_id -> handle
         uint64_t version = 0;  // Monotonically increasing version
+        std::chrono::steady_clock::time_point created_at{};  // retention
     };
 
     // Get list of Tier IDs sorted by priority (descending)
@@ -386,8 +390,9 @@ class TieredBackend {
     RemoveReplicaCallback remove_replica_callback_;
     // Callback for segment lifecycle synchronization with Master
     SegmentSyncCallback segment_sync_callback_;
-    // Optional per-tier metrics; null when metric collection is disabled
+    // Optional metrics sinks; null when metric collection is disabled
     std::shared_ptr<TierMetric> tier_metric_;
+    std::shared_ptr<KeyRetentionMetric> retention_metric_;
 
     // Scheduler
     std::unique_ptr<IClientScheduler> scheduler_;

--- a/mooncake-store/src/client_metrics_aggregator.cpp
+++ b/mooncake-store/src/client_metrics_aggregator.cpp
@@ -1,8 +1,11 @@
 #include "client_metrics_aggregator.h"
 
+#include <glog/logging.h>
+
 #include <iomanip>
 #include <sstream>
 
+#include "p2p_client_metric.h"
 #include "utils.h"
 
 namespace mooncake {
@@ -66,9 +69,23 @@ ClientMetricsAggregator::ClientMetricsAggregator()
           "Cluster-wide remote read retries (route-based remote flow)"),
       remote_write_retries_(
           "master_cluster_remote_write_retries",
-          "Cluster-wide remote write retries (route-based remote flow)") {
+          "Cluster-wide remote write retries (route-based remote flow)"),
+      key_live_count_(
+          "master_cluster_key_retention_live_count",
+          "Cluster-wide number of keys currently retained on clients"),
+      key_removed_count_(
+          "master_cluster_key_retention_removed_total",
+          "Cluster-wide cumulative number of keys removed from clients "
+          "(deleted, evicted or cleared)") {
     remote_read_retries_.inc(0);
     remote_write_retries_.inc(0);
+    // Mark retention gauges changed once so zero values are serialized.
+    key_live_count_.inc(0);
+    key_removed_count_.inc(0);
+    key_live_age_buckets_.assign(
+        KeyRetentionMetric::LifetimeBuckets().size() + 1, 0);
+    key_removed_age_buckets_.assign(
+        KeyRetentionMetric::LifetimeBuckets().size() + 1, 0);
 }
 
 void ClientMetricsAggregator::Update(const UUID& client_id,
@@ -89,6 +106,7 @@ void ClientMetricsAggregator::Update(const UUID& client_id,
                    old_v.remote_request.write_retries,
                remote_write_retries_);
     client_snapshots_[client_id] = snapshot;
+    RefreshRetentionAggregates();
 }
 
 void ClientMetricsAggregator::ApplyDataMetricDelta(
@@ -124,6 +142,47 @@ void ClientMetricsAggregator::OnClientRemoved(const UUID& client_id) {
     ApplyDelta(-snap.remote_request.read_retries, remote_read_retries_);
     ApplyDelta(-snap.remote_request.write_retries, remote_write_retries_);
     client_snapshots_.erase(it);
+    RefreshRetentionAggregates();
+}
+
+void ClientMetricsAggregator::RefreshRetentionAggregates() {
+    const size_t num_buckets = KeyRetentionMetric::LifetimeBuckets().size() + 1;
+
+    int64_t live_sum = 0;
+    int64_t removed_sum = 0;
+    key_live_age_buckets_.assign(num_buckets, 0);
+    key_removed_age_buckets_.assign(num_buckets, 0);
+
+    auto accumulate = [&](std::vector<int64_t>& dst,
+                          const std::vector<int64_t>& src,
+                          const UUID& client_id, const char* what) {
+        if (src.empty()) {
+            return;  // client does not report retention data
+        }
+        if (src.size() != num_buckets) {
+            LOG(ERROR) << "ClientMetricsAggregator: key retention " << what
+                       << " bucket count mismatch, client_id=" << client_id
+                       << ", expected=" << num_buckets << ", got=" << src.size()
+                       << "; treated as zero contribution";
+            return;
+        }
+        for (size_t i = 0; i < num_buckets; ++i) {
+            dst[i] += src[i];
+        }
+    };
+
+    for (const auto& [client_id, snap] : client_snapshots_) {
+        const KeyRetentionSnapshot& r = snap.key_retention;
+        live_sum += r.live_count;
+        removed_sum += r.removed_total;
+        accumulate(key_live_age_buckets_, r.live_age_buckets, client_id,
+                   "live_age");
+        accumulate(key_removed_age_buckets_, r.removed_buckets, client_id,
+                   "removed");
+    }
+
+    key_live_count_.update(live_sum);
+    key_removed_count_.update(removed_sum);
 }
 
 void ClientMetricsAggregator::ApplyDelta(int64_t delta,
@@ -173,6 +232,33 @@ void ClientMetricsAggregator::Serialize(std::string& out) {
 
     serialize_metric(remote_read_retries_);
     serialize_metric(remote_write_retries_);
+
+    serialize_metric(key_live_count_);
+    serialize_metric(key_removed_count_);
+    // Merged retention distributions, rendered as scrape-time histograms
+    // (quantiles via histogram_quantile() at query time).
+    KeyRetentionMetric::SerializeBucketHistogram(
+        out, "master_cluster_key_retention_live_age_seconds",
+        "Cluster-wide current age distribution of live keys on clients "
+        "(seconds; approximate, merged from per-client birth cohorts; sum "
+        "estimated from bucket midpoints)",
+        {}, KeyRetentionMetric::LifetimeBuckets(), key_live_age_buckets_);
+    KeyRetentionMetric::SerializeBucketHistogram(
+        out, "master_cluster_key_retention_removed_age_seconds",
+        "Cluster-wide lifetime distribution of removed keys on clients "
+        "(seconds; sum estimated from bucket midpoints)",
+        {}, KeyRetentionMetric::LifetimeBuckets(), key_removed_age_buckets_);
+    std::vector<int64_t> all_buckets(key_live_age_buckets_.size(), 0);
+    for (size_t i = 0;
+         i < all_buckets.size() && i < key_removed_age_buckets_.size(); ++i) {
+        all_buckets[i] = key_live_age_buckets_[i] + key_removed_age_buckets_[i];
+    }
+    KeyRetentionMetric::SerializeBucketHistogram(
+        out, "master_cluster_key_retention_all_lifetime_seconds",
+        "Cluster-wide lifetime distribution of all keys seen by clients "
+        "(seconds): live keys censored at current age + removed keys' "
+        "exact lifetime; sum estimated from bucket midpoints)",
+        {}, KeyRetentionMetric::LifetimeBuckets(), all_buckets);
 }
 
 std::string ClientMetricsAggregator::Summary() {
@@ -215,6 +301,28 @@ std::string ClientMetricsAggregator::Summary() {
     append_put("Put(remote)", remote_);
     ss << " | Retries: read=" << remote_read_retries_.value()
        << ", write=" << remote_write_retries_.value();
+
+    const std::vector<double> kQuantiles = {0.30, 0.50, 0.80, 0.95};
+    const std::vector<double>& lifetime_buckets =
+        KeyRetentionMetric::LifetimeBuckets();
+    std::vector<int64_t> all_buckets(key_live_age_buckets_.size(), 0);
+    for (size_t i = 0;
+         i < all_buckets.size() && i < key_removed_age_buckets_.size(); ++i) {
+        all_buckets[i] = key_live_age_buckets_[i] + key_removed_age_buckets_[i];
+    }
+    const std::vector<int64_t> live_q =
+        KeyRetentionMetric::InterpolateQuantiles(
+            lifetime_buckets, key_live_age_buckets_, kQuantiles);
+    const std::vector<int64_t> removed_q =
+        KeyRetentionMetric::InterpolateQuantiles(
+            lifetime_buckets, key_removed_age_buckets_, kQuantiles);
+    const std::vector<int64_t> all_q = KeyRetentionMetric::InterpolateQuantiles(
+        lifetime_buckets, all_buckets, kQuantiles);
+    ss << " | Retention: live=" << key_live_count_.value()
+       << ", removed=" << key_removed_count_.value()
+       << ", live_age p50=" << live_q[1] << "s, p95=" << live_q[3]
+       << "s, removed_age p50=" << removed_q[1] << "s, p95=" << removed_q[3]
+       << "s, all_lifetime p50=" << all_q[1] << "s, p95=" << all_q[3] << "s";
     return ss.str();
 }
 

--- a/mooncake-store/src/client_metrics_aggregator.cpp
+++ b/mooncake-store/src/client_metrics_aggregator.cpp
@@ -73,10 +73,10 @@ ClientMetricsAggregator::ClientMetricsAggregator()
       key_live_count_(
           "master_cluster_key_retention_live_count",
           "Cluster-wide number of keys currently retained on clients"),
-      key_removed_count_(
-          "master_cluster_key_retention_removed_total",
-          "Cluster-wide cumulative number of keys removed from clients "
-          "(deleted, evicted or cleared)") {
+      key_removed_count_("master_cluster_key_retention_removed_count",
+                         "Cluster-wide number of keys removed from clients;"
+                         "gauge summed from client-reported cumulative counts, "
+                         "may decrease when clients restart or rejoin") {
     remote_read_retries_.inc(0);
     remote_write_retries_.inc(0);
     // Mark retention gauges changed once so zero values are serialized.

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -3,7 +3,9 @@
 #include <glog/logging.h>
 
 #include <algorithm>
+#include <array>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include "tiered_cache/tiers/cache_tier.h"
@@ -480,6 +482,316 @@ std::string TierMetric::summary_metrics() {
 }
 
 // ============================================================================
+// KeyRetentionMetric
+// ============================================================================
+
+const std::vector<double>& KeyRetentionMetric::LifetimeBuckets() {
+    static const std::vector<double> kBoundaries = {
+        1, 2, 5, 10, 30, 60, 300, 600, 1800, 3600, 21600, 86400, 604800};
+    return kBoundaries;
+}
+
+std::vector<int64_t> KeyRetentionMetric::InterpolateQuantiles(
+    const std::vector<double>& boundaries,
+    const std::vector<int64_t>& bucket_counts,
+    const std::vector<double>& quantiles) {
+    std::vector<int64_t> result(quantiles.size(), 0);
+    const bool valid_qs =
+        !quantiles.empty() &&
+        std::is_sorted(quantiles.begin(), quantiles.end()) &&
+        std::all_of(quantiles.begin(), quantiles.end(),
+                    [](double q) { return q > 0.0 && q <= 1.0; });
+    if (!valid_qs) {
+        LOG(ERROR) << "KeyRetentionMetric::InterpolateQuantiles: quantiles "
+                      "must be sorted ascending and within (0, 1]";
+        return result;
+    }
+
+    int64_t total = 0;
+    for (const int64_t count : bucket_counts) {
+        total += count;
+    }
+    if (total <= 0 || boundaries.empty()) {
+        return result;
+    }
+
+    const double total_d = static_cast<double>(total);
+    size_t next = 0;
+    int64_t cumulative = 0;
+    for (size_t i = 0; i < bucket_counts.size() && next < quantiles.size();
+         ++i) {
+        cumulative += bucket_counts[i];
+        if (static_cast<double>(cumulative) < quantiles[next] * total_d) {
+            continue;
+        }
+        if (i >= boundaries.size()) {
+            // Open +Inf bucket: resolve to the largest finite boundary.
+            while (next < quantiles.size() && static_cast<double>(cumulative) >=
+                                                  quantiles[next] * total_d) {
+                result[next++] = static_cast<int64_t>(boundaries.back());
+            }
+            continue;
+        }
+        const double lower = (i == 0) ? 0.0 : boundaries[i - 1];
+        const double upper = boundaries[i];
+        const double before =
+            static_cast<double>(cumulative - bucket_counts[i]);
+        // bucket_counts[i] > 0 here: a zero-count bucket can never raise
+        // the cumulative past a still-unresolved target.
+        while (next < quantiles.size() &&
+               static_cast<double>(cumulative) >= quantiles[next] * total_d) {
+            const double target = quantiles[next] * total_d;
+            const double frac =
+                (target - before) / static_cast<double>(bucket_counts[i]);
+            result[next++] =
+                static_cast<int64_t>(lower + (upper - lower) * frac);
+        }
+    }
+    // Targets never reached (numerical edge): clamp like the +Inf bucket.
+    while (next < quantiles.size()) {
+        result[next++] = static_cast<int64_t>(boundaries.back());
+    }
+    return result;
+}
+
+void KeyRetentionMetric::SerializeBucketHistogram(
+    std::string& str, const std::string& name, const std::string& help,
+    const std::map<std::string, std::string>& labels,
+    const std::vector<double>& boundaries,
+    const std::vector<int64_t>& bucket_counts) {
+    if (bucket_counts.size() != boundaries.size() + 1) {
+        LOG(ERROR) << "KeyRetentionMetric::SerializeBucketHistogram: metric "
+                   << name << " expects " << boundaries.size() + 1
+                   << " buckets, got " << bucket_counts.size();
+        return;
+    }
+    int64_t total = 0;
+    for (const int64_t count : bucket_counts) {
+        total += count;
+    }
+    if (total <= 0) {
+        return;  // Consistent with ylt histograms: skip empty distributions.
+    }
+
+    str.append("# HELP ").append(name).append(" ").append(help).append("\n");
+    str.append("# TYPE ").append(name).append(" histogram\n");
+
+    // Appends the label block: static labels plus, for bucket samples, the
+    // le label. Omitted entirely when both are empty.
+    const auto append_labels = [&str, &labels](const std::string& le) {
+        if (labels.empty() && le.empty()) {
+            str.append(" ");
+            return;
+        }
+        str.append("{");
+        for (const auto& [k, v] : labels) {
+            str.append(k).append("=\"").append(v).append("\",");
+        }
+        if (!le.empty()) {
+            str.append("le=\"").append(le).append("\"");
+        } else {
+            str.pop_back();  // Drop the trailing comma of the last label.
+        }
+        str.append("} ");
+    };
+
+    double sum = 0.0;
+    int64_t cumulative = 0;
+    for (size_t i = 0; i < bucket_counts.size(); ++i) {
+        cumulative += bucket_counts[i];
+        const double lower = (i == 0) ? 0.0 : boundaries[i - 1];
+        const double upper =
+            (i < boundaries.size()) ? boundaries[i] : boundaries.back();
+        sum += static_cast<double>(bucket_counts[i]) * (lower + upper) / 2.0;
+
+        str.append(name).append("_bucket");
+        const std::string le =
+            (i == boundaries.size()) ? "+Inf" : std::to_string(boundaries[i]);
+        append_labels(le);
+        str.append(std::to_string(cumulative)).append("\n");
+    }
+    str.append(name).append("_sum");
+    append_labels("");
+    str.append(std::to_string(sum)).append("\n");
+    str.append(name).append("_count");
+    append_labels("");
+    str.append(std::to_string(total)).append("\n");
+}
+
+KeyRetentionMetric::KeyRetentionMetric(
+    const std::string& prefix, const std::map<std::string, std::string>& labels,
+    std::chrono::steady_clock::time_point anchor)
+    : anchor_(anchor),
+      prefix_(prefix),
+      labels_(labels),
+      live_keys(prefix + "_live_count",
+                "Number of keys currently retained on this client", labels),
+      removed_keys(prefix + "_removed_total",
+                   "Cumulative number of keys removed from this client "
+                   "(deleted or evicted)",
+                   labels),
+      removed_age(prefix + "_removed_age_seconds",
+                  "Lifetime distribution of removed keys on this "
+                  "client (seconds; deleted, evicted or cleared)",
+                  LifetimeBuckets(), labels) {
+    // Geometric (~1.3x) birth-offset boundaries for the cohort counters.
+    int64_t bound = 1;
+    while (bound < kCohortCoverageSeconds) {
+        cohort_bounds_.push_back(bound);
+        const int64_t next = static_cast<int64_t>(bound * 1.3) + 1;
+        bound = next > bound ? next : bound + 1;
+    }
+    cohort_bounds_.push_back(bound);
+    cohorts_.resize(cohort_bounds_.size());
+    for (auto& cohort : cohorts_) {
+        cohort.store(0, std::memory_order_relaxed);
+    }
+}
+
+void KeyRetentionMetric::OnKeyCreated(
+    std::chrono::steady_clock::time_point birth) {
+    live_keys.inc();
+    cohorts_[CohortIndex(ToOffsetSeconds(birth))].fetch_add(
+        1, std::memory_order_relaxed);
+}
+
+void KeyRetentionMetric::OnKeyRemoved(
+    std::chrono::steady_clock::time_point birth) {
+    const int64_t birth_offset = ToOffsetSeconds(birth);
+    const int64_t lifetime = std::max<int64_t>(
+        0, ToOffsetSeconds(std::chrono::steady_clock::now()) - birth_offset);
+
+    live_keys.dec();
+    cohorts_[CohortIndex(birth_offset)].fetch_sub(1, std::memory_order_relaxed);
+    removed_keys.inc();
+    removed_age.observe(lifetime);
+}
+
+int64_t KeyRetentionMetric::ToOffsetSeconds(
+    std::chrono::steady_clock::time_point tp) const {
+    return std::chrono::duration_cast<std::chrono::seconds>(tp - anchor_)
+        .count();
+}
+
+size_t KeyRetentionMetric::CohortIndex(int64_t birth_offset_seconds) const {
+    const size_t not_greater = static_cast<size_t>(std::distance(
+        cohort_bounds_.begin(),
+        std::upper_bound(cohort_bounds_.begin(), cohort_bounds_.end(),
+                         birth_offset_seconds)));
+    if (not_greater == 0) {
+        return 0;  // clamp (e.g. negative offset) into the first slot
+    }
+    return std::min(not_greater - 1, cohorts_.size() - 1);
+}
+
+KeyRetentionSnapshot KeyRetentionMetric::Snapshot() {
+    KeyRetentionSnapshot snap;
+    snap.live_count = live_keys.value();
+    snap.removed_total = removed_keys.value();
+    CollectBuckets(snap.live_age_buckets, snap.removed_buckets);
+    return snap;
+}
+
+void KeyRetentionMetric::serialize(std::string& str) {
+    std::vector<int64_t> live_age_buckets;
+    std::vector<int64_t> removed_buckets;
+    CollectBuckets(live_age_buckets, removed_buckets);
+    live_keys.serialize(str);
+    removed_keys.serialize(str);
+    removed_age.serialize(str);
+    SerializeBucketHistogram(
+        str, prefix_ + "_live_age_seconds",
+        "Current age distribution of live keys on this client (seconds); "
+        "approximate (birth cohorts); sum estimated from bucket midpoints",
+        labels_, LifetimeBuckets(), live_age_buckets);
+    std::vector<int64_t> all_buckets(live_age_buckets.size(), 0);
+    for (size_t i = 0; i < all_buckets.size() && i < removed_buckets.size();
+         ++i) {
+        all_buckets[i] = live_age_buckets[i] + removed_buckets[i];
+    }
+    SerializeBucketHistogram(
+        str, prefix_ + "_all_lifetime_seconds",
+        "Lifetime distribution of all keys seen by this client (seconds): "
+        "live keys censored at current age + removed keys' exact lifetime; "
+        "sum estimated from bucket midpoints",
+        labels_, LifetimeBuckets(), all_buckets);
+}
+
+std::string KeyRetentionMetric::summary_metrics() {
+    std::vector<int64_t> live_age_buckets;
+    std::vector<int64_t> removed_buckets;
+    CollectBuckets(live_age_buckets, removed_buckets);
+    std::vector<int64_t> all_buckets(live_age_buckets.size(), 0);
+    for (size_t i = 0; i < all_buckets.size() && i < removed_buckets.size();
+         ++i) {
+        all_buckets[i] = live_age_buckets[i] + removed_buckets[i];
+    }
+
+    const std::vector<double>& boundaries = LifetimeBuckets();
+    static const std::vector<double> kQuantiles = {0.30, 0.50, 0.80, 0.95};
+    const std::vector<int64_t> live_q =
+        InterpolateQuantiles(boundaries, live_age_buckets, kQuantiles);
+    const std::vector<int64_t> removed_q =
+        InterpolateQuantiles(boundaries, removed_buckets, kQuantiles);
+    const std::vector<int64_t> all_q =
+        InterpolateQuantiles(boundaries, all_buckets, kQuantiles);
+
+    std::stringstream ss;
+    ss << "live=" << live_keys.value() << ", removed=" << removed_keys.value()
+       << "\n";
+    ss << "live_age: p30=" << live_q[0] << "s, p50=" << live_q[1]
+       << "s, p80=" << live_q[2] << "s, p95=" << live_q[3] << "s\n";
+    ss << "removed_age: p30=" << removed_q[0] << "s, p50=" << removed_q[1]
+       << "s, p80=" << removed_q[2] << "s, p95=" << removed_q[3] << "s\n";
+    ss << "all_lifetime: p30=" << all_q[0] << "s, p50=" << all_q[1]
+       << "s, p80=" << all_q[2] << "s, p95=" << all_q[3] << "s\n";
+    return ss.str();
+}
+
+// Builds the two scrape-time distributions: current age of live keys
+// (from birth cohorts) and lifetime of removed keys.
+void KeyRetentionMetric::CollectBuckets(std::vector<int64_t>& live_age_buckets,
+                                        std::vector<int64_t>& removed_buckets) {
+    live_age_buckets =
+        BuildLiveAgeBuckets(ToOffsetSeconds(std::chrono::steady_clock::now()));
+    removed_buckets.clear();
+    for (const auto& counter : removed_age.get_bucket_counts()) {
+        removed_buckets.push_back(counter->value());
+    }
+}
+
+std::vector<int64_t> KeyRetentionMetric::BuildLiveAgeBuckets(int64_t t) const {
+    const std::vector<double>& boundaries = LifetimeBuckets();
+    std::vector<int64_t> buckets(boundaries.size() + 1, 0);
+    for (size_t i = 0; i < cohorts_.size(); ++i) {
+        const int64_t count = cohorts_[i].load(std::memory_order_relaxed);
+        if (count <= 0) {
+            if (count < 0) {
+                LOG(ERROR) << "KeyRetentionMetric: negative cohort count "
+                           << count << " at slot " << i;
+            }
+            continue;
+        }
+        const int64_t lo = cohort_bounds_[i];
+        // Clamp the slot's upper edge to t (no birth is newer than now) so
+        // the frontier slot stays centered on the possible birth range.
+        int64_t hi =
+            (i + 1 < cohort_bounds_.size()) ? cohort_bounds_[i + 1] : t;
+        hi = std::min(hi, std::max(t, lo + 1));
+        if (hi <= lo) {
+            hi = lo + 1;
+        }
+        const int64_t mid_age = std::max<int64_t>(0, t - (lo + hi) / 2);
+        const size_t bucket = static_cast<size_t>(
+            std::distance(boundaries.begin(),
+                          std::lower_bound(boundaries.begin(), boundaries.end(),
+                                           static_cast<double>(mid_age))));
+        buckets[bucket] += count;
+    }
+    return buckets;
+}
+
+// ============================================================================
 // P2PClientMetric
 // ============================================================================
 
@@ -491,7 +803,9 @@ P2PClientMetric::P2PClientMetric(
       remote_request("mooncake_p2p_remote", labels),
       rollback("mooncake_p2p_rollback", labels),
       peer_request_metrics("mooncake_p2p_peer", labels),
-      tier_metric(std::make_shared<TierMetric>()) {}
+      tier_metric(std::make_shared<TierMetric>()),
+      key_retention(std::make_shared<KeyRetentionMetric>(
+          "mooncake_p2p_key_retention", labels)) {}
 
 ClientMetricSnapshot P2PClientMetric::BuildSyncSnapshot() {
     ClientMetricSnapshot snap;
@@ -501,6 +815,7 @@ ClientMetricSnapshot P2PClientMetric::BuildSyncSnapshot() {
     snap.remote_request.data = SnapshotDataMetric(remote_request);
     snap.remote_request.read_retries = remote_request.read_retries.value();
     snap.remote_request.write_retries = remote_request.write_retries.value();
+    snap.key_retention = key_retention->Snapshot();
     return snap;
 }
 
@@ -512,6 +827,7 @@ void P2PClientMetric::serialize(std::string& str) {
     rollback.serialize(str);
     peer_request_metrics.serialize(str);
     tier_metric->serialize(str);
+    key_retention->serialize(str);
 }
 
 std::string P2PClientMetric::summary_metrics() {
@@ -537,6 +853,9 @@ std::string P2PClientMetric::summary_metrics() {
 
     ss << "=== P2P Tier Metrics ===\n";
     ss << tier_metric->summary_metrics();
+
+    ss << "=== P2P Key Retention ===\n";
+    ss << key_retention->summary_metrics();
 
     return ss.str();
 }

--- a/mooncake-store/src/p2p_client_metric.cpp
+++ b/mooncake-store/src/p2p_client_metric.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <iomanip>
 #include <sstream>
 #include <utility>
 #include <vector>
@@ -13,6 +14,24 @@
 namespace mooncake {
 
 namespace {
+
+// Renders a histogram bucket boundary for the `le` label without
+// redundant trailing zeros ("1" instead of "1.000000", "2.5" unchanged)
+// for cleaner Prometheus exposition.
+std::string FormatBucketBoundary(double boundary) {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(6) << boundary;
+    std::string text = oss.str();
+    if (text.find('.') != std::string::npos) {
+        while (!text.empty() && text.back() == '0') {
+            text.pop_back();
+        }
+        if (!text.empty() && text.back() == '.') {
+            text.pop_back();
+        }
+    }
+    return text;
+}
 
 DataMetricSnapshot SnapshotDataMetric(DataMetric& m) {
     DataMetricSnapshot s;
@@ -605,8 +624,9 @@ void KeyRetentionMetric::SerializeBucketHistogram(
         sum += static_cast<double>(bucket_counts[i]) * (lower + upper) / 2.0;
 
         str.append(name).append("_bucket");
-        const std::string le =
-            (i == boundaries.size()) ? "+Inf" : std::to_string(boundaries[i]);
+        const std::string le = (i == boundaries.size())
+                                   ? "+Inf"
+                                   : FormatBucketBoundary(boundaries[i]);
         append_labels(le);
         str.append(std::to_string(cumulative)).append("\n");
     }
@@ -633,19 +653,24 @@ KeyRetentionMetric::KeyRetentionMetric(
       removed_age(prefix + "_removed_age_seconds",
                   "Lifetime distribution of removed keys on this "
                   "client (seconds; deleted, evicted or cleared)",
-                  LifetimeBuckets(), labels) {
-    // Geometric (~1.3x) birth-offset boundaries for the cohort counters.
-    int64_t bound = 1;
-    while (bound < kCohortCoverageSeconds) {
-        cohort_bounds_.push_back(bound);
-        const int64_t next = static_cast<int64_t>(bound * 1.3) + 1;
-        bound = next > bound ? next : bound + 1;
-    }
-    cohort_bounds_.push_back(bound);
-    cohorts_.resize(cohort_bounds_.size());
+                  LifetimeBuckets(), labels),
+      cohort_bounds_(BuildCohortBounds()),
+      cohorts_(cohort_bounds_.size()) {
     for (auto& cohort : cohorts_) {
         cohort.store(0, std::memory_order_relaxed);
     }
+}
+
+std::vector<int64_t> KeyRetentionMetric::BuildCohortBounds() {
+    std::vector<int64_t> bounds;
+    int64_t bound = 1;
+    while (bound < kCohortCoverageSeconds) {
+        bounds.push_back(bound);
+        const int64_t next = static_cast<int64_t>(bound * 1.3) + 1;
+        bound = next > bound ? next : bound + 1;
+    }
+    bounds.push_back(bound);
+    return bounds;
 }
 
 void KeyRetentionMetric::OnKeyCreated(

--- a/mooncake-store/src/p2p_client_service.cpp
+++ b/mooncake-store/src/p2p_client_service.cpp
@@ -322,7 +322,8 @@ ErrorCode P2PClientService::InitStorage(const P2PClientConfig& config) {
     auto init_result = tiered_backend->Init(
         config.tiered_backend_config, transfer_engine_.get(),
         add_replica_callback, remove_replica_callback, segment_sync_callback,
-        metrics_ ? metrics_->tier_metric : nullptr);
+        metrics_ ? metrics_->tier_metric : nullptr,
+        metrics_ ? metrics_->key_retention : nullptr);
     if (!init_result) {
         LOG(ERROR) << "Failed to init TieredBackend: " << init_result.error();
         return init_result.error();

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -148,7 +148,8 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     AddReplicaCallback add_replica_callback,
     RemoveReplicaCallback remove_replica_callback,
     SegmentSyncCallback segment_sync_callback,
-    std::shared_ptr<TierMetric> tier_metric) {
+    std::shared_ptr<TierMetric> tier_metric,
+    std::shared_ptr<KeyRetentionMetric> retention_metric) {
     // Initialize DataCopier
     try {
         DataCopierBuilder builder;
@@ -165,6 +166,7 @@ tl::expected<void, ErrorCode> TieredBackend::Init(
     segment_sync_callback_ = segment_sync_callback;
     // Optional per-tier metrics sink
     tier_metric_ = std::move(tier_metric);
+    retention_metric_ = std::move(retention_metric);
 
     // Initialize Tiers
     if (!root.isMember("tiers")) {
@@ -559,7 +561,11 @@ tl::expected<void, ErrorCode> TieredBackend::Commit(
             entry = it->second;
         } else {
             entry = std::make_shared<MetadataEntry>();
+            entry->created_at = std::chrono::steady_clock::now();
             shard.index.emplace(std::string(key), entry);
+            if (retention_metric_) {
+                retention_metric_->OnKeyCreated(entry->created_at);
+            }
         }
     }
 
@@ -751,6 +757,7 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
     AllocationHandle handle_ref = nullptr;
     std::vector<AllocationHandle> handles_to_free;
     std::vector<UUID> removed_tier_ids;
+    std::optional<std::chrono::steady_clock::time_point> removed_birth;
 
     if (tier_id.has_value()) {
         // Delete Specific Replica
@@ -820,12 +827,16 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
                 std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
 
                 if (entry->replicas.empty()) {
+                    removed_birth = entry->created_at;
                     shard.index.erase(it);
                 }
             }
         }
 
         if (found_tier) {
+            if (removed_birth && retention_metric_) {
+                retention_metric_->OnKeyRemoved(*removed_birth);
+            }
             if (tier_metric_) {
                 tier_metric_->OnReplicaRemoved(*tier_id);
             }
@@ -871,7 +882,12 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
             entry->replicas.clear();
         }
 
+        removed_birth = entry->created_at;
         shard.index.erase(it);
+    }
+
+    if (removed_birth && retention_metric_) {
+        retention_metric_->OnKeyRemoved(*removed_birth);
     }
 
     // Per-tier key-count accounting for the removed replicas.
@@ -942,6 +958,7 @@ size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
 
         // Remove an emptied entry under the shard write lock (zombie cleanup),
         // double-checking that no replica was re-added concurrently.
+        std::optional<std::chrono::steady_clock::time_point> removed_birth;
         if (need_cleanup) {
             std::unique_lock<std::shared_mutex> write_lock(shard.mutex);
             auto it = shard.index.find(key);
@@ -949,6 +966,7 @@ size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
                 auto entry = it->second;
                 std::unique_lock<std::shared_mutex> entry_lock(entry->mutex);
                 if (entry->replicas.empty()) {
+                    removed_birth = entry->created_at;
                     shard.index.erase(it);
                 }
             }
@@ -956,6 +974,9 @@ size_t TieredBackend::NotifyBucketEviction(const std::vector<std::string>& keys,
 
         if (found_tier) {
             ++removed;
+            if (removed_birth && retention_metric_) {
+                retention_metric_->OnKeyRemoved(*removed_birth);
+            }
             if (tier_metric_) {
                 tier_metric_->OnReplicaRemoved(tier_id);
                 tier_metric_->OnEvicted(tier_id);
@@ -1041,6 +1062,11 @@ tl::expected<long, ErrorCode> TieredBackend::RemoveAll() {
 
             if (scheduler_) {
                 scheduler_->OnDelete(DeleteContext{key, std::nullopt});
+            }
+
+            // Includes zombie entries: each drained entry ends its lifetime.
+            if (retention_metric_) {
+                retention_metric_->OnKeyRemoved(entry->created_at);
             }
 
             ++total_removed;

--- a/mooncake-store/src/tiered_cache/tiered_backend.cpp
+++ b/mooncake-store/src/tiered_cache/tiered_backend.cpp
@@ -833,10 +833,11 @@ tl::expected<void, ErrorCode> TieredBackend::Delete(std::string_view key,
             }
         }
 
+        if (removed_birth && retention_metric_) {
+            retention_metric_->OnKeyRemoved(*removed_birth);
+        }
+
         if (found_tier) {
-            if (removed_birth && retention_metric_) {
-                retention_metric_->OnKeyRemoved(*removed_birth);
-            }
             if (tier_metric_) {
                 tier_metric_->OnReplicaRemoved(*tier_id);
             }

--- a/mooncake-store/tests/client_metrics_aggregator_test.cpp
+++ b/mooncake-store/tests/client_metrics_aggregator_test.cpp
@@ -368,7 +368,7 @@ TEST_F(ClientMetricsAggregatorTest, RetentionCountsSumAcrossClients) {
 
     const std::string text = Serialize();
     ExpectMetricValue(text, "master_cluster_key_retention_live_count", 8);
-    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 9);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_count", 9);
 }
 
 // The merged histogram preserves the true distribution instead of
@@ -383,10 +383,10 @@ TEST_F(ClientMetricsAggregatorTest, RetentionHistogramsMergeDistributions) {
 
     const std::string text = Serialize();
     EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
-                        "seconds_bucket{le=\"5.000000\"} 10"),
+                        "seconds_bucket{le=\"5\"} 10"),
               std::string::npos);
     EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
-                        "seconds_bucket{le=\"3600.000000\"} 20"),
+                        "seconds_bucket{le=\"3600\"} 20"),
               std::string::npos);
     EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
                         "seconds_count 20"),
@@ -407,13 +407,13 @@ TEST_F(ClientMetricsAggregatorTest, RetentionLiveAgeHistogramFromBuckets) {
 
     const std::string text = Serialize();
     EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
-                        "bucket{le=\"1.000000\"} 4"),
+                        "bucket{le=\"1\"} 4"),
               std::string::npos);
     EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
                         "count 4"),
               std::string::npos);
     EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
-                        "seconds_bucket{le=\"1800.000000\"} 6"),
+                        "seconds_bucket{le=\"1800\"} 6"),
               std::string::npos);
     // Summary quantiles are interpolated from the merged buckets on the fly.
     const std::string summary =
@@ -427,12 +427,12 @@ TEST_F(ClientMetricsAggregatorTest, RetentionRecomputesOnUpdateAndRemove) {
                                          RetentionBucketWith(5, 1)));
     std::string text = Serialize();
     ExpectMetricValue(text, "master_cluster_key_retention_live_count", 2);
-    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 1);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_count", 1);
     EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
-                        "bucket{le=\"60.000000\"} 2"),
+                        "bucket{le=\"60\"} 2"),
               std::string::npos);
     EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
-                        "seconds_bucket{le=\"60.000000\"} 1"),
+                        "seconds_bucket{le=\"60\"} 1"),
               std::string::npos);
 
     // Values can decrease on a fresh snapshot.
@@ -440,9 +440,9 @@ TEST_F(ClientMetricsAggregatorTest, RetentionRecomputesOnUpdateAndRemove) {
                                          ZeroRetentionBuckets()));
     text = Serialize();
     ExpectMetricValue(text, "master_cluster_key_retention_live_count", 1);
-    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 0);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_count", 0);
     EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
-                        "bucket{le=\"60.000000\"} 1"),
+                        "bucket{le=\"60\"} 1"),
               std::string::npos);
     // No removed keys -> the empty histogram is omitted.
     EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
@@ -452,7 +452,7 @@ TEST_F(ClientMetricsAggregatorTest, RetentionRecomputesOnUpdateAndRemove) {
     Remove(client);
     text = Serialize();
     ExpectMetricValue(text, "master_cluster_key_retention_live_count", 0);
-    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 0);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_count", 0);
     EXPECT_EQ(text.find("master_cluster_key_retention_live_age_seconds"),
               std::string::npos);
     EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
@@ -473,7 +473,7 @@ TEST_F(ClientMetricsAggregatorTest, RetentionBucketSizeMismatchIsIgnored) {
     // Counts still aggregate; malformed buckets are skipped, so both
     // merged distributions stay empty and no histogram is emitted.
     ExpectMetricValue(text, "master_cluster_key_retention_live_count", 3);
-    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 1);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_count", 1);
     EXPECT_EQ(text.find("master_cluster_key_retention_live_age_seconds"),
               std::string::npos);
     EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
@@ -492,7 +492,7 @@ TEST_F(ClientMetricsAggregatorTest, RetentionSerializeAndSummary) {
                         "gauge"),
               std::string::npos);
     EXPECT_NE(text.find("# TYPE master_cluster_key_retention_removed_"
-                        "lifetime_seconds histogram"),
+                        "age_seconds histogram"),
               std::string::npos);
     // The quantile gauges were replaced by scrape-time histograms.
     EXPECT_EQ(text.find("master_cluster_key_retention_live_age_p"),

--- a/mooncake-store/tests/client_metrics_aggregator_test.cpp
+++ b/mooncake-store/tests/client_metrics_aggregator_test.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "heartbeat_type.h"
+#include "p2p_client_metric.h"
 #include "p2p_master_metric_manager.h"
 
 namespace mooncake {
@@ -327,6 +328,184 @@ TEST_F(ClientMetricsAggregatorTest, ConcurrentUpdateSerializeAndRemove) {
     ExpectMetricValue(empty, "master_cluster_total_get_requests", 0);
     ExpectMetricValue(empty, "master_cluster_total_get_bytes", 0);
     ExpectMetricValue(empty, "master_cluster_remote_get_requests", 0);
+}
+
+namespace {
+
+size_t NumRetentionBuckets() {
+    return KeyRetentionMetric::LifetimeBuckets().size() + 1;
+}
+
+std::vector<int64_t> ZeroRetentionBuckets() {
+    return std::vector<int64_t>(NumRetentionBuckets(), 0);
+}
+
+std::vector<int64_t> RetentionBucketWith(size_t index, int64_t count) {
+    std::vector<int64_t> buckets(NumRetentionBuckets(), 0);
+    buckets[index] = count;
+    return buckets;
+}
+
+ClientMetricSnapshot MakeRetentionSnapshot(
+    int64_t live_count, int64_t removed_total,
+    std::vector<int64_t> live_age_buckets,
+    std::vector<int64_t> removed_buckets) {
+    ClientMetricSnapshot snap;
+    snap.key_retention.live_count = live_count;
+    snap.key_retention.removed_total = removed_total;
+    snap.key_retention.live_age_buckets = std::move(live_age_buckets);
+    snap.key_retention.removed_buckets = std::move(removed_buckets);
+    return snap;
+}
+
+}  // namespace
+
+TEST_F(ClientMetricsAggregatorTest, RetentionCountsSumAcrossClients) {
+    Update({1, 1}, MakeRetentionSnapshot(3, 2, ZeroRetentionBuckets(),
+                                         RetentionBucketWith(2, 2)));
+    Update({2, 2}, MakeRetentionSnapshot(5, 7, ZeroRetentionBuckets(),
+                                         RetentionBucketWith(4, 7)));
+
+    const std::string text = Serialize();
+    ExpectMetricValue(text, "master_cluster_key_retention_live_count", 8);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 9);
+}
+
+// The merged histogram preserves the true distribution instead of
+// averaging per-client values: 10 short-lived plus 10 long-lived removals
+// reach cumulative 10 at le=5 and 20 at le=3600, so any quantile can be
+// resolved against the merged distribution at query time.
+TEST_F(ClientMetricsAggregatorTest, RetentionHistogramsMergeDistributions) {
+    Update({1, 1}, MakeRetentionSnapshot(0, 10, ZeroRetentionBuckets(),
+                                         RetentionBucketWith(2, 10)));
+    Update({2, 2}, MakeRetentionSnapshot(0, 10, ZeroRetentionBuckets(),
+                                         RetentionBucketWith(9, 10)));
+
+    const std::string text = Serialize();
+    EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds_bucket{le=\"5.000000\"} 10"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds_bucket{le=\"3600.000000\"} 20"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds_count 20"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_all_lifetime_"
+                        "seconds_count 20"),
+              std::string::npos);
+    // No live keys -> the empty live-age histogram is omitted.
+    EXPECT_EQ(text.find("master_cluster_key_retention_live_age_seconds"),
+              std::string::npos);
+}
+
+TEST_F(ClientMetricsAggregatorTest, RetentionLiveAgeHistogramFromBuckets) {
+    // 4 live ages in (0,1] and 6 removed lifetimes in (600,1800]; both
+    // distributions are exported as histograms.
+    Update({1, 1}, MakeRetentionSnapshot(4, 6, RetentionBucketWith(0, 4),
+                                         RetentionBucketWith(8, 6)));
+
+    const std::string text = Serialize();
+    EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
+                        "bucket{le=\"1.000000\"} 4"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
+                        "count 4"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds_bucket{le=\"1800.000000\"} 6"),
+              std::string::npos);
+    // Summary quantiles are interpolated from the merged buckets on the fly.
+    const std::string summary =
+        P2PMasterMetricManager::instance().get_summary_string();
+    EXPECT_NE(summary.find("Retention: live=4, removed=6"), std::string::npos);
+}
+
+TEST_F(ClientMetricsAggregatorTest, RetentionRecomputesOnUpdateAndRemove) {
+    UUID client{1, 1};
+    Update(client, MakeRetentionSnapshot(2, 1, RetentionBucketWith(5, 2),
+                                         RetentionBucketWith(5, 1)));
+    std::string text = Serialize();
+    ExpectMetricValue(text, "master_cluster_key_retention_live_count", 2);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 1);
+    EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
+                        "bucket{le=\"60.000000\"} 2"),
+              std::string::npos);
+    EXPECT_NE(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds_bucket{le=\"60.000000\"} 1"),
+              std::string::npos);
+
+    // Values can decrease on a fresh snapshot.
+    Update(client, MakeRetentionSnapshot(1, 0, RetentionBucketWith(5, 1),
+                                         ZeroRetentionBuckets()));
+    text = Serialize();
+    ExpectMetricValue(text, "master_cluster_key_retention_live_count", 1);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 0);
+    EXPECT_NE(text.find("master_cluster_key_retention_live_age_seconds_"
+                        "bucket{le=\"60.000000\"} 1"),
+              std::string::npos);
+    // No removed keys -> the empty histogram is omitted.
+    EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds"),
+              std::string::npos);
+
+    Remove(client);
+    text = Serialize();
+    ExpectMetricValue(text, "master_cluster_key_retention_live_count", 0);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 0);
+    EXPECT_EQ(text.find("master_cluster_key_retention_live_age_seconds"),
+              std::string::npos);
+    EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds"),
+              std::string::npos);
+    EXPECT_EQ(text.find("master_cluster_key_retention_all_lifetime_seconds"),
+              std::string::npos);
+}
+
+TEST_F(ClientMetricsAggregatorTest, RetentionBucketSizeMismatchIsIgnored) {
+    ClientMetricSnapshot snap;
+    snap.key_retention.live_count = 3;
+    snap.key_retention.removed_total = 1;
+    snap.key_retention.live_age_buckets = {1};  // wrong size
+    Update({1, 1}, snap);
+
+    const std::string text = Serialize();
+    // Counts still aggregate; malformed buckets are skipped, so both
+    // merged distributions stay empty and no histogram is emitted.
+    ExpectMetricValue(text, "master_cluster_key_retention_live_count", 3);
+    ExpectMetricValue(text, "master_cluster_key_retention_removed_total", 1);
+    EXPECT_EQ(text.find("master_cluster_key_retention_live_age_seconds"),
+              std::string::npos);
+    EXPECT_EQ(text.find("master_cluster_key_retention_removed_age_"
+                        "seconds"),
+              std::string::npos);
+    EXPECT_EQ(text.find("master_cluster_key_retention_all_lifetime_seconds"),
+              std::string::npos);
+}
+
+TEST_F(ClientMetricsAggregatorTest, RetentionSerializeAndSummary) {
+    Update({1, 1}, MakeRetentionSnapshot(2, 2, ZeroRetentionBuckets(),
+                                         RetentionBucketWith(6, 2)));
+
+    const std::string text = Serialize();
+    EXPECT_NE(text.find("# TYPE master_cluster_key_retention_live_count "
+                        "gauge"),
+              std::string::npos);
+    EXPECT_NE(text.find("# TYPE master_cluster_key_retention_removed_"
+                        "lifetime_seconds histogram"),
+              std::string::npos);
+    // The quantile gauges were replaced by scrape-time histograms.
+    EXPECT_EQ(text.find("master_cluster_key_retention_live_age_p"),
+              std::string::npos);
+    EXPECT_EQ(text.find("master_cluster_key_retention_all_lifetime_p"),
+              std::string::npos);
+    EXPECT_NE(text.find("# TYPE master_cluster_key_retention_all_lifetime_"
+                        "seconds histogram"),
+              std::string::npos);
+
+    const std::string summary =
+        P2PMasterMetricManager::instance().get_summary_string();
+    EXPECT_NE(summary.find("Retention: live=2, removed=2"), std::string::npos);
 }
 
 }  // namespace test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -6,7 +6,10 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <thread>
 #include <vector>
+
+#include <ylt/struct_pack.hpp>
 
 #include "client_metric.h"
 #include "p2p_client_metric.h"
@@ -883,6 +886,294 @@ TEST_F(ClientMetricsTest, TierMetricMovementCountersTest) {
     metric.serialize(serialized);
     EXPECT_TRUE(serialized.find("mooncake_p2p_tier_evicted_keys_total") !=
                 std::string::npos);
+}
+
+// ============================================================================
+// KeyRetentionMetric::InterpolateQuantiles
+// ============================================================================
+
+namespace {
+
+// Alias to keep the golden-value assertions readable.
+int64_t Quantile(const std::vector<double>& boundaries,
+                 const std::vector<int64_t>& bucket_counts, double q) {
+    return KeyRetentionMetric::InterpolateQuantiles(boundaries, bucket_counts,
+                                                    {q})[0];
+}
+
+}  // namespace
+
+TEST(InterpolateQuantilesTest, EmptyDistributionReturnsZero) {
+    const std::vector<double> boundaries = {10, 20};
+    EXPECT_EQ(Quantile(boundaries, {0, 0, 0}, 0.5), 0);
+    EXPECT_EQ(Quantile(boundaries, {}, 0.5), 0);
+}
+
+TEST(InterpolateQuantilesTest, SingleBucketInterpolates) {
+    const std::vector<double> boundaries = {10, 20};
+    const std::vector<int64_t> buckets = {0, 4, 0};  // 4 values in (10, 20]
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.5), 15);
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.25), 12);  // 12.5 -> 12
+}
+
+TEST(InterpolateQuantilesTest, PlusInfBucketClampsToLargestBoundary) {
+    const std::vector<double> boundaries = {10};
+    const std::vector<int64_t> buckets = {0, 5};  // 5 values above 10
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.5), 10);
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.95), 10);
+}
+
+TEST(InterpolateQuantilesTest, SkewedDistributionQuantiles) {
+    const std::vector<double> boundaries = {10, 50, 100};
+    // 4 values in (0, 10], 1 value in (50, 100].
+    const std::vector<int64_t> buckets = {4, 0, 1};
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.5), 6);
+    EXPECT_EQ(Quantile(boundaries, buckets, 0.95), 87);
+}
+
+TEST(InterpolateQuantilesTest, ResolvesAllRequestedQuantilesInOrder) {
+    const std::vector<double> boundaries = {10, 50, 100};
+    const std::vector<int64_t> buckets = {4, 0, 1};
+    const std::vector<int64_t> result =
+        KeyRetentionMetric::InterpolateQuantiles(boundaries, buckets,
+                                                 {0.30, 0.50, 0.80, 0.95});
+    EXPECT_EQ(result, (std::vector<int64_t>{3, 6, 10, 87}));
+}
+
+TEST(InterpolateQuantilesTest, RejectsUnsortedOrOutOfRangeQuantiles) {
+    const std::vector<double> boundaries = {10, 20};
+    const std::vector<int64_t> buckets = {1, 2, 3};
+    EXPECT_EQ(KeyRetentionMetric::InterpolateQuantiles(boundaries, buckets,
+                                                       {0.80, 0.50}),
+              (std::vector<int64_t>{0, 0}));
+    EXPECT_EQ(KeyRetentionMetric::InterpolateQuantiles(boundaries, buckets,
+                                                       {0.0, 0.50}),
+              (std::vector<int64_t>{0, 0}));
+    EXPECT_TRUE(
+        KeyRetentionMetric::InterpolateQuantiles(boundaries, buckets, {})
+            .empty());
+}
+
+// ============================================================================
+// KeyRetentionMetric
+// ============================================================================
+
+namespace {
+
+int64_t SumBuckets(const std::vector<int64_t>& buckets) {
+    int64_t sum = 0;
+    for (const int64_t count : buckets) {
+        sum += count;
+    }
+    return sum;
+}
+
+size_t NumRetentionBuckets() {
+    return KeyRetentionMetric::LifetimeBuckets().size() + 1;
+}
+
+}  // namespace
+
+TEST_F(ClientMetricsTest, KeyRetentionCountsAndSnapshot) {
+    using Clock = std::chrono::steady_clock;
+    const auto anchor = Clock::now() - std::chrono::seconds(1000);
+    KeyRetentionMetric metric("test_retention", {}, anchor);
+
+    EXPECT_EQ(metric.Snapshot().live_count, 0);
+
+    metric.OnKeyCreated(Clock::now() - std::chrono::seconds(500));
+    metric.OnKeyCreated(Clock::now() - std::chrono::seconds(3));
+
+    auto snap = metric.Snapshot();
+    EXPECT_EQ(snap.live_count, 2);
+    EXPECT_EQ(snap.removed_total, 0);
+    ASSERT_EQ(snap.live_age_buckets.size(), NumRetentionBuckets());
+    ASSERT_EQ(snap.removed_buckets.size(), NumRetentionBuckets());
+    EXPECT_EQ(SumBuckets(snap.live_age_buckets), 2);
+
+    // Removal with lifetime ~500s lands in the (300, 600] bucket.
+    metric.OnKeyRemoved(Clock::now() - std::chrono::seconds(500));
+    snap = metric.Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+    EXPECT_EQ(snap.removed_total, 1);
+    EXPECT_EQ(SumBuckets(snap.removed_buckets), 1);
+    EXPECT_EQ(snap.removed_buckets[7], 1);  // bucket le=600
+    EXPECT_EQ(SumBuckets(snap.live_age_buckets), 1);
+}
+
+TEST_F(ClientMetricsTest, KeyRetentionRemovalRecordsLifetime) {
+    using Clock = std::chrono::steady_clock;
+    const auto anchor = Clock::now() - std::chrono::seconds(1000);
+    KeyRetentionMetric metric("test_retention", {}, anchor);
+
+    metric.OnKeyCreated(Clock::now() - std::chrono::seconds(120));
+    metric.OnKeyRemoved(Clock::now() - std::chrono::seconds(120));
+    auto snap = metric.Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, 1);
+    // Removal records the exact lifetime: ~120s lands in the (60, 300]
+    // bucket.
+    EXPECT_EQ(SumBuckets(snap.removed_buckets), 1);
+    EXPECT_EQ(snap.removed_buckets[6], 1);
+    EXPECT_EQ(SumBuckets(snap.live_age_buckets), 0);
+}
+
+TEST_F(ClientMetricsTest, KeyRetentionClampsNegativeLifetime) {
+    using Clock = std::chrono::steady_clock;
+    KeyRetentionMetric metric("test_retention", {});
+    const auto future_birth = Clock::now() + std::chrono::seconds(100);
+    metric.OnKeyCreated(future_birth);
+    metric.OnKeyRemoved(future_birth);
+    auto snap = metric.Snapshot();
+    EXPECT_EQ(snap.removed_total, 1);
+    // Lifetime clamped to 0 -> first bucket (le=1).
+    EXPECT_EQ(snap.removed_buckets[0], 1);
+}
+
+TEST_F(ClientMetricsTest, KeyRetentionConcurrentHooksStayConsistent) {
+    using Clock = std::chrono::steady_clock;
+    KeyRetentionMetric metric("test_retention", {});
+
+    constexpr int kThreads = 4;
+    constexpr int kPerThread = 250;
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([&metric]() {
+            for (int i = 0; i < kPerThread; ++i) {
+                const auto birth = Clock::now();
+                metric.OnKeyCreated(birth);
+                metric.OnKeyRemoved(birth);
+            }
+        });
+    }
+    for (auto& th : threads) {
+        th.join();
+    }
+
+    auto snap = metric.Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, kThreads * kPerThread);
+    EXPECT_EQ(SumBuckets(snap.live_age_buckets), 0);
+    EXPECT_EQ(SumBuckets(snap.removed_buckets), kThreads * kPerThread);
+}
+
+TEST_F(ClientMetricsTest, KeyRetentionSerializeAndSummary) {
+    using Clock = std::chrono::steady_clock;
+    const auto anchor = Clock::now() - std::chrono::seconds(1000);
+    KeyRetentionMetric metric("test_retention", {}, anchor);
+    // One key stays alive so the live-age histogram is non-empty.
+    metric.OnKeyCreated(Clock::now() - std::chrono::seconds(500));
+    metric.OnKeyCreated(Clock::now() - std::chrono::seconds(500));
+    metric.OnKeyRemoved(Clock::now() - std::chrono::seconds(500));
+
+    std::string serialized;
+    metric.serialize(serialized);
+    EXPECT_TRUE(serialized.find("test_retention_live_count 1") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("test_retention_removed_total 1") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("test_retention_removed_age_seconds_bucket") !=
+                std::string::npos);
+    // Live age is exposed as a scrape-time histogram instead of quantile
+    // gauges.
+    EXPECT_TRUE(serialized.find("# TYPE test_retention_live_age_seconds "
+                                "histogram") != std::string::npos);
+    EXPECT_TRUE(serialized.find("test_retention_live_age_seconds_bucket") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("test_retention_live_age_seconds_count 1") !=
+                std::string::npos);
+    // all_lifetime mirrors the summary report: live + removed as one
+    // histogram (here 1 live + 1 removed = 2 samples).
+    EXPECT_TRUE(serialized.find("test_retention_all_lifetime_seconds_bucket") !=
+                std::string::npos);
+    EXPECT_TRUE(serialized.find("test_retention_all_lifetime_seconds_count "
+                                "2") != std::string::npos);
+    // The quantile gauges are gone; quantiles are derived at query time.
+    EXPECT_TRUE(serialized.find("_p30_seconds") == std::string::npos);
+    EXPECT_TRUE(serialized.find("_p50_seconds") == std::string::npos);
+    EXPECT_TRUE(serialized.find("_p80_seconds") == std::string::npos);
+    EXPECT_TRUE(serialized.find("_p95_seconds") == std::string::npos);
+
+    const std::string summary = metric.summary_metrics();
+    EXPECT_TRUE(summary.find("live=1, removed=1") != std::string::npos);
+    EXPECT_TRUE(summary.find("live_age: p30=") != std::string::npos);
+    EXPECT_TRUE(summary.find("removed_age: p95=") != std::string::npos);
+    EXPECT_TRUE(summary.find("all_lifetime: p95=") != std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, SerializeBucketHistogramFormat) {
+    const std::vector<double> boundaries = {1, 10};
+    // Non-cumulative counts: 2 in (0,1], 0 in (1,10], 3 in (10,+Inf).
+    std::string out;
+    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "help text", {},
+                                                 boundaries, {2, 0, 3});
+    EXPECT_TRUE(out.find("# HELP m help text") != std::string::npos);
+    EXPECT_TRUE(out.find("# TYPE m histogram") != std::string::npos);
+    // Exposition is cumulative: 2, 2, 5.
+    EXPECT_TRUE(out.find("m_bucket{le=\"1.000000\"} 2") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"10.000000\"} 2") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"+Inf\"} 5") != std::string::npos);
+    EXPECT_TRUE(out.find("m_count 5") != std::string::npos);
+    // _sum estimate: 2 * 0.5 + 0 * 5.5 + 3 * 10 (midpoints; +Inf resolves
+    // to the largest finite boundary).
+    EXPECT_TRUE(out.find("m_sum 31.000000") != std::string::npos);
+
+    // Labels are rendered on every sample.
+    out.clear();
+    KeyRetentionMetric::SerializeBucketHistogram(
+        out, "m", "h", {{"client", "c1"}}, boundaries, {2, 0, 3});
+    EXPECT_TRUE(out.find("m_bucket{client=\"c1\",le=\"1.000000\"} 2") !=
+                std::string::npos);
+    EXPECT_TRUE(out.find("m_sum{client=\"c1\"} ") != std::string::npos);
+    EXPECT_TRUE(out.find("m_count{client=\"c1\"} 5") != std::string::npos);
+
+    // Empty distribution emits nothing (consistent with ylt histograms).
+    out.clear();
+    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "h", {}, boundaries,
+                                                 {0, 0, 0});
+    EXPECT_TRUE(out.empty());
+
+    // Malformed bucket arrays are rejected with an error log, no output.
+    out.clear();
+    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "h", {}, boundaries,
+                                                 {1, 2});
+    EXPECT_TRUE(out.empty());
+}
+
+TEST_F(ClientMetricsTest, BuildSyncSnapshotIncludesKeyRetention) {
+    P2PClientMetric metrics;
+    metrics.key_retention->OnKeyCreated(std::chrono::steady_clock::now());
+
+    const auto snap = metrics.BuildSyncSnapshot();
+    EXPECT_EQ(snap.key_retention.live_count, 1);
+    EXPECT_EQ(snap.key_retention.removed_total, 0);
+    EXPECT_EQ(snap.key_retention.live_age_buckets.size(),
+              NumRetentionBuckets());
+
+    const std::string summary = metrics.summary_metrics();
+    EXPECT_TRUE(summary.find("=== P2P Key Retention ===") != std::string::npos);
+}
+
+TEST_F(ClientMetricsTest, ClientMetricSnapshotStructPackRoundTrip) {
+    ClientMetricSnapshot snap;
+    snap.total_request.get_requests = 3;
+    snap.key_retention.live_count = 7;
+    snap.key_retention.removed_total = 2;
+    snap.key_retention.live_age_buckets.assign(NumRetentionBuckets(), 0);
+    snap.key_retention.live_age_buckets[4] = 7;
+    snap.key_retention.removed_buckets.assign(NumRetentionBuckets(), 1);
+
+    auto buffer = struct_pack::serialize(snap);
+    auto res = struct_pack::deserialize<ClientMetricSnapshot>(buffer);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_EQ(res.value().total_request.get_requests, 3);
+    EXPECT_EQ(res.value().key_retention.live_count, 7);
+    EXPECT_EQ(res.value().key_retention.removed_total, 2);
+    ASSERT_EQ(res.value().key_retention.live_age_buckets.size(),
+              NumRetentionBuckets());
+    EXPECT_EQ(res.value().key_retention.live_age_buckets[4], 7);
+    EXPECT_EQ(res.value().key_retention.removed_buckets[0], 1);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -1132,8 +1132,8 @@ TEST_F(ClientMetricsTest, SerializeBucketHistogramFormat) {
     // Fractional boundaries keep their significant digits ("2.5", not
     // "2.500000" nor "2").
     out.clear();
-    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "h", {},
-                                                 {1, 2.5}, {1, 1, 1});
+    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "h", {}, {1, 2.5},
+                                                 {1, 1, 1});
     EXPECT_TRUE(out.find("m_bucket{le=\"1\"} 1") != std::string::npos);
     EXPECT_TRUE(out.find("m_bucket{le=\"2.5\"} 2") != std::string::npos);
     EXPECT_TRUE(out.find("m_bucket{le=\"+Inf\"} 3") != std::string::npos);

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -1098,8 +1098,9 @@ TEST_F(ClientMetricsTest, KeyRetentionSerializeAndSummary) {
     const std::string summary = metric.summary_metrics();
     EXPECT_TRUE(summary.find("live=1, removed=1") != std::string::npos);
     EXPECT_TRUE(summary.find("live_age: p30=") != std::string::npos);
-    EXPECT_TRUE(summary.find("removed_age: p95=") != std::string::npos);
-    EXPECT_TRUE(summary.find("all_lifetime: p95=") != std::string::npos);
+    EXPECT_TRUE(summary.find("removed_age: p30=") != std::string::npos);
+    EXPECT_TRUE(summary.find("all_lifetime: p30=") != std::string::npos);
+    EXPECT_TRUE(summary.find(", p95=") != std::string::npos);
 }
 
 TEST_F(ClientMetricsTest, SerializeBucketHistogramFormat) {
@@ -1111,8 +1112,8 @@ TEST_F(ClientMetricsTest, SerializeBucketHistogramFormat) {
     EXPECT_TRUE(out.find("# HELP m help text") != std::string::npos);
     EXPECT_TRUE(out.find("# TYPE m histogram") != std::string::npos);
     // Exposition is cumulative: 2, 2, 5.
-    EXPECT_TRUE(out.find("m_bucket{le=\"1.000000\"} 2") != std::string::npos);
-    EXPECT_TRUE(out.find("m_bucket{le=\"10.000000\"} 2") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"1\"} 2") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"10\"} 2") != std::string::npos);
     EXPECT_TRUE(out.find("m_bucket{le=\"+Inf\"} 5") != std::string::npos);
     EXPECT_TRUE(out.find("m_count 5") != std::string::npos);
     // _sum estimate: 2 * 0.5 + 0 * 5.5 + 3 * 10 (midpoints; +Inf resolves
@@ -1123,10 +1124,19 @@ TEST_F(ClientMetricsTest, SerializeBucketHistogramFormat) {
     out.clear();
     KeyRetentionMetric::SerializeBucketHistogram(
         out, "m", "h", {{"client", "c1"}}, boundaries, {2, 0, 3});
-    EXPECT_TRUE(out.find("m_bucket{client=\"c1\",le=\"1.000000\"} 2") !=
+    EXPECT_TRUE(out.find("m_bucket{client=\"c1\",le=\"1\"} 2") !=
                 std::string::npos);
     EXPECT_TRUE(out.find("m_sum{client=\"c1\"} ") != std::string::npos);
     EXPECT_TRUE(out.find("m_count{client=\"c1\"} 5") != std::string::npos);
+
+    // Fractional boundaries keep their significant digits ("2.5", not
+    // "2.500000" nor "2").
+    out.clear();
+    KeyRetentionMetric::SerializeBucketHistogram(out, "m", "h", {},
+                                                 {1, 2.5}, {1, 1, 1});
+    EXPECT_TRUE(out.find("m_bucket{le=\"1\"} 1") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"2.5\"} 2") != std::string::npos);
+    EXPECT_TRUE(out.find("m_bucket{le=\"+Inf\"} 3") != std::string::npos);
 
     // Empty distribution emits nothing (consistent with ylt histograms).
     out.clear();

--- a/mooncake-store/tests/p2p_client_integration_test.cpp
+++ b/mooncake-store/tests/p2p_client_integration_test.cpp
@@ -1443,5 +1443,63 @@ TEST_F(P2PClientIntegrationTest, MetricPutFailure) {
     EXPECT_EQ(m->local_request.put_requests.value(), before_local_put_req);
 }
 
+TEST_F(P2PClientIntegrationTest, KeyRetentionMetricsLifecycle) {
+    auto* m = GetP2PMetrics(client_.get());
+    ASSERT_NE(m, nullptr);
+    ASSERT_NE(m->key_retention, nullptr);
+
+    const std::string key = "p2p_key_retention_metric";
+    const std::string data = "retention payload";
+    const auto before = m->key_retention->Snapshot();
+
+    std::vector<Slice> put_slices;
+    put_slices.emplace_back(Slice{const_cast<char*>(data.data()), data.size()});
+    ASSERT_TRUE(
+        client_->Put(key, put_slices, WriteRouteRequestConfig{}).has_value());
+
+    // Let the key age into a non-zero bucket.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+
+    const auto mid = m->key_retention->Snapshot();
+    EXPECT_EQ(mid.live_count, before.live_count + 1);
+    EXPECT_EQ(mid.removed_total, before.removed_total);
+
+    ASSERT_TRUE(client_->RemoveLocal(key).has_value());
+
+    // RemoveLocal ends the key's lifetime and records it in the removed
+    // lifetime distribution.
+    const auto after = m->key_retention->Snapshot();
+    EXPECT_EQ(after.live_count, before.live_count);
+    EXPECT_EQ(after.removed_total, before.removed_total + 1);
+
+    auto serialized = client_->SerializeMetrics();
+    ASSERT_TRUE(serialized.has_value());
+    const std::string& text = serialized.value();
+    EXPECT_NE(text.find("mooncake_p2p_key_retention_live_count"),
+              std::string::npos);
+    EXPECT_NE(text.find("mooncake_p2p_key_retention_removed_total"),
+              std::string::npos);
+    // The RemoveLocal above fed the histogram, so buckets are serialized.
+    EXPECT_NE(text.find("mooncake_p2p_key_retention_removed_age_"
+                        "seconds_bucket"),
+              std::string::npos);
+    // The quantile gauges were replaced by scrape-time histograms; the
+    // live-age histogram is present only while keys are alive.
+    EXPECT_EQ(text.find("mooncake_p2p_key_retention_live_age_p"),
+              std::string::npos);
+    EXPECT_EQ(text.find("mooncake_p2p_key_retention_removed_age_p"),
+              std::string::npos);
+    EXPECT_EQ(text.find("mooncake_p2p_key_retention_all_lifetime_p"),
+              std::string::npos);
+    // The RemoveLocal above guarantees at least one removed sample, so
+    // the all-lifetime histogram is present.
+    EXPECT_NE(text.find("mooncake_p2p_key_retention_all_lifetime_seconds_"
+                        "bucket"),
+              std::string::npos);
+    EXPECT_EQ(text.find("mooncake_p2p_key_retention_live_age_seconds_"
+                        "bucket") != std::string::npos,
+              after.live_count > 0);
+}
+
 }  // namespace testing
 }  // namespace mooncake

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -1708,4 +1708,141 @@ TEST_F(TieredBackendTest, TierMetricCountsStorageSelfEviction) {
     fs::remove_all(storage_path);
 }
 
+namespace {
+
+int64_t SumRetentionBuckets(const std::vector<int64_t>& buckets) {
+    int64_t sum = 0;
+    for (const int64_t count : buckets) {
+        sum += count;
+    }
+    return sum;
+}
+
+}  // namespace
+
+// Creation counts once (overwrite does not re-count), reads do not touch
+// retention, full-key deletion ends the lifetime and records it.
+TEST_F(TieredBackendTest, KeyRetentionCreateDeleteLifecycle) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    auto retention = std::make_shared<KeyRetentionMetric>("test_retention");
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr,
+                          /*tier_metric=*/nullptr,
+                          /*retention_metric=*/retention)
+                    .has_value());
+
+    auto test_buffer = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle1 =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
+    ASSERT_TRUE(handle1.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle1.value()).has_value());
+
+    auto snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+    EXPECT_EQ(snap.removed_total, 0);
+    EXPECT_EQ(SumRetentionBuckets(snap.live_age_buckets), 1);
+
+    auto handle2 =
+        AllocateAndWrite(backend, SMALL_DATA_SIZE, test_buffer.get());
+    ASSERT_TRUE(handle2.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle2.value()).has_value());
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+
+    ASSERT_TRUE(backend.Get("key1").has_value());
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+    EXPECT_EQ(snap.removed_total, 0);
+
+    ASSERT_TRUE(backend.Delete("key1").has_value());
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, 1);
+    EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 1);
+}
+
+// Every removal path (delete/evict/clear) records the removed lifetime.
+TEST_F(TieredBackendTest, KeyRetentionAllRemovalPathsRecord) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    auto retention = std::make_shared<KeyRetentionMetric>("test_retention");
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr,
+                          /*tier_metric=*/nullptr,
+                          /*retention_metric=*/retention)
+                    .has_value());
+
+    auto buffer1 = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle1 = AllocateAndWrite(backend, SMALL_DATA_SIZE, buffer1.get());
+    ASSERT_TRUE(handle1.has_value());
+    ASSERT_TRUE(backend.Commit("key1", handle1.value()).has_value());
+
+    auto buffer2 = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle2 = AllocateAndWrite(backend, SMALL_DATA_SIZE, buffer2.get());
+    ASSERT_TRUE(handle2.has_value());
+    ASSERT_TRUE(backend.Commit("key2", handle2.value()).has_value());
+
+    auto views = backend.GetTierViews();
+    ASSERT_EQ(views.size(), 1u);
+    const UUID tier_id = views[0].id;
+
+    EXPECT_EQ(backend.NotifyBucketEviction({"key1"}, tier_id), 1u);
+    auto snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+    EXPECT_EQ(snap.removed_total, 1);
+    EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 1);
+
+    // Deletion records too.
+    ASSERT_TRUE(backend.Delete("key2").has_value());
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, 2);
+    EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 2);
+
+    // Clear records too.
+    auto buffer3 = CreateTestBuffer(SMALL_DATA_SIZE);
+    auto handle3 = AllocateAndWrite(backend, SMALL_DATA_SIZE, buffer3.get());
+    ASSERT_TRUE(handle3.has_value());
+    ASSERT_TRUE(backend.Commit("key3", handle3.value()).has_value());
+    auto removed = backend.RemoveAll();
+    ASSERT_TRUE(removed.has_value());
+    EXPECT_EQ(removed.value(), 1);
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, 3);
+    EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 3);
+    EXPECT_EQ(SumRetentionBuckets(snap.live_age_buckets), 0);
+}
+
 }  // namespace mooncake

--- a/mooncake-store/tests/tiered_backend_test.cpp
+++ b/mooncake-store/tests/tiered_backend_test.cpp
@@ -75,6 +75,42 @@ class FixedStatsTier : public CacheTier {
     std::vector<std::string> tags_;
 };
 
+// A CacheTier whose Commit always fails; lets tests drive the failed-commit
+// path of TieredBackend::Commit, which leaves a "zombie" entry (indexed,
+// without replicas) behind.
+class FailingCommitTier : public CacheTier {
+   public:
+    FailingCommitTier(UUID id, size_t capacity)
+        : id_(id), capacity_(capacity) {}
+
+    tl::expected<void, ErrorCode> Init(TieredBackend*,
+                                       TransferEngine*) override {
+        return {};
+    }
+    tl::expected<void, ErrorCode> Allocate(size_t size,
+                                           DataSource& data_source) override {
+        data_source.buffer = std::make_unique<TempDRAMBuffer>(
+            std::make_unique<char[]>(size), size);
+        data_source.type = MemoryType::DRAM;
+        return {};
+    }
+    tl::expected<void, ErrorCode> Free(DataSource) override { return {}; }
+    tl::expected<void, ErrorCode> Commit(std::string_view,
+                                         const DataSource&) override {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    UUID GetTierId() const override { return id_; }
+    size_t GetCapacity() const override { return capacity_; }
+    size_t GetUsage() const override { return 0; }
+    MemoryType GetMemoryType() const override { return MemoryType::DRAM; }
+    const std::vector<std::string>& GetTags() const override { return tags_; }
+
+   private:
+    UUID id_;
+    size_t capacity_;
+    std::vector<std::string> tags_;
+};
+
 class TieredBackendTest : public ::testing::Test {
    protected:
     void SetUp() override {
@@ -1842,6 +1878,63 @@ TEST_F(TieredBackendTest, KeyRetentionAllRemovalPathsRecord) {
     EXPECT_EQ(snap.live_count, 0);
     EXPECT_EQ(snap.removed_total, 3);
     EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 3);
+    EXPECT_EQ(SumRetentionBuckets(snap.live_age_buckets), 0);
+}
+
+// A zombie entry (a Commit that failed after indexing the entry leaves it
+// without replicas) erased by a tier-specific Delete must still end its
+// retention lifetime, even though the call itself reports TIER_NOT_FOUND.
+TEST_F(TieredBackendTest, KeyRetentionZombieErasedByTierSpecificDelete) {
+    std::string json_config_str = R"({
+        "tiers": [
+            {
+                "type": "DRAM",
+                "capacity": 1073741824,
+                "priority": 10,
+                "allocator_type": "OFFSET"
+            }
+        ]
+    })";
+    Json::Value config;
+    ASSERT_TRUE(parseJsonString(json_config_str, config));
+
+    TieredBackend backend;
+    auto retention = std::make_shared<KeyRetentionMetric>("test_retention");
+    ASSERT_TRUE(backend
+                    .Init(config, /*engine=*/nullptr,
+                          /*add_replica_callback=*/nullptr,
+                          /*remove_replica_callback=*/nullptr,
+                          /*segment_sync_callback=*/nullptr,
+                          /*tier_metric=*/nullptr,
+                          /*retention_metric=*/retention)
+                    .has_value());
+
+    // Allocate from a tier whose Commit always fails: Commit indexes the
+    // entry first and fails afterwards, leaving a zombie behind.
+    const UUID failing_tier_id{9, 9};
+    InjectTier(backend,
+               std::make_shared<FailingCommitTier>(failing_tier_id,
+                                                   /*capacity=*/1073741824),
+               /*priority=*/1);
+    auto handle = backend.Allocate(SMALL_DATA_SIZE, failing_tier_id);
+    ASSERT_TRUE(handle.has_value());
+    EXPECT_FALSE(backend.Commit("zombie_key", handle.value()).has_value());
+
+    auto snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 1);
+    EXPECT_EQ(snap.removed_total, 0);
+    EXPECT_EQ(SumRetentionBuckets(snap.live_age_buckets), 1);
+
+    // The zombie has no replica on the tier, so the delete reports
+    // TIER_NOT_FOUND; the zombie cleanup must still record the lifetime.
+    auto result = backend.Delete("zombie_key", failing_tier_id);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::TIER_NOT_FOUND);
+
+    snap = retention->Snapshot();
+    EXPECT_EQ(snap.live_count, 0);
+    EXPECT_EQ(snap.removed_total, 1);
+    EXPECT_EQ(SumRetentionBuckets(snap.removed_buckets), 1);
     EXPECT_EQ(SumRetentionBuckets(snap.live_age_buckets), 0);
 }
 


### PR DESCRIPTION
## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)