### PR TITLE
[TransferEngine] Fix duplicate cleanup in transport tests

### DIFF
--- a/mooncake-transfer-engine/tests/cxl_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/cxl_transport_test.cpp
@@ -230,7 +230,6 @@ TEST_F(CXLTransportTest, MultipleRead) {
 
         freeMemoryPool(src, kDataLength);
     }
-    engine->unregisterLocalMemory(addr);
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/nvmeof_transport_test.cpp
@@ -197,8 +197,6 @@ TEST_F(NVMeofTransportTest, MultipleRead) {
                      kDataLength);
         ASSERT_EQ(ret, 0);
     }
-    engine->unregisterLocalMemory(addr);
-    freeMemoryPool(addr, ram_buffer_size);
 }
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_test2.cpp
@@ -243,8 +243,6 @@ TEST_F(RDMATransportTest, MultipleRead) {
                      kDataLength);
         ASSERT_EQ(ret, 0);
     }
-    engine->unregisterLocalMemory(addr);
-    freeMemoryPool(addr, ram_buffer_size);
 }
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description

This PR fixes incorrect memory cleanup in three Transfer Engine transport tests.

The NVMe-oF and RDMA tests allocate and register a buffer in `SetUp()`, and release it in the fixture `TearDown()`. Their `MultipleRead` test bodies also performed the same unregistration and free operations, causing duplicate
cleanup of the same buffer.

The CXL test allocates a NUMA host buffer at `addr`, but registers a separate CXL-mapped range at `base_addr + offset_1`. The test then attempted to unregister the unregistered host buffer. This invalid unregistration is
removed separately from the duplicate-cleanup fixes.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
git diff origin/main...HEAD --check
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- Reviewed the fixture lifecycle against GoogledTest's TearDown() semantics (each TEST_F runs SetUp → test body → TearDown); the buffer is owned by the fixture and already released there.
- Reproduced the equivalent NUMA double-free path with a minimal standalone program: strace shows the same address passed to munmap() twice.
- Confirmed the CXL path: unregisterLocalMemory(addr) would return ERR_ADDRESS_NOT_REGISTERED because addr was never registered; only base_addr + offset_1 was.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)


AI tools were used to inspect the cleanup lifecycle, analyze the related transport implementations, reproduce the equivalent NUMA double-free behavior, and prepare the focused test changes. The final changes were reviewed manually.