### PR TITLE
[CI] Install sgl-eval for T-One SGLang tests

### DIFF
--- a/scripts/tone_tests/scripts/common.sh
+++ b/scripts/tone_tests/scripts/common.sh
@@ -100,6 +100,11 @@ docker_launch(){
         else
             echo "sglang-router already installed, skipping"
         fi
+
+        # Reuse SGLang CI's single source of truth for the git-only evaluator
+        # pin instead of duplicating the commit here.
+        pip_cmd=$(append_str "${pip_cmd}" \
+            'source /sgl-workspace/sglang/scripts/ci/utils/sgl_eval_ref.sh && pip install "$SGL_EVAL_SPEC"')
     fi
 
     echo "Installing ERDMA drivers"

--- a/scripts/tone_tests/scripts/test_moe_mooncake.sh
+++ b/scripts/tone_tests/scripts/test_moe_mooncake.sh
@@ -14,6 +14,12 @@ run_test()
 
     echo "Running tests in container and saving output to: $log_file"
 
+    if ! ${docker_exec} "command -v sgl-eval >/dev/null 2>&1"; then
+        echo "ERROR: sgl-eval is missing from the SGLang test container" >&2
+        echo "The T-One setup must install the pinned sgl-eval dependency before pytest." >&2
+        return 1
+    fi
+
     # Use local HF cache (offline) when the model is already downloaded.
     local offline_prefix=$(hf_offline_prefix "deepseek-ai/DeepSeek-Coder-V2-Lite-Instruct")
 


### PR DESCRIPTION
## Description

Install the SGLang evaluation CLI required by the T-One MMLU integration test. SGLang now routes MMLU through the git-only `sgl-eval` CLI, but the T-One container setup only installed the Mooncake wheel and optional `sglang-router`, causing the test to fail with a missing executable before evaluation started.

## Module

- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
bash -n scripts/tone_tests/scripts/common.sh scripts/tone_tests/scripts/test_moe_mooncake.sh
git diff --check
```

**Test results:**
- [x] Manual shell syntax and diff validation passed
- [ ] T-One GPU integration test rerun pending

The setup sources SGLang's canonical `scripts/ci/utils/sgl_eval_ref.sh` inside the container and installs `$SGL_EVAL_SPEC`, so the evaluator pin is maintained by SGLang rather than duplicated in Mooncake. The test script also checks `command -v sgl-eval` before allocating the model server.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted code using `./scripts/code_format.sh` (shell-only change)
- [ ] I have run pre-commit on the files changed in this PR
- [ ] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (investigation, patch, and validation)

The human submitter is responsible for reviewing and defending the change.