### PR TITLE
[Store] Sweep stale handles in bounded write-lock batches

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1064,7 +1064,12 @@ class MasterService {
     // misclassify a concurrent mount, whatever the interleaving.
     void ClearLocalDiskHandlesOwnedBy(const UUID& owner);
     // Shard walk shared by the two sweeps above; removes completed replicas
-    // matching is_stale, erasing a key when no valid replica remains.
+    // matching is_stale, erasing a key when no valid replica remains. Each
+    // shard is first scanned under its shared lock to pick the keys that
+    // match, and only those are cleaned, in bounded batches under the write
+    // lock: a mass client expiry marks handles stale table-wide, and walking
+    // a whole shard while holding it exclusively blocked every RPC for that
+    // shard until the sweep moved on.
     tl::expected<void, ErrorCode> ClearStaleHandles(
         const std::function<bool(const Replica&)>& is_stale);
     bool ProcessClientOffboardingJob(ClientOffboardingJob& job);

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -70,6 +70,13 @@ namespace {
 
 constexpr int kMaxTenantQuotaEvictionRetries = 2;
 
+// Upper bound on the number of keys MasterService::ClearStaleHandles cleans
+// up while holding one metadata shard's write lock. A mass client expiry
+// marks handles stale all over the table, and without a cap the sweep held
+// each shard exclusively for as long as it took to walk that whole shard,
+// so every RPC that touched those keys stalled behind the sweep.
+constexpr size_t kStaleHandleCleanupBatchSize = 64;
+
 // Per-cycle offload cap as a fraction of `offloading_queue_limit_`. Used only
 // when offload-on-evict mode is active. Defers memory eviction for at most
 // this fraction of the queue limit per BatchEvict cycle; beyond that, eviction
@@ -2791,40 +2798,69 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
     const std::function<bool(const Replica&)>& is_stale) {
     std::optional<ErrorCode> first_persist_error;
     for (size_t i = 0; i < kNumShards; i++) {
-        MetadataShardAccessorRW shard(this, i);
-        for (auto tenant_it = shard->tenants.begin();
-             tenant_it != shard->tenants.end();) {
-            auto& tenant_state = tenant_it->second;
-            auto it = tenant_state.metadata.begin();
-            while (it != tenant_state.metadata.end()) {
+        // Pass 1: pick out the keys that need work under the shard's shared
+        // lock. A sweep normally finds nothing in most shards, and such a
+        // shard never takes the exclusive lock at all.
+        std::vector<std::pair<TenantId, std::string>> stale_keys;
+        std::vector<TenantId> empty_tenants;
+        {
+            MetadataShardAccessorRO shard(this, i);
+            for (const auto& [tenant_id, tenant_state] : shard->tenants) {
+                if (tenant_state.Empty()) {
+                    empty_tenants.push_back(tenant_id);
+                    continue;
+                }
+                for (const auto& [key, metadata] : tenant_state.metadata) {
+                    if (metadata.HasReplica(is_stale) || !metadata.IsValid()) {
+                        stale_keys.emplace_back(tenant_id, key);
+                    }
+                }
+            }
+        }
+
+        // Pass 2: clean the picked keys in bounded batches, so the exclusive
+        // hold is capped by kStaleHandleCleanupBatchSize instead of by the
+        // size of the shard. The shard may have changed while the lock was
+        // released, so every key is looked up and re-classified here.
+        for (size_t begin = 0; begin < stale_keys.size();
+             begin += kStaleHandleCleanupBatchSize) {
+            const size_t end = std::min(begin + kStaleHandleCleanupBatchSize,
+                                        stale_keys.size());
+            MetadataShardAccessorRW shard(this, i);
+            for (size_t j = begin; j < end; j++) {
+                auto tenant_it = shard->tenants.find(stale_keys[j].first);
+                if (tenant_it == shard->tenants.end()) {
+                    continue;
+                }
+                auto& tenant_state = tenant_it->second;
+                auto it = tenant_state.metadata.find(stale_keys[j].second);
+                if (it == tenant_state.metadata.end()) {
+                    continue;
+                }
                 const auto cleanup_plan =
                     BuildStaleHandleCleanupPlan(it->second, is_stale);
                 if (!cleanup_plan.removed_ids.empty()) {
                     if (enable_ha_) {
                         if (enable_oplog_) {
+                            // The erase runs from the durable-finalize
+                            // callback.
                             auto persist_result =
                                 PersistStaleHandleCleanupForHA(
                                     "ClearStaleHandles", tenant_it->first,
                                     it->first, it->second, cleanup_plan);
-                            if (!persist_result) {
-                                if (!first_persist_error) {
-                                    first_persist_error =
-                                        persist_result.error();
-                                }
-                                ++it;
-                                continue;
+                            if (!persist_result && !first_persist_error) {
+                                first_persist_error = persist_result.error();
                             }
-                            ++it;
                             continue;
                         }
                     }
                     if (CleanupStaleHandles(it->first, tenant_it->first,
                                             tenant_state, it->second, is_stale,
                                             &shard)) {
-                        it = EraseMetadata(tenant_state, it, tenant_it->first,
-                                           QuotaEraseMode::kFull, &shard);
+                        EraseMetadata(tenant_state, it, tenant_it->first,
+                                      QuotaEraseMode::kFull, &shard);
                     } else {
-                        ++it;
+                        continue;
                     }
                 } else if (!it->second.IsValid()) {
                     if (enable_ha_) {
@@ -2848,23 +2884,30 @@ tl::expected<void, ErrorCode> MasterService::ClearStaleHandles(
                                     first_persist_error =
                                         persist_result.error();
                                 }
-                                ++it;
-                                continue;
                             }
-                            ++it;
                             continue;
                         }
+                        continue;
                     }
-                    it = EraseMetadata(tenant_state, it, tenant_it->first,
-                                       QuotaEraseMode::kFull, &shard);
+                    EraseMetadata(tenant_state, it, tenant_it->first,
+                                  QuotaEraseMode::kFull, &shard);
                 } else {
-                    ++it;
+                    continue;
+                }
+                if (tenant_it->second.Empty()) {
+                    shard->tenants.erase(tenant_it);
                 }
             }
-            if (tenant_state.Empty()) {
-                tenant_it = shard->tenants.erase(tenant_it);
-            } else {
-                ++tenant_it;
+        }
+
+        if (!empty_tenants.empty()) {
+            MetadataShardAccessorRW shard(this, i);
+            for (const auto& tenant_id : empty_tenants) {
+                auto tenant_it = shard->tenants.find(tenant_id);
+                if (tenant_it != shard->tenants.end() &&
+                    tenant_it->second.Empty()) {
+                    shard->tenants.erase(tenant_it);
+                }
             }
         }
     }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -1230,6 +1230,87 @@ TEST_F(MasterServiceTest, UnmountSegmentHidesReplicasBeforeAsyncCleanup) {
     EXPECT_EQ(2u, service_->GetKeyCount());
 }
 
+// A mass client expiry marks handles stale all over the metadata table, so
+// the sweep cleans a shard in bounded write-lock batches instead of holding
+// it exclusively for the whole walk. Dropping and retaking the lock mid-shard
+// must not cost coverage: every key of the departed segment is erased, and
+// every key of a live segment survives. The keys are forced onto one shard
+// because the batch bound is per shard.
+TEST_F(MasterServiceTest, ClearInvalidHandlesSweepsShardAcrossLockBatches) {
+    auto service = std::make_unique<MasterService>();
+    PauseReplicaCleanup(*service);
+
+    constexpr size_t kSegmentSize = 1024 * 1024 * 128;
+    const std::string stale_segment_name = "batch_sweep_stale_segment";
+    const std::string live_segment_name = "batch_sweep_live_segment";
+    const auto stale_segment = PrepareSimpleSegment(
+        *service, stale_segment_name, 0x300000000, kSegmentSize);
+    const auto live_segment = PrepareSimpleSegment(*service, live_segment_name,
+                                                   0x400000000, kSegmentSize);
+
+    // Enough keys per segment that draining the shard takes several batches.
+    constexpr size_t kKeysPerSegment = 100;
+    const size_t target_shard =
+        MetadataShardIndex(*service, "batch_sweep_seed");
+
+    std::vector<std::string> stale_keys;
+    std::vector<std::string> live_keys;
+    for (size_t i = 0;
+         stale_keys.size() + live_keys.size() < 2 * kKeysPerSegment; ++i) {
+        ASSERT_LT(i, 1000000u)
+            << "could not gather enough keys on shard " << target_shard;
+        const std::string key = "batch_sweep_key_" + std::to_string(i);
+        if (MetadataShardIndex(*service, key) != target_shard) {
+            continue;
+        }
+
+        const bool on_stale_segment = stale_keys.size() < kKeysPerSegment;
+        const UUID& client_id =
+            on_stale_segment ? stale_segment.client_id : live_segment.client_id;
+        const std::string& segment_name =
+            on_stale_segment ? stale_segment_name : live_segment_name;
+        ReplicateConfig config;
+        config.replica_num = 1;
+        config.preferred_segments = {segment_name};
+
+        auto put_start = service->PutStart(client_id, key, TenantId::Default(),
+                                           1024, config);
+        ASSERT_TRUE(put_start.has_value()) << "key=" << key;
+        ASSERT_EQ(1u, put_start->size());
+        ASSERT_EQ(segment_name, (*put_start)[0]
+                                    .get_memory_descriptor()
+                                    .buffer_descriptor.transport_endpoint_);
+        ASSERT_TRUE(service
+                        ->PutEnd(client_id, key, TenantId::Default(),
+                                 ReplicaType::MEMORY)
+                        .has_value());
+        (on_stale_segment ? stale_keys : live_keys).push_back(key);
+    }
+
+    ASSERT_TRUE(
+        service
+            ->UnmountSegment(stale_segment.segment_id, stale_segment.client_id)
+            .has_value());
+    ClearInvalidHandlesForTest(*service);
+
+    // GetKeyCount counts physical metadata, so it distinguishes "swept" from
+    // "merely hidden from the read paths by the unmount".
+    EXPECT_EQ(live_keys.size(), service->GetKeyCount());
+    for (const auto& key : stale_keys) {
+        auto get_result = service->GetReplicaList(key, TenantId::Default());
+        ASSERT_FALSE(get_result.has_value()) << "key=" << key;
+        EXPECT_EQ(ErrorCode::OBJECT_NOT_FOUND, get_result.error())
+            << "key=" << key;
+    }
+    for (const auto& key : live_keys) {
+        auto get_result = service->GetReplicaList(key, TenantId::Default());
+        ASSERT_TRUE(get_result.has_value()) << "key=" << key << " was swept";
+        ASSERT_EQ(1u, get_result->replicas.size()) << "key=" << key;
+        EXPECT_TRUE(get_result->replicas[0].is_memory_replica())
+            << "key=" << key;
+    }
+}
+
 TEST_F(MasterServiceTest, UnmountSegmentKeepsSynchronousCleanupInHaMode) {
     auto config = MasterServiceConfig::builder().set_enable_ha(true).build();
     auto service = std::make_unique<MasterService>(config);

--- a/mooncake-store/tests/master_service_test_fixture.h
+++ b/mooncake-store/tests/master_service_test_fixture.h
@@ -93,6 +93,12 @@ class MasterServiceTest : public ::testing::Test {
         return ClientOffboardingWorker::ShouldAlert(retry_count);
     }
 
+    // Runs the stale-handle sweep inline. The fixture is a friend of
+    // MasterService, the classes gtest derives from it are not.
+    void ClearInvalidHandlesForTest(MasterService& service) {
+        service.ClearInvalidHandles();
+    }
+
     void ExpectKeyHiddenFromReadApis(MasterService& service,
                                      const std::string& key) {
         auto get = service.GetReplicaList(key, TenantId::Default());


### PR DESCRIPTION
# Issue #3395: mass client expiry freezes the RPC layer

## 1. Root cause

`MasterService::ClearStaleHandles()`
(`mooncake-store/src/master_service.cpp`) is the shard walk behind both
stale-handle sweeps:

* `ClearInvalidHandles()` / `ClearInvalidHandles(alive_clients)` — run by the
  replica cleanup worker, by `UnmountSegment` / `UnmountNoFSegment`, and, most
  importantly here, by the expiry branch of `ClientMonitorFunc()`.
* `ClearLocalDiskHandlesOwnedBy(owner)` — run by `UnmountLocalDiskSegment`.

The walk was structured as:

```cpp
for (size_t i = 0; i < kNumShards; i++) {
    MetadataShardAccessorRW shard(this, i);   // exclusive shard lock
    for (every tenant in the shard)
        for (every key of that tenant)
            ... classify, and clean if stale ...
}
```

The exclusive lock was taken unconditionally for every one of the 1024 shards
and held for the *entire* walk of that shard, whether or not the shard had
anything to clean. Every RPC that touches metadata (`Get`, `Put`, `Remove`,
`ExistKey`, ...) needs the same shard lock, so each of them blocked until the
sweep had finished walking its shard, and the whole table was walked with no
window in between.

That is tolerable on a small table. It is not tolerable in the reported
scenario:

* When a cache-heavy node goes away, `ClientMonitorFunc` expires all of its
  clients in one `client_ttl` tick (with Context Parallelism there are many
  clients per node, which is why the reporter sees it ~100% of the time with CP
  and rarely without). The expiry branch then calls
  `ClearInvalidHandles(alive_clients)`, which sweeps the *whole* metadata
  table.
* Every memory replica of the departed segments now reports
  `has_invalid_mem_handle()`, and with LOCAL_DISK offload every replica of the
  departed owners matches `has_stale_local_disk_client()`, so the sweep does
  not just classify — it also erases, publishes quota releases and (in HA mode)
  appends an OpLog record per key, all still under the shard's write lock.
* The sweep runs on the client monitor thread itself, so while it is running no
  `Ping` is drained from `client_ping_queue_` and no further expiry is
  processed. That is what makes it look like "one core busy, everything else
  blocked, ping stopped": the sweep is single threaded, and the RPC threads are
  queued behind the shard locks it holds.

So the freeze duration scales with the number of objects in the master, not
with the number of expired clients, and it is paid in one uninterruptible
block.

## 2. The fix and why

`ClearStaleHandles()` now walks each shard in two passes:

1. **Pick** — under the shard's *shared* lock, collect the tenant/key pairs
   that either own a replica matching `is_stale` or are already invalid.
   Readers are unaffected by a shared lock, and a shard with no candidate never
   takes the exclusive lock at all. The predicate used here
   (`metadata.HasReplica(is_stale) || !metadata.IsValid()`) is exactly the pair
   of conditions the old loop branched on, so nothing new is selected or
   skipped. Tenants that are already fully empty are collected separately, so
   the sweep still garbage-collects them the way it used to.
2. **Clean** — take the exclusive lock for at most
   `kStaleHandleCleanupBatchSize` (64) picked keys at a time, then release it.
   The lock is dropped and retaken between batches, so RPCs on that shard get a
   turn instead of waiting for the whole shard.

Because the lock is released between the two passes and between batches, pass 2
looks each key up again and re-runs `BuildStaleHandleCleanupPlan()` under the
exclusive lock before touching anything; a key that disappeared or stopped
being stale in the meantime is simply skipped. The HA/OpLog branch, the quota
accounting, the `disk_object_count` accounting and the empty-tenant erase are
all unchanged — only the locking shape changed.

Worst-case total work is the same; what changed is that it is no longer one
uninterruptible exclusive hold per shard. The peak exclusive hold drops from
"one whole shard" to "64 keys", and the common case (nothing stale in the
shard) drops to a shared-lock scan.

## 3. Files changed

* `mooncake-store/src/master_service.cpp` — rewrote
  `MasterService::ClearStaleHandles()` as pick-under-shared-lock plus
  clean-in-bounded-write-lock-batches; added the
  `kStaleHandleCleanupBatchSize` constant to the file's anonymous namespace.
* `mooncake-store/include/master_service.h` — extended the `ClearStaleHandles`
  declaration comment to describe the new locking contract.
* `mooncake-store/tests/master_service_test.cpp` — added
  `MasterServiceTest.ClearInvalidHandlesSweepsShardAcrossLockBatches`, plus the
  `ClearInvalidHandlesForTest` / `MetadataShardIndexForTest` fixture helpers it
  needs.

## 4. Risk and uncertainty

* **Widened race window, bounded.** A liveness-complement sweep
  (`ClearInvalidHandles`) classifies by absence from a point-in-time
  `alive_clients` set, so a client that re-registers mid-sweep can have a fresh
  replica swept. That hazard already existed for every shard the sweep had not
  reached yet (it is called out in the `ClearLocalDiskHandlesOwnedBy` comment
  in `master_service.h`, and is why the owner-targeted sweep exists). This
  change widens it within a shard by the time between pass 1 and the batch that
  covers a key. It does not add a new class of misclassification, and the
  owner-targeted sweep used by `UnmountLocalDiskSegment` is immune to it by
  construction.
* **`UnmountSegment` ordering.** `UnmountSegment` sweeps between
  `PrepareUnmountSegment` and `CommitUnmountSegment`. The replicas it must
  catch are already invalid before the sweep starts (the allocator is dropped
  in Prepare), so both passes see them. Objects whose replicas go stale after
  pass 1 were already missed by the old code once the shard had been passed;
  they are picked up by the periodic `replica_cleanup_worker_` sweep and by the
  lazy cleanup in the `MetadataAccessorRW` constructor.
* **Memory.** Pass 1 materialises the candidate list for one shard (tenant id +
  key string per candidate). It is bounded by the shard's key count — the same
  order of memory as one shard's key set, and only for candidates.
* **Batch size** (64) is a fixed constant, not a flag. It is a latency/overhead
  tradeoff; a smaller value yields shorter stalls at the cost of more
  lock round trips.
* This is the sweep half of the problem. It does not change the fact that the
  sweep runs inline on the client monitor thread, so a very large sweep still
  delays that thread's next tick; it just no longer holds shard locks across
  the whole table while doing it.

## 5. How this was verified

* Reviewed every caller of `ClearStaleHandles` (`ClearInvalidHandles` x2,
  `ClearLocalDiskHandlesOwnedBy`) and confirmed the new code reproduces the old
  branch-for-branch behaviour: stale-plan branch, HA/OpLog branch, invalid-key
  erase branch, and empty-tenant erase.
* Confirmed that reading `ObjectMetadata::HasReplica` / `IsValid` under a
  *shared* shard lock is already an established pattern in this file
  (`GetKeyCount`, `ExistKey` via `MetadataAccessorRO`): replica vectors are
  only mutated under the exclusive shard lock.
* Added a regression test,
  `MasterServiceTest.ClearInvalidHandlesSweepsShardAcrossLockBatches`, that
  forces 100 keys per segment onto a *single* metadata shard (the batch bound
  is per shard, so keys spread over 1024 shards would never cross a batch
  boundary), unmounts one of two segments, runs the sweep, and asserts via
  `GetKeyCount()` that exactly the departed segment's keys were physically
  erased while the live segment's keys still resolve to a memory replica.
  `GetKeyCount()` is the meaningful assertion here: `GetReplicaList` already
  hides replicas of an unmounted segment before any sweep runs, so only the
  physical key count distinguishes "swept" from "hidden".
* `clang-format` (16.0.0, the repo's pre-commit formatter) was run on the three
  touched files; it reported no changes outside the edited regions.
* **Not verified by a build or a test run.** This checkout is a shallow clone
  with empty `extern/` submodules and none of the required dependencies
  (boost, glog, gtest, yalantinglibs) present, so `mooncake-store` cannot be
  configured or compiled here. The new test and the refactor have not been
  executed. They need `mooncake_store_test` (or
  `scripts/run_ci_test.sh`) to be run on a machine with the toolchain before
  merge.