### PR TITLE
[Store] Add exist_key_grant_lease flag to opt out of leasing on existence probes

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -598,6 +598,7 @@ mooncake_master \
 | `--eviction_ratio` | `0.05` | Fraction evicted at high watermark |
 | `--eviction_high_watermark_ratio` | `0.90` | Usage ratio triggering eviction |
 | `--client_ttl` | `10` s | Seconds before a silent client is considered disconnected |
+| `--exist_key_grant_lease` | `true` | Grant a read lease on `ExistKey`/`BatchExistKey` hits. Set `false` if these leases block eviction |
 
 ### Tenant Quota
 

--- a/docs/source/deployment/ssd/ssd-offload.md
+++ b/docs/source/deployment/ssd/ssd-offload.md
@@ -122,6 +122,8 @@ These flags control when the master asks clients to persist objects to SSD, whet
 
 Start with `--enable_offload=true` for eager SSD persistence. Add `--offload_on_evict=true` when SSD writes should happen only under memory pressure. For SSD-heavy workloads where offload-on-evict is dropping too many objects, raise both `--offloading_queue_limit` and `--offload_cap_ratio`; for example, `--offloading_queue_limit=500000 --offload_cap_ratio=0.8` allows up to `400000` objects to be queued in one eviction cycle.
 
+With `--offload_on_evict=true`, eviction is what moves objects to SSD, and read leases block eviction. If existence checks are used as speculative scans, the leases they grant can keep DRAM full and stall SSD writes; set `--exist_key_grant_lease=false` on the master in that case.
+
 ---
 
 ## SSD Offload Configuration

