### PR TITLE
[Integration] Migrate vLLM modules to unified Python package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,12 @@
 /mooncake-integration/transfer_engine @ShangmingCai @alogfans
 /mooncake-integration/store @ykwd @stmatengss @zxpdemonio
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
-/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio 
+/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-store/*/ha/ @Libotry @YiXR @00fish0 @Icedcoco @Aionw
+/python/mooncake/mooncake_connector_v1.py @stmatengss @ShangmingCai
+/python/mooncake/vllm_v1_proxy_server.py @stmatengss @ShangmingCai
+/python/tests/vllm/ @stmatengss @ShangmingCai
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -29,7 +29,11 @@ P2P Store:
 
 Integration:
   - changed-files:
-    - any-glob-to-any-file: 'mooncake-integration/**/*'
+    - any-glob-to-any-file:
+      - 'mooncake-integration/**/*'
+      - 'python/mooncake/mooncake_connector_v1.py'
+      - 'python/mooncake/vllm_v1_proxy_server.py'
+      - 'python/tests/vllm/**/*'
 
 Common:
   - changed-files:
@@ -57,6 +61,7 @@ Tests:
       - 'scripts/test_*'
       - 'mooncake-wheel/tests/**/*'
       - 'mooncake-reshard/tests/**/*'
+      - 'python/tests/vllm/**/*'
       - 'scripts/tone_tests/**/*'
 
 Ascend/NPU:

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -200,8 +200,8 @@ if(NOT SKBUILD)
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/http_metadata_server.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli_bench.py"
       "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/transfer_engine_topology_dump.py"
