### PR TITLE
[TransferEngine] Link gcov runtime for Rust coverage builds

### DIFF
--- a/mooncake-transfer-engine/rust/build.rs
+++ b/mooncake-transfer-engine/rust/build.rs
@@ -55,6 +55,14 @@ fn has_library(search_dirs: &[PathBuf], name: &str) -> bool {
             })
 }
 
+fn has_static_library(search_dirs: &[PathBuf], name: &str) -> bool {
+    let file_name = format!("lib{name}.a");
+    search_dirs.iter().any(|dir| dir.join(&file_name).exists())
+        || ["/usr/lib/x86_64-linux-gnu", "/usr/lib64", "/usr/local/lib"]
+            .into_iter()
+            .any(|dir| Path::new(dir).join(&file_name).exists())
+}
+
 fn is_tent_archive(lib: &str) -> bool {
     lib == "tent"
         || lib.starts_with("tent_")
@@ -343,13 +351,16 @@ fn main() {
     }
 
     // Coverage-instrumented C++ archives reference __gcov_* symbols. Cargo
-    // links the Rust test binary directly, so add the compiler's gcov runtime
-    // when it is available.
-    if emit_compiler_runtime_search("libgcov.a")
-        || emit_compiler_runtime_search("libgcov.so")
-        || has_library(&search_dirs, "gcov")
-    {
-        println!("cargo:rustc-link-lib=gcov");
+    // links the Rust test binary directly, so add GCC's static gcov runtime
+    // when it is available. Keep this last: libgcov.a must follow the
+    // instrumented archives on the link line. Non-coverage builds have no
+    // __gcov_* references, so the static archive contributes no objects.
+    if emit_compiler_runtime_search("libgcov.a") || has_static_library(&search_dirs, "gcov") {
+        if link_tent {
+            println!("cargo:rustc-link-arg=-lgcov");
+        } else {
+            println!("cargo:rustc-link-lib=gcov");
+        }
     }
 
     let include_dir = env::var("MOONCAKE_TE_INCLUDE_DIR").unwrap_or_else(|_| {

--- a/mooncake-transfer-engine/rust/build.rs
+++ b/mooncake-transfer-engine/rust/build.rs
@@ -125,6 +125,18 @@ fn compiler_print_file_name(file_name: &str) -> Option<PathBuf> {
     None
 }
 
+fn emit_compiler_runtime_search(file_name: &str) -> bool {
+    let Some(path) = compiler_print_file_name(file_name) else {
+        return false;
+    };
+    let Some(parent) = path.parent() else {
+        return false;
+    };
+
+    println!("cargo:rustc-link-search=native={}", parent.display());
+    true
+}
+
 fn main() {
     println!("cargo:rerun-if-env-changed=MOONCAKE_BUILD_DIR");
     println!("cargo:rerun-if-env-changed=MOONCAKE_TE_LIB_DIR");
@@ -328,6 +340,16 @@ fn main() {
         if has_library(&search_dirs, name) {
             println!("cargo:rustc-link-lib={name}");
         }
+    }
+
+    // Coverage-instrumented C++ archives reference __gcov_* symbols. Cargo
+    // links the Rust test binary directly, so add the compiler's gcov runtime
+    // when it is available.
+    if emit_compiler_runtime_search("libgcov.a")
+        || emit_compiler_runtime_search("libgcov.so")
+        || has_library(&search_dirs, "gcov")
+    {
+        println!("cargo:rustc-link-lib=gcov");
     }
 
     let include_dir = env::var("MOONCAKE_TE_INCLUDE_DIR").unwrap_or_else(|_| {


### PR DESCRIPTION
## Description

Fix Transfer Engine Rust smoke test linking when the underlying C++ libraries are built with coverage instrumentation.

Coverage builds compile C/C++ objects with `--coverage`, which introduces references to gcov runtime symbols such as `__gcov_init`, `__gcov_exit`, and `__gcov_merge_add`. When Cargo links the `transfer_engine_rust` test binary directly against those archives, the gcov runtime was not included, causing `minimal_smoke` to fail at link time.

This change teaches `mooncake-transfer-engine/rust/build.rs` to locate the compiler-provided `libgcov` runtime and link it when available.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] CI/CD

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
rustfmt mooncake-transfer-engine/rust/build.rs

cd mooncake-transfer-engine/rust
cargo test --test minimal_smoke --verbose -- --nocapture
```

**Test results:**
- [x] Manual testing done (describe below)

Manual verification confirmed that the Rust build script now emits:

```text
cargo:rustc-link-search=native=/usr/lib/gcc/x86_64-linux-gnu/11
cargo:rustc-link-lib=gcov
```

Full local test execution is still blocked on the local environment missing `libclang.so`, which is required by bindgen and unrelated to the gcov link failure.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Codex was used to analyze the Rust/C++ link failure, identify the missing gcov runtime, and prepare the build script change.