### PR TITLE
[Wheel] Migrate SSD administration to unified Python package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,9 +19,9 @@
 /python/mooncake/mooncake_elastic_buffer.py @UNIDY2002 @ympcMark @yuechen-sys
 /python/mooncake/mooncake_ep_buffer.py @UNIDY2002 @ympcMark @yuechen-sys
 /python/tests/ep/ @UNIDY2002 @ympcMark @yuechen-sys
-/python/mooncake/mooncake_ssd_*.py @ykwd @stmatengss @XucSh @YiXR
-/python/mooncake/spdk_tgt_create.py @ykwd @stmatengss @XucSh @YiXR
-/python/tests/ssd/ @ykwd @stmatengss @XucSh @YiXR
+/python/mooncake/mooncake_ssd_*.py @ykwd @stmatengss
+/python/mooncake/spdk_tgt_create.py @ykwd @stmatengss
+/python/tests/ssd/ @ykwd @stmatengss
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,9 @@
 /python/mooncake/mooncake_elastic_buffer.py @UNIDY2002 @ympcMark @yuechen-sys
 /python/mooncake/mooncake_ep_buffer.py @UNIDY2002 @ympcMark @yuechen-sys
 /python/tests/ep/ @UNIDY2002 @ympcMark @yuechen-sys
+/python/mooncake/mooncake_ssd_*.py @ykwd @stmatengss @XucSh @YiXR
+/python/mooncake/spdk_tgt_create.py @ykwd @stmatengss @XucSh @YiXR
+/python/tests/ssd/ @ykwd @stmatengss @XucSh @YiXR
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,11 @@ run-ci:
 
 store:
   - changed-files:
-    - any-glob-to-any-file: 'mooncake-store/**/*'
+    - any-glob-to-any-file:
+      - 'mooncake-store/**/*'
+      - 'python/mooncake/mooncake_ssd_*.py'
+      - 'python/mooncake/spdk_tgt_create.py'
+      - 'python/tests/ssd/**/*'
 
 Transfer Engine:
   - changed-files:

--- a/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
+++ b/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
@@ -95,9 +95,15 @@ If a timeout error occurs during startup, check whether a proxy is configured on
 
 ### 3.2 Install SSH Dependencies
 
+Install the administration extra for the Mooncake distribution used by the
+deployment. For the default CUDA distribution, run:
+
 ```bash
-python3 -m pip install "paramiko>=3.4.0"
+python3 -m pip install "mooncake-transfer-engine[administration]"
 ```
+
+For another hardware variant, substitute its distribution name while keeping
+the `[administration]` extra.
 
 ### 3.3 Deploy the SSD Pool
 

--- a/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
+++ b/docs/source/deployment/ssd/nvmf-ssd-deployment-guide.md
@@ -95,15 +95,9 @@ If a timeout error occurs during startup, check whether a proxy is configured on
 
 ### 3.2 Install SSH Dependencies
 
-Install the administration extra for the Mooncake distribution used by the
-deployment. For the default CUDA distribution, run:
-
 ```bash
-python3 -m pip install "mooncake-transfer-engine[administration]"
+python3 -m pip install "paramiko>=3.4.0"
 ```
