### PR TITLE
[Bugfix] [TransferEngine] Fence stale RDMA handshakes after QP reconstruction

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_endpoint.h
@@ -212,6 +212,7 @@ class RdmaEndPoint {
 
     RWSpinlock lock_;
     std::vector<ibv_qp *> qp_list_;
+    uint64_t qp_generation_;
 
     std::string peer_nic_path_;
     std::vector<uint32_t> peer_qp_num_list_;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -92,6 +92,7 @@ static std::string gidToString(const ibv_gid &gid) {
 RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
     : context_(context),
       status_(INITIALIZING),
+      qp_generation_(0),
       has_connected_(false),
       ready_wait_start_ts_(0),
       wr_depth_list_(nullptr),
@@ -153,6 +154,10 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
 }
 
 int RdmaEndPoint::reconstruct() {
+    // Invalidate any handshake that captured the previous QP set, even when
+    // reconstruction fails before fresh QPs can be created.
+    ++qp_generation_;
+
     // Save original construction parameters
     size_t num_qp = qp_list_.size();
     auto max_wr_depth = max_wr_depth_;
@@ -345,6 +350,7 @@ void RdmaEndPoint::setPeerNicPath(const std::string &peer_nic_path) {
 int RdmaEndPoint::setupConnectionsByActive() {
     HandShakeDesc local_desc, peer_desc;
     std::string peer_server_name, peer_nic_name;
+    uint64_t qp_generation = 0;
     bool do_rpc = false;
     int auto_gid_retry_count = 0;
     std::vector<AutoGidSelectionIdentity> attempted_auto_gid_selections;
@@ -355,6 +361,8 @@ int RdmaEndPoint::setupConnectionsByActive() {
             LOG(INFO) << "Connection has been established";
             return 0;
         }
+
+        qp_generation = qp_generation_;
 
         // loopback mode
         if (context_.nicPath() == peer_nic_path_) {
@@ -407,6 +415,12 @@ int RdmaEndPoint::setupConnectionsByActive() {
                 // The QP state on this endpoint may have changed; therefore,
                 // reset the connection so that subsequent callers can retry.
                 RWSpinlock::WriteGuard write_guard(lock_);
+                if (qp_generation != qp_generation_) {
+                    return connected() ? 0 : ERR_ENDPOINT;
+                }
+                auto current_status = status_.load(std::memory_order_relaxed);
+                if (isConnectedStatus(current_status)) return 0;
+                if (current_status != CONNECTING) return ERR_ENDPOINT;
                 resetConnection("wait existing handshake timeout");
                 return ERR_ENDPOINT;
             }
@@ -420,6 +434,14 @@ int RdmaEndPoint::setupConnectionsByActive() {
         std::vector<uint32_t> local_qp_num;
         {
             RWSpinlock::ReadGuard guard(lock_);
+            if (qp_generation != qp_generation_) {
+                return connected() ? 0 : ERR_ENDPOINT;
+            }
+            auto current_status = status_.load(std::memory_order_relaxed);
+            if (current_status != CONNECTING &&
+                !isConnectedStatus(current_status)) {
+                return ERR_ENDPOINT;
+            }
             local_qp_num = qpNum();
         }
         auto local_gid_selection = fillLocalHandshakeDesc(
@@ -433,46 +455,74 @@ int RdmaEndPoint::setupConnectionsByActive() {
         int rc = context_.engine().sendHandshake(peer_server_name, local_desc,
                                                  peer_desc);
 
-        // We should check the RPC return code before comparing
-        // `peer_qp_num_list_` with `peer_desc.qp_num`, since a failed RPC may
-        // result in an invalid `peer_desc.qp_num`.
-        //
-        // If the RPC failed but simultaneous-open passive setup has already
-        // made this endpoint CONNECTED with the same local QPs used by this
-        // RPC, reuse that connection. Otherwise reset because
-        // `peer_desc.qp_num` is invalid and we cannot safely infer the peer
-        // state.
-        if (rc) {
-            RWSpinlock::WriteGuard write_guard(lock_);
-            if (connected()) {
-                auto current_qp_num = qpNum();
-                if (current_qp_num == local_desc.qp_num) {
-                    LOG(WARNING)
-                        << "Active handshake RPC failed, but simultaneous-open "
-                           "passive setup already connected this endpoint. "
-                           "Reusing existing connection. rc="
-                        << rc << ", local_desc.qp_num="
-                        << qpListToString(local_desc.qp_num)
-                        << ", current_qp_num=" << qpListToString(current_qp_num)
-                        << ", endpoint=" << toString();
-                    return 0;
-                }
-            }
-
-            LOG(ERROR) << "Active handshake RPC failed; resetting endpoint. rc="
-                       << rc << ", local_desc.qp_num="
-                       << qpListToString(local_desc.qp_num)
-                       << ", endpoint=" << toString();
-            resetConnection("handshake RPC failure");
-            return rc;
-        }
-
         bool retry_with_new_gid = false;
         bool should_send_ready_ack = false;
         HandShakeDesc ready_ack_desc;
         {
-            // Re-acquire lock after RPC to finalize state transition
+            // Re-acquire lock before inspecting either the RPC result or
+            // endpoint state. A waiter may have reconstructed this endpoint
+            // with fresh QPs while the RPC was in flight.
             RWSpinlock::WriteGuard guard(lock_);
+            if (qp_generation != qp_generation_) {
+                if (connected()) {
+                    LOG(INFO) << "Discarding stale active handshake reply and "
+                                 "reusing "
+                                 "the newer passive connection: "
+                              << toString();
+                    return 0;
+                }
+                LOG(WARNING)
+                    << "Discarding stale active handshake reply after local "
+                       "QP reconstruction: "
+                    << toString();
+                return ERR_ENDPOINT;
+            }
+
+            auto current_status = status_.load(std::memory_order_relaxed);
+            if (current_status != CONNECTING &&
+                !isConnectedStatus(current_status)) {
+                LOG(WARNING)
+                    << "Discarding active handshake reply for endpoint "
+                       "in state "
+                    << current_status << ": " << toString();
+                return ERR_ENDPOINT;
+            }
+
+            // We should check the RPC return code before comparing
+            // `peer_qp_num_list_` with `peer_desc.qp_num`, since a failed RPC
+            // may result in an invalid `peer_desc.qp_num`.
+            //
+            // If the RPC failed but simultaneous-open passive setup has
+            // already connected this endpoint with the same local QPs used by
+            // this RPC, reuse that connection. Otherwise reset because
+            // `peer_desc.qp_num` is invalid and we cannot safely infer the peer
+            // state.
+            if (rc) {
+                if (connected()) {
+                    auto current_qp_num = qpNum();
+                    if (current_qp_num == local_desc.qp_num) {
+                        LOG(WARNING)
+                            << "Active handshake RPC failed, but "
+                               "simultaneous-open passive setup already "
+                               "connected this endpoint. Reusing existing "
+                               "connection. rc="
+                            << rc << ", local_desc.qp_num="
+                            << qpListToString(local_desc.qp_num)
+                            << ", current_qp_num="
+                            << qpListToString(current_qp_num)
+                            << ", endpoint=" << toString();
+                        return 0;
+                    }
+                }
+
+                LOG(ERROR)
+                    << "Active handshake RPC failed; resetting endpoint. rc="
+                    << rc << ", local_desc.qp_num="
+                    << qpListToString(local_desc.qp_num)
+                    << ", endpoint=" << toString();
+                resetConnection("handshake RPC failure");
+                return rc;
+            }
 
             // Handle simultaneous open: if the peer initiates a connection
             // during our RPC and it is passively established in
@@ -595,6 +645,7 @@ int RdmaEndPoint::setupConnectionsByActive() {
                                     : "retry with externally reprobed GID "
                                       "(active)");
                             if (reset_ret) return reset_ret;
+                            qp_generation = qp_generation_;
                             status_.store(CONNECTING,
                                           std::memory_order_relaxed);
                             ++auto_gid_retry_count;

--- a/mooncake-transfer-engine/tests/rdma_endpoint_state_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_endpoint_state_test.cpp
@@ -15,12 +15,21 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <cstdint>
+#include <future>
 #include <memory>
+#include <mutex>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "common.h"
+#include "config.h"
 #include "error.h"
+#include "transfer_metadata.h"
+#include "transfer_metadata_plugin.h"
 #include "transport/rdma_transport/rdma_context.h"
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
@@ -41,6 +50,33 @@ using namespace mooncake;
 
 namespace mooncake {
 
+class RdmaTransportTestPeer {
+   public:
+    static void bindMetadata(RdmaTransport &transport,
+                             std::shared_ptr<TransferMetadata> metadata,
+                             const std::string &local_server_name) {
+        transport.metadata_ = std::move(metadata);
+        transport.local_server_name_ = local_server_name;
+        transport.rdma_server_name_ = local_server_name;
+    }
+};
+
+class RdmaContextTestPeer {
+   public:
+    static void bindCompletionQueue(RdmaContext &context, ibv_cq *cq) {
+        context.cq_list_.emplace_back();
+        context.cq_list_.back().native = cq;
+        cq->cq_context = &context.cq_list_.back().outstanding;
+        context.gid_ = {};
+        context.gid_index_ = 0;
+        context.lid_ = 0;
+    }
+
+    static void clearCompletionQueues(RdmaContext &context) {
+        context.cq_list_.clear();
+    }
+};
+
 class RdmaEndPointTestPeer {
    public:
     static void setStatus(RdmaEndPoint &endpoint, RdmaEndPoint::Status status) {
@@ -55,6 +91,11 @@ class RdmaEndPointTestPeer {
     static void setPeerQpNums(RdmaEndPoint &endpoint,
                               std::vector<uint32_t> peer_qp_nums) {
         endpoint.peer_qp_num_list_ = std::move(peer_qp_nums);
+    }
+
+    static int reconstruct(RdmaEndPoint &endpoint) {
+        RWSpinlock::WriteGuard guard(endpoint.lock_);
+        return endpoint.reconstruct();
     }
 };
 
@@ -71,6 +112,11 @@ class RdmaEndPointStateTest : public ::testing::Test {
         MC_LSAN_IGNORE_OBJECT(transport_);
         context_ = std::make_unique<RdmaContext>(*transport_, "unused");
         endpoint_ = std::make_unique<RdmaEndPoint>(*context_);
+    }
+
+    void TearDown() override {
+        endpoint_->destroyQP();
+        RdmaContextTestPeer::clearCompletionQueues(*context_);
     }
 
     RdmaTransport *transport_ = nullptr;
@@ -143,6 +189,93 @@ TEST_F(RdmaEndPointStateTest, StaleReadyAckWithDifferentPeerQpDoesNotReset) {
     EXPECT_TRUE(endpoint_->connected());
     EXPECT_FALSE(endpoint_->readyToSend());
     EXPECT_TRUE(endpoint_->readyAckTimedOut());
+}
+
+TEST_F(RdmaEndPointStateTest,
+       StaleActiveHandshakeReplyDoesNotConnectReconstructedEndpoint) {
+    TransferMetadata server_metadata(P2PHANDSHAKE);
+    int sockfd = -1;
+    const uint16_t port = findAvailableTcpPort(sockfd);
+    ASSERT_NE(port, 0);
+    const std::string host = globalConfig().use_ipv6 ? "::1" : "127.0.0.1";
+    const std::string peer_server_name =
+        maybeWrapIpV6(host) + ":" + std::to_string(port);
+
+    std::mutex callback_mutex;
+    std::condition_variable callback_cv;
+    bool callback_started = false;
+    bool release_reply = false;
+    // Hold the Q1 reply until the test has reconstructed the endpoint as Q2.
+    ASSERT_EQ(server_metadata.startHandshakeDaemon(
+                  [&](const RdmaEndPoint::HandShakeDesc &peer_desc,
+                      RdmaEndPoint::HandShakeDesc &local_desc) {
+                      std::unique_lock<std::mutex> lock(callback_mutex);
+                      callback_started = true;
+                      callback_cv.notify_all();
+                      callback_cv.wait(lock, [&] { return release_reply; });
+
+                      local_desc.local_nic_path = peer_desc.peer_nic_path;
+                      local_desc.peer_nic_path = peer_desc.local_nic_path;
+                      local_desc.local_gid =
+                          "00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00";
+                      local_desc.local_lid = 0;
+                      local_desc.qp_num.clear();
+                      local_desc.ready_ack_supported = false;
+                      return 0;
+                  },
+                  port, sockfd),
+              0);
+
+    auto client_metadata = std::make_shared<TransferMetadata>(P2PHANDSHAKE);
+    RdmaTransportTestPeer::bindMetadata(*transport_, client_metadata,
+                                        "rdma-endpoint-state-client");
+
+    // Zero QPs keep the regression hardware-free while still exercising the
+    // real active-handshake and reconstruct state transitions.
+    ibv_cq fake_cq = {};
+    RdmaContextTestPeer::bindCompletionQueue(*context_, &fake_cq);
+    ASSERT_EQ(endpoint_->construct(&fake_cq, 0), 0);
+    endpoint_->setPeerNicPath(peer_server_name + "@peer-nic");
+
+    auto active_result = std::async(std::launch::async, [&] {
+        return endpoint_->setupConnectionsByActive();
+    });
+
+    bool observed_callback = false;
+    {
+        std::unique_lock<std::mutex> lock(callback_mutex);
+        observed_callback = callback_cv.wait_for(
+            lock, std::chrono::seconds(5), [&] { return callback_started; });
+    }
+    if (!observed_callback) {
+        {
+            std::lock_guard<std::mutex> lock(callback_mutex);
+            release_reply = true;
+        }
+        callback_cv.notify_all();
+        if (active_result.wait_for(std::chrono::seconds(5)) ==
+            std::future_status::ready) {
+            active_result.get();
+        }
+        FAIL() << "Active handshake did not reach the blocking callback";
+    }
+
+    const int reconstruct_result =
+        RdmaEndPointTestPeer::reconstruct(*endpoint_);
+    const bool connected_after_reconstruct = endpoint_->connected();
+
+    // The successful Q1 reply is now stale and must not configure Q2.
+    {
+        std::lock_guard<std::mutex> lock(callback_mutex);
+        release_reply = true;
+    }
+    callback_cv.notify_all();
+
+    const int active_rc = active_result.get();
+    ASSERT_EQ(reconstruct_result, 0);
+    ASSERT_FALSE(connected_after_reconstruct);
+    EXPECT_EQ(active_rc, ERR_ENDPOINT);
+    EXPECT_FALSE(endpoint_->connected());
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

### Problem

Under high connection fanout (20 clients × 40 stores), an RDMA endpoint could remain unusable after reconnection:

```text
W0821 11:53:39.872644 rdma_endpoint.cpp:325] Re-establish connection: EndPoint: local <local>@mlx5_1, peer <peer>@mlx5_31
I0821 11:53:39.877859 rdma_endpoint.cpp:433] Successfully reset the endpoint (triggered by: re-establishing connection (passive)).

E20260821 06:02:58.045536 worker_pool.cpp:297] Process failed for slice (... retry_cnt: 0): transport retry counter exceeded
E20260821 06:03:01.803566 worker_pool.cpp:297] Process failed for slice (... retry_cnt: 1): transport retry counter exceeded

[mooncake-store] remote put wait failed ... stalled for 10000ms after 0 byte(s)
```

The endpoint reported a successful reset, but subsequent WRs continued to fail.

### Root Cause

`setupConnectionsByActive()` sends the handshake RPC without holding the endpoint lock.

While the RPC for QP generation Q1 is in flight, another waiter can time out and reconstruct the endpoint as Q2. The stale Q1 reply can then configure or reset Q2 because the endpoint does not verify that the reply belongs to the current QP generation.

This can leave the endpoint marked `CONNECTED` while the peer still references Q1.

### Fix

- Add a monotonically increasing QP generation to `RdmaEndPoint`.
- Increment it before reconstructing QPs.
- Capture the generation when starting or waiting for a handshake.
- Reject stale RPC success/failure replies before they can configure or reset a newer endpoint.
- Recheck generation and connection state under the lock before a timeout waiter resets the endpoint.

No handshake wire-format change is required.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Natural RDMA stress tests completed successfully:
60 clients × 70 stores: 60/60 completed, 70/70 stores Ready, 0 restarts, 0 errors.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)