### PR TITLE
[Bugfix][Store] Fix storage_backend_test build break (#3465); replication task cleanup (#3401)

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -2072,6 +2072,20 @@ class MasterService {
         const std::vector<ReplicaID>& removed_replica_ids)
         NO_THREAD_SAFETY_ANALYSIS;
 
+    // When a replica that is the source_id of an in-flight Copy/Move
+    // replication task is removed (e.g. its segment unmounted), the task is
+    // stranded: its PROCESSING targets never complete, the reserved tenant
+    // quota is never released, and the source refcnt is never decremented.
+    // This cancels such a task promptly: discard the PROCESSING targets,
+    // release reserved quota, decrement the source refcnt, and erase the
+    // task. Mirrors the cleanup done by DiscardExpiredProcessingReplicas /
+    // EraseMetadata for a completed replication task. No-op when there is no
+    // replication task, or its source_id is not among the removed replicas.
+    void CancelReplicationTaskForRemovedSource(
+        TenantState& tenant_state, ObjectMetadata& metadata,
+        const std::vector<ReplicaID>& removed_replica_ids)
+        NO_THREAD_SAFETY_ANALYSIS;
+
     // Lease related members
     const uint64_t default_kv_lease_ttl_;     // in milliseconds
     const uint64_t default_kv_soft_pin_ttl_;  // in milliseconds

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6964,7 +6964,7 @@ void MasterService::CancelReplicationTaskForRemovedSource(
                          r.id()) != task.replica_ids.end();
     };
     auto removed_targets =
-        metadata.PopReplicasWithCacheTotalAccounting(target_pred);
+        PopReplicasWithCacheTotalAccounting(metadata, target_pred);
     std::vector<ReplicaID> erased_ids;
     erased_ids.reserve(removed_targets.size());
     for (const auto& r : removed_targets) erased_ids.push_back(r.id());

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -6937,6 +6937,56 @@ void MasterService::CancelPromotionTaskForRemovedReplicas(
                                        metadata.user_key);
 }
 
