### PR TITLE
[TE] Add RDMA two-sided data-plane channel

### DIFF
--- a/mooncake-transfer-engine/example/CMakeLists.txt
+++ b/mooncake-transfer-engine/example/CMakeLists.txt
@@ -29,6 +29,11 @@ add_executable(transfer_engine_bench_with_notify
                ${WORKSPACE}/transfer_engine_bench_with_notify.cpp)
 target_link_libraries(transfer_engine_bench_with_notify PUBLIC transfer_engine)
 
+# Heavy-workload benchmark for the two-sided (SEND/RECV + bounce) data path.
+add_executable(rdma_twosided_bench ${WORKSPACE}/rdma_twosided_bench.cpp)
+target_link_libraries(rdma_twosided_bench PUBLIC transfer_engine gflags::gflags
+                                                 glog::glog)
+
 if(USE_EFA)
   add_executable(efa_first_submit_probe
                  ${WORKSPACE}/efa_first_submit_probe.cpp)

--- a/mooncake-transfer-engine/example/rdma_twosided_bench.cpp
+++ b/mooncake-transfer-engine/example/rdma_twosided_bench.cpp
@@ -1,0 +1,530 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Sustained-load benchmark for the two-sided RDMA data path (SEND/RECV over
+// TE-managed bounce buffers). Two TransferEngine instances run in one process
+// over the same NIC, so a single command reproduces a concurrent workload whose
+// in-flight chunk count far exceeds the bounce pool, which is what exercises
+// slot backpressure and mid-transfer resume.
+//
+// Each thread keeps --queue_depth batches in flight instead of submitting one
+// batch and waiting for it, and the run is time-bounded so throughput is
+// reported as a steady-state rate with per-interval samples rather than a
+// single burst. Every batch carries (thread, slot, iteration) stamps every 4
+// KiB that are checked on completion, so a chunk that is dropped, reordered or
+// replayed is caught while the load is running.
+//
+// With the defaults (16 threads x 4 depth x 4 requests x 1 MiB, 64 KiB slots)
+// about 4096 chunks are in flight against a pool of 64..256 slots.
+//
+// Note the two engines talk over one local NIC, so the reported bandwidth is a
+// NIC loopback figure and is not a cross-node line-rate measurement.
+//
+// Usage:
+//   ./rdma_twosided_bench [--threads=16] [--queue_depth=4] [--batch_size=4]
+//                         [--block_size=1048576] [--duration_s=30]
+//                         [--warmup_s=3] [--report_interval_s=5] [--iters=0]
+//                         [--opcode=write|read] [--verify] [--device=mlx5_0]
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <infiniband/verbs.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "config.h"
+#include "transfer_engine.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+DEFINE_uint32(threads, 16, "Concurrent submitting threads");
+DEFINE_uint32(queue_depth, 4, "Batches kept in flight per thread");
+DEFINE_uint32(batch_size, 1, "Requests per batch");
+// The defaults keep threads*queue_depth*batch_size chunks in flight, which is
+// the peer's bounce pool size (MC_RDMA_MSG_POOL_BASE). Past that the transfers
+// queue for bounce slots and throughput drops by an order of magnitude, so
+// raise the pool along with the load when driving more.
+DEFINE_uint64(block_size, 64 * 1024, "Bytes per request");
+DEFINE_uint32(duration_s, 30, "Steady-state duration, after warmup");
+DEFINE_uint32(warmup_s, 3, "Warmup seconds excluded from the statistics");
+DEFINE_uint32(report_interval_s, 5, "Progress report period, 0 disables");
+DEFINE_uint32(iters, 0, "Batches per thread instead of a timed run");
+DEFINE_string(opcode, "write", "write | read");
+DEFINE_bool(verify, true, "Check payload stamps on every batch");
+DEFINE_string(device, "", "RDMA device name (default: first usable)");
+DEFINE_uint32(timeout_ms, 60000, "Per-batch completion timeout");
+DEFINE_uint32(drain_timeout_ms, 5000,
+              "Completion budget for batches still in flight when the "
+              "measured window ends");
+
+using namespace mooncake;
+using Clock = std::chrono::steady_clock;
+
+namespace {
+
+bool deviceUsable(ibv_device *device) {
+    ibv_context *ctx = ibv_open_device(device);
+    if (!ctx) return false;
+    ibv_device_attr attr{};
+    if (ibv_query_device(ctx, &attr) != 0) {
+        ibv_close_device(ctx);
+        return false;
+    }
+    bool ok = false;
+    for (uint8_t port = 1; port <= attr.phys_port_cnt; ++port) {
+        ibv_port_attr port_attr{};
+        if (ibv_query_port(ctx, port, &port_attr) != 0) continue;
+        if (port_attr.gid_tbl_len > 0 && port_attr.state == IBV_PORT_ACTIVE) {
+            ok = true;
+            break;
+        }
+    }
+    ibv_close_device(ctx);
+    return ok;
+}
+
+std::string pickDevice() {
+    if (!FLAGS_device.empty()) return FLAGS_device;
+    int num_devices = 0;
+    ibv_device **list = ibv_get_device_list(&num_devices);
+    if (!list || num_devices == 0) {
+        if (list) ibv_free_device_list(list);
+        return "";
+    }
+    std::string name;
+    for (int i = 0; i < num_devices; ++i) {
+        if (deviceUsable(list[i])) {
+            name = ibv_get_device_name(list[i]);
+            break;
+        }
+    }
+    ibv_free_device_list(list);
+    return name;
+}
+
+// Written every kStampStride bytes of a request so a completed batch can be
+// attributed to the exact submission that produced it. The bytes between two
+// stamps stay at kFiller, which lets a completion be checked end to end without
+// keeping a shadow copy of the payload.
+struct Stamp {
+    uint32_t tid;
+    uint32_t slot;
+    uint64_t iter;
+    uint64_t off;
+};
+constexpr size_t kStampStride = 4096;
+constexpr char kFiller = 0x5a;
+
+void stampRegion(char *base, size_t len, uint32_t tid, uint32_t slot,
+                 uint64_t iter) {
+    for (size_t off = 0; off + sizeof(Stamp) <= len; off += kStampStride) {
+        Stamp s{tid, slot, iter, off};
+        std::memcpy(base + off, &s, sizeof(s));
+    }
+}
+
+bool checkRegion(const char *base, size_t len, uint32_t tid, uint32_t slot,
+                 uint64_t iter) {
+    static const std::vector<char> filler(kStampStride, kFiller);
+    for (size_t off = 0; off < len; off += kStampStride) {
+        const size_t span = std::min(kStampStride, len - off);
+        size_t body = 0;
+        if (span >= sizeof(Stamp)) {
+            Stamp s{};
+            std::memcpy(&s, base + off, sizeof(s));
+            if (s.tid != tid || s.slot != slot || s.iter != iter ||
+                s.off != off)
+                return false;
+            body = sizeof(Stamp);
+        }
+        if (std::memcmp(base + off + body, filler.data(), span - body) != 0)
+            return false;
+    }
+    return true;
+}
+
+struct ThreadStats {
+    std::vector<double> lat_us;
+    uint64_t batches = 0;
+    uint64_t failures = 0;
+    uint64_t mismatches = 0;
+    uint64_t drain_failures = 0;
+    std::atomic<uint64_t> live_bytes{0};
+    std::atomic<uint64_t> live_batches{0};
+    std::atomic<uint64_t> live_failures{0};
+};
+
+double percentile(const std::vector<double> &sorted, double p) {
+    if (sorted.empty()) return 0.0;
+    size_t idx = static_cast<size_t>(p * (sorted.size() - 1));
+    return sorted[idx];
+}
+
+size_t rssBytes() {
+    FILE *f = std::fopen("/proc/self/statm", "r");
+    if (!f) return 0;
+    long total = 0, resident = 0;
+    if (std::fscanf(f, "%ld %ld", &total, &resident) != 2) resident = 0;
+    std::fclose(f);
+    return static_cast<size_t>(resident) *
+           static_cast<size_t>(sysconf(_SC_PAGESIZE));
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = 1;
+
+    const bool is_read = FLAGS_opcode == "read";
+    if (!is_read && FLAGS_opcode != "write") {
+        LOG(ERROR) << "--opcode must be write or read";
+        return 1;
+    }
+    if (!FLAGS_threads || !FLAGS_queue_depth || !FLAGS_batch_size ||
+        FLAGS_block_size < sizeof(Stamp)) {
+        LOG(ERROR) << "threads/queue_depth/batch_size must be non-zero and "
+                      "block_size must hold a stamp";
+        return 1;
+    }
+    const bool timed = FLAGS_iters == 0;
+    if (timed && !FLAGS_duration_s) {
+        LOG(ERROR) << "--duration_s must be non-zero unless --iters is set";
+        return 1;
+    }
+
+    std::string device = pickDevice();
+    if (device.empty()) {
+        LOG(ERROR) << "no usable RDMA device";
+        return 1;
+    }
+    setenv("MC_TE_FILTERS", device.c_str(), 1);
+    setenv("MC_USE_RDMA_TWOSIDED", "1", 1);
+    setenv("MC_RDMA_MSG_ENABLED", "1", 1);
+    loadGlobalConfig(globalConfig());
+
+    std::vector<std::string> filter{device};
+    auto sender = std::make_unique<TransferEngine>(true, filter);
+    auto receiver = std::make_unique<TransferEngine>(true, filter);
+    if (sender->init("P2PHANDSHAKE", "127.0.0.1:0") ||
+        receiver->init("P2PHANDSHAKE", "127.0.0.1:0")) {
+        LOG(ERROR) << "TransferEngine init failed";
+        return 1;
+    }
+
+    auto *sender_ts = dynamic_cast<RdmaTwoSidedTransport *>(
+        sender->getTransport("rdma_twosided"));
+    auto *receiver_ts = dynamic_cast<RdmaTwoSidedTransport *>(
+        receiver->getTransport("rdma_twosided"));
+    if (!sender_ts || !receiver_ts) {
+        LOG(ERROR) << "rdma_twosided transport not installed";
+        return 1;
+    }
+
+    // One contiguous managed buffer per side, sliced per (thread, queue slot)
+    // so in-flight batches never share a destination range.
+    const size_t slice = FLAGS_block_size * FLAGS_batch_size;
+    const size_t slices = static_cast<size_t>(FLAGS_threads) *
+                          static_cast<size_t>(FLAGS_queue_depth);
+    const size_t total = slice * slices;
+    char *local = static_cast<char *>(sender_ts->allocateManagedBuffer(total));
+    char *remote =
+        static_cast<char *>(receiver_ts->allocateManagedBuffer(total));
+    if (!local || !remote) {
+        LOG(ERROR) << "managed buffer allocation failed, total=" << total;
+        return 1;
+    }
+    char *src_side = is_read ? remote : local;
+    char *dst_side = is_read ? local : remote;
+    std::memset(src_side, kFiller, total);
+    std::memset(dst_side, 0, total);
+
+    auto segment = sender->openSegment(receiver->getLocalIpAndPort());
+    if (!segment) {
+        LOG(ERROR) << "openSegment failed";
+        return 1;
+    }
+
+    std::vector<std::unique_ptr<ThreadStats>> stats;
+    for (uint32_t i = 0; i < FLAGS_threads; ++i)
+        stats.emplace_back(std::make_unique<ThreadStats>());
+    std::atomic<bool> running{true};
+    std::atomic<bool> measuring{!timed || FLAGS_warmup_s == 0};
+
+    auto worker = [&](uint32_t tid) {
+        auto &st = *stats[tid];
+        st.lat_us.reserve(1 << 16);
+        struct Slot {
+            BatchID batch = 0;
+            bool active = false;
+            uint64_t iter = 0;
+            Clock::time_point start;
+            Clock::time_point deadline;
+        };
+        std::vector<Slot> slots(FLAGS_queue_depth);
+        uint64_t next_iter = 0;
+        uint64_t done = 0;
+        Clock::time_point drain_start{};
+        const auto drain_budget =
+            std::chrono::milliseconds(FLAGS_drain_timeout_ms);
+
+        auto submit = [&](uint32_t s) -> bool {
+            const size_t base =
+                slice * (static_cast<size_t>(tid) * FLAGS_queue_depth + s);
+            auto &slot = slots[s];
+            slot.iter = next_iter++;
+            for (uint32_t i = 0; i < FLAGS_batch_size; ++i)
+                stampRegion(src_side + base + FLAGS_block_size * i,
+                            FLAGS_block_size, tid, s, slot.iter);
+            std::vector<TransferRequest> requests(FLAGS_batch_size);
+            for (uint32_t i = 0; i < FLAGS_batch_size; ++i) {
+                const size_t off = base + FLAGS_block_size * i;
+                requests[i].opcode =
+                    is_read ? TransferRequest::READ : TransferRequest::WRITE;
+                requests[i].source = local + off;
+                requests[i].target_id = segment;
+                requests[i].target_offset =
+                    reinterpret_cast<uint64_t>(remote + off);
+                requests[i].length = FLAGS_block_size;
+            }
+            slot.batch = sender->allocateBatchID(FLAGS_batch_size);
+            slot.start = Clock::now();
+            slot.deadline =
+                slot.start + std::chrono::milliseconds(FLAGS_timeout_ms);
+            if (!sender->submitTransfer(slot.batch, requests).ok()) {
+                sender->freeBatchID(slot.batch);
+                slot.active = false;
+                return false;
+            }
+            slot.active = true;
+            return true;
+        };
+
+        auto retire = [&](uint32_t s, bool ok) {
+            auto &slot = slots[s];
+            const size_t base =
+                slice * (static_cast<size_t>(tid) * FLAGS_queue_depth + s);
+            double us = std::chrono::duration<double, std::micro>(Clock::now() -
+                                                                  slot.start)
+                            .count();
+            sender->freeBatchID(slot.batch);
+            slot.active = false;
+            const bool record = measuring.load(std::memory_order_relaxed);
+            if (!ok) {
+                if (record)
+                    ++st.failures;
+                else if (!running.load(std::memory_order_relaxed))
+                    ++st.drain_failures;
+                st.live_failures.fetch_add(1, std::memory_order_relaxed);
+                return;
+            }
+            if (FLAGS_verify) {
+                for (uint32_t i = 0; i < FLAGS_batch_size; ++i) {
+                    if (!checkRegion(dst_side + base + FLAGS_block_size * i,
+                                     FLAGS_block_size, tid, s, slot.iter)) {
+                        if (record) ++st.mismatches;
+                        break;
+                    }
+                }
+            }
+            if (record) {
+                st.lat_us.push_back(us);
+                ++st.batches;
+            }
+            st.live_bytes.fetch_add(slice, std::memory_order_relaxed);
+            st.live_batches.fetch_add(1, std::memory_order_relaxed);
+            ++done;
+        };
+
+        auto want_more = [&]() {
+            if (!running.load(std::memory_order_relaxed)) return false;
+            return timed || next_iter < FLAGS_iters;
+        };
+
+        for (uint32_t s = 0; s < FLAGS_queue_depth && want_more(); ++s) {
+            if (!submit(s)) {
+                st.live_failures.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+
+        while (true) {
+            const bool live = running.load(std::memory_order_relaxed);
+            if (!live && drain_start.time_since_epoch().count() == 0)
+                drain_start = Clock::now();
+            bool progressed = false;
+            bool any_active = false;
+            for (uint32_t s = 0; s < FLAGS_queue_depth; ++s) {
+                auto &slot = slots[s];
+                if (!slot.active) {
+                    if (want_more() && submit(s)) progressed = true;
+                    if (slot.active) any_active = true;
+                    continue;
+                }
+                any_active = true;
+                TransferStatus status;
+                if (!sender->getBatchTransferStatus(slot.batch, status).ok()) {
+                    retire(s, false);
+                    progressed = true;
+                    continue;
+                }
+                auto now = Clock::now();
+                if (status.s == TransferStatusEnum::COMPLETED) {
+                    retire(s, true);
+                    progressed = true;
+                } else if (status.s == TransferStatusEnum::FAILED ||
+                           now > slot.deadline ||
+                           (!live && now > drain_start + drain_budget)) {
+                    retire(s, false);
+                    progressed = true;
+                }
+            }
+            if (!any_active && !want_more()) break;
+            if (!progressed) std::this_thread::yield();
+        }
+        (void)done;
+    };
+
+    std::vector<std::thread> workers;
+    auto wall_start = Clock::now();
+    for (uint32_t tid = 0; tid < FLAGS_threads; ++tid)
+        workers.emplace_back(worker, tid);
+
+    auto snapshot = [&](uint64_t &bytes, uint64_t &batches, uint64_t &fails) {
+        bytes = batches = fails = 0;
+        for (auto &st : stats) {
+            bytes += st->live_bytes.load(std::memory_order_relaxed);
+            batches += st->live_batches.load(std::memory_order_relaxed);
+            fails += st->live_failures.load(std::memory_order_relaxed);
+        }
+    };
+
+    size_t rss_peak = rssBytes();
+    uint64_t last_bytes = 0, last_batches = 0, last_fails = 0;
+    uint64_t last_resumes = sender_ts->twoSidedResumeCount();
+    auto tick = Clock::now();
+    if (timed && FLAGS_warmup_s) {
+        std::this_thread::sleep_for(std::chrono::seconds(FLAGS_warmup_s));
+        snapshot(last_bytes, last_batches, last_fails);
+        last_resumes = sender_ts->twoSidedResumeCount();
+        tick = Clock::now();
+        measuring.store(true, std::memory_order_relaxed);
+        LOG(INFO) << "warmup done after " << FLAGS_warmup_s
+                  << "s, measuring for " << FLAGS_duration_s << "s";
+    }
+
+    auto measure_start = Clock::now();
+    auto measure_end = measure_start + std::chrono::seconds(FLAGS_duration_s);
+    while (timed && Clock::now() < measure_end) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        rss_peak = std::max(rss_peak, rssBytes());
+        if (!FLAGS_report_interval_s) continue;
+        auto now = Clock::now();
+        double dt = std::chrono::duration<double>(now - tick).count();
+        if (dt < FLAGS_report_interval_s) continue;
+        uint64_t bytes = 0, batches = 0, fails = 0;
+        snapshot(bytes, batches, fails);
+        uint64_t resumes = sender_ts->twoSidedResumeCount();
+        LOG(INFO) << "interval t=+"
+                  << std::chrono::duration<double>(now - measure_start).count()
+                  << "s GB/s=" << (bytes - last_bytes) / 1e9 / dt
+                  << " batch_IOPS=" << (batches - last_batches) / dt
+                  << " failures=" << (fails - last_fails)
+                  << " resumes=" << (resumes - last_resumes)
+                  << " rss_MB=" << rssBytes() / (1024 * 1024);
+        last_bytes = bytes;
+        last_batches = batches;
+        last_fails = fails;
+        last_resumes = resumes;
+        tick = now;
+    }
+    // The measured window closes before the in-flight batches are drained, so
+    // the drain does not dilute the reported rate.
+    Clock::time_point measure_stop;
+    if (timed) {
+        measure_stop = Clock::now();
+        measuring.store(false, std::memory_order_relaxed);
+        running.store(false, std::memory_order_relaxed);
+    }
+    for (auto &t : workers) t.join();
+    if (!timed) measure_stop = Clock::now();
+    double measured_s =
+        std::chrono::duration<double>(measure_stop - measure_start).count();
+    double wall_s =
+        std::chrono::duration<double>(Clock::now() - wall_start).count();
+    rss_peak = std::max(rss_peak, rssBytes());
+
+    std::vector<double> all_us;
+    uint64_t batches = 0, failures = 0, mismatches = 0, drain_failures = 0;
+    for (auto &st : stats) {
+        all_us.insert(all_us.end(), st->lat_us.begin(), st->lat_us.end());
+        batches += st->batches;
+        failures += st->failures;
+        mismatches += st->mismatches;
+        drain_failures += st->drain_failures;
+    }
+    std::sort(all_us.begin(), all_us.end());
+    const uint64_t measured_bytes = batches * slice;
+
+    const size_t chunk_payload =
+        globalConfig().rdma_msg_slot_size - kMsgHeaderSize;
+    const uint64_t chunks_per_request =
+        (FLAGS_block_size + chunk_payload - 1) / chunk_payload;
+    LOG(INFO) << "two-sided " << FLAGS_opcode << " device=" << device
+              << " threads=" << FLAGS_threads
+              << " queue_depth=" << FLAGS_queue_depth
+              << " batch_size=" << FLAGS_batch_size
+              << " block_size=" << FLAGS_block_size << " inflight_requests="
+              << FLAGS_threads * FLAGS_queue_depth * FLAGS_batch_size
+              << " inflight_chunks="
+              << FLAGS_threads * FLAGS_queue_depth * FLAGS_batch_size *
+                     chunks_per_request
+              << " pool_base=" << globalConfig().rdma_msg_pool_base
+              << " pool_max=" << globalConfig().rdma_msg_pool_max
+              << " buffer_MB_per_side=" << total / (1024 * 1024);
+    LOG(INFO) << "steady state batches=" << batches << " failures=" << failures
+              << " stamp_mismatches=" << mismatches
+              << " GB=" << measured_bytes / 1e9 << " seconds=" << measured_s
+              << " GB/s="
+              << (measured_s > 0 ? measured_bytes / 1e9 / measured_s : 0.0)
+              << " batch_IOPS=" << (measured_s > 0 ? batches / measured_s : 0.0)
+              << " wall_s=" << wall_s;
+    LOG(INFO) << "batch latency us p50=" << percentile(all_us, 0.50)
+              << " p99=" << percentile(all_us, 0.99)
+              << " p999=" << percentile(all_us, 0.999)
+              << " max=" << (all_us.empty() ? 0.0 : all_us.back());
+    LOG(INFO) << "mid-transfer resumes after bounce-slot backpressure="
+              << sender_ts->twoSidedResumeCount()
+              << " rss_peak_MB=" << rss_peak / (1024 * 1024)
+              << " drain_failures=" << drain_failures;
+    LOG(INFO) << "note: both engines share one local NIC, so this is a "
+                 "loopback rate, not a cross-node line rate";
+
+    if (FLAGS_verify && !mismatches)
+        LOG(INFO) << "payload stamps verified on every completed batch, "
+                  << measured_bytes / 1e9 << " GB";
+
+    sender_ts->releaseManagedBuffer(local);
+    receiver_ts->releaseManagedBuffer(remote);
+    return (failures || mismatches) ? 1 : 0;
+}

--- a/mooncake-transfer-engine/include/config.h
+++ b/mooncake-transfer-engine/include/config.h
@@ -148,6 +148,38 @@ struct GlobalConfig {
     // handshake that may never complete.
     // MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS.
     uint32_t rdma_notify_connect_timeout_ms = 10000;
+    // Credit admission + SESSION/GRANT on CtrlChannel. MC_RDMA_CREDIT_ENABLED.
+    bool rdma_credit_enabled = true;
+    // One-sided sliding window (bytes / request slots). 0 disables that
+    // resource. MC_RDMA_CREDIT_WINDOW_BYTES / _REQUESTS.
+    uint64_t rdma_credit_window_bytes = 256ull << 20;  // 256 MiB
+    uint64_t rdma_credit_window_requests = 4096;
+    // Pending WAITING timeout; 0 = never. MC_RDMA_CREDIT_QUEUE_TIMEOUT_MS.
+    uint64_t rdma_credit_queue_timeout_ms = 0;
+    // Two-sided msg QP / bounce capability. MC_RDMA_MSG_ENABLED.
+    bool rdma_msg_enabled = true;
+    // Prefer managed two-sided when peer supports it. MC_RDMA_MSG_DEFAULT.
+    bool rdma_msg_default = true;
+    // Bounce slot size including msg header. MC_RDMA_MSG_SLOT_SIZE.
+    size_t rdma_msg_slot_size = (64 * 1024) + 64;
+    // Base / max posted bounce slots. MC_RDMA_MSG_POOL_BASE / _MAX.
+    // Defaults from eRDMA workload: base covers common concurrency with credit
+    // return; max caps QP WR depth for async expand.
+    size_t rdma_msg_pool_base = 64;
+    size_t rdma_msg_pool_max = 256;
+    // Bounce auto expand/shrink. Tuned on eRDMA two-sided WRITE smoke:
+    // step 16 balances reg_mr cost vs WAITING drain; watermarks avoid flapping.
+    size_t rdma_msg_expand_step = 16;
+    // Free-send ratio below this triggers expand (0-100).
+    size_t rdma_msg_expand_low_watermark_pct = 25;
+    // Free-send ratio above this (sustained) triggers shrink (0-100).
+    size_t rdma_msg_shrink_high_watermark_pct = 75;
+    // WAITING queue length that hints expand / CREDIT_REQUEST.
+    size_t rdma_msg_pending_expand_threshold = 4;
+    // Idle time at high watermark before shrink.
+    uint64_t rdma_msg_shrink_idle_ms = 2000;
+    // Bounce manager tick period.
+    uint64_t rdma_msg_bounce_manager_tick_ms = 50;
     // ib_pci_relaxed_ordering_mode: 0: off, 1: on if supported, 2: auto
     int ib_pci_relaxed_ordering_mode = 1;
     bool ascend_use_fabric_mem = false;

--- a/mooncake-transfer-engine/include/transfer_metadata.h
+++ b/mooncake-transfer-engine/include/transfer_metadata.h
@@ -138,6 +138,11 @@ class TransferMetadata {
         // of `name`.
         std::string rdma_server_name;
 
+        // Peer advertises the TE two-sided msg path (Ctrl/Msg + bounce).
+        // Managed buffers are TE-local only and are NOT published as registered
+        // BufferDesc entries; senders select two-sided via this capability bit.
+        bool supports_two_sided_msg = false;
+
         // Returns the server name to use for NIC path construction.
         // Uses rdma_server_name when available, otherwise falls back
         // to name.
@@ -184,6 +189,11 @@ class TransferMetadata {
         uint32_t notify_qp_num = 0;
         uint16_t notify_rq_depth = 0;
         bool ctrl_channel = false;
+        // Per-peer MsgChannel (two-sided data QP). When msg_channel is true,
+        // this handshake only sets up the msg path (qp_num may be empty).
+        uint32_t msg_qp_num = 0;
+        uint16_t msg_rq_depth = 0;
+        bool msg_channel = false;
         std::string reply_msg;  // on error
 #ifdef USE_EFA
         std::string efa_addr;  // EFA endpoint address (hex encoded)

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -47,6 +47,7 @@ class RdmaTransport;
 class RdmaContextTestPeer;
 class WorkerPool;
 class EndpointStore;
+class MsgChannel;
 
 // Enum to represent the network state of the GID found
 enum class GidNetworkState {
@@ -283,6 +284,12 @@ class RdmaContext {
 
     int socketId();
 
+    // Two-sided MsgChannel CQ registration (polled by WorkerPool).
+    void registerMsgChannel(MsgChannel *channel);
+    void unregisterMsgChannel(MsgChannel *channel);
+    int pollMsgChannels(int max_per_channel = 16);
+    bool hasMsgChannels() const;
+
    private:
     int openRdmaDevice(const std::string &device_name, uint8_t port,
                        int gid_index);
@@ -347,6 +354,9 @@ class RdmaContext {
     std::shared_ptr<WorkerPool> worker_pool_;
 
     std::atomic<bool> active_;
+
+    mutable std::mutex msg_channels_mutex_;
+    std::vector<MsgChannel *> msg_channels_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_context.h
@@ -284,8 +284,9 @@ class RdmaContext {
 
     int socketId();
 
-    // Two-sided MsgChannel CQ registration (polled by WorkerPool).
-    void registerMsgChannel(MsgChannel *channel);
+    // Two-sided MsgChannel CQ registration (polled by WorkerPool). Held
+    // weakly: a rail may be replaced while the poller holds a reference.
+    void registerMsgChannel(std::shared_ptr<MsgChannel> channel);
     void unregisterMsgChannel(MsgChannel *channel);
     int pollMsgChannels(int max_per_channel = 16);
     bool hasMsgChannels() const;
@@ -356,7 +357,7 @@ class RdmaContext {
     std::atomic<bool> active_;
 
     mutable std::mutex msg_channels_mutex_;
-    std::vector<MsgChannel *> msg_channels_;
+    std::vector<std::weak_ptr<MsgChannel>> msg_channels_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/rdma_transport.h
@@ -141,6 +141,17 @@ class RdmaTransport : public Transport {
         return context_list_;
     }
 
+   protected:
+    // Local NIC topology, for subclasses that map peer NICs onto local rails
+    // (e.g. the two-sided MsgChannel path).
+    const std::shared_ptr<Topology> &localTopology() const {
+        return local_topology_;
+    }
+
+    // Advertised in the local SegmentDesc so senders can pick the two-sided
+    // path. Classic one-sided RDMA has no msg path, hence false.
+    virtual bool supportsTwoSidedMsg() const { return false; }
+
    private:
     std::vector<std::shared_ptr<RdmaContext>> context_list_;
     std::shared_ptr<Topology> local_topology_;

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/bounce_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/bounce_pool.h
@@ -1,0 +1,88 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_BOUNCE_POOL_H_
+#define RDMA_BOUNCE_POOL_H_
+
+#include <infiniband/verbs.h>
+
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+namespace mooncake {
+
+// TE-managed bounce slot pool used by MsgChannel SEND/RECV.
+// Each slot is slot_size bytes (header + payload capacity).
+class BouncePool {
+   public:
+    BouncePool() = default;
+    ~BouncePool() { destroy(); }
+
+    BouncePool(const BouncePool &) = delete;
+    BouncePool &operator=(const BouncePool &) = delete;
+
+    int construct(ibv_pd *pd, size_t slot_size, size_t slot_count);
+    void destroy();
+
+    size_t slotSize() const { return slot_size_; }
+    // Allocated slot count (may include retiring trailing slots).
+    size_t slotCount() const;
+    // Slots currently usable for send/recv (excludes retiring).
+    size_t activeCount() const;
+    size_t freeSendCount() const;
+
+    // Acquire a free active send slot. Returns -1 if none.
+    int acquireSendSlot();
+    void releaseSendSlot(int idx);
+
+    char *slotPtr(int idx);
+    ibv_mr *slotMr(int idx);
+    uint32_t slotLkey(int idx);
+
+    char *recvSlotPtr(size_t idx);
+    ibv_mr *recvSlotMr(size_t idx);
+
+    void markRecvPosted(size_t idx, bool posted);
+    bool recvPosted(size_t idx) const;
+
+    // Expand by `extra` slots (send+recv). New slots start active.
+    // Returns 0 on success. Caller must post_recv for new indices.
+    int expand(size_t extra);
+
+    // Shrink toward `target_active` (must be >= min_active). Trailing idle
+    // slots are deregistered. Returns new active count (may be > target if
+    // trailing slots are still in use / posted).
+    size_t shrinkToward(size_t target_active, size_t min_active);
+
+   private:
+    void destroyUnlocked();
+    struct Slot {
+        std::vector<char> buf;
+        ibv_mr *mr = nullptr;
+        bool in_use = false;
+        bool recv_posted = false;
+    };
+
+    ibv_pd *pd_ = nullptr;
+    size_t slot_size_ = 0;
+    size_t active_count_ = 0;
+    std::vector<Slot> slots_;
+    std::vector<Slot> recv_slots_;
+    mutable std::mutex mutex_;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_BOUNCE_POOL_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -83,16 +84,24 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     // Send DATA_WRITE with payload copied from src. total_chunks is how many
     // chunks the whole task is split into, so the receiver can retire its ACK
     // bookkeeping once it has seen them all. Returns 0 on post success.
-    int sendDataWrite(uint64_t task_id, uint8_t slice_seq, uint64_t dest_addr,
+    int sendDataWrite(uint64_t task_id, uint32_t slice_seq, uint64_t dest_addr,
                       const void *src, uint32_t length, uint32_t total_chunks);
 
     // Send READ_REQ (header only).
-    int sendReadReq(uint64_t task_id, uint8_t slice_seq, uint64_t src_addr,
+    int sendReadReq(uint64_t task_id, uint32_t slice_seq, uint64_t src_addr,
                     uint32_t length);
 
     // Send READ_RESP with payload.
-    int sendReadResp(uint64_t task_id, uint8_t slice_seq, uint64_t dest_addr,
+    int sendReadResp(uint64_t task_id, uint32_t slice_seq, uint64_t dest_addr,
                      const void *src, uint32_t length);
+
+    // Send READ_RESP, or hold it for replay when the bounce pool is momentarily
+    // full. Never drops the response: a dropped READ_RESP would strand the
+    // requester, which waits for that exact slice forever. The payload is read
+    // from `addr` (a validated local managed buffer) at (re)send time. Returns
+    // 0 unless the channel is down.
+    int sendOrQueueReadResp(uint64_t task_id, uint32_t slice_seq, uint64_t addr,
+                            uint32_t length);
 
     int pollCompletions(int max_entries = 16);
     void disconnect();
@@ -108,6 +117,9 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     int postSend(const MsgHeader &hdr, const void *payload, uint32_t length);
     void dispatchRecv(size_t idx, size_t byte_len);
     void handleSendComplete(uint64_t wr_id);
+    // Replay READ_RESPs held back by a full bounce pool. Called whenever a send
+    // slot frees up (SEND completion) or the pool grows (expandPool).
+    void drainPendingReadResps();
 
     RdmaTwoSidedTransport &transport_;
     RdmaContext &context_;
@@ -126,6 +138,17 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     // wr_id -> send slot index for completion release
     std::mutex inflight_mutex_;
     std::vector<int> inflight_slots_;  // indexed by wr_id % capacity
+
+    // READ_RESP deferred because the bounce pool was full; replayed in order on
+    // the next slot recycle or pool expansion. Guarded by resp_mutex_.
+    struct PendingReadResp {
+        uint64_t task_id;
+        uint64_t addr;
+        uint32_t length;
+        uint32_t slice_seq;
+    };
+    std::mutex resp_mutex_;
+    std::deque<PendingReadResp> pending_resps_;
 
     std::mutex resource_mutex_;
     std::atomic<bool> connected_{false};

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -33,7 +34,8 @@ class RdmaContext;
 class RdmaTwoSidedTransport;
 
 // Per-peer RC QP for two-sided data (SEND/RECV with TE bounce buffers).
-class MsgChannel {
+// Always owned by a shared_ptr; RdmaContext holds only weak references.
+class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
    public:
     using HandShakeDesc = TransferMetadata::HandShakeDesc;
 

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
@@ -80,9 +80,11 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
 
     const std::string &peerServerName() const { return peer_server_name_; }
 
-    // Send DATA_WRITE with payload copied from src. Returns 0 on post success.
+    // Send DATA_WRITE with payload copied from src. total_chunks is how many
+    // chunks the whole task is split into, so the receiver can retire its ACK
+    // bookkeeping once it has seen them all. Returns 0 on post success.
     int sendDataWrite(uint64_t task_id, uint8_t slice_seq, uint64_t dest_addr,
-                      const void *src, uint32_t length);
+                      const void *src, uint32_t length, uint32_t total_chunks);
 
     // Send READ_REQ (header only).
     int sendReadReq(uint64_t task_id, uint8_t slice_seq, uint64_t src_addr,

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
@@ -1,0 +1,134 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_MSG_CHANNEL_H_
+#define RDMA_MSG_CHANNEL_H_
+
+#include <infiniband/verbs.h>
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "transfer_metadata.h"
+#include "transport/rdma_twosided/bounce_pool.h"
+#include "transport/rdma_twosided/msg_header.h"
+
+namespace mooncake {
+
+class RdmaContext;
+class RdmaTwoSidedTransport;
+
+// Per-peer RC QP for two-sided data (SEND/RECV with TE bounce buffers).
+class MsgChannel {
+   public:
+    using HandShakeDesc = TransferMetadata::HandShakeDesc;
+
+    MsgChannel(RdmaTwoSidedTransport &transport, RdmaContext &context,
+               std::string peer_server_name);
+    ~MsgChannel();
+
+    MsgChannel(const MsgChannel &) = delete;
+    MsgChannel &operator=(const MsgChannel &) = delete;
+
+    int construct();
+    int connectActive();
+    int acceptPassive(const HandShakeDesc &peer_desc,
+                      HandShakeDesc &local_desc);
+
+    bool connected() const {
+        return connected_.load(std::memory_order_acquire);
+    }
+
+    uint32_t msgQpNum() const { return qp_ ? qp_->qp_num : 0; }
+    // Advertised RQ capacity (QP max / pool_max), not current active slots.
+    uint16_t msgRqDepth() const { return static_cast<uint16_t>(pool_max_); }
+
+    RdmaContext &context() { return context_; }
+    const RdmaContext &context() const { return context_; }
+    std::string nicPath() const;
+
+    size_t activeSlots() const { return pool_.activeCount(); }
+    size_t freeSendSlots() const { return pool_.freeSendCount(); }
+    size_t allocatedSlots() const { return pool_.slotCount(); }
+    size_t waitingHints() const {
+        return expand_hint_.load(std::memory_order_relaxed);
+    }
+    void requestExpand() {
+        expand_hint_.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    // Background manager: grow pool then post_recv new slots. Returns 0 ok.
+    int expandPool(size_t extra);
+    // Background manager: shrink toward target (>= pool_base).
+    size_t shrinkPoolToward(size_t target_active);
+
+    const std::string &peerServerName() const { return peer_server_name_; }
+
+    // Send DATA_WRITE with payload copied from src. Returns 0 on post success.
+    int sendDataWrite(uint64_t task_id, uint8_t slice_seq, uint64_t dest_addr,
+                      const void *src, uint32_t length);
+
+    // Send READ_REQ (header only).
+    int sendReadReq(uint64_t task_id, uint8_t slice_seq, uint64_t src_addr,
+                    uint32_t length);
+
+    // Send READ_RESP with payload.
+    int sendReadResp(uint64_t task_id, uint8_t slice_seq, uint64_t dest_addr,
+                     const void *src, uint32_t length);
+
+    int pollCompletions(int max_entries = 16);
+    void disconnect();
+
+   private:
+    int createResources();
+    void destroyResources();
+    int postRecv(size_t idx);
+    int repostAllRecvs();
+    int connectQp(const std::string &peer_gid, uint16_t peer_lid,
+                  uint32_t peer_qp_num);
+    void fillLocalDesc(HandShakeDesc &local_desc) const;
+    int postSend(const MsgHeader &hdr, const void *payload, uint32_t length);
+    void dispatchRecv(size_t idx, size_t byte_len);
+    void handleSendComplete(uint64_t wr_id);
+
+    RdmaTwoSidedTransport &transport_;
+    RdmaContext &context_;
+    std::string peer_server_name_;
+
+    ibv_cq *cq_ = nullptr;
+    ibv_qp *qp_ = nullptr;
+    BouncePool pool_;
+
+    size_t pool_base_ = 0;
+    size_t pool_max_ = 0;
+    size_t max_pending_sends_ = 0;
+    std::mutex send_mutex_;
+    size_t pending_sends_ = 0;
+    uint64_t send_wr_id_ = 0;
+    // wr_id -> send slot index for completion release
+    std::mutex inflight_mutex_;
+    std::vector<int> inflight_slots_;  // indexed by wr_id % capacity
+
+    std::mutex resource_mutex_;
+    std::atomic<bool> connected_{false};
+    std::atomic<uint64_t> expand_hint_{0};
+    bool registered_with_context_ = false;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_MSG_CHANNEL_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_channel.h
@@ -19,7 +19,6 @@
 
 #include <atomic>
 #include <cstdint>
-#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -28,6 +27,7 @@
 #include "transfer_metadata.h"
 #include "transport/rdma_twosided/bounce_pool.h"
 #include "transport/rdma_twosided/msg_header.h"
+#include "transport/rdma_twosided/pending_read_resp_queue.h"
 
 namespace mooncake {
 
@@ -98,8 +98,10 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     // Send READ_RESP, or hold it for replay when the bounce pool is momentarily
     // full. Never drops the response: a dropped READ_RESP would strand the
     // requester, which waits for that exact slice forever. The payload is read
-    // from `addr` (a validated local managed buffer) at (re)send time. Returns
-    // 0 unless the channel is down.
+    // from `addr` (a validated local managed buffer) at (re)send time. Uses a
+    // single-drainer / recheck queue so a SEND completion between the failed
+    // post and enqueue cannot leave the response stranded. Returns 0 unless
+    // the channel is down.
     int sendOrQueueReadResp(uint64_t task_id, uint32_t slice_seq, uint64_t addr,
                             uint32_t length);
 
@@ -117,9 +119,8 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     int postSend(const MsgHeader &hdr, const void *payload, uint32_t length);
     void dispatchRecv(size_t idx, size_t byte_len);
     void handleSendComplete(uint64_t wr_id);
-    // Replay READ_RESPs held back by a full bounce pool. Called whenever a send
-    // slot frees up (SEND completion) or the pool grows (expandPool).
-    void drainPendingReadResps();
+    // TrySend callback shared by enqueue and slot-free drains.
+    PendingReadRespQueue::TrySendFn pendingReadRespSender();
 
     RdmaTwoSidedTransport &transport_;
     RdmaContext &context_;
@@ -139,16 +140,10 @@ class MsgChannel : public std::enable_shared_from_this<MsgChannel> {
     std::mutex inflight_mutex_;
     std::vector<int> inflight_slots_;  // indexed by wr_id % capacity
 
-    // READ_RESP deferred because the bounce pool was full; replayed in order on
-    // the next slot recycle or pool expansion. Guarded by resp_mutex_.
-    struct PendingReadResp {
-        uint64_t task_id;
-        uint64_t addr;
-        uint32_t length;
-        uint32_t slice_seq;
-    };
-    std::mutex resp_mutex_;
-    std::deque<PendingReadResp> pending_resps_;
+    // READ_RESP deferred because the bounce pool was full. Single-drainer /
+    // recheck protocol closes the lost-wakeup window between a failed post and
+    // enqueue, and between a mid-drain slot free and exit.
+    PendingReadRespQueue pending_read_resps_;
 
     std::mutex resource_mutex_;
     std::atomic<bool> connected_{false};

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
@@ -24,7 +24,7 @@ namespace mooncake {
 
 // Msg QP payload header (host endian). Fixed 32 bytes.
 // | magic:u32 | ver:u8 | type:u8 | flags:u8 | slice_seq:u8 |
-// | task_id:u64 | dest_addr:u64 | length:u32 | reserved:u32 |
+// | task_id:u64 | dest_addr:u64 | length:u32 | total_chunks:u32 |
 constexpr uint32_t kMsgMagic = 0x47534D4Du;  // 'MSGM' LE
 constexpr uint8_t kMsgVersion = 1;
 constexpr size_t kMsgHeaderSize = 32;
@@ -43,6 +43,10 @@ struct MsgHeader {
     uint64_t task_id = 0;
     uint64_t dest_addr = 0;
     uint32_t length = 0;
+    // Chunks the whole task is split into, so the receiver knows when it has
+    // seen all of them and can drop the task's ACK bookkeeping. Order-agnostic,
+    // unlike a last-chunk flag. Zero means the sender did not report it.
+    uint32_t total_chunks = 0;
 };
 
 inline int encodeMsgHeader(const MsgHeader &h, void *out, size_t out_len) {
@@ -57,6 +61,7 @@ inline int encodeMsgHeader(const MsgHeader &h, void *out, size_t out_len) {
     std::memcpy(p + 8, &h.task_id, 8);
     std::memcpy(p + 16, &h.dest_addr, 8);
     std::memcpy(p + 24, &h.length, 4);
+    std::memcpy(p + 28, &h.total_chunks, 4);
     return 0;
 }
 
@@ -73,6 +78,7 @@ inline int decodeMsgHeader(const void *in, size_t in_len, MsgHeader &h) {
     std::memcpy(&h.task_id, p + 8, 8);
     std::memcpy(&h.dest_addr, p + 16, 8);
     std::memcpy(&h.length, p + 24, 4);
+    std::memcpy(&h.total_chunks, p + 28, 4);
     return 0;
 }
 

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
@@ -22,12 +22,13 @@
 
 namespace mooncake {
 
-// Msg QP payload header (host endian). Fixed 32 bytes.
-// | magic:u32 | ver:u8 | type:u8 | flags:u8 | slice_seq:u8 |
+// Msg QP payload header (host endian). Fixed 44 bytes.
+// | magic:u32 | ver:u8 | type:u8 | flags:u8 | reserved:u8 |
 // | task_id:u64 | dest_addr:u64 | length:u32 | total_chunks:u32 |
+// | session:u64 | slice_seq:u32 |
 constexpr uint32_t kMsgMagic = 0x47534D4Du;  // 'MSGM' LE
 constexpr uint8_t kMsgVersion = 1;
-constexpr size_t kMsgHeaderSize = 32;
+constexpr size_t kMsgHeaderSize = 44;
 
 enum class MsgType : uint8_t {
     DATA_WRITE = 1,
@@ -39,7 +40,7 @@ struct MsgHeader {
     uint8_t version = kMsgVersion;
     MsgType type = MsgType::DATA_WRITE;
     uint8_t flags = 0;
-    uint8_t slice_seq = 0;
+    uint8_t reserved = 0;
     uint64_t task_id = 0;
     uint64_t dest_addr = 0;
     uint32_t length = 0;
@@ -47,6 +48,18 @@ struct MsgHeader {
     // seen all of them and can drop the task's ACK bookkeeping. Order-agnostic,
     // unlike a last-chunk flag. Zero means the sender did not report it.
     uint32_t total_chunks = 0;
+    // Sender transport's per-instance session id. The receiver keys its ACK
+    // ledger by (peer, session, task_id): task_id alone collides because every
+    // sender starts next_task_id_ at 1, and session additionally separates a
+    // peer's incarnations so a restart reusing task_ids cannot land in a stale
+    // entry.
+    uint64_t session = 0;
+    // Chunk index within the task. Widened from u8 to u32: at the default
+    // ~64 KiB payload an 8-bit index wrapped after 256 chunks (~16 MiB), so a
+    // READ larger than that reconstructed the wrong local offset from
+    // slice_seq * max_payload and silently corrupted the buffer while still
+    // counting the bytes as delivered. u32 covers any practical transfer size.
+    uint32_t slice_seq = 0;
 };
 
 inline int encodeMsgHeader(const MsgHeader &h, void *out, size_t out_len) {
@@ -57,11 +70,13 @@ inline int encodeMsgHeader(const MsgHeader &h, void *out, size_t out_len) {
     p[4] = h.version;
     p[5] = static_cast<uint8_t>(h.type);
     p[6] = h.flags;
-    p[7] = h.slice_seq;
+    p[7] = h.reserved;
     std::memcpy(p + 8, &h.task_id, 8);
     std::memcpy(p + 16, &h.dest_addr, 8);
     std::memcpy(p + 24, &h.length, 4);
     std::memcpy(p + 28, &h.total_chunks, 4);
+    std::memcpy(p + 32, &h.session, 8);
+    std::memcpy(p + 40, &h.slice_seq, 4);
     return 0;
 }
 
@@ -74,11 +89,13 @@ inline int decodeMsgHeader(const void *in, size_t in_len, MsgHeader &h) {
     h.version = p[4];
     h.type = static_cast<MsgType>(p[5]);
     h.flags = p[6];
-    h.slice_seq = p[7];
+    h.reserved = p[7];
     std::memcpy(&h.task_id, p + 8, 8);
     std::memcpy(&h.dest_addr, p + 16, 8);
     std::memcpy(&h.length, p + 24, 4);
     std::memcpy(&h.total_chunks, p + 28, 4);
+    std::memcpy(&h.session, p + 32, 8);
+    std::memcpy(&h.slice_seq, p + 40, 4);
     return 0;
 }
 

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/msg_header.h
@@ -1,0 +1,81 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_MSG_HEADER_H_
+#define RDMA_MSG_HEADER_H_
+
+#include <cstdint>
+#include <cstring>
+
+#include "error.h"
+
+namespace mooncake {
+
+// Msg QP payload header (host endian). Fixed 32 bytes.
+// | magic:u32 | ver:u8 | type:u8 | flags:u8 | slice_seq:u8 |
+// | task_id:u64 | dest_addr:u64 | length:u32 | reserved:u32 |
+constexpr uint32_t kMsgMagic = 0x47534D4Du;  // 'MSGM' LE
+constexpr uint8_t kMsgVersion = 1;
+constexpr size_t kMsgHeaderSize = 32;
+
+enum class MsgType : uint8_t {
+    DATA_WRITE = 1,
+    READ_REQ = 2,
+    READ_RESP = 3,
+};
+
+struct MsgHeader {
+    uint8_t version = kMsgVersion;
+    MsgType type = MsgType::DATA_WRITE;
+    uint8_t flags = 0;
+    uint8_t slice_seq = 0;
+    uint64_t task_id = 0;
+    uint64_t dest_addr = 0;
+    uint32_t length = 0;
+};
+
+inline int encodeMsgHeader(const MsgHeader &h, void *out, size_t out_len) {
+    if (!out || out_len < kMsgHeaderSize) return ERR_INVALID_ARGUMENT;
+    auto *p = static_cast<uint8_t *>(out);
+    std::memset(p, 0, kMsgHeaderSize);
+    std::memcpy(p + 0, &kMsgMagic, 4);
+    p[4] = h.version;
+    p[5] = static_cast<uint8_t>(h.type);
+    p[6] = h.flags;
+    p[7] = h.slice_seq;
+    std::memcpy(p + 8, &h.task_id, 8);
+    std::memcpy(p + 16, &h.dest_addr, 8);
+    std::memcpy(p + 24, &h.length, 4);
+    return 0;
+}
+
+inline int decodeMsgHeader(const void *in, size_t in_len, MsgHeader &h) {
+    if (!in || in_len < kMsgHeaderSize) return ERR_INVALID_ARGUMENT;
+    auto *p = static_cast<const uint8_t *>(in);
+    uint32_t magic = 0;
+    std::memcpy(&magic, p, 4);
+    if (magic != kMsgMagic) return ERR_INVALID_ARGUMENT;
+    h.version = p[4];
+    h.type = static_cast<MsgType>(p[5]);
+    h.flags = p[6];
+    h.slice_seq = p[7];
+    std::memcpy(&h.task_id, p + 8, 8);
+    std::memcpy(&h.dest_addr, p + 16, 8);
+    std::memcpy(&h.length, p + 24, 4);
+    return 0;
+}
+
+}  // namespace mooncake
+
+#endif  // RDMA_MSG_HEADER_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/pending_read_resp_queue.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/pending_read_resp_queue.h
@@ -1,0 +1,73 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RDMA_PENDING_READ_RESP_QUEUE_H_
+#define RDMA_PENDING_READ_RESP_QUEUE_H_
+
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <mutex>
+
+#include "error.h"
+
+namespace mooncake {
+
+// Serialized queue for READ_RESP frames deferred when the bounce pool is full.
+//
+// A naive "enqueue then hope a later SEND completion drains" path loses the
+// wakeup when the last outstanding SEND completes between the failed post and
+// the enqueue. This helper uses a single-drainer / recheck protocol:
+//
+//   - At most one thread runs the drain loop at a time (drain_running_).
+//   - enqueue() and onSlotFreed() both kick(); a kick that finds an active
+//     drainer sets recheck_ so that drainer re-examines the queue before exit.
+//   - ERR_TOO_MANY_REQUESTS pushes the item back and exits the loop only when
+//     no concurrent kick arrived; otherwise it retries (the kick may have been
+//     a real slot free during try_send).
+struct PendingReadResp {
+    uint64_t task_id = 0;
+    uint64_t addr = 0;
+    uint32_t length = 0;
+    uint32_t slice_seq = 0;
+};
+
+class PendingReadRespQueue {
+   public:
+    // Returns 0 on post success, ERR_TOO_MANY_REQUESTS when the pool is still
+    // full, or another error to drop the item.
+    using TrySendFn = std::function<int(const PendingReadResp &)>;
+
+    // Hold `item` and participate in a serialized drain.
+    void enqueue(PendingReadResp item, const TrySendFn &try_send);
+
+    // A send bounce slot just freed (SEND completion or pool expand).
+    void onSlotFreed(const TrySendFn &try_send);
+
+    // Test / diagnostics.
+    size_t size() const;
+    bool drainRunningForTest() const;
+
+   private:
+    void kick(const TrySendFn &try_send);
+
+    mutable std::mutex mutex_;
+    std::deque<PendingReadResp> pending_;
+    bool drain_running_ = false;
+    bool recheck_ = false;
+};
+
+}  // namespace mooncake
+
+#endif  // RDMA_PENDING_READ_RESP_QUEUE_H_

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -17,24 +17,32 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <vector>
 
+#include "config.h"
 #include "transport/rdma_transport/rdma_transport.h"
 #include "transport/rdma_twosided/ctrl_frame.h"
+#include "transport/rdma_twosided/msg_header.h"
+#include "transport/rdma_twosided/sender_credit.h"
 
 namespace mooncake {
 
 class CtrlChannel;
+class MsgChannel;
 
-// RDMA transport with a dedicated CtrlChannel for typed notify frames.
-// One-sided data path is inherited from RdmaTransport; install name is
+// RDMA transport with a dedicated CtrlChannel for typed notify frames and a
+// per-peer MsgChannel for the two-sided (SEND/RECV + bounce) data path. The
+// one-sided data path is inherited from RdmaTransport; install name is
 // "rdma_twosided" (mutually exclusive with classic "rdma" in MultiTransport).
 class RdmaTwoSidedTransport : public RdmaTransport {
     friend class CtrlChannel;
+    friend class MsgChannel;
 
    public:
     using NotifyDesc = TransferMetadata::NotifyDesc;
@@ -52,20 +60,63 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     int onSetupRdmaConnections(const HandShakeDesc &peer_desc,
                                HandShakeDesc &local_desc) override;
 
+    // TE-managed / upper-layer buffer for the default two-sided path (no
+    // ibv_reg_mr on the peer side, hence no rkey exchange).
+    // registerManagedBuffer: caller owns memory (owned=false).
+    void *allocateManagedBuffer(size_t length);
+    int registerManagedBuffer(void *addr, size_t length);
+    int releaseManagedBuffer(void *addr);
+
+    // Splits the batch: managed source/target pairs go through the two-sided
+    // MsgChannel path, everything else falls back to the inherited one-sided
+    // path.
+    Status submitTransferTask(
+        const std::vector<TransferTask *> &task_list) override;
+
     int sendRdmaNotify(const std::string &peer_server_name,
                        const NotifyDesc &notify);
 
     void onCtrlNotifyReceived(const NotifyDesc &notify);
     void onCtrlFrameReceived(const std::string &peer_server_name,
                              const CtrlFrame &frame);
+    void onMsgReceived(const std::string &peer_server_name,
+                       const MsgHeader &hdr, const void *payload,
+                       MsgChannel *channel = nullptr);
 
     uint64_t localCtrlSessionId() const { return local_ctrl_session_id_; }
+
+    SenderCreditLedger &senderCreditLedger() { return sender_credit_; }
+
+    uint64_t peerGrantedBounceSlots(const std::string &peer_server_name);
+
+    // Local MsgChannel active bounce slot count for peer (0 if none).
+    size_t msgBounceActiveSlots(const std::string &peer_server_name);
+
+    int sendInitialCreditGrant(const std::string &peer_server_name);
+
+   protected:
+    // Peers select the two-sided path from this bit in our SegmentDesc, so it
+    // tracks whether the msg path is actually enabled on this transport.
+    bool supportsTwoSidedMsg() const override {
+        return globalConfig().rdma_msg_enabled;
+    }
 
    private:
     int onSetupCtrlChannel(const HandShakeDesc &peer_desc,
                            HandShakeDesc &local_desc);
+    int onSetupMsgChannel(const HandShakeDesc &peer_desc,
+                          HandShakeDesc &local_desc);
+    int registerManagedBufferInternal(void *addr, size_t length, bool owned);
     std::shared_ptr<CtrlChannel> ensureCtrlChannel(
         const std::string &peer_server_name);
+    std::shared_ptr<MsgChannel> ensureMsgChannel(
+        const std::string &peer_server_name);
+    // One MsgChannel per local RdmaContext (NIC rail). Partial success OK if
+    // at least one rail connects. Empty vector on total failure.
+    std::vector<std::shared_ptr<MsgChannel>> ensureMsgRails(
+        const std::string &peer_server_name);
+    std::shared_ptr<RdmaContext> selectMsgContext(
+        const HandShakeDesc &peer_desc, size_t existing_rail_count);
 
     // RAII publisher for one connect attempt. On construction it installs the
     // placeholder entry and marks the peer as having a connect in flight; on
@@ -96,10 +147,88 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     void stopCtrlWorker();
     void ctrlWorkerLoop();
 
+    bool shouldUseTwoSided(const TransferRequest &req);
+    bool isLocalManaged(uint64_t addr, size_t length) const;
+    bool isRemoteTwoSided(SegmentID target_id, uint64_t offset,
+                          size_t length) const;
+    Status submitTwoSidedTasks(const std::vector<TransferTask *> &tasks);
+    int dispatchTwoSidedTask(TransferTask *task);
+    void redispatchWaitingTasks();
+    void completeTwoSidedAck(uint64_t task_id, uint64_t acked_bytes);
+    int sendDataAck(const std::string &peer, uint64_t task_id,
+                    uint64_t acked_bytes);
+    bool validateLocalManagedDest(uint64_t dest_addr, uint32_t length) const;
+
+    struct PeerCtrlState {
+        uint64_t peer_session = 0;
+        uint64_t epoch = 1;
+        uint64_t next_grant_seq = 1;
+        uint32_t peer_bounce_slots = 0;
+        uint32_t peer_bounce_slot_size = 0;
+        bool session_open_received = false;
+        bool initial_grant_sent = false;
+        bool grant_pending = false;
+        // Peer asked us to expand bounce capacity (CREDIT_REQUEST).
+        bool expand_requested = false;
+        uint64_t last_credit_request_ms = 0;
+        // Last bounce slots advertised in CREDIT_GRANT to this peer.
+        uint64_t granted_bounce_slots = 0;
+        uint64_t high_watermark_since_ms = 0;
+    };
+
+    struct ManagedBuffer {
+        void *addr = nullptr;
+        size_t length = 0;
+        bool owned = false;  // allocated by TE
+    };
+
+    struct TwoSidedTaskState {
+        TransferTask *task = nullptr;
+        uint64_t task_id = 0;
+        uint64_t total_bytes = 0;
+        uint64_t acked_bytes = 0;
+        std::string peer;
+        uint64_t peer_session = 0;
+        // Session generation the reservation was made under; the ledger
+        // rejects a rollback carrying a stale epoch.
+        uint64_t peer_epoch = 1;
+        bool waiting_credit = false;
+        size_t slices_posted = 0;
+        bool credit_reserved = false;
+        uint64_t reserved_slots = 0;
+        uint64_t reserved_bytes = 0;
+        // Copied from TransferRequest: submitTransfer({req}) leaves
+        // task->request dangling after the temporary vector is destroyed.
+        TransferRequest::OpCode opcode = TransferRequest::WRITE;
+        void *local_buf = nullptr;
+    };
+
+    int sendCreditGrant(const std::string &peer_server_name, uint64_t epoch,
+                        uint64_t bounce_slots = 0);
+    void handleSessionOpen(const std::string &peer_server_name,
+                           const CtrlFrame &frame);
+    void handleCreditGrant(const std::string &peer_server_name,
+                           const CtrlFrame &frame);
+    void handleCreditRequest(const std::string &peer_server_name,
+                             const CtrlFrame &frame);
+    void handleDataAck(const std::string &peer_server_name,
+                       const CtrlFrame &frame);
+
+    void startBounceManager();
+    void stopBounceManager();
+    void bounceManagerLoop();
+    void manageBouncePoolsTick();
+    size_t waitingTaskCount();
+    int sendCreditRequest(const std::string &peer_server_name);
+
     std::mutex ctrl_mutex_;
     std::condition_variable ctrl_cv_;
     std::unordered_map<std::string, std::shared_ptr<CtrlChannel>>
         ctrl_channels_;
+    // Ordered MsgChannel rails per peer (one per local NIC / RdmaContext).
+    std::unordered_map<std::string, std::vector<std::shared_ptr<MsgChannel>>>
+        msg_channels_;
+    std::unordered_map<std::string, PeerCtrlState> peer_ctrl_state_;
     // Peers with a connect handshake in flight. Only such peers are worth
     // waiting for: an entry in ctrl_channels_ that is not connected and not
     // listed here is a dead channel, which the next caller reclaims instead of
@@ -111,7 +240,29 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     bool ctrl_stopping_ = false;
     std::thread ctrl_worker_;
     std::atomic<bool> ctrl_worker_running_{false};
+    std::thread bounce_manager_;
+    std::atomic<bool> bounce_manager_running_{false};
     uint64_t local_ctrl_session_id_ = 0;
+    SenderCreditLedger sender_credit_;
+
+    mutable std::mutex managed_mutex_;
+    std::unordered_map<uint64_t, ManagedBuffer> managed_buffers_;  // addr ->
+
+    std::mutex twosided_mutex_;
+    std::unordered_map<uint64_t, TwoSidedTaskState> twosided_tasks_;
+    std::deque<TransferTask *> waiting_tasks_;
+    std::atomic<uint64_t> next_task_id_{1};
+    // Tasks dispatched on MsgChannel awaiting DATA_ACK. Non-zero keeps the
+    // ctrl worker spinning so ACKs are drained without the idle sleep.
+    std::atomic<size_t> twosided_inflight_{0};
+    // Wakes the ctrl worker when a task is dispatched: the worker may be in
+    // its idle sleep, which would otherwise delay the DATA_ACK drain by the
+    // whole sleep period.
+    std::mutex ctrl_idle_mutex_;
+    std::condition_variable ctrl_idle_cv_;
+    // Receiver-side cumulative bytes per remote task_id (per-transport).
+    std::mutex recv_ack_mutex_;
+    std::unordered_map<uint64_t, uint64_t> recv_acked_bytes_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -15,6 +15,8 @@
 #ifndef RDMA_TWOSIDED_TRANSPORT_H_
 #define RDMA_TWOSIDED_TRANSPORT_H_
 
+#include <glog/logging.h>
+
 #include <atomic>
 #include <condition_variable>
 #include <deque>
@@ -23,6 +25,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "config.h"
@@ -124,6 +127,25 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::shared_ptr<RdmaContext> selectMsgContext(
         const HandShakeDesc &peer_desc, size_t existing_rail_count);
 
+    // Releases an already-held lock for the duration of a blocking call and
+    // reacquires it on scope exit, including when that call throws. Keeps the
+    // lock state uniform for an enclosing connect scope, whose destructor may
+    // then assume the lock is held.
+    class UnlockGuard {
+       public:
+        explicit UnlockGuard(std::unique_lock<std::mutex> &lock) : lock_(lock) {
+            DCHECK(lock_.owns_lock());
+            lock_.unlock();
+        }
+        ~UnlockGuard() { lock_.lock(); }
+
+        UnlockGuard(const UnlockGuard &) = delete;
+        UnlockGuard &operator=(const UnlockGuard &) = delete;
+
+       private:
+        std::unique_lock<std::mutex> &lock_;
+    };
+
     // RAII publisher for one connect attempt. On construction it installs the
     // placeholder entry and marks the peer as having a connect in flight; on
     // destruction it always retracts the marker and wakes waiters, and drops
@@ -147,6 +169,27 @@ class RdmaTwoSidedTransport : public RdmaTransport {
         std::string peer_;
         std::shared_ptr<CtrlChannel> channel_;
         bool success_ = false;
+    };
+
+    // Data-plane counterpart of ConnectScope, for one rail handshake. Nothing
+    // is published speculatively because rail waiters key off msg_connecting_
+    // rather than off a placeholder rail, so the destructor only has to clear
+    // the key and wake waiters -- but it has to do so on every path, or a
+    // handshake that throws strands the key and every later builder waits out
+    // the full deadline. Hold the scope open until the new rail is installed:
+    // a waiter woken earlier would find neither key nor rail and start the
+    // duplicate handshake this serialisation exists to prevent.
+    class RailConnectScope {
+       public:
+        RailConnectScope(RdmaTwoSidedTransport &transport, std::string key);
+        ~RailConnectScope();
+
+        RailConnectScope(const RailConnectScope &) = delete;
+        RailConnectScope &operator=(const RailConnectScope &) = delete;
+
+       private:
+        RdmaTwoSidedTransport &transport_;
+        std::string key_;
     };
 
     void startCtrlWorker();
@@ -227,6 +270,8 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     void stopBounceManager();
     void bounceManagerLoop();
     void manageBouncePoolsTick();
+    // Drops receiver-side ACK bookkeeping for task_ids that went idle.
+    void pruneRecvAckLedger();
     size_t waitingTaskCount();
     int sendCreditRequest(const std::string &peer_server_name);
 
@@ -244,6 +289,10 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     // waiting for a wakeup that never comes. Refcounted because an active and
     // a passive connect to the same peer can overlap.
     std::unordered_map<std::string, int> ctrl_connecting_;
+    // "peer|nicPath" keys whose MsgChannel handshake is in flight. A second
+    // builder would make the peer replace the first rail, stranding the SENDs
+    // already posted on it, so builders wait on ctrl_cv_ instead.
+    std::unordered_set<std::string> msg_connecting_;
     // Set once by stopCtrlWorker() to release waiters during shutdown.
     // Guarded by ctrl_mutex_.
     bool ctrl_stopping_ = false;
@@ -260,6 +309,9 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::mutex twosided_mutex_;
     std::unordered_map<uint64_t, TwoSidedTaskState> twosided_tasks_;
     std::deque<TransferTask *> waiting_tasks_;
+    // Readable without twosided_mutex_ so the ctrl worker's idle retry costs
+    // one load while nothing is queued.
+    std::atomic<uint64_t> waiting_count_{0};
     std::atomic<uint64_t> next_task_id_{1};
     std::atomic<uint64_t> twosided_resume_count_{0};
     // Tasks dispatched on MsgChannel awaiting DATA_ACK. Non-zero keeps the
@@ -271,8 +323,15 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::mutex ctrl_idle_mutex_;
     std::condition_variable ctrl_idle_cv_;
     // Receiver-side cumulative bytes per remote task_id (per-transport).
+    // Retired as soon as MsgHeader::total_chunks chunks have arrived; the idle
+    // sweep in pruneRecvAckLedger() only has to cover tasks that never do.
+    struct RecvAckState {
+        uint64_t bytes = 0;
+        uint64_t chunks = 0;
+        uint64_t last_ms = 0;
+    };
     std::mutex recv_ack_mutex_;
-    std::unordered_map<uint64_t, uint64_t> recv_acked_bytes_;
+    std::unordered_map<uint64_t, RecvAckState> recv_acked_bytes_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -20,10 +20,12 @@
 #include <atomic>
 #include <condition_variable>
 #include <deque>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -322,7 +324,11 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     // whole sleep period.
     std::mutex ctrl_idle_mutex_;
     std::condition_variable ctrl_idle_cv_;
-    // Receiver-side cumulative bytes per remote task_id (per-transport).
+    // Receiver-side cumulative bytes per (peer, session, remote task_id).
+    // task_id alone is not unique across senders (each starts next_task_id_ at
+    // 1) nor across a peer's restarts, so two transfers would merge into one
+    // entry and complete each other early; session separates incarnations and
+    // peer_server_name is the channel-verified identity the frame arrived on.
     // Retired as soon as MsgHeader::total_chunks chunks have arrived; the idle
     // sweep in pruneRecvAckLedger() only has to cover tasks that never do.
     struct RecvAckState {
@@ -330,8 +336,10 @@ class RdmaTwoSidedTransport : public RdmaTransport {
         uint64_t chunks = 0;
         uint64_t last_ms = 0;
     };
+    // (peer_server_name, sender session, remote task_id)
+    using RecvAckKey = std::tuple<std::string, uint64_t, uint64_t>;
     std::mutex recv_ack_mutex_;
-    std::unordered_map<uint64_t, RecvAckState> recv_acked_bytes_;
+    std::map<RecvAckKey, RecvAckState> recv_acked_bytes_;
 };
 
 }  // namespace mooncake

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/rdma_twosided_transport.h
@@ -94,6 +94,12 @@ class RdmaTwoSidedTransport : public RdmaTransport {
 
     int sendInitialCreditGrant(const std::string &peer_server_name);
 
+    // Number of dispatches that resumed from a recorded offset after
+    // bounce-slot backpressure stopped them mid-transfer.
+    uint64_t twoSidedResumeCount() const {
+        return twosided_resume_count_.load(std::memory_order_relaxed);
+    }
+
    protected:
     // Peers select the two-sided path from this bit in our SegmentDesc, so it
     // tracks whether the msg path is actually enabled on this transport.
@@ -187,6 +193,9 @@ class RdmaTwoSidedTransport : public RdmaTransport {
         uint64_t task_id = 0;
         uint64_t total_bytes = 0;
         uint64_t acked_bytes = 0;
+        // Next unsent offset. A dispatch stopped by send-queue backpressure
+        // resumes from here instead of replaying chunks already on the wire.
+        uint64_t sent_bytes = 0;
         std::string peer;
         uint64_t peer_session = 0;
         // Session generation the reservation was made under; the ledger
@@ -252,6 +261,7 @@ class RdmaTwoSidedTransport : public RdmaTransport {
     std::unordered_map<uint64_t, TwoSidedTaskState> twosided_tasks_;
     std::deque<TransferTask *> waiting_tasks_;
     std::atomic<uint64_t> next_task_id_{1};
+    std::atomic<uint64_t> twosided_resume_count_{0};
     // Tasks dispatched on MsgChannel awaiting DATA_ACK. Non-zero keeps the
     // ctrl worker spinning so ACKs are drained without the idle sleep.
     std::atomic<size_t> twosided_inflight_{0};

--- a/mooncake-transfer-engine/include/transport/rdma_twosided/sender_credit.h
+++ b/mooncake-transfer-engine/include/transport/rdma_twosided/sender_credit.h
@@ -54,6 +54,11 @@ class SenderCreditLedger {
     int available(const std::string &peer, uint64_t session, uint64_t epoch,
                   CreditResource resource, uint64_t &out) const;
 
+    // Cumulative grant for the session, ignoring what is already consumed. It
+    // is the ceiling a single reservation can ever reach.
+    int grantTotal(const std::string &peer, uint64_t session, uint64_t epoch,
+                   CreditResource resource, uint64_t &out) const;
+
     // Sum available units of `resource` across all sessions for peer.
     uint64_t availableForPeer(const std::string &peer,
                               CreditResource resource) const;

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -633,6 +633,126 @@ void loadGlobalConfig(GlobalConfig& config) {
             LOG(WARNING) << "Ignore value from environment variable "
                             "MC_RDMA_NOTIFY_CONNECT_TIMEOUT_MS";
     }
+    const char* rdma_credit_enabled_env = std::getenv("MC_RDMA_CREDIT_ENABLED");
+    if (rdma_credit_enabled_env) {
+        parseBoolConfigEnv(rdma_credit_enabled_env, "MC_RDMA_CREDIT_ENABLED",
+                           config.rdma_credit_enabled);
+    }
+    const char* rdma_credit_window_bytes_env =
+        std::getenv("MC_RDMA_CREDIT_WINDOW_BYTES");
+    if (rdma_credit_window_bytes_env) {
+        config.rdma_credit_window_bytes =
+            std::strtoull(rdma_credit_window_bytes_env, nullptr, 10);
+    }
+    const char* rdma_credit_window_requests_env =
+        std::getenv("MC_RDMA_CREDIT_WINDOW_REQUESTS");
+    if (rdma_credit_window_requests_env) {
+        config.rdma_credit_window_requests =
+            std::strtoull(rdma_credit_window_requests_env, nullptr, 10);
+    }
+    const char* rdma_credit_queue_timeout_ms_env =
+        std::getenv("MC_RDMA_CREDIT_QUEUE_TIMEOUT_MS");
+    if (rdma_credit_queue_timeout_ms_env) {
+        config.rdma_credit_queue_timeout_ms =
+            std::strtoull(rdma_credit_queue_timeout_ms_env, nullptr, 10);
+    }
+    const char* rdma_msg_enabled_env = std::getenv("MC_RDMA_MSG_ENABLED");
+    if (rdma_msg_enabled_env) {
+        parseBoolConfigEnv(rdma_msg_enabled_env, "MC_RDMA_MSG_ENABLED",
+                           config.rdma_msg_enabled);
+    }
+    const char* rdma_msg_default_env = std::getenv("MC_RDMA_MSG_DEFAULT");
+    if (rdma_msg_default_env) {
+        parseBoolConfigEnv(rdma_msg_default_env, "MC_RDMA_MSG_DEFAULT",
+                           config.rdma_msg_default);
+    }
+    const char* rdma_msg_slot_size_env = std::getenv("MC_RDMA_MSG_SLOT_SIZE");
+    if (rdma_msg_slot_size_env) {
+        int val = atoi(rdma_msg_slot_size_env);
+        if (val >= 1024 && val <= (1 << 20))
+            config.rdma_msg_slot_size = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_SLOT_SIZE";
+    }
+    const char* rdma_msg_pool_base_env = std::getenv("MC_RDMA_MSG_POOL_BASE");
+    if (rdma_msg_pool_base_env) {
+        int val = atoi(rdma_msg_pool_base_env);
+        if (val > 0 && val <= 65536)
+            config.rdma_msg_pool_base = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_POOL_BASE";
+    }
+    const char* rdma_msg_pool_max_env = std::getenv("MC_RDMA_MSG_POOL_MAX");
+    if (rdma_msg_pool_max_env) {
+        int val = atoi(rdma_msg_pool_max_env);
+        if (val > 0 && val <= 65536)
+            config.rdma_msg_pool_max = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_POOL_MAX";
+    }
+    if (config.rdma_msg_pool_max < config.rdma_msg_pool_base)
+        config.rdma_msg_pool_max = config.rdma_msg_pool_base;
+
+    const char* expand_step_env = std::getenv("MC_RDMA_MSG_EXPAND_STEP");
+    if (expand_step_env) {
+        int val = atoi(expand_step_env);
+        if (val > 0 && val <= 65536)
+            config.rdma_msg_expand_step = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_EXPAND_STEP";
+    }
+    const char* low_wm_env = std::getenv("MC_RDMA_MSG_EXPAND_LOW_WM_PCT");
+    if (low_wm_env) {
+        int val = atoi(low_wm_env);
+        if (val >= 0 && val <= 100)
+            config.rdma_msg_expand_low_watermark_pct = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_EXPAND_LOW_WM_PCT";
+    }
+    const char* high_wm_env = std::getenv("MC_RDMA_MSG_SHRINK_HIGH_WM_PCT");
+    if (high_wm_env) {
+        int val = atoi(high_wm_env);
+        if (val >= 0 && val <= 100)
+            config.rdma_msg_shrink_high_watermark_pct =
+                static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_SHRINK_HIGH_WM_PCT";
+    }
+    const char* pending_exp_env =
+        std::getenv("MC_RDMA_MSG_PENDING_EXPAND_THRESHOLD");
+    if (pending_exp_env) {
+        int val = atoi(pending_exp_env);
+        if (val >= 0 && val <= 65536)
+            config.rdma_msg_pending_expand_threshold = static_cast<size_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_PENDING_EXPAND_THRESHOLD";
+    }
+    const char* shrink_idle_env = std::getenv("MC_RDMA_MSG_SHRINK_IDLE_MS");
+    if (shrink_idle_env) {
+        int val = atoi(shrink_idle_env);
+        if (val >= 0)
+            config.rdma_msg_shrink_idle_ms = static_cast<uint64_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_SHRINK_IDLE_MS";
+    }
+    const char* bounce_tick_env =
+        std::getenv("MC_RDMA_MSG_BOUNCE_MANAGER_TICK_MS");
+    if (bounce_tick_env) {
+        int val = atoi(bounce_tick_env);
+        if (val > 0 && val <= 60000)
+            config.rdma_msg_bounce_manager_tick_ms = static_cast<uint64_t>(val);
+        else
+            LOG(WARNING) << "Ignore value from environment variable "
+                            "MC_RDMA_MSG_BOUNCE_MANAGER_TICK_MS";
+    }
 
     const char* enable_parallel_reg_mr =
         std::getenv("MC_ENABLE_PARALLEL_REG_MR");

--- a/mooncake-transfer-engine/src/transfer_metadata.cpp
+++ b/mooncake-transfer-engine/src/transfer_metadata.cpp
@@ -86,6 +86,11 @@ struct TransferHandshakeUtil {
             root["notify_rq_depth"] = Json::UInt(desc.notify_rq_depth);
             root["ctrl_channel"] = desc.ctrl_channel;
         }
+        if (desc.msg_qp_num != 0 || desc.msg_channel) {
+            root["msg_qp_num"] = Json::UInt(desc.msg_qp_num);
+            root["msg_rq_depth"] = Json::UInt(desc.msg_rq_depth);
+            root["msg_channel"] = desc.msg_channel;
+        }
         root["reply_msg"] = desc.reply_msg;
 #ifdef USE_EFA
         root["efa_addr"] = desc.efa_addr;  // EFA endpoint address
@@ -133,6 +138,9 @@ struct TransferHandshakeUtil {
         desc.notify_qp_num = 0;
         desc.notify_rq_depth = 0;
         desc.ctrl_channel = false;
+        desc.msg_qp_num = 0;
+        desc.msg_rq_depth = 0;
+        desc.msg_channel = false;
         if (root.isMember("notify_qp_num") && root["notify_qp_num"].isUInt()) {
             desc.notify_qp_num = root["notify_qp_num"].asUInt();
         }
@@ -144,6 +152,17 @@ struct TransferHandshakeUtil {
         }
         if (root.isMember("ctrl_channel") && root["ctrl_channel"].isBool()) {
             desc.ctrl_channel = root["ctrl_channel"].asBool();
+        }
+        if (root.isMember("msg_qp_num") && root["msg_qp_num"].isUInt()) {
+            desc.msg_qp_num = root["msg_qp_num"].asUInt();
+        }
+        if (root.isMember("msg_rq_depth") && root["msg_rq_depth"].isUInt()) {
+            unsigned int depth = root["msg_rq_depth"].asUInt();
+            if (depth > 0xFFFFu) return ERR_INVALID_ARGUMENT;
+            desc.msg_rq_depth = static_cast<uint16_t>(depth);
+        }
+        if (root.isMember("msg_channel") && root["msg_channel"].isBool()) {
+            desc.msg_channel = root["msg_channel"].asBool();
         }
         desc.reply_msg = root["reply_msg"].asString();
 #ifdef USE_EFA
@@ -326,6 +345,9 @@ static int encodeMultiProtocolSegmentDesc(
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
     }
+    if (desc.supports_two_sided_msg) {
+        segmentJSON["supports_two_sided_msg"] = true;
+    }
     Json::Value protocolJSON(Json::arrayValue);
     for (const auto &proto : protocols) {
         if (proto == "rdma") {
@@ -429,6 +451,9 @@ int TransferMetadata::encodeSegmentDesc(const SegmentDesc &desc,
     segmentJSON["timestamp"] = getCurrentDateTime();
     if (!desc.rdma_server_name.empty()) {
         segmentJSON["rdma_server_name"] = desc.rdma_server_name;
+    }
+    if (desc.supports_two_sided_msg) {
+        segmentJSON["supports_two_sided_msg"] = true;
     }
 
     if (segmentJSON["protocol"] == "rdma" ||
@@ -648,6 +673,11 @@ decodeMultiProtocolSegmentDesc(Json::Value &segmentJSON,
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))
         desc->rdma_server_name = segmentJSON["rdma_server_name"].asString();
+    if (segmentJSON.isMember("supports_two_sided_msg") &&
+        segmentJSON["supports_two_sided_msg"].isBool()) {
+        desc->supports_two_sided_msg =
+            segmentJSON["supports_two_sided_msg"].asBool();
+    }
 
     for (const auto &protocolStr : segmentJSON["protocol"]) {
         std::string proto = protocolStr.asString();
@@ -817,6 +847,11 @@ TransferMetadata::decodeSegmentDesc(Json::Value &segmentJSON,
         desc->timestamp = segmentJSON["timestamp"].asString();
     if (segmentJSON.isMember("rdma_server_name"))
         desc->rdma_server_name = segmentJSON["rdma_server_name"].asString();
+    if (segmentJSON.isMember("supports_two_sided_msg") &&
+        segmentJSON["supports_two_sided_msg"].isBool()) {
+        desc->supports_two_sided_msg =
+            segmentJSON["supports_two_sided_msg"].asBool();
+    }
 
     if (desc->protocol == "rdma" || desc->protocol == "barex" ||
         desc->protocol == "efa" || desc->protocol == "cxi") {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -1567,32 +1567,48 @@ int RdmaContext::poll(int num_entries, ibv_wc *wc, int cq_index) {
     return nr_poll;
 }
 
-void RdmaContext::registerMsgChannel(MsgChannel *channel) {
+void RdmaContext::registerMsgChannel(std::shared_ptr<MsgChannel> channel) {
     if (!channel) return;
     std::lock_guard<std::mutex> lock(msg_channels_mutex_);
-    for (auto *existing : msg_channels_) {
+    for (auto it = msg_channels_.begin(); it != msg_channels_.end();) {
+        auto existing = it->lock();
+        if (!existing) {
+            it = msg_channels_.erase(it);
+            continue;
+        }
         if (existing == channel) return;
+        ++it;
     }
-    msg_channels_.push_back(channel);
+    msg_channels_.push_back(std::move(channel));
 }
 
 void RdmaContext::unregisterMsgChannel(MsgChannel *channel) {
     if (!channel) return;
     std::lock_guard<std::mutex> lock(msg_channels_mutex_);
+    // Called from ~MsgChannel, where the weak_ptr no longer locks, so match on
+    // identity and drop expired entries as we go.
     msg_channels_.erase(
-        std::remove(msg_channels_.begin(), msg_channels_.end(), channel),
+        std::remove_if(msg_channels_.begin(), msg_channels_.end(),
+                       [channel](const std::weak_ptr<MsgChannel> &entry) {
+                           auto held = entry.lock();
+                           return !held || held.get() == channel;
+                       }),
         msg_channels_.end());
 }
 
 int RdmaContext::pollMsgChannels(int max_per_channel) {
-    std::vector<MsgChannel *> snapshot;
+    // Promote under the lock so each polled channel stays alive for the poll
+    // even if the transport replaces the rail concurrently.
+    std::vector<std::shared_ptr<MsgChannel>> snapshot;
     {
         std::lock_guard<std::mutex> lock(msg_channels_mutex_);
-        snapshot = msg_channels_;
+        snapshot.reserve(msg_channels_.size());
+        for (auto &entry : msg_channels_) {
+            if (auto channel = entry.lock()) snapshot.push_back(channel);
+        }
     }
     int processed = 0;
-    for (auto *channel : snapshot) {
-        if (!channel) continue;
+    for (auto &channel : snapshot) {
         int n = channel->pollCompletions(max_per_channel);
         if (n > 0) processed += n;
     }
@@ -1601,7 +1617,10 @@ int RdmaContext::pollMsgChannels(int max_per_channel) {
 
 bool RdmaContext::hasMsgChannels() const {
     std::lock_guard<std::mutex> lock(msg_channels_mutex_);
-    return !msg_channels_.empty();
+    for (auto &entry : msg_channels_) {
+        if (!entry.expired()) return true;
+    }
+    return false;
 }
 
 int RdmaContext::submitPostSend(

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -48,6 +48,7 @@
 #include "transport/rdma_transport/rdma_endpoint.h"
 #include "transport/rdma_transport/rdma_transport.h"
 #include "transport/rdma_transport/worker_pool.h"
+#include "transport/rdma_twosided/msg_channel.h"
 #include "transport/transport.h"
 
 namespace mooncake {
@@ -1564,6 +1565,43 @@ int RdmaContext::poll(int num_entries, ibv_wc *wc, int cq_index) {
         return ERR_CONTEXT;
     }
     return nr_poll;
+}
+
+void RdmaContext::registerMsgChannel(MsgChannel *channel) {
+    if (!channel) return;
+    std::lock_guard<std::mutex> lock(msg_channels_mutex_);
+    for (auto *existing : msg_channels_) {
+        if (existing == channel) return;
+    }
+    msg_channels_.push_back(channel);
+}
+
+void RdmaContext::unregisterMsgChannel(MsgChannel *channel) {
+    if (!channel) return;
+    std::lock_guard<std::mutex> lock(msg_channels_mutex_);
+    msg_channels_.erase(
+        std::remove(msg_channels_.begin(), msg_channels_.end(), channel),
+        msg_channels_.end());
+}
+
+int RdmaContext::pollMsgChannels(int max_per_channel) {
+    std::vector<MsgChannel *> snapshot;
+    {
+        std::lock_guard<std::mutex> lock(msg_channels_mutex_);
+        snapshot = msg_channels_;
+    }
+    int processed = 0;
+    for (auto *channel : snapshot) {
+        if (!channel) continue;
+        int n = channel->pollCompletions(max_per_channel);
+        if (n > 0) processed += n;
+    }
+    return processed;
+}
+
+bool RdmaContext::hasMsgChannels() const {
+    std::lock_guard<std::mutex> lock(msg_channels_mutex_);
+    return !msg_channels_.empty();
 }
 
 int RdmaContext::submitPostSend(

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -687,6 +687,7 @@ int RdmaTransport::allocateLocalSegmentID() {
         desc->devices.push_back(device_desc);
     }
     desc->topology = *(local_topology_.get());
+    desc->supports_two_sided_msg = supportsTwoSidedMsg();
     metadata_->addLocalSegment(LOCAL_SEGMENT_ID, local_server_name_,
                                std::move(desc));
     return 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -1098,12 +1098,21 @@ void WorkerPool::transferWorker(int thread_id) {
     const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
     uint64_t last_wait_ts = getCurrentTimeInNano();
     while (workers_running_.load(std::memory_order_relaxed)) {
+#ifndef USE_FAKE_POST_SEND
+        // Two-sided MsgChannel CQs live on this NIC; poll every loop so pure
+        // receivers keep making progress even with no one-sided traffic.
+        if (can_poll) {
+            context_.pollMsgChannels();
+        }
+#endif
         auto processed_slice_count =
             processed_slice_count_.load(std::memory_order_relaxed);
         auto submitted_slice_count =
             submitted_slice_count_.load(std::memory_order_relaxed);
+        // Do not park while MsgChannels are registered: recv-only peers would
+        // otherwise stop polling after the one-sided idle timeout.
         if (processed_slice_count == submitted_slice_count &&
-            !hasOutstandingCq(thread_id)) {
+            !hasOutstandingCq(thread_id) && !context_.hasMsgChannels()) {
             uint64_t curr_wait_ts = getCurrentTimeInNano();
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
@@ -1113,7 +1122,8 @@ void WorkerPool::transferWorker(int thread_id) {
                 // producers that submit after it will notify this worker.
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
                         submitted_slice_count_.load() &&
-                    !hasOutstandingCq(thread_id)) {
+                    !hasOutstandingCq(thread_id) &&
+                    !context_.hasMsgChannels()) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
                 parked_worker_count_.fetch_sub(1, std::memory_order_acq_rel);

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -1101,9 +1101,9 @@ void WorkerPool::transferWorker(int thread_id) {
 #ifndef USE_FAKE_POST_SEND
         // Two-sided MsgChannel CQs live on this NIC; poll every loop so pure
         // receivers keep making progress even with no one-sided traffic.
-        if (can_poll) {
-            context_.pollMsgChannels();
-        }
+        // (After the peer-owner CQ split on main there is no can_poll helper;
+        // every transfer worker may poll — MsgChannel serializes on its CQ.)
+        context_.pollMsgChannels();
 #endif
         auto processed_slice_count =
             processed_slice_count_.load(std::memory_order_relaxed);

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/bounce_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/bounce_pool.cpp
@@ -1,0 +1,233 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/bounce_pool.h"
+
+#include <glog/logging.h>
+
+namespace mooncake {
+
+void BouncePool::destroyUnlocked() {
+    for (auto &s : slots_) {
+        if (s.mr) {
+            ibv_dereg_mr(s.mr);
+            s.mr = nullptr;
+        }
+    }
+    for (auto &s : recv_slots_) {
+        if (s.mr) {
+            ibv_dereg_mr(s.mr);
+            s.mr = nullptr;
+        }
+    }
+    slots_.clear();
+    recv_slots_.clear();
+    pd_ = nullptr;
+    slot_size_ = 0;
+    active_count_ = 0;
+}
+
+int BouncePool::construct(ibv_pd *pd, size_t slot_size, size_t slot_count) {
+    if (!pd || slot_size == 0 || slot_count == 0) return -1;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (pd_) return -1;
+    pd_ = pd;
+    slot_size_ = slot_size;
+    slots_.resize(slot_count);
+    recv_slots_.resize(slot_count);
+    for (size_t i = 0; i < slot_count; ++i) {
+        slots_[i].buf.resize(slot_size);
+        slots_[i].mr = ibv_reg_mr(pd, slots_[i].buf.data(), slot_size,
+                                  IBV_ACCESS_LOCAL_WRITE);
+        if (!slots_[i].mr) {
+            LOG(ERROR) << "BouncePool: failed to register send slot " << i;
+            destroyUnlocked();
+            return -1;
+        }
+        recv_slots_[i].buf.resize(slot_size);
+        recv_slots_[i].mr = ibv_reg_mr(pd, recv_slots_[i].buf.data(), slot_size,
+                                       IBV_ACCESS_LOCAL_WRITE);
+        if (!recv_slots_[i].mr) {
+            LOG(ERROR) << "BouncePool: failed to register recv slot " << i;
+            destroyUnlocked();
+            return -1;
+        }
+    }
+    active_count_ = slot_count;
+    return 0;
+}
+
+void BouncePool::destroy() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    destroyUnlocked();
+}
+
+size_t BouncePool::slotCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return slots_.size();
+}
+
+size_t BouncePool::activeCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return active_count_;
+}
+
+size_t BouncePool::freeSendCount() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t n = 0;
+    for (size_t i = 0; i < active_count_; ++i) {
+        if (!slots_[i].in_use) ++n;
+    }
+    return n;
+}
+
+int BouncePool::acquireSendSlot() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (size_t i = 0; i < active_count_; ++i) {
+        if (!slots_[i].in_use) {
+            slots_[i].in_use = true;
+            return static_cast<int>(i);
+        }
+    }
+    return -1;
+}
+
+void BouncePool::releaseSendSlot(int idx) {
+    if (idx < 0) return;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (static_cast<size_t>(idx) >= slots_.size()) return;
+    slots_[idx].in_use = false;
+}
+
+char *BouncePool::slotPtr(int idx) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx < 0 || static_cast<size_t>(idx) >= slots_.size()) return nullptr;
+    return slots_[idx].buf.data();
+}
+
+ibv_mr *BouncePool::slotMr(int idx) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx < 0 || static_cast<size_t>(idx) >= slots_.size()) return nullptr;
+    return slots_[idx].mr;
+}
+
+uint32_t BouncePool::slotLkey(int idx) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx < 0 || static_cast<size_t>(idx) >= slots_.size()) return 0;
+    return slots_[idx].mr ? slots_[idx].mr->lkey : 0;
+}
+
+char *BouncePool::recvSlotPtr(size_t idx) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= recv_slots_.size()) return nullptr;
+    return recv_slots_[idx].buf.data();
+}
+
+ibv_mr *BouncePool::recvSlotMr(size_t idx) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= recv_slots_.size()) return nullptr;
+    return recv_slots_[idx].mr;
+}
+
+void BouncePool::markRecvPosted(size_t idx, bool posted) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= recv_slots_.size()) return;
+    recv_slots_[idx].recv_posted = posted;
+}
+
+bool BouncePool::recvPosted(size_t idx) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (idx >= recv_slots_.size()) return false;
+    return recv_slots_[idx].recv_posted;
+}
+
+int BouncePool::expand(size_t extra) {
+    if (extra == 0) return 0;
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!pd_) return -1;
+    size_t old = slots_.size();
+    slots_.resize(old + extra);
+    recv_slots_.resize(old + extra);
+    for (size_t i = old; i < old + extra; ++i) {
+        slots_[i].buf.resize(slot_size_);
+        slots_[i].mr = ibv_reg_mr(pd_, slots_[i].buf.data(), slot_size_,
+                                  IBV_ACCESS_LOCAL_WRITE);
+        if (!slots_[i].mr) {
+            LOG(ERROR) << "BouncePool::expand failed at send slot " << i;
+            while (slots_.size() > old) {
+                auto &s = slots_.back();
+                if (s.mr) ibv_dereg_mr(s.mr);
+                slots_.pop_back();
+            }
+            while (recv_slots_.size() > old) {
+                auto &s = recv_slots_.back();
+                if (s.mr) ibv_dereg_mr(s.mr);
+                recv_slots_.pop_back();
+            }
+            return -1;
+        }
+        recv_slots_[i].buf.resize(slot_size_);
+        recv_slots_[i].mr = ibv_reg_mr(pd_, recv_slots_[i].buf.data(),
+                                       slot_size_, IBV_ACCESS_LOCAL_WRITE);
+        if (!recv_slots_[i].mr) {
+            LOG(ERROR) << "BouncePool::expand failed at recv slot " << i;
+            if (slots_[i].mr) {
+                ibv_dereg_mr(slots_[i].mr);
+                slots_[i].mr = nullptr;
+            }
+            while (slots_.size() > old) {
+                auto &s = slots_.back();
+                if (s.mr) ibv_dereg_mr(s.mr);
+                slots_.pop_back();
+            }
+            while (recv_slots_.size() > old) {
+                auto &s = recv_slots_.back();
+                if (s.mr) ibv_dereg_mr(s.mr);
+                recv_slots_.pop_back();
+            }
+            return -1;
+        }
+    }
+    active_count_ = slots_.size();
+    return 0;
+}
+
+size_t BouncePool::shrinkToward(size_t target_active, size_t min_active) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (min_active == 0) min_active = 1;
+    if (target_active < min_active) target_active = min_active;
+    if (active_count_ <= target_active) return active_count_;
+
+    active_count_ = target_active;
+
+    while (slots_.size() > active_count_) {
+        size_t i = slots_.size() - 1;
+        if (slots_[i].in_use || recv_slots_[i].recv_posted) {
+            break;
+        }
+        if (slots_[i].mr) {
+            ibv_dereg_mr(slots_[i].mr);
+            slots_[i].mr = nullptr;
+        }
+        if (recv_slots_[i].mr) {
+            ibv_dereg_mr(recv_slots_[i].mr);
+            recv_slots_[i].mr = nullptr;
+        }
+        slots_.pop_back();
+        recv_slots_.pop_back();
+    }
+    return active_count_;
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_channel.cpp
@@ -403,9 +403,19 @@ int CtrlChannel::acceptPassive(const HandShakeDesc &peer_desc,
 }
 
 int CtrlChannel::postSessionOpen() {
-    // PR2: SESSION_OPEN / credit / MsgChannel deferred to later PRs.
-    (void)transport_;
-    return 0;
+    if (!globalConfig().rdma_credit_enabled && !globalConfig().rdma_msg_enabled)
+        return 0;
+    CtrlFrame frame;
+    frame.type = CtrlFrameType::SESSION_OPEN;
+    frame.session = transport_.localCtrlSessionId();
+    frame.epoch = 1;
+    frame.seq = 0;  // filled by sendCtrlFrame
+    uint32_t slots = static_cast<uint32_t>(globalConfig().rdma_msg_pool_base);
+    uint32_t slot_size =
+        static_cast<uint32_t>(globalConfig().rdma_msg_slot_size);
+    if (encodeSessionOpenPayload(slots, slot_size, frame.payload))
+        return ERR_INVALID_ARGUMENT;
+    return sendCtrlFrame(frame);
 }
 
 int CtrlChannel::sendCtrlFrame(const CtrlFrame &frame_in) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -52,25 +52,6 @@ inline void cpuRelax() {
 #endif
 }
 
-// Releases an already-held lock for the duration of a blocking call and
-// reacquires it on scope exit, including when that call throws. Keeps the
-// lock state uniform for the enclosing ConnectScope, whose destructor may
-// then assume the lock is held.
-class UnlockGuard {
-   public:
-    explicit UnlockGuard(std::unique_lock<std::mutex> &lock) : lock_(lock) {
-        DCHECK(lock_.owns_lock());
-        lock_.unlock();
-    }
-    ~UnlockGuard() { lock_.lock(); }
-
-    UnlockGuard(const UnlockGuard &) = delete;
-    UnlockGuard &operator=(const UnlockGuard &) = delete;
-
-   private:
-    std::unique_lock<std::mutex> &lock_;
-};
-
 }  // namespace
 
 RdmaTwoSidedTransport::ConnectScope::ConnectScope(
@@ -95,6 +76,17 @@ RdmaTwoSidedTransport::ConnectScope::~ConnectScope() {
             transport_.ctrl_channels_.erase(it);
         }
     }
+    transport_.ctrl_cv_.notify_all();
+}
+
+RdmaTwoSidedTransport::RailConnectScope::RailConnectScope(
+    RdmaTwoSidedTransport &transport, std::string key)
+    : transport_(transport), key_(std::move(key)) {
+    transport_.msg_connecting_.insert(key_);
+}
+
+RdmaTwoSidedTransport::RailConnectScope::~RailConnectScope() {
+    transport_.msg_connecting_.erase(key_);
     transport_.ctrl_cv_.notify_all();
 }
 
@@ -569,6 +561,13 @@ size_t RdmaTwoSidedTransport::waitingTaskCount() {
 void RdmaTwoSidedTransport::bounceManagerLoop() {
     while (bounce_manager_running_.load(std::memory_order_acquire)) {
         manageBouncePoolsTick();
+        // Backstop for queued tasks. A queued task is normally woken by the
+        // event that frees the resource it waits for, but that event can land
+        // between its failed retry and its requeue, and then nothing wakes it
+        // once the traffic that would have is gone. Retried here rather than in
+        // the ctrl worker, which must stay free to drain DATA_ACKs.
+        redispatchWaitingTasks();
+        pruneRecvAckLedger();
         auto tick_ms = globalConfig().rdma_msg_bounce_manager_tick_ms;
         if (tick_ms == 0) tick_ms = 50;
         std::this_thread::sleep_for(std::chrono::milliseconds(tick_ms));

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/ctrl_plane.cpp
@@ -15,6 +15,9 @@
 #include "transport/rdma_twosided/rdma_twosided_transport.h"
 
 #include <glog/logging.h>
+#ifdef __linux__
+#include <sys/prctl.h>
+#endif
 
 #include <chrono>
 #include <memory>
@@ -28,10 +31,26 @@
 #include "error.h"
 #include "transport/rdma_twosided/ctrl_channel.h"
 #include "transport/rdma_twosided/ctrl_frame.h"
+#include "transport/rdma_twosided/msg_channel.h"
 
 namespace mooncake {
 
 namespace {
+
+// Pause iterations per idle turn while DATA_ACKs are outstanding. Sized so one
+// turn stays well under the ACK round trip, keeping the poll interval short
+// without pinning the core.
+constexpr int kCtrlSpinPauses = 200;
+
+// Spin hint for the busy-wait above: yields the pipeline to the sibling
+// hyperthread on x86 and is a no-op elsewhere.
+inline void cpuRelax() {
+#if defined(__x86_64__) || defined(__i386__)
+    __builtin_ia32_pause();
+#elif defined(__aarch64__)
+    __asm__ __volatile__("yield" ::: "memory");
+#endif
+}
 
 // Releases an already-held lock for the duration of a blocking call and
 // reacquires it on scope exit, including when that call throws. Keeps the
@@ -217,17 +236,25 @@ void RdmaTwoSidedTransport::onCtrlFrameReceived(
             break;
         }
         case CtrlFrameType::SESSION_OPEN:
-        case CtrlFrameType::SESSION_CLOSE:
+            handleSessionOpen(peer_server_name, frame);
+            break;
         case CtrlFrameType::CREDIT_GRANT:
+            handleCreditGrant(peer_server_name, frame);
+            break;
         case CtrlFrameType::CREDIT_REQUEST:
-        case CtrlFrameType::CREDIT_PROGRESS:
+            handleCreditRequest(peer_server_name, frame);
+            break;
         case CtrlFrameType::DATA_ACK:
+            handleDataAck(peer_server_name, frame);
+            break;
+        case CtrlFrameType::SESSION_CLOSE:
+        case CtrlFrameType::CREDIT_PROGRESS:
         case CtrlFrameType::FENCE:
         case CtrlFrameType::DRAIN_ACK:
         case CtrlFrameType::CTRL_ACK:
             VLOG(1) << "CtrlChannel: ignoring frame type "
                     << static_cast<int>(frame.type) << " from "
-                    << peer_server_name << " (PR2 notify-only)";
+                    << peer_server_name;
             break;
         default:
             LOG(WARNING) << "CtrlChannel: unknown frame type "
@@ -256,13 +283,25 @@ void RdmaTwoSidedTransport::stopCtrlWorker() {
 }
 
 void RdmaTwoSidedTransport::ctrlWorkerLoop() {
+#ifdef __linux__
+    // Linux inflates short sleeps with per-process timer slack (~50us by
+    // default), which would dominate DATA_ACK latency. Request minimal slack
+    // so the idle wait below approximates its requested duration.
+    prctl(PR_SET_TIMERSLACK, 1, 0, 0, 0);
+#endif
     while (ctrl_worker_running_.load(std::memory_order_acquire)) {
         std::vector<std::shared_ptr<CtrlChannel>> channels;
+        std::vector<std::string> pending_grants;
         {
             std::lock_guard<std::mutex> lock(ctrl_mutex_);
             channels.reserve(ctrl_channels_.size());
             for (auto &entry : ctrl_channels_) {
                 if (entry.second) channels.push_back(entry.second);
+            }
+            for (auto &entry : peer_ctrl_state_) {
+                if (entry.second.grant_pending) {
+                    pending_grants.push_back(entry.first);
+                }
             }
         }
         int processed = 0;
@@ -270,10 +309,453 @@ void RdmaTwoSidedTransport::ctrlWorkerLoop() {
             int ret = channel->pollCompletions(16);
             if (ret > 0) processed += ret;
         }
+        for (const auto &peer : pending_grants) {
+            if (sendInitialCreditGrant(peer) == 0) processed++;
+        }
         if (processed == 0) {
-            std::this_thread::sleep_for(std::chrono::microseconds(100));
+            // Busy-wait while two-sided tasks await DATA_ACK: timer
+            // granularity (especially on virtualized hosts) is far coarser
+            // than the ACK path, so sleeping here would dominate ACK latency.
+            if (twosided_inflight_.load(std::memory_order_acquire) > 0) {
+                for (int i = 0; i < kCtrlSpinPauses; ++i) cpuRelax();
+            } else {
+                // Sleep until a task is dispatched or the idle period elapses.
+                // The predicate check and the fetch_add in
+                // dispatchTwoSidedTask share ctrl_idle_mutex_, so a task
+                // submitted just before the sleep cannot be missed.
+                std::unique_lock<std::mutex> lock(ctrl_idle_mutex_);
+                ctrl_idle_cv_.wait_for(
+                    lock, std::chrono::microseconds(100), [this] {
+                        return twosided_inflight_.load(
+                                   std::memory_order_acquire) > 0;
+                    });
+            }
         }
     }
 }
 
+void RdmaTwoSidedTransport::handleSessionOpen(
+    const std::string &peer_server_name, const CtrlFrame &frame) {
+    uint32_t bounce_slots = 0, bounce_slot_size = 0;
+    if (decodeSessionOpenPayload(frame.payload.data(), frame.payload.size(),
+                                 bounce_slots, bounce_slot_size)) {
+        LOG(ERROR) << "CtrlChannel: bad SESSION_OPEN from " << peer_server_name;
+        return;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &state = peer_ctrl_state_[peer_server_name];
+        state.peer_session = frame.session;
+        state.epoch = frame.epoch ? frame.epoch : 1;
+        state.peer_bounce_slots = bounce_slots;
+        state.peer_bounce_slot_size = bounce_slot_size;
+        state.session_open_received = true;
+
+        if (sender_credit_.activate(peer_server_name, frame.session,
+                                    state.epoch)) {
+            LOG(ERROR) << "CtrlChannel: credit activate failed for "
+                       << peer_server_name;
+            return;
+        }
+        // Defer GRANT to ctrl worker so we never sendCtrlFrame inside the
+        // recv dispatch stack.
+        if (!state.initial_grant_sent && globalConfig().rdma_credit_enabled) {
+            state.grant_pending = true;
+        }
+    }
+
+    LOG(INFO) << "CtrlChannel: SESSION_OPEN from " << peer_server_name
+              << " peer_session=" << frame.session
+              << " bounce_slots=" << bounce_slots
+              << " slot_size=" << bounce_slot_size;
+}
+
+int RdmaTwoSidedTransport::sendInitialCreditGrant(
+    const std::string &peer_server_name) {
+    if (!globalConfig().rdma_credit_enabled) return 0;
+    uint64_t epoch = 1;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &state = peer_ctrl_state_[peer_server_name];
+        if (state.initial_grant_sent) return 0;
+        state.initial_grant_sent = true;
+        state.grant_pending = false;
+        epoch = state.epoch ? state.epoch : 1;
+    }
+    int ret = sendCreditGrant(peer_server_name, epoch);
+    if (ret) {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        peer_ctrl_state_[peer_server_name].initial_grant_sent = false;
+        peer_ctrl_state_[peer_server_name].grant_pending = true;
+    }
+    return ret;
+}
+
+int RdmaTwoSidedTransport::sendCreditGrant(const std::string &peer_server_name,
+                                           uint64_t epoch,
+                                           uint64_t bounce_slots) {
+    std::shared_ptr<CtrlChannel> channel;
+    uint64_t seq = 0;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = ctrl_channels_.find(peer_server_name);
+        if (it == ctrl_channels_.end() || !it->second) return ERR_ENDPOINT;
+        channel = it->second;
+        auto &state = peer_ctrl_state_[peer_server_name];
+        if (epoch == 0) epoch = state.epoch;
+        seq = state.next_grant_seq;
+    }
+    if (!channel || !channel->connected()) return ERR_ENDPOINT;
+
+    if (bounce_slots == 0) {
+        size_t sum = 0;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            auto it = msg_channels_.find(peer_server_name);
+            if (it != msg_channels_.end()) {
+                for (auto &rail : it->second) {
+                    if (rail && rail->connected()) sum += rail->activeSlots();
+                }
+            }
+        }
+        bounce_slots = sum ? sum : globalConfig().rdma_msg_pool_base;
+        if (bounce_slots == 0) bounce_slots = globalConfig().rdma_msg_pool_base;
+    }
+
+    uint64_t bytes =
+        bounce_slots * static_cast<uint64_t>(globalConfig().rdma_msg_slot_size);
+    std::vector<CreditAmount> grants = {
+        {CreditResource::BounceSlots, bounce_slots},
+        {CreditResource::BounceBytes, bytes},
+    };
+    if (globalConfig().rdma_credit_window_bytes > 0) {
+        grants.push_back({CreditResource::DataBytes,
+                          globalConfig().rdma_credit_window_bytes});
+    }
+    if (globalConfig().rdma_credit_window_requests > 0) {
+        grants.push_back({CreditResource::RequestSlots,
+                          globalConfig().rdma_credit_window_requests});
+    }
+
+    CtrlFrame frame;
+    frame.type = CtrlFrameType::CREDIT_GRANT;
+    frame.session = local_ctrl_session_id_;
+    frame.epoch = epoch;
+    frame.seq = seq;
+    if (encodeCreditGrantPayload(grants, frame.payload))
+        return ERR_INVALID_ARGUMENT;
+
+    int ret = channel->sendCtrlFrame(frame);
+    if (ret == 0) {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &state = peer_ctrl_state_[peer_server_name];
+        if (state.next_grant_seq == seq) state.next_grant_seq++;
+        state.granted_bounce_slots = bounce_slots;
+    }
+    return ret;
+}
+
+void RdmaTwoSidedTransport::handleCreditGrant(
+    const std::string &peer_server_name, const CtrlFrame &frame) {
+    std::vector<CreditAmount> grants;
+    if (decodeCreditGrantPayload(frame.payload.data(), frame.payload.size(),
+                                 grants)) {
+        LOG(ERROR) << "CtrlChannel: bad CREDIT_GRANT from " << peer_server_name;
+        return;
+    }
+    int disposition = 0;
+    // Ensure ledger entry exists before apply (GRANT may race SESSION_OPEN).
+    if (sender_credit_.activate(peer_server_name, frame.session, frame.epoch)) {
+        LOG(ERROR) << "CtrlChannel: credit activate failed for grant from "
+                   << peer_server_name;
+        return;
+    }
+    int ret =
+        sender_credit_.applyGrant(peer_server_name, frame.session, frame.epoch,
+                                  frame.seq, grants, disposition);
+    if (ret) {
+        LOG(ERROR) << "CtrlChannel: apply CREDIT_GRANT failed from "
+                   << peer_server_name << " ret=" << ret
+                   << " session=" << frame.session << " epoch=" << frame.epoch
+                   << " seq=" << frame.seq << " grants=" << grants.size();
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &state = peer_ctrl_state_[peer_server_name];
+        state.peer_session = frame.session;
+        state.epoch = frame.epoch ? frame.epoch : state.epoch;
+    }
+    LOG(INFO) << "CtrlChannel: CREDIT_GRANT from " << peer_server_name
+              << " seq=" << frame.seq << " disposition=" << disposition
+              << " grants=" << grants.size();
+    redispatchWaitingTasks();
+}
+
+void RdmaTwoSidedTransport::handleCreditRequest(
+    const std::string &peer_server_name, const CtrlFrame &frame) {
+    (void)frame;
+    std::lock_guard<std::mutex> lock(ctrl_mutex_);
+    peer_ctrl_state_[peer_server_name].expand_requested = true;
+    VLOG(1) << "CtrlChannel: CREDIT_REQUEST from " << peer_server_name;
+}
+
+int RdmaTwoSidedTransport::sendCreditRequest(
+    const std::string &peer_server_name) {
+    std::shared_ptr<CtrlChannel> channel;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = ctrl_channels_.find(peer_server_name);
+        if (it == ctrl_channels_.end() || !it->second) return ERR_ENDPOINT;
+        channel = it->second;
+    }
+    if (!channel || !channel->connected()) return ERR_ENDPOINT;
+    CtrlFrame frame;
+    frame.type = CtrlFrameType::CREDIT_REQUEST;
+    frame.session = local_ctrl_session_id_;
+    frame.epoch = 1;
+    return channel->sendCtrlFrame(frame);
+}
+
+void RdmaTwoSidedTransport::handleDataAck(const std::string &peer_server_name,
+                                          const CtrlFrame &frame) {
+    std::vector<DataAckEntry> acks;
+    if (decodeDataAckPayload(frame.payload.data(), frame.payload.size(),
+                             acks)) {
+        LOG(ERROR) << "CtrlChannel: bad DATA_ACK from " << peer_server_name;
+        return;
+    }
+    for (const auto &ack : acks) {
+        completeTwoSidedAck(ack.task_id, ack.acked_bytes);
+    }
+    VLOG(1) << "CtrlChannel: DATA_ACK from " << peer_server_name
+            << " entries=" << acks.size();
+}
+
+uint64_t RdmaTwoSidedTransport::peerGrantedBounceSlots(
+    const std::string &peer_server_name) {
+    return sender_credit_.availableForPeer(peer_server_name,
+                                           CreditResource::BounceSlots);
+}
+
+size_t RdmaTwoSidedTransport::msgBounceActiveSlots(
+    const std::string &peer_server_name) {
+    std::lock_guard<std::mutex> lock(ctrl_mutex_);
+    auto it = msg_channels_.find(peer_server_name);
+    if (it == msg_channels_.end()) return 0;
+    size_t sum = 0;
+    for (auto &rail : it->second) {
+        if (rail) sum += rail->activeSlots();
+    }
+    return sum;
+}
+
+void RdmaTwoSidedTransport::startBounceManager() {
+    if (bounce_manager_running_.exchange(true)) return;
+    bounce_manager_ = std::thread([this] { bounceManagerLoop(); });
+}
+
+void RdmaTwoSidedTransport::stopBounceManager() {
+    if (!bounce_manager_running_.exchange(false)) return;
+    if (bounce_manager_.joinable()) bounce_manager_.join();
+}
+
+size_t RdmaTwoSidedTransport::waitingTaskCount() {
+    std::lock_guard<std::mutex> lock(twosided_mutex_);
+    return waiting_tasks_.size();
+}
+
+void RdmaTwoSidedTransport::bounceManagerLoop() {
+    while (bounce_manager_running_.load(std::memory_order_acquire)) {
+        manageBouncePoolsTick();
+        auto tick_ms = globalConfig().rdma_msg_bounce_manager_tick_ms;
+        if (tick_ms == 0) tick_ms = 50;
+        std::this_thread::sleep_for(std::chrono::milliseconds(tick_ms));
+    }
+}
+
+void RdmaTwoSidedTransport::manageBouncePoolsTick() {
+    if (!globalConfig().rdma_msg_enabled) return;
+    auto &cfg = globalConfig();
+    const size_t waiting = waitingTaskCount();
+    const auto now_ms = static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+
+    // Ask peers to expand when local transfers are credit-blocked.
+    if (waiting >= cfg.rdma_msg_pending_expand_threshold) {
+        std::vector<std::string> peers;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            for (auto &entry : ctrl_channels_) {
+                if (!entry.second || !entry.second->connected()) continue;
+                auto &st = peer_ctrl_state_[entry.first];
+                if (st.last_credit_request_ms != 0 &&
+                    now_ms < st.last_credit_request_ms +
+                                 cfg.rdma_msg_bounce_manager_tick_ms)
+                    continue;
+                st.last_credit_request_ms = now_ms;
+                peers.push_back(entry.first);
+            }
+        }
+        for (const auto &peer : peers) sendCreditRequest(peer);
+    }
+
+    // Ensure MsgChannel rails exist for peers that requested expand.
+    {
+        std::vector<std::string> need_msg;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            for (auto &entry : peer_ctrl_state_) {
+                if (!entry.second.expand_requested) continue;
+                auto it = msg_channels_.find(entry.first);
+                bool have = false;
+                if (it != msg_channels_.end()) {
+                    for (auto &rail : it->second) {
+                        if (rail && rail->connected()) {
+                            have = true;
+                            break;
+                        }
+                    }
+                }
+                if (!have) need_msg.push_back(entry.first);
+            }
+        }
+        for (const auto &peer : need_msg) ensureMsgRails(peer);
+    }
+
+    std::vector<
+        std::pair<std::string, std::vector<std::shared_ptr<MsgChannel>>>>
+        peer_rails;
+    std::unordered_map<std::string, bool> expand_requested;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        peer_rails.reserve(msg_channels_.size());
+        for (auto &entry : msg_channels_) {
+            std::vector<std::shared_ptr<MsgChannel>> rails;
+            for (auto &rail : entry.second) {
+                if (rail && rail->connected()) rails.push_back(rail);
+            }
+            if (!rails.empty())
+                peer_rails.emplace_back(entry.first, std::move(rails));
+        }
+        for (auto &entry : peer_ctrl_state_) {
+            expand_requested[entry.first] = entry.second.expand_requested;
+        }
+    }
+
+    for (auto &entry : peer_rails) {
+        const std::string &peer = entry.first;
+        auto &rails = entry.second;
+        size_t active_sum = 0;
+        size_t free_send_sum = 0;
+        uint64_t waiting_hints = 0;
+        for (auto &msg : rails) {
+            active_sum += msg->activeSlots();
+            free_send_sum += msg->freeSendSlots();
+            waiting_hints += msg->waitingHints();
+        }
+        if (active_sum == 0) continue;
+        const size_t free_pct = (free_send_sum * 100) / active_sum;
+        const bool peer_asked =
+            expand_requested.count(peer) && expand_requested[peer];
+        const bool expand_hint =
+            waiting_hints > 0 || peer_asked ||
+            waiting >= cfg.rdma_msg_pending_expand_threshold;
+        const bool low_water =
+            free_pct <= cfg.rdma_msg_expand_low_watermark_pct;
+
+        if ((low_water || expand_hint) &&
+            active_sum < cfg.rdma_msg_pool_max * rails.size()) {
+            bool expanded = false;
+            for (auto &msg : rails) {
+                const size_t active = msg->activeSlots();
+                if (active >= cfg.rdma_msg_pool_max) continue;
+                size_t step = cfg.rdma_msg_expand_step;
+                if (step == 0) step = 1;
+                if (active + step > cfg.rdma_msg_pool_max)
+                    step = cfg.rdma_msg_pool_max - active;
+                if (step > 0 && msg->expandPool(step) == 0) expanded = true;
+            }
+            if (expanded) {
+                uint64_t epoch = 1;
+                size_t new_sum = 0;
+                for (auto &msg : rails) new_sum += msg->activeSlots();
+                {
+                    std::lock_guard<std::mutex> lock(ctrl_mutex_);
+                    auto it = peer_ctrl_state_.find(peer);
+                    if (it != peer_ctrl_state_.end()) {
+                        epoch = it->second.epoch ? it->second.epoch : 1;
+                        it->second.high_watermark_since_ms = 0;
+                        it->second.expand_requested = false;
+                    }
+                }
+                if (globalConfig().rdma_credit_enabled) {
+                    sendCreditGrant(peer, epoch, new_sum);
+                }
+                redispatchWaitingTasks();
+            }
+            continue;
+        }
+
+        if (peer_asked) {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            auto it = peer_ctrl_state_.find(peer);
+            if (it != peer_ctrl_state_.end())
+                it->second.expand_requested = false;
+        }
+
+        const bool high_water =
+            free_pct >= cfg.rdma_msg_shrink_high_watermark_pct &&
+            waiting == 0 && waiting_hints == 0 && !peer_asked;
+        if (!high_water ||
+            active_sum <= cfg.rdma_msg_pool_base * rails.size()) {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            auto it = peer_ctrl_state_.find(peer);
+            if (it != peer_ctrl_state_.end()) {
+                it->second.high_watermark_since_ms = 0;
+            }
+            continue;
+        }
+
+        uint64_t since = 0;
+        uint64_t granted = 0;
+        uint64_t epoch = 1;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            auto &state = peer_ctrl_state_[peer];
+            if (state.high_watermark_since_ms == 0) {
+                state.high_watermark_since_ms = now_ms;
+            }
+            since = state.high_watermark_since_ms;
+            granted = state.granted_bounce_slots;
+            epoch = state.epoch ? state.epoch : 1;
+        }
+        if (now_ms < since + cfg.rdma_msg_shrink_idle_ms) continue;
+
+        size_t step = cfg.rdma_msg_expand_step;
+        if (step == 0) step = 1;
+        size_t min_total = cfg.rdma_msg_pool_base * rails.size();
+        size_t target = active_sum > step ? active_sum - step : min_total;
+        if (target < min_total) target = min_total;
+        if (target >= active_sum) continue;
+
+        if (globalConfig().rdma_credit_enabled) {
+            if (granted == 0 || target < granted) {
+                if (sendCreditGrant(peer, epoch, target)) continue;
+            }
+        }
+        // Shrink rails toward a fair per-rail share of the peer total target.
+        size_t per_rail = (target + rails.size() - 1) / rails.size();
+        if (per_rail < cfg.rdma_msg_pool_base)
+            per_rail = cfg.rdma_msg_pool_base;
+        for (auto &msg : rails) msg->shrinkPoolToward(per_rail);
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            peer_ctrl_state_[peer].high_watermark_since_ms = now_ms;
+        }
+    }
+}
 }  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -135,7 +135,9 @@ int MsgChannel::createResources() {
         destroyResources();
         return ERR_ENDPOINT;
     }
-    context_.registerMsgChannel(this);
+    // construct() only runs from connectActive() / acceptPassive(), i.e. after
+    // make_shared has published the owner.
+    context_.registerMsgChannel(shared_from_this());
     registered_with_context_ = true;
     return 0;
 }
@@ -508,9 +510,16 @@ void MsgChannel::dispatchRecv(size_t idx, size_t byte_len) {
 }
 
 int MsgChannel::pollCompletions(int max_entries) {
-    if (!cq_) return 0;
     std::vector<ibv_wc> wc(static_cast<size_t>(max_entries));
-    int n = ibv_poll_cq(cq_, max_entries, wc.data());
+    int n = 0;
+    {
+        // disconnect() destroys cq_ under this lock, so the null check and the
+        // poll must be atomic with respect to it. The WC loop below stays out:
+        // it re-takes the lock and dispatchRecv() re-enters the transport.
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        if (!cq_) return 0;
+        n = ibv_poll_cq(cq_, max_entries, wc.data());
+    }
     if (n < 0) return n;
     for (int i = 0; i < n; ++i) {
         if (wc[i].status != IBV_WC_SUCCESS) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -1,0 +1,545 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/msg_channel.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <sstream>
+#include <vector>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+#include "transport/rdma_transport/rdma_context.h"
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+namespace mooncake {
+
+namespace {
+
+constexpr int kMsgHopLimit = 16;
+constexpr int kMsgTimeout = 14;
+constexpr int kMsgRetryCount = 7;
+
+int parseGidString(const std::string &gid_str, ibv_gid &gid_out) {
+    if (gid_str.empty()) return ERR_INVALID_ARGUMENT;
+    std::istringstream iss(":" + gid_str);
+    for (size_t i = 0; i < sizeof(gid_out.raw); i++) {
+        if (iss.get() != ':') return ERR_INVALID_ARGUMENT;
+        uint32_t byte = 0;
+        iss >> std::hex >> byte;
+        if (iss.fail() || byte > 0xFF) return ERR_INVALID_ARGUMENT;
+        gid_out.raw[i] = static_cast<uint8_t>(byte);
+    }
+    char extra;
+    if (iss.get(extra)) return ERR_INVALID_ARGUMENT;
+    return 0;
+}
+
+}  // namespace
+
+MsgChannel::MsgChannel(RdmaTwoSidedTransport &transport, RdmaContext &context,
+                       std::string peer_server_name)
+    : transport_(transport),
+      context_(context),
+      peer_server_name_(std::move(peer_server_name)) {
+    pool_base_ = globalConfig().rdma_msg_pool_base;
+    pool_max_ = globalConfig().rdma_msg_pool_max;
+    if (pool_max_ < pool_base_) pool_max_ = pool_base_;
+    max_pending_sends_ = pool_max_;
+}
+
+MsgChannel::~MsgChannel() { destroyResources(); }
+
+int MsgChannel::construct() {
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    if (qp_) return 0;
+    return createResources();
+}
+
+int MsgChannel::createResources() {
+    auto &cfg = globalConfig();
+    pool_base_ = cfg.rdma_msg_pool_base;
+    pool_max_ = cfg.rdma_msg_pool_max;
+    if (pool_max_ < pool_base_) pool_max_ = pool_base_;
+    size_t slots = pool_base_;
+    size_t slot_size = cfg.rdma_msg_slot_size;
+    // Soft send cap tracks peer RQ; hard QP/inflight sized to pool_max.
+    max_pending_sends_ = pool_max_;
+    if (slots == 0 || pool_max_ == 0 || slot_size < kMsgHeaderSize + 64) {
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    cq_ = ibv_create_cq(context_.context(), static_cast<int>(cfg.max_cqe),
+                        nullptr, nullptr, 0);
+    if (!cq_) {
+        PLOG(ERROR) << "MsgChannel: failed to create CQ for "
+                    << peer_server_name_;
+        return ERR_ENDPOINT;
+    }
+
+    if (pool_.construct(context_.pd(), slot_size, slots)) {
+        destroyResources();
+        return ERR_MEMORY;
+    }
+
+    ibv_qp_init_attr attr{};
+    attr.send_cq = cq_;
+    attr.recv_cq = cq_;
+    attr.qp_type = IBV_QPT_RC;
+    // Size QP to pool_max so background expand can post_recv without recreate.
+    attr.cap.max_send_wr = static_cast<uint32_t>(pool_max_);
+    attr.cap.max_recv_wr = static_cast<uint32_t>(pool_max_);
+    attr.cap.max_send_sge = 1;
+    attr.cap.max_recv_sge = 1;
+    attr.cap.max_inline_data = static_cast<uint32_t>(cfg.max_inline);
+
+    qp_ = ibv_create_qp(context_.pd(), &attr);
+    if (!qp_) {
+        PLOG(ERROR) << "MsgChannel: failed to create QP for "
+                    << peer_server_name_;
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+
+    ibv_qp_attr qp_attr{};
+    qp_attr.qp_state = IBV_QPS_INIT;
+    qp_attr.port_num = context_.portNum();
+    qp_attr.pkey_index = cfg.pkey_index;
+    qp_attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+    if (ibv_modify_qp(qp_, &qp_attr,
+                      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                          IBV_QP_ACCESS_FLAGS)) {
+        PLOG(ERROR) << "MsgChannel: QP INIT failed";
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+
+    inflight_slots_.assign(pool_max_, -1);
+    if (repostAllRecvs()) {
+        destroyResources();
+        return ERR_ENDPOINT;
+    }
+    context_.registerMsgChannel(this);
+    registered_with_context_ = true;
+    return 0;
+}
+
+void MsgChannel::destroyResources() {
+    if (registered_with_context_) {
+        context_.unregisterMsgChannel(this);
+        registered_with_context_ = false;
+    }
+    connected_.store(false, std::memory_order_release);
+    if (qp_) {
+        ibv_destroy_qp(qp_);
+        qp_ = nullptr;
+    }
+    if (cq_) {
+        ibv_destroy_cq(cq_);
+        cq_ = nullptr;
+    }
+    pool_.destroy();
+    inflight_slots_.clear();
+    pending_sends_ = 0;
+}
+
+std::string MsgChannel::nicPath() const { return context_.nicPath(); }
+
+int MsgChannel::postRecv(size_t idx) {
+    if (!qp_ || idx >= pool_.slotCount()) return ERR_ENDPOINT;
+    auto *mr = pool_.recvSlotMr(idx);
+    auto *ptr = pool_.recvSlotPtr(idx);
+    if (!mr || !ptr) return ERR_ENDPOINT;
+
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<uint64_t>(ptr);
+    sge.length = static_cast<uint32_t>(pool_.slotSize());
+    sge.lkey = mr->lkey;
+
+    ibv_recv_wr wr{};
+    wr.wr_id = idx;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    ibv_recv_wr *bad = nullptr;
+    int ret = ibv_post_recv(qp_, &wr, &bad);
+    if (ret) {
+        LOG(ERROR) << "MsgChannel: ibv_post_recv failed: "
+                   << strerror(std::abs(ret)) << " [" << ret << "]";
+        return ERR_ENDPOINT;
+    }
+    pool_.markRecvPosted(idx, true);
+    return 0;
+}
+
+int MsgChannel::repostAllRecvs() {
+    for (size_t i = 0; i < pool_.activeCount(); ++i) {
+        if (postRecv(i)) return ERR_ENDPOINT;
+    }
+    return 0;
+}
+
+int MsgChannel::expandPool(size_t extra) {
+    if (extra == 0) return 0;
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    if (!qp_) return ERR_ENDPOINT;
+    size_t cur = pool_.slotCount();
+    if (cur >= pool_max_) return 0;
+    if (cur + extra > pool_max_) extra = pool_max_ - cur;
+    size_t old = cur;
+    if (pool_.expand(extra)) return ERR_MEMORY;
+    for (size_t i = old; i < old + extra; ++i) {
+        if (postRecv(i)) return ERR_ENDPOINT;
+    }
+    expand_hint_.store(0, std::memory_order_relaxed);
+    LOG(INFO) << "MsgChannel: expanded bounce pool for " << peer_server_name_
+              << " active=" << pool_.activeCount() << " max=" << pool_max_;
+    return 0;
+}
+
+size_t MsgChannel::shrinkPoolToward(size_t target_active) {
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    if (!qp_) return pool_.activeCount();
+    size_t next = pool_.shrinkToward(target_active, pool_base_);
+    VLOG(1) << "MsgChannel: shrink toward " << target_active
+            << " active=" << next << " allocated=" << pool_.slotCount()
+            << " peer=" << peer_server_name_;
+    return next;
+}
+
+void MsgChannel::fillLocalDesc(HandShakeDesc &local_desc) const {
+    local_desc = HandShakeDesc();
+    local_desc.local_nic_path = context_.nicPath();
+    local_desc.local_lid = context_.lid();
+    local_desc.local_gid = context_.gid();
+    local_desc.peer_nic_path = "__msg__";
+    local_desc.msg_channel = true;
+    local_desc.msg_qp_num = msgQpNum();
+    local_desc.msg_rq_depth = msgRqDepth();
+}
+
+int MsgChannel::connectQp(const std::string &peer_gid, uint16_t peer_lid,
+                          uint32_t peer_qp_num) {
+    if (!qp_ || peer_qp_num == 0) return ERR_INVALID_ARGUMENT;
+    ibv_gid peer_gid_raw{};
+    if (parseGidString(peer_gid, peer_gid_raw)) return ERR_INVALID_ARGUMENT;
+
+    ibv_qp_attr query_attr{};
+    ibv_qp_init_attr query_init{};
+    if (ibv_query_qp(qp_, &query_attr, IBV_QP_STATE, &query_init)) {
+        return ERR_ENDPOINT;
+    }
+
+    ibv_qp_attr attr{};
+    if (query_attr.qp_state != IBV_QPS_INIT) {
+        attr.qp_state = IBV_QPS_RESET;
+        if (ibv_modify_qp(qp_, &attr, IBV_QP_STATE)) return ERR_ENDPOINT;
+        memset(&attr, 0, sizeof(attr));
+        attr.qp_state = IBV_QPS_INIT;
+        attr.port_num = context_.portNum();
+        attr.pkey_index = globalConfig().pkey_index;
+        attr.qp_access_flags = IBV_ACCESS_LOCAL_WRITE;
+        if (ibv_modify_qp(qp_, &attr,
+                          IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
+                              IBV_QP_ACCESS_FLAGS))
+            return ERR_ENDPOINT;
+        if (repostAllRecvs()) return ERR_ENDPOINT;
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTR;
+    attr.path_mtu = context_.activeMTU();
+    if (globalConfig().mtu_length < attr.path_mtu)
+        attr.path_mtu = globalConfig().mtu_length;
+    attr.ah_attr.is_global = 1;
+    attr.ah_attr.grh.dgid = peer_gid_raw;
+    attr.ah_attr.grh.sgid_index = context_.gidIndex();
+    attr.ah_attr.grh.hop_limit = kMsgHopLimit;
+    if (globalConfig().ib_traffic_class >= 0) {
+        attr.ah_attr.grh.traffic_class =
+            static_cast<uint8_t>(globalConfig().ib_traffic_class);
+    }
+    attr.ah_attr.dlid = peer_lid;
+    attr.ah_attr.sl = 0;
+    if (globalConfig().ib_service_level >= 0) {
+        attr.ah_attr.sl = static_cast<uint8_t>(globalConfig().ib_service_level);
+    }
+    attr.ah_attr.port_num = context_.portNum();
+    attr.dest_qp_num = peer_qp_num;
+    attr.rq_psn = 0;
+    attr.max_dest_rd_atomic = 1;
+    attr.min_rnr_timer = 12;
+    if (ibv_modify_qp(qp_, &attr,
+                      IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_MIN_RNR_TIMER |
+                          IBV_QP_AV | IBV_QP_MAX_DEST_RD_ATOMIC |
+                          IBV_QP_DEST_QPN | IBV_QP_RQ_PSN)) {
+        PLOG(ERROR) << "MsgChannel: QP RTR failed";
+        return ERR_ENDPOINT;
+    }
+
+    memset(&attr, 0, sizeof(attr));
+    attr.qp_state = IBV_QPS_RTS;
+    attr.timeout = kMsgTimeout;
+    attr.retry_cnt = kMsgRetryCount;
+    attr.rnr_retry = 7;
+    attr.sq_psn = 0;
+    attr.max_rd_atomic = 1;
+    if (ibv_modify_qp(qp_, &attr,
+                      IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT |
+                          IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN |
+                          IBV_QP_MAX_QP_RD_ATOMIC)) {
+        PLOG(ERROR) << "MsgChannel: QP RTS failed";
+        return ERR_ENDPOINT;
+    }
+    connected_.store(true, std::memory_order_release);
+    return 0;
+}
+
+int MsgChannel::connectActive() {
+    if (construct()) return ERR_ENDPOINT;
+    HandShakeDesc local_desc, peer_desc;
+    fillLocalDesc(local_desc);
+    int ret =
+        transport_.sendHandshake(peer_server_name_, local_desc, peer_desc);
+    if (ret) {
+        LOG(ERROR) << "MsgChannel: active handshake failed to "
+                   << peer_server_name_;
+        return ret;
+    }
+    if (peer_desc.msg_qp_num == 0) {
+        LOG(ERROR) << "MsgChannel: peer has no msg_qp_num";
+        return ERR_ENDPOINT;
+    }
+    if (peer_desc.msg_rq_depth) {
+        max_pending_sends_ =
+            std::min(pool_max_, static_cast<size_t>(peer_desc.msg_rq_depth));
+    }
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
+                    peer_desc.msg_qp_num);
+    if (ret == 0) {
+        LOG(INFO) << "MsgChannel: connected to " << peer_server_name_
+                  << " local_qp=" << msgQpNum()
+                  << " peer_qp=" << peer_desc.msg_qp_num
+                  << " max_pending=" << max_pending_sends_;
+    }
+    return ret;
+}
+
+int MsgChannel::acceptPassive(const HandShakeDesc &peer_desc,
+                              HandShakeDesc &local_desc) {
+    if (construct()) {
+        local_desc.reply_msg = "MsgChannel construct failed";
+        return ERR_ENDPOINT;
+    }
+    if (peer_desc.msg_qp_num == 0) {
+        local_desc.reply_msg = "Peer msg_qp_num missing";
+        return ERR_INVALID_ARGUMENT;
+    }
+    if (peer_desc.msg_rq_depth) {
+        max_pending_sends_ =
+            std::min(pool_max_, static_cast<size_t>(peer_desc.msg_rq_depth));
+    }
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    fillLocalDesc(local_desc);
+    int ret = connectQp(peer_desc.local_gid, peer_desc.local_lid,
+                        peer_desc.msg_qp_num);
+    if (ret) {
+        local_desc.reply_msg = "MsgChannel connectQp failed";
+        return ret;
+    }
+    LOG(INFO) << "MsgChannel: accepted from " << peer_server_name_
+              << " local_qp=" << msgQpNum()
+              << " peer_qp=" << peer_desc.msg_qp_num
+              << " max_pending=" << max_pending_sends_;
+    return 0;
+}
+
+int MsgChannel::postSend(const MsgHeader &hdr, const void *payload,
+                         uint32_t length) {
+    if (!connected_.load(std::memory_order_acquire)) return ERR_ENDPOINT;
+    size_t total = kMsgHeaderSize + length;
+    if (total > pool_.slotSize()) return ERR_INVALID_ARGUMENT;
+
+    std::unique_lock<std::mutex> lock(send_mutex_);
+    if (pending_sends_ >= max_pending_sends_) {
+        requestExpand();
+        return ERR_TOO_MANY_REQUESTS;
+    }
+
+    // resource_mutex_ before BouncePool locks (same order as expand/shrink).
+    std::lock_guard<std::mutex> resource_guard(resource_mutex_);
+    if (!qp_) return ERR_ENDPOINT;
+
+    int slot = pool_.acquireSendSlot();
+    if (slot < 0) {
+        requestExpand();
+        return ERR_TOO_MANY_REQUESTS;
+    }
+
+    char *buf = pool_.slotPtr(slot);
+    if (encodeMsgHeader(hdr, buf, kMsgHeaderSize)) {
+        pool_.releaseSendSlot(slot);
+        return ERR_INVALID_ARGUMENT;
+    }
+    if (length && payload) {
+        std::memcpy(buf + kMsgHeaderSize, payload, length);
+    }
+
+    uint64_t wr_id = send_wr_id_++;
+    {
+        std::lock_guard<std::mutex> inflight(inflight_mutex_);
+        size_t idx = wr_id % inflight_slots_.size();
+        inflight_slots_[idx] = slot;
+    }
+
+    ibv_sge sge{};
+    sge.addr = reinterpret_cast<uint64_t>(buf);
+    sge.length = static_cast<uint32_t>(total);
+    sge.lkey = pool_.slotLkey(slot);
+
+    ibv_send_wr wr{};
+    wr.wr_id = wr_id;
+    wr.sg_list = &sge;
+    wr.num_sge = 1;
+    wr.opcode = IBV_WR_SEND;
+    wr.send_flags = IBV_SEND_SIGNALED;
+    if (total <= globalConfig().max_inline) wr.send_flags |= IBV_SEND_INLINE;
+
+    ibv_send_wr *bad = nullptr;
+    int ret = ibv_post_send(qp_, &wr, &bad);
+    if (ret) {
+        pool_.releaseSendSlot(slot);
+        LOG(ERROR) << "MsgChannel: ibv_post_send failed: "
+                   << strerror(std::abs(ret));
+        return ERR_ENDPOINT;
+    }
+    pending_sends_++;
+    return 0;
+}
+
+int MsgChannel::sendDataWrite(uint64_t task_id, uint8_t slice_seq,
+                              uint64_t dest_addr, const void *src,
+                              uint32_t length) {
+    MsgHeader hdr;
+    hdr.type = MsgType::DATA_WRITE;
+    hdr.task_id = task_id;
+    hdr.slice_seq = slice_seq;
+    hdr.dest_addr = dest_addr;
+    hdr.length = length;
+    return postSend(hdr, src, length);
+}
+
+int MsgChannel::sendReadReq(uint64_t task_id, uint8_t slice_seq,
+                            uint64_t src_addr, uint32_t length) {
+    MsgHeader hdr;
+    hdr.type = MsgType::READ_REQ;
+    hdr.task_id = task_id;
+    hdr.slice_seq = slice_seq;
+    hdr.dest_addr = src_addr;  // remote source address to read from
+    hdr.length = length;
+    return postSend(hdr, nullptr, 0);
+}
+
+int MsgChannel::sendReadResp(uint64_t task_id, uint8_t slice_seq,
+                             uint64_t dest_addr, const void *src,
+                             uint32_t length) {
+    MsgHeader hdr;
+    hdr.type = MsgType::READ_RESP;
+    hdr.task_id = task_id;
+    hdr.slice_seq = slice_seq;
+    hdr.dest_addr = dest_addr;
+    hdr.length = length;
+    return postSend(hdr, src, length);
+}
+
+void MsgChannel::handleSendComplete(uint64_t wr_id) {
+    int slot = -1;
+    {
+        std::lock_guard<std::mutex> inflight(inflight_mutex_);
+        if (!inflight_slots_.empty()) {
+            size_t idx = wr_id % inflight_slots_.size();
+            slot = inflight_slots_[idx];
+            inflight_slots_[idx] = -1;
+        }
+    }
+    if (slot >= 0) pool_.releaseSendSlot(slot);
+    std::lock_guard<std::mutex> lock(send_mutex_);
+    if (pending_sends_ > 0) pending_sends_--;
+}
+
+void MsgChannel::dispatchRecv(size_t idx, size_t byte_len) {
+    if (byte_len < kMsgHeaderSize) return;
+    char *buf = pool_.recvSlotPtr(idx);
+    if (!buf) return;
+    MsgHeader hdr;
+    if (decodeMsgHeader(buf, byte_len, hdr)) {
+        LOG(ERROR) << "MsgChannel: bad msg header from " << peer_server_name_;
+        return;
+    }
+    // READ_REQ carries length in the header but no payload.
+    const bool expects_payload =
+        hdr.type == MsgType::DATA_WRITE || hdr.type == MsgType::READ_RESP;
+    if (expects_payload && kMsgHeaderSize + hdr.length > byte_len) {
+        LOG(ERROR) << "MsgChannel: truncated payload from "
+                   << peer_server_name_;
+        return;
+    }
+    const void *payload = nullptr;
+    if (expects_payload && hdr.length > 0) {
+        payload = static_cast<const void *>(buf + kMsgHeaderSize);
+    }
+    transport_.onMsgReceived(peer_server_name_, hdr, payload, this);
+}
+
+int MsgChannel::pollCompletions(int max_entries) {
+    if (!cq_) return 0;
+    std::vector<ibv_wc> wc(static_cast<size_t>(max_entries));
+    int n = ibv_poll_cq(cq_, max_entries, wc.data());
+    if (n < 0) return n;
+    for (int i = 0; i < n; ++i) {
+        if (wc[i].status != IBV_WC_SUCCESS) {
+            LOG(ERROR) << "MsgChannel: WC error status=" << wc[i].status
+                       << " opcode=" << wc[i].opcode
+                       << " peer=" << peer_server_name_;
+            connected_.store(false, std::memory_order_release);
+            continue;
+        }
+        if (wc[i].opcode == IBV_WC_RECV) {
+            size_t idx = static_cast<size_t>(wc[i].wr_id);
+            size_t len = wc[i].byte_len;
+            // Keep recv_posted=true through dispatch so shrink cannot dereg.
+            dispatchRecv(idx, len);
+            std::lock_guard<std::mutex> lock(resource_mutex_);
+            pool_.markRecvPosted(idx, false);
+            if (idx < pool_.activeCount()) {
+                postRecv(idx);
+            }
+        } else if (wc[i].opcode == IBV_WC_SEND) {
+            handleSendComplete(wc[i].wr_id);
+        }
+    }
+    return n;
+}
+
+void MsgChannel::disconnect() {
+    std::lock_guard<std::mutex> lock(resource_mutex_);
+    destroyResources();
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -198,20 +198,29 @@ int MsgChannel::repostAllRecvs() {
 
 int MsgChannel::expandPool(size_t extra) {
     if (extra == 0) return 0;
-    std::lock_guard<std::mutex> lock(resource_mutex_);
-    if (!qp_) return ERR_ENDPOINT;
-    size_t cur = pool_.slotCount();
-    if (cur >= pool_max_) return 0;
-    if (cur + extra > pool_max_) extra = pool_max_ - cur;
-    size_t old = cur;
-    if (pool_.expand(extra)) return ERR_MEMORY;
-    for (size_t i = old; i < old + extra; ++i) {
-        if (postRecv(i)) return ERR_ENDPOINT;
+    int rc = 0;
+    {
+        std::lock_guard<std::mutex> lock(resource_mutex_);
+        if (!qp_) return ERR_ENDPOINT;
+        size_t cur = pool_.slotCount();
+        if (cur >= pool_max_) return 0;
+        if (cur + extra > pool_max_) extra = pool_max_ - cur;
+        size_t old = cur;
+        if (pool_.expand(extra)) return ERR_MEMORY;
+        for (size_t i = old; i < old + extra; ++i) {
+            if (postRecv(i)) {
+                rc = ERR_ENDPOINT;
+                break;
+            }
+        }
+        expand_hint_.store(0, std::memory_order_relaxed);
+        LOG(INFO) << "MsgChannel: expanded bounce pool for "
+                  << peer_server_name_ << " active=" << pool_.activeCount()
+                  << " max=" << pool_max_;
     }
-    expand_hint_.store(0, std::memory_order_relaxed);
-    LOG(INFO) << "MsgChannel: expanded bounce pool for " << peer_server_name_
-              << " active=" << pool_.activeCount() << " max=" << pool_max_;
-    return 0;
+    // New send slots are available now: replay any held-back READ_RESP.
+    drainPendingReadResps();
+    return rc;
 }
 
 size_t MsgChannel::shrinkPoolToward(size_t target_active) {
@@ -444,11 +453,12 @@ int MsgChannel::postSend(const MsgHeader &hdr, const void *payload,
     return 0;
 }
 
-int MsgChannel::sendDataWrite(uint64_t task_id, uint8_t slice_seq,
+int MsgChannel::sendDataWrite(uint64_t task_id, uint32_t slice_seq,
                               uint64_t dest_addr, const void *src,
                               uint32_t length, uint32_t total_chunks) {
     MsgHeader hdr;
     hdr.type = MsgType::DATA_WRITE;
+    hdr.session = transport_.localCtrlSessionId();
     hdr.task_id = task_id;
     hdr.slice_seq = slice_seq;
     hdr.dest_addr = dest_addr;
@@ -457,10 +467,11 @@ int MsgChannel::sendDataWrite(uint64_t task_id, uint8_t slice_seq,
     return postSend(hdr, src, length);
 }
 
-int MsgChannel::sendReadReq(uint64_t task_id, uint8_t slice_seq,
+int MsgChannel::sendReadReq(uint64_t task_id, uint32_t slice_seq,
                             uint64_t src_addr, uint32_t length) {
     MsgHeader hdr;
     hdr.type = MsgType::READ_REQ;
+    hdr.session = transport_.localCtrlSessionId();
     hdr.task_id = task_id;
     hdr.slice_seq = slice_seq;
     hdr.dest_addr = src_addr;  // remote source address to read from
@@ -468,16 +479,60 @@ int MsgChannel::sendReadReq(uint64_t task_id, uint8_t slice_seq,
     return postSend(hdr, nullptr, 0);
 }
 
-int MsgChannel::sendReadResp(uint64_t task_id, uint8_t slice_seq,
+int MsgChannel::sendReadResp(uint64_t task_id, uint32_t slice_seq,
                              uint64_t dest_addr, const void *src,
                              uint32_t length) {
     MsgHeader hdr;
     hdr.type = MsgType::READ_RESP;
+    hdr.session = transport_.localCtrlSessionId();
     hdr.task_id = task_id;
     hdr.slice_seq = slice_seq;
     hdr.dest_addr = dest_addr;
     hdr.length = length;
     return postSend(hdr, src, length);
+}
+
+int MsgChannel::sendOrQueueReadResp(uint64_t task_id, uint32_t slice_seq,
+                                    uint64_t addr, uint32_t length) {
+    int rc = sendReadResp(task_id, slice_seq, addr,
+                          reinterpret_cast<const void *>(addr), length);
+    if (rc != ERR_TOO_MANY_REQUESTS) return rc;
+    // Bounce pool is momentarily full (postSend already requested an expand).
+    // Hold the response and replay it once a SEND completion or the expansion
+    // frees a slot; the requester waits for this exact slice, so dropping it
+    // would hang the transfer.
+    std::lock_guard<std::mutex> lock(resp_mutex_);
+    pending_resps_.push_back({task_id, addr, length, slice_seq});
+    return 0;
+}
+
+void MsgChannel::drainPendingReadResps() {
+    for (;;) {
+        PendingReadResp item;
+        {
+            std::lock_guard<std::mutex> lock(resp_mutex_);
+            if (pending_resps_.empty()) return;
+            item = pending_resps_.front();
+            pending_resps_.pop_front();
+        }
+        int rc = sendReadResp(item.task_id, item.slice_seq, item.addr,
+                              reinterpret_cast<const void *>(item.addr),
+                              item.length);
+        if (rc == ERR_TOO_MANY_REQUESTS) {
+            // Still full: put it back at the front (order is not required for
+            // correctness since the requester places by slice_seq, but keeping
+            // FIFO avoids starving the oldest response) and wait for the next
+            // recycle.
+            std::lock_guard<std::mutex> lock(resp_mutex_);
+            pending_resps_.push_front(item);
+            return;
+        }
+        if (rc != 0) {
+            LOG(ERROR) << "MsgChannel: dropping queued READ_RESP after send "
+                          "error rc="
+                       << rc << " peer=" << peer_server_name_;
+        }
+    }
 }
 
 void MsgChannel::handleSendComplete(uint64_t wr_id) {
@@ -491,8 +546,12 @@ void MsgChannel::handleSendComplete(uint64_t wr_id) {
         }
     }
     if (slot >= 0) pool_.releaseSendSlot(slot);
-    std::lock_guard<std::mutex> lock(send_mutex_);
-    if (pending_sends_ > 0) pending_sends_--;
+    {
+        std::lock_guard<std::mutex> lock(send_mutex_);
+        if (pending_sends_ > 0) pending_sends_--;
+    }
+    // A send slot just freed up: replay any READ_RESP held back by a full pool.
+    drainPendingReadResps();
 }
 
 void MsgChannel::dispatchRecv(size_t idx, size_t byte_len) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -426,6 +426,15 @@ int MsgChannel::postSend(const MsgHeader &hdr, const void *payload,
     ibv_send_wr *bad = nullptr;
     int ret = ibv_post_send(qp_, &wr, &bad);
     if (ret) {
+        // It is undefined whether the WR entered the queue on failure, so
+        // clear the table entry as well as releasing the slot: a SEND
+        // completion that does arrive must find -1 and skip the release
+        // instead of double-freeing the slot.
+        {
+            std::lock_guard<std::mutex> inflight(inflight_mutex_);
+            size_t idx = wr_id % inflight_slots_.size();
+            if (inflight_slots_[idx] == slot) inflight_slots_[idx] = -1;
+        }
         pool_.releaseSendSlot(slot);
         LOG(ERROR) << "MsgChannel: ibv_post_send failed: "
                    << strerror(std::abs(ret));
@@ -528,6 +537,23 @@ int MsgChannel::pollCompletions(int max_entries) {
                        << " opcode=" << wc[i].opcode
                        << " peer=" << peer_server_name_;
             connected_.store(false, std::memory_order_release);
+            // The channel is dead, so every outstanding SEND is now void.
+            // Error WCs may not carry a reliable opcode/wr_id, so instead of
+            // routing them through handleSendComplete(), return every
+            // in-flight slot to the pool and settle the count here. Entries
+            // are cleared under the lock before release, so a later success
+            // WC for the same wr_id finds -1 and cannot double-release.
+            std::vector<int> slots;
+            {
+                std::lock_guard<std::mutex> inflight(inflight_mutex_);
+                for (int &slot : inflight_slots_) {
+                    if (slot >= 0) slots.push_back(slot);
+                }
+                std::fill(inflight_slots_.begin(), inflight_slots_.end(), -1);
+            }
+            for (int slot : slots) pool_.releaseSendSlot(slot);
+            std::lock_guard<std::mutex> lock(send_mutex_);
+            pending_sends_ = 0;
             continue;
         }
         if (wc[i].opcode == IBV_WC_RECV) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -437,13 +437,14 @@ int MsgChannel::postSend(const MsgHeader &hdr, const void *payload,
 
 int MsgChannel::sendDataWrite(uint64_t task_id, uint8_t slice_seq,
                               uint64_t dest_addr, const void *src,
-                              uint32_t length) {
+                              uint32_t length, uint32_t total_chunks) {
     MsgHeader hdr;
     hdr.type = MsgType::DATA_WRITE;
     hdr.task_id = task_id;
     hdr.slice_seq = slice_seq;
     hdr.dest_addr = dest_addr;
     hdr.length = length;
+    hdr.total_chunks = total_chunks;
     return postSend(hdr, src, length);
 }
 

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/msg_channel.cpp
@@ -219,7 +219,7 @@ int MsgChannel::expandPool(size_t extra) {
                   << " max=" << pool_max_;
     }
     // New send slots are available now: replay any held-back READ_RESP.
-    drainPendingReadResps();
+    pending_read_resps_.onSlotFreed(pendingReadRespSender());
     return rc;
 }
 
@@ -492,47 +492,32 @@ int MsgChannel::sendReadResp(uint64_t task_id, uint32_t slice_seq,
     return postSend(hdr, src, length);
 }
 
+PendingReadRespQueue::TrySendFn MsgChannel::pendingReadRespSender() {
+    return [this](const PendingReadResp &item) {
+        int rc = sendReadResp(item.task_id, item.slice_seq, item.addr,
+                              reinterpret_cast<const void *>(item.addr),
+                              item.length);
+        if (rc != 0 && rc != ERR_TOO_MANY_REQUESTS) {
+            LOG(ERROR) << "MsgChannel: dropping queued READ_RESP after send "
+                          "error rc="
+                       << rc << " peer=" << peer_server_name_;
+        }
+        return rc;
+    };
+}
+
 int MsgChannel::sendOrQueueReadResp(uint64_t task_id, uint32_t slice_seq,
                                     uint64_t addr, uint32_t length) {
     int rc = sendReadResp(task_id, slice_seq, addr,
                           reinterpret_cast<const void *>(addr), length);
     if (rc != ERR_TOO_MANY_REQUESTS) return rc;
     // Bounce pool is momentarily full (postSend already requested an expand).
-    // Hold the response and replay it once a SEND completion or the expansion
-    // frees a slot; the requester waits for this exact slice, so dropping it
-    // would hang the transfer.
-    std::lock_guard<std::mutex> lock(resp_mutex_);
-    pending_resps_.push_back({task_id, addr, length, slice_seq});
+    // Enqueue then kick a serialized drain so a SEND completion that landed
+    // between the failed post and this enqueue cannot leave the response
+    // stranded (lost wakeup).
+    pending_read_resps_.enqueue({task_id, addr, length, slice_seq},
+                                pendingReadRespSender());
     return 0;
-}
-
-void MsgChannel::drainPendingReadResps() {
-    for (;;) {
-        PendingReadResp item;
-        {
-            std::lock_guard<std::mutex> lock(resp_mutex_);
-            if (pending_resps_.empty()) return;
-            item = pending_resps_.front();
-            pending_resps_.pop_front();
-        }
-        int rc = sendReadResp(item.task_id, item.slice_seq, item.addr,
-                              reinterpret_cast<const void *>(item.addr),
-                              item.length);
-        if (rc == ERR_TOO_MANY_REQUESTS) {
-            // Still full: put it back at the front (order is not required for
-            // correctness since the requester places by slice_seq, but keeping
-            // FIFO avoids starving the oldest response) and wait for the next
-            // recycle.
-            std::lock_guard<std::mutex> lock(resp_mutex_);
-            pending_resps_.push_front(item);
-            return;
-        }
-        if (rc != 0) {
-            LOG(ERROR) << "MsgChannel: dropping queued READ_RESP after send "
-                          "error rc="
-                       << rc << " peer=" << peer_server_name_;
-        }
-    }
 }
 
 void MsgChannel::handleSendComplete(uint64_t wr_id) {
@@ -551,7 +536,7 @@ void MsgChannel::handleSendComplete(uint64_t wr_id) {
         if (pending_sends_ > 0) pending_sends_--;
     }
     // A send slot just freed up: replay any READ_RESP held back by a full pool.
-    drainPendingReadResps();
+    pending_read_resps_.onSlotFreed(pendingReadRespSender());
 }
 
 void MsgChannel::dispatchRecv(size_t idx, size_t byte_len) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/pending_read_resp_queue.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/pending_read_resp_queue.cpp
@@ -1,0 +1,90 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/pending_read_resp_queue.h"
+
+namespace mooncake {
+
+void PendingReadRespQueue::enqueue(PendingReadResp item,
+                                   const TrySendFn &try_send) {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        pending_.push_back(std::move(item));
+    }
+    kick(try_send);
+}
+
+void PendingReadRespQueue::onSlotFreed(const TrySendFn &try_send) {
+    kick(try_send);
+}
+
+size_t PendingReadRespQueue::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return pending_.size();
+}
+
+bool PendingReadRespQueue::drainRunningForTest() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return drain_running_;
+}
+
+void PendingReadRespQueue::kick(const TrySendFn &try_send) {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (drain_running_) {
+            // A concurrent enqueue or slot free arrived while another thread
+            // owns the drain loop. That owner must re-examine the queue before
+            // clearing drain_running_, or this kick is lost.
+            recheck_ = true;
+            return;
+        }
+        drain_running_ = true;
+    }
+
+    for (;;) {
+        PendingReadResp item;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (pending_.empty()) {
+                if (!recheck_) {
+                    drain_running_ = false;
+                    return;
+                }
+                recheck_ = false;
+                continue;
+            }
+            item = pending_.front();
+            pending_.pop_front();
+        }
+
+        int rc = try_send(item);
+        if (rc == ERR_TOO_MANY_REQUESTS) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            pending_.push_front(item);
+            if (recheck_) {
+                // Slot may have freed (or a new item arrived) during try_send.
+                // Clear the flag and retry; if the pool is still full we will
+                // hit TOO_MANY again with recheck_ false and exit cleanly.
+                recheck_ = false;
+                continue;
+            }
+            drain_running_ = false;
+            return;
+        }
+        // Success (0) or hard error (item dropped by try_send / caller): keep
+        // draining any remaining queued responses.
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/rdma_twosided_transport.cpp
@@ -18,9 +18,11 @@
 
 #include <mutex>
 #include <random>
+#include <vector>
 
 #include "config.h"
 #include "transport/rdma_twosided/ctrl_channel.h"
+#include "transport/rdma_twosided/msg_channel.h"
 
 namespace mooncake {
 
@@ -32,13 +34,26 @@ RdmaTwoSidedTransport::RdmaTwoSidedTransport() {
 }
 
 RdmaTwoSidedTransport::~RdmaTwoSidedTransport() {
+    stopBounceManager();
     stopCtrlWorker();
-    std::lock_guard<std::mutex> lock(ctrl_mutex_);
-    for (auto &entry : ctrl_channels_) {
-        if (entry.second) entry.second->disconnect();
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        for (auto &entry : ctrl_channels_) {
+            if (entry.second) entry.second->disconnect();
+        }
+        ctrl_channels_.clear();
+        msg_channels_.clear();
+        ctrl_cv_.notify_all();
     }
-    ctrl_channels_.clear();
-    ctrl_cv_.notify_all();
+    // Release TE-owned managed buffers; peer-owned ones are only unregistered.
+    std::vector<void *> owned;
+    {
+        std::lock_guard<std::mutex> lock(managed_mutex_);
+        for (auto &entry : managed_buffers_) {
+            if (entry.second.owned) owned.push_back(entry.second.addr);
+        }
+    }
+    for (auto *addr : owned) releaseManagedBuffer(addr);
 }
 
 int RdmaTwoSidedTransport::install(std::string &local_server_name,
@@ -46,8 +61,11 @@ int RdmaTwoSidedTransport::install(std::string &local_server_name,
                                    std::shared_ptr<Topology> topo) {
     int ret = RdmaTransport::install(local_server_name, meta, topo);
     if (ret) return ret;
-    if (globalConfig().rdma_notify_enabled) {
+    if (globalConfig().rdma_notify_enabled || globalConfig().rdma_msg_enabled) {
         startCtrlWorker();
+    }
+    if (globalConfig().rdma_msg_enabled) {
+        startBounceManager();
     }
     return 0;
 }
@@ -56,6 +74,9 @@ int RdmaTwoSidedTransport::onSetupRdmaConnections(
     const HandShakeDesc &peer_desc, HandShakeDesc &local_desc) {
     if (peer_desc.ctrl_channel) {
         return onSetupCtrlChannel(peer_desc, local_desc);
+    }
+    if (peer_desc.msg_channel) {
+        return onSetupMsgChannel(peer_desc, local_desc);
     }
     return RdmaTransport::onSetupRdmaConnections(peer_desc, local_desc);
 }

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/sender_credit.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/sender_credit.cpp
@@ -167,6 +167,21 @@ int SenderCreditLedger::available(const std::string &peer, uint64_t session,
     return 0;
 }
 
+int SenderCreditLedger::grantTotal(const std::string &peer, uint64_t session,
+                                   uint64_t epoch, CreditResource resource,
+                                   uint64_t &out) const {
+    if (epoch == 0) return ERR_INVALID_ARGUMENT;
+    size_t i = 0;
+    if (resourceIndex(resource, i)) return ERR_INVALID_ARGUMENT;
+    std::lock_guard<std::mutex> lock(mutex_);
+    Key key{peer, session};
+    auto it = entries_.find(key);
+    if (it == entries_.end() || it->second.epoch != epoch)
+        return ERR_INVALID_ARGUMENT;
+    out = it->second.grants[i];
+    return 0;
+}
+
 uint64_t SenderCreditLedger::availableForPeer(const std::string &peer,
                                               CreditResource resource) const {
     size_t i = 0;

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
@@ -1,0 +1,684 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "transport/rdma_twosided/rdma_twosided_transport.h"
+
+#include <glog/logging.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+#include "common.h"
+#include "config.h"
+#include "error.h"
+#include "transport/rdma_twosided/ctrl_channel.h"
+#include "transport/rdma_twosided/msg_channel.h"
+#include "transport/rdma_transport/rdma_context.h"
+
+namespace mooncake {
+
+void *RdmaTwoSidedTransport::allocateManagedBuffer(size_t length) {
+    if (length == 0 || !globalConfig().rdma_msg_enabled) return nullptr;
+    void *addr = nullptr;
+    if (posix_memalign(&addr, 64, length)) return nullptr;
+    std::memset(addr, 0, length);
+    if (registerManagedBufferInternal(addr, length, /*owned=*/true)) {
+        free(addr);
+        return nullptr;
+    }
+    return addr;
+}
+
+int RdmaTwoSidedTransport::registerManagedBuffer(void *addr, size_t length) {
+    return registerManagedBufferInternal(addr, length, /*owned=*/false);
+}
+
+int RdmaTwoSidedTransport::registerManagedBufferInternal(void *addr,
+                                                         size_t length,
+                                                         bool owned) {
+    if (!addr || length == 0) return ERR_INVALID_ARGUMENT;
+    if (!globalConfig().rdma_msg_enabled) return ERR_INVALID_ARGUMENT;
+    const uint64_t base = reinterpret_cast<uint64_t>(addr);
+    const uint64_t end = base + length;
+    std::lock_guard<std::mutex> lock(managed_mutex_);
+    for (const auto &entry : managed_buffers_) {
+        uint64_t ebase = entry.first;
+        uint64_t eend = ebase + entry.second.length;
+        if (!(end <= ebase || base >= eend)) return ERR_ADDRESS_OVERLAPPED;
+    }
+    // Two-sided buffers stay host memory only: no ibv_reg_mr / BufferDesc.
+    managed_buffers_[base] = {addr, length, owned};
+    return 0;
+}
+
+int RdmaTwoSidedTransport::releaseManagedBuffer(void *addr) {
+    if (!addr) return ERR_INVALID_ARGUMENT;
+    ManagedBuffer mb;
+    {
+        std::lock_guard<std::mutex> lock(managed_mutex_);
+        auto it = managed_buffers_.find(reinterpret_cast<uint64_t>(addr));
+        if (it == managed_buffers_.end()) return ERR_ADDRESS_NOT_REGISTERED;
+        mb = it->second;
+        managed_buffers_.erase(it);
+    }
+    if (mb.owned) free(mb.addr);
+    return 0;
+}
+
+bool RdmaTwoSidedTransport::isLocalManaged(uint64_t addr, size_t length) const {
+    std::lock_guard<std::mutex> lock(managed_mutex_);
+    for (const auto &entry : managed_buffers_) {
+        uint64_t base = entry.first;
+        uint64_t end = base + entry.second.length;
+        if (addr >= base && addr + length <= end) return true;
+    }
+    return false;
+}
+
+bool RdmaTwoSidedTransport::isRemoteTwoSided(SegmentID target_id,
+                                             uint64_t offset,
+                                             size_t length) const {
+    (void)offset;
+    (void)length;
+    auto desc = metadata_->getSegmentDescByID(target_id);
+    if (!desc) return false;
+    // Peer capability bit (not per-buffer registration). Dest validity is
+    // checked on the receiver via validateLocalManagedDest.
+    return desc->supports_two_sided_msg;
+}
+
+bool RdmaTwoSidedTransport::shouldUseTwoSided(const TransferRequest &req) {
+    if (!globalConfig().rdma_msg_enabled || !globalConfig().rdma_msg_default)
+        return false;
+    if (!isLocalManaged(reinterpret_cast<uint64_t>(req.source), req.length))
+        return false;
+    return isRemoteTwoSided(req.target_id, req.target_offset, req.length);
+}
+
+bool RdmaTwoSidedTransport::validateLocalManagedDest(uint64_t dest_addr,
+                                                     uint32_t length) const {
+    return isLocalManaged(dest_addr, length);
+}
+
+int RdmaTwoSidedTransport::onSetupMsgChannel(const HandShakeDesc &peer_desc,
+                                             HandShakeDesc &local_desc) {
+    if (!globalConfig().rdma_msg_enabled) {
+        local_desc.reply_msg = "RDMA msg disabled";
+        return ERR_INVALID_ARGUMENT;
+    }
+    if (getContextList().empty()) {
+        local_desc.reply_msg = "No local RDMA context for MsgChannel";
+        return ERR_DEVICE_NOT_FOUND;
+    }
+    std::string peer_server_name =
+        getServerNameFromNicPath(peer_desc.local_nic_path);
+    if (peer_server_name.empty()) {
+        local_desc.reply_msg = "Cannot derive peer server name";
+        return ERR_INVALID_ARGUMENT;
+    }
+
+    std::shared_ptr<MsgChannel> channel;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &rails = msg_channels_[peer_server_name];
+        auto context = selectMsgContext(peer_desc, rails.size());
+        if (!context) {
+            local_desc.reply_msg = "No local RDMA context for MsgChannel rail";
+            return ERR_DEVICE_NOT_FOUND;
+        }
+        // Replace an existing rail on the same local NIC, if any.
+        const std::string local_path = context->nicPath();
+        for (auto &existing : rails) {
+            if (existing && existing->nicPath() == local_path) {
+                existing->disconnect();
+                existing = std::make_shared<MsgChannel>(*this, *context,
+                                                        peer_server_name);
+                channel = existing;
+                break;
+            }
+        }
+        if (!channel) {
+            channel =
+                std::make_shared<MsgChannel>(*this, *context, peer_server_name);
+            rails.push_back(channel);
+        }
+    }
+    return channel->acceptPassive(peer_desc, local_desc);
+}
+
+std::shared_ptr<RdmaContext> RdmaTwoSidedTransport::selectMsgContext(
+    const HandShakeDesc &peer_desc, size_t existing_rail_count) {
+    if (getContextList().empty()) return nullptr;
+    // Prefer matching peer NIC device name to a local HCA / context.
+    const std::string peer_nic =
+        getNicNameFromNicPath(peer_desc.local_nic_path);
+    if (!peer_nic.empty() && localTopology()) {
+        int index = 0;
+        for (auto &entry : localTopology()->getHcaList()) {
+            if (entry == peer_nic &&
+                index < static_cast<int>(getContextList().size())) {
+                return getContextList()[index];
+            }
+            index++;
+        }
+        for (auto &ctx : getContextList()) {
+            if (ctx && ctx->deviceName() == peer_nic) return ctx;
+        }
+    }
+    // Fallback: zip by handshake order (active iterates context list order).
+    size_t idx = existing_rail_count % getContextList().size();
+    return getContextList()[idx];
+}
+
+std::vector<std::shared_ptr<MsgChannel>> RdmaTwoSidedTransport::ensureMsgRails(
+    const std::string &peer_server_name) {
+    std::vector<std::shared_ptr<MsgChannel>> connected;
+    if (!globalConfig().rdma_msg_enabled || getContextList().empty()) {
+        return connected;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = msg_channels_.find(peer_server_name);
+        if (it != msg_channels_.end()) {
+            for (auto &rail : it->second) {
+                if (rail && rail->connected()) connected.push_back(rail);
+            }
+            if (connected.size() == getContextList().size()) return connected;
+        }
+    }
+
+    // Build / reconnect missing rails outside the lock (handshake may block).
+    std::vector<std::shared_ptr<MsgChannel>> created;
+    created.reserve(getContextList().size());
+    for (auto &ctx : getContextList()) {
+        if (!ctx) continue;
+        bool have = false;
+        {
+            std::lock_guard<std::mutex> lock(ctrl_mutex_);
+            auto it = msg_channels_.find(peer_server_name);
+            if (it != msg_channels_.end()) {
+                for (auto &rail : it->second) {
+                    if (rail && rail->nicPath() == ctx->nicPath() &&
+                        rail->connected()) {
+                        have = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if (have) continue;
+        auto channel =
+            std::make_shared<MsgChannel>(*this, *ctx, peer_server_name);
+        if (channel->connectActive()) {
+            LOG(WARNING) << "MsgChannel: rail connect failed peer="
+                         << peer_server_name << " nic=" << ctx->nicPath();
+            continue;
+        }
+        created.push_back(channel);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto &rails = msg_channels_[peer_server_name];
+        for (auto &channel : created) {
+            bool replaced = false;
+            for (auto &existing : rails) {
+                if (existing && existing->nicPath() == channel->nicPath()) {
+                    if (existing.get() != channel.get()) {
+                        existing->disconnect();
+                        existing = channel;
+                    }
+                    replaced = true;
+                    break;
+                }
+            }
+            if (!replaced) rails.push_back(channel);
+        }
+        connected.clear();
+        for (auto &rail : rails) {
+            if (rail && rail->connected()) connected.push_back(rail);
+        }
+    }
+    return connected;
+}
+
+std::shared_ptr<MsgChannel> RdmaTwoSidedTransport::ensureMsgChannel(
+    const std::string &peer_server_name) {
+    auto rails = ensureMsgRails(peer_server_name);
+    if (rails.empty()) return nullptr;
+    return rails.front();
+}
+
+Status RdmaTwoSidedTransport::submitTransferTask(
+    const std::vector<TransferTask *> &task_list) {
+    std::vector<TransferTask *> one_sided, two_sided;
+    one_sided.reserve(task_list.size());
+    for (auto *task : task_list) {
+        if (task && task->request && shouldUseTwoSided(*task->request))
+            two_sided.push_back(task);
+        else
+            one_sided.push_back(task);
+    }
+    if (!two_sided.empty()) {
+        Status s = submitTwoSidedTasks(two_sided);
+        if (!s.ok()) return s;
+    }
+    if (!one_sided.empty()) return RdmaTransport::submitTransferTask(one_sided);
+    return Status::OK();
+}
+
+Status RdmaTwoSidedTransport::submitTwoSidedTasks(
+    const std::vector<TransferTask *> &tasks) {
+    for (auto *task : tasks) {
+        assert(task && task->request);
+        // One logical slice covering the whole transfer for status tracking.
+        Slice *slice = getSliceCache().allocate();
+        slice->source_addr = task->request->source;
+        slice->length = task->request->length;
+        slice->opcode = task->request->opcode;
+        slice->rdma.dest_addr = task->request->target_offset;
+        slice->task = task;
+        slice->target_id = task->request->target_id;
+        slice->status = Slice::PENDING;
+        task->slice_list.push_back(slice);
+        task->total_bytes = task->request->length;
+        __sync_fetch_and_add(&task->slice_count, 1);
+
+        int rc = dispatchTwoSidedTask(task);
+        if (rc == ERR_TOO_MANY_REQUESTS) {
+            std::lock_guard<std::mutex> lock(twosided_mutex_);
+            waiting_tasks_.push_back(task);
+            // dispatchTwoSidedTask already inserted TwoSidedTaskState; just
+            // mark waiting (do not allocate a second task_id for the same
+            // task).
+            for (auto &entry : twosided_tasks_) {
+                if (entry.second.task == task) {
+                    entry.second.waiting_credit = true;
+                    if (!task->slice_list.empty())
+                        task->slice_list[0]->ts = entry.first;
+                    break;
+                }
+            }
+            continue;
+        }
+        if (rc) {
+            slice->markFailed();
+            return Status::InvalidArgument("two-sided submit failed");
+        }
+    }
+    return Status::OK();
+}
+
+int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
+    if (!task || task->slice_list.empty() || !task->slice_list[0])
+        return ERR_INVALID_ARGUMENT;
+    // submitTransfer({req}) only keeps request alive for the call; after that
+    // task->request dangles. Slice fields are snapshotted while it was valid.
+    Slice *slice = task->slice_list[0];
+    const auto opcode = slice->opcode;
+    void *source = slice->source_addr;
+    const size_t length = slice->length;
+    const SegmentID target_id = slice->target_id;
+    const uint64_t target_offset = slice->rdma.dest_addr;
+
+    auto desc = metadata_->getSegmentDescByID(target_id);
+    if (!desc) return ERR_METADATA;
+    const std::string &peer = desc->name;
+
+    // Ensure ctrl + multi-rail msg channels.
+    if (!ensureCtrlChannel(peer)) return ERR_ENDPOINT;
+    auto rails = ensureMsgRails(peer);
+    if (rails.empty()) return ERR_ENDPOINT;
+
+    uint64_t session = 0;
+    // The ledger rejects mutations whose epoch does not match the session's
+    // current generation, so the epoch has to travel with every reserve and
+    // rollback for this task.
+    uint64_t epoch = 1;
+    bool session_known = false;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = peer_ctrl_state_.find(peer);
+        if (it != peer_ctrl_state_.end()) {
+            session = it->second.peer_session;
+            if (it->second.epoch) epoch = it->second.epoch;
+        }
+    }
+    if (session == 0)
+        session = 1;  // may still be bootstrapping
+    else
+        session_known = true;
+
+    size_t max_payload =
+        globalConfig().rdma_msg_slot_size > kMsgHeaderSize
+            ? globalConfig().rdma_msg_slot_size - kMsgHeaderSize
+            : 0;
+    if (max_payload == 0) return ERR_INVALID_ARGUMENT;
+
+    uint64_t task_id = 0;
+    {
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        // Reuse existing state if redispatching a waiting task.
+        for (auto &entry : twosided_tasks_) {
+            if (entry.second.task == task) {
+                task_id = entry.first;
+                entry.second.waiting_credit = false;
+                entry.second.peer = peer;
+                entry.second.peer_session = session;
+                entry.second.peer_epoch = epoch;
+                entry.second.opcode = opcode;
+                entry.second.local_buf = source;
+                entry.second.total_bytes = length;
+                break;
+            }
+        }
+        if (task_id == 0) {
+            task_id = next_task_id_.fetch_add(1);
+            TwoSidedTaskState st;
+            st.task = task;
+            st.task_id = task_id;
+            st.total_bytes = length;
+            st.peer = peer;
+            st.peer_session = session;
+            st.peer_epoch = epoch;
+            st.opcode = opcode;
+            st.local_buf = source;
+            twosided_tasks_[task_id] = st;
+            slice->ts = task_id;
+        }
+    }
+
+    // Credit reserve for full transfer (bounce slots ≈ ceil(len/payload)).
+    size_t slots_needed = (length + max_payload - 1) / max_payload;
+    if (slots_needed == 0) slots_needed = 1;
+    if (globalConfig().rdma_credit_enabled) {
+        // Credits exist only after the peer's CREDIT_GRANT activated the
+        // session in the ledger. Dispatching before that is backpressure, not
+        // an error, so queue the task; handleCreditGrant redispatches it.
+        if (!session_known) return ERR_TOO_MANY_REQUESTS;
+        int rc = sender_credit_.tryReserve(
+            peer, session, epoch,
+            {{CreditResource::BounceSlots, slots_needed},
+             {CreditResource::BounceBytes, length}});
+        if (rc) {
+            for (auto &rail : rails) {
+                if (rail) rail->requestExpand();
+            }
+            return rc;
+        }
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        auto it = twosided_tasks_.find(task_id);
+        if (it != twosided_tasks_.end()) {
+            it->second.credit_reserved = true;
+            it->second.reserved_slots = slots_needed;
+            it->second.reserved_bytes = length;
+            it->second.peer_session = session;
+            it->second.peer = peer;
+        }
+    }
+
+    auto spraySend = [&](uint8_t seq, auto &&send_fn) -> int {
+        const size_t n = rails.size();
+        const size_t start = static_cast<size_t>(seq) % n;
+        int last_rc = ERR_ENDPOINT;
+        for (size_t attempt = 0; attempt < n; ++attempt) {
+            auto &rail = rails[(start + attempt) % n];
+            if (!rail || !rail->connected()) continue;
+            last_rc = send_fn(rail);
+            if (last_rc == 0) return 0;
+            if (last_rc != ERR_TOO_MANY_REQUESTS) return last_rc;
+        }
+        for (auto &rail : rails) {
+            if (rail) rail->requestExpand();
+        }
+        return last_rc ? last_rc : ERR_TOO_MANY_REQUESTS;
+    };
+
+    if (opcode == TransferRequest::WRITE) {
+        uint8_t seq = 0;
+        for (size_t off = 0; off < length; off += max_payload, ++seq) {
+            uint32_t chunk =
+                static_cast<uint32_t>(std::min(max_payload, length - off));
+            const char *src = static_cast<const char *>(source) + off;
+            int rc =
+                spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
+                    return msg->sendDataWrite(task_id, seq, target_offset + off,
+                                              src, chunk);
+                });
+            if (rc) {
+                if (globalConfig().rdma_credit_enabled) {
+                    sender_credit_.rollbackReservation(
+                        peer, session, epoch,
+                        {{CreditResource::BounceSlots, slots_needed},
+                         {CreditResource::BounceBytes, length}});
+                    std::lock_guard<std::mutex> lock(twosided_mutex_);
+                    auto it = twosided_tasks_.find(task_id);
+                    if (it != twosided_tasks_.end()) {
+                        it->second.credit_reserved = false;
+                    }
+                }
+                return rc;
+            }
+        }
+    } else {
+        uint8_t seq = 0;
+        for (size_t off = 0; off < length; off += max_payload, ++seq) {
+            uint32_t chunk =
+                static_cast<uint32_t>(std::min(max_payload, length - off));
+            int rc =
+                spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
+                    return msg->sendReadReq(task_id, seq, target_offset + off,
+                                            chunk);
+                });
+            if (rc) {
+                if (globalConfig().rdma_credit_enabled) {
+                    sender_credit_.rollbackReservation(
+                        peer, session, epoch,
+                        {{CreditResource::BounceSlots, slots_needed},
+                         {CreditResource::BounceBytes, length}});
+                    std::lock_guard<std::mutex> lock(twosided_mutex_);
+                    auto it = twosided_tasks_.find(task_id);
+                    if (it != twosided_tasks_.end()) {
+                        it->second.credit_reserved = false;
+                    }
+                }
+                return rc;
+            }
+        }
+    }
+    // Publish the dispatch under ctrl_idle_mutex_ and wake the ctrl worker:
+    // the worker may be parked in its idle wait, which would otherwise delay
+    // the DATA_ACK drain by the whole wait period.
+    {
+        std::lock_guard<std::mutex> lock(ctrl_idle_mutex_);
+        twosided_inflight_.fetch_add(1, std::memory_order_acq_rel);
+    }
+    ctrl_idle_cv_.notify_one();
+    return 0;
+}
+
+void RdmaTwoSidedTransport::redispatchWaitingTasks() {
+    std::deque<TransferTask *> pending;
+    {
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        pending.swap(waiting_tasks_);
+    }
+    for (auto *task : pending) {
+        int rc = dispatchTwoSidedTask(task);
+        if (rc == ERR_TOO_MANY_REQUESTS) {
+            std::lock_guard<std::mutex> lock(twosided_mutex_);
+            waiting_tasks_.push_back(task);
+        } else if (rc) {
+            if (!task->slice_list.empty()) task->slice_list[0]->markFailed();
+        }
+    }
+}
+
+void RdmaTwoSidedTransport::completeTwoSidedAck(uint64_t task_id,
+                                                uint64_t acked_bytes) {
+    TransferTask *task = nullptr;
+    TwoSidedTaskState finished;
+    bool do_rollback = false;
+    {
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        auto it = twosided_tasks_.find(task_id);
+        if (it == twosided_tasks_.end()) return;
+        if (acked_bytes > it->second.acked_bytes)
+            it->second.acked_bytes = acked_bytes;
+        if (it->second.acked_bytes < it->second.total_bytes) return;
+        finished = it->second;
+        task = it->second.task;
+        do_rollback = it->second.credit_reserved;
+        twosided_tasks_.erase(it);
+    }
+    twosided_inflight_.fetch_sub(1, std::memory_order_acq_rel);
+    if (do_rollback && globalConfig().rdma_credit_enabled) {
+        sender_credit_.rollbackReservation(
+            finished.peer, finished.peer_session, finished.peer_epoch,
+            {{CreditResource::BounceSlots, finished.reserved_slots},
+             {CreditResource::BounceBytes, finished.reserved_bytes}});
+        redispatchWaitingTasks();
+    }
+    if (task && !task->slice_list.empty()) {
+        task->slice_list[0]->markSuccess();
+    }
+}
+
+int RdmaTwoSidedTransport::sendDataAck(const std::string &peer,
+                                       uint64_t task_id, uint64_t acked_bytes) {
+    std::shared_ptr<CtrlChannel> channel;
+    {
+        std::lock_guard<std::mutex> lock(ctrl_mutex_);
+        auto it = ctrl_channels_.find(peer);
+        if (it == ctrl_channels_.end()) return ERR_ENDPOINT;
+        channel = it->second;
+    }
+    if (!channel || !channel->connected()) return ERR_ENDPOINT;
+    CtrlFrame frame;
+    frame.type = CtrlFrameType::DATA_ACK;
+    frame.session = local_ctrl_session_id_;
+    frame.epoch = 1;
+    std::vector<DataAckEntry> acks = {{task_id, acked_bytes}};
+    if (encodeDataAckPayload(acks, frame.payload)) return ERR_INVALID_ARGUMENT;
+    return channel->sendCtrlFrame(frame);
+}
+
+void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
+                                          const MsgHeader &hdr,
+                                          const void *payload,
+                                          MsgChannel *channel) {
+    if (hdr.type == MsgType::DATA_WRITE) {
+        if (!validateLocalManagedDest(hdr.dest_addr, hdr.length)) {
+            LOG(ERROR) << "MsgChannel: illegal DATA_WRITE dest from "
+                       << peer_server_name;
+            return;
+        }
+        if (payload && hdr.length) {
+            std::memcpy(reinterpret_cast<void *>(hdr.dest_addr), payload,
+                        hdr.length);
+        }
+        // Accumulate per-task received bytes and ACK cumulatively.
+        uint64_t cumulative = 0;
+        {
+            std::lock_guard<std::mutex> lock(recv_ack_mutex_);
+            recv_acked_bytes_[hdr.task_id] += hdr.length;
+            cumulative = recv_acked_bytes_[hdr.task_id];
+        }
+        (void)sendDataAck(peer_server_name, hdr.task_id, cumulative);
+        return;
+    }
+    if (hdr.type == MsgType::READ_REQ) {
+        // hdr.dest_addr is remote(=our) source address; respond to peer's
+        // request. Peer expects READ_RESP into their local buffer — we don't
+        // know their dest here, so encode dest_addr=0 and length; the
+        // requester places data at its TransferRequest::source + slice.
+        // For MVP: READ_RESP.dest_addr carries the original src offset; the
+        // requester maps slice_seq → local dest.
+        if (!validateLocalManagedDest(hdr.dest_addr, hdr.length)) {
+            LOG(ERROR) << "MsgChannel: illegal READ_REQ src from "
+                       << peer_server_name;
+            return;
+        }
+        // Prefer same rail that received READ_REQ to avoid cross-rail hop.
+        if (channel && channel->connected()) {
+            (void)channel->sendReadResp(
+                hdr.task_id, hdr.slice_seq, hdr.dest_addr,
+                reinterpret_cast<const void *>(hdr.dest_addr), hdr.length);
+            return;
+        }
+        auto msg = ensureMsgChannel(peer_server_name);
+        if (!msg) return;
+        (void)msg->sendReadResp(hdr.task_id, hdr.slice_seq, hdr.dest_addr,
+                                reinterpret_cast<const void *>(hdr.dest_addr),
+                                hdr.length);
+        return;
+    }
+    if (hdr.type == MsgType::READ_RESP) {
+        // Place into local buffer based on task_id + slice_seq.
+        void *local_buf = nullptr;
+        size_t total_len = 0;
+        TransferRequest::OpCode opcode = TransferRequest::WRITE;
+        {
+            std::lock_guard<std::mutex> lock(twosided_mutex_);
+            auto it = twosided_tasks_.find(hdr.task_id);
+            if (it == twosided_tasks_.end()) return;
+            opcode = it->second.opcode;
+            local_buf = it->second.local_buf;
+            total_len = it->second.total_bytes;
+        }
+        if (opcode != TransferRequest::READ) {
+            LOG(ERROR) << "MsgChannel: READ_RESP for non-READ task_id="
+                       << hdr.task_id << " from " << peer_server_name;
+            return;
+        }
+        if (!local_buf || !hdr.length) return;
+        size_t max_payload =
+            globalConfig().rdma_msg_slot_size > kMsgHeaderSize
+                ? globalConfig().rdma_msg_slot_size - kMsgHeaderSize
+                : 0;
+        uint64_t offset = static_cast<uint64_t>(hdr.slice_seq) * max_payload;
+        if (offset > total_len || hdr.length > total_len - offset) {
+            LOG(ERROR) << "MsgChannel: illegal READ_RESP range task_id="
+                       << hdr.task_id;
+            return;
+        }
+        if (payload) {
+            std::memcpy(static_cast<char *>(local_buf) + offset, payload,
+                        hdr.length);
+        }
+        uint64_t acked = 0;
+        TransferTask *task = nullptr;
+        {
+            std::lock_guard<std::mutex> lock(twosided_mutex_);
+            auto it = twosided_tasks_.find(hdr.task_id);
+            if (it == twosided_tasks_.end()) return;
+            it->second.acked_bytes += hdr.length;
+            acked = it->second.acked_bytes;
+            if (acked >= it->second.total_bytes) {
+                task = it->second.task;
+                twosided_tasks_.erase(it);
+                if (task && !task->slice_list.empty())
+                    task->slice_list[0]->markSuccess();
+            }
+        }
+        (void)acked;
+        return;
+    }
+}
+
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
@@ -17,8 +17,10 @@
 #include <glog/logging.h>
 
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -432,74 +434,79 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
         }
     }
 
-    auto spraySend = [&](uint8_t seq, auto &&send_fn) -> int {
+    // Once a chunk is on the wire the task is no longer replayable, so wait in
+    // place for a recycled slot rather than rolling back and resending it.
+    constexpr auto kMidTransferRetryWindow = std::chrono::milliseconds(200);
+
+    auto spraySend = [&](uint8_t seq, bool allow_wait, auto &&send_fn) -> int {
         const size_t n = rails.size();
         const size_t start = static_cast<size_t>(seq) % n;
+        const auto deadline =
+            std::chrono::steady_clock::now() + kMidTransferRetryWindow;
         int last_rc = ERR_ENDPOINT;
-        for (size_t attempt = 0; attempt < n; ++attempt) {
-            auto &rail = rails[(start + attempt) % n];
-            if (!rail || !rail->connected()) continue;
-            last_rc = send_fn(rail);
-            if (last_rc == 0) return 0;
-            if (last_rc != ERR_TOO_MANY_REQUESTS) return last_rc;
+        for (;;) {
+            for (size_t attempt = 0; attempt < n; ++attempt) {
+                auto &rail = rails[(start + attempt) % n];
+                if (!rail || !rail->connected()) continue;
+                last_rc = send_fn(rail);
+                if (last_rc == 0) return 0;
+                if (last_rc != ERR_TOO_MANY_REQUESTS) return last_rc;
+            }
+            // All rails out of slots: grow them, then wait for a DATA_ACK to
+            // recycle one if the caller cannot requeue.
+            for (auto &rail : rails) {
+                if (rail) rail->requestExpand();
+            }
+            if (!allow_wait || std::chrono::steady_clock::now() >= deadline)
+                return last_rc ? last_rc : ERR_TOO_MANY_REQUESTS;
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
-        for (auto &rail : rails) {
-            if (rail) rail->requestExpand();
-        }
-        return last_rc ? last_rc : ERR_TOO_MANY_REQUESTS;
     };
 
-    if (opcode == TransferRequest::WRITE) {
-        uint8_t seq = 0;
-        for (size_t off = 0; off < length; off += max_payload, ++seq) {
-            uint32_t chunk =
-                static_cast<uint32_t>(std::min(max_payload, length - off));
-            const char *src = static_cast<const char *>(source) + off;
-            int rc =
-                spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
-                    return msg->sendDataWrite(task_id, seq, target_offset + off,
-                                              src, chunk);
-                });
-            if (rc) {
-                if (globalConfig().rdma_credit_enabled) {
-                    sender_credit_.rollbackReservation(
-                        peer, session, epoch,
-                        {{CreditResource::BounceSlots, slots_needed},
-                         {CreditResource::BounceBytes, length}});
-                    std::lock_guard<std::mutex> lock(twosided_mutex_);
-                    auto it = twosided_tasks_.find(task_id);
-                    if (it != twosided_tasks_.end()) {
-                        it->second.credit_reserved = false;
-                    }
-                }
-                return rc;
-            }
+    // Safe after partial progress too: the peer never ACKs an incomplete task,
+    // and recycles the slots it already consumed on its own.
+    auto rollbackReservation = [&]() {
+        if (!globalConfig().rdma_credit_enabled) return;
+        sender_credit_.rollbackReservation(
+            peer, session, epoch,
+            {{CreditResource::BounceSlots, slots_needed},
+             {CreditResource::BounceBytes, length}});
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        auto it = twosided_tasks_.find(task_id);
+        if (it != twosided_tasks_.end()) it->second.credit_reserved = false;
+    };
+
+    uint8_t seq = 0;
+    size_t sent_chunks = 0;
+    for (size_t off = 0; off < length; off += max_payload, ++seq) {
+        uint32_t chunk =
+            static_cast<uint32_t>(std::min(max_payload, length - off));
+        const bool partial = sent_chunks > 0;
+        int rc = spraySend(seq, /*allow_wait=*/partial,
+                           [&](const std::shared_ptr<MsgChannel> &msg) {
+                               if (opcode == TransferRequest::WRITE) {
+                                   return msg->sendDataWrite(
+                                       task_id, seq, target_offset + off,
+                                       static_cast<const char *>(source) + off,
+                                       chunk);
+                               }
+                               return msg->sendReadReq(
+                                   task_id, seq, target_offset + off, chunk);
+                           });
+        if (rc == 0) {
+            ++sent_chunks;
+            continue;
         }
-    } else {
-        uint8_t seq = 0;
-        for (size_t off = 0; off < length; off += max_payload, ++seq) {
-            uint32_t chunk =
-                static_cast<uint32_t>(std::min(max_payload, length - off));
-            int rc =
-                spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
-                    return msg->sendReadReq(task_id, seq, target_offset + off,
-                                            chunk);
-                });
-            if (rc) {
-                if (globalConfig().rdma_credit_enabled) {
-                    sender_credit_.rollbackReservation(
-                        peer, session, epoch,
-                        {{CreditResource::BounceSlots, slots_needed},
-                         {CreditResource::BounceBytes, length}});
-                    std::lock_guard<std::mutex> lock(twosided_mutex_);
-                    auto it = twosided_tasks_.find(task_id);
-                    if (it != twosided_tasks_.end()) {
-                        it->second.credit_reserved = false;
-                    }
-                }
-                return rc;
-            }
+        rollbackReservation();
+        // Requeueing now would resend the prefix already on the wire, so
+        // backpressure has to become a hard failure.
+        if (partial && rc == ERR_TOO_MANY_REQUESTS) {
+            LOG(WARNING) << "MsgChannel: no bounce slot mid-transfer, failing"
+                         << " task_id=" << task_id << " peer=" << peer
+                         << " sent_chunks=" << sent_chunks;
+            return ERR_ENDPOINT;
         }
+        return rc;
     }
     // Publish the dispatch under ctrl_idle_mutex_ and wake the ctrl worker:
     // the worker may be parked in its idle wait, which would otherwise delay
@@ -661,22 +668,17 @@ void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
             std::memcpy(static_cast<char *>(local_buf) + offset, payload,
                         hdr.length);
         }
-        uint64_t acked = 0;
-        TransferTask *task = nullptr;
+        // Finish through the same path as WRITE: completeTwoSidedAck releases
+        // the reservation and redispatches waiting tasks.
+        uint64_t cumulative = 0;
         {
             std::lock_guard<std::mutex> lock(twosided_mutex_);
             auto it = twosided_tasks_.find(hdr.task_id);
             if (it == twosided_tasks_.end()) return;
             it->second.acked_bytes += hdr.length;
-            acked = it->second.acked_bytes;
-            if (acked >= it->second.total_bytes) {
-                task = it->second.task;
-                twosided_tasks_.erase(it);
-                if (task && !task->slice_list.empty())
-                    task->slice_list[0]->markSuccess();
-            }
+            cumulative = it->second.acked_bytes;
         }
-        (void)acked;
+        completeTwoSidedAck(hdr.task_id, cumulative);
         return;
     }
 }

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
@@ -505,7 +505,7 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
         }
     }
 
-    auto spraySend = [&](uint8_t seq, auto &&send_fn) -> int {
+    auto spraySend = [&](uint32_t seq, auto &&send_fn) -> int {
         const size_t n = rails.size();
         const size_t start = static_cast<size_t>(seq) % n;
         int last_rc = ERR_ENDPOINT;
@@ -544,7 +544,7 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
     if (resume_off)
         twosided_resume_count_.fetch_add(1, std::memory_order_relaxed);
     for (size_t off = resume_off; off < length; off += max_payload) {
-        uint8_t seq = static_cast<uint8_t>(off / max_payload);
+        uint32_t seq = static_cast<uint32_t>(off / max_payload);
         uint32_t chunk =
             static_cast<uint32_t>(std::min(max_payload, length - off));
         int rc = spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
@@ -703,7 +703,8 @@ void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
         uint64_t cumulative = 0;
         {
             std::lock_guard<std::mutex> lock(recv_ack_mutex_);
-            auto &state = recv_acked_bytes_[hdr.task_id];
+            RecvAckKey key{peer_server_name, hdr.session, hdr.task_id};
+            auto &state = recv_acked_bytes_[key];
             state.bytes += hdr.length;
             state.chunks++;
             state.last_ms = nowMs();
@@ -714,7 +715,7 @@ void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
             // re-creates the entry and its ACK is dropped by the sender, whose
             // task is already gone.
             if (hdr.total_chunks && state.chunks >= hdr.total_chunks)
-                recv_acked_bytes_.erase(hdr.task_id);
+                recv_acked_bytes_.erase(key);
         }
         (void)sendDataAck(peer_server_name, hdr.task_id, cumulative);
         return;
@@ -733,16 +734,14 @@ void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
         }
         // Prefer same rail that received READ_REQ to avoid cross-rail hop.
         if (channel && channel->connected()) {
-            (void)channel->sendReadResp(
-                hdr.task_id, hdr.slice_seq, hdr.dest_addr,
-                reinterpret_cast<const void *>(hdr.dest_addr), hdr.length);
+            (void)channel->sendOrQueueReadResp(hdr.task_id, hdr.slice_seq,
+                                               hdr.dest_addr, hdr.length);
             return;
         }
         auto msg = ensureMsgChannel(peer_server_name);
         if (!msg) return;
-        (void)msg->sendReadResp(hdr.task_id, hdr.slice_seq, hdr.dest_addr,
-                                reinterpret_cast<const void *>(hdr.dest_addr),
-                                hdr.length);
+        (void)msg->sendOrQueueReadResp(hdr.task_id, hdr.slice_seq,
+                                       hdr.dest_addr, hdr.length);
         return;
     }
     if (hdr.type == MsgType::READ_RESP) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
@@ -17,10 +17,8 @@
 #include <glog/logging.h>
 
 #include <cassert>
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
-#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -373,12 +371,22 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
     if (max_payload == 0) return ERR_INVALID_ARGUMENT;
 
     uint64_t task_id = 0;
+    // Non-zero when resuming a task that was stopped mid-transfer; its
+    // reservation is still held, so it must not be reserved again.
+    uint64_t resume_off = 0;
+    bool credit_held = false;
+    uint64_t held_slots = 0;
+    uint64_t held_bytes = 0;
     {
         std::lock_guard<std::mutex> lock(twosided_mutex_);
         // Reuse existing state if redispatching a waiting task.
         for (auto &entry : twosided_tasks_) {
             if (entry.second.task == task) {
                 task_id = entry.first;
+                resume_off = entry.second.sent_bytes;
+                credit_held = entry.second.credit_reserved;
+                held_slots = entry.second.reserved_slots;
+                held_bytes = entry.second.reserved_bytes;
                 entry.second.waiting_credit = false;
                 entry.second.peer = peer;
                 entry.second.peer_session = session;
@@ -408,15 +416,34 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
     // Credit reserve for full transfer (bounce slots ≈ ceil(len/payload)).
     size_t slots_needed = (length + max_payload - 1) / max_payload;
     if (slots_needed == 0) slots_needed = 1;
-    if (globalConfig().rdma_credit_enabled) {
+    uint64_t reserve_bytes = length;
+    if (credit_held) {
+        // Roll back exactly what was reserved, which may have been capped.
+        slots_needed = held_slots;
+        reserve_bytes = held_bytes;
+    } else if (globalConfig().rdma_credit_enabled) {
         // Credits exist only after the peer's CREDIT_GRANT activated the
         // session in the ledger. Dispatching before that is backpressure, not
         // an error, so queue the task; handleCreditGrant redispatches it.
         if (!session_known) return ERR_TOO_MANY_REQUESTS;
+        // A grant never exceeds the peer's bounce pool, so a transfer needing
+        // more slots than the whole pool would wait for credits that can never
+        // arrive. Reserve at most the full grant and let mid-transfer resume
+        // carry the rest.
+        uint64_t grant_slots = 0;
+        if (sender_credit_.grantTotal(peer, session, epoch,
+                                      CreditResource::BounceSlots,
+                                      grant_slots) == 0 &&
+            grant_slots && slots_needed > grant_slots) {
+            slots_needed = grant_slots;
+            reserve_bytes = std::min<uint64_t>(
+                length, grant_slots * static_cast<uint64_t>(
+                                          globalConfig().rdma_msg_slot_size));
+        }
         int rc = sender_credit_.tryReserve(
             peer, session, epoch,
             {{CreditResource::BounceSlots, slots_needed},
-             {CreditResource::BounceBytes, length}});
+             {CreditResource::BounceBytes, reserve_bytes}});
         if (rc) {
             for (auto &rail : rails) {
                 if (rail) rail->requestExpand();
@@ -428,39 +455,29 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
         if (it != twosided_tasks_.end()) {
             it->second.credit_reserved = true;
             it->second.reserved_slots = slots_needed;
-            it->second.reserved_bytes = length;
+            it->second.reserved_bytes = reserve_bytes;
             it->second.peer_session = session;
             it->second.peer = peer;
         }
     }
 
-    // Once a chunk is on the wire the task is no longer replayable, so wait in
-    // place for a recycled slot rather than rolling back and resending it.
-    constexpr auto kMidTransferRetryWindow = std::chrono::milliseconds(200);
-
-    auto spraySend = [&](uint8_t seq, bool allow_wait, auto &&send_fn) -> int {
+    auto spraySend = [&](uint8_t seq, auto &&send_fn) -> int {
         const size_t n = rails.size();
         const size_t start = static_cast<size_t>(seq) % n;
-        const auto deadline =
-            std::chrono::steady_clock::now() + kMidTransferRetryWindow;
         int last_rc = ERR_ENDPOINT;
-        for (;;) {
-            for (size_t attempt = 0; attempt < n; ++attempt) {
-                auto &rail = rails[(start + attempt) % n];
-                if (!rail || !rail->connected()) continue;
-                last_rc = send_fn(rail);
-                if (last_rc == 0) return 0;
-                if (last_rc != ERR_TOO_MANY_REQUESTS) return last_rc;
-            }
-            // All rails out of slots: grow them, then wait for a DATA_ACK to
-            // recycle one if the caller cannot requeue.
-            for (auto &rail : rails) {
-                if (rail) rail->requestExpand();
-            }
-            if (!allow_wait || std::chrono::steady_clock::now() >= deadline)
-                return last_rc ? last_rc : ERR_TOO_MANY_REQUESTS;
-            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        for (size_t attempt = 0; attempt < n; ++attempt) {
+            auto &rail = rails[(start + attempt) % n];
+            if (!rail || !rail->connected()) continue;
+            last_rc = send_fn(rail);
+            if (last_rc == 0) return 0;
+            if (last_rc != ERR_TOO_MANY_REQUESTS) return last_rc;
         }
+        // Every rail is out of bounce slots: grow them. The caller resumes
+        // from the next unsent offset once a DATA_ACK recycles one.
+        for (auto &rail : rails) {
+            if (rail) rail->requestExpand();
+        }
+        return last_rc;
     };
 
     // Safe after partial progress too: the peer never ACKs an incomplete task,
@@ -470,42 +487,36 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
         sender_credit_.rollbackReservation(
             peer, session, epoch,
             {{CreditResource::BounceSlots, slots_needed},
-             {CreditResource::BounceBytes, length}});
+             {CreditResource::BounceBytes, reserve_bytes}});
         std::lock_guard<std::mutex> lock(twosided_mutex_);
         auto it = twosided_tasks_.find(task_id);
         if (it != twosided_tasks_.end()) it->second.credit_reserved = false;
     };
 
-    uint8_t seq = 0;
-    size_t sent_chunks = 0;
-    for (size_t off = 0; off < length; off += max_payload, ++seq) {
+    if (resume_off)
+        twosided_resume_count_.fetch_add(1, std::memory_order_relaxed);
+    for (size_t off = resume_off; off < length; off += max_payload) {
+        uint8_t seq = static_cast<uint8_t>(off / max_payload);
         uint32_t chunk =
             static_cast<uint32_t>(std::min(max_payload, length - off));
-        const bool partial = sent_chunks > 0;
-        int rc = spraySend(seq, /*allow_wait=*/partial,
-                           [&](const std::shared_ptr<MsgChannel> &msg) {
-                               if (opcode == TransferRequest::WRITE) {
-                                   return msg->sendDataWrite(
-                                       task_id, seq, target_offset + off,
-                                       static_cast<const char *>(source) + off,
-                                       chunk);
-                               }
-                               return msg->sendReadReq(
-                                   task_id, seq, target_offset + off, chunk);
-                           });
-        if (rc == 0) {
-            ++sent_chunks;
-            continue;
+        int rc = spraySend(seq, [&](const std::shared_ptr<MsgChannel> &msg) {
+            if (opcode == TransferRequest::WRITE) {
+                return msg->sendDataWrite(
+                    task_id, seq, target_offset + off,
+                    static_cast<const char *>(source) + off, chunk);
+            }
+            return msg->sendReadReq(task_id, seq, target_offset + off, chunk);
+        });
+        if (rc == 0) continue;
+        if (rc == ERR_TOO_MANY_REQUESTS && off > 0) {
+            // Keep the reservation and record where to resume: replaying the
+            // prefix would duplicate chunks the peer already counted.
+            std::lock_guard<std::mutex> lock(twosided_mutex_);
+            auto it = twosided_tasks_.find(task_id);
+            if (it != twosided_tasks_.end()) it->second.sent_bytes = off;
+            return rc;
         }
         rollbackReservation();
-        // Requeueing now would resend the prefix already on the wire, so
-        // backpressure has to become a hard failure.
-        if (partial && rc == ERR_TOO_MANY_REQUESTS) {
-            LOG(WARNING) << "MsgChannel: no bounce slot mid-transfer, failing"
-                         << " task_id=" << task_id << " peer=" << peer
-                         << " sent_chunks=" << sent_chunks;
-            return ERR_ENDPOINT;
-        }
         return rc;
     }
     // Publish the dispatch under ctrl_idle_mutex_ and wake the ctrl worker:
@@ -541,17 +552,29 @@ void RdmaTwoSidedTransport::completeTwoSidedAck(uint64_t task_id,
     TransferTask *task = nullptr;
     TwoSidedTaskState finished;
     bool do_rollback = false;
+    bool completed = false;
+    bool slot_recycled = false;
     {
         std::lock_guard<std::mutex> lock(twosided_mutex_);
         auto it = twosided_tasks_.find(task_id);
         if (it == twosided_tasks_.end()) return;
         if (acked_bytes > it->second.acked_bytes)
             it->second.acked_bytes = acked_bytes;
-        if (it->second.acked_bytes < it->second.total_bytes) return;
-        finished = it->second;
-        task = it->second.task;
-        do_rollback = it->second.credit_reserved;
-        twosided_tasks_.erase(it);
+        if (it->second.acked_bytes < it->second.total_bytes) {
+            // This ACK freed a bounce slot, which is exactly what a task
+            // stopped mid-transfer is queued for.
+            slot_recycled = !waiting_tasks_.empty();
+        } else {
+            finished = it->second;
+            task = it->second.task;
+            do_rollback = it->second.credit_reserved;
+            completed = true;
+            twosided_tasks_.erase(it);
+        }
+    }
+    if (!completed) {
+        if (slot_recycled) redispatchWaitingTasks();
+        return;
     }
     twosided_inflight_.fetch_sub(1, std::memory_order_acq_rel);
     if (do_rollback && globalConfig().rdma_credit_enabled) {

--- a/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_twosided/two_sided.cpp
@@ -17,6 +17,7 @@
 #include <glog/logging.h>
 
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <unordered_map>
@@ -30,6 +31,21 @@
 #include "transport/rdma_transport/rdma_context.h"
 
 namespace mooncake {
+namespace {
+// Backstop for receiver-side ACK bookkeeping. A completed task retires itself
+// once all its chunks arrive; this only reclaims tasks that never complete.
+// Keep it well above any transfer lifetime, because pruning an entry that is
+// still receiving would restart its cumulative count from zero and the sender
+// would never see the task complete.
+constexpr uint64_t kRecvAckIdleMs = 60000;
+
+uint64_t nowMs() {
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now().time_since_epoch())
+            .count());
+}
+}  // namespace
 
 void *RdmaTwoSidedTransport::allocateManagedBuffer(size_t length) {
     if (length == 0 || !globalConfig().rdma_msg_enabled) return nullptr;
@@ -191,66 +207,92 @@ std::vector<std::shared_ptr<MsgChannel>> RdmaTwoSidedTransport::ensureMsgRails(
         return connected;
     }
 
-    {
-        std::lock_guard<std::mutex> lock(ctrl_mutex_);
-        auto it = msg_channels_.find(peer_server_name);
-        if (it != msg_channels_.end()) {
-            for (auto &rail : it->second) {
-                if (rail && rail->connected()) connected.push_back(rail);
-            }
-            if (connected.size() == getContextList().size()) return connected;
-        }
-    }
+    // Absolute deadline for the whole call so repeated waits cannot extend it.
+    const auto deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(
+                              globalConfig().rdma_notify_connect_timeout_ms);
 
-    // Build / reconnect missing rails outside the lock (handshake may block).
-    std::vector<std::shared_ptr<MsgChannel>> created;
-    created.reserve(getContextList().size());
+    auto find_rail = [&](const std::string &nic_path) {
+        std::shared_ptr<MsgChannel> found;
+        auto it = msg_channels_.find(peer_server_name);
+        if (it == msg_channels_.end()) return found;
+        for (auto &rail : it->second) {
+            if (rail && rail->nicPath() == nic_path && rail->connected()) {
+                found = rail;
+                break;
+            }
+        }
+        return found;
+    };
+
+    std::unique_lock<std::mutex> lock(ctrl_mutex_);
     for (auto &ctx : getContextList()) {
         if (!ctx) continue;
-        bool have = false;
-        {
-            std::lock_guard<std::mutex> lock(ctrl_mutex_);
-            auto it = msg_channels_.find(peer_server_name);
-            if (it != msg_channels_.end()) {
-                for (auto &rail : it->second) {
-                    if (rail && rail->nicPath() == ctx->nicPath() &&
-                        rail->connected()) {
-                        have = true;
-                        break;
-                    }
-                }
-            }
-        }
-        if (have) continue;
-        auto channel =
-            std::make_shared<MsgChannel>(*this, *ctx, peer_server_name);
-        if (channel->connectActive()) {
-            LOG(WARNING) << "MsgChannel: rail connect failed peer="
-                         << peer_server_name << " nic=" << ctx->nicPath();
-            continue;
-        }
-        created.push_back(channel);
-    }
-
-    {
-        std::lock_guard<std::mutex> lock(ctrl_mutex_);
-        auto &rails = msg_channels_[peer_server_name];
-        for (auto &channel : created) {
-            bool replaced = false;
-            for (auto &existing : rails) {
-                if (existing && existing->nicPath() == channel->nicPath()) {
-                    if (existing.get() != channel.get()) {
-                        existing->disconnect();
-                        existing = channel;
-                    }
-                    replaced = true;
+        const std::string nic_path = ctx->nicPath();
+        const std::string key = peer_server_name + "|" + nic_path;
+        while (!ctrl_stopping_) {
+            if (find_rail(nic_path)) break;
+            if (msg_connecting_.count(key)) {
+                // Another thread is handshaking this rail. A second handshake
+                // would make the peer replace its rail, and the SENDs already
+                // posted on the replaced one never land: their QP is gone on
+                // the peer, and rnr_retry=7 means they never complete either.
+                if (ctrl_cv_.wait_until(lock, deadline) ==
+                    std::cv_status::timeout) {
+                    LOG(WARNING) << "MsgChannel: timed out waiting for "
+                                    "in-flight rail connect to "
+                                 << peer_server_name << " nic=" << nic_path;
                     break;
                 }
+                continue;
             }
-            if (!replaced) rails.push_back(channel);
+
+            {
+                // Publishes the in-flight key and, on every exit path
+                // including a throwing handshake, clears it and wakes the
+                // waiters above.
+                RailConnectScope scope(*this, key);
+                auto channel =
+                    std::make_shared<MsgChannel>(*this, *ctx, peer_server_name);
+                int ret = 0;
+                {
+                    // The handshake blocks and re-enters this transport on the
+                    // passive side, so it cannot run under ctrl_mutex_.
+                    UnlockGuard unlocked(lock);
+                    ret = channel->connectActive();
+                }
+                if (ret == 0) {
+                    auto existing_rail = find_rail(nic_path);
+                    if (existing_rail) {
+                        // A passive accept published a rail for this NIC while
+                        // the lock was released; keep it and drop ours rather
+                        // than stranding whatever is already in flight on it.
+                        UnlockGuard unlocked(lock);
+                        channel->disconnect();
+                    } else {
+                        auto &rails = msg_channels_[peer_server_name];
+                        bool replaced = false;
+                        for (auto &rail : rails) {
+                            if (rail && rail->nicPath() == nic_path) {
+                                rail = channel;
+                                replaced = true;
+                                break;
+                            }
+                        }
+                        if (!replaced) rails.push_back(channel);
+                    }
+                } else {
+                    LOG(WARNING) << "MsgChannel: rail connect failed peer="
+                                 << peer_server_name << " nic=" << nic_path;
+                }
+            }
+            break;
         }
-        connected.clear();
-        for (auto &rail : rails) {
+    }
+
+    auto it = msg_channels_.find(peer_server_name);
+    if (it != msg_channels_.end()) {
+        for (auto &rail : it->second) {
             if (rail && rail->connected()) connected.push_back(rail);
         }
     }
@@ -303,6 +345,8 @@ Status RdmaTwoSidedTransport::submitTwoSidedTasks(
         if (rc == ERR_TOO_MANY_REQUESTS) {
             std::lock_guard<std::mutex> lock(twosided_mutex_);
             waiting_tasks_.push_back(task);
+            waiting_count_.store(waiting_tasks_.size(),
+                                 std::memory_order_relaxed);
             // dispatchTwoSidedTask already inserted TwoSidedTaskState; just
             // mark waiting (do not allocate a second task_id for the same
             // task).
@@ -493,6 +537,10 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
         if (it != twosided_tasks_.end()) it->second.credit_reserved = false;
     };
 
+    // Chunk count for the whole task, not just this dispatch: the receiver
+    // counts across resumes, so a resumed dispatch must report the same total.
+    const uint32_t total_chunks =
+        static_cast<uint32_t>((length + max_payload - 1) / max_payload);
     if (resume_off)
         twosided_resume_count_.fetch_add(1, std::memory_order_relaxed);
     for (size_t off = resume_off; off < length; off += max_payload) {
@@ -503,7 +551,8 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
             if (opcode == TransferRequest::WRITE) {
                 return msg->sendDataWrite(
                     task_id, seq, target_offset + off,
-                    static_cast<const char *>(source) + off, chunk);
+                    static_cast<const char *>(source) + off, chunk,
+                    total_chunks);
             }
             return msg->sendReadReq(task_id, seq, target_offset + off, chunk);
         });
@@ -531,19 +580,36 @@ int RdmaTwoSidedTransport::dispatchTwoSidedTask(TransferTask *task) {
 }
 
 void RdmaTwoSidedTransport::redispatchWaitingTasks() {
+    if (waiting_count_.load(std::memory_order_relaxed) == 0) return;
+    // One recycled slot cannot admit the whole queue, so retrying every waiter
+    // on every ACK costs O(queue) per event and collapses throughput once the
+    // queue is deep. Retry a bounded prefix instead and leave the rest to the
+    // next event.
+    constexpr size_t kMaxRetryPerEvent = 8;
     std::deque<TransferTask *> pending;
     {
         std::lock_guard<std::mutex> lock(twosided_mutex_);
-        pending.swap(waiting_tasks_);
+        while (!waiting_tasks_.empty() && pending.size() < kMaxRetryPerEvent) {
+            pending.push_back(waiting_tasks_.front());
+            waiting_tasks_.pop_front();
+        }
+        waiting_count_.store(waiting_tasks_.size(), std::memory_order_relaxed);
     }
+    std::deque<TransferTask *> requeue;
     for (auto *task : pending) {
         int rc = dispatchTwoSidedTask(task);
         if (rc == ERR_TOO_MANY_REQUESTS) {
-            std::lock_guard<std::mutex> lock(twosided_mutex_);
-            waiting_tasks_.push_back(task);
+            requeue.push_back(task);
         } else if (rc) {
             if (!task->slice_list.empty()) task->slice_list[0]->markFailed();
         }
+    }
+    if (!requeue.empty()) {
+        std::lock_guard<std::mutex> lock(twosided_mutex_);
+        // At the front: a task that already waited keeps its place in line.
+        waiting_tasks_.insert(waiting_tasks_.begin(), requeue.begin(),
+                              requeue.end());
+        waiting_count_.store(waiting_tasks_.size(), std::memory_order_relaxed);
     }
 }
 
@@ -589,6 +655,17 @@ void RdmaTwoSidedTransport::completeTwoSidedAck(uint64_t task_id,
     }
 }
 
+void RdmaTwoSidedTransport::pruneRecvAckLedger() {
+    const uint64_t now = nowMs();
+    std::lock_guard<std::mutex> lock(recv_ack_mutex_);
+    for (auto it = recv_acked_bytes_.begin(); it != recv_acked_bytes_.end();) {
+        if (it->second.last_ms + kRecvAckIdleMs < now)
+            it = recv_acked_bytes_.erase(it);
+        else
+            ++it;
+    }
+}
+
 int RdmaTwoSidedTransport::sendDataAck(const std::string &peer,
                                        uint64_t task_id, uint64_t acked_bytes) {
     std::shared_ptr<CtrlChannel> channel;
@@ -626,8 +703,18 @@ void RdmaTwoSidedTransport::onMsgReceived(const std::string &peer_server_name,
         uint64_t cumulative = 0;
         {
             std::lock_guard<std::mutex> lock(recv_ack_mutex_);
-            recv_acked_bytes_[hdr.task_id] += hdr.length;
-            cumulative = recv_acked_bytes_[hdr.task_id];
+            auto &state = recv_acked_bytes_[hdr.task_id];
+            state.bytes += hdr.length;
+            state.chunks++;
+            state.last_ms = nowMs();
+            cumulative = state.bytes;
+            // Retire the entry as soon as the task is whole. Counting chunks
+            // works regardless of the order they arrive in across rails, which
+            // a last-chunk flag would not. A duplicate landing afterwards just
+            // re-creates the entry and its ACK is dropped by the sender, whose
+            // task is already gone.
+            if (hdr.total_chunks && state.chunks >= hdr.total_chunks)
+                recv_acked_bytes_.erase(hdr.task_id);
         }
         (void)sendDataAck(peer_server_name, hdr.task_id, cumulative);
         return;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -96,6 +96,13 @@ target_link_libraries(sender_credit_test PUBLIC transfer_engine gtest
                                                 gtest_main)
 add_test(NAME sender_credit_test COMMAND sender_credit_test)
 
+# Serialized READ_RESP backpressure queue (lost-wakeup regression; no RDMA).
+add_executable(pending_read_resp_queue_test
+               ${WORKSPACE}/pending_read_resp_queue_test.cpp)
+target_link_libraries(pending_read_resp_queue_test PUBLIC transfer_engine gtest
+                                                          gtest_main)
+add_test(NAME pending_read_resp_queue_test COMMAND pending_read_resp_queue_test)
+
 # CtrlChannel RDMA notify correctness. Self-skips without RDMA.
 add_executable(rdma_notify_test ${WORKSPACE}/rdma_notify_test.cpp)
 target_link_libraries(rdma_notify_test PUBLIC transfer_engine gflags::gflags

--- a/mooncake-transfer-engine/tests/pending_read_resp_queue_test.cpp
+++ b/mooncake-transfer-engine/tests/pending_read_resp_queue_test.cpp
@@ -1,0 +1,152 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "error.h"
+#include "transport/rdma_twosided/pending_read_resp_queue.h"
+
+using namespace mooncake;
+
+namespace {
+
+PendingReadResp MakeItem(uint64_t task_id, uint32_t slice_seq = 0) {
+    return PendingReadResp{task_id, /*addr=*/0, /*length=*/64, slice_seq};
+}
+
+}  // namespace
+
+// Reviewer race: observe pool-full, then a slot frees and drains an empty
+// queue, then enqueue. Without enqueue→kick the response would strand.
+TEST(PendingReadRespQueueTest, EnqueueAfterEmptyDrainDoesNotLoseWakeup) {
+    PendingReadRespQueue q;
+    std::atomic<int> posts{0};
+    std::atomic<bool> pool_full{true};
+
+    auto try_send = [&](const PendingReadResp &) {
+        if (pool_full.load(std::memory_order_acquire))
+            return ERR_TOO_MANY_REQUESTS;
+        posts.fetch_add(1, std::memory_order_relaxed);
+        return 0;
+    };
+
+    // Immediate send would have failed; a completion drains while queue empty.
+    ASSERT_EQ(try_send(MakeItem(1)), ERR_TOO_MANY_REQUESTS);
+    pool_full.store(false, std::memory_order_release);
+    q.onSlotFreed(try_send);  // empty: no-op
+    EXPECT_EQ(posts.load(), 0);
+
+    // Enqueue must kick drain itself so the response is posted without waiting
+    // for another completion or pool expand.
+    q.enqueue(MakeItem(1), try_send);
+    EXPECT_EQ(posts.load(), 1);
+    EXPECT_EQ(q.size(), 0u);
+    EXPECT_FALSE(q.drainRunningForTest());
+}
+
+// Slot frees while drain is blocked inside try_send (still full). The free
+// must arm recheck so the response is posted when try_send returns.
+TEST(PendingReadRespQueueTest, SlotFreeDuringDrainIsNotLost) {
+    PendingReadRespQueue q;
+    std::mutex gate_mu;
+    std::condition_variable gate_cv;
+    bool entered_try_send = false;
+    bool release_try_send = false;
+    std::atomic<int> attempt{0};
+    std::atomic<int> posts{0};
+
+    auto try_send = [&](const PendingReadResp &) {
+        const int n = attempt.fetch_add(1, std::memory_order_relaxed);
+        if (n == 0) {
+            {
+                std::lock_guard<std::mutex> lock(gate_mu);
+                entered_try_send = true;
+            }
+            gate_cv.notify_all();
+            std::unique_lock<std::mutex> lock(gate_mu);
+            gate_cv.wait(lock, [&] { return release_try_send; });
+            return ERR_TOO_MANY_REQUESTS;
+        }
+        posts.fetch_add(1, std::memory_order_relaxed);
+        return 0;
+    };
+
+    std::thread drainer([&] { q.enqueue(MakeItem(7), try_send); });
+
+    {
+        std::unique_lock<std::mutex> lock(gate_mu);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2),
+                                     [&] { return entered_try_send; }));
+    }
+    // Mid-drain slot free: must set recheck_ rather than return as a no-op.
+    q.onSlotFreed(try_send);
+    {
+        std::lock_guard<std::mutex> lock(gate_mu);
+        release_try_send = true;
+    }
+    gate_cv.notify_all();
+    drainer.join();
+
+    EXPECT_EQ(posts.load(), 1);
+    EXPECT_EQ(q.size(), 0u);
+    EXPECT_FALSE(q.drainRunningForTest());
+}
+
+TEST(PendingReadRespQueueTest, StaysQueuedUntilSlotFrees) {
+    PendingReadRespQueue q;
+    std::atomic<bool> pool_full{true};
+    std::atomic<int> posts{0};
+    auto try_send = [&](const PendingReadResp &) {
+        if (pool_full.load(std::memory_order_acquire))
+            return ERR_TOO_MANY_REQUESTS;
+        posts.fetch_add(1, std::memory_order_relaxed);
+        return 0;
+    };
+
+    q.enqueue(MakeItem(3), try_send);
+    EXPECT_EQ(posts.load(), 0);
+    EXPECT_EQ(q.size(), 1u);
+
+    pool_full.store(false, std::memory_order_release);
+    q.onSlotFreed(try_send);
+    EXPECT_EQ(posts.load(), 1);
+    EXPECT_EQ(q.size(), 0u);
+}
+
+TEST(PendingReadRespQueueTest, DrainsFifoAcrossMultipleItems) {
+    PendingReadRespQueue q;
+    std::vector<uint64_t> order;
+    auto try_send = [&](const PendingReadResp &item) {
+        order.push_back(item.task_id);
+        return 0;
+    };
+
+    // First enqueue drains immediately; subsequent items enqueue while the
+    // first drain may still be conceptually "done" — just verify all post.
+    q.enqueue(MakeItem(1), try_send);
+    q.enqueue(MakeItem(2), try_send);
+    q.enqueue(MakeItem(3), try_send);
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 1u);
+    EXPECT_EQ(order[1], 2u);
+    EXPECT_EQ(order[2], 3u);
+    EXPECT_EQ(q.size(), 0u);
+}

--- a/mooncake-transfer-engine/tests/sender_credit_test.cpp
+++ b/mooncake-transfer-engine/tests/sender_credit_test.cpp
@@ -112,6 +112,23 @@ TEST(SenderCreditTest, RollbackRestores) {
     EXPECT_EQ(slots, 4u);
 }
 
+TEST(SenderCreditTest, GrantTotalIgnoresConsumed) {
+    SenderCreditLedger l;
+    ASSERT_EQ(l.activate(kPeer, kSession, kEpoch), 0);
+    grant(l, 1, 4, 400);
+    ASSERT_EQ(l.tryReserve(kPeer, kSession, kEpoch,
+                           {{CreditResource::BounceSlots, 3},
+                            {CreditResource::BounceBytes, 300}}),
+              0);
+    uint64_t total = 0;
+    ASSERT_EQ(l.grantTotal(kPeer, kSession, kEpoch, CreditResource::BounceSlots,
+                           total),
+              0);
+    // An oversized transfer caps its reservation against this ceiling, which
+    // must stay put while other transfers hold credits.
+    EXPECT_EQ(total, 4u);
+}
+
 TEST(SenderCreditTest, StaleEpochCannotTouchNewGeneration) {
     SenderCreditLedger l;
     ASSERT_EQ(l.activate(kPeer, kSession, kEpoch), 0);


### PR DESCRIPTION
## Description

Data-plane channel for `rdma_twosided` (RFC #3377, PR3 of 4).

Builds on the control plane merged in #3440. Adds:

- **MsgChannel** – per-peer SEND/RECV QP for data frames; multi-rail capable.
- **BouncePool** – MR-registered bounce buffer with dynamic expand/shrink (low-watermark trigger / idle-shrink).
- **Credit admission** – wires SenderCreditLedger into SESSION_OPEN / CREDIT_GRANT / DATA_ACK ctrl frames; tasks exceeding the window enter WAITING and redispatch on grant.
- **Config** – ~15 `MC_RDMA_MSG_*` / `MC_RDMA_CREDIT_*` env knobs.
- **Handshake** – extends capability fields (`msg_qp_num`, `msg_rq_psn`, `supports_two_sided_msg`).

End-to-end TE integration (managed-buffer APIs, `submitTransfer` routing, correctness + perf tests) follows in PR4.

Closes no issue (tracked under #3377).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Test commands:**
```bash
# PR3 compiles independently (no TE-layer dependency)
ninja transfer_engine   # OK

# PR2 regression (full suite, eRDMA loopback)
MC_TE_FILTERS=erdma_0 MC_TEST_DEVICE_NAME=erdma_0 MC_MTU=1024 \
  ./build-tent/mooncake-transfer-engine/tests/rdma_notify_test
  ./build-tent/mooncake-transfer-engine/tests/ctrl_frame_test
  ./build-tent/mooncake-transfer-engine/tests/sender_credit_test
```

**Test results:**
- [x] Unit tests pass (rdma_notify 7/7, ctrl_frame 6/6, sender_credit 5/5)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Functional validation (MsgChannel SEND/RECV, bounce expand, credit sustainability) requires PR4 TE integration; verified locally with PR4 applied (6/6 rdma_twosided_test).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI pair-programming assistant used for code review feedback analysis, concurrency fix design (PR2 review comments), and PR workflow automation. All code reviewed and validated by the human submitter.