### PR TITLE
[Store] Migrate Store REST service to unified Python package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,11 @@
 /mooncake-integration/transfer_engine @ShangmingCai @alogfans
 /mooncake-integration/store @ykwd @stmatengss @zxpdemonio
 /mooncake-pg @UNIDY2002 @ympcMark @yuechen-sys
-/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio 
+/mooncake-reshard @ShangmingCai @stmatengss @Bo-Vincent @zxpdemonio
 /mooncake-store @ykwd @stmatengss @XucSh @YiXR
 /mooncake-store/*/ha/ @Libotry @YiXR @00fish0 @Icedcoco @Aionw
+/python/mooncake/mooncake_store_service.py @ykwd @stmatengss
+/python/tests/store/test_mooncake_store_service_api.py @ykwd @stmatengss
 /mooncake-transfer-engine @alogfans @doujiang24 @chestnut-Q @staryxchen
 /mooncake-transfer-engine/tent @alogfans @doujiang24 @chestnut-Q @staryxchen @00fish0 @dtcccc
 /mooncake-transfer-engine/*/transport/hip_transport/ @alogfans @amd-arozanov

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,7 +5,10 @@ run-ci:
 
 store:
   - changed-files:
-    - any-glob-to-any-file: 'mooncake-store/**/*'
+    - any-glob-to-any-file:
+      - 'mooncake-store/**/*'
+      - 'python/mooncake/mooncake_store_service.py'
+      - 'python/tests/store/test_mooncake_store_service_api.py'
 
 Transfer Engine:
   - changed-files:
@@ -57,6 +60,7 @@ Tests:
       - 'scripts/test_*'
       - 'mooncake-wheel/tests/**/*'
       - 'mooncake-reshard/tests/**/*'
+      - 'python/tests/**/*'
       - 'scripts/tone_tests/**/*'
 
 Ascend/NPU:

--- a/docs/source/zh_archive/mooncake-store.md
+++ b/docs/source/zh_archive/mooncake-store.md
@@ -910,7 +910,7 @@ retcode = store.setup(
 
 ### 将 Client 作为独立进程启动并通过 HTTP 访问
 
-使用 `mooncake-wheel/mooncake/mooncake_store_service.py` 可以以独立进程的形式启动 **真实**`Client` 并通过 HTTP 访问。
+使用 `python/mooncake/mooncake_store_service.py` 可以以独立进程的形式启动 **真实**`Client` 并通过 HTTP 访问。
 
 首先，创建并保存一个 JSON 格式的配置文件。例如：
 

--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -207,7 +207,7 @@ if(NOT SKBUILD)
   if(WITH_STORE)
     install(
       FILES
-        "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_store_service.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../python/mooncake/mooncake_store_service.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/mooncake_config.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/../mooncake-wheel/mooncake/cli.py"
       DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR})

--- a/python/mooncake/mooncake_store_service.py
+++ b/python/mooncake/mooncake_store_service.py
@@ -41,9 +41,7 @@ def _shm_name_to_path(name):
 
 def _unblock_shutdown_signals():
     try:
-        signal.pthread_sigmask(
-            signal.SIG_UNBLOCK, {signal.SIGINT, signal.SIGTERM}
-        )
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT, signal.SIGTERM})
     except AttributeError:
         pass
 
@@ -126,9 +124,7 @@ class MooncakeStoreService:
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
-    async def start_store_service(
-        self, max_wait_time: float = 60, shutdown_event=None
-    ):
+    async def start_store_service(self, max_wait_time: float = 60, shutdown_event=None):
         """
         Start the store service with retry mechanism.
 
@@ -191,9 +187,7 @@ class MooncakeStoreService:
                     # chance to publish a shutdown requested while it ran.
                     await asyncio.sleep(0)
                     if shutdown_event.is_set():
-                        logging.info(
-                            "Store startup cancelled by shutdown request"
-                        )
+                        logging.info("Store startup cancelled by shutdown request")
                         await self.stop()
                         return False
 
@@ -228,9 +222,7 @@ class MooncakeStoreService:
                                 shutdown_event.wait(),
                                 timeout=actual_sleep_time,
                             )
-                            logging.info(
-                                "Store startup cancelled by shutdown request"
-                            )
+                            logging.info("Store startup cancelled by shutdown request")
                             return False
                         except asyncio.TimeoutError:
                             pass

--- a/python/tests/packaging/test_installed_wheel.py
+++ b/python/tests/packaging/test_installed_wheel.py
@@ -43,8 +43,16 @@ def test_wheel_imports_outside_the_repository(tmp_path: Path) -> None:
     smoke_script = f"""
 from importlib import metadata
 from pathlib import Path