-      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_connector_v1.py"
-      "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/vllm_v1_proxy_server.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_connector_v1.py"
+      "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/vllm_v1_proxy_server.py"
     DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR})
 
   if(WITH_STORE)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ vllm = [
     "numpy",
     "pyzmq",
     "torch",
+    "uvicorn",
     "vllm",
 ]
 administration = [

--- a/python/mooncake/README.md
+++ b/python/mooncake/README.md
@@ -8,7 +8,8 @@ For 0.13.0 or later, please use the intree vllm mooncake_connector.
 
 ### Usage
 
-Add proper "--kv-transfer-config" parameters to your vLLM command. See comments in `mooncake_connector_v1.py`.
+Add proper `--kv-transfer-config` parameters to your vLLM command. See the
+comments in [`mooncake_connector_v1.py`](mooncake_connector_v1.py).
 
 For example, a whole demo could be:
 

--- a/python/mooncake/mooncake_connector_v1.py
+++ b/python/mooncake/mooncake_connector_v1.py
@@ -3,7 +3,7 @@ Usage:
 Adding the following params to vllm command:
 Prefill: --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_producer", "kv_connector_module_path":"mooncake.mooncake_connector_v1"}'
 Decode: --kv-transfer-config '{"kv_connector":"MooncakeConnector","kv_role":"kv_consumer", "kv_connector_module_path":"mooncake.mooncake_connector_v1"}'
-Proxy: Running vllm_v1_proxy_server.py
+Proxy: python -m mooncake.vllm_v1_proxy_server
 """
 
 import contextlib
@@ -26,7 +26,10 @@ import zmq
 from vllm.attention.selector import get_attn_backend
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVConnectorBase_V1, KVConnectorMetadata, KVConnectorRole)
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
 
 # SupportsHMA was introduced in vllm-project/vllm PR #25712 and is enforced
 # for KV connectors by PR #27592. It is the marker the Hybrid Memory
@@ -36,14 +39,13 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 # releases the marker is a no-op object base and the
 # `request_finished_all_groups` shim below is dead code.
 try:
-    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-        SupportsHMA)
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import SupportsHMA
 except ImportError:  # pragma: no cover - older vLLM
     SupportsHMA = object  # type: ignore[assignment, misc]
-from vllm.distributed.parallel_state import (get_tensor_model_parallel_rank,
-                                             get_tp_group)
+from vllm.distributed.parallel_state import get_tensor_model_parallel_rank, get_tp_group
 from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
+
 try:
     from vllm.utils import get_ip, make_zmq_path, make_zmq_socket
 except ImportError:
@@ -63,7 +65,9 @@ ReqId = str
 TRANS_DONE = b"trans_done"
 TRANS_ERROR = b"trans_error"
 VLLM_MOONCAKE_SIDE_CHANNEL_PORT = int(getenv("VLLM_MOONCAKE_SIDE_CHANNEL_PORT", 6557))
-VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT = int(getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", 120))
+VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT = int(
+    getenv("VLLM_MOONCAKE_ABORT_REQUEST_TIMEOUT", 120)
+)
 VLLM_MOONCAKE_SENDER_WORKERS = int(getenv("VLLM_MOONCAKE_SENDER_WORKERS", 10))
 VLLM_MOONCAKE_PROTOCOL = getenv("VLLM_MOONCAKE_PROTOCOL", "rdma")
 
@@ -71,10 +75,11 @@ logger = init_logger(__name__)
 
 
 class MooncakeAgentMetadata(
-        msgspec.Struct,
-        omit_defaults=True,  # type: ignore[call-arg]
-        # required for @cached_property.
-        dict=True):
+    msgspec.Struct,
+    omit_defaults=True,  # type: ignore[call-arg]
+    # required for @cached_property.
+    dict=True,
+):
     remote_hostname: str
     remote_port: int
     request_ids: list[ReqId]
@@ -98,22 +103,24 @@ class SendBlockMeta:
 
 
 class MooncakeConnectorMetadata(KVConnectorMetadata):
-
     def __init__(self):
         self.reqs_to_recv: dict[ReqId, RecvReqMeta] = {}
         self.reqs_to_send: dict[ReqId, list[int]] = {}
 
-    def add_new_req(self,
-                    request_id: ReqId,
-                    local_block_ids: list[int],
-                    kv_transfer_params: dict[str, Any],
-                    load_remote_cache: bool = True):
+    def add_new_req(
+        self,
+        request_id: ReqId,
+        local_block_ids: list[int],
+        kv_transfer_params: dict[str, Any],
+        load_remote_cache: bool = True,
+    ):
         if load_remote_cache:
             self.reqs_to_recv[request_id] = RecvReqMeta(
                 local_block_ids=local_block_ids,
                 remote_host=kv_transfer_params["remote_host"],
                 remote_port=kv_transfer_params["remote_port"],
-                remote_request_id=kv_transfer_params.get("remote_request_id"))
+                remote_request_id=kv_transfer_params.get("remote_request_id"),
+            )
         else:
             self.reqs_to_send[request_id] = local_block_ids
 
@@ -130,33 +137,35 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert vllm_config.kv_transfer_config.engine_id is not None
         super().__init__(vllm_config, role)
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
-        
+
         if role == KVConnectorRole.SCHEDULER:
-            self.connector_scheduler: Optional[MooncakeConnectorScheduler] = \
+            self.connector_scheduler: Optional[MooncakeConnectorScheduler] = (
                 MooncakeConnectorScheduler(vllm_config, self.engine_id)
+            )
             self.connector_worker: Optional[MooncakeConnectorWorker] = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
-            self.connector_worker = MooncakeConnectorWorker(
-                vllm_config, self.engine_id)
+            self.connector_worker = MooncakeConnectorWorker(vllm_config, self.engine_id)
 
     ############################################################
     # Scheduler Side Methods
     ############################################################
 
     def get_num_new_matched_tokens(
-            self, request: "Request",
-            num_computed_tokens: int) -> tuple[int, bool]:
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, bool]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.get_num_new_matched_tokens(
-            request, num_computed_tokens)
+            request, num_computed_tokens
+        )
 
-    def update_state_after_alloc(self, request: "Request",
-                                 blocks: "KVCacheBlocks",
-                                 num_external_tokens: int):
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
         assert self.connector_scheduler is not None
         return self.connector_scheduler.update_state_after_alloc(
-            request, blocks, num_external_tokens)
+            request, blocks, num_external_tokens
+        )
 
     def build_connector_meta(
         self,
@@ -209,8 +218,7 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         assert self.connector_worker is not None
         return self.connector_worker.get_finished()
 
-    def start_load_kv(self, forward_context: "ForwardContext",
-                      **kwargs) -> None:
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         assert self.connector_worker is not None
         assert isinstance(self._connector_metadata, MooncakeConnectorMetadata)
         self.connector_worker.start_load_kv(self._connector_metadata)
@@ -219,8 +227,13 @@ class MooncakeConnector(KVConnectorBase_V1, SupportsHMA):
         """MooncakeConnector does not do layerwise saving."""
         pass
 
-    def save_kv_layer(self, layer_name: str, kv_layer: torch.Tensor,
-                      attn_metadata: "AttentionMetadata", **kwargs) -> None:
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: "AttentionMetadata",
+        **kwargs,
+    ) -> None:
         """MooncakeConnector does not save explicitly."""
         pass
 
@@ -239,8 +252,7 @@ class MooncakeConnectorScheduler:
 
         assert vllm_config.kv_transfer_config
         self.kv_role = vllm_config.kv_transfer_config.kv_role
-        logger.info("Initializing Mooncake Transfer Engine Scheduler %s",
-                    engine_id)
+        logger.info("Initializing Mooncake Transfer Engine Scheduler %s", engine_id)
 
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
@@ -249,8 +261,8 @@ class MooncakeConnectorScheduler:
         self._reqs_need_send: dict[ReqId, list[int]] = {}
 
     def get_num_new_matched_tokens(
-            self, request: "Request",
-            num_computed_tokens: int) -> tuple[int, bool]:
+        self, request: "Request", num_computed_tokens: int
+    ) -> tuple[int, bool]:
         """
         For remote prefill, pull all prompt blocks from remote
         asynchronously relative to engine execution.
@@ -270,7 +282,9 @@ class MooncakeConnectorScheduler:
         logger.debug(
             "MooncakeConnector get_num_new_matched_tokens: "
             "num_computed_tokens=%s, kv_transfer_params=%s",
-            num_computed_tokens, params)
+            num_computed_tokens,
+            params,
+        )
 
         if params is not None and params.get("do_remote_prefill"):
             # Remote prefill: get all prompt blocks from remote.
@@ -281,15 +295,16 @@ class MooncakeConnectorScheduler:
         # No remote prefill for this request.
         return 0, False
 
