### PR TITLE
[Store] Add fenced snapshot publication with maintenance lease

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -35,6 +35,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +43,7 @@ import (
 
 	rpctypes "go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
 )
 
 // prefixWatchInfo stores cancel function and callback context for a prefix watch
@@ -54,6 +56,44 @@ type prefixWatchInfo struct {
 	broken bool
 	// brokenNotified prevents duplicate WATCH_BROKEN callbacks from exit races.
 	brokenNotified bool
+}
+
+type maintenanceSession struct {
+	session *concurrency.Session
+	cancel  context.CancelFunc
+}
+
+func (s *maintenanceSession) close() error {
+	err := s.session.Close()
+	s.cancel()
+	return err
+}
+
+var startMaintenanceSession = func(ctx context.Context, cli *clientv3.Client,
+	ttl int) (*concurrency.Session, error) {
+	return concurrency.NewSession(cli, concurrency.WithTTL(ttl), concurrency.WithContext(ctx))
+}
+
+func newMaintenanceSession(cli *clientv3.Client, ttl int,
+	startupTimeout time.Duration) (*maintenanceSession, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	timer := time.AfterFunc(startupTimeout, cancel)
+	session, err := startMaintenanceSession(ctx, cli, ttl)
+	timedOut := !timer.Stop()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	if session == nil {
+		cancel()
+		return nil, errors.New("maintenance session creation returned nil")
+	}
+	if timedOut {
+		_ = session.Close()
+		cancel()
+		return nil, context.DeadlineExceeded
+	}
+	return &maintenanceSession{session: session, cancel: cancel}, nil
 }
 
 // Use different etcd client so they are not affected by each other,