--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -141,6 +141,13 @@ struct MasterConfig {
     // rich clusters may safely raise it.
     uint32_t promotion_max_per_heartbeat = 1;
 
+    // Grant a read lease on ExistKey/BatchExistKey hits (upstream default).
+    // Set false for read-heavy workloads (e.g. vLLM KV-offload lookup) where
+    // high-rate existence probes would otherwise pin the working set and
+    // starve eviction. Actual reads stay protected: GetReplicaList grants its
+    // own lease.
+    bool exist_key_grant_lease = true;
+
     // Dynamic MEMORY replica fanout for hot read-only objects.
     // Kept intentionally small: mode + frequency window + max replicas.
     std::string dynamic_replication_mode = "off";
@@ -249,6 +256,7 @@ class MasterServiceSupervisorConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+    bool exist_key_grant_lease = true;
     std::string dynamic_replication_mode = "off";
     uint32_t dynamic_replication_heat_window_seconds = 10;
     double dynamic_replication_admission_qps_threshold = 0.8;
@@ -309,6 +317,7 @@ class MasterServiceSupervisorConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        exist_key_grant_lease = config.exist_key_grant_lease;
         dynamic_replication_mode = config.dynamic_replication_mode;
         dynamic_replication_heat_window_seconds =
             config.dynamic_replication_heat_window_seconds;
@@ -505,6 +514,7 @@ class WrappedMasterServiceConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+    bool exist_key_grant_lease = true;
     std::string dynamic_replication_mode = "off";
     uint32_t dynamic_replication_heat_window_seconds = 10;
     double dynamic_replication_admission_qps_threshold = 0.8;
@@ -599,6 +609,7 @@ class WrappedMasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        exist_key_grant_lease = config.exist_key_grant_lease;
         dynamic_replication_mode = config.dynamic_replication_mode;
         dynamic_replication_heat_window_seconds =
             config.dynamic_replication_heat_window_seconds;
@@ -723,6 +734,7 @@ class WrappedMasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        exist_key_grant_lease = config.exist_key_grant_lease;
         dynamic_replication_mode = config.dynamic_replication_mode;
         dynamic_replication_heat_window_seconds =
             config.dynamic_replication_heat_window_seconds;
@@ -796,6 +808,7 @@ class MasterServiceConfigBuilder {
     uint64_t max_kv_soft_pin_ttl_ = DEFAULT_MAX_KV_SOFT_PIN_TTL_MS;
     bool allow_evict_soft_pinned_objects_ =
         DEFAULT_ALLOW_EVICT_SOFT_PINNED_OBJECTS;
+    bool exist_key_grant_lease_ = true;
     double eviction_ratio_ = DEFAULT_EVICTION_RATIO;
     double eviction_high_watermark_ratio_ =
         DEFAULT_EVICTION_HIGH_WATERMARK_RATIO;
@@ -872,6 +885,11 @@ class MasterServiceConfigBuilder {
     MasterServiceConfigBuilder& set_allow_evict_soft_pinned_objects(
         bool allow) {
         allow_evict_soft_pinned_objects_ = allow;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_exist_key_grant_lease(bool grant) {
+        exist_key_grant_lease_ = grant;
         return *this;
     }
 
@@ -1182,6 +1200,7 @@ class MasterServiceConfig {
     uint32_t promotion_admission_threshold = 2;
     uint32_t promotion_queue_limit = 50000;
     uint32_t promotion_max_per_heartbeat = 1;
+    bool exist_key_grant_lease = true;
     std::string dynamic_replication_mode = "off";
     uint32_t dynamic_replication_heat_window_seconds = 10;
     double dynamic_replication_admission_qps_threshold = 0.8;
@@ -1272,6 +1291,7 @@ class MasterServiceConfig {
         promotion_admission_threshold = config.promotion_admission_threshold;
         promotion_queue_limit = config.promotion_queue_limit;
         promotion_max_per_heartbeat = config.promotion_max_per_heartbeat;
+        exist_key_grant_lease = config.exist_key_grant_lease;
         dynamic_replication_mode = config.dynamic_replication_mode;
         dynamic_replication_heat_window_seconds =
             config.dynamic_replication_heat_window_seconds;
@@ -1348,6 +1368,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.default_kv_soft_pin_ttl = default_kv_soft_pin_ttl_;
     config.max_kv_soft_pin_ttl = max_kv_soft_pin_ttl_;
     config.allow_evict_soft_pinned_objects = allow_evict_soft_pinned_objects_;
+    config.exist_key_grant_lease = exist_key_grant_lease_;
     config.eviction_ratio = eviction_ratio_;
     config.eviction_high_watermark_ratio = eviction_high_watermark_ratio_;
     config.nof_eviction_ratio = nof_eviction_ratio_;

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -2205,6 +2205,10 @@ class MasterService {
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds
     const uint64_t max_kv_soft_pin_ttl_;      // in milliseconds
     const bool allow_evict_soft_pinned_objects_;
+    // When false, ExistKey/BatchExistKey hits do not grant a read lease.
+    // Default true (upstream behavior); real reads still lease via
+    // GetReplicaList. See master_config.h exist_key_grant_lease.
+    const bool exist_key_grant_lease_;
 
     // Eviction related members
     std::atomic<bool> need_mem_eviction_{

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -226,6 +226,12 @@ DEFINE_validator(offload_cap_ratio, [](const char* flagname, double value) {
 DEFINE_bool(promotion_on_hit, false,
             "Promote LOCAL_DISK-only keys to MEMORY on read access (mirror of "
             "offload_on_evict)");
+DEFINE_bool(
+    exist_key_grant_lease, true,
+    "Grant a read lease on ExistKey/BatchExistKey hits (upstream "
+    "default). Set false for read-heavy workloads (e.g. vLLM KV-offload "
+    "lookup) where high-rate existence probes would otherwise pin the "
+    "working set and starve eviction");
 DEFINE_uint32(promotion_admission_threshold, 2,
               "Min CountMinSketch count for a key before promotion fires "
               "(set 1 to disable second-touch gating)");
@@ -536,6 +542,9 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
                              FLAGS_offload_cap_ratio);
     default_config.GetBool("promotion_on_hit", &master_config.promotion_on_hit,
                            FLAGS_promotion_on_hit);
+    default_config.GetBool("exist_key_grant_lease",
+                           &master_config.exist_key_grant_lease,
+                           FLAGS_exist_key_grant_lease);
     default_config.GetUInt32("promotion_admission_threshold",
                              &master_config.promotion_admission_threshold,
                              FLAGS_promotion_admission_threshold);
@@ -916,6 +925,11 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.promotion_on_hit = FLAGS_promotion_on_hit;
+    }
+    if ((google::GetCommandLineFlagInfo("exist_key_grant_lease", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.exist_key_grant_lease = FLAGS_exist_key_grant_lease;
     }
     if ((google::GetCommandLineFlagInfo("promotion_admission_threshold",
                                         &info) &&

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -190,6 +190,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
       default_kv_soft_pin_ttl_(config.default_kv_soft_pin_ttl),
       max_kv_soft_pin_ttl_(config.max_kv_soft_pin_ttl),
       allow_evict_soft_pinned_objects_(config.allow_evict_soft_pinned_objects),
+      exist_key_grant_lease_(config.exist_key_grant_lease),
       eviction_ratio_(config.eviction_ratio),
       eviction_high_watermark_ratio_(config.eviction_high_watermark_ratio),
       nof_eviction_ratio_(config.nof_eviction_ratio),
@@ -2903,8 +2904,17 @@ auto MasterService::ExistKey(const std::string& key, const TenantId& tenant_id)
     }
 
     // Grant a lease to the object as it may be further used by the client.
-    // Read path is group-agnostic: only the object's own lease is refreshed.
-    metadata.GrantReadLease(std::chrono::milliseconds(default_kv_lease_ttl_));
+    // Read path is group-agnostic: only the object's own lease is refreshed
+    // (grouped objects share one Lease, so this extends the whole group TTL).
+    // Skipped when exist_key_grant_lease_ is false: probes can arrive far more
+    // often than real reads (e.g. vLLM KV-offload lookup), and every hit would
+    // keep the object -- or, for grouped objects, the whole group -- out of
+    // eviction. Real reads stay protected either way: GetReplicaList grants
+    // its own lease.
+    if (exist_key_grant_lease_) {
+        metadata.GrantReadLease(
+            std::chrono::milliseconds(default_kv_lease_ttl_));
+    }
     return true;
 }
 
@@ -2960,8 +2970,11 @@ std::vector<tl::expected<bool, ErrorCode>> MasterService::BatchExistKey(
                 results[i] = false;
                 continue;
             }
-            metadata.GrantReadLease(
-                std::chrono::milliseconds(default_kv_lease_ttl_));
+            // See ExistKey: skipped when exist_key_grant_lease_ is false.
+            if (exist_key_grant_lease_) {
+                metadata.GrantReadLease(
+                    std::chrono::milliseconds(default_kv_lease_ttl_));
+            }
             results[i] = true;
         }
     }

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -738,6 +738,77 @@ TEST_F(MasterServiceTest, DfsEvictionSplitsAcceptedAndRejectedCandidates) {
              {std::nullopt, std::nullopt, size_t{1}, size_t{1}}, true);
 }
 
+TEST_F(MasterServiceTest, ExistKeyGrantsLeaseByDefaultBlockingEviction) {
+    // Upstream default: an ExistKey hit grants a read lease, so the object
+    // survives an eviction pass even under full eviction pressure.
+    auto service_config = MasterServiceConfig::builder().build();
+    MasterService service(service_config);
+    const auto context = PrepareSimpleSegment(service);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "exist_lease_default";
+    PutCompletedObject(service, context.client_id, key, config);
+
+    auto exists = service.ExistKey(key, TenantId::Default());
+    ASSERT_TRUE(exists.has_value());
+    EXPECT_TRUE(exists.value());
+
+    // ExistKey granted a lease -> not evictable.
+    service.RunBatchEvictForTesting(1.0, 1.0);
+    EXPECT_TRUE(service.GetReplicaList(key, TenantId::Default()).has_value());
+}
+
+TEST_F(MasterServiceTest, ExistKeyDoesNotGrantLeaseWhenDisabled) {
+    // exist_key_grant_lease=false: ExistKey probes must not lease, so the
+    // object stays evictable. This is the read-heavy (e.g. vLLM KV-offload
+    // lookup) opt-out that keeps eviction from being starved.
+    auto service_config =
+        MasterServiceConfig::builder().set_exist_key_grant_lease(false).build();
+    MasterService service(service_config);
+    const auto context = PrepareSimpleSegment(service);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "exist_lease_disabled";
+    PutCompletedObject(service, context.client_id, key, config);
+
+    auto exists = service.ExistKey(key, TenantId::Default());
+    ASSERT_TRUE(exists.has_value());
+    EXPECT_TRUE(exists.value());
+
+    // No lease from ExistKey -> object is evicted under full pressure.
+    service.RunBatchEvictForTesting(1.0, 1.0);
+    EXPECT_FALSE(service.GetReplicaList(key, TenantId::Default()).has_value());
+
+    // A real read still grants its own lease regardless of the flag, so a
+    // freshly re-put object protected by GetReplicaList survives eviction.
+    PutCompletedObject(service, context.client_id, key, config);
+    ASSERT_TRUE(service.GetReplicaList(key, TenantId::Default()).has_value());
+    service.RunBatchEvictForTesting(1.0, 1.0);
+    EXPECT_TRUE(service.GetReplicaList(key, TenantId::Default()).has_value());
+}
+
+TEST_F(MasterServiceTest, BatchExistKeyDoesNotGrantLeaseWhenDisabled) {
+    auto service_config =
+        MasterServiceConfig::builder().set_exist_key_grant_lease(false).build();
+    MasterService service(service_config);
+    const auto context = PrepareSimpleSegment(service);
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    const std::string key = "batch_exist_lease_disabled";
+    PutCompletedObject(service, context.client_id, key, config);
+
+    auto results = service.BatchExistKey({key}, TenantId::Default());
+    ASSERT_EQ(results.size(), 1u);
+    ASSERT_TRUE(results[0].has_value());
+    EXPECT_TRUE(results[0].value());
+
+    service.RunBatchEvictForTesting(1.0, 1.0);
+    EXPECT_FALSE(service.GetReplicaList(key, TenantId::Default()).has_value());
+}
+
 TEST_F(MasterServiceTest, StandbySnapshotRestorePreservesTenantScopedKeys) {
     const TenantId tenant_a("tenant_restore_a");
     const TenantId tenant_b("tenant_restore_b");


### PR DESCRIPTION
## Description

`ExistKey` / `BatchExistKey` currently grant a read lease on **every hit** (`master_service.cpp:2780` and `:2851`). A read lease pins the object so it cannot be evicted until the lease TTL expires (default 10s), and `BatchEvict` skips any leased object outright:

```cpp
// master_service.cpp:10250
if (!it->second.IsLeaseExpired(now) || !has_evictable) continue;
```

This is fine when existence checks track actual reads one-to-one. **But for read-heavy workloads the probe rate and coverage vastly exceed the read rate, and leasing on probes starves eviction.** The concrete trigger is vLLM's KV-cache-offload connector (`MooncakeStoreConnector`, in the vLLM tree at `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/store/`):

- On every request, the scheduler calls `client.lookup(...)` (`connector.py` → `scheduler.py`) to decide how much prefix it can reuse.
- `lookup` expands **all** prefix-candidate block hashes — further multiplied across each rank namespace — into one big `candidate_keys` list and issues a single `store.batch_is_exist(candidate_keys)` (`worker.py:1944`), which lands as `BatchExistKey` on the master.
- It then reads back **only the longest matching prefix** (`worker.py:1964-1990`). Every other hit — probed but not read this request — still got a fresh 10s lease.

With a small memory tier under steady-state eviction, the same hot blocks are re-probed faster than TTL/2, so their leases never expire. Nearly the entire working set stays pinned, `BatchEvict` finds no evictable candidates, and new `Put`s fail with `NO_AVAILABLE_HANDLE`. This was observed in production as **Eviction Success/Attempts = 39/1123** with puts rejected (`-200`).

**Fix:** add a master config flag `exist_key_grant_lease` (default `true`, i.e. upstream behavior unchanged), wired through the existing gflag/config path exactly like `promotion_on_hit`. When set to `false`, `ExistKey`/`BatchExistKey` no longer grant leases — intended for read-heavy + frequent-eviction deployments (e.g. vLLM KV offload on a small memory tier).

**Why this is safe:** actual reads are unaffected — `GetReplicaList` grants its own lease (`master_service.cpp:3678` / `3865`) to protect the read-in-flight window. The only behavioral change when disabled is that a probe→read race may evict an entry in between, which for the offload connector is just a normal cache miss (the tokens are recomputed locally). Correctness is preserved either way. This is an opt-in, backward-compatible flag with no `USE_PHOENIX` dependency.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix
- [x] Performance improvement

## How Has This Been Tested?

Added three unit tests in `mooncake-store/tests/master_service_test.cpp`:

- `ExistKeyGrantsLeaseByDefaultBlockingEviction` — default (`true`): an `ExistKey` hit leases the object, so it survives `RunBatchEvictForTesting(1.0, 1.0)`.
- `ExistKeyDoesNotGrantLeaseWhenDisabled` — `false`: the probed object is evicted under full pressure; a subsequently re-put object read via `GetReplicaList` still survives (confirming real reads remain protected).
- `BatchExistKeyDoesNotGrantLeaseWhenDisabled` — `false`: same for the batch path.

- [x] Unit tests pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (verified with clang-format 20.1.0)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: N/A (~130 LOC)

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

> AI assistance was used to trace the root cause across the Mooncake and vLLM codebases, draft the config wiring (following the existing `promotion_on_hit` pattern), and write the tests. The human submitter has reviewed every changed line and can defend the change end-to-end.