### PR TITLE
[Bugfix][TENT] Preserve ownership after failed memory free

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -690,8 +690,9 @@ Status TransferEngineImpl::freeLocalMemory(void* addr) {
          ++it) {
         if (it->addr == addr) {
             auto status = it->transport->freeLocalMemory(addr, it->size);
+            if (!status.ok()) return status;
             allocated_memory_.erase(it);
-            return status;
+            return Status::OK();
         }
     }
     return Status::InvalidArgument("Address region not registered" LOC_MARK);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -690,7 +690,12 @@ Status TransferEngineImpl::freeLocalMemory(void* addr) {
          ++it) {
         if (it->addr == addr) {
             auto status = it->transport->freeLocalMemory(addr, it->size);
-            if (!status.ok()) return status;
+            if (!status.ok()) {
+                LOG(WARNING)
+                    << "Failed to free local memory, addr=" << addr
+                    << ", size=" << it->size << ": " << status.ToString();
+                return status;
+            }
             allocated_memory_.erase(it);
             return Status::OK();
         }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -428,6 +428,18 @@ target_include_directories(tent_runtime_queue_dispatch_test
 add_test(NAME tent_runtime_queue_dispatch_test
          COMMAND tent_runtime_queue_dispatch_test)
 
+add_executable(tent_local_memory_lifecycle_test
+               local_memory_lifecycle_test.cpp)
+target_link_libraries(tent_local_memory_lifecycle_test
+                      PRIVATE gtest gtest_main tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_local_memory_lifecycle_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_local_memory_lifecycle_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_local_memory_lifecycle_test
+         COMMAND tent_local_memory_lifecycle_test)
+
 # Causal chain stage decomposition: validates that dispatch_time and post_time
 # timestamps are populated on both queue and direct-commit paths.
 add_executable(causal_chain_test causal_chain_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/local_memory_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/local_memory_lifecycle_test.cpp
@@ -1,0 +1,95 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+#include "tent/common/config.h"
+#include "tent/runtime/transfer_engine_impl.h"
+#include "tent/runtime/transport.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class FailOnceFreeTransport : public Transport {
+   public:
+    Status allocateLocalMemory(void** addr, size_t size,
+                               MemoryOptions&) override {
+        *addr = std::malloc(size);
+        return *addr ? Status::OK()
+                     : Status::InternalError("malloc failed" LOC_MARK);
+    }
+
+    Status freeLocalMemory(void* addr, size_t) override {
+        ++free_calls;
+        if (free_calls == 1) {
+            return Status::InternalError("injected free failure" LOC_MARK);
+        }
+        std::free(addr);
+        return Status::OK();
+    }
+
+    const char* getName() const override { return "fail-once-free"; }
+
+    int free_calls{0};
+};
+
+std::shared_ptr<Config> makeConfig() {
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("metadata_servers", "");
+    config->set("rpc_server_hostname", "127.0.0.1");
+    config->set("rpc_server_port", "0");
+    config->set("log_level", "warning");
+
+    for (const char* transport : {"tcp", "shm", "rdma", "io_uring", "nvlink",
+                                  "mnnvl", "gds", "ascend_direct"}) {
+        config->set(std::string("transports/") + transport + "/enable", false);
+    }
+    return config;
+}
+
+TEST(LocalMemoryLifecycle, RetainsOwnershipWhenTransportFreeFails) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+
+    auto transport = std::make_shared<FailOnceFreeTransport>();
+    engine.swapTransportForTest(RDMA, transport);
+
+    MemoryOptions options;
+    options.type = RDMA;
+    options.location = "cpu:0";
+    void* addr = nullptr;
+    ASSERT_TRUE(engine.allocateLocalMemory(&addr, 4096, options).ok());
+
+    auto first = engine.freeLocalMemory(addr);
+    EXPECT_FALSE(first.ok());
+    EXPECT_EQ(transport->free_calls, 1);
+
+    auto second = engine.freeLocalMemory(addr);
+    EXPECT_TRUE(second.ok()) << second.ToString();
+    EXPECT_EQ(transport->free_calls, 2);
+
+    auto third = engine.freeLocalMemory(addr);
+    EXPECT_TRUE(third.IsInvalidArgument());
+    EXPECT_EQ(transport->free_calls, 2);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

`TransferEngineImpl::freeLocalMemory()` removed an allocation from `allocated_memory_` even when the owning transport returned an error. The memory could remain allocated while the engine permanently lost the ownership record, so callers could not retry the release.

This change commits the ownership removal only after the transport reports a successful free. A fail-once transport regression test verifies that the first error preserves the allocation, the second call reaches the transport and succeeds, and a later call is correctly rejected after ownership has been released.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build /workspaces/build --target \
  tent_local_memory_lifecycle_test tent_runtime_queue_dispatch_test -j8
/workspaces/build/tests/tent_local_memory_lifecycle_test
/workspaces/build/tests/tent_runtime_queue_dispatch_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: before the fix, a fail-once transport was called only once and the retry returned `Address region not registered`; the regression test now observes two transport free calls and a successful retry.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`pre-commit` is not installed in the available development image; `git diff --check` and the PR-scoped C++ formatting script pass.

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Codex helped identify and reproduce the ownership-loss path, implement the success-only ownership commit, and add the fail-once regression test. The human submitter should review and understand every changed line before merge.