### PR TITLE
fix(store): avoid P2P oplog sequence reuse after promotion

### DIFF
--- a/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
+++ b/mooncake-store/include/ha/oplog/p2p_hot_standby_service.h
@@ -84,6 +84,7 @@ class P2PHotStandbyService {
     P2PStandbySyncStatus GetSyncStatus() const;
     bool IsReadyForPromotion() const;
     uint64_t GetLatestAppliedSequenceId() const;
+    ErrorCode GetLatestOpLogSequenceId(uint64_t& sequence_id) const;
 
     P2PStandbyMetadataStore::ExportedMetadata ExportMetadata() const;
     bool WaitForAppliedSequence(
@@ -115,7 +116,6 @@ class P2PHotStandbyService {
         uint64_t& baseline_sequence_id,
         const std::vector<std::string>& discovered_endpoints = {});
     ErrorCode ResyncFromSnapshotLocked();
-    ErrorCode GetLatestOpLogSequenceId(uint64_t& sequence_id) const;
     bool WaitForAppliedSequenceLocked(
         uint64_t sequence_id,
         std::chrono::milliseconds timeout = std::chrono::seconds(30),

--- a/mooncake-store/src/ha_helper.cpp
+++ b/mooncake-store/src/ha_helper.cpp
@@ -9,6 +9,7 @@
 #include "redis_master_view_helper.h"
 #endif
 
+#include <algorithm>
 #include <limits>
 #include <optional>
 #include <iomanip>
@@ -335,8 +336,34 @@ int MasterServiceSupervisor::Start() {
                 keep_leader_thread.join();
                 return -1;
             }
-            p2p_promoted_sequence_id =
+            const uint64_t p2p_promoted_applied_sequence_id =
                 p2p_standby->GetLatestAppliedSequenceId();
+            p2p_promoted_sequence_id = p2p_promoted_applied_sequence_id;
+            uint64_t p2p_latest_oplog_sequence_id = 0;
+            auto latest_sequence_err = p2p_standby->GetLatestOpLogSequenceId(
+                p2p_latest_oplog_sequence_id);
+            if (latest_sequence_err != ErrorCode::OK) {
+                LOG(ERROR) << "Failed to read latest P2P OpLog sequence after "
+                              "promotion"
+                           << ", error=" << toString(latest_sequence_err)
+                           << ", applied_sequence_id="
+                           << p2p_promoted_applied_sequence_id;
+                mv_helper->CancelKeepAlive(lease_id);
+                keep_leader_thread.join();
+                return -1;
+            }
+            p2p_promoted_sequence_id = std::max(
+                p2p_promoted_applied_sequence_id, p2p_latest_oplog_sequence_id);
+            if (p2p_promoted_sequence_id > p2p_promoted_applied_sequence_id) {
+                LOG(WARNING)
+                    << "P2P promoted standby is behind latest OpLog; "
+                       "continuing new Primary sequence from OpLog latest"
+                    << ", applied_sequence_id="
+                    << p2p_promoted_applied_sequence_id
+                    << ", latest_oplog_sequence_id="
+                    << p2p_latest_oplog_sequence_id
+                    << ", initial_sequence_id=" << p2p_promoted_sequence_id;
+            }
             p2p_promoted_metadata = p2p_standby->ExportMetadata();
 #ifdef STORE_USE_REDIS
             if (master_registry_heartbeat) {

--- a/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp
@@ -784,6 +784,50 @@ TEST_F(P2PHotStandbyServiceTest, RestoreExportedMetadataIntoP2PMasterService) {
               promoted_sequence_id + 2);
 }
 
+TEST_F(P2PHotStandbyServiceTest,
+       RestorePromotedMetadataCanContinueFromStoreLatestSequence) {
+    P2PMasterService master(MakeMasterConfig());
+    const UUID client_id{37, 37};
+    const UUID segment_id{38, 38};
+    const auto segment = MakeSegment(segment_id);
+
+    RegisterClient(master, client_id, segment);
+    AddReplica(master, "lagged-key-before-promotion", client_id, segment_id,
+               2048);
+
+    P2PHotStandbyService standby(MakeStandbyConfig());
+    ASSERT_EQ(standby.Start(), ErrorCode::OK);
+    ASSERT_TRUE(
+        standby.WaitForAppliedSequence(2, std::chrono::milliseconds(2000)));
+    ASSERT_EQ(standby.Promote(), ErrorCode::OK);
+
+    const uint64_t applied_sequence_id = standby.GetLatestAppliedSequenceId();
+    ASSERT_EQ(applied_sequence_id, 2u);
+
+    LocalFsOpLogStore writer(kClusterId, test_dir_.string(),
+                             /*enable_batch_write=*/false);
+    ASSERT_EQ(writer.Init(), ErrorCode::OK);
+    ASSERT_EQ(writer.UpdateLatestSequenceId(5), ErrorCode::OK);
+
+    uint64_t latest_sequence_id = 0;
+    ASSERT_EQ(standby.GetLatestOpLogSequenceId(latest_sequence_id),
+              ErrorCode::OK);
+    ASSERT_EQ(latest_sequence_id, 5u);
+
+    const uint64_t initial_sequence_id =
+        latest_sequence_id > applied_sequence_id ? latest_sequence_id
+                                                 : applied_sequence_id;
+    P2PMasterService restored_master(MakeMasterConfig());
+    ASSERT_EQ(restored_master.RestoreFromStandbyMetadata(
+                  standby.ExportMetadata(), initial_sequence_id),
+              ErrorCode::OK);
+
+    AddReplica(restored_master, "lagged-key-after-promotion", client_id,
+               segment_id, 1024);
+    ASSERT_NE(restored_master.GetOpLogManager(), nullptr);
+    EXPECT_EQ(restored_master.GetOpLogManager()->GetLastSequenceId(), 6u);
+}
+
 TEST_F(P2PHotStandbyServiceTest, RestorePromotedMetadataIntoWrappedRuntime) {
     P2PMasterService primary_master(MakeMasterConfig());
     const UUID client_id{17, 17};


### PR DESCRIPTION
## Description

  Fix P2P HA promotion sequence initialization to avoid reusing OpLog sequence IDs when the promoted standby has not applied up to the latest persisted OpLog sequence.

  After promotion, the new primary now initializes its next sequence from `max(latest_applied_sequence_id, latest_oplog_sequence_id)`, so subsequent writes continue from `latest + 1` instead
  of potentially overwriting existing OpLog entries.

  ## Module

  - [ ] Transfer Engine (`mooncake-transfer-engine`)
  - [ ] Mooncake Store (`mooncake-store`)
  - [ ] Reshard (`mooncake-reshard`)
  - [ ] Mooncake EP (`mooncake-ep`)
  - [ ] Mooncake PG (`mooncake-pg`)
  - [ ] Integration (`mooncake-integration`)
  - [x] P2P Store (`mooncake-p2p-store`)
  - [ ] Python Wheel (`mooncake-wheel`)
  - [ ] Common (`mooncake-common`)
  - [ ] Mooncake RL (`mooncake-rl`)
  - [ ] CI/CD
  - [ ] Docs
  - [ ] Other

  ## Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  ## How Has This Been Tested?

  Validated in local Docker container `mooncake-dev-p2p-promote-latest-sequence`.

  **Test commands:**
  ```bash
  clang-format-20 -style=file -i \
    mooncake-store/include/ha/oplog/p2p_hot_standby_service.h \
    mooncake-store/src/ha_helper.cpp \
    mooncake-store/tests/ha/oplog/p2p_hot_standby_service_test.cpp

  git diff --check

  cmake -S . -B build-codex-p2p -G Ninja \
    -DCMAKE_BUILD_TYPE=Debug \
    -DWITH_STORE=ON \
    -DWITH_TE=ON \
    -DWITH_P2P_STORE=OFF \
    -DBUILD_UNIT_TESTS=ON \
    -DBUILD_EXAMPLES=OFF \
    -DUSE_ETCD=OFF \
    -DSTORE_USE_ETCD=OFF \
    -DUSE_REDIS=OFF \
    -DSTORE_USE_REDIS=OFF \
    -DUSE_HTTP=OFF \
    -DUSE_CXL=OFF \
    -DUSE_CUDA=OFF \
    -DENABLE_ASAN=OFF

  cmake --build build-codex-p2p --target p2p_oplog_test -j2

  cd build-codex-p2p
  ./mooncake-store/tests/p2p_oplog_test \
    --gtest_filter=P2PHotStandbyServiceTest.RestorePromotedMetadataCanContinueFromStoreLatestSequence
```
  Test results:

  - [x] Unit tests pass
  - [ ] Integration tests pass (if applicable)
  - [ ] Manual testing done (describe below)

  ## Checklist

  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [ ] I have run pre-commit on the files changed in this PR and all hooks pass
  - [ ] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue

  ## AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)

  AI tools were used to inspect the code path, implement the fix, format the touched files, and run local build/test validation. The human submitter is responsible for reviewing and defending
  all changes.