### PR TITLE
[PG] Migrate Python loader to unified package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,11 @@
 /mooncake-integration/transfer_engine @ShangmingCai @alogfans
 /mooncake-integration/store @ykwd @stmatengss @zxpdemonio
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
-/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio 
+/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-store/*/ha/ @Libotry @YiXR @00fish0 @Icedcoco @Aionw
+/python/mooncake/pg.py @UNIDY2002 @ympcMark @yuechen-sys
+/python/tests/pg/ @UNIDY2002 @ympcMark @yuechen-sys
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,7 +13,10 @@ Transfer Engine:
 
 PyTorch Backend:
   - changed-files:
-    - any-glob-to-any-file: 'mooncake-pg/**/*'
+    - any-glob-to-any-file:
+      - 'mooncake-pg/**/*'
+      - 'python/mooncake/pg.py'
+      - 'python/tests/pg/**/*'
 
 Mooncake EP:
   - changed-files:
@@ -57,6 +60,7 @@ Tests:
       - 'scripts/test_*'
       - 'mooncake-wheel/tests/**/*'
       - 'mooncake-reshard/tests/**/*'
+      - 'python/tests/pg/**/*'
       - 'scripts/tone_tests/**/*'
 
 Ascend/NPU:

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -256,7 +256,7 @@ if(WITH_EP)
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/ep.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ep_buffer.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_elastic_buffer.py"
-      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/pg.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/pg.py"
     DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR}
     COMPONENT python)
   # ep.so / pg.so link against engine.so by that exact bare name. Create a

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -22,7 +22,8 @@ install(
   COMPONENT python
   FILES_MATCHING
   PATTERN "*.py"
-  PATTERN "__init__.py" EXCLUDE)
+  PATTERN "__init__.py" EXCLUDE
+  PATTERN "pg.py" EXCLUDE)
 install(
   DIRECTORY
     "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-reshard/python/mooncake/reshard/"

--- a/python/mooncake/pg.py
+++ b/python/mooncake/pg.py
@@ -13,4 +13,6 @@ except ModuleNotFoundError:
         f"Mooncake PG was not built against torch=={torch_version}.\n"
         f"Open an issue at https://github.com/kvcache-ai/Mooncake/issues."
     )
-globals().update({k: v for k, v in backend_module.__dict__.items() if not k.startswith("_")})
+globals().update(
+    {k: v for k, v in backend_module.__dict__.items() if not k.startswith("_")}
+)

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import zipfile
 
 import pytest
 
@@ -28,6 +29,8 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
 
     wheel = Path(wheel_value).resolve()
     assert wheel.is_file(), f"wheel does not exist: {wheel}"
+    with zipfile.ZipFile(wheel) as archive:
+        assert archive.namelist().count("mooncake/pg.py") == 1
 
     environment = tmp_path / "environment"
     subprocess.run([sys.executable, "-m", "venv", str(environment)], check=True)