-    def update_state_after_alloc(self, request: "Request",
-                                 blocks: "KVCacheBlocks",
-                                 num_external_tokens: int):
-
+    def update_state_after_alloc(
+        self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int
+    ):
         params = request.kv_transfer_params
         logger.debug(
             "MooncakeConnector update_state_after_alloc: "
             "num_external_tokens=%s, kv_transfer_params=%s",
-            num_external_tokens, params)
+            num_external_tokens,
+            params,
+        )
 
         if not params:
             return
@@ -300,15 +315,17 @@ class MooncakeConnectorScheduler:
                 # If remote_blocks and num_external_tokens = 0, we have
                 # a full prefix cache hit on the D worker. We need to call
                 # send_notif in _read_blocks to free the memory on the P.
-                local_block_ids = (blocks.get_unhashed_block_ids()
-                                   if num_external_tokens > 0 else [])
+                local_block_ids = (
+                    blocks.get_unhashed_block_ids() if num_external_tokens > 0 else []
+                )
                 # Get unhashed blocks to pull from remote.
-                self._reqs_need_recv[request.request_id] = (request,
-                                                            local_block_ids)
+                self._reqs_need_recv[request.request_id] = (request, local_block_ids)
             else:
                 logger.warning(
                     "Got invalid KVTransferParams: %s. This "
-                    "request will not utilize KVTransfer", params)
+                    "request will not utilize KVTransfer",
+                    params,
+                )
             # Only trigger 1 KV transfer per request.
             params["do_remote_prefill"] = False
 
@@ -326,17 +343,21 @@ class MooncakeConnectorScheduler:
         if self.kv_role != "kv_producer":
             for req_id, (req, block_ids) in self._reqs_need_recv.items():
                 assert req.kv_transfer_params is not None
-                meta.add_new_req(request_id=req_id,
-                                 local_block_ids=block_ids,
-                                 kv_transfer_params=req.kv_transfer_params)
+                meta.add_new_req(
+                    request_id=req_id,
+                    local_block_ids=block_ids,
+                    kv_transfer_params=req.kv_transfer_params,
+                )
             self._reqs_need_recv.clear()
 
         if self.kv_role != "kv_consumer":
             for req_id, block_ids in self._reqs_need_send.items():
-                meta.add_new_req(request_id=req_id,
-                                 local_block_ids=block_ids,
-                                 kv_transfer_params={},
-                                 load_remote_cache=False)
+                meta.add_new_req(
+                    request_id=req_id,
+                    local_block_ids=block_ids,
+                    kv_transfer_params={},
+                    load_remote_cache=False,
+                )
             self._reqs_need_send.clear()
 
         return meta
@@ -354,7 +375,10 @@ class MooncakeConnectorScheduler:
         params = request.kv_transfer_params
         logger.debug(
             "MooncakeConnector request_finished, request_status=%s, "
-            "kv_transfer_params=%s", request.status, params)
+            "kv_transfer_params=%s",
+            request.status,
+            params,
+        )
         if not params:
             return False, None
 
@@ -370,8 +394,10 @@ class MooncakeConnectorScheduler:
             params["do_remote_prefill"] = False
             return False, None
 
-        if (not params.get("do_remote_decode")
-                or request.status != RequestStatus.FINISHED_LENGTH_CAPPED):
+        if (
+            not params.get("do_remote_decode")
+            or request.status != RequestStatus.FINISHED_LENGTH_CAPPED
+        ):
             return False, None
 
         assert self.kv_role != "kv_consumer"
@@ -388,7 +414,8 @@ class MooncakeConnectorScheduler:
             do_remote_decode=False,
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
-            remote_request_id=request.request_id)
+            remote_request_id=request.request_id,
+        )
 
 
 class MooncakeConnectorWorker:
@@ -401,24 +428,27 @@ class MooncakeConnectorWorker:
             raise ImportError(
                 "Please install mooncake by following the instructions at "
                 "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
-                "to run VLLM with MooncakeTransferEngine.") from e
-        logger.info("Initializing Mooncake Transfer Engine worker %s",
-                    engine_id)
+                "to run VLLM with MooncakeTransferEngine."
+            ) from e
+        logger.info("Initializing Mooncake Transfer Engine worker %s", engine_id)
 
         self.vllm_config = vllm_config
 
         self.engine = TransferEngine()
         self.hostname = get_ip()
-        ret_value = self.engine.initialize(self.hostname, "P2PHANDSHAKE",
-                                           VLLM_MOONCAKE_PROTOCOL, "")
+        ret_value = self.engine.initialize(
+            self.hostname, "P2PHANDSHAKE", VLLM_MOONCAKE_PROTOCOL, ""
+        )
         if ret_value != 0:
-            raise RuntimeError(
-                "Mooncake Transfer Engine initialization failed.")
+            raise RuntimeError("Mooncake Transfer Engine initialization failed.")
 
         self.rpc_port = self.engine.get_rpc_port()
 
-        logger.debug("Mooncake Transfer Engine initialized at %s:%d",
-                     self.hostname, self.rpc_port)
+        logger.debug(
+            "Mooncake Transfer Engine initialized at %s:%d",
+            self.hostname,
+            self.rpc_port,
+        )
 
         # Mooncake handshake port.
         self.side_channel_port = get_mooncake_side_channel_port(vllm_config)
