### PR TITLE
[Store] Migrate async Python client to unified package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,12 @@
 /mooncake-integration/transfer_engine @ShangmingCai @alogfans
 /mooncake-integration/store @ykwd @stmatengss @zxpdemonio
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
-/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio 
+/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-store/*/ha/ @Libotry @YiXR @00fish0 @Icedcoco @Aionw
+/python/mooncake/async_store.py @ykwd @stmatengss @zxpdemonio
+/python/tests/store/async_store_integration.py @ykwd @stmatengss @zxpdemonio
+/python/tests/store/test_async_store.py @ykwd @stmatengss @zxpdemonio
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,10 @@ run-ci:
 
 store:
   - changed-files:
-    - any-glob-to-any-file: 'mooncake-store/**/*'
+    - any-glob-to-any-file:
+      - 'mooncake-store/**/*'
+      - 'python/mooncake/async_store.py'
+      - 'python/tests/store/*async_store*'
 
 Transfer Engine:
   - changed-files:
@@ -57,6 +60,7 @@ Tests:
       - 'scripts/test_*'
       - 'mooncake-wheel/tests/**/*'
       - 'mooncake-reshard/tests/**/*'
+      - 'python/tests/store/*async_store*'
       - 'scripts/tone_tests/**/*'
 
 Ascend/NPU:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
         LOCAL_HOSTNAME: "127.0.0.1"
       run: |
         source test_env/bin/activate
-        python scripts/test_async_store.py
+        python python/tests/store/async_store_integration.py
       shell: bash
 
     - name: Test Mooncake Copy/Move API

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -181,7 +181,7 @@ if(USE_INTRA_NVLINK)
 endif()
 
 install(
-  FILES "${CMAKE_CURRENT_SOURCE_DIR}/store/async_store.py"
+  FILES "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/async_store.py"
   DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR}
   COMPONENT python)
 

--- a/python/mooncake/async_store.py
+++ b/python/mooncake/async_store.py
@@ -1,16 +1,23 @@
 import asyncio
 import functools
+
 from mooncake.store import MooncakeDistributedStore
+
 
 class MooncakeDistributedStoreAsync(MooncakeDistributedStore):
     def __getattr__(self, name: str):
         if not name.startswith("async_"):
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}'"
+            )
 
         sync_method_name = name[6:]
 
         if not hasattr(self, sync_method_name):
-            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}' (nor '{sync_method_name}')")
+            raise AttributeError(
+                f"'{type(self).__name__}' object has no attribute '{name}' "
+                f"(nor '{sync_method_name}')"
+            )
 
         sync_method = getattr(self, sync_method_name)
 

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -44,6 +44,7 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
 from importlib import metadata
 from pathlib import Path
 import mooncake
+import mooncake.async_store
 import mooncake.engine
 import mooncake.reshard
 import mooncake.store
@@ -53,6 +54,11 @@ repository_path = Path({str(REPOSITORY_ROOT)!r}).resolve()
 assert not package_path.is_relative_to(repository_path), (package_path, repository_path)
 assert metadata.version("mooncake-transfer-engine") == {_project_version()!r}
 assert mooncake.BufferPool is mooncake.store.BufferPool