@@ -42,7 +45,10 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
     clean_environment["PYTHONNOUSERSITE"] = "1"
     smoke_script = f"""
 from importlib import metadata
+import importlib
 from pathlib import Path
+import sys
+from types import ModuleType
 import mooncake
 import mooncake.engine
 import mooncake.reshard
@@ -54,6 +60,19 @@ assert not package_path.is_relative_to(repository_path), (package_path, reposito
 assert metadata.version("mooncake-transfer-engine") == {_project_version()!r}
 assert mooncake.BufferPool is mooncake.store.BufferPool
 assert mooncake.engine.TransferEngine is not None
+assert "mooncake.pg" not in sys.modules
+assert "torch" not in sys.modules
+
+torch = ModuleType("torch")
+torch.__version__ = "2.7.1+cu128"
+sys.modules["torch"] = torch
+backend = ModuleType("mooncake.pg_2_7_1")
+backend.installed_wheel_marker = object()
+sys.modules[backend.__name__] = backend
+
+pg = importlib.import_module("mooncake.pg")
+assert Path(pg.__file__).resolve().parent == package_path.parent
+assert pg.installed_wheel_marker is backend.installed_wheel_marker
 """
     subprocess.run(
         [str(python), "-I", "-c", smoke_script],

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -57,6 +57,12 @@ def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
     assert not list((REPOSITORY_ROOT / "mooncake-pg" / "torch").rglob("*.so"))
 
 
+def test_pg_loader_has_one_authoritative_source() -> None:
+    assert (REPOSITORY_ROOT / "python" / "mooncake" / "pg.py").is_file()
+    assert (REPOSITORY_ROOT / "python" / "tests" / "pg" / "test_loader.py").is_file()
+    assert not (REPOSITORY_ROOT / "mooncake-wheel" / "mooncake" / "pg.py").exists()
+
+
 def test_pg_extension_build_stages_outside_the_source_tree(
     tmp_path: Path,
 ) -> None:

--- a/python/tests/pg/test_loader.py
+++ b/python/tests/pg/test_loader.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PG_LOADER = REPOSITORY_ROOT / "python" / "mooncake" / "pg.py"
+
+
+def _load_pg(monkeypatch: pytest.MonkeyPatch, torch_version: str) -> ModuleType:
+    package = ModuleType("mooncake")
+    package.__path__ = []
+    monkeypatch.setitem(sys.modules, "mooncake", package)
+
+    torch = ModuleType("torch")
+    torch.__version__ = torch_version
+    monkeypatch.setitem(sys.modules, "torch", torch)
+
+    spec = importlib.util.spec_from_file_location("mooncake.pg", PG_LOADER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_loader_selects_the_torch_abi_extension(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = ModuleType("mooncake.pg_2_7_1")
+    exported = object()
+    backend.exported = exported
+    backend._private = object()
+    monkeypatch.setitem(sys.modules, backend.__name__, backend)
+
+    loader = _load_pg(monkeypatch, "2.7.1+cu128")
+
+    assert loader.torch_version == "2.7.1"
+    assert loader.version_suffix == "_2_7_1"
+    assert loader.exported is exported
+    assert not hasattr(loader, "_private")
+
+
+def test_loader_reports_an_unsupported_torch_abi(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(
+        ImportError,
+        match=r"Mooncake PG was not built against torch==2\.8\.0",
+    ):
+        _load_pg(monkeypatch, "2.8.0")

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -180,15 +180,19 @@ if [ "$NPU_BUILD" = "1" ]; then
 fi
 
 echo "Building wheel package..."
-# Stage the reshard Python package for the combined Mooncake wheel. The tracked
-# source of truth remains in the top-level module.
+# Stage the migrated PG loader and the Reshard Python package for the combined
+# Mooncake wheel. Their tracked sources remain in their authoritative trees.
+PG_SOURCE="python/mooncake/pg.py"
+PG_STAGING_PATH="$(pwd)/mooncake-wheel/mooncake/pg.py"
 RESHARD_SOURCE_DIR="mooncake-reshard/python/mooncake/reshard"
 RESHARD_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake/reshard"
-cleanup_reshard_staging() {
+cleanup_migrated_python_staging() {
+    rm -f "${PG_STAGING_PATH}"
     rm -rf "${RESHARD_STAGING_DIR}"
 }
-trap cleanup_reshard_staging EXIT
-rm -rf "${RESHARD_STAGING_DIR}"
+trap cleanup_migrated_python_staging EXIT
+cleanup_migrated_python_staging
+cp "${PG_SOURCE}" "${PG_STAGING_PATH}"
 cp -R "${RESHARD_SOURCE_DIR}" "${RESHARD_STAGING_DIR}"
 
 # Build the wheel package
@@ -204,7 +208,7 @@ WHEEL_DIR="$(pwd)"
 cleanup_wheel_metadata_state() {
     [[ -f "${WHEEL_DIR}/pyproject.toml.backup" ]] && mv "${WHEEL_DIR}/pyproject.toml.backup" "${WHEEL_DIR}/pyproject.toml"
     rm -f "${WHEEL_DIR}/README.md"
-    cleanup_reshard_staging
+    cleanup_migrated_python_staging
 }
 trap cleanup_wheel_metadata_state EXIT
 


### PR DESCRIPTION
## Description

Implement the Mooncake PG Python loader increment of Phase 2 in #3534.

- move `mooncake.pg` from `mooncake-wheel/mooncake/pg.py` to the canonical `python/mooncake/pg.py` source tree;
- preserve the public import behavior and version-suffixed Torch ABI selection without renaming native extensions;
- update scikit-build/CMake installation and the temporary legacy wheel staging input to consume the canonical loader;
- add source-tree loader tests and installed-wheel coverage proving the loader is packaged exactly once and stays lazy until `mooncake.pg` is imported;
- update PG ownership and labeling for the canonical source and tests.

Overlap review:

- #3484 adds an opt-in native collective framework under `mooncake-pg`; it does not modify the Python loader. This PR only migrates that loader and does not include any of #3484's native collective feature work.
- #3585 and #3586 are independent Phase 2 migrations for Reshard and lightweight Store utilities/configuration. This branch is based directly on `main` and does not duplicate either migration.
- No other open PR was found that migrates the PG Python loader.

Closes no issue; contributes to #3534.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
MOONCAKE_TEST_WHEEL="$PWD/dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl" python -m pytest -q python/tests/pg python/tests/packaging
CMAKE_BUILD_PARALLEL_LEVEL=128 python -m build --wheel
python -m twine check dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl
bash -n scripts/build_wheel.sh
git fetch origin main
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```

**Test results:**

- [x] Unit tests pass (8 focused PG and packaging tests passed)
- [x] Integration tests pass (root PEP 517 wheel build, isolated wheel installation under `python -I`, and installed `mooncake.pg` ABI-loader smoke test)
- [x] Manual testing done (`twine check` passed and the wheel manifest contains exactly one `mooncake/pg.py`)

## Checklist

- [x] I have performed a self-review of my own code
- [x] C/C++ formatting is not applicable; no C/C++ sources changed and the pre-commit hook skipped them
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation updates are not applicable because public imports and behavior are unchanged
- [x] I have added tests to prove my changes are effective
- [x] RFC #3534 covers this migration (the effective diff is 116 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with the module migration, build-path audit, test coverage,
validation, and PR preparation. The human submitter remains responsible for
understanding and defending every changed line.