### PR TITLE
Fix missing datasync in PosixFile write path for BucketStorageBackend

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -2699,6 +2699,17 @@ tl::expected<void, ErrorCode> BucketStorageBackend::WriteBucket(
             MutexLocker cache_locker(&file_cache_mutex_);
             file_cache_.erase(bucket_data_path);
         }
+
+        // Flush bucket data to stable storage before committing metadata.
+        // This prevents a crash from leaving valid metadata pointing at
+        // incomplete data (write-ordering durability guarantee).
+        // OpenFile returns PosixFile for writes (UringFile is read-only),
+        // so this datasync is the effective flush for the fallback path.
+        auto sync_result = file->datasync();
+        if (!sync_result) {
+            LOG(ERROR) << "datasync failed for bucket: " << bucket_id;
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
     }
     auto store_bucket_metadata_result =
         StoreBucketMetadata(bucket_id, bucket_metadata);


### PR DESCRIPTION
BucketStorageBackend::WriteBucket claims to flush bucket data to stable storage before committing metadata (write-ordering durability guarantee). However, the datasync() call was only in the UringFile code path — which is never reached for writes because OpenFile returns UringFile only for FileMode::Read.

This is a regression from PR #1562, which changed OpenFile to use O_DIRECT for reads only, orphaning the datasync() that PR #1500 had made reachable.

The fix adds file->datasync() in the fallback PosixFile write path. PosixFile::datasync() correctly calls fdatasync(fd_). This restores the write-ordering durability guarantee for the common (non-uring) case.

Fixes #3089

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)