### PR TITLE
[CI] Add Reshard module test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,6 +415,7 @@ jobs:
     outputs:
       should-run-downstream: ${{ steps.dispatch-override.outputs.src || steps.filter.outputs.src }}
       should-run-tent: ${{ steps.dispatch-override.outputs.tent || steps.filter.outputs.tent }}
+      should-run-reshard: ${{ steps.dispatch-override.outputs.reshard || steps.filter.outputs.reshard }}
     steps:
       # workflow_dispatch has no PR/push diff context — skip paths-filter and default to true
       - name: Default to true for workflow_dispatch
@@ -423,6 +424,7 @@ jobs:
         run: |
           echo "src=true" >> $GITHUB_OUTPUT
           echo "tent=true" >> $GITHUB_OUTPUT
+          echo "reshard=true" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         if: github.event_name != 'workflow_dispatch'
         with:
@@ -447,6 +449,49 @@ jobs:
               - 'CMakeLists.txt'
               - 'dependencies.sh'
               - '.github/workflows/ci.yml'
+            reshard:
+              - 'mooncake-reshard/**'
+              - 'mooncake-wheel/pyproject.toml'
+              - 'requirements.txt'
+              - 'scripts/check_reshard_types.sh'
+              - '.github/workflows/ci.yml'
+
+  reshard-test:
+    name: Test Reshard (Python ${{ matrix.python-version }})
+    needs: [check-paths]
+    if: >-
+      (needs.check-paths.outputs.should-run-reshard == 'true' ||
+       github.event_name == 'workflow_dispatch') &&
+      (github.event_name == 'push' ||
+       github.event_name == 'workflow_dispatch' ||
+       github.event.action == 'opened' ||
+       contains(github.event.pull_request.labels.*.name, 'run-ci'))
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Reshard test dependencies
+      run: |
+        python -m pip install --disable-pip-version-check --upgrade pip
+        python -m pip install --disable-pip-version-check \
+          -r requirements.txt pytest==8.3.5
+
+    - name: Test Reshard
+      run: |
+        PYTHONPATH=mooncake-reshard/python \
+          python -m pytest -q mooncake-reshard/tests
+      shell: bash
 
   build-wheel-cu13:
     needs: [spell-check, clang-format, check-paths]
@@ -639,6 +684,8 @@ jobs:
       - spell-check
       - clang-format
       - docs-check
+      - reshard-type-check
+      - reshard-test
       - build-wheel
       - build-flags
       - test-wheel-ubuntu


### PR DESCRIPTION
## Description

Adds a path-aware Reshard module test gate to the central Linux CI workflow.

The existing `reshard-type-check` job remains the static contract check. This
PR adds the complementary pytest gate:

- recognizes Reshard-related changes in `check-paths`;
- runs `mooncake-reshard/tests` on Python 3.10 and 3.12;
- installs the Python test dependencies required by the job;
- adds `reshard-test` to the final `CI Gate`;
- skips the new job for unrelated changes.

This PR does not change Reshard runtime, planner, Mooncake Store, or Transfer
Engine behavior.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [x] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other

## How Has This Been Tested?

**Test commands:**

```bash
PYTHONPATH=mooncake-reshard/python \
  python -m pytest -q mooncake-reshard/tests

bash scripts/check_reshard_types.sh

./scripts/code_format.sh --check --base origin/main

pre-commit run --files .github/workflows/ci.yml
```

**Test results:**

- [x] Unit tests pass
  - `289 passed in 4.88s`
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

The central CI workflow was parsed and checked to confirm that:

- Reshard source, test, type-check, wheel, requirements, and workflow changes
  activate the Reshard path filter.
- The new test job runs on Python 3.10 and 3.12.
- The job executes the Reshard pytest suite with the required `PYTHONPATH`.
- `CI Gate` depends on both the existing Reshard type-check job and the new
  Reshard test job.

The positive strict type-check suite reports `0 errors`. The negative type
fixtures intentionally report two invalid contract usages, and the type-check
script accepts those expected failures.

On `h20-8`, `./scripts/code_format.sh --check` passed for the actual CI
diff and reported no C/C++ files changed. Scoped pre-commit also passed for
`.github/workflows/ci.yml`, including YAML validation, trailing-whitespace,
end-of-file, merge-conflict, large-file, and codespell checks.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used for implementation assistance, workflow review, and test
orchestration. The human author reviewed the final diff and verification
output.