+assert issubclass(
+    mooncake.async_store.MooncakeDistributedStoreAsync,
+    mooncake.store.MooncakeDistributedStore,
+)
+assert Path(mooncake.async_store.__file__).resolve().parent == package_path.parent
 assert mooncake.engine.TransferEngine is not None
 """
     subprocess.run(

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -57,6 +57,30 @@ def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
     assert not list((REPOSITORY_ROOT / "mooncake-pg" / "torch").rglob("*.so"))
 
 
+def test_async_store_has_one_authoritative_source() -> None:
+    canonical_module = REPOSITORY_ROOT / "python" / "mooncake" / "async_store.py"
+    legacy_module = (
+        REPOSITORY_ROOT / "mooncake-integration" / "store" / "async_store.py"
+    )
+
+    assert canonical_module.is_file()
+    assert not legacy_module.exists()
+    assert (
+        REPOSITORY_ROOT / "python" / "tests" / "store" / "test_async_store.py"
+    ).is_file()
+    assert (
+        REPOSITORY_ROOT / "python" / "tests" / "store" / "async_store_integration.py"
+    ).is_file()
+    assert not (REPOSITORY_ROOT / "scripts" / "test_async_store.py").exists()
+
+    cmake = (REPOSITORY_ROOT / "mooncake-integration" / "CMakeLists.txt").read_text()
+    legacy_builder = (REPOSITORY_ROOT / "scripts" / "build_wheel.sh").read_text()
+    assert '../python/mooncake/async_store.py"' in cmake
+    assert 'CMAKE_CURRENT_SOURCE_DIR}/store/async_store.py"' not in cmake
+    assert "cp python/mooncake/async_store.py " in legacy_builder
+    assert "cp mooncake-integration/store/async_store.py " not in legacy_builder
+
+
 def test_pg_extension_build_stages_outside_the_source_tree(
     tmp_path: Path,
 ) -> None:

--- a/python/tests/store/async_store_integration.py
+++ b/python/tests/store/async_store_integration.py
@@ -27,15 +27,17 @@ GLOBAL_CONFIG = None
 
 DEFAULT_MOONCAKE_CONFIG_PATH_ENV = "MOONCAKE_CONFIG_PATH"
 DEFAULT_GLOBAL_SEGMENT_SIZE = 16 * 1024 * 1024 * 1024  # 16 GiB
-DEFAULT_LOCAL_BUFFER_SIZE = 8 * 1024 * 1024 * 1024    # 8 GB
+DEFAULT_LOCAL_BUFFER_SIZE = 8 * 1024 * 1024 * 1024  # 8 GB
 DEFAULT_MASTER_METRICS_PORT = 9003
 DEFAULT_CHECK_SERVER = False
+
 
 def verify_tensor_equality(original, received, rtol=0, atol=0, verbose=True):
     """
     Utility to compare two tensors (CPU/GPU/Numpy).
     Identical to the synchronous version.
     """
+
     def to_numpy(x):
         if isinstance(x, torch.Tensor):
             if x.is_cuda:
@@ -56,12 +58,16 @@ def verify_tensor_equality(original, received, rtol=0, atol=0, verbose=True):
 
     if orig_np.shape != recv_np.shape:
         if verbose:
-            print(f"❌ Shape mismatch: original {orig_np.shape} vs received {recv_np.shape}")
+            print(
+                f"❌ Shape mismatch: original {orig_np.shape} vs received {recv_np.shape}"
+            )
         return False
 
     if orig_np.dtype != recv_np.dtype:
         if verbose:
-            print(f"❌ Dtype mismatch: original {orig_np.dtype} vs received {recv_np.dtype}")
+            print(
+                f"❌ Dtype mismatch: original {orig_np.dtype} vs received {recv_np.dtype}"
+            )
         return False
 
     if np.array_equal(orig_np, recv_np):
@@ -80,8 +86,10 @@ def verify_tensor_equality(original, received, rtol=0, atol=0, verbose=True):
                 print(f"   Received: {recv_val}")
         return False
 
+
 def parse_global_segment_size(value) -> int:
-    if isinstance(value, int): return value
+    if isinstance(value, int):
+        return value
     if isinstance(value, str):
         s = value.strip().lower()
         if s.endswith("gb"):
@@ -97,18 +105,23 @@ def generate_tensors(num_tensors, size_mb):
     dim = int(np.sqrt(num_elements))
     dim = (dim // 8) * 8
 
-    tensors = [torch.randn(dim, dim, dtype=torch.float32).contiguous() for _ in range(num_tensors)]
+    tensors = [
+        torch.randn(dim, dim, dtype=torch.float32).contiguous()
+        for _ in range(num_tensors)
+    ]
     keys = [f"test_tensor_{i}_{int(time.time()*1000)}" for i in range(num_tensors)]
     return keys, tensors
+
 
 # ==========================================
 #  Module Level Setup/Teardown
 # ==========================================
 
+
 def setUpModule():
     """
     Initialize the Async wrapper globally.
