### PR TITLE
[Bugfix][TE] Evict stale endpoints on RDMA port recovery

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -64,6 +64,11 @@ class RdmaContext {
 
     int resume();
 
+    // Evict all cached endpoints so they are rebuilt with fresh QPs.
+    // Called on port recovery (IBV_EVENT_PORT_ACTIVE): QPs that entered
+    // IBV_QPS_ERR while the link was down are stale and must be torn down.
+    void evictEndpoints();
+
     enum DeviceStatus {
         DEVICE_UNINIT,
         DEVICE_DISABLED,

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -107,6 +107,7 @@ class SIEVEEndpointStore : public EndpointStore {
     size_t size() override;
 
     int remove(RdmaEndPoint *ep) override;
+    void evictAll() override;
     void evictOne() override;
     void reclaim() override;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -74,6 +74,7 @@ class FIFOEndpointStore : public EndpointStore {
 
     size_t size() override;
 
+    void evictAll() override;
     void evictOne() override;
     void reclaim() override;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
@@ -48,6 +48,13 @@ class EndpointStore {
     virtual size_t size() = 0;
 
     virtual void evictOne() = 0;
+
+    // Evict all endpoints: move every entry to the waiting list and begin
+    // destroying it.  Called on port recovery so that QPs that entered
+    // IBV_QPS_ERR while the link was down are torn down and rebuilt on the
+    // next getOrInsert().
+    virtual void evictAll() = 0;
+
     virtual void reclaim() = 0;
 };
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -505,10 +505,19 @@ int RdmaContext::pause() {
     return (expected == DEVICE_PAUSED) ? 0 : -1;
 }
 
+void RdmaContext::evictEndpoints() {
+    if (endpoint_store_) endpoint_store_->evictAll();
+}
+
 int RdmaContext::resume() {
     DeviceStatus expected = DEVICE_PAUSED;
     status_.compare_exchange_strong(expected, DEVICE_ENABLED);
-    return (expected == DEVICE_ENABLED) ? 0 : -1;
+    if (expected != DEVICE_PAUSED) return -1;
+    // Port recovered: evict all cached endpoints so stale QPs (which may
+    // have entered IBV_QPS_ERR while the link was down) are torn down and
+    // rebuilt on the next getOrInsert() call.
+    evictEndpoints();
+    return 0;
 }
 
 RdmaContext::MemReg RdmaContext::registerMemReg(void* addr, size_t length,

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -119,6 +119,24 @@ void FIFOEndpointStore::evictOne() {
     LOG(INFO) << victim << " evicted from FIFOEndpointStore";
 }
 
+void FIFOEndpointStore::evictAll() {
+    std::vector<std::shared_ptr<RdmaEndPoint>> to_evict;
+    {
+        RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+        to_evict.reserve(endpoint_map_.size());
+        for (auto& entry : endpoint_map_) to_evict.push_back(entry.second);
+        endpoint_map_.clear();
+        fifo_list_.clear();
+        fifo_map_.clear();
+    }
+    for (auto& ep : to_evict) {
+        waiting_list_.insert(ep);
+        ep->beginDestroy();
+    }
+    LOG(INFO) << "FIFOEndpointStore: evicted all " << to_evict.size()
+              << " endpoints on port recovery";
+}
+
 void FIFOEndpointStore::reclaim() {
     std::vector<std::shared_ptr<RdmaEndPoint>> candidates;
     {
@@ -298,6 +316,26 @@ void SIEVEEndpointStore::evictOne() {
     endpoint_map_.erase(victim);
     LOG(INFO) << "Endpoint " << victim << " has been evicted";
     return;
+}
+
+void SIEVEEndpointStore::evictAll() {
+    std::vector<std::shared_ptr<RdmaEndPoint>> to_evict;
+    {
+        RWSpinlock::WriteGuard guard(endpoint_map_lock_);
+        to_evict.reserve(endpoint_map_.size());
+        for (auto& entry : endpoint_map_) to_evict.push_back(entry.second.first);
+        endpoint_map_.clear();
+        fifo_list_.clear();
+        fifo_map_.clear();
+        hand_ = std::nullopt;
+    }
+    for (auto& ep : to_evict) {
+        waiting_list_.insert(ep);
+        waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
+        ep->beginDestroy();
+    }
+    LOG(INFO) << "SIEVEEndpointStore: evicted all " << to_evict.size()
+              << " endpoints on port recovery";
 }
 
 void SIEVEEndpointStore::reclaim() {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -323,7 +323,9 @@ void SIEVEEndpointStore::evictAll() {
     {
         RWSpinlock::WriteGuard guard(endpoint_map_lock_);
         to_evict.reserve(endpoint_map_.size());
-        for (auto& entry : endpoint_map_) to_evict.push_back(entry.second.first);
+        for (auto& entry : endpoint_map_) {
+            to_evict.push_back(entry.second.first);
+        }
         endpoint_map_.clear();
         fifo_list_.clear();
         fifo_map_.clear();

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
@@ -124,13 +124,20 @@ void FIFOEndpointStore::evictAll() {
     {
         RWSpinlock::WriteGuard guard(endpoint_map_lock_);
         to_evict.reserve(endpoint_map_.size());
-        for (auto& entry : endpoint_map_) to_evict.push_back(entry.second);
+        for (auto& entry : endpoint_map_) {
+            to_evict.push_back(entry.second);
+            // Publish into waiting_list_ under the same lock: reclaim()
+            // iterates waiting_list_ under endpoint_map_lock_, so inserting
+            // here avoids an unsynchronized read/write on the unordered_set.
+            waiting_list_.insert(entry.second);
+        }
         endpoint_map_.clear();
         fifo_list_.clear();
         fifo_map_.clear();
     }
+    // beginDestroy() may call back into reclaim() (which takes
+    // endpoint_map_lock_), so it must run after the lock is released.
     for (auto& ep : to_evict) {
-        waiting_list_.insert(ep);
         ep->beginDestroy();
     }
     LOG(INFO) << "FIFOEndpointStore: evicted all " << to_evict.size()
@@ -325,6 +332,11 @@ void SIEVEEndpointStore::evictAll() {
         to_evict.reserve(endpoint_map_.size());
         for (auto& entry : endpoint_map_) {
             to_evict.push_back(entry.second.first);
+            // Publish into waiting_list_ under the same lock: reclaim()
+            // iterates waiting_list_ under endpoint_map_lock_, so inserting
+            // here avoids an unsynchronized read/write on the unordered_set.
+            waiting_list_.insert(entry.second.first);
+            waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
         }
         endpoint_map_.clear();
         fifo_list_.clear();
@@ -332,8 +344,6 @@ void SIEVEEndpointStore::evictAll() {
         hand_ = std::nullopt;
     }
     for (auto& ep : to_evict) {
-        waiting_list_.insert(ep);
-        waiting_list_len_.fetch_add(1, std::memory_order_relaxed);
         ep->beginDestroy();
     }
     LOG(INFO) << "SIEVEEndpointStore: evicted all " << to_evict.size()


### PR DESCRIPTION
## Affected code paths
- mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
  - RdmaContext::resume(): now calls evictEndpoints()
  - new RdmaContext::evictEndpoints() accessor
- mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
  - resume(): flips status then evicts all endpoints
  - evictEndpoints(): delegates to endpoint_store_->evictAll()
- mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint_store.h
  - EndpointStore: new pure virtual evictAll()
- mooncake-transfer-engine/tent/src/transport/rdma/endpoint_store.cpp
  - FIFOEndpointStore::evictAll()
  - SIEVEEndpointStore::evictAll()

## Root cause
When an RDMA port goes down and comes back up, the
IBV_EVENT_PORT_ACTIVE path only called context->resume(), which flips a
DeviceStatus flag. QPs that entered IBV_QPS_ERR while the link was down
were never destroyed or rebuilt. The endpoint store kept returning these
stale endpoints, so work requests were posted into dead QPs and never
completed, causing transfers to stall.

Counter-intuitive effect: post-recovery transfers run ~5x SLOWER than
during the outage (5.48s vs 1.03s in the reporter's 7-rail setup), with
persistent 20s timeouts.

## The fix
Add EndpointStore::evictAll() to both FIFOEndpointStore and
SIEVEEndpointStore. evictAll() moves every entry from the active map to
the waiting list and calls beginDestroy() on each, transitioning QPs to
ERR state so the hardware flushes inflight WRs to the CQ.

RdmaContext::resume() now calls evictEndpoints() after successfully
flipping status back to DEVICE_ENABLED. The next getOrInsert() call for
each peer creates a fresh endpoint with a new QP, restoring full
throughput.

## How it has been tested
- git diff reviewed: 4 files, 60 insertions, 1 deletion.
- getOrInsert() already handles the transition: a looked-up endpoint in
  EP_DESTROYING/EP_DESTROYED is removed and a fresh one is created.

Fixes kvcache-ai/Mooncake#3596

## Description



## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)