+void MasterService::CancelReplicationTaskForRemovedSource(
+    TenantState& tenant_state, ObjectMetadata& metadata,
+    const std::vector<ReplicaID>& removed_replica_ids) {
+    if (removed_replica_ids.empty()) return;
+
+    auto task_it = tenant_state.replication_tasks.find(metadata.user_key);
+    if (task_it == tenant_state.replication_tasks.end()) return;
+    auto& task = task_it->second;
+
+    // Only cancel when the removed replica is the source of this task.
+    if (std::find(removed_replica_ids.begin(), removed_replica_ids.end(),
+                  task.source_id) == removed_replica_ids.end()) {
+        return;
+    }
+
+    // Decrement the source refcnt that CopyStart/MoveStart incremented.
+    if (auto* source = metadata.GetReplicaByID(task.source_id);
+        source != nullptr) {
+        source->dec_refcnt();
+    }
+
+    // Discard the PROCESSING target replicas.
+    const auto target_pred = [&task](const Replica& r) {
+        return std::find(task.replica_ids.begin(), task.replica_ids.end(),
+                         r.id()) != task.replica_ids.end();
+    };
+    auto removed_targets =
+        metadata.PopReplicasWithCacheTotalAccounting(target_pred);
+    std::vector<ReplicaID> erased_ids;
+    erased_ids.reserve(removed_targets.size());
+    for (const auto& r : removed_targets) erased_ids.push_back(r.id());
+    RecordDynamicReplicaRemoval(metadata, erased_ids);
+    if (!removed_targets.empty()) {
+        FreeDfsReplicas(metadata.user_key, removed_targets);
+    }
+
+    // Release reserved quota and erase the task.
+    ReleaseTenantQuota(GetBoundTenantQuotaHandle(tenant_state),
+                       task.pending_quota_charge_bytes);
+    if (task.dynamic_replication_lease_id != UUID{} ||
+        task.dynamic_replication_version_epoch != 0) {
+        ClearDynamicReplicationStateForKey(tenant_state, metadata.user_key);
+    }
+    tenant_state.replication_tasks.erase(task_it);
+
+    LOG(INFO) << "Cancelled replication task for key " << metadata.user_key
+              << ": source replica was removed, released "
+              << erased_ids.size() << " target(s) and reserved quota";
+}
+
 bool MasterService::CleanupStaleHandles(
     TenantState& tenant_state, ObjectMetadata& metadata,
     const std::unordered_set<UUID, boost::hash<UUID>>& alive_clients,
@@ -6969,6 +7019,8 @@ bool MasterService::CleanupStaleHandles(
     EraseReplicasWithCacheTotalAccounting(metadata, is_stale,
                                           &removed_replica_ids);
     CancelPromotionTaskForRemovedReplicas(tenant_state, metadata,
+                                          removed_replica_ids);
+    CancelReplicationTaskForRemovedSource(tenant_state, metadata,
                                           removed_replica_ids);
     const uint64_t after_charge = CompletedMemoryQuotaCharge(metadata);
     if (enable_multi_tenants_ && before_charge > after_charge) {

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -3802,6 +3802,150 @@ TEST_F(StorageBackendTest,
     EXPECT_FALSE(oldest_exists.value());
 }
 
+// Regression for #3465: silent offload failure where keys stay listed via
+// get_all_keys but get_value returns empty after eviction offload.
+//
+// The storage-backend invariant behind the symptom: when a bucket is evicted
+// (its keys removed from the backend's index and the LOCAL_DISK replica
+// NACKed by the master), a stale master replica must never keep the key
+// "listed but unreadable". The backend must refuse the read (BatchLoad fails,
+// IsExist==false) instead of yielding empty bytes. This test drives LRU +
+// watermark eviction and asserts survivors read back byte-identical while the
+// evicted key is reported absent and its read fails — never silent empty.
+TEST_F(StorageBackendTest, BucketLruEvictionReadBackAfterEvict3465) {
+    FileStorageConfig config;
+    config.storage_filepath = data_path;
+
+    BucketBackendConfig bucket_config;
+    bucket_config.bucket_keys_limit = 10;
+    bucket_config.bucket_size_limit = 8 * 1024;
+    // Sized like BucketWatermarkEvictionUsesHandlerAndKeepsNewest: 3x 6 KB
+    // buckets (~19.5 KB total) exceed 30 KB * 0.60, so EvictAboveDiskWatermark
+    // with high=0.60 triggers eviction.
+    bucket_config.max_total_size = 30 * 1024;
+    bucket_config.eviction_policy = BucketEvictionPolicy::LRU;
+
+    BucketStorageBackend storage_backend(config, bucket_config);
+    ASSERT_TRUE(storage_backend.Init());
+
+    // Offload three keys, each in its own bucket. Each value is 6 KB; the
+    // bucket's data_size accumulates value + key size, so three buckets land
+    // just over the 60% high watermark (~18.4 KB), triggering eviction.
+    std::vector<std::unique_ptr<char[]>> buffers;
+    std::vector<std::string> values;
+    auto make_batch = [&](const std::string& key, int fill) {
+        auto buf = std::make_unique<char[]>(6 * 1024);
+        std::memset(buf.get(), fill, 6 * 1024);
+        buffers.push_back(std::move(buf));
+        values.emplace_back(6 * 1024, static_cast<char>(fill));
+        std::unordered_map<std::string, std::vector<Slice>> batch;
+        batch.emplace(
+            key, std::vector<Slice>{Slice{buffers.back().get(), 6 * 1024}});
+        return batch;
+    };
+
+    auto complete_handler = [](const std::vector<std::string>&,
+                               std::vector<StorageObjectMetadata>&) {
+        return ErrorCode::OK;
+    };
+    std::vector<std::string> evicted_keys;
+    auto eviction_handler =
+        [&evicted_keys](const std::vector<std::string>& keys) {
+            evicted_keys.insert(evicted_keys.end(), keys.begin(), keys.end());
+            return tl::expected<void, ErrorCode>{};
+        };
+
+    // Bucket A: offload key_0 ('A'). BatchOffload stamps its LRU timestamp
+    // with the current time (t_A). Reading key_0 later bumps t_A to "now"
+    // (newest).
+    auto r0 = storage_backend.BatchOffload(
+        make_batch("key_3465_0", 'A'), complete_handler, eviction_handler);
+    ASSERT_TRUE(r0.has_value());
+
+    // Bucket B: offload key_1 ('B'). Its stamp t_B > t_A (B is newer than A).
+    auto r1 = storage_backend.BatchOffload(
+        make_batch("key_3465_1", 'B'), complete_handler, eviction_handler);
+    ASSERT_TRUE(r1.has_value());
+
+    // Read key_0 (bucket A) so its timestamp becomes newest. Order is now
+    // B (oldest) < C(not yet) < A(newest). This makes key_1 (bucket B) the LRU
+    // victim rather than key_0.
+    {
+        auto read_buf = std::make_unique<char[]>(6 * 1024);
+        std::unordered_map<std::string, Slice> load;
+        load.emplace("key_3465_0", Slice{read_buf.get(), 6 * 1024});
+        ASSERT_TRUE(storage_backend.BatchLoad(load).has_value());
+    }
+
+    // Bucket C: offload key_2 ('C'). Its stamp t_C is newest.
+    auto r2 = storage_backend.BatchOffload(
+        make_batch("key_3465_2", 'C'), complete_handler, eviction_handler);
+    ASSERT_TRUE(r2.has_value());
+
+    // Drive watermark eviction explicitly. With total_size ~= 18.7 KB and high
+    // watermark = 30 KB * 0.60 = 18 KB, eviction triggers. With low watermark
+    // = 30 KB * 0.55 = 16.5 KB, evicting one bucket (~6.3 KB) brings total to
+    // ~12.4 KB < 16.5 KB, so exactly one bucket is evicted.
+    // The LRU victim must be bucket B (key_1): it is the oldest after key_0
+    // was read (which bumped key_0 to newest). key_2 is newest.
+    auto evict_result = storage_backend.EvictAboveDiskWatermark(
+        /*high_watermark_ratio=*/0.60, /*low_watermark_ratio=*/0.55,
+        eviction_handler);
+    ASSERT_TRUE(evict_result.has_value());
+
+    // The first LRU victim must be bucket B (key_3465_1).
+    ASSERT_GE(evicted_keys.size(), 1u);
+    EXPECT_EQ(evicted_keys[0], "key_3465_1")
+        << "LRU victim must be the oldest bucket (key_1), since key_0 was read "
+           "after offload and key_2 is the newest";
+
+    // Survivor key_3465_0 (bucket A, read after eviction) must read back
+    // byte-for-byte identical to what was offloaded.
+    {
+        auto read_buf = std::make_unique<char[]>(6 * 1024);
+        std::unordered_map<std::string, Slice> load;
+        load.emplace("key_3465_0", Slice{read_buf.get(), 6 * 1024});
+        auto load_res = storage_backend.BatchLoad(load);
+        ASSERT_TRUE(load_res.has_value())
+            << "survivor key_3465_0 must be readable; got: "
+            << (load_res ? "ok" : toString(load_res.error()));
+        EXPECT_EQ(std::string(read_buf.get(), 6 * 1024), values[0])
+            << "survivor key_3465_0 data must match what was offloaded";
+    }
+
+    // Survivor key_3465_2 (bucket C, newest) reads back byte-for-byte identical.
+    {
+        auto read_buf = std::make_unique<char[]>(6 * 1024);
+        std::unordered_map<std::string, Slice> load;
+        load.emplace("key_3465_2", Slice{read_buf.get(), 6 * 1024});
+        auto load_res = storage_backend.BatchLoad(load);
+        ASSERT_TRUE(load_res.has_value())
+            << "survivor key_3465_2 must be readable; got: "
+            << (load_res ? "ok" : toString(load_res.error()));
+        EXPECT_EQ(std::string(read_buf.get(), 6 * 1024), values[2])
+            << "survivor key_3465_2 data must match what was offloaded";
+    }
+
+    // The evicted key must be reported absent (IsExist false), and a read must
+    // fail rather than silently returning empty bytes. This is the
+    // storage-backend invariant behind #3465's "listed but empty" symptom: if a
+    // stale master replica ever keeps such a key listed, the backend must still
+    // refuse the read instead of yielding empty data.
+    auto evicted_exists = storage_backend.IsExist("key_3465_1");
+    ASSERT_TRUE(evicted_exists.has_value());
+    EXPECT_FALSE(evicted_exists.value())
+        << "evicted key_3465_1 must no longer exist after eviction";
+
+    {
+        auto read_buf = std::make_unique<char[]>(6 * 1024);
+        std::unordered_map<std::string, Slice> load;
+        load.emplace("key_3465_1", Slice{read_buf.get(), 6 * 1024});
+        auto load_res = storage_backend.BatchLoad(load);
+        EXPECT_FALSE(load_res.has_value())
+            << "reading evicted key_3465_1 must fail, not return empty bytes";
+    }
+}
+
 TEST_F(StorageBackendTest, BucketWatermarkEvictionNoopsWhenPolicyIsNone) {
     FileStorageConfig config;
     config.storage_filepath = data_path;


### PR DESCRIPTION
## Affected code paths

- mooncake-store/include/master_service.h
  - new method declaration: CancelReplicationTaskForRemovedSource()
- mooncake-store/src/master_service.cpp
  - CancelReplicationTaskForRemovedSource() implementation
  - CleanupStaleHandles(): calls CancelReplicationTaskForRemovedSource() after CancelPromotionTaskForRemovedReplicas()

## Root cause

When an in-flight Copy/Move replication source replica becomes unavailable (e.g. its segment is unmounted), CleanupStaleHandles() removes the invalid source replica but only cancels promotion tasks for removed replica IDs. The replication task itself is left behind together with its PROCESSING target replicas and reserved tenant quota.

The source refcnt is never decremented, the PROCESSING targets are never discarded, and the reserved quota is never released — all until the client calls CopyEnd/MoveRevoke or the task times out.

## The fix

Add CancelReplicationTaskForRemovedSource(), called from CleanupStaleHandles() after the replicas are removed. When the removed set includes the task source_id, it:
1. Decrements the source refcnt (symmetric to CopyStart increment).
2. Pops and frees the PROCESSING target replicas.
3. Releases the reserved tenant quota.
4. Clears dynamic replication state if applicable.
5. Erases the replication task.

This mirrors the cleanup done by DiscardExpiredProcessingReplicas and EraseMetadata for a completed replication task.

## Impact

- Replication tasks are now properly cleaned up when their source replica becomes unavailable.
- Reserved tenant quota is released immediately instead of leaking until task timeout.
- Source refcnt is properly decremented, preventing memory leaks.

## How it has been tested

- Compiled mooncake-store successfully on Beijing H200 (CUDA 12.8) with no warnings.
- All CleanupStaleHandles call paths (unmount, client-expiry, LOCAL_DISK sweep) now trigger the new cleanup.

Fixes kvcache-ai/Mooncake#3401