### PR TITLE
[Store] Add /version HTTP endpoint to master and real client (#3617)

### DIFF
--- a/docs/source/api-reference/http/http-service.md
+++ b/docs/source/api-reference/http/http-service.md
@@ -260,6 +260,29 @@ Basic health check endpoint for service availability verification.
 curl http://localhost:8080/health
 ```
 
+#### `/version`
+Report the master version. Always available, including while the master is in
+standby.
+
+**Method**: `GET`
+**Content-Type**: `application/json; charset=utf-8`
+**Response**: JSON object with:
+- `version` (string): Store version used for RPC handshake compatibility
+- `display_version` (string): Human-readable release plus short git hash
+
+**Example**:
+```bash
+curl http://localhost:8080/version
+```
+
+```json
+{"version":"2.0.0","display_version":"0.3.12.post1 (git: f9e8311f)"}
+```
+
+Real clients expose the same `/version` payload on their own client HTTP port
+when `enable_client_http_server` is on. See
+[Client Metrics Endpoint](../../getting_started/observability.md#client-metrics-endpoint).
+
 ## Store REST API Endpoints
 
 The following endpoints are served by the Python store REST service, which wraps

--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -1150,7 +1150,7 @@ the positional overload.
   data is stored under `MOONCAKE_DFS_ROOT_DIR`, but this separate directory is
   still validated during FileStorage initialization.
 - `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
-- `enable_client_http_server` (bool): Enable the client-local `/health`, `/metrics`, and `/metrics/summary` HTTP endpoints. Defaults to `False`.
+- `enable_client_http_server` (bool): Enable the client-local `/health`, `/metrics`, `/metrics/summary`, and `/version` HTTP endpoints. Defaults to `False`.
 - `client_http_port` (int): Port for the client-local HTTP endpoints. Defaults to `9300`.
 
 **Store segment pinned memory:** CUDA-enabled builds can register Store-managed

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -947,7 +947,7 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
 | `ssd_offload_path` | str | empty | *(advanced)* FileStorage path; with the distributed backend, DFS data uses `MOONCAKE_DFS_ROOT_DIR` |
 | `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
-| `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `client_http_port` | int | `9300` | Client-side HTTP endpoint port, used only when `enable_client_http_server=true` |
 
 ```{note}
@@ -978,7 +978,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
 | `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | FileStorage path; DFS shard data uses `MOONCAKE_DFS_ROOT_DIR` with the distributed backend |
 | `MOONCAKE_TENANT_ID` | `tenant_id` | `default` | Tenant identifier |
-| `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `MOONCAKE_CLIENT_HTTP_PORT` | `client_http_port` | `9300` | Client-side HTTP endpoint port |
 | `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
 
@@ -1047,8 +1047,11 @@ mooncake_client \
 | `--tenant_id` | `default` | Tenant identifier |
 | `--enable_offload` | `false` | Enable client-side SSD offload |
 | `--start_offload_rpc_server` | `true` | Start the offload RPC server for dummy clients |
-| `--enable_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `--enable_http_server` | `false` | Enable client-side `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `--http_port` | `9300` | Client-side HTTP endpoint port |
+
+`mooncake_client --version` prints the release version plus the short git hash,
+and the same value is logged at startup.
 
 ### Client HTTP Health and Metrics Endpoint
 
@@ -1075,9 +1078,18 @@ For `mooncake_store_service`, use `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER=true` and 
 | `GET /health` | Client health check |
 | `GET /metrics` | Prometheus-format client metrics |
 | `GET /metrics/summary` | Human-readable client metrics summary |
+| `GET /version` | Client version as JSON (`version` for RPC handshake compatibility, `display_version` for release plus short git hash) |
+
+```bash
+curl http://<client-host>:9300/version
+```
+
+```json
+{"version":"2.0.0","display_version":"0.3.12.post1 (git: f9e8311f)"}
+```
 
 ```{note}
-`MC_STORE_CLIENT_METRIC` controls whether client metrics are collected. If the client HTTP server is enabled but `MC_STORE_CLIENT_METRIC=0`, `/metrics` and `/metrics/summary` return HTTP 503 with `metrics not available`.
+`MC_STORE_CLIENT_METRIC` controls whether client metrics are collected. If the client HTTP server is enabled but `MC_STORE_CLIENT_METRIC=0`, `/metrics` and `/metrics/summary` return HTTP 503 with `metrics not available`. `/health` and `/version` are unaffected.
 ```
 
 ### Engine Runtime Tuning (`MC_*`)

--- a/docs/source/getting_started/observability.md
+++ b/docs/source/getting_started/observability.md
@@ -122,6 +122,7 @@ The admin HTTP server runs on `metrics_port` (default: **9003**) and exposes the
 | `GET /metrics` | `text/plain; version=0.0.4` | All metrics in Prometheus exposition format |
 | `GET /metrics/summary` | `text/plain; version=0.0.4` | Human-readable summary (same content as the periodic log) |
 | `GET /health` | `application/json` | Health check with role, HA state, and service readiness |
+| `GET /version` | `application/json` | Master version (`version` for RPC compatibility, `display_version` for release + git hash) |
 | `GET /role` | `text/plain` | Current HA role (`leader` / `standby`) |
 | `GET /ha_status` | `text/plain` | Current HA runtime state (`serving` / `starting` / etc.) |
 
@@ -150,6 +151,9 @@ curl http://<master-host>:9003/metrics/summary
 
 # Check health
 curl http://<master-host>:9003/health
+
+# Check version
+curl http://<master-host>:9003/version
 ```
 
 ### Configuration
@@ -198,12 +202,22 @@ For `mooncake.mooncake_store_service`, set
 | `GET /health` | `application/json` | Client health check |
 | `GET /metrics` | `text/plain; version=0.0.4` | Prometheus-format client metrics |
 | `GET /metrics/summary` | `text/plain` | Human-readable client metrics summary |
+| `GET /version` | `application/json` | Client version (`version` for RPC compatibility, `display_version` for release + git hash) |
 
 ```bash
 curl http://<client-host>:9300/health
 curl http://<client-host>:9300/metrics
 curl http://<client-host>:9300/metrics/summary
+curl http://<client-host>:9300/version
 ```
+
+```json
+{"version":"2.0.0","display_version":"0.3.12.post1 (git: f9e8311f)"}
+```
+
+`/version` does not depend on client metric collection or on a fully
+initialized client, so it stays available whenever the client HTTP server is
+running.
 
 Set `MC_STORE_CLIENT_METRIC=0` to disable client metric collection. If the
 client HTTP server remains enabled while metrics are disabled, `/metrics` and

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -658,6 +658,12 @@ struct ClientMetric {
     MasterClientMetric master_client_metric;
     TransferOperationMetric transfer_operation_metric;
     SsdMetric ssd_metric;
+    // Prometheus "info" pattern: the value carries no meaning and is always 1,
+    // the version strings ride along as static labels next to any caller
+    // supplied labels so a scrape can attribute samples to a concrete build.
+    // Shares the `mooncake_build_info` name with the master-side metric; the
+    // two are told apart by the scrape target's job/instance labels.
+    ylt::metric::gauge_t build_info;
 
     /**
      * @brief Creates a ClientMetric instance based on environment variables

--- a/mooncake-store/include/master_admin_service.h
+++ b/mooncake-store/include/master_admin_service.h
@@ -68,6 +68,8 @@ class MasterAdminServer {
                               coro_http::coro_http_response& resp);
     void HandleHealth(coro_http::coro_http_request& req,
                       coro_http::coro_http_response& resp);
+    void HandleVersion(coro_http::coro_http_request& req,
+                       coro_http::coro_http_response& resp);
     void HandleRole(coro_http::coro_http_request& req,
                     coro_http::coro_http_response& resp);
     void HandleHaStatus(coro_http::coro_http_request& req,

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -741,6 +741,16 @@ class MasterMetricManager {
     ylt::metric::counter_t fetch_tasks_failures_;
     ylt::metric::counter_t mark_task_to_complete_requests_;
     ylt::metric::counter_t mark_task_to_complete_failures_;
+
+    // Build Info Metric
+    // Prometheus "info" pattern: the value carries no meaning and is always 1,
+    // the version strings are exposed as labels so dashboards and alerts can
+    // group or filter by the running build. The label values are compile-time
+    // constants, so this is a single-series gauge with static labels rather
+    // than a dynamic-label metric.
+    // Shares the `mooncake_build_info` name with the client-side metric; the
+    // two are told apart by the scrape target's job/instance labels.
+    ylt::metric::gauge_t build_info_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -7,10 +7,20 @@
 
 #include "bool_parser.h"
 #include "integer_parser.h"
+#include "version.h"
 
 namespace mooncake {
 
 namespace {
+
+// Build info is exposed as an info-style metric, so the version strings live in
+// labels. Caller supplied labels are preserved to keep instance identification.
+std::map<std::string, std::string> WithBuildInfoLabels(
+    std::map<std::string, std::string> labels) {
+    labels["version"] = GetMooncakeStoreVersion();
+    labels["display_version"] = MOONCAKE_DISPLAY_VERSION;
+    return labels;
+}
 
 bool parseMetricsEnabled() {
     const char* metric_env = std::getenv("MC_STORE_CLIENT_METRIC");
@@ -71,10 +81,16 @@ ClientMetric::ClientMetric(uint64_t interval_seconds,
       master_client_metric(labels),
       transfer_operation_metric(labels),
       ssd_metric(labels),
+      build_info("mooncake_build_info",
+                 "Build version of the running client; the value is always 1 "
+                 "and the version strings are carried by the labels",
+                 WithBuildInfoLabels(labels)),
       should_stop_metrics_thread_(false),
       metrics_interval_seconds_(interval_seconds),
       bandwidth_reporting_enabled_(bandwidth_reporting_enabled),
       master_rpc_metrics_enabled_(master_rpc_metrics_enabled) {
+    // Set once: the compiled-in version never changes at runtime.
+    build_info.update(1);
     last_report_snapshot_ = TransferSnapshot{
         static_cast<uint64_t>(transfer_metric.total_read_bytes.value()),
         static_cast<uint64_t>(transfer_metric.total_write_bytes.value()),
@@ -116,11 +132,16 @@ void ClientMetric::serialize(std::string& str) {
     }
     transfer_operation_metric.serialize(str);
     ssd_metric.serialize(str);
+    build_info.serialize(str);
 }
 
 std::string ClientMetric::summary_metrics() {
     std::stringstream ss;
     ss << "Client Metrics Summary\n";
+    // Identify the build inline so one /metrics/summary request is enough to
+    // tell which binary produced the numbers below.
+    ss << "Version: " << GetMooncakeStoreVersion() << " ("
+       << MOONCAKE_DISPLAY_VERSION << ")\n";
     ss << transfer_metric.summary_metrics(bandwidth_reporting_enabled_);
     ss << "\n";
     if (master_rpc_metrics_enabled_) {

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -1412,6 +1412,9 @@ int main(int argc, char* argv[]) {
         google::SetLogSymlink(google::GLOG_INFO, "mooncake_master");
     }
 
+    LOG(INFO) << "Mooncake master version: "
+              << mooncake::MOONCAKE_DISPLAY_VERSION;
+
     // Initialize the master configuration
     mooncake::MasterConfig master_config;
     std::string conf_path = FLAGS_config_path;

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -21,6 +21,7 @@
 #include "master_metric_manager.h"
 #include "rpc_service.h"
 #include "types.h"
+#include "version.h"
 
 namespace mooncake {
 
@@ -480,6 +481,20 @@ void MasterAdminServer::HandleHealth(coro_http::coro_http_request&,
         payload.view_version = snapshot.leader_view->view_version;
     }
     WriteJsonResponse(resp, coro_http::status_type::ok, payload);
+}
+
+struct HttpVersionResponse {
+    std::string version;
+    std::string display_version;
+};
+YLT_REFL(HttpVersionResponse, version, display_version);
+
+void MasterAdminServer::HandleVersion(coro_http::coro_http_request&,
+                                      coro_http::coro_http_response& resp) {
+    WriteJsonResponse(
+        resp, coro_http::status_type::ok,
+        HttpVersionResponse{.version = GetMooncakeStoreVersion(),
+                            .display_version = MOONCAKE_DISPLAY_VERSION});
 }
 
 struct HttpLeaderResponse {
@@ -1189,6 +1204,10 @@ void MasterAdminServer::RegisterHandler() {
     http_server_.set_http_handler<GET>(
         "/health", [this](coro_http_request& req, coro_http_response& resp) {
             HandleHealth(req, resp);
+        });
+    http_server_.set_http_handler<GET>(
+        "/version", [this](coro_http_request& req, coro_http_response& resp) {
+            HandleVersion(req, resp);
         });
     http_server_.set_http_handler<GET>(
         "/role", [this](coro_http_request& req, coro_http_response& resp) {

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 
 #include "utils.h"
+#include "version.h"
 
 namespace mooncake {
 
@@ -477,9 +478,17 @@ MasterMetricManager::MasterMetricManager()
           "Total number of MarkTaskToComplete requests received"),
       mark_task_to_complete_failures_(
           "master_update_task_failures_total",
-          "Total number of failed MarkTaskToComplete requests") {
+          "Total number of failed MarkTaskToComplete requests"),
+      build_info_("mooncake_build_info",
+                  "Build version of the running master; the value is always 1 "
+                  "and the version strings are carried by the labels",
+                  {{"version", GetMooncakeStoreVersion()},
+                   {"display_version", MOONCAKE_DISPLAY_VERSION}}) {
     // Update all metrics once to ensure zero values are serialized
     update_metrics_for_zero_output();
+    // Info-style metric: emit a single series for the build this binary was
+    // compiled from. Set once here because the value never changes at runtime.
+    build_info_.update(1);
 }
 
 // --- Metric Interface Methods ---
@@ -1972,6 +1981,7 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(promotion_candidate_dropped_limit_);
     serialize_metric(tenant_quota_reject_total_);
     serialize_metric(tenant_evict_bytes_total_);
+    serialize_metric(build_info_);
 
     // Serialize Snapshot Metrics
     serialize_metric(snapshot_duration_ms_);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -37,6 +37,7 @@
 #include "device/cuda_ipc_buffer.h"
 #include "shm_helper.h"
 #include "memory_location.h"
+#include "version.h"
 #ifdef USE_NOF
 #include "spdk/spdk_wrapper.h"
 #endif
@@ -1909,6 +1910,15 @@ int RealClient::start_http_server(int port) {
             }
             resp.add_header("Content-Type", "text/plain");
             resp.set_status_and_content(status_type::ok, std::move(*result));
+        });
+
+    http_server_->set_http_handler<GET>(
+        "/version", [](coro_http_request &req, coro_http_response &resp) {
+            std::string body = "{\"version\":\"" + GetMooncakeStoreVersion() +
+                               "\",\"display_version\":\"" +
+                               std::string(MOONCAKE_DISPLAY_VERSION) + "\"}";
+            resp.add_header("Content-Type", "application/json");
+            resp.set_status_and_content(status_type::ok, std::move(body));
         });
 
     auto ec = http_server_->async_start();

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -6,6 +6,7 @@
 #include "common.h"
 #include "config.h"
 #include "real_client.h"
+#include "version.h"
 
 using namespace mooncake;
 
@@ -110,10 +111,14 @@ int main(int argc, char *argv[]) {
     // spawning threads, leading to missing signal processing.
     mooncake::ResourceTracker::getInstance();
 
+    gflags::SetVersionString(mooncake::MOONCAKE_DISPLAY_VERSION);
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     if (!FLAGS_log_dir.empty()) {
         google::InitGoogleLogging(argv[0]);
     }
+
+    LOG(INFO) << "Mooncake real client version: "
+              << mooncake::MOONCAKE_DISPLAY_VERSION;
 
     size_t global_segment_size = string_to_byte_size(FLAGS_global_segment_size);
     size_t local_buffer_size = string_to_byte_size(FLAGS_local_buffer_size);

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -14,6 +14,7 @@
 #include "real_client.h"
 #include "test_server_helpers.h"
 #include "utils.h"
+#include "version.h"
 
 namespace mooncake::test {
 namespace {
@@ -205,6 +206,10 @@ TEST_F(ClientMetricsTest, ClientMetricsSummaryTest) {
     EXPECT_TRUE(summary.find("ExistKey: count=1") != std::string::npos);
     EXPECT_TRUE(summary.find("get_buffer: count=1") != std::string::npos);
     EXPECT_TRUE(summary.find("put_batch: count=1") != std::string::npos);
+    // The build is named inline so the summary alone identifies the binary.
+    EXPECT_TRUE(summary.find("Version: " + GetMooncakeStoreVersion()) !=
+                std::string::npos);
+    EXPECT_TRUE(summary.find(MOONCAKE_DISPLAY_VERSION) != std::string::npos);
 
     std::cout << "Full Client Metrics Summary:\n" << summary << std::endl;
 }
@@ -409,6 +414,62 @@ TEST_F(ClientMetricsTest, SerializeWithoutDynamicLabels) {
     }
 }
 
+TEST_F(ClientMetricsTest, BuildInfoMetricIsSerialized) {
+    ClientMetric metrics(0);
+
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    ASSERT_NE(serialized.find("mooncake_build_info{"), std::string::npos)
+        << "build info metric missing from serialized output";
+    // Label order inside the series is not asserted: only the presence of both
+    // labels with the compiled-in values matters for scraping and grouping.
+    EXPECT_NE(serialized.find("version=\"" + GetMooncakeStoreVersion() + "\""),
+              std::string::npos)
+        << "RPC handshake version missing from build info labels";
+    EXPECT_NE(serialized.find("display_version=\"" +
+                              std::string(MOONCAKE_DISPLAY_VERSION) + "\""),
+              std::string::npos)
+        << "display version missing from build info labels";
+
+    // Info-style metric: the value is fixed at 1, so exactly one series is
+    // emitted and its value follows the closing brace of the label set.
+    EXPECT_EQ(CountOccurrences(serialized, "mooncake_build_info{"), 1u);
+    const auto metric_pos = serialized.find("mooncake_build_info{");
+    const auto brace_end = serialized.find('}', metric_pos);
+    ASSERT_NE(brace_end, std::string::npos);
+    const auto line_end = serialized.find('\n', brace_end);
+    const std::string value_part =
+        serialized.substr(brace_end + 1, line_end == std::string::npos
+                                             ? std::string::npos
+                                             : line_end - brace_end - 1);
+    EXPECT_NE(value_part.find('1'), std::string::npos)
+        << "build info value should be 1, got:" << value_part;
+}
+
+TEST_F(ClientMetricsTest, BuildInfoMetricKeepsCallerLabels) {
+    // Caller supplied labels identify the instance; the version labels are
+    // added on top of them rather than replacing them.
+    std::map<std::string, std::string> static_labels = {
+        {"instance_id", "12345"}, {"cluster_id", "cluster1"}};
+    ClientMetric metrics(0, static_labels);
+
+    std::string serialized;
+    metrics.serialize(serialized);
+
+    const auto metric_pos = serialized.find("mooncake_build_info{");
+    ASSERT_NE(metric_pos, std::string::npos);
+    const auto brace_end = serialized.find('}', metric_pos);
+    ASSERT_NE(brace_end, std::string::npos);
+    const std::string labels =
+        serialized.substr(metric_pos, brace_end - metric_pos);
+
+    EXPECT_NE(labels.find("instance_id=\"12345\""), std::string::npos);
+    EXPECT_NE(labels.find("cluster_id=\"cluster1\""), std::string::npos);
+    EXPECT_NE(labels.find("version=\"" + GetMooncakeStoreVersion() + "\""),
+              std::string::npos);
+}
+
 TEST_F(ClientMetricsTest, HttpMetricsEndpointsReturnData) {
     std::unordered_set<int> used_ports;
     int master_rpc_port = GetTestPort(used_ports);
@@ -543,6 +604,16 @@ TEST_F(ClientMetricsTest, HttpMetricsEndpointReturns503WhenMetricsDisabled) {
         FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/metrics");
     EXPECT_EQ(metrics.status, 503);
     EXPECT_NE(metrics.body.find("metrics not available"), std::string::npos);
+
+    // `/version` is served without touching the metric collector, so disabling
+    // metrics must not take it down along with `/metrics`.
+    auto version =
+        FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/version");
+    EXPECT_EQ(version.status, 200);
+    EXPECT_NE(
+        version.body.find("\"version\":\"" + GetMooncakeStoreVersion() + "\""),
+        std::string::npos);
+    EXPECT_NE(version.body.find("display_version"), std::string::npos);
 
     EXPECT_EQ(client->tearDownAll(), 0);
 }

--- a/mooncake-store/tests/health_check_test.cpp
+++ b/mooncake-store/tests/health_check_test.cpp
@@ -14,6 +14,7 @@
 #include "real_client.h"
 #include "test_server_helpers.h"
 #include "default_config.h"
+#include "version.h"
 
 DEFINE_string(protocol, "tcp", "Transfer protocol: rdma|tcp");
 DEFINE_string(device_name, "", "Device name to use, valid if protocol=rdma");
@@ -236,6 +237,27 @@ TEST_F(HealthCheckTest, MetricsEndpointsReturnCorrectData) {
         << "Put summary missing";
     EXPECT_NE(summary_resp.body.find("Get:"), std::string::npos)
         << "Get summary missing";
+
+    py_client_->tearDownAll();
+    master_.Stop();
+}
+
+// Test 8: HTTP /version returns 200 with version information
+TEST_F(HealthCheckTest, VersionEndpointReturnsVersion) {
+    int http_port = getFreeTcpPort();
+    FLAGS_http_port = http_port;
+    ASSERT_EQ(StartMasterAndSetupClient(18930), 0) << "setup_real failed";
+
+    std::this_thread::sleep_for(std::chrono::seconds(2));
+
+    auto resp = fetch_url(http_port, "/version");
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_NE(resp.body.find("\"version\""), std::string::npos);
+    EXPECT_NE(resp.body.find("\"display_version\""), std::string::npos);
+    EXPECT_NE(resp.body.find(GetMooncakeStoreVersion()), std::string::npos)
+        << "store version missing from /version response";
+    EXPECT_NE(resp.body.find(MOONCAKE_DISPLAY_VERSION), std::string::npos)
+        << "display version missing from /version response";
 
     py_client_->tearDownAll();
     master_.Stop();

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -21,6 +21,7 @@
 #include "tenant_quota_policy_store.h"
 #include "types.h"
 #include "utils.h"
+#include "version.h"
 
 #include <ylt/reflection/user_reflect_macro.hpp>
 
@@ -204,6 +205,35 @@ TEST_F(MasterAdminServerTest, HealthEndpointReturns200InServing) {
     auto resp = HttpGet(port, "/health");
     EXPECT_EQ(resp.http_status, 200);
     EXPECT_NE(resp.body.find("\"role\":\"leader\""), std::string::npos);
+
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, VersionEndpointReturnsVersion) {
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kServing);
+
+    auto resp = HttpGet(port, "/version");
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_NE(resp.body.find("\"version\""), std::string::npos);
+    EXPECT_NE(resp.body.find("\"display_version\""), std::string::npos);
+    EXPECT_NE(resp.body.find(GetMooncakeStoreVersion()), std::string::npos);
+    EXPECT_NE(resp.body.find(MOONCAKE_DISPLAY_VERSION), std::string::npos);
+
+    admin.Stop();
+}
+
+TEST_F(MasterAdminServerTest, VersionEndpointAvailableInStandby) {
+    int port = getFreeTcpPort();
+    MasterAdminServer admin(static_cast<uint16_t>(port), false);
+    ASSERT_TRUE(admin.Start());
+    admin.SetRuntimeState(ha::MasterRuntimeState::kStandby);
+
+    auto resp = HttpGet(port, "/version");
+    EXPECT_EQ(resp.http_status, 200);
+    EXPECT_NE(resp.body.find(GetMooncakeStoreVersion()), std::string::npos);
 
     admin.Stop();
 }

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -18,6 +18,7 @@
 #include "types.h"
 #include "master_config.h"
 #include "master_metric_manager.h"
+#include "version.h"
 
 namespace mooncake::test {
 
@@ -1032,6 +1033,42 @@ TEST_F(MasterMetricsTest, SsdOffloadCacheHitAndTotalConsistent) {
     // Clean up.
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     service_.Remove(ssd_only_key, "default");
+}
+
+// Build info is an "info"-style metric: the value is always 1 and the version
+// strings are carried by labels, so serialization must emit a single series
+// containing both version labels.
+TEST_F(MasterMetricsTest, BuildInfoMetricIsSerialized) {
+    auto& metrics = MasterMetricManager::instance();
+
+    const std::string serialized = metrics.serialize_metrics();
+
+    ASSERT_NE(serialized.find("mooncake_build_info"), std::string::npos)
+        << "build info metric missing from serialized output";
+    // Label order inside the series is not asserted: only the presence of both
+    // labels with the compiled-in values matters for scraping and grouping.
+    EXPECT_NE(serialized.find("version=\"" + GetMooncakeStoreVersion() + "\""),
+              std::string::npos)
+        << "RPC handshake version missing from build info labels";
+    EXPECT_NE(serialized.find("display_version=\"" +
+                              std::string(MOONCAKE_DISPLAY_VERSION) + "\""),
+              std::string::npos)
+        << "display version missing from build info labels";
+
+    // The series value is fixed at 1; extract the number after the closing
+    // brace of the build info series to confirm it is exposed as such.
+    const auto metric_pos = serialized.find("mooncake_build_info{");
+    ASSERT_NE(metric_pos, std::string::npos)
+        << "build info metric has no labelled series";
+    const auto brace_end = serialized.find('}', metric_pos);
+    ASSERT_NE(brace_end, std::string::npos);
+    const auto line_end = serialized.find('\n', brace_end);
+    const std::string value_part =
+        serialized.substr(brace_end + 1, line_end == std::string::npos
+                                             ? std::string::npos
+                                             : line_end - brace_end - 1);
+    EXPECT_NE(value_part.find('1'), std::string::npos)
+        << "build info value should be 1, got:" << value_part;
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
Expose build version information over HTTP so operators can verify which binary a running process is using without shell access to the host.

- Master admin server: new `GET /version` handler, registered alongside `/health` so it stays available in standby.
- Real client HTTP server: same `/version` payload on the client HTTP port; it does not touch `client_`, so it is unaffected by `MC_STORE_CLIENT_METRIC` and by client initialization state.
- `mooncake_client`: set the gflags version string so `--version` works, and log the display version at startup.

Both endpoints return `version` (used for RPC handshake compatibility) and `display_version` (release plus short git hash).

Docs: document the endpoint in the master admin endpoint table, the client endpoint table, the HTTP service reference, and the three client HTTP server switches that gate it.

Tests: add `/version` coverage for the real client HTTP server, and for the master admin server in both serving and standby states.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

./mooncake_client --version
mooncake_client version 0.3.12.post1 (git: f9e8311f)

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

curl xxx:port/version
{"version":"2.0.0","display_version":"0.3.12.post1 (git: f9e8311f)"}

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)