### PR TITLE
[Store] Avoid direct-I/O padding for POSIX restores

### DIFF
--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -1,5 +1,6 @@
 #include "file_storage.h"
 
+#include <algorithm>
 #include <memory>
 #include <optional>
 #include <utility>
@@ -1101,13 +1102,14 @@ FileStorage::AllocateBatch(const std::vector<std::string>& keys,
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
 
-        // Allocate oversized buffer for O_DIRECT alignment:
-        //   +4096 for aligning the ptr to 4096 boundary
-        //   +4096 for aligned read tail padding (actual_offset may not be
-        //   aligned)
         size_t data_size = static_cast<size_t>(sizes[i]);
-        size_t alloc_size =
-            align_up(data_size, kDirectIOAlignment) + 2 * kDirectIOAlignment;
+        size_t alloc_size = std::max<size_t>(data_size, 1);
+        if (config_.use_uring) {
+            // O_DIRECT reads need room to align the pointer and to round an
+            // unaligned file range out to full pages.
+            alloc_size = align_up(data_size, kDirectIOAlignment) +
+                         2 * kDirectIOAlignment;
+        }
 
         auto alloc_result = allocator.allocate(alloc_size);
         if (!alloc_result && !gc_triggered &&
@@ -1131,19 +1133,19 @@ FileStorage::AllocateBatch(const std::vector<std::string>& keys,
             return tl::make_unexpected(ErrorCode::BUFFER_OVERFLOW);
         }
 
-        // Align ptr to 4096 boundary for O_DIRECT
-        void* raw_ptr = alloc_result->ptr();
-        void* aligned_ptr = reinterpret_cast<void*>(
-            (reinterpret_cast<uintptr_t>(raw_ptr) + kDirectIOAlignment - 1) &
-            ~(kDirectIOAlignment - 1));
+        void* data_ptr = alloc_result->ptr();
+        if (config_.use_uring) {
+            data_ptr =
+                reinterpret_cast<void*>((reinterpret_cast<uintptr_t>(data_ptr) +
+                                         kDirectIOAlignment - 1) &
+                                        ~(kDirectIOAlignment - 1));
+        }
 
         total_size += data_size;
-        // Slice records data_size; the buffer behind aligned_ptr is oversized
-        // to accommodate aligned reads
-        result->slices.emplace(keys[i], Slice{aligned_ptr, data_size});
+        result->slices.emplace(keys[i], Slice{data_ptr, data_size});
         // pointers will be adjusted after BatchLoad (offset_in_buffer
         // correction)
-        result->pointers.emplace_back(reinterpret_cast<uintptr_t>(aligned_ptr));
+        result->pointers.emplace_back(reinterpret_cast<uintptr_t>(data_ptr));
         result->handles.emplace_back(std::move(alloc_result.value()));
         result->lease_timeout = lease_timeout;
     }

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -285,21 +285,26 @@ TEST_F(FileStorageTest, BatchGetUsesPinnedArenaAndFallsBackWhenFull) {
     auto file_storage_config = FileStorageConfig::FromEnvironment();
     file_storage_config.storage_filepath = data_path;
     file_storage_config.local_buffer_size = 128 * 1024 * 1024;
-    constexpr size_t kArenaSize = 2 * 1024 * 1024;
-    std::vector<char> restore_arena(kArenaSize + 4096);
     FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
+
+    size_t payload_size = 0;
+    for (const auto size : sizes) {
+        payload_size += static_cast<size_t>(size);
+    }
+    const size_t arena_size = payload_size * 3 / 2;
+    std::vector<char> restore_arena(arena_size + 4096);
     const auto arena_begin =
         (reinterpret_cast<uintptr_t>(restore_arena.data()) + 4095) & ~4095ULL;
     SetPinnedRestoreArena(fileStorage, reinterpret_cast<void*>(arena_begin),
-                          kArenaSize);
-    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
+                          arena_size);
 
     auto pinned_result = fileStorage.BatchGetLocal(keys, sizes);
     ASSERT_TRUE(pinned_result);
     ASSERT_EQ(pinned_result->pointers.size(), keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         EXPECT_GE(pinned_result->pointers[i], arena_begin);
-        EXPECT_LT(pinned_result->pointers[i], arena_begin + kArenaSize);
+        EXPECT_LT(pinned_result->pointers[i], arena_begin + arena_size);
         EXPECT_EQ(
             std::string(reinterpret_cast<char*>(pinned_result->pointers[i]),
                         sizes[i]),
@@ -311,11 +316,36 @@ TEST_F(FileStorageTest, BatchGetUsesPinnedArenaAndFallsBackWhenFull) {
     ASSERT_EQ(fallback_result->pointers.size(), keys.size());
     for (size_t i = 0; i < keys.size(); ++i) {
         EXPECT_TRUE(fallback_result->pointers[i] < arena_begin ||
-                    fallback_result->pointers[i] >= arena_begin + kArenaSize);
+                    fallback_result->pointers[i] >= arena_begin + arena_size);
         EXPECT_EQ(
             std::string(reinterpret_cast<char*>(fallback_result->pointers[i]),
                         sizes[i]),
             batch_data.at(keys[i]));
+    }
+}
+
+TEST_F(FileStorageTest, AllocateBatchAvoidsDirectIoPaddingForPosixReads) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+    file_storage_config.local_buffer_size = 64 * 1024;
+    file_storage_config.use_uring = false;
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+
+    std::vector<std::string> keys;
+    std::vector<int64_t> sizes;
+    for (size_t i = 0; i < 16; ++i) {
+        keys.emplace_back("key" + std::to_string(i));
+        sizes.emplace_back(4 * 1024);
+    }
+
+    auto allocate_result = FileStorageAllocateBatch(fileStorage, keys, sizes);
+    ASSERT_TRUE(allocate_result)
+        << "POSIX reads should not reserve O_DIRECT padding";
+    EXPECT_EQ(allocate_result.value()->total_size,
+              file_storage_config.local_buffer_size);
+    ASSERT_EQ(allocate_result.value()->handles.size(), keys.size());
+    for (const auto& handle : allocate_result.value()->handles) {
+        EXPECT_EQ(handle.size(), 4 * 1024);
     }
 }
 


### PR DESCRIPTION
## Description

`FileStorage::AllocateBatch` currently reserves
`align_up(data_size, 4096) + 8192` bytes and aligns every destination pointer,
even when `use_uring=false` (the default). That extra space is required by the
io_uring/O_DIRECT bucket-read path, which rounds unaligned file ranges out to
full pages, but POSIX reads write exactly `slice.size` bytes.

This change:

- allocates only the object payload (or one byte for an empty object) for POSIX
  restores;
- preserves the existing alignment and tail space when `use_uring=true`;
- makes the pinned-arena fallback test size the arena relative to its payload,
  instead of relying on the old O_DIRECT padding to exhaust it; and
- adds a regression test showing that sixteen 4 KiB objects fit in a 64 KiB
  POSIX restore buffer.

No public API or configuration changes are involved.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## Resource impact

The table uses the repository's `OffsetAllocator::normalizedAllocationSize`
and a 64 MiB arena. It includes allocator size-class rounding, not just the
requested-byte formula.

| Object size | Before / object | After / object | Objects before | Objects after |
| ---: | ---: | ---: | ---: | ---: |
| 4 KiB | 12 KiB | 4 KiB | 5,461 | 16,384 |
| 128 KiB | 144 KiB | 128 KiB | 455 | 512 |
| 1 MiB | 1,152 KiB | 1,024 KiB | 56 | 64 |

The 1 MiB case gains 14.3% effective restore-buffer capacity because the extra
8 KiB pushed the old request into the next allocator size class. The 4 KiB
case gains approximately 3x capacity.

## How Has This Been Tested?

Base commit: `3b5a594133958449a1feaf1c9e0fc1b553e34a28`

The new regression test was first run against the base implementation and
failed with `allocate_result == false` (`BUFFER_OVERFLOW`). It passes after the
change.

**POSIX build and full related suite:**

```bash
cmake --build build-posix --target file_storage_test -j8
LD_LIBRARY_PATH="$PWD/.local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
  build-posix/mooncake-store/tests/file_storage_test --gtest_color=no
```

Result: 28/28 tests passed.

**io_uring/O_DIRECT compatibility build:**

Built with liburing 2.15 (`io_uring: Enabled for mooncake_store`), then ran:

```bash
cmake --build build-uring --target file_storage_test -j8
MOONCAKE_OFFLOAD_USE_URING=true \
LD_LIBRARY_PATH="$PWD/.local/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
  build-uring/mooncake-store/tests/file_storage_test \
  --gtest_filter=FileStorageTest.BatchLoadRecordsSsdMetrics:FileStorageTest.AllocateBatchAvoidsDirectIoPaddingForPosixReads \
  --gtest_color=no
```

Result: 2/2 tests passed. The run logged `O_DIRECT mode enabled` for the bucket
files and restored 100 non-page-aligned objects totaling 21,000 bytes.

**Formatting:**

```bash
PATH="$PWD/.format-venv/bin:$PATH" \
  ./scripts/code_format.sh --staged --check
```

Result: clang-format 20.1.8 reported no changes.

The host could not register the 1.25 GiB client buffer as an io_uring fixed
buffer (`EFAULT`) and used the implementation's documented regular-io_uring
fallback. O_DIRECT itself was active and the data-integrity checks passed. No
GPU or RDMA hardware was required for these storage-path tests.

- [x] Unit tests pass
- [x] Integration testing performed for POSIX and O_DIRECT bucket reads
- [x] Manual resource-capacity measurement performed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run the complete pre-commit hook set
- [x] Documentation is not applicable (no user-facing API or configuration change)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 53 insertions)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

AI assistance was used for code-path inspection and initial test drafting. The
diff was reviewed, formatted, and validated with the commands above.