@@ -476,21 +506,23 @@ class MooncakeConnectorWorker:
         self.cache_config = vllm_config.cache_config
         self.use_mla = self.model_config.use_mla
 
-        backend = get_attn_backend(self.model_config.get_head_size(),
-                                   self.model_config.dtype,
-                                   self.cache_config.cache_dtype,
-                                   self.block_size,
-                                   use_mla=self.use_mla)
+        backend = get_attn_backend(
+            self.model_config.get_head_size(),
+            self.model_config.dtype,
+            self.cache_config.cache_dtype,
+            self.block_size,
+            use_mla=self.use_mla,
+        )
         self.backend_name = backend.get_name()
         vllm_version = importlib.metadata.version("vllm")
         versions_to_check = ("0.10.", "0.11.0", "0.11.1", "0.11.2", "0.12.0")
         version_checks = {
-            version: vllm_version.startswith(version) 
-            for version in versions_to_check
+            version: vllm_version.startswith(version) for version in versions_to_check
         }
         if any(version_checks[v] for v in ("0.10.", "0.11.0")):
             from vllm.attention.selector import backend_name_to_enum
             from vllm.platforms import _Backend
+
             attn_backend = backend_name_to_enum(self.backend_name)
             if version_checks["0.11.0"]:
                 self._use_flashinfer = attn_backend == _Backend.FLASHINFER
@@ -500,13 +532,20 @@ class MooncakeConnectorWorker:
                 self._use_pallas_v1 = attn_backend == _Backend.PALLAS_VLLM_V1
         elif any(version_checks[v] for v in ("0.11.1", "0.11.2", "0.12.0")):
             from vllm.attention.selector import AttentionBackendEnum
+
             attn_backend = AttentionBackendEnum[self.backend_name]
-            self._use_flashinfer = attn_backend in [AttentionBackendEnum.FLASHINFER, AttentionBackendEnum.FLASHINFER_MLA]
+            self._use_flashinfer = attn_backend in [
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLASHINFER_MLA,
+            ]
             self._use_pallas_v1 = attn_backend == AttentionBackendEnum.PALLAS
         else:
-            raise Exception("Unsupported vllm version %s: This OOT module is intended for "
-            "backward compatibility with earlier versions of vllm. For vllm 0.13.0 and newer, "
-            "please use the built-in mooncake connector.", vllm_version)
+            raise Exception(
+                "Unsupported vllm version %s: This OOT module is intended for "
+                "backward compatibility with earlier versions of vllm. For vllm 0.13.0 and newer, "
+                "please use the built-in mooncake connector.",
+                vllm_version,
+            )
         self.kv_cache_layout = get_kv_cache_layout()
         logger.debug("Detected attention backend %s", self.backend_name)
         logger.debug("Detected kv cache layout %s", self.kv_cache_layout)
@@ -699,15 +738,15 @@ class MooncakeConnectorWorker:
         kv_data_lens = []
         seen_base_addresses = []
 
-        self.split_k_and_v = not (self.use_mla or self._use_pallas_v1
-                                  or self._use_flashinfer)
+        self.split_k_and_v = not (
+            self.use_mla or self._use_pallas_v1 or self._use_flashinfer
+        )
         tensor_size_bytes = None
         for layer_name, cache_or_caches in kv_caches.items():
-            logger.debug("registering layer %s with shape %s", layer_name,
-                         cache_or_caches.shape)
-            cache_list = cache_or_caches if self.split_k_and_v else [
-                cache_or_caches
-            ]
+            logger.debug(
+                "registering layer %s with shape %s", layer_name, cache_or_caches.shape
+            )
+            cache_list = cache_or_caches if self.split_k_and_v else [cache_or_caches]
 
             for cache in cache_list:
                 base_addr = cache.data_ptr()
@@ -721,15 +760,15 @@ class MooncakeConnectorWorker:
                     tensor_size_bytes = curr_tensor_size_bytes
                     self.num_blocks = cache.shape[0]
 
-                assert tensor_size_bytes == curr_tensor_size_bytes, \
-                    "All kv cache tensors must have the same size"
+                assert (
+                    tensor_size_bytes == curr_tensor_size_bytes
+                ), "All kv cache tensors must have the same size"
                 kv_data_ptrs.append(base_addr)
                 kv_data_lens.append(tensor_size_bytes)
 
         self.kv_caches_base_addr = seen_base_addresses
 
-        ret_value = self.engine.batch_register_memory(kv_data_ptrs,
-                                                      kv_data_lens)
+        ret_value = self.engine.batch_register_memory(kv_data_ptrs, kv_data_lens)
         if ret_value != 0:
             raise RuntimeError("Mooncake batch memory registration failed.")
 
@@ -738,8 +777,9 @@ class MooncakeConnectorWorker:
         assert tensor_size_bytes % self.num_blocks == 0
         self.block_len = tensor_size_bytes // self.num_blocks
         self.device_kv_caches = kv_caches
-        logger.debug("regiestered num_blocks=%d block_len=%d", self.num_blocks,
-                     self.block_len)
+        logger.debug(
+            "regiestered num_blocks=%d block_len=%d", self.num_blocks, self.block_len
+        )
 
         # No need to launch server for D node.
         if self.kv_role == "kv_consumer":
@@ -815,9 +855,7 @@ class MooncakeConnectorWorker:
 
         return finished_sending_reqs or None, finished_recving_reqs or None
 
