### PR TITLE
[Bugfix][Store] Properly enable O_DIRECT for OffsetAllocator vector I/O

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -3764,7 +3764,7 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
+                data_file_path_, fd_guard.release(), 32, false);
         } else
 #endif
         {
@@ -4551,7 +4551,7 @@ OffsetAllocatorStorageBackend::TryRecoverFromMetadata() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
+                data_file_path_, fd_guard.release(), 32, false);
         } else
 #endif
         {
@@ -5471,7 +5471,7 @@ void OffsetAllocatorStorageBackend::RemoveAll() {
 #ifdef USE_URING
             if (file_storage_config_.use_uring) {
                 data_file_ =
-                    std::make_shared<UringFile>(data_file_path_, fd, 32, true);
+                    std::make_shared<UringFile>(data_file_path_, fd, 32, false);
             } else
 #endif
             {

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -3742,6 +3742,11 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
 
         // Open/truncate data file in read-write mode
         int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
+#ifdef USE_URING
+        if (file_storage_config_.use_uring) {
+            flags |= O_DIRECT;
+        }
+#endif
         int raw_fd = open(data_file_path_.c_str(), flags, 0644);
         if (raw_fd < 0) {
             LOG(ERROR) << "Failed to open data file: " << data_file_path_;
@@ -3764,7 +3769,7 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, false);
+                data_file_path_, fd_guard.release(), 32, true);
         } else
 #endif
         {
@@ -4517,6 +4522,11 @@ OffsetAllocatorStorageBackend::TryRecoverFromMetadata() {
         // Open data file without truncation
         data_file_path_ = GetDataFilePath();
         int flags = O_CLOEXEC | O_RDWR;
+#ifdef USE_URING
+        if (file_storage_config_.use_uring) {
+            flags |= O_DIRECT;
+        }
+#endif
         int raw_fd = open(data_file_path_.c_str(), flags, 0644);
         if (raw_fd < 0) {
             const int open_errno = errno;
@@ -4551,7 +4561,7 @@ OffsetAllocatorStorageBackend::TryRecoverFromMetadata() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, false);
+                data_file_path_, fd_guard.release(), 32, true);
         } else
 #endif
         {
@@ -5465,13 +5475,18 @@ void OffsetAllocatorStorageBackend::RemoveAll() {
     // BatchLoad/BatchStore that pinned the old data_file_ keeps it alive until
     // its I/O completes — no use-after-free.
     if (!data_file_path_.empty()) {
-        int fd = open(data_file_path_.c_str(),
-                      O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC, 0644);
+        int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
+#ifdef USE_URING
+        if (file_storage_config_.use_uring) {
+            flags |= O_DIRECT;
+        }
+#endif
+        int fd = open(data_file_path_.c_str(), flags, 0644);
         if (fd >= 0) {
 #ifdef USE_URING
             if (file_storage_config_.use_uring) {
                 data_file_ =
-                    std::make_shared<UringFile>(data_file_path_, fd, 32, false);
+                    std::make_shared<UringFile>(data_file_path_, fd, 32, true);
             } else
 #endif
             {

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -858,8 +858,13 @@ tl::expected<size_t, ErrorCode> UringFile::vector_write(const iovec* iov,
             auto read_res = SharedUringRing::instance().read(
                 fd_, bounce, aligned_len, aligned_off);
             if (!read_res) {
-                std::memset(bounce, 0, aligned_len);
-            } else if (read_res.value() < aligned_len) {
+                // A real read error must not proceed with a zero-filled
+                // bounce buffer — that would silently corrupt neighbors.
+                free_aligned_buffer(bounce);
+                return make_error<size_t>(ErrorCode::FILE_READ_FAIL);
+            }
+            if (read_res.value() < aligned_len) {
+                // EOF / short read: only zero the unread suffix.
                 std::memset(static_cast<char*>(bounce) + read_res.value(), 0,
                             aligned_len - read_res.value());
             }

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -788,13 +788,95 @@ tl::expected<void, ErrorCode> UringFile::batch_read(ReadDesc* descs, int cnt) {
 // vector_write / vector_read
 // ---------------------------------------------------------------------------
 
+namespace {
+
+size_t IovecTotalLen(const iovec* iov, int iovcnt) {
+    size_t total = 0;
+    for (int i = 0; i < iovcnt; ++i) total += iov[i].iov_len;
+    return total;
+}
+
+bool IovecRegionDirectReady(const iovec* iov, int iovcnt, off_t offset,
+                            size_t alignment) {
+    if (offset % static_cast<off_t>(alignment) != 0) return false;
+    for (int i = 0; i < iovcnt; ++i) {
+        if (reinterpret_cast<uintptr_t>(iov[i].iov_base) % alignment != 0) {
+            return false;
+        }
+        if (iov[i].iov_len % alignment != 0) return false;
+    }
+    return true;
+}
+
+void CopyFromIovec(char* dst, const iovec* iov, int iovcnt) {
+    for (int i = 0; i < iovcnt; ++i) {
+        std::memcpy(dst, iov[i].iov_base, iov[i].iov_len);
+        dst += iov[i].iov_len;
+    }
+}
+
+void CopyToIovec(char* src, iovec* iov, int iovcnt) {
+    for (int i = 0; i < iovcnt; ++i) {
+        std::memcpy(iov[i].iov_base, src, iov[i].iov_len);
+        src += iov[i].iov_len;
+    }
+}
+
+}  // namespace
+
 tl::expected<size_t, ErrorCode> UringFile::vector_write(const iovec* iov,
                                                         int iovcnt,
                                                         off_t offset) {
     if (fd_ < 0) return make_error<size_t>(ErrorCode::FILE_NOT_FOUND);
+    if (!iov || iovcnt <= 0)
+        return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
+
+    const size_t total = IovecTotalLen(iov, iovcnt);
+    if (total == 0) return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
+
     auto start = std::chrono::steady_clock::now();
-    auto res =
-        SharedUringRing::instance().vector_write(fd_, iov, iovcnt, offset);
+    tl::expected<size_t, ErrorCode> res;
+
+    if (!use_direct_io_ ||
+        IovecRegionDirectReady(iov, iovcnt, offset, ALIGNMENT_)) {
+        res = SharedUringRing::instance().vector_write(fd_, iov, iovcnt,
+                                                       offset);
+    } else {
+        const off_t aligned_off = offset & ~static_cast<off_t>(ALIGNMENT_ - 1);
+        const size_t head = static_cast<size_t>(offset - aligned_off);
+        const size_t span = head + total;
+        const size_t aligned_len =
+            ((span + ALIGNMENT_ - 1) / ALIGNMENT_) * ALIGNMENT_;
+
+        void* bounce = alloc_aligned_buffer(aligned_len);
+        if (!bounce) return make_error<size_t>(ErrorCode::FILE_WRITE_FAIL);
+
+        // Preserve bytes outside [offset, offset+total) within the aligned
+        // region; otherwise padding would clobber neighboring data.
+        const bool needs_rmw = (head != 0) || (aligned_len != total);
+        if (needs_rmw) {
+            auto read_res = SharedUringRing::instance().read(
+                fd_, bounce, aligned_len, aligned_off);
+            if (!read_res) {
+                std::memset(bounce, 0, aligned_len);
+            } else if (read_res.value() < aligned_len) {
+                std::memset(static_cast<char*>(bounce) + read_res.value(), 0,
+                            aligned_len - read_res.value());
+            }
+        }
+        CopyFromIovec(static_cast<char*>(bounce) + head, iov, iovcnt);
+
+        res = SharedUringRing::instance().write(fd_, bounce, aligned_len,
+                                                aligned_off);
+        free_aligned_buffer(bounce);
+
+        if (res && res.value() >= span) {
+            res = total;
+        } else if (res) {
+            res = make_error<size_t>(ErrorCode::FILE_WRITE_FAIL);
+        }
+    }
+
     auto us = std::chrono::duration_cast<std::chrono::microseconds>(
                   std::chrono::steady_clock::now() - start)
                   .count();
@@ -808,13 +890,41 @@ tl::expected<size_t, ErrorCode> UringFile::vector_read(const iovec* iov,
                                                        int iovcnt,
                                                        off_t offset) {
     if (fd_ < 0) return make_error<size_t>(ErrorCode::FILE_NOT_FOUND);
+    if (!iov || iovcnt <= 0)
+        return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
 
-    size_t expected_bytes = 0;
-    for (int i = 0; i < iovcnt; ++i) expected_bytes += iov[i].iov_len;
+    const size_t expected_bytes = IovecTotalLen(iov, iovcnt);
+    if (expected_bytes == 0)
+        return make_error<size_t>(ErrorCode::FILE_INVALID_BUFFER);
+
     auto start = std::chrono::steady_clock::now();
+    tl::expected<size_t, ErrorCode> res;
 
-    auto res =
-        SharedUringRing::instance().vector_read(fd_, iov, iovcnt, offset);
+    if (!use_direct_io_ ||
+        IovecRegionDirectReady(iov, iovcnt, offset, ALIGNMENT_)) {
+        res =
+            SharedUringRing::instance().vector_read(fd_, iov, iovcnt, offset);
+    } else {
+        const off_t aligned_off = offset & ~static_cast<off_t>(ALIGNMENT_ - 1);
+        const size_t head = static_cast<size_t>(offset - aligned_off);
+        const size_t span = head + expected_bytes;
+        const size_t aligned_len =
+            ((span + ALIGNMENT_ - 1) / ALIGNMENT_) * ALIGNMENT_;
+
+        void* bounce = alloc_aligned_buffer(aligned_len);
+        if (!bounce) return make_error<size_t>(ErrorCode::FILE_READ_FAIL);
+
+        res = SharedUringRing::instance().read(fd_, bounce, aligned_len,
+                                               aligned_off);
+        if (res && res.value() >= span) {
+            CopyToIovec(static_cast<char*>(bounce) + head,
+                        const_cast<iovec*>(iov), iovcnt);
+            res = expected_bytes;
+        } else if (res) {
+            res = make_error<size_t>(ErrorCode::FILE_READ_FAIL);
+        }
+        free_aligned_buffer(bounce);
+    }
 
     auto us = std::chrono::duration_cast<std::chrono::microseconds>(
                   std::chrono::steady_clock::now() - start)

--- a/mooncake-store/src/uring_file.cpp
+++ b/mooncake-store/src/uring_file.cpp
@@ -839,8 +839,8 @@ tl::expected<size_t, ErrorCode> UringFile::vector_write(const iovec* iov,
 
     if (!use_direct_io_ ||
         IovecRegionDirectReady(iov, iovcnt, offset, ALIGNMENT_)) {
-        res = SharedUringRing::instance().vector_write(fd_, iov, iovcnt,
-                                                       offset);
+        res =
+            SharedUringRing::instance().vector_write(fd_, iov, iovcnt, offset);
     } else {
         const off_t aligned_off = offset & ~static_cast<off_t>(ALIGNMENT_ - 1);
         const size_t head = static_cast<size_t>(offset - aligned_off);
@@ -902,8 +902,7 @@ tl::expected<size_t, ErrorCode> UringFile::vector_read(const iovec* iov,
 
     if (!use_direct_io_ ||
         IovecRegionDirectReady(iov, iovcnt, offset, ALIGNMENT_)) {
-        res =
-            SharedUringRing::instance().vector_read(fd_, iov, iovcnt, offset);
+        res = SharedUringRing::instance().vector_read(fd_, iov, iovcnt, offset);
     } else {
         const off_t aligned_off = offset & ~static_cast<off_t>(ALIGNMENT_ - 1);
         const size_t head = static_cast<size_t>(offset - aligned_off);

--- a/mooncake-store/tests/posix_file_test.cpp
+++ b/mooncake-store/tests/posix_file_test.cpp
@@ -4,6 +4,7 @@
 #include <cerrno>
 #include <csignal>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <fcntl.h>
 #include <sys/resource.h>
@@ -405,6 +406,76 @@ TEST_F(PosixFileTest, UringBatchReadDrainsErrorsBeforeNextOperation) {
     EXPECT_EQ(desc.error, ErrorCode::OK);
     EXPECT_EQ(desc.bytes_read, data.size());
     EXPECT_EQ(std::string_view(output.data(), output.size()), data);
+}
+
+TEST_F(PosixFileTest, UringVectorIoHandlesUnalignedDirectIo) {
+    const std::string direct_filename = "direct_vector_test.bin";
+    remove(direct_filename.c_str());
+
+    int direct_fd = open(direct_filename.c_str(),
+                         O_CREAT | O_RDWR | O_DIRECT | O_CLOEXEC, 0644);
+    ASSERT_GE(direct_fd, 0) << strerror(errno);
+    ASSERT_EQ(ftruncate(direct_fd, 16384), 0);
+
+    UringFile uring_file(direct_filename, direct_fd, 32, true);
+
+    // Neighboring data in the same 4KiB block must survive RMW writes.
+    const std::string neighbor = "keep-me";
+    iovec neighbor_iov;
+    neighbor_iov.iov_base = const_cast<char*>(neighbor.data());
+    neighbor_iov.iov_len = neighbor.size();
+    auto neighbor_write = uring_file.vector_write(&neighbor_iov, 1, 0);
+    ASSERT_TRUE(neighbor_write.has_value())
+        << toString(neighbor_write.error());
+
+    char header[48] = {};
+    std::memcpy(header, "HDR", 3);
+    const std::string key = "object-key";
+    const std::string payload = "payload-bytes-for-direct-io";
+
+    iovec write_iov[3];
+    write_iov[0].iov_base = header;
+    write_iov[0].iov_len = sizeof(header);
+    write_iov[1].iov_base = const_cast<char*>(key.data());
+    write_iov[1].iov_len = key.size();
+    write_iov[2].iov_base = const_cast<char*>(payload.data());
+    write_iov[2].iov_len = payload.size();
+
+    constexpr off_t kOffset = 513;
+    auto write_result = uring_file.vector_write(write_iov, 3, kOffset);
+    ASSERT_TRUE(write_result.has_value()) << toString(write_result.error());
+    const size_t expected = sizeof(header) + key.size() + payload.size();
+    EXPECT_EQ(*write_result, expected);
+
+    char out_header[sizeof(header)] = {};
+    std::string out_key(key.size(), '\0');
+    std::string out_payload(payload.size(), '\0');
+    iovec read_iov[3];
+    read_iov[0].iov_base = out_header;
+    read_iov[0].iov_len = sizeof(out_header);
+    read_iov[1].iov_base = out_key.data();
+    read_iov[1].iov_len = out_key.size();
+    read_iov[2].iov_base = out_payload.data();
+    read_iov[2].iov_len = out_payload.size();
+
+    auto read_result = uring_file.vector_read(read_iov, 3, kOffset);
+    ASSERT_TRUE(read_result.has_value()) << toString(read_result.error());
+    EXPECT_EQ(*read_result, expected);
+    EXPECT_EQ(std::string_view(out_header, 3), "HDR");
+    EXPECT_EQ(out_key, key);
+    EXPECT_EQ(out_payload, payload);
+
+    std::string out_neighbor(neighbor.size(), '\0');
+    iovec neighbor_read_iov;
+    neighbor_read_iov.iov_base = out_neighbor.data();
+    neighbor_read_iov.iov_len = out_neighbor.size();
+    auto neighbor_read =
+        uring_file.vector_read(&neighbor_read_iov, 1, 0);
+    ASSERT_TRUE(neighbor_read.has_value())
+        << toString(neighbor_read.error());
+    EXPECT_EQ(out_neighbor, neighbor);
+
+    remove(direct_filename.c_str());
 }
 #endif
 

--- a/mooncake-store/tests/posix_file_test.cpp
+++ b/mooncake-store/tests/posix_file_test.cpp
@@ -425,8 +425,7 @@ TEST_F(PosixFileTest, UringVectorIoHandlesUnalignedDirectIo) {
     neighbor_iov.iov_base = const_cast<char*>(neighbor.data());
     neighbor_iov.iov_len = neighbor.size();
     auto neighbor_write = uring_file.vector_write(&neighbor_iov, 1, 0);
-    ASSERT_TRUE(neighbor_write.has_value())
-        << toString(neighbor_write.error());
+    ASSERT_TRUE(neighbor_write.has_value()) << toString(neighbor_write.error());
 
     char header[48] = {};
     std::memcpy(header, "HDR", 3);
@@ -469,10 +468,8 @@ TEST_F(PosixFileTest, UringVectorIoHandlesUnalignedDirectIo) {
     iovec neighbor_read_iov;
     neighbor_read_iov.iov_base = out_neighbor.data();
     neighbor_read_iov.iov_len = out_neighbor.size();
-    auto neighbor_read =
-        uring_file.vector_read(&neighbor_read_iov, 1, 0);
-    ASSERT_TRUE(neighbor_read.has_value())
-        << toString(neighbor_read.error());
+    auto neighbor_read = uring_file.vector_read(&neighbor_read_iov, 1, 0);
+    ASSERT_TRUE(neighbor_read.has_value()) << toString(neighbor_read.error());
     EXPECT_EQ(out_neighbor, neighbor);
 
     remove(direct_filename.c_str());

--- a/mooncake-store/tests/posix_file_test.cpp
+++ b/mooncake-store/tests/posix_file_test.cpp
@@ -474,6 +474,63 @@ TEST_F(PosixFileTest, UringVectorIoHandlesUnalignedDirectIo) {
 
     remove(direct_filename.c_str());
 }
+
+TEST_F(PosixFileTest, UringVectorWriteAbortsWhenPreservationReadFails) {
+    const std::string direct_filename = "direct_vector_preserve_fail.bin";
+    remove(direct_filename.c_str());
+
+    {
+        int setup_fd = open(direct_filename.c_str(),
+                            O_CREAT | O_RDWR | O_DIRECT | O_CLOEXEC, 0644);
+        ASSERT_GE(setup_fd, 0) << strerror(errno);
+        ASSERT_EQ(ftruncate(setup_fd, 16384), 0);
+        UringFile setup_file(direct_filename, setup_fd, 32, true);
+
+        const std::string neighbor = "keep-neighbor-bytes";
+        iovec neighbor_iov;
+        neighbor_iov.iov_base = const_cast<char*>(neighbor.data());
+        neighbor_iov.iov_len = neighbor.size();
+        auto neighbor_write = setup_file.vector_write(&neighbor_iov, 1, 0);
+        ASSERT_TRUE(neighbor_write.has_value())
+            << toString(neighbor_write.error());
+    }
+
+    // Re-open write-only so the RMW preservation read must fail. The write
+    // must abort without clobbering the already-written neighbor bytes.
+    int write_only_fd =
+        open(direct_filename.c_str(), O_WRONLY | O_DIRECT | O_CLOEXEC);
+    ASSERT_GE(write_only_fd, 0) << strerror(errno);
+    {
+        UringFile write_only_file(direct_filename, write_only_fd, 32, true);
+        char payload[64];
+        std::memset(payload, 'X', sizeof(payload));
+        iovec write_iov;
+        write_iov.iov_base = payload;
+        write_iov.iov_len = sizeof(payload);
+
+        constexpr off_t kOffset = 513;
+        auto write_result =
+            write_only_file.vector_write(&write_iov, 1, kOffset);
+        ASSERT_FALSE(write_result.has_value());
+        EXPECT_EQ(write_result.error(), ErrorCode::FILE_READ_FAIL);
+    }
+
+    int verify_fd =
+        open(direct_filename.c_str(), O_RDONLY | O_DIRECT | O_CLOEXEC);
+    ASSERT_GE(verify_fd, 0) << strerror(errno);
+    UringFile verify_file(direct_filename, verify_fd, 32, true);
+
+    const std::string neighbor = "keep-neighbor-bytes";
+    std::string out_neighbor(neighbor.size(), '\0');
+    iovec neighbor_read_iov;
+    neighbor_read_iov.iov_base = out_neighbor.data();
+    neighbor_read_iov.iov_len = out_neighbor.size();
+    auto neighbor_read = verify_file.vector_read(&neighbor_read_iov, 1, 0);
+    ASSERT_TRUE(neighbor_read.has_value()) << toString(neighbor_read.error());
+    EXPECT_EQ(out_neighbor, neighbor);
+
+    remove(direct_filename.c_str());
+}
 #endif
 
 }  // namespace mooncake


### PR DESCRIPTION
## Description

Fixes #3611.

`OffsetAllocatorStorageBackend` passed `use_direct_io=true` to `UringFile` and logged "O_DIRECT mode enabled", but the data file was opened without `O_DIRECT`, and `BatchOffload`/`BatchLoad` use unaligned `vector_write`/`vector_read` iovecs that bypassed direct-I/O alignment handling.

This PR properly enables O_DIRECT end-to-end:

1. Set `O_DIRECT` on the fd when opening OffsetAllocator data files (`Init`, `TryRecoverFromMetadata`, `RemoveAll`) when uring is enabled.
2. Add bounce-buffer alignment handling (with RMW on writes) in `UringFile::vector_read` and `vector_write` so unaligned iovecs work under `use_direct_io=true`.
3. Add `UringVectorIoHandlesUnalignedDirectIo` in `posix_file_test.cpp` to cover unaligned vector I/O under O_DIRECT, including neighbor-data preservation across RMW writes.

Follow-up to maintainer review: the earlier approach of setting `use_direct_io=false` was incorrect; this implements the expected O_DIRECT behavior instead.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added unit test `UringVectorIoHandlesUnalignedDirectIo` for unaligned vector read/write with `use_direct_io=true`.

Full build/tests not run locally (Windows environment without Mooncake build toolchain); please rely on CI.

**Test commands:**
```bash
# CI: Build & Test (Linux)
# Local (Linux): ctest --test-dir build -R PosixFileTest.UringVectorIoHandlesUnalignedDirectIo
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (code review; unit test added)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor AI assisted with issue analysis, O_DIRECT implementation, unit test, clang-format fixes, and PR description drafting. The submitter reviewed the changes.