-    Note: We invoke setup() synchronously via asyncio.run() to ensure C++ client is ready 
+    Note: We invoke setup() synchronously via asyncio.run() to ensure C++ client is ready
     before any tests run. This mimics the sync script's behavior.
     """
     global GLOBAL_STORE, GLOBAL_CONFIG
@@ -121,7 +134,9 @@ def setUpModule():
         # Increase max_workers to simulate high async concurrency
         GLOBAL_STORE = MooncakeDistributedStoreAsync()
 
-        print(f"[{os.getpid()}] (Async) Connecting to Mooncake Master at {GLOBAL_CONFIG.master_server_address}...")
+        print(
+            f"[{os.getpid()}] (Async) Connecting to Mooncake Master at {GLOBAL_CONFIG.master_server_address}..."
+        )
 
         def _do_setup():
             return GLOBAL_STORE.setup(
@@ -146,6 +161,7 @@ def setUpModule():
         print(f"❌ Failed to establish global store connection: {e}")
         sys.exit(1)
 
+
 def tearDownModule():
     global GLOBAL_STORE
     if GLOBAL_STORE:
@@ -157,9 +173,11 @@ def tearDownModule():
         finally:
             GLOBAL_STORE = None
 
+
 # ==========================================
 #  Base Test Class (Async)
 # ==========================================
+
 
 class MooncakeAsyncTestBase(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
@@ -176,9 +194,11 @@ class MooncakeAsyncTestBase(unittest.IsolatedAsyncioTestCase):
         # For now, we assume remove_all wraps C++ synchronous logic nicely in a thread.
         await self.store.async_remove_all()
 
+
 # ==========================================
 #  Basic Bytes I/O & Auxiliary Tests
 # ==========================================
+
 
 class TestMooncakeBasicFunctional(MooncakeAsyncTestBase):
     async def test_01_bytes_put_get(self):
@@ -201,7 +221,7 @@ class TestMooncakeBasicFunctional(MooncakeAsyncTestBase):
         count = 10
         keys = [f"test_bytes_batch_{i}" for i in range(count)]
         # Generate different length values
-        values = [f"value_{i}_{'x'*i}".encode('utf-8') for i in range(count)]
+        values = [f"value_{i}_{'x'*i}".encode("utf-8") for i in range(count)]
 
         # 1. Batch Put
         rcs = await self.store.async_put_batch(keys, values)
@@ -287,7 +307,7 @@ class TestMooncakeBasicFunctional(MooncakeAsyncTestBase):
     async def test_07_large_bytes_io(self):
         """Test larger bytes payload (non-tensor path)."""
         key = "test_large_bytes"
-        size = 10 * 1024 * 1024 # 10MB
+        size = 10 * 1024 * 1024  # 10MB
         # Create random bytes
         data = os.urandom(size)
 
@@ -298,9 +318,11 @@ class TestMooncakeBasicFunctional(MooncakeAsyncTestBase):
         self.assertEqual(len(retrieved), size)
         self.assertEqual(retrieved, data)
 
+
 # ==========================================
 #  Tensor Functional Tests
 # ==========================================
+
 
 class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
     async def test_01_basic_put_get(self):
@@ -329,7 +351,9 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         target_tensor = tensors[0]
 
         # 1. Put with TP
-        rc = await self.store.async_put_tensor_with_tp(key, target_tensor, tp_size=tp_size, split_dim=split_dim)
+        rc = await self.store.async_put_tensor_with_tp(
+            key, target_tensor, tp_size=tp_size, split_dim=split_dim
+        )
         self.assertEqual(rc, 0, "put_tensor_with_tp failed")
 
         # 2. Verify existence of shards
@@ -344,16 +368,25 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         # Launch all gets in parallel
         tasks = []
         for rank in range(tp_size):
-            tasks.append(self.store.async_get_tensor_with_tp(key, tp_rank=rank, tp_size=tp_size, split_dim=split_dim))
+            tasks.append(
+                self.store.async_get_tensor_with_tp(
+                    key, tp_rank=rank, tp_size=tp_size, split_dim=split_dim
+                )
+            )
 
         slices = await asyncio.gather(*tasks)
 
         for rank, t_slice in enumerate(slices):
             self.assertIsNotNone(t_slice, f"Slice for rank {rank} is None")
-            self.assertTrue(torch.equal(t_slice, expected_chunks[rank]), f"Data mismatch for rank {rank}")
+            self.assertTrue(
+                torch.equal(t_slice, expected_chunks[rank]),
+                f"Data mismatch for rank {rank}",
+            )
 
         reconstructed = torch.cat(slices, dim=split_dim)
-        self.assertTrue(torch.equal(reconstructed, target_tensor), "Reconstruction mismatch")
+        self.assertTrue(
+            torch.equal(reconstructed, target_tensor), "Reconstruction mismatch"
+        )
 
     async def test_03_tp_batch(self):
         tp_size = 2
@@ -362,15 +395,23 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         keys, tensors = generate_tensors(num_tensors, 8)
 
         # 1. Batch Put with TP
-        results = await self.store.async_batch_put_tensor_with_tp(keys, tensors, tp_size=tp_size, split_dim=split_dim)
-        self.assertTrue(all(r == 0 for r in results), f"Batch put failed. Results: {results}")
+        results = await self.store.async_batch_put_tensor_with_tp(
+            keys, tensors, tp_size=tp_size, split_dim=split_dim
+        )
+        self.assertTrue(
+            all(r == 0 for r in results), f"Batch put failed. Results: {results}"
+        )
 
         # 2. Batch Get per Rank (Concurrently fetch both ranks)
         tasks = []
         for rank in range(tp_size):
-            tasks.append(self.store.async_batch_get_tensor_with_tp(keys, tp_rank=rank, tp_size=tp_size))
+            tasks.append(
+                self.store.async_batch_get_tensor_with_tp(
+                    keys, tp_rank=rank, tp_size=tp_size
+                )
+            )
 
-        all_shards = await asyncio.gather(*tasks) # List of lists
+        all_shards = await asyncio.gather(*tasks)  # List of lists
 
         # 3. Verify & Reconstruct
         for i in range(num_tensors):
@@ -380,8 +421,10 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
 
             for rank in range(tp_size):
                 shard = all_shards[rank][i]
-                self.assertTrue(torch.equal(shard, expected_chunks[rank]),
-                                f"Tensor {i} Rank {rank} data mismatch")
+                self.assertTrue(
+                    torch.equal(shard, expected_chunks[rank]),
+                    f"Tensor {i} Rank {rank} data mismatch",
+                )
                 reconstruction_parts.append(shard)
 
             recon = torch.cat(reconstruction_parts, dim=split_dim)
@@ -391,13 +434,19 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         input_tensor = torch.arange(12).view(3, 4)
         tp_size = 2
 
-        await self.store.async_batch_put_tensor_with_tp(['key'], [input_tensor], tp_size=tp_size, split_dim=1)
+        await self.store.async_batch_put_tensor_with_tp(
+            ["key"], [input_tensor], tp_size=tp_size, split_dim=1
+        )
         chunked_tensors = input_tensor.chunk(chunks=2, dim=1)
 
         # Parallel fetch
         t0, t1 = await asyncio.gather(
-            self.store.async_batch_get_tensor_with_tp(['key'], tp_rank=0, tp_size=tp_size),
-            self.store.async_batch_get_tensor_with_tp(['key'], tp_rank=1, tp_size=tp_size)
+            self.store.async_batch_get_tensor_with_tp(
+                ["key"], tp_rank=0, tp_size=tp_size
+            ),
+            self.store.async_batch_get_tensor_with_tp(
+                ["key"], tp_rank=1, tp_size=tp_size
+            ),
         )
         tmp_tensor_0 = t0[0]
         tmp_tensor_1 = t1[0]
@@ -420,9 +469,11 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
 
         # Parallel get_into
         t2_task = self.store.async_batch_get_tensor_with_tp_into(
-            ['key'], [buffer_ptr_2], [buffer_spacing], tp_rank=0, tp_size=tp_size)
+            ["key"], [buffer_ptr_2], [buffer_spacing], tp_rank=0, tp_size=tp_size
+        )
         t3_task = self.store.async_batch_get_tensor_with_tp_into(
-            ['key'], [buffer_ptr_3], [buffer_spacing], tp_rank=1, tp_size=tp_size)
+            ["key"], [buffer_ptr_3], [buffer_spacing], tp_rank=1, tp_size=tp_size
+        )
 
         t2_res, t3_res = await asyncio.gather(t2_task, t3_task)
         tmp_tensor_2 = t2_res[0]
@@ -447,7 +498,9 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         rc = await self.store.async_put_tensor(key, tensor)
         self.assertEqual(rc, 0)
 
-        retrieved = await self.store.async_get_tensor_into(key, large_buffer_ptr, total_buffer_size)
+        retrieved = await self.store.async_get_tensor_into(
+            key, large_buffer_ptr, total_buffer_size
+        )
         self.assertIsNotNone(retrieved)
         self.assertTrue(torch.equal(tensor, retrieved))
 
@@ -475,7 +528,9 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         results = await self.store.async_batch_put_tensor(keys, tensors)
         self.assertTrue(all(r == 0 for r in results))
 
-        res = await self.store.async_batch_get_tensor_into(keys, buffer_ptrs, buffer_sizes)
+        res = await self.store.async_batch_get_tensor_into(
+            keys, buffer_ptrs, buffer_sizes
+        )
 
         self.assertEqual(len(res), len(tensors))
         for j in range(batch_size):
@@ -489,7 +544,9 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         key = "get_into_with_tp_test"
         tensor = torch.randn(1024, 1024, dtype=torch.float32)
 
-        result = await self.store.async_put_tensor_with_tp(key, tensor, tp_size=tp_size, split_dim=split_dim)
+        result = await self.store.async_put_tensor_with_tp(
+            key, tensor, tp_size=tp_size, split_dim=split_dim
+        )
         self.assertEqual(result, 0)
 
         all_shards = []
@@ -516,7 +573,7 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
 
         for _, shard, buf, ptr in results:
             all_shards.append(shard)
-            registered_buffers.append((buf, ptr)) # Keep buf alive
+            registered_buffers.append((buf, ptr))  # Keep buf alive
 
         # Validate
         original = tensor
@@ -540,7 +597,9 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
         num_tensors = 4
         keys, tensors = generate_tensors(num_tensors, 8)
 
-        results = await self.store.async_batch_put_tensor_with_tp(keys, tensors, tp_size=tp_size, split_dim=split_dim)
+        results = await self.store.async_batch_put_tensor_with_tp(
+            keys, tensors, tp_size=tp_size, split_dim=split_dim
+        )
         self.assertTrue(all(r == 0 for r in results))
 
         async def _fetch_batch_rank(rank):
@@ -551,7 +610,7 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
             l_buf = (ctypes.c_ubyte * total_size)()
             l_ptr = ctypes.addressof(l_buf)
 
-            ptrs = [l_ptr + i*spacing for i in range(batch_size)]
+            ptrs = [l_ptr + i * spacing for i in range(batch_size)]
             sizes = [spacing] * batch_size
 
             await self.store.async_register_buffer(l_ptr, total_size)
@@ -586,8 +645,12 @@ class TestMooncakeTensorFunctional(MooncakeAsyncTestBase):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Async Mooncake Store Tests")
-    parser.add_argument("--mode", type=str, default="all", choices=["all", "Tensorfunc", "Basicfunc"])
-    parser.add_argument("--threads", type=int, default=8, help="Number of concurrent tasks")
+    parser.add_argument(
+        "--mode", type=str, default="all", choices=["all", "Tensorfunc", "Basicfunc"]
+    )
+    parser.add_argument(
+        "--threads", type=int, default=8, help="Number of concurrent tasks"
+    )
     parser.add_argument("--count", type=int, default=800, help="Total items")
     parser.add_argument("--size_mb", type=float, default=0.5, help="Tensor MB")
 

--- a/python/tests/store/test_async_store.py
+++ b/python/tests/store/test_async_store.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+import importlib
+from pathlib import Path
+import sys
+import threading
+from types import ModuleType
+
+import pytest
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_ROOT = REPOSITORY_ROOT / "python"
+CANONICAL_MODULE = PYTHON_ROOT / "mooncake" / "async_store.py"
+_MISSING = object()
+
+
+class MockMooncakeDistributedStore:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes, int, int]] = []
+        self.non_callable = 42
+
+    def put(self, key: str, value: bytes, *, ttl: int = 0) -> tuple[str, int]:
+        self.calls.append((key, value, ttl, threading.get_ident()))
+        return key, ttl
+
+
+@pytest.fixture()
+def async_store_module() -> Iterator[ModuleType]:
+    module_names = (
+        "mooncake",
+        "mooncake.async_store",
+        "mooncake.store",
+    )
+    saved_modules = {name: sys.modules.get(name, _MISSING) for name in module_names}
+    for name in module_names:
+        sys.modules.pop(name, None)
+
+    package = ModuleType("mooncake")
+    package.__path__ = [str(PYTHON_ROOT / "mooncake")]
+    store = ModuleType("mooncake.store")
+    store.MooncakeDistributedStore = MockMooncakeDistributedStore
+    sys.modules["mooncake"] = package
+    sys.modules["mooncake.store"] = store
+
+    try:
+        yield importlib.import_module("mooncake.async_store")
+    finally:
+        for name in module_names:
+            sys.modules.pop(name, None)
+            saved = saved_modules[name]
+            if saved is not _MISSING:
+                sys.modules[name] = saved
+
+
+def test_source_tree_import_uses_canonical_module(
+    async_store_module: ModuleType,
+) -> None:
+    assert Path(async_store_module.__file__).resolve() == CANONICAL_MODULE
+    assert (
+        async_store_module.MooncakeDistributedStoreAsync.__module__
+        == "mooncake.async_store"
+    )
+
+
+def test_async_wrapper_forwards_arguments_and_is_cached(
+    async_store_module: ModuleType,
+) -> None:
+    store = async_store_module.MooncakeDistributedStoreAsync()
+    calling_thread = threading.get_ident()
+
+    async_put = store.async_put
+    assert async_put is store.async_put
+    assert async_put.__name__ == "put"
+    assert asyncio.run(async_put("key", b"value", ttl=7)) == ("key", 7)
+    assert store.calls[0][:3] == ("key", b"value", 7)
+    assert store.calls[0][3] != calling_thread
+
+
+def test_async_wrapper_rejects_invalid_attributes(
+    async_store_module: ModuleType,
+) -> None:
+    store = async_store_module.MooncakeDistributedStoreAsync()
+
+    with pytest.raises(AttributeError, match="has no attribute 'missing'"):
+        getattr(store, "missing")
+    with pytest.raises(AttributeError, match="nor 'missing'"):
+        getattr(store, "async_missing")
+    with pytest.raises(AttributeError, match="'non_callable' is not callable"):
+        getattr(store, "async_non_callable")

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -63,8 +63,8 @@ if compgen -G "${BUILD_DIR}/mooncake-integration/store.*.so" >/dev/null; then
     cp ${BUILD_DIR}/mooncake-store/src/mooncake_master mooncake-wheel/mooncake/
     # Copy client binary
     cp ${BUILD_DIR}/mooncake-store/src/mooncake_client mooncake-wheel/mooncake/
-    # Copy async_store.py
-    cp mooncake-integration/store/async_store.py mooncake-wheel/mooncake/async_store.py
+    # Stage the canonical async Store client for the legacy wheel builder.
+    cp python/mooncake/async_store.py mooncake-wheel/mooncake/async_store.py
 else
     echo "Skipping store.so (not built - likely WITH_STORE is set to OFF)"
 fi


### PR DESCRIPTION
## Description

Implements the async Store Python client slice of RFC #3534 Phase 2.

- Moves `mooncake-integration/store/async_store.py` to the canonical `python/mooncake/async_store.py` package source and removes the old tracked location.
- Moves the directly owned live-cluster test to `python/tests/store/async_store_integration.py`, updates its CI invocation, and adds mocked source-import and behavior tests that need no Store cluster.
- Updates direct CMake installation, the transitional legacy wheel builder, packaging invariants, installed-wheel smoke coverage, CODEOWNERS, and labeling for the canonical path.
- Preserves the public `mooncake.async_store.MooncakeDistributedStoreAsync` import and behavior. This does not rename the native Store extension, create the final Store facade, or migrate structured Store/services/config/buffer-pool code.

### Overlap

- #3585 migrates Reshard and touches shared packaging/build metadata; this PR does not duplicate any Reshard source or tests.
- #3586 migrates Store lightweight utilities/config and touches some of the same shared metadata files. This PR is limited to `async_store.py` and its directly owned tests, so the module changes are complementary even though a later rebase may be needed.
- #1861 and #3355 change native Store async/coroutine APIs, but neither owns or moves `mooncake.async_store`; this PR intentionally preserves current wrapper behavior.
- There is no async-client entry point or existing type-check path on `main` to relocate. The shared Python pyright configuration is separately owned by #3585 and is not duplicated here.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
MOONCAKE_TEST_WHEEL=/absolute/path/to/dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl \
  python -m pytest -q python/tests/store/test_async_store.py python/tests/packaging
python -m compileall -q python/mooncake/async_store.py \
  python/tests/store/async_store_integration.py python/tests/store/test_async_store.py
CMAKE_BUILD_PARALLEL_LEVEL=128 python -m build --wheel
python -m twine check dist/*.whl
git fetch origin main
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```

**Test results:**

- [x] Unit tests pass: 9 focused source, behavior, packaging, and isolated installed-wheel tests passed.
- [ ] Integration tests pass (if applicable): the moved live-cluster script was not run locally because this environment has no running Store cluster; the existing CI job now invokes it from its canonical test location.
- [x] Manual testing done: the root PEP 517 wheel build completed, `twine check` passed, and the wheel smoke test installed with `--no-deps` in a clean venv outside the repository.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable: no C/C++ files changed; all relevant pre-commit format hooks passed)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: imports and behavior are unchanged, and no directly relevant docs reference the old source path)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed RFC #3534

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex performed the scoped migration, updated build/packaging metadata, added tests, and ran the reported validation. The human submitter remains responsible for reviewing and defending every changed line.