-
-For another hardware variant, substitute its distribution name while keeping
-the `[administration]` extra.
 
 ### 3.3 Deploy the SSD Pool
 

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -215,9 +215,9 @@ if(NOT SKBUILD)
     if(USE_NOF)
       install(
         FILES
-          "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ssd_register.py"
-          "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_ssd_unregister.py"
-          "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/spdk_tgt_create.py"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_ssd_register.py"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_ssd_unregister.py"
+          "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/spdk_tgt_create.py"
         DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR})
     endif()
   endif()

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -215,6 +215,7 @@ if(NOT SKBUILD)
     if(USE_NOF)
       install(
         FILES
+          "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/_administration.py"
           "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_ssd_register.py"
           "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_ssd_unregister.py"
           "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/spdk_tgt_create.py"

--- a/mooncake-wheel/pyproject.toml
+++ b/mooncake-wheel/pyproject.toml
@@ -35,6 +35,9 @@ dependencies = ["aiohttp", "requests", "msgpack", "typing_extensions>=4.0; pytho
 keywords = ["mooncake", "transfer engine", "kv cache", "llm inference", "rdma"]
 classifiers = ["Development Status :: 5 - Production/Stable", "Environment :: GPU :: NVIDIA CUDA", "Intended Audience :: Developers", "Intended Audience :: Science/Research", "License :: OSI Approved :: Apache Software License", "Operating System :: POSIX :: Linux", "Programming Language :: C++", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only", "Programming Language :: Python :: 3.10", "Programming Language :: Python :: 3.11", "Programming Language :: Python :: 3.12", "Programming Language :: Python :: 3.13", "Programming Language :: Python :: Implementation :: CPython", "Topic :: Scientific/Engineering :: Artificial Intelligence", "Topic :: System :: Distributed Computing"]
 
+[project.optional-dependencies]
+administration = ["paramiko"]
+
 [project.urls]
 Homepage = "https://github.com/kvcache-ai/Mooncake"
 Documentation = "https://kvcache-ai.github.io/Mooncake"

--- a/python/mooncake/_administration.py
+++ b/python/mooncake/_administration.py
@@ -1,0 +1,15 @@
+"""Optional dependencies for the SSD administration tools."""
+
+
+def require_paramiko():
+    """Load SSH support only when an administration operation needs it."""
+    try:
+        import paramiko
+    except ModuleNotFoundError as exc:
+        if exc.name != "paramiko":
+            raise
+        raise RuntimeError(
+            "SSH administration requires paramiko. Install it with: "
+            "python -m pip install 'mooncake-transfer-engine[administration]'"
+        ) from None
+    return paramiko

--- a/python/mooncake/mooncake_ssd_register.py
+++ b/python/mooncake/mooncake_ssd_register.py
@@ -29,9 +29,11 @@ class MooncakeNoFRegister:
             # Only support getting SSD info from remote SPDK targets
             if self.spdk_targets:
                 # Get SSD info from remote SPDK targets
-                master_server_address = self.cli_config.get('master_server_address')
+                master_server_address = self.cli_config.get("master_server_address")
                 if not master_server_address:
-                    raise ValueError("master_server_address is required when using spdk_target_info")
+                    raise ValueError(
+                        "master_server_address is required when using spdk_target_info"
+                    )
                 self.config_list = self._get_remote_ssd_info(master_server_address)
             else:
                 raise ValueError("spdk_target_info is required")
@@ -57,8 +59,6 @@ class MooncakeNoFRegister:
             logging.error("Configuration load failed: %s", e)
             raise
 
-
-
     def _remove_duplicate_ssds(self):
         """
         Remove duplicate SSD configurations from the config list
@@ -68,24 +68,24 @@ class MooncakeNoFRegister:
 
         for config in self.config_list:
             # Generate unique key directly without calling _get_ssd_unique_key
-            key = (config['nqn'], config['nsid'], config['traddr'], config['trsvcid'])
+            key = (config["nqn"], config["nsid"], config["traddr"], config["trsvcid"])
             if key not in seen_keys:
                 seen_keys.add(key)
                 unique_configs.append(config)
 
         if len(unique_configs) < len(self.config_list):
-            logging.info(f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)")
+            logging.info(
+                f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)"
+            )
 
         self.config_list = unique_configs
-
-
 
     def _parse_spdk_target_info(self, target_info: str) -> Dict[str, str]:
         """
         Parse spdk target info string like "ip:192.168.65.56 path:/home"
         """
         result = {}
-        parts = re.findall(r'(\w+):([^\s]+)', target_info)
+        parts = re.findall(r"(\w+):([^\s]+)", target_info)
         for key, value in parts:
             result[key] = value
         return result
@@ -99,17 +99,17 @@ class MooncakeNoFRegister:
         try:
             ssh.connect(
                 ip,
-                port=int(self.cli_config.get('port', 22)),
-                username=self.cli_config.get('username', 'root'),
-                password=self.cli_config.get('password'),
-                key_filename=self.cli_config.get('key_file'),
-                timeout=10
+                port=int(self.cli_config.get("port", 22)),
+                username=self.cli_config.get("username", "root"),
+                password=self.cli_config.get("password"),
+                key_filename=self.cli_config.get("key_file"),
+                timeout=10,
             )
 
             # Try multiple possible paths to find the RPC script
             possible_paths = [
                 path,  # Direct path provided by user
-                f"{path}/spdk"  # Common case: spdk is a subdirectory
+                f"{path}/spdk",  # Common case: spdk is a subdirectory
             ]
 
             for test_path in possible_paths:
@@ -120,15 +120,17 @@ class MooncakeNoFRegister:
                     full_command = f"cd {shlex.quote(test_path)} && {command}"
                     stdin, stdout, stderr = ssh.exec_command(full_command, timeout=30)
                     exit_status = stdout.channel.recv_exit_status()
-                    output = stdout.read().decode('utf-8')
-                    error = stderr.read().decode('utf-8')
+                    output = stdout.read().decode("utf-8")
+                    error = stderr.read().decode("utf-8")
                     if exit_status != 0:
                         logging.error(f"SSH command error on {ip}: {error}")
                         raise RuntimeError(f"SSH command failed: {error or output}")
                     return output
 
             # If we get here, none of the paths worked
-            raise RuntimeError(f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}")
+            raise RuntimeError(
+                f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}"
+            )
         finally:
             ssh.close()
 
@@ -140,8 +142,8 @@ class MooncakeNoFRegister:
 
         for target_info in self.spdk_targets:
             target = self._parse_spdk_target_info(target_info)
-            ip = target.get('ip')
-            path = target.get('path')
+            ip = target.get("ip")
+            path = target.get("path")
 
             if not ip or not path:
                 logging.error(f"Invalid target info: {target_info}")
@@ -157,27 +159,27 @@ class MooncakeNoFRegister:
 
                 # Process each subsystem
                 for subsystem in subsystems:
-                    if subsystem.get('subtype') != 'NVMe':
+                    if subsystem.get("subtype") != "NVMe":
                         continue
 
-                    nqn = subsystem.get('nqn')
-                    listen_addresses = subsystem.get('listen_addresses', [])
+                    nqn = subsystem.get("nqn")
+                    listen_addresses = subsystem.get("listen_addresses", [])
 
                     if not nqn or not listen_addresses:
                         continue
 
                     # Get transport info from first listen address
-                    traddr = listen_addresses[0].get('traddr')
-                    trsvcid = listen_addresses[0].get('trsvcid')
+                    traddr = listen_addresses[0].get("traddr")
+                    trsvcid = listen_addresses[0].get("trsvcid")
 
                     if not traddr or not trsvcid:
                         continue
 
                     # Process each namespace
-                    namespaces = subsystem.get('namespaces', [])
+                    namespaces = subsystem.get("namespaces", [])
                     for namespace in namespaces:
-                        nsid = namespace.get('nsid')
-                        bdev_name = namespace.get('bdev_name')
+                        nsid = namespace.get("nsid")
+                        bdev_name = namespace.get("bdev_name")
 
                         if not nsid or not bdev_name:
                             continue
@@ -191,24 +193,26 @@ class MooncakeNoFRegister:
                             continue
 
                         bdev = bdevs[0]
-                        block_size = bdev.get('block_size', 512)
-                        num_blocks = bdev.get('num_blocks', 0)
+                        block_size = bdev.get("block_size", 512)
+                        num_blocks = bdev.get("num_blocks", 0)
                         size = block_size * num_blocks
 
                         # Create SSD config
                         ssd_config = {
-                            'nqn': nqn,
-                            'nsid': nsid,
-                            'traddr': traddr,
-                            'trsvcid': int(trsvcid),  # Ensure trsvcid is integer
-                            'base': 0,
-                            'size': size,
-                            'master_server_address': master_server_address,
-                            'metadata_server': ''
+                            "nqn": nqn,
+                            "nsid": nsid,
+                            "traddr": traddr,
+                            "trsvcid": int(trsvcid),  # Ensure trsvcid is integer
+                            "base": 0,
+                            "size": size,
+                            "master_server_address": master_server_address,
+                            "metadata_server": "",
                         }
 
                         ssd_configs.append(ssd_config)
-                        logging.info(f"Found SSD: nqn={nqn}, nsid={nsid}, traddr={traddr}, size={size}")
+                        logging.info(
+                            f"Found SSD: nqn={nqn}, nsid={nsid}, traddr={traddr}, size={size}"
+                        )
 
             except Exception as e:
                 logging.error(f"Failed to get SSD info from {ip}: {e}")
@@ -222,7 +226,7 @@ class MooncakeNoFRegister:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
     def start_ssd_service(self):
@@ -233,7 +237,13 @@ class MooncakeNoFRegister:
 
         for i, cfg in enumerate(self.config_list):
             try:
-                logging.info("Registering SSD %d/%d: nqn=%s, traddr=%s", i + 1, total, cfg.get("nqn"), cfg.get("traddr"))
+                logging.info(
+                    "Registering SSD %d/%d: nqn=%s, traddr=%s",
+                    i + 1,
+                    total,
+                    cfg.get("nqn"),
+                    cfg.get("traddr"),
+                )
 
                 # Create register instance and register SSD
                 self.register = MooncakeDistributedNoFRegister()
@@ -244,7 +254,7 @@ class MooncakeNoFRegister:
                     cfg["trsvcid"],
                     cfg["base"],
                     cfg["size"],
-                    cfg["master_server_address"]
+                    cfg["master_server_address"],
                 )
 
                 if ret != 0:
@@ -255,9 +265,16 @@ class MooncakeNoFRegister:
 
             except Exception as e:
                 # Check if the error is due to the segment already existing on the server
-                if "SEGMENT_ALREADY_EXISTS" in str(e) or "segment already exists" in str(e):
-                    logging.info("SSD %d/%d (nqn=%s, traddr=%s) already registered on server, skipping",
-                                i + 1, total, cfg.get("nqn"), cfg.get("traddr"))
+                if "SEGMENT_ALREADY_EXISTS" in str(
+                    e
+                ) or "segment already exists" in str(e):
+                    logging.info(
+                        "SSD %d/%d (nqn=%s, traddr=%s) already registered on server, skipping",
+                        i + 1,
+                        total,
+                        cfg.get("nqn"),
+                        cfg.get("traddr"),
+                    )
                     skipped_count += 1
                 else:
                     logging.error("Failed to register SSD %d/%d: %s", i + 1, total, e)
@@ -275,24 +292,37 @@ class MooncakeNoFRegister:
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Mooncake SSD Register with REST API')
-    parser.add_argument('--master_server_address', type=str,
-                        help='Master server address (e.g., 192.168.65.81:50051)',
-                        required=True)
-    parser.add_argument('--spdk_target_info', action='append',
-                        help='SPDK target information (e.g., "ip:192.168.65.56 path:/home")',
-                        required=True)
-    parser.add_argument('--username', type=str, default='root',
-                        help='SSH username for target nodes (default: root)')
-    parser.add_argument('--port', type=int, default=22,
-                        help='SSH port for target nodes (default: 22)')
-    parser.add_argument('--password', type=str,
-                        help='SSH password for target nodes')
-    parser.add_argument('--key-file', type=str,
-                        help='SSH private key file path')
-    parser.add_argument('-D', '--define', action='append',
-                        help='Override configuration fields globally (e.g., -Dtrsvcid=4420)',
-                        default=[])
+    parser = argparse.ArgumentParser(description="Mooncake SSD Register with REST API")
+    parser.add_argument(
+        "--master_server_address",
+        type=str,
+        help="Master server address (e.g., 192.168.65.81:50051)",
+        required=True,
+    )
+    parser.add_argument(
+        "--spdk_target_info",
+        action="append",
+        help='SPDK target information (e.g., "ip:192.168.65.56 path:/home")',
+        required=True,
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default="root",
+        help="SSH username for target nodes (default: root)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=22, help="SSH port for target nodes (default: 22)"
+    )
+    parser.add_argument("--password", type=str, help="SSH password for target nodes")
+    parser.add_argument("--key-file", type=str, help="SSH private key file path")
+    parser.add_argument(
+        "-D",
+        "--define",
+        action="append",
+        help="Override configuration fields globally (e.g., -Dtrsvcid=4420)",
+        default=[],
+    )
     return parser.parse_args()
 
 
@@ -301,26 +331,27 @@ def main():
 
     cli_config = {}
     for item in args.define:
-        if '=' in item:
-            key, value = item.split('=', 1)
+        if "=" in item:
+            key, value = item.split("=", 1)
             cli_config[key] = value
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")
 
     # Add master_server_address to cli_config if provided
     if args.master_server_address:
-        cli_config['master_server_address'] = args.master_server_address
-    cli_config['username'] = args.username
-    cli_config['port'] = args.port
+        cli_config["master_server_address"] = args.master_server_address
+    cli_config["username"] = args.username
+    cli_config["port"] = args.port
     if args.password:
-        cli_config['password'] = args.password
+        cli_config["password"] = args.password
     if args.key_file:
-        cli_config['key_file'] = args.key_file
+        cli_config["key_file"] = args.key_file
 
     register = MooncakeNoFRegister(cli_config, args.spdk_target_info)
     success = register.start_ssd_service()
     if not success:
         exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/python/mooncake/mooncake_ssd_register.py
+++ b/python/mooncake/mooncake_ssd_register.py
@@ -8,7 +8,7 @@ import re
 import shlex
 from typing import List, Dict, Any
 
-import paramiko
+from mooncake._administration import require_paramiko
 
 from mooncake.store import MooncakeDistributedNoFRegister
 
@@ -94,6 +94,7 @@ class MooncakeNoFRegister:
         """
         Execute command on remote server via SSH
         """
+        paramiko = require_paramiko()
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:

--- a/python/mooncake/mooncake_ssd_unregister.py
+++ b/python/mooncake/mooncake_ssd_unregister.py
@@ -28,9 +28,11 @@ class MooncakeNoFUnregister:
             # Only support getting SSD info from command line
             if self.spdk_targets:
                 # Get SSD info from command line parameters
-                master_server_address = self.cli_config.get('master_server_address')
+                master_server_address = self.cli_config.get("master_server_address")
                 if not master_server_address:
-                    raise ValueError("master_server_address is required when using spdk_target_info")
+                    raise ValueError(
+                        "master_server_address is required when using spdk_target_info"
+                    )
                 self.config_list = self._parse_spdk_targets(master_server_address)
             else:
                 raise ValueError("spdk_target_info is required")
@@ -51,7 +53,9 @@ class MooncakeNoFUnregister:
             # Remove duplicate SSDs based on their unique identifiers
             self._remove_duplicate_ssds()
 
-            logging.info("Loaded %d SSD configuration(s) to unregister", len(self.config_list))
+            logging.info(
+                "Loaded %d SSD configuration(s) to unregister", len(self.config_list)
+            )
         except Exception as e:
             logging.error("Configuration load failed: %s", e)
             raise
@@ -65,13 +69,15 @@ class MooncakeNoFUnregister:
 
         for config in self.config_list:
             # Generate unique key directly
-            key = (config['nqn'], config['nsid'], config['traddr'], config['trsvcid'])
+            key = (config["nqn"], config["nsid"], config["traddr"], config["trsvcid"])
             if key not in seen_keys:
                 seen_keys.add(key)
                 unique_configs.append(config)
 
         if len(unique_configs) < len(self.config_list):
-            logging.info(f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)")
+            logging.info(
+                f"Removed {len(self.config_list) - len(unique_configs)} duplicate SSD configuration(s)"
+            )
 
         self.config_list = unique_configs
 
@@ -84,17 +90,17 @@ class MooncakeNoFUnregister:
         try:
             ssh.connect(
                 ip,
-                port=int(self.cli_config.get('port', 22)),
-                username=self.cli_config.get('username', 'root'),
-                password=self.cli_config.get('password'),
-                key_filename=self.cli_config.get('key_file'),
-                timeout=10
+                port=int(self.cli_config.get("port", 22)),
+                username=self.cli_config.get("username", "root"),
+                password=self.cli_config.get("password"),
+                key_filename=self.cli_config.get("key_file"),
+                timeout=10,
             )
 
             # Try multiple possible paths to find the RPC script
             possible_paths = [
                 path,  # Direct path provided by user
-                f"{path}/spdk"  # Common case: spdk is a subdirectory
+                f"{path}/spdk",  # Common case: spdk is a subdirectory
             ]
 
             for test_path in possible_paths:
@@ -105,15 +111,17 @@ class MooncakeNoFUnregister:
                     full_command = f"cd {shlex.quote(test_path)} && {command}"
                     stdin, stdout, stderr = ssh.exec_command(full_command, timeout=30)
                     exit_status = stdout.channel.recv_exit_status()
-                    output = stdout.read().decode('utf-8')
-                    error = stderr.read().decode('utf-8')
+                    output = stdout.read().decode("utf-8")
+                    error = stderr.read().decode("utf-8")
                     if exit_status != 0:
                         logging.error(f"SSH command error on {ip}: {error}")
                         raise RuntimeError(f"SSH command failed: {error or output}")
                     return output
 
             # If we get here, none of the paths worked
-            raise RuntimeError(f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}")
+            raise RuntimeError(
+                f"Could not find scripts/rpc.py in any of the possible paths: {possible_paths}"
+            )
         finally:
             ssh.close()
 
@@ -129,123 +137,137 @@ class MooncakeNoFUnregister:
             target = {}
             parts = target_info.split()
             for part in parts:
-                if ':' in part:
-                    key, value = part.split(':', 1)
+                if ":" in part:
+                    key, value = part.split(":", 1)
                     target[key.strip()] = value.strip()
 
             # Validate required fields
-            if 'ip' not in target:
+            if "ip" not in target:
                 raise ValueError("spdk_target_info must contain 'ip' field")
 
-            ip = target['ip']
-            specified_ns = int(target['ns']) if 'ns' in target else None
-            path = target.get('path')
+            ip = target["ip"]
+            specified_ns = int(target["ns"]) if "ns" in target else None
+            path = target.get("path")
 
             # We need to know the NQN to build the te_endpoint
             # For now, we'll use a default NQN pattern (this should be improved)
             default_nqn = "nqn.2016-06.io.spdk:cnode1"
-            nqn = target.get('nqn', default_nqn)
+            nqn = target.get("nqn", default_nqn)
 
             # Default transport parameters
-            trsvcid = int(target.get('port', '4420'))
+            trsvcid = int(target.get("port", "4420"))
 
             # Create SSD config for each namespace (or specified ns only)
             if specified_ns is not None:
                 # Unregister specific namespace
                 ssd_config = {
-                    'nqn': nqn,
-                    'nsid': specified_ns,
-                    'traddr': ip,
-                    'trsvcid': trsvcid,
-                    'base': 0,
-                    'size': 0,  # Size is not needed for unregister
-                    'master_server_address': master_server_address,
-                    'metadata_server': ''
+                    "nqn": nqn,
+                    "nsid": specified_ns,
+                    "traddr": ip,
+                    "trsvcid": trsvcid,
+                    "base": 0,
+                    "size": 0,  # Size is not needed for unregister
+                    "master_server_address": master_server_address,
+                    "metadata_server": "",
                 }
                 ssd_configs.append(ssd_config)
-                logging.info(f"Will unregister SSD: nqn={nqn}, nsid={specified_ns}, traddr={ip}")
+                logging.info(
+                    f"Will unregister SSD: nqn={nqn}, nsid={specified_ns}, traddr={ip}"
+                )
             elif path is not None:
                 # Get actual namespaces from SPDK target
                 logging.info(f"Getting namespace info from target: {ip} (path: {path})")
                 try:
                     # Get subsystems info
                     subsystems_cmd = "./scripts/rpc.py nvmf_get_subsystems"
-                    subsystems_output = self._execute_ssh_command(ip, subsystems_cmd, path)
+                    subsystems_output = self._execute_ssh_command(
+                        ip, subsystems_cmd, path
+                    )
                     subsystems = json.loads(subsystems_output)
 
                     # Process each subsystem
                     for subsystem in subsystems:
-                        if subsystem.get('subtype') != 'NVMe':
+                        if subsystem.get("subtype") != "NVMe":
                             continue
 
-                        subsystem_nqn = subsystem.get('nqn')
-                        listen_addresses = subsystem.get('listen_addresses', [])
+                        subsystem_nqn = subsystem.get("nqn")
+                        listen_addresses = subsystem.get("listen_addresses", [])
 
                         if not subsystem_nqn or not listen_addresses:
                             continue
 
                         # Get transport info from first listen address
-                        traddr = listen_addresses[0].get('traddr')
-                        target_trsvcid = listen_addresses[0].get('trsvcid')
+                        traddr = listen_addresses[0].get("traddr")
+                        target_trsvcid = listen_addresses[0].get("trsvcid")
 
                         if not traddr or not target_trsvcid:
                             continue
 
                         # Use the nqn from the subsystem if not specified
                         current_nqn = nqn if nqn != default_nqn else subsystem_nqn
-                        current_trsvcid = int(target_trsvcid) if target_trsvcid else trsvcid
+                        current_trsvcid = (
+                            int(target_trsvcid) if target_trsvcid else trsvcid
+                        )
 
                         # Process each namespace
-                        namespaces = subsystem.get('namespaces', [])
+                        namespaces = subsystem.get("namespaces", [])
                         for namespace in namespaces:
-                            nsid = namespace.get('nsid')
+                            nsid = namespace.get("nsid")
 
                             if not nsid:
                                 continue
 
                             # Create SSD config
                             ssd_config = {
-                                'nqn': current_nqn,
-                                'nsid': nsid,
-                                'traddr': traddr,
-                                'trsvcid': current_trsvcid,
-                                'base': 0,
-                                'size': 0,  # Size is not needed for unregister
-                                'master_server_address': master_server_address,
-                                'metadata_server': ''
+                                "nqn": current_nqn,
+                                "nsid": nsid,
+                                "traddr": traddr,
+                                "trsvcid": current_trsvcid,
+                                "base": 0,
+                                "size": 0,  # Size is not needed for unregister
+                                "master_server_address": master_server_address,
+                                "metadata_server": "",
                             }
                             ssd_configs.append(ssd_config)
-                            logging.info(f"Will unregister SSD: nqn={current_nqn}, nsid={nsid}, traddr={traddr}")
+                            logging.info(
+                                f"Will unregister SSD: nqn={current_nqn}, nsid={nsid}, traddr={traddr}"
+                            )
 
                 except Exception as e:
                     logging.error(f"Failed to get namespace info from {ip}: {e}")
-                    logging.warning("Falling back to unregistering default namespace (nsid=1)")
+                    logging.warning(
+                        "Falling back to unregistering default namespace (nsid=1)"
+                    )
                     # Fall back to unregistering default namespace
                     ssd_config = {
-                        'nqn': nqn,
-                        'nsid': 1,
-                        'traddr': ip,
-                        'trsvcid': trsvcid,
-                        'base': 0,
-                        'size': 0,
-                        'master_server_address': master_server_address,
-                        'metadata_server': ''
+                        "nqn": nqn,
+                        "nsid": 1,
+                        "traddr": ip,
+                        "trsvcid": trsvcid,
+                        "base": 0,
+                        "size": 0,
+                        "master_server_address": master_server_address,
+                        "metadata_server": "",
                     }
                     ssd_configs.append(ssd_config)
-                    logging.info(f"Will unregister SSD (fallback): nqn={nqn}, nsid=1, traddr={ip}")
+                    logging.info(
+                        f"Will unregister SSD (fallback): nqn={nqn}, nsid=1, traddr={ip}"
+                    )
             else:
                 # No path provided, unregister default namespace only
-                logging.warning("No 'path' provided in spdk_target_info, cannot query actual namespaces from SPDK target")
+                logging.warning(
+                    "No 'path' provided in spdk_target_info, cannot query actual namespaces from SPDK target"
+                )
                 logging.warning("Will unregister default namespace (nsid=1) only")
                 ssd_config = {
-                    'nqn': nqn,
-                    'nsid': 1,
-                    'traddr': ip,
-                    'trsvcid': trsvcid,
-                    'base': 0,
-                    'size': 0,
-                    'master_server_address': master_server_address,
-                    'metadata_server': ''
+                    "nqn": nqn,
+                    "nsid": 1,
+                    "traddr": ip,
+                    "trsvcid": trsvcid,
+                    "base": 0,
+                    "size": 0,
+                    "master_server_address": master_server_address,
+                    "metadata_server": "",
                 }
                 ssd_configs.append(ssd_config)
                 logging.info(f"Will unregister SSD: nqn={nqn}, nsid=1, traddr={ip}")
@@ -258,7 +280,7 @@ class MooncakeNoFUnregister:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
     def start_ssd_unregister_service(self):
@@ -268,7 +290,14 @@ class MooncakeNoFUnregister:
 
         for i, cfg in enumerate(self.config_list):
             try:
-                logging.info("Unregistering SSD %d/%d: nqn=%s, traddr=%s, nsid=%d", i + 1, total, cfg.get("nqn"), cfg.get("traddr"), cfg.get("nsid"))
+                logging.info(
+                    "Unregistering SSD %d/%d: nqn=%s, traddr=%s, nsid=%d",
+                    i + 1,
+                    total,
+                    cfg.get("nqn"),
+                    cfg.get("traddr"),
+                    cfg.get("nsid"),
+                )
 
                 # Create register instance and unregister SSD
                 self.register = MooncakeDistributedNoFRegister()
@@ -277,7 +306,7 @@ class MooncakeNoFUnregister:
                     cfg["nsid"],
                     cfg["traddr"],
                     cfg["trsvcid"],
-                    cfg["master_server_address"]
+                    cfg["master_server_address"],
                 )
 
                 if ret != 0:
@@ -301,29 +330,44 @@ class MooncakeNoFUnregister:
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='Mooncake SSD Unregister with REST API')
-    parser.add_argument('--master_server_address', type=str,
-                        help='Master server address (e.g., 192.168.65.81:50051)',
-                        default='192.168.65.81:50051')
-    parser.add_argument('--spdk_target_info', action='append',
-                        help='SPDK target information (e.g., "ip:192.168.65.56 ns:2 nqn:nqn.2016-06.io.spdk:cnode1" or "ip:192.168.65.56 path:/home/spdk")',
-                        default=None)
-    parser.add_argument('--username', type=str, default='root',
-                        help='SSH username for target nodes (default: root)')
-    parser.add_argument('--port', type=int, default=22,
-                        help='SSH port for target nodes (default: 22)')
-    parser.add_argument('--password', type=str,
-                        help='SSH password for target nodes')
-    parser.add_argument('--key-file', type=str,
-                        help='SSH private key file path')
-    parser.add_argument('-D', '--define', action='append',
-                        help='Override configuration fields globally (e.g., -Dtrsvcid=4420)',
-                        default=[])
+    parser = argparse.ArgumentParser(
+        description="Mooncake SSD Unregister with REST API"
+    )
+    parser.add_argument(
+        "--master_server_address",
+        type=str,
+        help="Master server address (e.g., 192.168.65.81:50051)",
+        default="192.168.65.81:50051",
+    )
+    parser.add_argument(
+        "--spdk_target_info",
+        action="append",
+        help='SPDK target information (e.g., "ip:192.168.65.56 ns:2 nqn:nqn.2016-06.io.spdk:cnode1" or "ip:192.168.65.56 path:/home/spdk")',
+        default=None,
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default="root",
+        help="SSH username for target nodes (default: root)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=22, help="SSH port for target nodes (default: 22)"
+    )
+    parser.add_argument("--password", type=str, help="SSH password for target nodes")
+    parser.add_argument("--key-file", type=str, help="SSH private key file path")
+    parser.add_argument(
+        "-D",
+        "--define",
+        action="append",
+        help="Override configuration fields globally (e.g., -Dtrsvcid=4420)",
+        default=[],
+    )
     args = parser.parse_args()
 
     # If no spdk_target_info is provided, use default
     if args.spdk_target_info is None:
-        args.spdk_target_info = ['ip:192.168.65.56 ns:1 nqn:nqn.2016-06.io.spdk:cnode1']
+        args.spdk_target_info = ["ip:192.168.65.56 ns:1 nqn:nqn.2016-06.io.spdk:cnode1"]
 
     return args
 
@@ -333,26 +377,27 @@ def main():
 
     cli_config = {}
     for item in args.define:
-        if '=' in item:
-            key, value = item.split('=', 1)
+        if "=" in item:
+            key, value = item.split("=", 1)
             cli_config[key] = value
         else:
             logging.warning(f"Ignoring invalid CLI config: {item}")
 
     # Add master_server_address to cli_config if provided
     if args.master_server_address:
-        cli_config['master_server_address'] = args.master_server_address
-    cli_config['username'] = args.username
-    cli_config['port'] = args.port
+        cli_config["master_server_address"] = args.master_server_address
+    cli_config["username"] = args.username
+    cli_config["port"] = args.port
     if args.password:
-        cli_config['password'] = args.password
+        cli_config["password"] = args.password
     if args.key_file:
-        cli_config['key_file'] = args.key_file
+        cli_config["key_file"] = args.key_file
 
     unregister = MooncakeNoFUnregister(cli_config, args.spdk_target_info)
     success = unregister.start_ssd_unregister_service()
     if not success:
         exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/python/mooncake/mooncake_ssd_unregister.py
+++ b/python/mooncake/mooncake_ssd_unregister.py
@@ -7,7 +7,7 @@ import json
 import shlex
 from typing import List, Dict, Any
 
-import paramiko
+from mooncake._administration import require_paramiko
 
 from mooncake.store import MooncakeDistributedNoFRegister
 
@@ -85,6 +85,7 @@ class MooncakeNoFUnregister:
         """
         Execute command on remote server via SSH
         """
+        paramiko = require_paramiko()
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
         try:

--- a/python/mooncake/spdk_tgt_create.py
+++ b/python/mooncake/spdk_tgt_create.py
@@ -17,34 +17,34 @@ class SPDKTgtCreator:
     """
 
     DEFAULT_TRANSPORT_OPTIONS = {
-        'trtype': 'RDMA',
-        'max_queue_depth': 128,
-        'max_io_qpairs_per_ctrlr': 127,
-        'max_io_size': 4096,
-        'in_capsule_data_size': 131072,
-        'io_unit_size': 131072,
-        'max_aq_depth': 128,
-        'num_shared_buffers': 4096,
-        'buf_cache_size': 32,
+        "trtype": "RDMA",
+        "max_queue_depth": 128,
+        "max_io_qpairs_per_ctrlr": 127,
+        "max_io_size": 4096,
+        "in_capsule_data_size": 131072,
+        "io_unit_size": 131072,
+        "max_aq_depth": 128,
+        "num_shared_buffers": 4096,
+        "buf_cache_size": 32,
     }
 
     TRANSPORT_RPC_FLAGS = {
-        'trtype': '-t',
-        'max_queue_depth': '-q',
-        'max_io_qpairs_per_ctrlr': '-m',
-        'max_io_size': '-c',
-        'in_capsule_data_size': '-i',
-        'io_unit_size': '-u',
-        'max_aq_depth': '-a',
-        'num_shared_buffers': '-n',
-        'buf_cache_size': '-b',
+        "trtype": "-t",
+        "max_queue_depth": "-q",
+        "max_io_qpairs_per_ctrlr": "-m",
+        "max_io_size": "-c",
+        "in_capsule_data_size": "-i",
+        "io_unit_size": "-u",
+        "max_aq_depth": "-a",
+        "num_shared_buffers": "-n",
+        "buf_cache_size": "-b",
     }
 
     def __init__(
         self,
         spdk_targets: List[str],
         transport_options: Dict[str, Any] = None,
-        core_mask: str = '0xff',
+        core_mask: str = "0xff",
         port: int = 22,
     ):
         self.spdk_targets = spdk_targets
@@ -59,7 +59,7 @@ class SPDKTgtCreator:
     def _setup_logging(self):
         logging.basicConfig(
             level=logging.INFO,
-            format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
         self.logger = logging.getLogger(self.__class__.__name__)
 
@@ -71,11 +71,7 @@ class SPDKTgtCreator:
         target_configs = []
 
         for target_info in self.spdk_targets:
-            target = {
-                'ip': None,
-                'path': None,
-                'pci_devices': []
-            }
+            target = {"ip": None, "path": None, "pci_devices": []}
 
             # Split the target info by spaces
             parts = target_info.split()
@@ -84,53 +80,63 @@ class SPDKTgtCreator:
             state = None  # Can be 'ip', 'path', or 'pci'
 
             for part in parts:
-                if ':' in part:
+                if ":" in part:
                     # This is a key-value pair
-                    key, value = part.split(':', 1)
+                    key, value = part.split(":", 1)
                     key = key.strip()
                     value = value.strip()
 
-                    if key == 'ip':
-                        target['ip'] = value
-                        state = 'ip'
-                    elif key == 'path':
-                        target['path'] = value
-                        state = 'path'
-                    elif key == 'pci':
+                    if key == "ip":
+                        target["ip"] = value
+                        state = "ip"
+                    elif key == "path":
+                        target["path"] = value
+                        state = "path"
+                    elif key == "pci":
                         # Parse PCI devices separated by commas
                         if value:
                             # Split by commas and strip whitespace
-                            pci_list = [dev.strip() for dev in value.split(',') if dev.strip()]
-                            target['pci_devices'].extend(pci_list)
-                        state = 'pci'
-                    elif state == 'pci':
-                        pci_list = [dev.strip() for dev in part.split(',') if dev.strip()]
-                        target['pci_devices'].extend(pci_list)
+                            pci_list = [
+                                dev.strip() for dev in value.split(",") if dev.strip()
+                            ]
+                            target["pci_devices"].extend(pci_list)
+                        state = "pci"
+                    elif state == "pci":
+                        pci_list = [
+                            dev.strip() for dev in part.split(",") if dev.strip()
+                        ]
+                        target["pci_devices"].extend(pci_list)
                 else:
                     # This is a continuation of the current state
-                    if state == 'path':
+                    if state == "path":
                         # Path might contain spaces (unlikely but possible)
-                        target['path'] += ' ' + part
-                    elif state == 'pci':
-                        pci_list = [dev.strip() for dev in part.split(',') if dev.strip()]
-                        target['pci_devices'].extend(pci_list)
+                        target["path"] += " " + part
+                    elif state == "pci":
+                        pci_list = [
+                            dev.strip() for dev in part.split(",") if dev.strip()
+                        ]
+                        target["pci_devices"].extend(pci_list)
 
             # Validate required fields
-            if not target['ip']:
+            if not target["ip"]:
                 raise ValueError("Each spdk_target_info must contain 'ip' field")
-            if not target['path']:
+            if not target["path"]:
                 raise ValueError("Each spdk_target_info must contain 'path' field")
 
             target_configs.append(target)
-            pci_info = target['pci_devices'] if target['pci_devices'] else 'auto-discover'
-            self.logger.info(f"Parsed target: IP={target['ip']}, Path={target['path']}, PCI devices={pci_info}")
+            pci_info = (
+                target["pci_devices"] if target["pci_devices"] else "auto-discover"
+            )
+            self.logger.info(
+                f"Parsed target: IP={target['ip']}, Path={target['path']}, PCI devices={pci_info}"
+            )
 
         return target_configs
 
     def _ssh_connect(
         self,
         ip: str,
-        username: str = 'root',
+        username: str = "root",
         password: str = None,
         key_file: str = None,
         port: int = 22,
@@ -153,7 +159,15 @@ class SPDKTgtCreator:
             self.logger.error(f"Failed to connect to {ip}: {e}")
             raise
 
-    def _execute_command(self, ssh: paramiko.SSHClient, command: str, working_dir: str = None, sudo: bool = False, log_errors: bool = True, timeout: Optional[int] = 30) -> tuple:
+    def _execute_command(
+        self,
+        ssh: paramiko.SSHClient,
+        command: str,
+        working_dir: str = None,
+        sudo: bool = False,
+        log_errors: bool = True,
+        timeout: Optional[int] = 30,
+    ) -> tuple:
         """
         Execute a command on the remote host via SSH.
         """
@@ -167,8 +181,8 @@ class SPDKTgtCreator:
 
         stdin, stdout, stderr = ssh.exec_command(command, timeout=timeout)
         exit_status = stdout.channel.recv_exit_status()
-        output = stdout.read().decode('utf-8')
-        error = stderr.read().decode('utf-8')
+        output = stdout.read().decode("utf-8")
+        error = stderr.read().decode("utf-8")
 
         if output:
             self.logger.debug(f"Command output: {output}")
@@ -176,7 +190,9 @@ class SPDKTgtCreator:
             self.logger.debug(f"Command error: {error}")
         if exit_status != 0:
             if log_errors:
-                self.logger.error(f"Command failed with exit code {exit_status}: {command}")
+                self.logger.error(
+                    f"Command failed with exit code {exit_status}: {command}"
+                )
                 if output:
                     self.logger.error(f"Command output: {output}")
                 self.logger.error(f"Error output: {error}")
@@ -188,7 +204,9 @@ class SPDKTgtCreator:
         """
         Discover SPDK-ready or unmounted NVMe controller PCI addresses on the target host.
         """
-        self.logger.info("No PCI devices specified, discovering SPDK-ready or unmounted NVMe PCI devices")
+        self.logger.info(
+            "No PCI devices specified, discovering SPDK-ready or unmounted NVMe PCI devices"
+        )
         output, _ = self._execute_command(
             ssh,
             r"""for dev in /sys/bus/pci/devices/*; do
@@ -227,38 +245,44 @@ class SPDKTgtCreator:
   else
     echo "SKIP $pci mounted"
   fi
-done"""
+done""",
         )
 
         pci_devices = []
         pci_pattern = re.compile(
-            r'^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$'
+            r"^(?:[0-9a-fA-F]{4}:)?[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.[0-7]$"
         )
         for line in output.splitlines():
             fields = line.split()
             if len(fields) < 2:
                 continue
             action, pci = fields[0], fields[1]
-            if action == 'USE' and pci_pattern.match(pci):
+            if action == "USE" and pci_pattern.match(pci):
                 pci_devices.append(pci)
-            elif action == 'SKIP' and pci_pattern.match(pci):
-                reason = ' '.join(fields[2:]) or 'not eligible'
+            elif action == "SKIP" and pci_pattern.match(pci):
+                reason = " ".join(fields[2:]) or "not eligible"
                 self.logger.warning(f"Skipping NVMe PCI device {pci}: {reason}")
 
         if not pci_devices:
-            raise RuntimeError("No SPDK-ready or unmounted NVMe PCI devices found on the target host")
+            raise RuntimeError(
+                "No SPDK-ready or unmounted NVMe PCI devices found on the target host"
+            )
 
-        self.logger.info(f"Selected NVMe PCI devices for SPDK setup: {', '.join(pci_devices)}")
+        self.logger.info(
+            f"Selected NVMe PCI devices for SPDK setup: {', '.join(pci_devices)}"
+        )
         return pci_devices
 
-    def _filter_spdk_ready_pci_devices(self, ssh: paramiko.SSHClient, pci_devices: List[str], strict: bool) -> List[str]:
+    def _filter_spdk_ready_pci_devices(
+        self, ssh: paramiko.SSHClient, pci_devices: List[str], strict: bool
+    ) -> List[str]:
         """
         Keep PCI devices that are bound to an SPDK-compatible userspace driver.
         """
         if not pci_devices:
             return []
 
-        pci_args = ' '.join(shlex.quote(pci) for pci in pci_devices)
+        pci_args = " ".join(shlex.quote(pci) for pci in pci_devices)
         output, _ = self._execute_command(
             ssh,
             f"""for pci in {pci_args}; do
@@ -268,7 +292,7 @@ done"""
     "") echo "NOT_READY $pci no_driver" ;;
     *) echo "NOT_READY $pci $driver" ;;
   esac
-done"""
+done""",
         )
 
         ready_devices = []
@@ -278,19 +302,23 @@ done"""
             if len(fields) < 3:
                 continue
             state, pci, driver = fields[0], fields[1], fields[2]
-            if state == 'READY':
+            if state == "READY":
                 ready_devices.append(pci)
-            elif state == 'NOT_READY':
+            elif state == "NOT_READY":
                 not_ready_devices.append((pci, driver))
 
         if not_ready_devices:
-            details = ', '.join(f"{pci} ({driver})" for pci, driver in not_ready_devices)
+            details = ", ".join(
+                f"{pci} ({driver})" for pci, driver in not_ready_devices
+            )
             if strict:
                 raise RuntimeError(
                     "Some PCI devices are not available to SPDK after setup.sh: "
                     f"{details}. Check whether they are mounted or still bound to the kernel driver."
                 )
-            self.logger.warning(f"Skipping PCI devices not available to SPDK after setup.sh: {details}")
+            self.logger.warning(
+                f"Skipping PCI devices not available to SPDK after setup.sh: {details}"
+            )
 
         if not ready_devices:
             raise RuntimeError("No PCI devices are available to SPDK after setup.sh")
@@ -318,18 +346,22 @@ done"""
         self._execute_command(
             ssh,
             f"nohup {tgt_binary} -m {shlex.quote(self.core_mask)} > {log_file} 2>&1 &",
-            timeout=None
+            timeout=None,
         )
         time.sleep(3)  # Give it time to start
 
-    def _setup_spdk(self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]) -> None:
+    def _setup_spdk(
+        self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]
+    ) -> None:
         """
         Setup SPDK with the specified PCI devices.
         """
         self.logger.info(f"Setting up SPDK with PCI devices: {', '.join(pci_devices)}")
-        pci_allowed = ' '.join(pci_devices)
+        pci_allowed = " ".join(pci_devices)
         setup_script = f"{spdk_path}/scripts/setup.sh"
-        self._execute_command(ssh, f"PCI_ALLOWED='{pci_allowed}' {setup_script}", sudo=True)
+        self._execute_command(
+            ssh, f"PCI_ALLOWED='{pci_allowed}' {setup_script}", sudo=True
+        )
 
     def _format_transport_options(self) -> str:
         """
@@ -339,7 +371,7 @@ done"""
         for option, flag in self.TRANSPORT_RPC_FLAGS.items():
             value = self.transport_options[option]
             formatted_options.extend([flag, shlex.quote(str(value))])
-        return ' '.join(formatted_options)
+        return " ".join(formatted_options)
 
     def _create_transport(self, ssh: paramiko.SSHClient, spdk_path: str) -> None:
         """
@@ -348,9 +380,13 @@ done"""
         self.logger.info(f"Creating {self.transport_options['trtype']} transport")
         rpc_script = f"{spdk_path}/scripts/rpc.py"
         transport_options = self._format_transport_options()
-        self._execute_command(ssh, f"{rpc_script} nvmf_create_transport {transport_options}")
+        self._execute_command(
+            ssh, f"{rpc_script} nvmf_create_transport {transport_options}"
+        )
 
-    def _create_bdevs(self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]) -> List[str]:
+    def _create_bdevs(
+        self, ssh: paramiko.SSHClient, spdk_path: str, pci_devices: List[str]
+    ) -> List[str]:
         """
         Create block devices for the specified PCI devices.
         """
@@ -359,7 +395,10 @@ done"""
         for i, pci in enumerate(pci_devices):
             bdev_name = f"Nvme{i}"
             self.logger.info(f"Creating bdev {bdev_name} for PCI {pci}")
-            self._execute_command(ssh, f"{rpc_script} bdev_nvme_attach_controller -b {bdev_name} -t PCIe -a {pci}")
+            self._execute_command(
+                ssh,
+                f"{rpc_script} bdev_nvme_attach_controller -b {bdev_name} -t PCIe -a {pci}",
+            )
             bdevs.append(f"{bdev_name}n1")
             self.logger.info(f"Attached PCI {pci} as bdev {bdev_name}n1")
         return bdevs
@@ -371,34 +410,50 @@ done"""
         subsystem_nqn = "nqn.2016-06.io.spdk:cnode1"
         self.logger.info(f"Creating subsystem {subsystem_nqn}")
         rpc_script = f"{spdk_path}/scripts/rpc.py"
-        self._execute_command(ssh, f"{rpc_script} nvmf_create_subsystem {subsystem_nqn} -a -s SPDK00000000000001 -m 12")
+        self._execute_command(
+            ssh,
+            f"{rpc_script} nvmf_create_subsystem {subsystem_nqn} -a -s SPDK00000000000001 -m 12",
+        )
         return subsystem_nqn
 
-    def _add_namespaces(self, ssh: paramiko.SSHClient, spdk_path: str, subsystem_nqn: str, bdevs: List[str]) -> None:
+    def _add_namespaces(
+        self,
+        ssh: paramiko.SSHClient,
+        spdk_path: str,
+        subsystem_nqn: str,
+        bdevs: List[str],
+    ) -> None:
         """
         Add namespaces to the subsystem.
         """
         rpc_script = f"{spdk_path}/scripts/rpc.py"
         for bdev in bdevs:
             self.logger.info(f"Adding namespace {bdev} to subsystem {subsystem_nqn}")
-            self._execute_command(ssh, f"{rpc_script} nvmf_subsystem_add_ns {subsystem_nqn} {bdev}")
+            self._execute_command(
+                ssh, f"{rpc_script} nvmf_subsystem_add_ns {subsystem_nqn} {bdev}"
+            )
 
-    def _add_listener(self, ssh: paramiko.SSHClient, spdk_path: str, subsystem_nqn: str, ip: str) -> None:
+    def _add_listener(
+        self, ssh: paramiko.SSHClient, spdk_path: str, subsystem_nqn: str, ip: str
+    ) -> None:
         """
         Add a listener to the subsystem.
         """
-        trtype = self.transport_options['trtype']
+        trtype = self.transport_options["trtype"]
         self.logger.info(f"Adding {trtype} listener on {ip}:4420")
         rpc_script = f"{spdk_path}/scripts/rpc.py"
-        self._execute_command(ssh, f"{rpc_script} nvmf_subsystem_add_listener {subsystem_nqn} -t {shlex.quote(str(trtype))} -a {ip} -s 4420")
+        self._execute_command(
+            ssh,
+            f"{rpc_script} nvmf_subsystem_add_listener {subsystem_nqn} -t {shlex.quote(str(trtype))} -a {ip} -s 4420",
+        )
 
     def deploy_target(self, target_config: Dict[str, Any]) -> bool:
         """
         Deploy SPDK target on a single node.
         """
-        ip = target_config['ip']
-        spdk_path = target_config['path']
-        pci_devices = target_config['pci_devices']
+        ip = target_config["ip"]
+        spdk_path = target_config["path"]
+        pci_devices = target_config["pci_devices"]
 
         self.logger.info(f"Deploying SPDK target on {ip}")
 
@@ -411,16 +466,18 @@ done"""
                 if not pci_devices:
                     pci_devices = self._discover_nvme_pci_devices(ssh)
                 else:
-                    self.logger.info(f"Using explicitly specified PCI devices for {ip}: {', '.join(pci_devices)}")
+                    self.logger.info(
+                        f"Using explicitly specified PCI devices for {ip}: {', '.join(pci_devices)}"
+                    )
 
                 # Setup SPDK
                 self._setup_spdk(ssh, spdk_path, pci_devices)
                 pci_devices = self._filter_spdk_ready_pci_devices(
-                    ssh,
-                    pci_devices,
-                    strict=not auto_discovered
+                    ssh, pci_devices, strict=not auto_discovered
                 )
-                self.logger.info(f"Target {ip} will expose PCI devices: {', '.join(pci_devices)}")
+                self.logger.info(
+                    f"Target {ip} will expose PCI devices: {', '.join(pci_devices)}"
+                )
 
                 # Start tgt service
                 self._start_spdk_tgt(ssh, spdk_path)
@@ -469,58 +526,103 @@ done"""
 
 
 def parse_arguments():
-    parser = argparse.ArgumentParser(description='SPDK Target Creator Tool')
+    parser = argparse.ArgumentParser(description="SPDK Target Creator Tool")
     parser.add_argument(
-        '--spdk_target_info',
-        action='append',
-        help=('SPDK target information (e.g., "ip:192.168.65.56 '
-              'path:/home/spdk pci:0000:01:00.0,0000:02:00.0"). If pci is '
-              'omitted, SPDK-ready or unmounted NVMe devices on the target are used.'),
-        required=True
+        "--spdk_target_info",
+        action="append",
+        help=(
+            'SPDK target information (e.g., "ip:192.168.65.56 '
+            'path:/home/spdk pci:0000:01:00.0,0000:02:00.0"). If pci is '
+            "omitted, SPDK-ready or unmounted NVMe devices on the target are used."
+        ),
+        required=True,
     )
-    parser.add_argument('--core-mask', type=str, default='0xff',
-                        help='CPU core mask used to start nvmf_tgt with -m (default: 0xff)')
-    parser.add_argument('--transport-type', type=str, default='RDMA',
-                        help='NVMe-oF transport type for nvmf_create_transport (default: RDMA)')
-    parser.add_argument('--max-queue-depth', type=int, default=128,
-                        help='Max number of outstanding I/O per queue (default: 128)')
-    parser.add_argument('--max-io-qpairs-per-ctrlr', type=int, default=127,
-                        help='Max number of I/O qpairs per controller (default: 127)')
-    parser.add_argument('--max-io-size', type=int, default=4096,
-                        help='Max I/O size in bytes (default: 4096)')
-    parser.add_argument('--in-capsule-data-size', type=int, default=131072,
-                        help='Max in-capsule data size in bytes (default: 131072)')
-    parser.add_argument('--io-unit-size', type=int, default=131072,
-                        help='I/O unit size in bytes (default: 131072)')
-    parser.add_argument('--max-aq-depth', type=int, default=128,
-                        help='Max number of admin commands per admin queue (default: 128)')
-    parser.add_argument('--num-shared-buffers', type=int, default=4096,
-                        help='Number of pooled data buffers available to the transport (default: 4096)')
-    parser.add_argument('--buf-cache-size', type=int, default=32,
-                        help='Number of shared buffers reserved for each poll group (default: 32)')
-    parser.add_argument('--username', type=str, default='root',
-                        help='SSH username for target nodes (default: root)')
-    parser.add_argument('--port', type=int, default=22,
-                        help='SSH port for target nodes (default: 22)')
-    parser.add_argument('--password', type=str,
-                        help='SSH password for target nodes')
-    parser.add_argument('--key-file', type=str,
-                        help='SSH private key file path')
+    parser.add_argument(
+        "--core-mask",
+        type=str,
+        default="0xff",
+        help="CPU core mask used to start nvmf_tgt with -m (default: 0xff)",
+    )
+    parser.add_argument(
+        "--transport-type",
+        type=str,
+        default="RDMA",
+        help="NVMe-oF transport type for nvmf_create_transport (default: RDMA)",
+    )
+    parser.add_argument(
+        "--max-queue-depth",
+        type=int,
+        default=128,
+        help="Max number of outstanding I/O per queue (default: 128)",
+    )
+    parser.add_argument(
+        "--max-io-qpairs-per-ctrlr",
+        type=int,
+        default=127,
+        help="Max number of I/O qpairs per controller (default: 127)",
+    )
+    parser.add_argument(
+        "--max-io-size",
+        type=int,
+        default=4096,
+        help="Max I/O size in bytes (default: 4096)",
+    )
+    parser.add_argument(
+        "--in-capsule-data-size",
+        type=int,
+        default=131072,
+        help="Max in-capsule data size in bytes (default: 131072)",
+    )
+    parser.add_argument(
+        "--io-unit-size",
+        type=int,
+        default=131072,
+        help="I/O unit size in bytes (default: 131072)",
+    )
+    parser.add_argument(
+        "--max-aq-depth",
+        type=int,
+        default=128,
+        help="Max number of admin commands per admin queue (default: 128)",
+    )
+    parser.add_argument(
+        "--num-shared-buffers",
+        type=int,
+        default=4096,
+        help="Number of pooled data buffers available to the transport (default: 4096)",
+    )
+    parser.add_argument(
+        "--buf-cache-size",
+        type=int,
+        default=32,
+        help="Number of shared buffers reserved for each poll group (default: 32)",
+    )
+    parser.add_argument(
+        "--username",
+        type=str,
+        default="root",
+        help="SSH username for target nodes (default: root)",
+    )
+    parser.add_argument(
+        "--port", type=int, default=22, help="SSH port for target nodes (default: 22)"
+    )
+    parser.add_argument("--password", type=str, help="SSH password for target nodes")
+    parser.add_argument("--key-file", type=str, help="SSH private key file path")
     return parser.parse_args()
 
 
 def main():
     args = parse_arguments()
     transport_options = {
-        'trtype': args.transport_type,
-        'max_queue_depth': args.max_queue_depth,
-        'max_io_qpairs_per_ctrlr': args.max_io_qpairs_per_ctrlr,
-        'max_io_size': args.max_io_size,
-        'in_capsule_data_size': args.in_capsule_data_size,
-        'io_unit_size': args.io_unit_size,
-        'max_aq_depth': args.max_aq_depth,
-        'num_shared_buffers': args.num_shared_buffers,
-        'buf_cache_size': args.buf_cache_size,
+        "trtype": args.transport_type,
+        "max_queue_depth": args.max_queue_depth,
+        "max_io_qpairs_per_ctrlr": args.max_io_qpairs_per_ctrlr,
+        "max_io_size": args.max_io_size,
+        "in_capsule_data_size": args.in_capsule_data_size,
+        "io_unit_size": args.io_unit_size,
+        "max_aq_depth": args.max_aq_depth,
+        "num_shared_buffers": args.num_shared_buffers,
+        "buf_cache_size": args.buf_cache_size,
     }
 
     try:
@@ -537,5 +639,5 @@ def main():
         exit(1)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/python/mooncake/spdk_tgt_create.py
+++ b/python/mooncake/spdk_tgt_create.py
@@ -2,13 +2,19 @@
 # Tool to remotely create SPDK targets on multiple nodes
 # Usage: python3 -m mooncake.spdk_tgt_create --spdk_target_info="ip:192.168.65.56 path:/home/spdk pci:0000:01:00.0,0000:02:00.0" --spdk_target_info="ip:192.168.65.57 path:/home/spdk"
 
+from __future__ import annotations
+
 import argparse
 import logging
-import paramiko
 import re
 import shlex
 import time
-from typing import List, Dict, Any, Optional
+from typing import TYPE_CHECKING, List, Dict, Any, Optional
+
+from mooncake._administration import require_paramiko
+
+if TYPE_CHECKING:
+    import paramiko
 
 
 class SPDKTgtCreator:
@@ -144,6 +150,7 @@ class SPDKTgtCreator:
         """
         Establish an SSH connection to the target host.
         """
+        paramiko = require_paramiko()
         ssh = paramiko.SSHClient()
         ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -11,20 +11,30 @@ import pytest
 REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
 
 
-def _project_version() -> str:
+def _project_version(project_file: str) -> str:
     try:
         import tomllib
     except ModuleNotFoundError:  # pragma: no cover - Python 3.10
         import tomli as tomllib
 
-    project = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text())
+    project = tomllib.loads((REPOSITORY_ROOT / project_file).read_text())
     return project["project"]["version"]
 
 
-def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
-    wheel_value = os.environ.get("MOONCAKE_TEST_WHEEL")
+@pytest.mark.parametrize(
+    ("wheel_variable", "project_file"),
+    [
+        ("MOONCAKE_TEST_WHEEL", "pyproject.toml"),
+        ("MOONCAKE_TEST_LEGACY_WHEEL", "mooncake-wheel/pyproject.toml"),
+    ],
+    ids=["unified", "legacy"],
+)
+def test_wheel_imports_outside_the_repository(
+    tmp_path: Path, wheel_variable: str, project_file: str
+) -> None:
+    wheel_value = os.environ.get(wheel_variable)
     if not wheel_value:
-        pytest.skip("set MOONCAKE_TEST_WHEEL to run the installed-wheel smoke test")
+        pytest.skip(f"set {wheel_variable} to run the installed-wheel smoke test")
 
     wheel = Path(wheel_value).resolve()
     assert wheel.is_file(), f"wheel does not exist: {wheel}"
@@ -52,7 +62,8 @@ import mooncake.store
 package_path = Path(mooncake.__file__).resolve()
 repository_path = Path({str(REPOSITORY_ROOT)!r}).resolve()
 assert not package_path.is_relative_to(repository_path), (package_path, repository_path)
-assert metadata.version("mooncake-transfer-engine") == {_project_version()!r}
+assert metadata.version("mooncake-transfer-engine") == {_project_version(project_file)!r}
+assert "administration" in metadata.metadata("mooncake-transfer-engine").get_all("Provides-Extra", [])
 assert mooncake.BufferPool is mooncake.store.BufferPool
 assert mooncake.engine.TransferEngine is not None
 for ep_module in (
@@ -72,6 +83,7 @@ assert "paramiko" not in sys.modules
 
 installed_files = {{str(path) for path in metadata.files("mooncake-transfer-engine") or []}}
 assert {{
+    "mooncake/_administration.py",
     "mooncake/mooncake_ssd_register.py",
     "mooncake/mooncake_ssd_unregister.py",
     "mooncake/spdk_tgt_create.py",

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -41,8 +41,9 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
     clean_environment.pop("PYTHONPATH", None)
     clean_environment["PYTHONNOUSERSITE"] = "1"
     smoke_script = f"""
-from importlib import metadata
+from importlib import metadata, util
 from pathlib import Path
+import sys
 import mooncake
 import mooncake.engine
 import mooncake.reshard
@@ -60,6 +61,20 @@ for ep_module in (
     "mooncake_elastic_buffer.py",
 ):
     assert (package_path.parent / ep_module).is_file(), ep_module
+for module in (
+    "mooncake.mooncake_ssd_register",
+    "mooncake.mooncake_ssd_unregister",
+    "mooncake.spdk_tgt_create",
+):
+    assert util.find_spec(module) is not None, module
+assert "paramiko" not in sys.modules
+
+installed_files = {{str(path) for path in metadata.files("mooncake-transfer-engine") or []}}
+assert {{
+    "mooncake/mooncake_ssd_register.py",
+    "mooncake/mooncake_ssd_unregister.py",
+    "mooncake/spdk_tgt_create.py",
+}} <= installed_files
 """
     subprocess.run(
         [str(python), "-I", "-c", smoke_script],

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -41,7 +41,7 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
     clean_environment.pop("PYTHONPATH", None)
     clean_environment["PYTHONNOUSERSITE"] = "1"
     smoke_script = f"""
-from importlib import metadata, util
+from importlib import import_module, metadata, util
 from pathlib import Path
 import sys
 import mooncake
@@ -66,7 +66,8 @@ for module in (
     "mooncake.mooncake_ssd_unregister",
     "mooncake.spdk_tgt_create",
 ):
-    assert util.find_spec(module) is not None, module
+    import_module(module)
+assert util.find_spec("paramiko") is None
 assert "paramiko" not in sys.modules
 
 installed_files = {{str(path) for path in metadata.files("mooncake-transfer-engine") or []}}
@@ -82,3 +83,32 @@ assert {{
         env=clean_environment,
         check=True,
     )
+
+    def check_help():
+        for module in (
+            "mooncake.mooncake_ssd_register",
+            "mooncake.mooncake_ssd_unregister",
+            "mooncake.spdk_tgt_create",
+        ):
+            result = subprocess.run(
+                [str(python), "-I", "-m", module, "--help"],
+                cwd=tmp_path,
+                env=clean_environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            assert "usage:" in result.stdout
+
+    check_help()
+    subprocess.run(
+        [str(python), "-m", "pip", "install", f"{wheel}[administration]"],
+        check=True,
+    )
+    subprocess.run(
+        [str(python), "-I", "-c", "import paramiko; assert paramiko.SSHClient"],
+        cwd=tmp_path,
+        env=clean_environment,
+        check=True,
+    )
+    check_help()

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -47,6 +47,7 @@ def test_dependency_boundaries_are_declared() -> None:
         "structured",
         "vllm",
     }
+    assert metadata["optional-dependencies"]["administration"] == ["paramiko"]
 
 
 def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
@@ -87,6 +88,34 @@ def test_ep_modules_have_one_authoritative_source() -> None:
         REPOSITORY_ROOT / "mooncake-wheel" / "tests" / "test_regmr_overhead.py",
     ):
         assert not legacy_test.exists()
+
+
+def test_ssd_administration_modules_have_one_authoritative_source() -> None:
+    package_root = REPOSITORY_ROOT / "python" / "mooncake"
+    legacy_package_root = REPOSITORY_ROOT / "mooncake-wheel" / "mooncake"
+    direct_install = (
+        REPOSITORY_ROOT / "mooncake-integration" / "CMakeLists.txt"
+    ).read_text()
+    legacy_builder = (REPOSITORY_ROOT / "scripts" / "build_wheel.sh").read_text()
+    modules = (
+        "mooncake_ssd_register.py",
+        "mooncake_ssd_unregister.py",
+        "spdk_tgt_create.py",
+    )
+
+    for module in modules:
+        assert (package_root / module).is_file()
+        assert not (legacy_package_root / module).exists()
+        assert f"../python/mooncake/{module}" in direct_install
+        assert f"../mooncake-wheel/mooncake/{module}" not in direct_install
+        assert module in legacy_builder
+
+    assert (
+        REPOSITORY_ROOT / "python" / "tests" / "ssd" / "test_spdk_tgt_create.py"
+    ).is_file()
+    assert not (
+        REPOSITORY_ROOT / "mooncake-wheel" / "tests" / "test_spdk_tgt_create.py"
+    ).exists()
 
 
 def test_pg_extension_build_stages_outside_the_source_tree(

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -50,6 +50,19 @@ def test_dependency_boundaries_are_declared() -> None:
     assert metadata["optional-dependencies"]["administration"] == ["paramiko"]
 
 
+def test_legacy_wheel_administration_extra_matches_root_project() -> None:
+    project = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text())
+    legacy = tomllib.loads(
+        (REPOSITORY_ROOT / "mooncake-wheel" / "pyproject.toml").read_text()
+    )
+
+    assert (
+        legacy["project"]["optional-dependencies"]["administration"]
+        == project["project"]["optional-dependencies"]["administration"]
+    )
+    assert not any("paramiko" in dep for dep in legacy["project"]["dependencies"])
+
+
 def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
     package_root = REPOSITORY_ROOT / "python" / "mooncake"
 
@@ -98,6 +111,7 @@ def test_ssd_administration_modules_have_one_authoritative_source() -> None:
     ).read_text()
     legacy_builder = (REPOSITORY_ROOT / "scripts" / "build_wheel.sh").read_text()
     modules = (
+        "_administration.py",
         "mooncake_ssd_register.py",
         "mooncake_ssd_unregister.py",
         "spdk_tgt_create.py",

--- a/python/tests/ssd/test_administration.py
+++ b/python/tests/ssd/test_administration.py
@@ -1,0 +1,35 @@
+import builtins
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mooncake._administration import require_paramiko
+from mooncake.spdk_tgt_create import SPDKTgtCreator
+
+
+def test_missing_paramiko_reports_install_command():
+    real_import = builtins.__import__
+
+    def without_paramiko(name, *args, **kwargs):
+        if name == "paramiko":
+            raise ModuleNotFoundError("No module named 'paramiko'", name=name)
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=without_paramiko):
+        creator = SPDKTgtCreator(["ip:127.0.0.1 path:/home/spdk"])
+        with pytest.raises(RuntimeError, match=r"pip install .*\[administration\]"):
+            creator._ssh_connect("127.0.0.1")
+
+
+def test_paramiko_is_loaded_on_demand():
+    paramiko = Mock()
+    with patch.dict("sys.modules", {"paramiko": paramiko}):
+        assert require_paramiko() is paramiko
+
+
+def test_broken_transitive_dependency_is_not_hidden():
+    error = ModuleNotFoundError("No module named 'cryptography'", name="cryptography")
+    with patch("builtins.__import__", side_effect=error):
+        with pytest.raises(ModuleNotFoundError) as caught:
+            require_paramiko()
+    assert caught.value is error

--- a/python/tests/ssd/test_spdk_tgt_create.py
+++ b/python/tests/ssd/test_spdk_tgt_create.py
@@ -1,23 +1,36 @@
+from importlib.util import find_spec
+from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch
 
-try:
-    import paramiko
-except ModuleNotFoundError:
+if find_spec("paramiko") is None:
     raise unittest.SkipTest("paramiko is required for SPDK target tests")
 
+import mooncake.spdk_tgt_create as spdk_tgt_create
 from mooncake.spdk_tgt_create import SPDKTgtCreator, parse_arguments
 
 
+def test_module_loads_from_canonical_source():
+    repository_root = Path(__file__).resolve().parents[3]
+
+    assert Path(spdk_tgt_create.__file__).resolve() == (
+        repository_root / "python" / "mooncake" / "spdk_tgt_create.py"
+    )
+
+
 def test_parse_arguments_accepts_ssh_port():
-    with patch.object(sys, "argv", [
-        "spdk_tgt_create",
-        "--spdk_target_info",
-        "ip:127.0.0.1 path:/home/spdk",
-        "--port",
-        "2222",
-    ]):
+    with patch.object(
+        sys,
+        "argv",
+        [
+            "spdk_tgt_create",
+            "--spdk_target_info",
+            "ip:127.0.0.1 path:/home/spdk",
+            "--port",
+            "2222",
+        ],
+    ):
         args = parse_arguments()
 
     assert args.port == 2222

--- a/python/tests/ssd/test_spdk_tgt_create.py
+++ b/python/tests/ssd/test_spdk_tgt_create.py
@@ -1,10 +1,5 @@
-from importlib.util import find_spec
 import sys
-import unittest
 from unittest.mock import patch
-
-if find_spec("paramiko") is None:
-    raise unittest.SkipTest("paramiko is required for SPDK target tests")
 
 from mooncake.spdk_tgt_create import SPDKTgtCreator, parse_arguments
 
@@ -29,7 +24,8 @@ def test_parse_arguments_accepts_ssh_port():
 def test_ssh_connect_uses_requested_port():
     creator = SPDKTgtCreator(["ip:127.0.0.1 path:/home/spdk"])
 
-    with patch("mooncake.spdk_tgt_create.paramiko.SSHClient") as ssh_client:
+    with patch("mooncake.spdk_tgt_create.require_paramiko") as require_paramiko:
+        ssh_client = require_paramiko.return_value.SSHClient
         creator._ssh_connect("127.0.0.1", port=2222)
 
     ssh_client.return_value.connect.assert_called_once_with(

--- a/python/tests/ssd/test_spdk_tgt_create.py
+++ b/python/tests/ssd/test_spdk_tgt_create.py
@@ -1,5 +1,4 @@
 from importlib.util import find_spec
-from pathlib import Path
 import sys
 import unittest
 from unittest.mock import patch
@@ -7,16 +6,7 @@ from unittest.mock import patch
 if find_spec("paramiko") is None:
     raise unittest.SkipTest("paramiko is required for SPDK target tests")
 
-import mooncake.spdk_tgt_create as spdk_tgt_create
 from mooncake.spdk_tgt_create import SPDKTgtCreator, parse_arguments
-
-
-def test_module_loads_from_canonical_source():
-    repository_root = Path(__file__).resolve().parents[3]
-
-    assert Path(spdk_tgt_create.__file__).resolve() == (
-        repository_root / "python" / "mooncake" / "spdk_tgt_create.py"
-    )
 
 
 def test_parse_arguments_accepts_ssh_port():

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -180,14 +180,17 @@ if [ "$NPU_BUILD" = "1" ]; then
 fi
 
 echo "Building wheel package..."
-# Stage migrated EP modules and the legacy Reshard package for the combined
-# wheel builder. Each tracked source remains in its authoritative tree.
+# Stage migrated root Python modules and the legacy Reshard package for the
+# combined-wheel builder. Each tracked source remains in its authoritative tree.
 MIGRATED_PYTHON_SOURCE_DIR="python/mooncake"
 MIGRATED_PYTHON_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake"
 MIGRATED_PYTHON_MODULES=(
     ep.py
     mooncake_ep_buffer.py
     mooncake_elastic_buffer.py
+    mooncake_ssd_register.py
+    mooncake_ssd_unregister.py
+    spdk_tgt_create.py
 )
 RESHARD_SOURCE_DIR="mooncake-reshard/python/mooncake/reshard"
 RESHARD_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake/reshard"

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -188,6 +188,7 @@ MIGRATED_PYTHON_MODULES=(
     ep.py
     mooncake_ep_buffer.py
     mooncake_elastic_buffer.py
+    _administration.py
     mooncake_ssd_register.py
     mooncake_ssd_unregister.py
     spdk_tgt_create.py

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -38,6 +38,7 @@ echo "Running import structure test..."
 # Run the import structure test
 cp -r mooncake-wheel/tests test_env/
 cp -r mooncake-reshard/tests test_env/reshard_tests
+cp -r python/tests/ssd test_env/ssd_tests
 cd test_env
 pip install torch numpy
 python -c "import mooncake._fast_copy"
@@ -48,8 +49,8 @@ echo "Running mooncake config test..."
 python tests/test_mooncake_config.py
 
 echo "Running reshard contract tests..."
-python -m pip install pytest hypothesis==6.141.0
-python -m pytest reshard_tests -q
+python -m pip install pytest hypothesis==6.141.0 paramiko
+python -m pytest reshard_tests ssd_tests -q
 
 echo "Verifying mooncake_master entry point..."
 # Check if the mooncake_master entry point is installed and executable


### PR DESCRIPTION
## Description

Implements the SSD/SPDK administration slice of Phase 2 from #3534 by moving
its tracked Python modules into the unified root Python project.

- move `mooncake_ssd_register.py`, `mooncake_ssd_unregister.py`, and
  `spdk_tgt_create.py` to `python/mooncake` as their single authoritative
  source;
- move the directly owned SPDK target tests to `python/tests/ssd`;
- preserve the existing `python -m mooncake.<module>` administration commands;
- keep Paramiko isolated in the `administration` optional dependency boundary;
- redirect direct CMake installation and temporary legacy wheel staging to the
  canonical sources;
- add source-tree, build-mapping, installed-wheel manifest, and isolated import
  coverage;
- update SSD administration ownership, labels, and deployment instructions.

This change is intentionally limited to SSD/SPDK administration. It does not
migrate Store services, the Store native API, general CLI modules, or perform
the later native-extension/release cutovers.

### Overlap

No other open PR specifically covers the SSD/SPDK administration migration.
#3585 migrates Reshard and #3586 migrates lightweight Store utilities/config;
their module sources and tests are disjoint from this PR and are not duplicated
here. Those PRs do touch some shared Phase 2 packaging, ownership, and test
plumbing, so a later rebase may require mechanical conflict resolution.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
PYTHONNOUSERSITE=1 PYTHONPATH="$PWD/mooncake-wheel:$PWD/python" \
  <isolated-admin-python> -m pytest -q python/tests/ssd/test_spdk_tgt_create.py
python -m pytest -q python/tests/packaging/test_project.py
CMAKE_BUILD_PARALLEL_LEVEL=128 python -m build --wheel
python -m twine check dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl
MOONCAKE_TEST_WHEEL="$PWD/dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl" \
  python -m pytest -q python/tests/packaging/test_installed_wheel.py
<isolated-admin-python> -I -m mooncake.spdk_tgt_create --help
<isolated-admin-python> -I -m mooncake.mooncake_ssd_register --help
<isolated-admin-python> -I -m mooncake.mooncake_ssd_unregister --help
make -C docs html
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```

The administration smoke environment installed the built wheel with the
`administration` extra, ran outside the repository without `PYTHONPATH`, and
loaded Paramiko 5.0.0. The core installed-wheel test used `--no-deps` and
verified that core imports did not load Paramiko.

**Test results:**

- [x] Unit tests pass (3 focused SSD/SPDK tests)
- [x] Integration tests pass (5 project packaging tests and 1 isolated
  installed-wheel test)
- [x] Manual testing done (all three installed-wheel `python -m ... --help`
  commands, wheel manifest, `twine check`, and Sphinx HTML build pass)

Environment-only gap: no live SPDK/NVMe-oF target and Mooncake master were
available, so registration/unregistration against hardware was not exercised.
The moved implementations are AST-identical to `main`, and their CLI, source,
and installed-wheel boundaries were validated locally.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (no C/C++
  sources changed; all applicable pre-commit format hooks pass)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed RFC issue #3534

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with the scoped module migration, reference and packaging
updates, validation, diff review, and PR preparation. The human submitter
remains responsible for understanding and defending every changed line.