-    async def receive_kv(
-        self, path: str, req_blocks: list[tuple[str, str, list[int]]]
-    ):
+    async def receive_kv(self, path: str, req_blocks: list[tuple[str, str, list[int]]]):
         local_req_ids, remote_req_ids, block_ids = map(list, zip(*req_blocks))
         metadata = MooncakeAgentMetadata(
             remote_hostname=self.hostname,
@@ -832,8 +870,11 @@ class MooncakeConnectorWorker:
             "Size of encoded MooncakeAgentMetadata: %d bytes", len(encoded_data)
         )
         logger.debug(
-            "Sending kv transfer request for %s on path: %s "
-            "(local requests: %s)", remote_req_ids, path, local_req_ids)
+            "Sending kv transfer request for %s on path: %s " "(local requests: %s)",
+            remote_req_ids,
+            path,
+            local_req_ids,
+        )
 
         # Send query for the request.
         sock: zmq.asyncio.Socket = make_zmq_socket(
@@ -853,8 +894,8 @@ class MooncakeConnectorWorker:
             logger.debug("ZMQ context terminated, exiting Mooncake receiver thread.")
         except Exception as e:
             logger.error(
-                "MooncakeAgentMetadata transfer failed for %s: %s",
-                remote_req_ids, e)
+                "MooncakeAgentMetadata transfer failed for %s: %s", remote_req_ids, e
+            )
             return
         finally:
             sock.close()
@@ -863,21 +904,29 @@ class MooncakeConnectorWorker:
 
         logger.debug(
             "pulling kv_caches for %s finished (local requests: %s)",
-            remote_req_ids, local_req_ids)
+            remote_req_ids,
+            local_req_ids,
+        )
 
     def group_kv_pull(self, metadata: MooncakeConnectorMetadata):
         kv_pulls = defaultdict(list)
         for req_id, meta in metadata.reqs_to_recv.items():
             logger.debug(
                 "start_load_kv for request %s from remote engine. "
-                "Num local_block_ids: %s.", req_id, len(meta.local_block_ids))
-            path = make_zmq_path("tcp", meta.remote_host,
-                                 meta.remote_port + self.tp_rank)
+                "Num local_block_ids: %s.",
+                req_id,
+                len(meta.local_block_ids),
+            )
+            path = make_zmq_path(
+                "tcp", meta.remote_host, meta.remote_port + self.tp_rank
+            )
             remote_req_id = meta.remote_request_id or req_id
             if remote_req_id != req_id:
                 logger.debug(
                     "request %s will pull remote kv for producer request %s",
-                    req_id, remote_req_id)
+                    req_id,
+                    remote_req_id,
+                )
             kv_pulls[path].append((req_id, remote_req_id, meta.local_block_ids))
 
         return kv_pulls
@@ -924,24 +973,22 @@ def zmq_ctx(socket_type: Any, addr: str) -> Iterator[zmq.Socket]:
     ctx: Optional[zmq.Context] = None
     try:
         ctx = zmq.Context()  # type: ignore[attr-defined]
-        yield make_zmq_socket(ctx=ctx,
-                              path=addr,
-                              socket_type=socket_type,
-                              bind=socket_type == zmq.ROUTER)
+        yield make_zmq_socket(
+            ctx=ctx, path=addr, socket_type=socket_type, bind=socket_type == zmq.ROUTER
+        )
     finally:
         if ctx is not None:
             ctx.destroy(linger=0)
 
 
 def group_concurrent_contiguous(
-        src_indices: list[int],
-        dst_indices: list[int]) -> tuple[list[list[int]], list[list[int]]]:
+    src_indices: list[int], dst_indices: list[int]
+) -> tuple[list[list[int]], list[list[int]]]:
     """Vectorised NumPy implementation."""
     if len(src_indices) == 0:
         return [], []
 
-    brk = np.where((np.diff(src_indices) != 1)
-                   | (np.diff(dst_indices) != 1))[0] + 1
+    brk = np.where((np.diff(src_indices) != 1) | (np.diff(dst_indices) != 1))[0] + 1
     src_groups = np.split(src_indices, brk)
     dst_groups = np.split(dst_indices, brk)
 