+import sys
+import types
+
+aiohttp = types.ModuleType("aiohttp")
+aiohttp.web = types.SimpleNamespace()
+sys.modules["aiohttp"] = aiohttp
+
 import mooncake
 import mooncake.engine
+import mooncake.mooncake_store_service
 import mooncake.reshard
 import mooncake.store
 
@@ -54,6 +62,14 @@ assert not package_path.is_relative_to(repository_path), (package_path, reposito
 assert metadata.version("mooncake-transfer-engine") == {_project_version()!r}
 assert mooncake.BufferPool is mooncake.store.BufferPool
 assert mooncake.engine.TransferEngine is not None
+assert mooncake.mooncake_store_service.MooncakeStoreService is not None
+store_entry_points = metadata.entry_points(
+    group="console_scripts", name="mc_store_rest_server"
+)
+assert len(store_entry_points) == 1
+store_entry_point = store_entry_points[0]
+assert store_entry_point.value == "mooncake.mooncake_store_service:sync_main"
+assert store_entry_point.load() is mooncake.mooncake_store_service.sync_main
 """
     subprocess.run(
         [str(python), "-I", "-c", smoke_script],

--- a/python/tests/packaging/test_project.py
+++ b/python/tests/packaging/test_project.py
@@ -57,6 +57,32 @@ def test_tracked_source_roots_contain_no_generated_native_artifacts() -> None:
     assert not list((REPOSITORY_ROOT / "mooncake-pg" / "torch").rglob("*.so"))
 
 
+def test_store_rest_service_has_one_authoritative_source() -> None:
+    package_root = REPOSITORY_ROOT / "python" / "mooncake"
+    tests_root = REPOSITORY_ROOT / "python" / "tests"
+    legacy_package_root = REPOSITORY_ROOT / "mooncake-wheel" / "mooncake"
+    legacy_tests_root = REPOSITORY_ROOT / "mooncake-wheel" / "tests"
+
+    assert (package_root / "mooncake_store_service.py").is_file()
+    assert (tests_root / "store" / "test_mooncake_store_service_api.py").is_file()
+    assert not (legacy_package_root / "mooncake_store_service.py").exists()
+    assert not (legacy_tests_root / "test_mooncake_store_service_api.py").exists()
+
+    project = tomllib.loads((REPOSITORY_ROOT / "pyproject.toml").read_text())
+    assert (
+        project["project"]["scripts"]["mc_store_rest_server"]
+        == "mooncake.mooncake_store_service:sync_main"
+    )
+
+    integration_cmake = (
+        REPOSITORY_ROOT / "mooncake-integration" / "CMakeLists.txt"
+    ).read_text()
+    assert "../python/mooncake/mooncake_store_service.py" in integration_cmake
+    assert (
+        "../mooncake-wheel/mooncake/mooncake_store_service.py" not in integration_cmake
+    )
+
+
 def test_pg_extension_build_stages_outside_the_source_tree(
     tmp_path: Path,
 ) -> None:

--- a/python/tests/store/test_mooncake_store_service_api.py
+++ b/python/tests/store/test_mooncake_store_service_api.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import asyncio
+import importlib.util
 import json
 import logging
 import signal
@@ -13,7 +14,13 @@ from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import patch
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+for module_name in tuple(sys.modules):
+    if module_name == "mooncake" or module_name.startswith("mooncake."):
+        del sys.modules[module_name]
+mooncake_package = types.ModuleType("mooncake")
+mooncake_package.__path__ = [str(REPOSITORY_ROOT / "mooncake-wheel" / "mooncake")]
+sys.modules["mooncake"] = mooncake_package
 
 try:
     from aiohttp import web as _unused_web  # noqa: F401
@@ -44,12 +51,29 @@ except ModuleNotFoundError:
     store_module.MooncakeDistributedStore = MooncakeDistributedStore
     sys.modules["mooncake.store"] = store_module
 
-from mooncake.mooncake_store_service import (
-    MooncakeStoreService,
-    _install_shutdown_signal_handlers,
-    _shm_name_to_path,
-    main as store_service_main,
+STORE_SERVICE_PATH = (
+    REPOSITORY_ROOT / "python" / "mooncake" / "mooncake_store_service.py"
 )
+STORE_SERVICE_SPEC = importlib.util.spec_from_file_location(
+    "mooncake.mooncake_store_service", STORE_SERVICE_PATH
+)
+assert STORE_SERVICE_SPEC is not None
+assert STORE_SERVICE_SPEC.loader is not None
+store_service_module = importlib.util.module_from_spec(STORE_SERVICE_SPEC)
+sys.modules[STORE_SERVICE_SPEC.name] = store_service_module
+STORE_SERVICE_SPEC.loader.exec_module(store_service_module)
+mooncake_package.mooncake_store_service = store_service_module
+
+MooncakeStoreService = store_service_module.MooncakeStoreService
+_install_shutdown_signal_handlers = (
+    store_service_module._install_shutdown_signal_handlers
+)
+_shm_name_to_path = store_service_module._shm_name_to_path
+store_service_main = store_service_module.main
+
+
+def test_store_service_loads_from_canonical_source() -> None:
+    assert Path(store_service_module.__file__).resolve() == STORE_SERVICE_PATH
 
 
 class FakeStore:
@@ -319,7 +343,9 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         # subsequent same-path detection keeps working.
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/old")
 
-    async def test_reconfigure_decode_same_path_remount_failure_keeps_previous_segments(self):
+    async def test_reconfigure_decode_same_path_remount_failure_keeps_previous_segments(
+        self,
+    ):
         # A remount to the SAME path that fails to mount must not destroy the
         # still-healthy previous segments: the node keeps serving from them and
         # stays in decode mode (make-before-break). Same-path MBB is safe here
@@ -397,7 +423,9 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.current_mode, "decode")
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/new")
 
-    async def test_reconfigure_decode_partial_unmount_failure_keeps_only_failed_ids(self):
+    async def test_reconfigure_decode_partial_unmount_failure_keeps_only_failed_ids(
+        self,
+    ):
         # New mount succeeds, but retiring the previous segments only PARTIALLY
         # fails. unmount_segment reports the first error for a batch, so the old
         # ids must be unmounted individually; mounted_segment_ids must then hold
@@ -596,7 +624,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
     async def test_handle_put_missing_value(self):
         self.fake_store.put = lambda key, value: 0
         resp = await self.service.handle_put(FakeRequest({"key": "k"}))
-        self.assertEqual(resp.status, 500)
+        self.assertEqual(resp.status, 400)
 
     async def test_handle_put_store_failure(self):
         self.fake_store.put = lambda key, value: -1
@@ -847,7 +875,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.service.mounted_segment_ids = [sid]
         resp = await self.service.handle_reconfigure(FakeRequest({"mode": "prefill"}))
         self.assertEqual(resp.status, 200)
-        self.assertEqual(self.fake_store.unmount_calls, [[sid]])
+        self.assertEqual(self.fake_store.unmount_calls, [([sid], 0)])
         self.assertEqual(self.service.mounted_segment_ids, [])
         self.assertEqual(self.service.current_mode, "prefill")
 
@@ -888,7 +916,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
             )
         )
         self.assertEqual(resp.status, 200)
-        self.assertEqual(self.fake_store.unmount_calls, [[old_id]])
+        self.assertEqual(self.fake_store.unmount_calls, [([old_id], 0)])
         self.assertEqual(self.service.current_mode, "decode")
 
     # ==================== /api/mount edge cases ====================
@@ -985,7 +1013,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(resp.status, 200)
         self.assertEqual(
             self.fake_store.unmount_calls,
-            [["00000000-0000-0000-0000-000000000001"]],
+            [(["00000000-0000-0000-0000-000000000001"], 0)],
         )
 
     async def test_unmount_shm_empty_list(self):
@@ -1008,6 +1036,8 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
             enable_ssd_offload=False,
             ssd_offload_path="",
             tenant_id="",
+            enable_client_http_server=False,
+            client_http_port=9300,
         )
 
     async def test_shutdown_event_stops_startup_retry_sleep(self):
@@ -1077,9 +1107,7 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
             await self.service.stop()
 
         self.assertIsNone(self.service.store)
-        self.assertTrue(
-            any("close returned 7" in message for message in logs.output)
-        )
+        self.assertTrue(any("close returned 7" in message for message in logs.output))
         await self.service.stop()
         store.close.assert_called_once_with()
 

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -180,15 +180,25 @@ if [ "$NPU_BUILD" = "1" ]; then
 fi
 
 echo "Building wheel package..."
-# Stage the reshard Python package for the combined Mooncake wheel. The tracked
-# source of truth remains in the top-level module.
+# Stage migrated root Python modules and the legacy Reshard package for the
+# combined-wheel builder. Each tracked source remains in its authoritative tree.
+MIGRATED_PYTHON_SOURCE_DIR="python/mooncake"
+MIGRATED_PYTHON_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake"
+MIGRATED_PYTHON_MODULES=(mooncake_store_service.py)
 RESHARD_SOURCE_DIR="mooncake-reshard/python/mooncake/reshard"
 RESHARD_STAGING_DIR="$(pwd)/mooncake-wheel/mooncake/reshard"
-cleanup_reshard_staging() {
+cleanup_migrated_python_staging() {
+    for module in "${MIGRATED_PYTHON_MODULES[@]}"; do
+        rm -f "${MIGRATED_PYTHON_STAGING_DIR}/${module}"
+    done
     rm -rf "${RESHARD_STAGING_DIR}"
 }
-trap cleanup_reshard_staging EXIT
-rm -rf "${RESHARD_STAGING_DIR}"
+trap cleanup_migrated_python_staging EXIT
+cleanup_migrated_python_staging
+for module in "${MIGRATED_PYTHON_MODULES[@]}"; do
+    cp "${MIGRATED_PYTHON_SOURCE_DIR}/${module}" \
+       "${MIGRATED_PYTHON_STAGING_DIR}/${module}"
+done
 cp -R "${RESHARD_SOURCE_DIR}" "${RESHARD_STAGING_DIR}"
 
 # Build the wheel package
@@ -204,7 +214,7 @@ WHEEL_DIR="$(pwd)"
 cleanup_wheel_metadata_state() {
     [[ -f "${WHEEL_DIR}/pyproject.toml.backup" ]] && mv "${WHEEL_DIR}/pyproject.toml.backup" "${WHEEL_DIR}/pyproject.toml"
     rm -f "${WHEEL_DIR}/README.md"
-    cleanup_reshard_staging
+    cleanup_migrated_python_staging
 }
 trap cleanup_wheel_metadata_state EXIT
 

--- a/scripts/test_installation.sh
+++ b/scripts/test_installation.sh
@@ -32,6 +32,7 @@ sudo apt-get install -y $SYSTEM_PACKAGES
 
 echo "Verifying that import succeeds after installation..."
 python -c "import mooncake.engine" && echo "Success: Import succeeded after installation" || { echo "ERROR: Import failed after installation!"; exit 1; }
+python -c "import mooncake.mooncake_store_service" && echo "Success: Store REST service import succeeded after installation" || { echo "ERROR: Store REST service import failed after installation!"; exit 1; }
 python -c "import mooncake.reshard.weight" && echo "Success: Reshard import succeeded after installation" || { echo "ERROR: Reshard import failed after installation!"; exit 1; }
 
 echo "Running import structure test..."
@@ -65,6 +66,11 @@ echo "Verifying transfer_engine_bench entry point..."
 # Check if the transfer_engine_bench entry point is installed and executable
 which transfer_engine_bench || { echo "ERROR: transfer_engine_bench entry point not found!"; exit 1; }
 echo "Success: transfer_engine_bench entry point found"
+
+echo "Verifying mc_store_rest_server entry point..."
+which mc_store_rest_server || { echo "ERROR: mc_store_rest_server entry point not found!"; exit 1; }
+mc_store_rest_server --help >/dev/null
+echo "Success: mc_store_rest_server entry point found"
 
 cd ..
 


### PR DESCRIPTION
## Description

Implements one Phase 2 module migration from RFC #3534:

- moves the Store REST service implementation to the canonical `python/mooncake/mooncake_store_service.py` source root;
- moves its directly owned API tests to `python/tests/store` and removes both old tracked locations;
- preserves the public `mooncake.mooncake_store_service` import and `mc_store_rest_server` command;
- updates the transitional setuptools wheel staging script, direct CMake install input, legacy installation smoke checks, ownership/labeling, packaging contracts, and the archived deployment source reference;
- adds source-tree and isolated installed-wheel coverage for the canonical module and console entry point.

This is part of #3534 and does not perform any Phase 3 native-extension rename or Phase 4/5 release cutover.

### Overlap with open work

- #3586 owns `mooncake_config.py`; this PR deliberately leaves that module at the location on `main` and keeps the existing `from mooncake.mooncake_config import MooncakeConfig` contract. The PRs touch the same CMake install block, wheel staging script, packaging tests, CODEOWNERS, and labeler configuration, but migrate distinct files.
- #3585 and the other open Phase 2 module migrations (#3623, #3624, #3625, #3626, #3627, #3628, and #3629) also touch shared transition surfaces such as `scripts/build_wheel.sh`, packaging checks, ownership, and labels. None owns the Store REST service implementation or tests.
- #3585 (Reshard) and #3586 (Store utilities/config) remain out of scope and are not duplicated here.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
python -m pytest -q python/tests/store/test_mooncake_store_service_api.py python/tests/packaging/test_project.py
python -m pytest -q python/tests/packaging
CMAKE_BUILD_PARALLEL_LEVEL=128 python -m build --wheel --outdir /tmp/mooncake-store-service-dist
MOONCAKE_TEST_WHEEL=/tmp/mooncake-store-service-dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl python -m pytest -q python/tests/packaging/test_installed_wheel.py
python -m twine check /tmp/mooncake-store-service-dist/mooncake_transfer_engine-0.3.12.post1-cp310-cp310-linux_x86_64.whl
python -m compileall -q python/mooncake/mooncake_store_service.py python/tests/store/test_mooncake_store_service_api.py python/tests/packaging/test_project.py python/tests/packaging/test_installed_wheel.py
bash -n scripts/build_wheel.sh scripts/test_installation.sh
pre-commit run --files $(git diff --name-only --diff-filter=ACMR origin/main...HEAD)
```

**Test results:**
- [x] Unit tests pass (96 focused Store REST service and source-packaging tests)
- [x] Integration tests pass (1 isolated installed-wheel smoke test; module import and `mc_store_rest_server` entry-point load succeed outside the repository)
- [x] Manual testing done (wheel manifest contains `mooncake/mooncake_store_service.py`, omits legacy/test paths, and `twine check` passes)

Documentation validation gap: `make html` could not run because Sphinx is absent. The documented `uv` executable is blocked by snap confinement in this container, while the pip fallback expands into the multi-gigabyte Torch/CUDA documentation dependency set. The changed Markdown passes `git diff --check`, trailing-whitespace, EOF, codespell, and the other PR-scoped pre-commit hooks.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh` (no C/C++ source changes; Python and CMake formatting passed through pre-commit)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (the only service document naming the old tracked source path)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3534)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with repository analysis, the scoped migration, test maintenance, packaging/build validation, and PR preparation. The human submitter remains responsible for reviewing, understanding, and defending every changed line.