@@ -69,6 +109,10 @@ var (
 	// keep alive contexts for store
 	storeKeepAliveCtx   = make(map[int64]context.CancelFunc)
 	storeKeepAliveMutex sync.Mutex
+	// maintenance sessions own their keepalive and lease lifecycle in Go.
+	storeMaintenanceSessions   = make(map[int64]*maintenanceSession)
+	storeMaintenanceNextHandle int64
+	storeMaintenanceMutex      sync.Mutex
 	// watch contexts for store
 	storeWatchCtx   = make(map[string]context.CancelFunc)
 	storeWatchMutex sync.Mutex
@@ -89,6 +133,7 @@ const (
 const (
 	storeDialKeepAliveTime    = 10 * time.Second
 	storeDialKeepAliveTimeout = 3 * time.Second
+	maintenanceStartupTimeout = 5 * time.Second
 )
 
 func newStoreClientConfig(validEndpoints []string) clientv3.Config {
@@ -280,6 +325,7 @@ func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
 	}
 
 	cancelAllStoreKeepAlives()
+	closeAllStoreMaintenanceSessions()
 	cancelAllStoreWatches()
 	cancelAllStorePrefixWatches()
 
@@ -442,6 +488,92 @@ func EtcdStoreCreateWithLeaseWrapper(key *C.char, keySize C.int, value *C.char, 
 	}
 }
 
+//export EtcdStoreAcquireMaintenanceSessionWrapper
+func EtcdStoreAcquireMaintenanceSessionWrapper(key *C.char, keySize C.int, ttl int64,
+	sessionHandle *int64, leaseId *int64, createRevision *int64, errMsg **C.char) int {
+	cli := getStoreClient()
+	if cli == nil {
+		*errMsg = C.CString("etcd client not initialized")
+		return -1
+	}
+	if ttl <= 0 {
+		*errMsg = C.CString("maintenance session TTL must be positive")
+		return -1
+	}
+
+	session, err := newMaintenanceSession(cli, int(ttl), maintenanceStartupTimeout)
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+
+	k := C.GoStringN(key, keySize)
+	id := int64(session.session.Lease())
+	ownerToken := strconv.FormatInt(id, 10)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	resp, err := cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.CreateRevision(k), "=", 0)).
+		Then(clientv3.OpPut(k, ownerToken, clientv3.WithLease(session.session.Lease()))).
+		Commit()
+	cancel()
+	if err != nil {
+		_ = session.close()
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+	if !resp.Succeeded {
+		_ = session.close()
+		*errMsg = C.CString("maintenance lock is already held")
+		return -2
+	}
+
+	storeMaintenanceMutex.Lock()
+	storeMaintenanceNextHandle++
+	handle := storeMaintenanceNextHandle
+	storeMaintenanceSessions[handle] = session
+	storeMaintenanceMutex.Unlock()
+
+	*sessionHandle = handle
+	*leaseId = id
+	*createRevision = resp.Header.Revision
+	return 0
+}
+
+//export EtcdStoreCloseMaintenanceSessionWrapper
+func EtcdStoreCloseMaintenanceSessionWrapper(sessionHandle int64, errMsg **C.char) int {
+	storeMaintenanceMutex.Lock()
+	session, exists := storeMaintenanceSessions[sessionHandle]
+	if exists {
+		delete(storeMaintenanceSessions, sessionHandle)
+	}
+	storeMaintenanceMutex.Unlock()
+	if !exists {
+		return 0
+	}
+	if err := session.close(); err != nil && !errors.Is(err, rpctypes.ErrLeaseNotFound) {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+	return 0
+}
+
+//export EtcdStoreMaintenanceSessionAliveWrapper
+func EtcdStoreMaintenanceSessionAliveWrapper(sessionHandle int64, errMsg **C.char) int {
+	storeMaintenanceMutex.Lock()
+	session, exists := storeMaintenanceSessions[sessionHandle]
+	storeMaintenanceMutex.Unlock()
+	if !exists {
+		*errMsg = C.CString("maintenance session handle not found")
+		return -1
+	}
+	select {
+	case <-session.session.Done():
+		return 0
+	default:
+		return 1
+	}
+}
+
 /*
 * @brief First cancel the watch context, then delete it from the map.
 *        Cancel must be called before delete in case this is a new context
@@ -472,6 +604,20 @@ func cancelAllStoreKeepAlives() {
 
 	for _, cancel := range cancels {
 		cancel()
+	}
+}
+
+func closeAllStoreMaintenanceSessions() {
+	storeMaintenanceMutex.Lock()
+	sessions := make([]*maintenanceSession, 0, len(storeMaintenanceSessions))
+	for handle, session := range storeMaintenanceSessions {
+		sessions = append(sessions, session)
+		delete(storeMaintenanceSessions, handle)
+	}
+	storeMaintenanceMutex.Unlock()
+
+	for _, session := range sessions {
+		_ = session.close()
 	}
 }
 
@@ -792,7 +938,7 @@ func EtcdStoreBatchCreateWrapper(keys **C.char, values **C.char, count C.int, er
 }
 
 //export EtcdStoreTxnCompareAndPutWrapper
-func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
+func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.int, compareKinds *C.int, compareValues **C.char, compareValueSizes *C.int, compareRevisions *int64, compareCount C.int, putKeys **C.char, putKeySizes *C.int, putValues **C.char, putValueSizes *C.int, putCount C.int, errMsg **C.char) int {
 	cli := getStoreClient()
 	if cli == nil {
 		*errMsg = C.CString("etcd client not initialized")
@@ -809,6 +955,7 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 		compareKindList := (*[1 << 28]C.int)(unsafe.Pointer(compareKinds))[:cmpN:cmpN]
 		compareValuePtrs := (*[1 << 28]*C.char)(unsafe.Pointer(compareValues))[:cmpN:cmpN]
 		compareValueSizeList := (*[1 << 28]C.int)(unsafe.Pointer(compareValueSizes))[:cmpN:cmpN]
+		compareRevisionList := (*[1 << 28]int64)(unsafe.Pointer(compareRevisions))[:cmpN:cmpN]
 		for i := 0; i < cmpN; i++ {
 			k := C.GoStringN(compareKeyPtrs[i], compareKeySizeList[i])
 			switch int(compareKindList[i]) {
@@ -817,6 +964,8 @@ func EtcdStoreTxnCompareAndPutWrapper(compareKeys **C.char, compareKeySizes *C.i
 				cmps = append(cmps, clientv3.Compare(clientv3.Value(k), "=", v))
 			case 1:
 				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", 0))
+			case 2:
+				cmps = append(cmps, clientv3.Compare(clientv3.CreateRevision(k), "=", compareRevisionList[i]))
 			default:
 				*errMsg = C.CString("unsupported compare kind")
 				return -1

--- a/mooncake-common/etcd/etcd_wrapper_test.go
+++ b/mooncake-common/etcd/etcd_wrapper_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+func TestNewMaintenanceSessionCancelsStartup(t *testing.T) {
+	original := startMaintenanceSession
+	defer func() { startMaintenanceSession = original }()
+
+	started := make(chan struct{})
+	startMaintenanceSession = func(ctx context.Context, _ *clientv3.Client,
+		_ int) (*concurrency.Session, error) {
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := newMaintenanceSession(nil, 30, 10*time.Millisecond)
+		result <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("maintenance session startup was not attempted")
+	}
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected startup cancellation error")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("maintenance session startup did not cancel")
+	}
+}

--- a/mooncake-store/include/etcd_helper.h
+++ b/mooncake-store/include/etcd_helper.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <glog/logging.h>
+#include <ylt/util/tl/expected.hpp>
+
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "types.h"
@@ -61,6 +64,15 @@ class EtcdHelper {
                                      EtcdLeaseId lease_id,
                                      EtcdRevisionId& revision_id);
 
+    static ErrorCode AcquireMaintenanceSession(std::string_view key,
+                                               int64_t lease_ttl,
+                                               int64_t& session_handle,
+                                               EtcdLeaseId& lease_id,
+                                               EtcdRevisionId& create_revision);
+    static ErrorCode CloseMaintenanceSession(int64_t session_handle);
+    static tl::expected<bool, ErrorCode> MaintenanceSessionAlive(
+        int64_t session_handle);
+
     /*
      * @brief Batch create key-value pairs in a single transaction.
      *        Fails if any key already exists.
@@ -74,12 +86,16 @@ class EtcdHelper {
     enum class TxnCompareKind {
         kValueEquals = 0,
         kKeyNotExists = 1,
+        // Compare the key's creation revision to expected_revision.
+        kCreateRevisionEquals = 2,
     };
 
     struct TxnCompare {
         std::string key;
         TxnCompareKind kind{TxnCompareKind::kValueEquals};
         std::string expected_value;
+        // Used only by kCreateRevisionEquals.
+        EtcdRevisionId expected_revision{0};
     };
 
     struct TxnPut {

--- a/mooncake-store/include/ha/kv/ha_kv_backend.h
+++ b/mooncake-store/include/ha/kv/ha_kv_backend.h
@@ -16,12 +16,15 @@ struct KvPair {
 enum class KvCompareKind {
     kValueEquals,
     kKeyNotExists,
+    kCreateRevisionEquals,
 };
 
 struct KvCompare {
     std::string key;
     KvCompareKind kind{KvCompareKind::kValueEquals};
     std::string expected_value;
+    // Used only by kCreateRevisionEquals.
+    EtcdRevisionId expected_revision{0};
 };
 
 struct KvTxn {

--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "types.h"
+
+namespace mooncake {
+
+class HaKvBackend;
+class SnapshotMaintenanceLease;
+
+class BatchOpLogSnapshotPublisher {
+   public:
+    BatchOpLogSnapshotPublisher(HaKvBackend& backend, std::string cluster_id);
+
+    ErrorCode Publish(const SnapshotMaintenanceLease& lease,
+                      std::string_view descriptor_json);
+
+   private:
+    ErrorCode PublishImpl(std::string_view owner_token,
+                          std::string_view descriptor_json,
+                          const SnapshotMaintenanceLease& lease);
+
+    HaKvBackend& backend_;
+    std::string cluster_id_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/batch_oplog_snapshot_publisher.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog_snapshot_publisher.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Compatibility include for the design-file path. Implementation stays in
+// the batch_oplog-specific directory.
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h"

--- a/mooncake-store/include/ha/snapshot/snapshot_maintenance_lease.h
+++ b/mooncake-store/include/ha/snapshot/snapshot_maintenance_lease.h
@@ -3,7 +3,6 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 
 #include "types.h"
 
@@ -12,7 +11,6 @@ namespace mooncake {
 class SnapshotMaintenanceLease {
    public:
     static constexpr int64_t kTtlSeconds = 30;
-    static constexpr int kKeepAliveReadyTimeoutMs = 1000;
 
     explicit SnapshotMaintenanceLease(std::string cluster_id);
     ~SnapshotMaintenanceLease();
@@ -26,30 +24,28 @@ class SnapshotMaintenanceLease {
 
     bool IsHeld() const;
     EtcdLeaseId lease_id() const;
+    EtcdRevisionId lock_create_revision() const;
     std::string owner_token() const;
     const std::string& lock_key() const { return lock_key_; }
 
     // Keeps publisher transaction tests independent of a live etcd process.
     static std::unique_ptr<SnapshotMaintenanceLease> MakeForTesting(
-        std::string cluster_id, std::string owner_token);
+        std::string cluster_id, std::string owner_token,
+        EtcdRevisionId lock_create_revision = 1);
 
    private:
     SnapshotMaintenanceLease(std::string cluster_id, std::string owner_token,
-                             bool testing);
-
-    ErrorCode StopKeepAlive(bool revoke);
+                             bool testing, EtcdRevisionId create_revision);
 
     std::string cluster_id_;
     std::string lock_key_;
     std::string owner_token_;
+    int64_t session_handle_{0};
     EtcdLeaseId lease_id_{0};
+    EtcdRevisionId lock_create_revision_{0};
     mutable std::mutex mutex_;
-    std::thread keepalive_thread_;
-    ErrorCode keepalive_result_{ErrorCode::OK};
     bool testing_{false};
     bool lock_created_{false};
-    bool keepalive_stopped_{true};
-    bool shutdown_requested_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/snapshot_maintenance_lease.h
+++ b/mooncake-store/include/ha/snapshot/snapshot_maintenance_lease.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include "types.h"
+
+namespace mooncake {
+
+class SnapshotMaintenanceLease {
+   public:
+    static constexpr int64_t kTtlSeconds = 30;
+    static constexpr int kKeepAliveReadyTimeoutMs = 1000;
+
+    explicit SnapshotMaintenanceLease(std::string cluster_id);
+    ~SnapshotMaintenanceLease();
+
+    SnapshotMaintenanceLease(const SnapshotMaintenanceLease&) = delete;
+    SnapshotMaintenanceLease& operator=(const SnapshotMaintenanceLease&) =
+        delete;
+
+    ErrorCode Acquire();
+    ErrorCode Release();
+
+    bool IsHeld() const;
+    EtcdLeaseId lease_id() const;
+    std::string owner_token() const;
+    const std::string& lock_key() const { return lock_key_; }
+
+    // Keeps publisher transaction tests independent of a live etcd process.
+    static std::unique_ptr<SnapshotMaintenanceLease> MakeForTesting(
+        std::string cluster_id, std::string owner_token);
+
+   private:
+    SnapshotMaintenanceLease(std::string cluster_id, std::string owner_token,
+                             bool testing);
+
+    ErrorCode StopKeepAlive(bool revoke);
+
+    std::string cluster_id_;
+    std::string lock_key_;
+    std::string owner_token_;
+    EtcdLeaseId lease_id_{0};
+    mutable std::mutex mutex_;
+    std::thread keepalive_thread_;
+    ErrorCode keepalive_result_{ErrorCode::OK};
+    bool testing_{false};
+    bool lock_created_{false};
+    bool keepalive_stopped_{true};
+    bool shutdown_requested_{false};
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -42,6 +42,8 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     ha/snapshot/batch_oplog/metadata.cpp
     ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
     ha/snapshot/batch_oplog/writer.cpp
+    ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
+    ha/snapshot/snapshot_maintenance_lease.cpp
     ha/snapshot/master_snapshot_codec.cpp
     ha/snapshot/local_ssd_codec.cpp
     ha/snapshot/object/snapshot_object_store.cpp

--- a/mooncake-store/src/etcd_helper.cpp
+++ b/mooncake-store/src/etcd_helper.cpp
@@ -116,6 +116,68 @@ ErrorCode EtcdHelper::CreateWithLease(const char* key, const size_t key_size,
     }
 }
 
+ErrorCode EtcdHelper::AcquireMaintenanceSession(
+    std::string_view key, int64_t lease_ttl, int64_t& session_handle,
+    EtcdLeaseId& lease_id, EtcdRevisionId& create_revision) {
+    char* err_msg = nullptr;
+    GoInt64 go_session_handle = 0;
+    GoInt64 go_lease_id = 0;
+    GoInt64 go_create_revision = 0;
+    int ret = EtcdStoreAcquireMaintenanceSessionWrapper(
+        const_cast<char*>(key.data()), static_cast<int>(key.size()),
+        static_cast<GoInt64>(lease_ttl), &go_session_handle, &go_lease_id,
+        &go_create_revision, &err_msg);
+    if (ret == -2) {
+        if (err_msg != nullptr) {
+            free(err_msg);
+        }
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
+    }
+    if (ret != 0) {
+        LOG(ERROR) << "Failed to acquire maintenance session: "
+                   << (err_msg == nullptr ? "" : err_msg);
+        if (err_msg != nullptr) {
+            free(err_msg);
+        }
+        return ErrorCode::ETCD_OPERATION_ERROR;
+    }
+    session_handle = static_cast<int64_t>(go_session_handle);
+    lease_id = static_cast<EtcdLeaseId>(go_lease_id);
+    create_revision = static_cast<EtcdRevisionId>(go_create_revision);
+    return ErrorCode::OK;
+}
+
+ErrorCode EtcdHelper::CloseMaintenanceSession(int64_t session_handle) {
+    char* err_msg = nullptr;
+    int ret = EtcdStoreCloseMaintenanceSessionWrapper(
+        static_cast<GoInt64>(session_handle), &err_msg);
+    if (ret != 0) {
+        LOG(ERROR) << "Failed to close maintenance session: "
+                   << (err_msg == nullptr ? "" : err_msg);
+        if (err_msg != nullptr) {
+            free(err_msg);
+        }
+        return ErrorCode::ETCD_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+tl::expected<bool, ErrorCode> EtcdHelper::MaintenanceSessionAlive(
+    int64_t session_handle) {
+    char* err_msg = nullptr;
+    int ret = EtcdStoreMaintenanceSessionAliveWrapper(
+        static_cast<GoInt64>(session_handle), &err_msg);
+    if (ret < 0) {
+        LOG(ERROR) << "Failed to check maintenance session: "
+                   << (err_msg == nullptr ? "" : err_msg);
+        if (err_msg != nullptr) {
+            free(err_msg);
+        }
+        return tl::make_unexpected(ErrorCode::ETCD_OPERATION_ERROR);
+    }
+    return ret == 1;
+}
+
 ErrorCode EtcdHelper::BatchCreate(const std::vector<std::string>& keys,
                                   const std::vector<std::string>& values) {
     if (keys.size() != values.size()) {
@@ -163,11 +225,13 @@ ErrorCode EtcdHelper::TxnCompareAndPut(const std::vector<TxnCompare>& compares,
     std::vector<int> compare_kinds;
     std::vector<char*> compare_values;
     std::vector<int> compare_value_sizes;
+    std::vector<GoInt64> compare_revisions;
     compare_keys.reserve(compares.size());
     compare_key_sizes.reserve(compares.size());
     compare_kinds.reserve(compares.size());
     compare_values.reserve(compares.size());
     compare_value_sizes.reserve(compares.size());
+    compare_revisions.reserve(compares.size());
     for (const auto& compare : compares) {
         compare_keys.push_back(const_cast<char*>(compare.key.data()));
         compare_key_sizes.push_back(static_cast<int>(compare.key.size()));
@@ -176,6 +240,8 @@ ErrorCode EtcdHelper::TxnCompareAndPut(const std::vector<TxnCompare>& compares,
             const_cast<char*>(compare.expected_value.data()));
         compare_value_sizes.push_back(
             static_cast<int>(compare.expected_value.size()));
+        compare_revisions.push_back(
+            static_cast<GoInt64>(compare.expected_revision));
     }
 
     std::vector<char*> put_keys;
@@ -197,9 +263,9 @@ ErrorCode EtcdHelper::TxnCompareAndPut(const std::vector<TxnCompare>& compares,
     int ret = EtcdStoreTxnCompareAndPutWrapper(
         compare_keys.data(), compare_key_sizes.data(), compare_kinds.data(),
         compare_values.data(), compare_value_sizes.data(),
-        static_cast<int>(compares.size()), put_keys.data(),
-        put_key_sizes.data(), put_values.data(), put_value_sizes.data(),
-        static_cast<int>(puts.size()), &err_msg);
+        compare_revisions.data(), static_cast<int>(compares.size()),
+        put_keys.data(), put_key_sizes.data(), put_values.data(),
+        put_value_sizes.data(), static_cast<int>(puts.size()), &err_msg);
     if (ret == -2) {
         if (err_msg != nullptr) {
             free(err_msg);
@@ -495,6 +561,31 @@ ErrorCode EtcdHelper::ConnectToEtcdStoreClient(
     (void)etcd_endpoints;
     LOG(FATAL) << "Etcd is not enabled in compilation";
     return ErrorCode::ETCD_OPERATION_ERROR;
+}
+
+ErrorCode EtcdHelper::AcquireMaintenanceSession(
+    std::string_view key, int64_t lease_ttl, int64_t& session_handle,
+    EtcdLeaseId& lease_id, EtcdRevisionId& create_revision) {
+    (void)key;
+    (void)lease_ttl;
+    (void)session_handle;
+    (void)lease_id;
+    (void)create_revision;
+    LOG(FATAL) << "Etcd is not enabled in compilation";
+    return ErrorCode::ETCD_OPERATION_ERROR;
+}
+
+ErrorCode EtcdHelper::CloseMaintenanceSession(int64_t session_handle) {
+    (void)session_handle;
+    LOG(FATAL) << "Etcd is not enabled in compilation";
+    return ErrorCode::ETCD_OPERATION_ERROR;
+}
+
+tl::expected<bool, ErrorCode> EtcdHelper::MaintenanceSessionAlive(
+    int64_t session_handle) {
+    (void)session_handle;
+    LOG(FATAL) << "Etcd is not enabled in compilation";
+    return tl::make_unexpected(ErrorCode::ETCD_OPERATION_ERROR);
 }
 
 ErrorCode EtcdHelper::ResetEtcdStoreClient(const std::string& etcd_endpoints) {

--- a/mooncake-store/src/ha/kv/etcd_ha_kv_backend.cpp
+++ b/mooncake-store/src/ha/kv/etcd_ha_kv_backend.cpp
@@ -22,6 +22,8 @@ EtcdHelper::TxnCompareKind ToEtcdCompareKind(KvCompareKind kind) {
             return EtcdHelper::TxnCompareKind::kValueEquals;
         case KvCompareKind::kKeyNotExists:
             return EtcdHelper::TxnCompareKind::kKeyNotExists;
+        case KvCompareKind::kCreateRevisionEquals:
+            return EtcdHelper::TxnCompareKind::kCreateRevisionEquals;
     }
     return EtcdHelper::TxnCompareKind::kValueEquals;
 }
@@ -80,7 +82,8 @@ ErrorCode EtcdHaKvBackend::Txn(const KvTxn& txn) {
     for (const auto& compare : txn.compares) {
         compares.push_back({.key = compare.key,
                             .kind = ToEtcdCompareKind(compare.kind),
-                            .expected_value = compare.expected_value});
+                            .expected_value = compare.expected_value,
+                            .expected_revision = compare.expected_revision});
     }
 
     std::vector<EtcdHelper::TxnPut> puts;

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
@@ -26,8 +26,8 @@ ErrorCode ReadPointer(HaKvBackend& backend, const std::string& key,
 
 }  // namespace
 
-BatchOpLogSnapshotPublisher::BatchOpLogSnapshotPublisher(
-    HaKvBackend& backend, std::string cluster_id)
+BatchOpLogSnapshotPublisher::BatchOpLogSnapshotPublisher(HaKvBackend& backend,
+                                                         std::string cluster_id)
     : backend_(backend), cluster_id_(std::move(cluster_id)) {}
 
 ErrorCode BatchOpLogSnapshotPublisher::Publish(
@@ -41,8 +41,8 @@ ErrorCode BatchOpLogSnapshotPublisher::Publish(
 ErrorCode BatchOpLogSnapshotPublisher::PublishImpl(
     std::string_view owner_token, std::string_view descriptor_json,
     const SnapshotMaintenanceLease& lease) {
-    if (owner_token.empty() || !lease.IsHeld() ||
-        !backend_.SupportsTxn() || cluster_id_.empty()) {
+    if (owner_token.empty() || !lease.IsHeld() || !backend_.SupportsTxn() ||
+        cluster_id_.empty()) {
         return ErrorCode::INVALID_PARAMS;
     }
 
@@ -78,23 +78,33 @@ ErrorCode BatchOpLogSnapshotPublisher::PublishImpl(
     if (err != ErrorCode::OK) {
         return err;
     }
-    if (!latest_exists && fallback_exists) {
-        return ErrorCode::INTERNAL_ERROR;
-    }
-    if (fallback_exists &&
-        !ha::DecodeBatchOpLogSnapshotDescriptor(fallback)) {
-        return ErrorCode::INTERNAL_ERROR;
-    }
-    if (latest_exists) {
-        auto decoded_latest =
-            ha::DecodeBatchOpLogSnapshotDescriptor(latest);
-        if (!decoded_latest) {
+    bool fallback_valid = false;
+    uint64_t fallback_batch_id = 0;
+    if (fallback_exists) {
+        auto decoded_fallback =
+            ha::DecodeBatchOpLogSnapshotDescriptor(fallback);
+        if (!decoded_fallback) {
             return ErrorCode::INTERNAL_ERROR;
         }
-        if (candidate->last_included_batch_id <=
-            decoded_latest->last_included_batch_id) {
-            return ErrorCode::ETCD_TRANSACTION_FAIL;
+        fallback_valid = true;
+        fallback_batch_id = decoded_fallback->last_included_batch_id;
+    }
+
+    bool latest_valid = false;
+    uint64_t latest_batch_id = 0;
+    if (latest_exists) {
+        auto decoded_latest = ha::DecodeBatchOpLogSnapshotDescriptor(latest);
+        if (decoded_latest) {
+            latest_valid = true;
+            latest_batch_id = decoded_latest->last_included_batch_id;
         }
+    }
+    if (latest_valid && candidate->last_included_batch_id <= latest_batch_id) {
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
+    }
+    if (!latest_valid && fallback_valid &&
+        candidate->last_included_batch_id <= fallback_batch_id) {
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
     }
 
     // Re-check immediately before the fenced transaction. A keepalive can
@@ -107,21 +117,21 @@ ErrorCode BatchOpLogSnapshotPublisher::PublishImpl(
     txn.compares.push_back({.key = maintenance_key,
                             .kind = KvCompareKind::kValueEquals,
                             .expected_value = std::string(owner_token)});
-    txn.compares.push_back(
-        {.key = latest_key,
-         .kind = latest_exists ? KvCompareKind::kValueEquals
-                               : KvCompareKind::kKeyNotExists,
-         .expected_value = latest});
-    txn.compares.push_back(
-        {.key = fallback_key,
-         .kind = fallback_exists ? KvCompareKind::kValueEquals
-                                 : KvCompareKind::kKeyNotExists,
-         .expected_value = fallback});
-    if (latest_exists) {
+    txn.compares.push_back({.key = latest_key,
+                            .kind = latest_exists
+                                        ? KvCompareKind::kValueEquals
+                                        : KvCompareKind::kKeyNotExists,
+                            .expected_value = latest});
+    txn.compares.push_back({.key = fallback_key,
+                            .kind = fallback_exists
+                                        ? KvCompareKind::kValueEquals
+                                        : KvCompareKind::kKeyNotExists,
+                            .expected_value = fallback});
+    if (latest_valid) {
         txn.puts.push_back({.key = fallback_key, .value = latest});
     }
-    txn.puts.push_back({.key = latest_key,
-                        .value = std::string(descriptor_json)});
+    txn.puts.push_back(
+        {.key = latest_key, .value = std::string(descriptor_json)});
     return backend_.Txn(txn);
 }
 

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
@@ -1,0 +1,128 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h"
+
+#include <utility>
+
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/snapshot_maintenance_lease.h"
+
+namespace mooncake {
+namespace {
+
+ErrorCode ReadPointer(HaKvBackend& backend, const std::string& key,
+                      std::string& value, bool& exists) {
+    const ErrorCode err = backend.Get(key, value);
+    if (err == ErrorCode::ETCD_KEY_NOT_EXIST) {
+        value.clear();
+        exists = false;
+        return ErrorCode::OK;
+    }
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    exists = true;
+    return ErrorCode::OK;
+}
+
+}  // namespace
+
+BatchOpLogSnapshotPublisher::BatchOpLogSnapshotPublisher(
+    HaKvBackend& backend, std::string cluster_id)
+    : backend_(backend), cluster_id_(std::move(cluster_id)) {}
+
+ErrorCode BatchOpLogSnapshotPublisher::Publish(
+    const SnapshotMaintenanceLease& lease, std::string_view descriptor_json) {
+    if (!lease.IsHeld()) {
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
+    }
+    return PublishImpl(lease.owner_token(), descriptor_json, lease);
+}
+
+ErrorCode BatchOpLogSnapshotPublisher::PublishImpl(
+    std::string_view owner_token, std::string_view descriptor_json,
+    const SnapshotMaintenanceLease& lease) {
+    if (owner_token.empty() || !lease.IsHeld() ||
+        !backend_.SupportsTxn() || cluster_id_.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    auto candidate = ha::DecodeBatchOpLogSnapshotDescriptor(descriptor_json);
+    if (!candidate) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (candidate->snapshot_id !=
+        std::to_string(candidate->last_included_batch_id) + "-" +
+            std::string(owner_token)) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    const std::string latest_key =
+        ha::BuildBatchOpLogSnapshotLatestKey(cluster_id_);
+    const std::string fallback_key =
+        ha::BuildBatchOpLogSnapshotFallbackKey(cluster_id_);
+    const std::string maintenance_key =
+        ha::BuildBatchOpLogSnapshotMaintenanceKey(cluster_id_);
+    if (latest_key.empty() || fallback_key.empty() || maintenance_key.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    std::string latest;
+    std::string fallback;
+    bool latest_exists = false;
+    bool fallback_exists = false;
+    ErrorCode err = ReadPointer(backend_, latest_key, latest, latest_exists);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    err = ReadPointer(backend_, fallback_key, fallback, fallback_exists);
+    if (err != ErrorCode::OK) {
+        return err;
+    }
+    if (!latest_exists && fallback_exists) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (fallback_exists &&
+        !ha::DecodeBatchOpLogSnapshotDescriptor(fallback)) {
+        return ErrorCode::INTERNAL_ERROR;
+    }
+    if (latest_exists) {
+        auto decoded_latest =
+            ha::DecodeBatchOpLogSnapshotDescriptor(latest);
+        if (!decoded_latest) {
+            return ErrorCode::INTERNAL_ERROR;
+        }
+        if (candidate->last_included_batch_id <=
+            decoded_latest->last_included_batch_id) {
+            return ErrorCode::ETCD_TRANSACTION_FAIL;
+        }
+    }
+
+    // Re-check immediately before the fenced transaction. A keepalive can
+    // stop while object metadata is being read; the compare remains the final
+    // etcd-side fence.
+    if (!lease.IsHeld()) {
+        return ErrorCode::ETCD_TRANSACTION_FAIL;
+    }
+    KvTxn txn;
+    txn.compares.push_back({.key = maintenance_key,
+                            .kind = KvCompareKind::kValueEquals,
+                            .expected_value = std::string(owner_token)});
+    txn.compares.push_back(
+        {.key = latest_key,
+         .kind = latest_exists ? KvCompareKind::kValueEquals
+                               : KvCompareKind::kKeyNotExists,
+         .expected_value = latest});
+    txn.compares.push_back(
+        {.key = fallback_key,
+         .kind = fallback_exists ? KvCompareKind::kValueEquals
+                                 : KvCompareKind::kKeyNotExists,
+         .expected_value = fallback});
+    if (latest_exists) {
+        txn.puts.push_back({.key = fallback_key, .value = latest});
+    }
+    txn.puts.push_back({.key = latest_key,
+                        .value = std::string(descriptor_json)});
+    return backend_.Txn(txn);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
@@ -117,6 +117,10 @@ ErrorCode BatchOpLogSnapshotPublisher::PublishImpl(
     txn.compares.push_back({.key = maintenance_key,
                             .kind = KvCompareKind::kValueEquals,
                             .expected_value = std::string(owner_token)});
+    txn.compares.push_back({.key = maintenance_key,
+                            .kind = KvCompareKind::kCreateRevisionEquals,
+                            .expected_value = "",
+                            .expected_revision = lease.lock_create_revision()});
     txn.compares.push_back({.key = latest_key,
                             .kind = latest_exists
                                         ? KvCompareKind::kValueEquals

--- a/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
+++ b/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
@@ -21,15 +21,14 @@ SnapshotMaintenanceLease::SnapshotMaintenanceLease(std::string cluster_id,
       lock_created_(testing),
       keepalive_stopped_(!testing) {}
 
-SnapshotMaintenanceLease::~SnapshotMaintenanceLease() {
-    (void)Release();
-}
+SnapshotMaintenanceLease::~SnapshotMaintenanceLease() { (void)Release(); }
 
 std::unique_ptr<SnapshotMaintenanceLease>
-SnapshotMaintenanceLease::MakeForTesting(
-    std::string cluster_id, std::string owner_token) {
-    return std::unique_ptr<SnapshotMaintenanceLease>(new SnapshotMaintenanceLease(
-        std::move(cluster_id), std::move(owner_token), true));
+SnapshotMaintenanceLease::MakeForTesting(std::string cluster_id,
+                                         std::string owner_token) {
+    return std::unique_ptr<SnapshotMaintenanceLease>(
+        new SnapshotMaintenanceLease(std::move(cluster_id),
+                                     std::move(owner_token), true));
 }
 
 ErrorCode SnapshotMaintenanceLease::Acquire() {
@@ -75,9 +74,9 @@ ErrorCode SnapshotMaintenanceLease::Acquire() {
         return err;
     }
     EtcdRevisionId revision = 0;
-    err = EtcdHelper::CreateWithLease(
-        lock_key_.c_str(), lock_key_.size(), owner_token_.c_str(),
-        owner_token_.size(), lease_id_, revision);
+    err = EtcdHelper::CreateWithLease(lock_key_.c_str(), lock_key_.size(),
+                                      owner_token_.c_str(), owner_token_.size(),
+                                      lease_id_, revision);
     if (err != ErrorCode::OK) {
         (void)StopKeepAlive(true);
         return err;

--- a/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
+++ b/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
@@ -11,24 +11,26 @@ SnapshotMaintenanceLease::SnapshotMaintenanceLease(std::string cluster_id)
     : cluster_id_(std::move(cluster_id)),
       lock_key_(ha::BuildBatchOpLogSnapshotMaintenanceKey(cluster_id_)) {}
 
-SnapshotMaintenanceLease::SnapshotMaintenanceLease(std::string cluster_id,
-                                                   std::string owner_token,
-                                                   bool testing)
+SnapshotMaintenanceLease::SnapshotMaintenanceLease(
+    std::string cluster_id, std::string owner_token, bool testing,
+    EtcdRevisionId create_revision)
     : cluster_id_(std::move(cluster_id)),
       lock_key_(ha::BuildBatchOpLogSnapshotMaintenanceKey(cluster_id_)),
       owner_token_(std::move(owner_token)),
+      lock_create_revision_(create_revision),
       testing_(testing),
-      lock_created_(testing),
-      keepalive_stopped_(!testing) {}
+      lock_created_(testing) {}
 
 SnapshotMaintenanceLease::~SnapshotMaintenanceLease() { (void)Release(); }
 
 std::unique_ptr<SnapshotMaintenanceLease>
 SnapshotMaintenanceLease::MakeForTesting(std::string cluster_id,
-                                         std::string owner_token) {
+                                         std::string owner_token,
+                                         EtcdRevisionId create_revision) {
     return std::unique_ptr<SnapshotMaintenanceLease>(
         new SnapshotMaintenanceLease(std::move(cluster_id),
-                                     std::move(owner_token), true));
+                                     std::move(owner_token), true,
+                                     create_revision));
 }
 
 ErrorCode SnapshotMaintenanceLease::Acquire() {
@@ -40,53 +42,29 @@ ErrorCode SnapshotMaintenanceLease::Acquire() {
     }
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (lock_created_ || keepalive_thread_.joinable()) {
+        if (lock_created_ || session_handle_ != 0) {
             return ErrorCode::INVALID_PARAMS;
         }
-        shutdown_requested_ = false;
-        keepalive_result_ = ErrorCode::OK;
-        keepalive_stopped_ = false;
     }
 
+    int64_t session_handle = 0;
     EtcdLeaseId lease_id = 0;
-    ErrorCode err = EtcdHelper::GrantLease(kTtlSeconds, lease_id);
+    EtcdRevisionId create_revision = 0;
+    ErrorCode err = EtcdHelper::AcquireMaintenanceSession(
+        lock_key_, kTtlSeconds, session_handle, lease_id, create_revision);
     if (err != ErrorCode::OK) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        keepalive_stopped_ = true;
-        keepalive_result_ = err;
         return err;
     }
     {
         std::lock_guard<std::mutex> lock(mutex_);
+        session_handle_ = session_handle;
         lease_id_ = lease_id;
+        lock_create_revision_ = create_revision;
         owner_token_ = std::to_string(lease_id);
-    }
-    keepalive_thread_ = std::thread([this, lease_id] {
-        const ErrorCode result = EtcdHelper::KeepAlive(lease_id);
-        std::lock_guard<std::mutex> lock(mutex_);
-        keepalive_result_ = result;
-        keepalive_stopped_ = true;
-    });
-
-    err = EtcdHelper::WaitKeepAliveReady(lease_id_, kKeepAliveReadyTimeoutMs);
-    if (err != ErrorCode::OK) {
-        (void)StopKeepAlive(true);
-        return err;
-    }
-    EtcdRevisionId revision = 0;
-    err = EtcdHelper::CreateWithLease(lock_key_.c_str(), lock_key_.size(),
-                                      owner_token_.c_str(), owner_token_.size(),
-                                      lease_id_, revision);
-    if (err != ErrorCode::OK) {
-        (void)StopKeepAlive(true);
-        return err;
-    }
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
         lock_created_ = true;
     }
     if (!IsHeld()) {
-        (void)StopKeepAlive(true);
+        (void)Release();
         return ErrorCode::ETCD_OPERATION_ERROR;
     }
     return ErrorCode::OK;
@@ -97,9 +75,16 @@ bool SnapshotMaintenanceLease::IsHeld() const {
         std::lock_guard<std::mutex> lock(mutex_);
         return lock_created_ && !owner_token_.empty();
     }
-    std::lock_guard<std::mutex> lock(mutex_);
-    return lock_created_ && !keepalive_stopped_ &&
-           keepalive_result_ == ErrorCode::OK && !shutdown_requested_;
+    int64_t session_handle = 0;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!lock_created_) {
+            return false;
+        }
+        session_handle = session_handle_;
+    }
+    auto alive = EtcdHelper::MaintenanceSessionAlive(session_handle);
+    return alive && *alive;
 }
 
 EtcdLeaseId SnapshotMaintenanceLease::lease_id() const {
@@ -112,52 +97,31 @@ std::string SnapshotMaintenanceLease::owner_token() const {
     return owner_token_;
 }
 
+EtcdRevisionId SnapshotMaintenanceLease::lock_create_revision() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return lock_create_revision_;
+}
+
 ErrorCode SnapshotMaintenanceLease::Release() {
     if (testing_) {
         std::lock_guard<std::mutex> lock(mutex_);
         lock_created_ = false;
         return ErrorCode::OK;
     }
-    return StopKeepAlive(true);
-}
-
-ErrorCode SnapshotMaintenanceLease::StopKeepAlive(bool revoke) {
-    std::thread thread_to_join;
-    EtcdLeaseId lease_id = 0;
-    bool should_cancel = false;
+    int64_t session_handle = 0;
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        shutdown_requested_ = true;
-        lease_id = lease_id_;
-        should_cancel = keepalive_thread_.joinable() && !keepalive_stopped_;
-        if (keepalive_thread_.joinable()) {
-            thread_to_join = std::move(keepalive_thread_);
-        }
+        session_handle = session_handle_;
+        session_handle_ = 0;
+        lease_id_ = 0;
+        lock_create_revision_ = 0;
+        owner_token_.clear();
         lock_created_ = false;
     }
-    ErrorCode result = ErrorCode::OK;
-    if (should_cancel && lease_id != 0) {
-        result = EtcdHelper::CancelKeepAlive(lease_id);
-        if (result == ErrorCode::ETCD_OPERATION_ERROR) {
-            result = ErrorCode::OK;
-        }
+    if (session_handle == 0) {
+        return ErrorCode::OK;
     }
-    if (thread_to_join.joinable()) {
-        thread_to_join.join();
-    }
-    if (revoke && lease_id != 0) {
-        const ErrorCode revoke_result = EtcdHelper::RevokeLease(lease_id);
-        if (result == ErrorCode::OK) {
-            result = revoke_result;
-        }
-    }
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        lease_id_ = 0;
-        owner_token_.clear();
-        keepalive_stopped_ = true;
-    }
-    return result;
+    return EtcdHelper::CloseMaintenanceSession(session_handle);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
+++ b/mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp
@@ -1,0 +1,164 @@
+#include "ha/snapshot/snapshot_maintenance_lease.h"
+
+#include <utility>
+
+#include "etcd_helper.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+
+namespace mooncake {
+
+SnapshotMaintenanceLease::SnapshotMaintenanceLease(std::string cluster_id)
+    : cluster_id_(std::move(cluster_id)),
+      lock_key_(ha::BuildBatchOpLogSnapshotMaintenanceKey(cluster_id_)) {}
+
+SnapshotMaintenanceLease::SnapshotMaintenanceLease(std::string cluster_id,
+                                                   std::string owner_token,
+                                                   bool testing)
+    : cluster_id_(std::move(cluster_id)),
+      lock_key_(ha::BuildBatchOpLogSnapshotMaintenanceKey(cluster_id_)),
+      owner_token_(std::move(owner_token)),
+      testing_(testing),
+      lock_created_(testing),
+      keepalive_stopped_(!testing) {}
+
+SnapshotMaintenanceLease::~SnapshotMaintenanceLease() {
+    (void)Release();
+}
+
+std::unique_ptr<SnapshotMaintenanceLease>
+SnapshotMaintenanceLease::MakeForTesting(
+    std::string cluster_id, std::string owner_token) {
+    return std::unique_ptr<SnapshotMaintenanceLease>(new SnapshotMaintenanceLease(
+        std::move(cluster_id), std::move(owner_token), true));
+}
+
+ErrorCode SnapshotMaintenanceLease::Acquire() {
+    if (testing_) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    if (lock_key_.empty()) {
+        return ErrorCode::INVALID_PARAMS;
+    }
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (lock_created_ || keepalive_thread_.joinable()) {
+            return ErrorCode::INVALID_PARAMS;
+        }
+        shutdown_requested_ = false;
+        keepalive_result_ = ErrorCode::OK;
+        keepalive_stopped_ = false;
+    }
+
+    EtcdLeaseId lease_id = 0;
+    ErrorCode err = EtcdHelper::GrantLease(kTtlSeconds, lease_id);
+    if (err != ErrorCode::OK) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        keepalive_stopped_ = true;
+        keepalive_result_ = err;
+        return err;
+    }
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lease_id_ = lease_id;
+        owner_token_ = std::to_string(lease_id);
+    }
+    keepalive_thread_ = std::thread([this, lease_id] {
+        const ErrorCode result = EtcdHelper::KeepAlive(lease_id);
+        std::lock_guard<std::mutex> lock(mutex_);
+        keepalive_result_ = result;
+        keepalive_stopped_ = true;
+    });
+
+    err = EtcdHelper::WaitKeepAliveReady(lease_id_, kKeepAliveReadyTimeoutMs);
+    if (err != ErrorCode::OK) {
+        (void)StopKeepAlive(true);
+        return err;
+    }
+    EtcdRevisionId revision = 0;
+    err = EtcdHelper::CreateWithLease(
+        lock_key_.c_str(), lock_key_.size(), owner_token_.c_str(),
+        owner_token_.size(), lease_id_, revision);
+    if (err != ErrorCode::OK) {
+        (void)StopKeepAlive(true);
+        return err;
+    }
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lock_created_ = true;
+    }
+    if (!IsHeld()) {
+        (void)StopKeepAlive(true);
+        return ErrorCode::ETCD_OPERATION_ERROR;
+    }
+    return ErrorCode::OK;
+}
+
+bool SnapshotMaintenanceLease::IsHeld() const {
+    if (testing_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return lock_created_ && !owner_token_.empty();
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    return lock_created_ && !keepalive_stopped_ &&
+           keepalive_result_ == ErrorCode::OK && !shutdown_requested_;
+}
+
+EtcdLeaseId SnapshotMaintenanceLease::lease_id() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return lease_id_;
+}
+
+std::string SnapshotMaintenanceLease::owner_token() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return owner_token_;
+}
+
+ErrorCode SnapshotMaintenanceLease::Release() {
+    if (testing_) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lock_created_ = false;
+        return ErrorCode::OK;
+    }
+    return StopKeepAlive(true);
+}
+
+ErrorCode SnapshotMaintenanceLease::StopKeepAlive(bool revoke) {
+    std::thread thread_to_join;
+    EtcdLeaseId lease_id = 0;
+    bool should_cancel = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        shutdown_requested_ = true;
+        lease_id = lease_id_;
+        should_cancel = keepalive_thread_.joinable() && !keepalive_stopped_;
+        if (keepalive_thread_.joinable()) {
+            thread_to_join = std::move(keepalive_thread_);
+        }
+        lock_created_ = false;
+    }
+    ErrorCode result = ErrorCode::OK;
+    if (should_cancel && lease_id != 0) {
+        result = EtcdHelper::CancelKeepAlive(lease_id);
+        if (result == ErrorCode::ETCD_OPERATION_ERROR) {
+            result = ErrorCode::OK;
+        }
+    }
+    if (thread_to_join.joinable()) {
+        thread_to_join.join();
+    }
+    if (revoke && lease_id != 0) {
+        const ErrorCode revoke_result = EtcdHelper::RevokeLease(lease_id);
+        if (result == ErrorCode::OK) {
+            result = revoke_result;
+        }
+    }
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        lease_id_ = 0;
+        owner_token_.clear();
+        keepalive_stopped_ = true;
+    }
+    return result;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -186,6 +186,8 @@ add_ha_test(batch_oplog_snapshot_writer_test
             ha/snapshot/batch_oplog/writer_test.cpp)
 add_ha_test(batch_oplog_snapshot_provider_test
             ha/snapshot/batch_oplog/provider_test.cpp)
+add_ha_test(batch_oplog_snapshot_publisher_test
+            ha/snapshot/batch_oplog/publisher_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
@@ -29,7 +29,11 @@ class FakeBackend final : public HaKvBackend {
     }
 
     ErrorCode Put(std::string_view key, std::string_view value) override {
-        values[std::string(key)] = std::string(value);
+        const std::string owned_key(key);
+        values[owned_key] = std::string(value);
+        if (!create_revisions.contains(owned_key)) {
+            create_revisions[owned_key] = next_create_revision++;
+        }
         return ErrorCode::OK;
     }
 
@@ -55,20 +59,33 @@ class FakeBackend final : public HaKvBackend {
             const auto it = values.find(compare.key);
             if (compare.kind == KvCompareKind::kKeyNotExists) {
                 if (it != values.end()) return ErrorCode::ETCD_TRANSACTION_FAIL;
+            } else if (compare.kind == KvCompareKind::kCreateRevisionEquals) {
+                auto revision = create_revisions.find(compare.key);
+                if (revision == create_revisions.end() ||
+                    revision->second != compare.expected_revision) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
             } else if (it == values.end() ||
                        it->second != compare.expected_value) {
                 return ErrorCode::ETCD_TRANSACTION_FAIL;
             }
         }
-        for (const auto& put : txn.puts) values[put.key] = put.value;
+        for (const auto& put : txn.puts) {
+            values[put.key] = put.value;
+            if (!create_revisions.contains(put.key)) {
+                create_revisions[put.key] = next_create_revision++;
+            }
+        }
         return ErrorCode::OK;
     }
 
     std::map<std::string, std::string> values;
+    std::map<std::string, EtcdRevisionId> create_revisions;
     ErrorCode next_txn_error{ErrorCode::OK};
     std::string mutate_key;
     std::string mutate_value;
     size_t txn_count{0};
+    EtcdRevisionId next_create_revision{1};
 };
 
 std::string MakeDescriptor(uint64_t batch_id, int64_t lease_id = 101,
@@ -277,6 +294,20 @@ TEST(BatchOpLogSnapshotPublisherTest, LockOwnerRaceCannotPublish) {
     BatchOpLogSnapshotPublisher publisher(backend, "cluster");
     backend.mutate_key = ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster");
     backend.mutate_value = "102";
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, MakeDescriptor(1)));
+    EXPECT_FALSE(backend.values.contains(
+        ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, FencesOldMaintenanceLockIncarnation) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101", 1);
+    const auto lock_key = ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster");
+    ASSERT_EQ(ErrorCode::OK, backend.Put(lock_key, "101"));
+    backend.create_revisions[lock_key] = 2;
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+
     EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
               publisher.Publish(*lease, MakeDescriptor(1)));
     EXPECT_FALSE(backend.values.contains(

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
@@ -1,0 +1,255 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/snapshot_maintenance_lease.h"
+#ifdef STORE_USE_ETCD
+#include <unistd.h>
+
+#include "etcd_helper.h"
+#include "ha/kv/etcd_ha_kv_backend.h"
+#endif
+
+namespace mooncake::test {
+namespace {
+
+class FakeBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        auto it = values.find(std::string(key));
+        if (it == values.end()) return ErrorCode::ETCD_KEY_NOT_EXIST;
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        values[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view, std::string_view, size_t,
+                    std::vector<KvPair>&) override {
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+
+    ErrorCode Txn(const KvTxn& txn) override {
+        ++txn_count;
+        if (!mutate_key.empty()) {
+            values[mutate_key] = mutate_value;
+            mutate_key.clear();
+        }
+        if (next_txn_error != ErrorCode::OK) {
+            const auto error = next_txn_error;
+            next_txn_error = ErrorCode::OK;
+            return error;
+        }
+        for (const auto& compare : txn.compares) {
+            const auto it = values.find(compare.key);
+            if (compare.kind == KvCompareKind::kKeyNotExists) {
+                if (it != values.end()) return ErrorCode::ETCD_TRANSACTION_FAIL;
+            } else if (it == values.end() || it->second != compare.expected_value) {
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+        }
+        for (const auto& put : txn.puts) values[put.key] = put.value;
+        return ErrorCode::OK;
+    }
+
+    std::map<std::string, std::string> values;
+    ErrorCode next_txn_error{ErrorCode::OK};
+    std::string mutate_key;
+    std::string mutate_value;
+    size_t txn_count{0};
+};
+
+std::string MakeDescriptor(uint64_t batch_id, int64_t lease_id = 101,
+                           ViewVersionId producer_view = 7) {
+    ha::BatchOpLogSnapshotDescriptor descriptor;
+    descriptor.snapshot_id = ha::BuildBatchOpLogSnapshotId(batch_id, lease_id);
+    descriptor.last_included_seq = batch_id * 10;
+    descriptor.last_included_batch_id = batch_id;
+    descriptor.producer_view_version = producer_view;
+    descriptor.manifest_key = "snapshots/batch-oplog/" + descriptor.snapshot_id +
+                              "/manifest.json";
+    descriptor.manifest_size = 1;
+    descriptor.created_at_ms = 1234;
+    return ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
+}
+
+}  // namespace
+
+TEST(BatchOpLogSnapshotPublisherTest, PublishesAndRotatesPointersAtomically) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+
+    const auto first = MakeDescriptor(1);
+    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, first));
+    EXPECT_EQ(first, backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_FALSE(backend.values.contains(
+        ha::BuildBatchOpLogSnapshotFallbackKey("cluster")));
+
+    const auto second = MakeDescriptor(2);
+    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, second));
+    EXPECT_EQ(second, backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_EQ(first, backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, RejectsStaleAndLostLeaseWithoutTxn) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    const auto lock_key = ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster");
+    ASSERT_EQ(ErrorCode::OK, backend.Put(lock_key, "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    const auto first = MakeDescriptor(4);
+    ASSERT_EQ(ErrorCode::OK, publisher.Publish(*lease, first));
+    const auto txn_count = backend.txn_count;
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, first));
+    EXPECT_EQ(txn_count, backend.txn_count);
+
+    lease->Release();
+    const auto next = MakeDescriptor(5);
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, next));
+    EXPECT_EQ(txn_count, backend.txn_count);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, LeavesPointersUnchangedOnCasFailure) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    const auto first = MakeDescriptor(1);
+    backend.next_txn_error = ErrorCode::ETCD_TRANSACTION_FAIL;
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, first));
+    EXPECT_FALSE(backend.values.contains(
+        ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, FencesLatestAndFallbackRaces) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    const auto first = MakeDescriptor(1);
+    ASSERT_EQ(ErrorCode::OK, publisher.Publish(*lease, first));
+
+    const auto latest_racer = MakeDescriptor(4);
+    backend.mutate_key = ha::BuildBatchOpLogSnapshotLatestKey("cluster");
+    backend.mutate_value = latest_racer;
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, MakeDescriptor(2)));
+    EXPECT_EQ(latest_racer,
+              backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+
+    backend.values.erase(ha::BuildBatchOpLogSnapshotFallbackKey("cluster"));
+    backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")] = first;
+    backend.mutate_key = ha::BuildBatchOpLogSnapshotFallbackKey("cluster");
+    backend.mutate_value = first;
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, MakeDescriptor(2)));
+    EXPECT_EQ(first,
+              backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, RejectsCandidateFromAnotherLease) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "102");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "102"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              publisher.Publish(*lease, MakeDescriptor(1)));
+    EXPECT_EQ(0u, backend.txn_count);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, AllowsOlderProducerViewWhenCursorAdvances) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    ASSERT_EQ(ErrorCode::OK, publisher.Publish(*lease, MakeDescriptor(1, 101, 9)));
+    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, MakeDescriptor(2, 101, 3)));
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, LockOwnerRaceCannotPublish) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    backend.mutate_key = ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster");
+    backend.mutate_value = "102";
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, MakeDescriptor(1)));
+    EXPECT_FALSE(backend.values.contains(
+        ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
+}
+
+TEST(BatchOpLogSnapshotPublisherTest, RejectsCorruptFallback) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("cluster"),
+                          "not-json"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR,
+              publisher.Publish(*lease, MakeDescriptor(1)));
+    EXPECT_EQ(0u, backend.txn_count);
+}
+
+#ifdef STORE_USE_ETCD
+TEST(BatchOpLogSnapshotPublisherTest, RealEtcdLeaseAndPublisherLifecycle) {
+    constexpr char kEndpoints[] = "127.0.0.1:2379";
+    if (EtcdHelper::ConnectToEtcdStoreClient(kEndpoints) != ErrorCode::OK) {
+        GTEST_SKIP() << "etcd is not available at " << kEndpoints;
+    }
+
+    const std::string cluster =
+        "n04-real-" + std::to_string(static_cast<long long>(getpid()));
+    SnapshotMaintenanceLease first(cluster);
+    const auto first_acquire = first.Acquire();
+    if (first_acquire != ErrorCode::OK) {
+        GTEST_SKIP() << "etcd lease unavailable: "
+                     << static_cast<int>(first_acquire);
+    }
+    SnapshotMaintenanceLease second(cluster);
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, second.Acquire());
+
+    EtcdHaKvBackend backend;
+    BatchOpLogSnapshotPublisher publisher(backend, cluster);
+    const auto first_descriptor = MakeDescriptor(1, first.lease_id());
+    ASSERT_EQ(ErrorCode::OK, publisher.Publish(first, first_descriptor));
+    const auto second_descriptor = MakeDescriptor(2, first.lease_id());
+    ASSERT_EQ(ErrorCode::OK, publisher.Publish(first, second_descriptor));
+
+    ASSERT_EQ(ErrorCode::OK, first.Release());
+    ASSERT_EQ(ErrorCode::OK, second.Acquire());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS,
+              publisher.Publish(second, second_descriptor));
+    ASSERT_EQ(ErrorCode::OK, second.Release());
+}
+#endif
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp
@@ -55,7 +55,8 @@ class FakeBackend final : public HaKvBackend {
             const auto it = values.find(compare.key);
             if (compare.kind == KvCompareKind::kKeyNotExists) {
                 if (it != values.end()) return ErrorCode::ETCD_TRANSACTION_FAIL;
-            } else if (it == values.end() || it->second != compare.expected_value) {
+            } else if (it == values.end() ||
+                       it->second != compare.expected_value) {
                 return ErrorCode::ETCD_TRANSACTION_FAIL;
             }
         }
@@ -77,8 +78,8 @@ std::string MakeDescriptor(uint64_t batch_id, int64_t lease_id = 101,
     descriptor.last_included_seq = batch_id * 10;
     descriptor.last_included_batch_id = batch_id;
     descriptor.producer_view_version = producer_view;
-    descriptor.manifest_key = "snapshots/batch-oplog/" + descriptor.snapshot_id +
-                              "/manifest.json";
+    descriptor.manifest_key =
+        "snapshots/batch-oplog/" + descriptor.snapshot_id + "/manifest.json";
     descriptor.manifest_size = 1;
     descriptor.created_at_ms = 1234;
     return ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
@@ -96,14 +97,85 @@ TEST(BatchOpLogSnapshotPublisherTest, PublishesAndRotatesPointersAtomically) {
 
     const auto first = MakeDescriptor(1);
     EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, first));
-    EXPECT_EQ(first, backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_EQ(first,
+              backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
     EXPECT_FALSE(backend.values.contains(
         ha::BuildBatchOpLogSnapshotFallbackKey("cluster")));
 
     const auto second = MakeDescriptor(2);
     EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, second));
-    EXPECT_EQ(second, backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
-    EXPECT_EQ(first, backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+    EXPECT_EQ(second,
+              backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_EQ(
+        first,
+        backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest,
+     RepairsMissingLatestAndPreservesFallback) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    const auto fallback = MakeDescriptor(5);
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("cluster"),
+                          fallback));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+
+    const auto candidate = MakeDescriptor(6);
+    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, candidate));
+    EXPECT_EQ(candidate,
+              backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_EQ(
+        fallback,
+        backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest,
+     RepairsCorruptLatestAndPreservesFallback) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    const auto fallback = MakeDescriptor(5);
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("cluster"),
+                          fallback));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotLatestKey("cluster"),
+                          "not-json"));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+
+    const auto candidate = MakeDescriptor(6);
+    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, candidate));
+    EXPECT_EQ(candidate,
+              backend.values[ha::BuildBatchOpLogSnapshotLatestKey("cluster")]);
+    EXPECT_EQ(
+        fallback,
+        backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+}
+
+TEST(BatchOpLogSnapshotPublisherTest,
+     RejectsRepairCandidateNotNewerThanFallback) {
+    FakeBackend backend;
+    auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
+                          "101"));
+    const auto fallback = MakeDescriptor(5);
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("cluster"),
+                          fallback));
+    BatchOpLogSnapshotPublisher publisher(backend, "cluster");
+
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, MakeDescriptor(5)));
+    EXPECT_FALSE(backend.values.contains(
+        ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
+    EXPECT_EQ(0u, backend.txn_count);
 }
 
 TEST(BatchOpLogSnapshotPublisherTest, RejectsStaleAndLostLeaseWithoutTxn) {
@@ -115,12 +187,14 @@ TEST(BatchOpLogSnapshotPublisherTest, RejectsStaleAndLostLeaseWithoutTxn) {
     const auto first = MakeDescriptor(4);
     ASSERT_EQ(ErrorCode::OK, publisher.Publish(*lease, first));
     const auto txn_count = backend.txn_count;
-    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, first));
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, first));
     EXPECT_EQ(txn_count, backend.txn_count);
 
     lease->Release();
     const auto next = MakeDescriptor(5);
-    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, next));
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, next));
     EXPECT_EQ(txn_count, backend.txn_count);
 }
 
@@ -133,7 +207,8 @@ TEST(BatchOpLogSnapshotPublisherTest, LeavesPointersUnchangedOnCasFailure) {
     BatchOpLogSnapshotPublisher publisher(backend, "cluster");
     const auto first = MakeDescriptor(1);
     backend.next_txn_error = ErrorCode::ETCD_TRANSACTION_FAIL;
-    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, publisher.Publish(*lease, first));
+    EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
+              publisher.Publish(*lease, first));
     EXPECT_FALSE(backend.values.contains(
         ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
 }
@@ -162,8 +237,9 @@ TEST(BatchOpLogSnapshotPublisherTest, FencesLatestAndFallbackRaces) {
     backend.mutate_value = first;
     EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL,
               publisher.Publish(*lease, MakeDescriptor(2)));
-    EXPECT_EQ(first,
-              backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
+    EXPECT_EQ(
+        first,
+        backend.values[ha::BuildBatchOpLogSnapshotFallbackKey("cluster")]);
 }
 
 TEST(BatchOpLogSnapshotPublisherTest, RejectsCandidateFromAnotherLease) {
@@ -178,15 +254,18 @@ TEST(BatchOpLogSnapshotPublisherTest, RejectsCandidateFromAnotherLease) {
     EXPECT_EQ(0u, backend.txn_count);
 }
 
-TEST(BatchOpLogSnapshotPublisherTest, AllowsOlderProducerViewWhenCursorAdvances) {
+TEST(BatchOpLogSnapshotPublisherTest,
+     AllowsOlderProducerViewWhenCursorAdvances) {
     FakeBackend backend;
     auto lease = SnapshotMaintenanceLease::MakeForTesting("cluster", "101");
     ASSERT_EQ(ErrorCode::OK,
               backend.Put(ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster"),
                           "101"));
     BatchOpLogSnapshotPublisher publisher(backend, "cluster");
-    ASSERT_EQ(ErrorCode::OK, publisher.Publish(*lease, MakeDescriptor(1, 101, 9)));
-    EXPECT_EQ(ErrorCode::OK, publisher.Publish(*lease, MakeDescriptor(2, 101, 3)));
+    ASSERT_EQ(ErrorCode::OK,
+              publisher.Publish(*lease, MakeDescriptor(1, 101, 9)));
+    EXPECT_EQ(ErrorCode::OK,
+              publisher.Publish(*lease, MakeDescriptor(2, 101, 3)));
 }
 
 TEST(BatchOpLogSnapshotPublisherTest, LockOwnerRaceCannotPublish) {
@@ -225,15 +304,21 @@ TEST(BatchOpLogSnapshotPublisherTest, RealEtcdLeaseAndPublisherLifecycle) {
     if (EtcdHelper::ConnectToEtcdStoreClient(kEndpoints) != ErrorCode::OK) {
         GTEST_SKIP() << "etcd is not available at " << kEndpoints;
     }
+    const std::string probe_key =
+        "/oplog/n04-probe-" + std::to_string(static_cast<long long>(getpid()));
+    std::string probe_value;
+    EtcdRevisionId probe_revision = 0;
+    const auto probe = EtcdHelper::Get(probe_key.c_str(), probe_key.size(),
+                                       probe_value, probe_revision);
+    if (probe != ErrorCode::OK && probe != ErrorCode::ETCD_KEY_NOT_EXIST) {
+        GTEST_SKIP() << "etcd is not reachable at " << kEndpoints << ": "
+                     << static_cast<int>(probe);
+    }
 
     const std::string cluster =
         "n04-real-" + std::to_string(static_cast<long long>(getpid()));
     SnapshotMaintenanceLease first(cluster);
-    const auto first_acquire = first.Acquire();
-    if (first_acquire != ErrorCode::OK) {
-        GTEST_SKIP() << "etcd lease unavailable: "
-                     << static_cast<int>(first_acquire);
-    }
+    ASSERT_EQ(ErrorCode::OK, first.Acquire());
     SnapshotMaintenanceLease second(cluster);
     EXPECT_EQ(ErrorCode::ETCD_TRANSACTION_FAIL, second.Acquire());
 


### PR DESCRIPTION
## Description

Add the N04 control-plane primitives for publishing batch OpLog standby snapshots.

This PR introduces:

- a fixed 30-second snapshot maintenance lease backed by `EtcdHelper`;
- keepalive readiness checks and active lease revocation on release;
- an owner token that is unique to each maintenance attempt;
- atomic publication of the `latest` and `fallback` snapshot pointers;
- CAS fencing on the maintenance lock and the previously observed pointer bytes;
- monotonic publication based on `last_included_batch_id`;
- validation that a candidate belongs to the currently held maintenance lease.

The first publication creates only `latest`. Subsequent publications atomically perform:

```text
fallback = old latest
latest = candidate
```

The pointer values are the original descriptor JSON bytes returned by the N03 artifact writer. `producer_view_version` remains diagnostic and does not participate in candidate selection.

This PR does not add snapshot scheduling, restoration, OpLog batch deletion, or post-publication artifact cleanup.

The batch OpLog-specific publisher implementation and tests are kept under `ha/snapshot/batch_oplog/` and do not modify the legacy snapshot catalog/provider path.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Coverage includes:

- first publication;
- atomic `latest`/`fallback` rotation;
- equal or stale batch rejection;
- maintenance owner fencing;
- candidate/lease owner mismatch;
- `latest` and `fallback` CAS races;
- publication from an older producer view when the cursor advances;
- corrupt fallback rejection;
- release and lost-lease behavior;
- real-etcd lease competition and revoke lifecycle when etcd is available.

**Test commands:**

```bash
GOCACHE=/tmp/mooncake-n04-gocache cmake --build build-n04 -j32

ctest --test-dir build-n04 --output-on-failure \
  -R 'batch_oplog_snapshot_(types|codec|writer)_test'

build-n04/mooncake-store/tests/batch_oplog_snapshot_publisher_test \
  --gtest_filter='-BatchOpLogSnapshotPublisherTest.RealEtcdLeaseAndPublisherLifecycle'

pre-commit run --files \
  mooncake-store/include/ha/snapshot/snapshot_maintenance_lease.h \
  mooncake-store/include/ha/snapshot/batch_oplog_snapshot_publisher.h \
  mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h \
  mooncake-store/src/ha/snapshot/snapshot_maintenance_lease.cpp \
  mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp \
  mooncake-store/tests/ha/snapshot/batch_oplog/publisher_test.cpp \
  mooncake-store/src/CMakeLists.txt \
  mooncake-store/tests/CMakeLists.txt
```

**Test results:**

- [x] Full `BUILD_UNIT_TESTS=ON`, `STORE_USE_ETCD=ON` build completed
- [x] Snapshot metadata, codec, and writer tests passed
- [x] All 8 fake-backend publisher tests passed
- [x] Pre-commit hooks passed
- [ ] Real-etcd lifecycle test passed locally

The real-etcd lifecycle test is included, but the local sandbox prevented connections to `127.0.0.1:2379`, so that case was skipped locally.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not required for this internal protocol primitive
- [x] I have added tests to prove my changes are effective
- [x] An existing standby snapshot and bounded OpLog retention RFC covers this work

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex assisted with implementation, focused test coverage, build troubleshooting, and preparation of this PR description. The submitter will review and validate all changed lines before submission.