@@ -949,6 +996,7 @@ def group_concurrent_contiguous(
     dst_groups = [g.tolist() for g in dst_groups]
 
     return src_groups, dst_groups
+
 
 def get_mooncake_side_channel_port(vllm_config: VllmConfig) -> int:
     # This logic is now centralized

--- a/python/mooncake/vllm_v1_proxy_server.py
+++ b/python/mooncake/vllm_v1_proxy_server.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # This is a copy from vLLM repo at tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
 
+"""Disaggregated prefill/decode proxy for the Mooncake vLLM integration."""
+
 import argparse
 import itertools
 import logging

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -41,8 +41,10 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
     clean_environment.pop("PYTHONPATH", None)
     clean_environment["PYTHONNOUSERSITE"] = "1"
     smoke_script = f"""
+import importlib.util
 from importlib import metadata
 from pathlib import Path
+import sys
 import mooncake
 import mooncake.engine
 import mooncake.reshard
@@ -54,6 +56,18 @@ assert not package_path.is_relative_to(repository_path), (package_path, reposito
 assert metadata.version("mooncake-transfer-engine") == {_project_version()!r}
 assert mooncake.BufferPool is mooncake.store.BufferPool
 assert mooncake.engine.TransferEngine is not None
+optional_roots = {{
+    "fastapi", "httpx", "msgspec", "numpy", "torch", "uvicorn", "vllm", "zmq"
+}}
+for module_name in (
+    "mooncake.mooncake_connector_v1",
+    "mooncake.vllm_v1_proxy_server",
+):
+    spec = importlib.util.find_spec(module_name)
+    assert spec is not None and spec.origin is not None, module_name
+    module_path = Path(spec.origin).resolve()
+    assert module_path.parent == package_path.parent, (module_name, module_path)
+assert not (optional_roots & {{name.partition(".")[0] for name in sys.modules}})
 """
     subprocess.run(
         [str(python), "-I", "-c", smoke_script],

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -47,6 +47,16 @@ def test_dependency_boundaries_are_declared() -> None:
         "structured",
         "vllm",
     }
+    assert set(metadata["optional-dependencies"]["vllm"]) == {
+        "fastapi",
+        "httpx",
+        "msgspec",
+        "numpy",
+        "pyzmq",
+        "torch",
+        "uvicorn",
+        "vllm",
+    }
 
 
 def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
@@ -55,6 +65,33 @@ def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
     assert (package_root / "__init__.py").is_file()
     assert not list(package_root.rglob("*.so"))
     assert not list((REPOSITORY_ROOT / "mooncake-pg" / "torch").rglob("*.so"))
+
+
+def test_vllm_modules_have_one_authoritative_source() -> None:
+    package_root = REPOSITORY_ROOT / "python" / "mooncake"
+    legacy_package_root = REPOSITORY_ROOT / "mooncake-wheel" / "mooncake"
+
+    for module in ("mooncake_connector_v1.py", "vllm_v1_proxy_server.py"):
+        assert (package_root / module).is_file()
+        assert not (legacy_package_root / module).exists()
+
+    assert (package_root / "README.md").is_file()
+    assert not (legacy_package_root / "README.md").exists()
+    assert (REPOSITORY_ROOT / "python" / "tests" / "vllm").is_dir()
+
+    direct_install = (
+        REPOSITORY_ROOT / "mooncake-integration" / "CMakeLists.txt"
+    ).read_text()
+    for module in ("mooncake_connector_v1.py", "vllm_v1_proxy_server.py"):
+        assert f"../python/mooncake/{module}" in direct_install
+        assert f"../mooncake-wheel/mooncake/{module}" not in direct_install
+
+    legacy_builder = (REPOSITORY_ROOT / "scripts" / "build_wheel.sh").read_text()
+    assert 'MIGRATED_PYTHON_SOURCE_DIR="python/mooncake"' in legacy_builder
+    migrated_modules = (
+        "MIGRATED_PYTHON_MODULES=(mooncake_connector_v1.py " "vllm_v1_proxy_server.py)"
+    )
+    assert migrated_modules in legacy_builder
 
 
 def test_pg_extension_build_stages_outside_the_source_tree(

--- a/python/tests/vllm/test_imports.py
+++ b/python/tests/vllm/test_imports.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_ROOT = REPOSITORY_ROOT / "python"
+
+
+def _run_source_script(script: str) -> None:
+    bootstrap = f"""
+import sys
+sys.path.insert(0, {str(PYTHON_ROOT)!r})
+{textwrap.dedent(script)}
+"""
+    subprocess.run(
+        [sys.executable, "-I", "-c", bootstrap],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )
+
+
+def test_core_import_does_not_load_vllm_dependencies() -> None:
+    _run_source_script(
+        f"""
+        from importlib.abc import MetaPathFinder
+        from pathlib import Path
+        import sys
+        import types
+
+        optional_roots = {{
+            "fastapi",
+            "httpx",
+            "msgspec",
+            "numpy",
+            "torch",
+            "uvicorn",
+            "vllm",
+            "zmq",
+        }}
+
+        class RejectOptionalImports(MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.partition(".")[0] in optional_roots:
+                    raise AssertionError(f"core import loaded optional module: {{fullname}}")
+                return None
+
+        buffer_pool = types.ModuleType("mooncake.buffer_pool")
+        buffer_pool.BufferPool = object()
+        buffer_pool.RegisteredBufferPool = buffer_pool.BufferPool
+        sys.modules[buffer_pool.__name__] = buffer_pool
+        sys.meta_path.insert(0, RejectOptionalImports())
+
+        import mooncake
+
+        assert Path(mooncake.__file__).resolve() == Path(
+            {str(PYTHON_ROOT / "mooncake" / "__init__.py")!r}
+        )
+        assert not (optional_roots & {{name.partition(".")[0] for name in sys.modules}})
+        """
+    )
+
+
+def test_connector_import_and_side_channel_configuration() -> None:
+    _run_source_script(
+        f"""
+        from pathlib import Path
+        from types import ModuleType, SimpleNamespace
+        import logging
+        import os
+        import sys
+
+        def install(name, **attributes):
+            parent = None
+            qualified = ""
+            for part in name.split("."):
+                qualified = f"{{qualified}}.{{part}}" if qualified else part
+                module = sys.modules.get(qualified)
+                if module is None:
+                    module = ModuleType(qualified)
+                    module.__path__ = []
+                    sys.modules[qualified] = module
+                if parent is not None:
+                    setattr(parent, part, module)
+                parent = module
+            for key, value in attributes.items():
+                setattr(parent, key, value)
+            return parent
+
+        buffer_pool = ModuleType("mooncake.buffer_pool")
+        buffer_pool.BufferPool = object()
+        buffer_pool.RegisteredBufferPool = buffer_pool.BufferPool
+        sys.modules[buffer_pool.__name__] = buffer_pool
+
+        class MsgspecStruct:
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__()
+
+        class Tensor:
+            pass
+
+        class Socket:
+            pass
+
+        class Context:
+            pass
+
+        class ContextTerminated(Exception):
+            pass
+
+        install("msgspec", Struct=MsgspecStruct)
+        install("msgspec.msgpack", Encoder=object, Decoder=object)
+        install("numpy")
+        install("torch", Tensor=Tensor)
+        zmq = install(
+            "zmq",
+            Context=Context,
+            ContextTerminated=ContextTerminated,
+            REQ=1,
+            RCVTIMEO=2,
+            ROUTER=3,
+            Socket=Socket,
+        )
+        zmq.asyncio = install("zmq.asyncio", Context=Context, Socket=Socket)
+
+        class KVConnectorBaseV1:
+            pass
+
+        class KVConnectorMetadata:
+            pass
+
+        class KVConnectorRole:
+            SCHEDULER = "scheduler"
+            WORKER = "worker"
+
+        class SupportsHMA:
+            pass
+
+        install("vllm.attention.selector", get_attn_backend=lambda *_: None)
+        install("vllm.config", VllmConfig=object)
+        install(
+            "vllm.distributed.kv_transfer.kv_connector.v1.base",
+            KVConnectorBase_V1=KVConnectorBaseV1,
+            KVConnectorMetadata=KVConnectorMetadata,
+            KVConnectorRole=KVConnectorRole,
+            SupportsHMA=SupportsHMA,
+        )
+        install(
+            "vllm.distributed.parallel_state",
+            get_tensor_model_parallel_rank=lambda: 0,
+            get_tp_group=lambda: None,
+        )
+        install("vllm.forward_context", ForwardContext=object)
+        install("vllm.logger", init_logger=lambda name: logging.getLogger(name))
+        install(
+            "vllm.utils",
+            get_ip=lambda: "127.0.0.1",
+            make_zmq_path=lambda *args: "",
+            make_zmq_socket=lambda *args, **kwargs: None,
+        )
+        install(
+            "vllm.v1.attention.backends.utils",
+            get_kv_cache_layout=lambda *_: None,
+        )
+        install("vllm.v1.core.sched.output", SchedulerOutput=object)
+        install("vllm.v1.request", RequestStatus=object)
+
+        os.environ["VLLM_MOONCAKE_SIDE_CHANNEL_PORT"] = "7000"
+        import mooncake.mooncake_connector_v1 as connector
+
+        assert Path(connector.__file__).resolve() == Path(
+            {str(PYTHON_ROOT / "mooncake" / "mooncake_connector_v1.py")!r}
+        )
+        config = SimpleNamespace(
+            parallel_config=SimpleNamespace(
+                data_parallel_rank=3,
+                tensor_parallel_size=8,
+            )
+        )
+        assert connector.get_mooncake_side_channel_port(config) == 7024
+        assert connector.MooncakeConnector.__module__ == connector.__name__
+        """
+    )

--- a/python/tests/vllm/test_proxy_config.py
+++ b/python/tests/vllm/test_proxy_config.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_ROOT = REPOSITORY_ROOT / "python"
+
+
+def test_proxy_command_aliases_and_instance_pairing() -> None:
+    script = f"""
+from pathlib import Path
+from types import ModuleType
+import sys
+
+sys.path.insert(0, {str(PYTHON_ROOT)!r})
+
+def install(name, **attributes):
+    module = ModuleType(name)
+    for key, value in attributes.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+buffer_pool = install("mooncake.buffer_pool")
+buffer_pool.BufferPool = object()
+buffer_pool.RegisteredBufferPool = buffer_pool.BufferPool
+
+class FakeFastAPI:
+    def __init__(self, **kwargs):
+        self.lifespan = kwargs.get("lifespan")
+
+    def _route(self, *args, **kwargs):
+        def decorate(function):
+            return function
+        return decorate
+
+    get = _route
+    post = _route
+
+class Request:
+    pass
+
+class StreamingResponse:
+    pass
+
+install("httpx")
+install("fastapi", FastAPI=FakeFastAPI, Request=Request)
+install("fastapi.responses", StreamingResponse=StreamingResponse)
+
+import mooncake.vllm_v1_proxy_server as proxy
+
+assert Path(proxy.__file__).resolve() == Path(
+    {str(PYTHON_ROOT / "mooncake" / "vllm_v1_proxy_server.py")!r}
+)
+
+sys.argv = [
+    "proxy",
+    "--host", "0.0.0.0",
+    "--port", "9000",
+    "--prefiller-host", "prefill-a", "prefill-b",
+    "--prefiller-port", "8010", "8011",
+    "--decoder-host", "decode-a", "decode-b",
+    "--decoder-port", "8020", "8021",
+]
+args = proxy.parse_args()
+assert args.host == "0.0.0.0"
+assert args.port == 9000
+assert args.prefiller_instances == [("prefill-a", 8010), ("prefill-b", 8011)]
+assert args.decoder_instances == [("decode-a", 8020), ("decode-b", 8021)]
+
+sys.argv = [
+    "proxy",
+    "--prefiller-hosts", "prefill-a", "prefill-b",
+    "--prefiller-ports", "8010",
+]
+try:
+    proxy.parse_args()
+except ValueError as error:
+    assert str(error) == "Number of prefiller hosts must match number of prefiller ports"
+else:
+    raise AssertionError("mismatched proxy endpoints were accepted")
+"""
+    subprocess.run(
+        [sys.executable, "-I", "-c", textwrap.dedent(script)],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+    )

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -180,15 +180,25 @@ if [ "$NPU_BUILD" = "1" ]; then
 fi
 
 echo "Building wheel package..."
-# Stage the reshard Python package for the combined Mooncake wheel. The tracked
-# source of truth remains in the top-level module.
+# Stage migrated root Python modules and the legacy Reshard package for the
+# combined-wheel builder. Each tracked source remains in its authoritative tree.
+MIGRATED_PYTHON_SOURCE_DIR="python/mooncake"
+MIGRATED_PYTHON_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake"
+MIGRATED_PYTHON_MODULES=(mooncake_connector_v1.py vllm_v1_proxy_server.py)
 RESHARD_SOURCE_DIR="mooncake-reshard/python/mooncake/reshard"
 RESHARD_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake/reshard"
-cleanup_reshard_staging() {
+cleanup_migrated_python_staging() {
+    for module in "${MIGRATED_PYTHON_MODULES[@]}"; do
+        rm -f "${MIGRATED_PYTHON_STAGING_DIR}/${module}"
+    done
     rm -rf "${RESHARD_STAGING_DIR}"
 }
-trap cleanup_reshard_staging EXIT
-rm -rf "${RESHARD_STAGING_DIR}"
+trap cleanup_migrated_python_staging EXIT
+cleanup_migrated_python_staging
+for module in "${MIGRATED_PYTHON_MODULES[@]}"; do
+    cp "${MIGRATED_PYTHON_SOURCE_DIR}/${module}" \
+       "${MIGRATED_PYTHON_STAGING_DIR}/${module}"
+done
 cp -R "${RESHARD_SOURCE_DIR}" "${RESHARD_STAGING_DIR}"
 
 # Build the wheel package
@@ -204,7 +214,7 @@ WHEEL_DIR="$(pwd)"
 cleanup_wheel_metadata_state() {
     [[ -f "${WHEEL_DIR}/pyproject.toml.backup" ]] && mv "${WHEEL_DIR}/pyproject.toml.backup" "${WHEEL_DIR}/pyproject.toml"
     rm -f "${WHEEL_DIR}/README.md"
-    cleanup_reshard_staging
+    cleanup_migrated_python_staging
 }
 trap cleanup_wheel_metadata_state EXIT
 


### PR DESCRIPTION
## Description

Implements the vLLM integration increment of Phase 2 from RFC #3534.

- moves `mooncake.mooncake_connector_v1` and `mooncake.vllm_v1_proxy_server` into `python/mooncake` as their single authoritative tracked source;
- preserves the vLLM connector module path and `python -m mooncake.vllm_v1_proxy_server` launch behavior;
- updates direct CMake installation and temporary legacy-wheel staging to consume the canonical files;
- declares the proxy's direct `uvicorn` dependency in the `vllm` extra;
- adds source-tree configuration/import tests and isolated installed-wheel coverage;
- verifies that importing core `mooncake` does not load vLLM, Torch, FastAPI, httpx, msgspec, NumPy, ZeroMQ, or uvicorn.

Part of #3534.

### Overlap

No open PR directly covers either vLLM module. PR #3585 migrates Reshard and PR #3586 migrates lightweight Store utilities/configuration. Those parallel Phase 2 PRs touch some shared packaging, ownership, labeling, and legacy-build files, but this branch is based directly on `main` and does not include or duplicate either migration.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
python -m pytest -q python/tests/vllm python/tests/packaging/test_project.py
CMAKE_BUILD_PARALLEL_LEVEL=128 python -m build --wheel
python -m twine check dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl
MOONCAKE_TEST_WHEEL="$PWD/dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl" \
  python -m pytest -q python/tests/vllm python/tests/packaging
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
git diff --check origin/main...HEAD
```

The installed-wheel test creates an isolated virtual environment, installs the wheel with `--no-deps`, removes `PYTHONPATH`, uses isolated Python mode, imports core Mooncake outside the repository, and verifies the installed vLLM module specs without loading optional dependencies.

**Test results:**

- [x] Unit tests pass (8 focused source/configuration and packaging-contract tests)
- [x] Integration tests pass (9 tests including isolated installed-wheel smoke coverage)
- [x] Manual testing done (root PEP 517 wheel build and `twine check` passed)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (not applicable; no C/C++ changes, and the pre-commit formatting hook skipped)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed RFC issue #3534

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with the module migration, dependency/import audit, configuration and packaging tests, validation, and pull request preparation. The human submitter remains responsible for reviewing, understanding, and defending every changed line.