### PR TITLE
[Store] Add batch OpLog snapshot bootstrap

### DIFF
--- a/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
+++ b/mooncake-store/include/ha/oplog/oplog_batch_standby_reader.h
@@ -34,6 +34,9 @@ class OpLogBatchStandbyReader {
                             OpLogApplier& applier);
 
     OpLogBatchStandbyPollResult PollOnce(size_t max_batches = 1024);
+    // Seed the reader after a materialized snapshot. The next poll starts at
+    // cursor.batch_id + 1 and validates the complete suffix.
+    ErrorCode SetBaselineCursor(const DurablePrefix& cursor);
     ErrorCode ReadProducerView(ViewVersionId& producer_view_version) const {
         return storage_.ReadProducerView(producer_view_version);
     }
@@ -49,6 +52,7 @@ class OpLogBatchStandbyReader {
     std::optional<DurablePrefix> last_applied_durable_prefix_;
     std::optional<uint64_t> last_scanned_batch_last_seq_;
     uint64_t last_applied_batch_id_{0};
+    bool require_complete_history_{false};
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include <ylt/util/tl/expected.hpp>
+
+#include "ha/standby_metadata_store.h"
+#include "types.h"
+
+namespace mooncake {
+
+class HaKvBackend;
+class OpLogApplier;
+class SnapshotObjectStore;
+
+struct BatchOpLogSnapshotRestoreResult {
+    uint64_t last_included_seq{0};
+    uint64_t last_included_batch_id{0};
+    ViewVersionId producer_view_version{0};
+    ReplicaID max_replica_id{0};
+};
+
+// Restores the new batch-OpLog snapshot format into caller-owned temporary
+// state. Legacy catalog snapshots intentionally do not use this provider.
+class BatchOpLogSnapshotProvider final {
+   public:
+    BatchOpLogSnapshotProvider(std::string cluster_id, HaKvBackend& backend,
+                               SnapshotObjectStore& object_store,
+                               std::string snapshot_root);
+
+    tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode> RestoreBaseline(
+        StandbyMetadataStore& metadata, StandbySegmentRegistry& registry,
+        OpLogApplier* applier = nullptr);
+
+   private:
+    std::string cluster_id_;
+    HaKvBackend& backend_;
+    SnapshotObjectStore& object_store_;
+    std::string snapshot_root_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h
@@ -17,6 +17,8 @@ class SnapshotObjectStore;
 struct BatchOpLogSnapshotRestoreResult {
     uint64_t last_included_seq{0};
     uint64_t last_included_batch_id{0};
+    uint64_t last_applied_seq{0};
+    uint64_t last_applied_batch_id{0};
     ViewVersionId producer_view_version{0};
     ReplicaID max_replica_id{0};
 };

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -13,7 +13,9 @@
 #include <vector>
 
 #include "ha/oplog/oplog_applier.h"
+#include "ha/oplog/oplog_batch_types.h"
 #include "ha/oplog/oplog_types.h"
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
 #include "ha/snapshot/batch_oplog/capture.h"
 #include "ha/snapshot/snapshot_provider.h"
 #include "ha/standby_metadata_store.h"
@@ -179,6 +181,11 @@ class HotStandbyService {
     // Inject a snapshot provider (from external snapshot implementation).
     void SetSnapshotProvider(std::unique_ptr<SnapshotProvider> provider);
 
+    // Inject the new batch-OpLog bootstrap path. It owns no running state;
+    // Start() gives it temporary stores and installs them only on success.
+    void SetBatchOpLogSnapshotProvider(
+        std::unique_ptr<BatchOpLogSnapshotProvider> provider);
+
     // Notify callers when standby sync status changes. The callback is invoked
     // from existing standby worker threads; no extra monitor thread is created.
     void SetSyncStatusCallback(SyncStatusCallback callback);
@@ -205,6 +212,7 @@ class HotStandbyService {
    private:
     ErrorCode PrepareBootstrapBaselineLocked(uint64_t& baseline_seq_id);
     ErrorCode LoadSnapshotBaselineLocked(uint64_t& baseline_seq_id);
+    ErrorCode LoadBatchOpLogSnapshotBaselineLocked(uint64_t& baseline_seq_id);
     ErrorCode StartOplogFollowingLocked(uint64_t baseline_seq_id);
     void ActivateSnapshotOnlyStandbyLocked(uint64_t baseline_seq_id);
     uint64_t GetLocalLastAppliedSequenceIdLocked() const;
@@ -238,11 +246,13 @@ class HotStandbyService {
     std::unique_ptr<StandbyMetadataStore> metadata_store_;
     std::unique_ptr<SnapshotProvider> snapshot_provider_{
         std::make_unique<NoopSnapshotProvider>()};
+    std::unique_ptr<BatchOpLogSnapshotProvider> batch_oplog_snapshot_provider_;
 
     // OpLog replication components
     std::unique_ptr<OpLogApplier> oplog_applier_;
     std::shared_ptr<HaKvBackend> batch_standby_kv_backend_;
     std::unique_ptr<OpLogBatchStandbyReader> batch_standby_reader_;
+    std::optional<DurablePrefix> batch_snapshot_baseline_;
 
     std::shared_ptr<HaKvBackend> catch_up_batch_kv_backend_for_testing_;
 

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -40,6 +40,7 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     ha/snapshot/catalog_backed_snapshot_provider.cpp
     ha/snapshot/batch_oplog/codec.cpp
     ha/snapshot/batch_oplog/metadata.cpp
+    ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
     ha/snapshot/batch_oplog/writer.cpp
     ha/snapshot/master_snapshot_codec.cpp
     ha/snapshot/local_ssd_codec.cpp

--- a/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_standby_reader.cpp
@@ -29,6 +29,26 @@ OpLogBatchStandbyReader::OpLogBatchStandbyReader(std::string cluster_id,
                                                  OpLogApplier& applier)
     : storage_(std::move(cluster_id), backend), applier_(applier) {}
 
+ErrorCode OpLogBatchStandbyReader::SetBaselineCursor(
+    const DurablePrefix& cursor) {
+    if ((cursor.batch_id == 0) != (cursor.last_seq == 0)) {
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    }
+    const uint64_t expected = applier_.GetExpectedSequenceId();
+    if (expected == 0 || IsSequenceOlder(expected - 1, cursor.last_seq)) {
+        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    }
+    batch_format_seen_ = true;
+    require_complete_history_ = cursor.batch_id == 0;
+    last_observed_prefix_ = cursor;
+    last_applied_durable_prefix_ = cursor;
+    last_applied_batch_id_ = cursor.batch_id;
+    last_scanned_batch_last_seq_ =
+        cursor.batch_id == 0 ? std::nullopt
+                             : std::optional<uint64_t>(cursor.last_seq);
+    return ErrorCode::OK;
+}
+
 OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
     size_t max_batches) {
     OpLogBatchStandbyPollResult result;
@@ -99,15 +119,24 @@ OpLogBatchStandbyPollResult OpLogBatchStandbyReader::PollOnce(
         return result;
     }
     for (const auto& batch : batches) {
-        if (last_scanned_batch_last_seq_ &&
-            (last_applied_batch_id_ == UINT64_MAX ||
-             batch.batch_id != last_applied_batch_id_ + 1)) {
+        if (last_applied_batch_id_ == UINT64_MAX ||
+            (last_applied_batch_id_ != 0 &&
+             batch.batch_id != last_applied_batch_id_ + 1) ||
+            (last_applied_batch_id_ == 0 && require_complete_history_ &&
+             batch.batch_id != 1)) {
             SetPollError(result, ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, false);
             return result;
         }
-        if (last_scanned_batch_last_seq_ &&
-            (*last_scanned_batch_last_seq_ == UINT64_MAX ||
-             batch.first_seq != *last_scanned_batch_last_seq_ + 1)) {
+        const std::optional<uint64_t> expected_first_seq =
+            last_scanned_batch_last_seq_
+                ? std::optional<uint64_t>(
+                      *last_scanned_batch_last_seq_ == UINT64_MAX
+                          ? 0
+                          : *last_scanned_batch_last_seq_ + 1)
+                : (require_complete_history_ ? std::optional<uint64_t>(1)
+                                             : std::nullopt);
+        if (expected_first_seq && (*expected_first_seq == 0 ||
+                                   batch.first_seq != *expected_first_seq)) {
             SetPollError(result, ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, false);
             return result;
         }

--- a/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
+++ b/mooncake-store/src/ha/oplog/oplog_batch_storage.cpp
@@ -1,7 +1,9 @@
 #include "ha/oplog/oplog_batch_storage.h"
 
 #include <algorithm>
+#include <array>
 #include <charconv>
+#include <string_view>
 
 #include <glog/logging.h>
 
@@ -517,17 +519,26 @@ ErrorCode OpLogBatchStorage::RejectLegacyLayout() const {
     }
 
     entries.clear();
-    err = backend_.Range(root + "snapshot/", root + "snapshot0",
-                         /*limit=*/1, entries);
+    const std::string snapshot_prefix = root + "snapshot/";
+    constexpr std::array<std::string_view, 4> kBatchSnapshotControlKeys{
+        "latest", "fallback", "maintenance", "compaction_floor"};
+    err = backend_.Range(snapshot_prefix, root + "snapshot0",
+                         kBatchSnapshotControlKeys.size() + 1, entries);
     if (err != ErrorCode::OK) {
         return err;
     }
-    if (!entries.empty()) {
-        LOG(ERROR) << "Legacy OpLog snapshot sidecar exists for cluster="
-                   << cluster_id_
-                   << "; clear the legacy OpLog namespace before enabling "
-                      "batch-record OpLog";
-        return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+    for (const auto& entry : entries) {
+        const std::string_view key(entry.key);
+        const std::string_view suffix = key.substr(snapshot_prefix.size());
+        if (std::find(kBatchSnapshotControlKeys.begin(),
+                      kBatchSnapshotControlKeys.end(),
+                      suffix) == kBatchSnapshotControlKeys.end()) {
+            LOG(ERROR) << "Legacy OpLog snapshot sidecar exists for cluster="
+                       << cluster_id_
+                       << "; clear the legacy OpLog namespace before enabling "
+                          "batch-record OpLog";
+            return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
+        }
     }
     return ErrorCode::OK;
 }

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
@@ -311,6 +311,8 @@ AttemptResult RestorePointer(
             ErrorCode::OK,
             {.last_included_seq = descriptor.last_included_seq,
              .last_included_batch_id = descriptor.last_included_batch_id,
+             .last_applied_seq = suffix.value.last_included_seq,
+             .last_applied_batch_id = suffix.value.last_included_batch_id,
              .producer_view_version = descriptor.producer_view_version,
              .max_replica_id = *live_max_replica_id}};
 }
@@ -345,6 +347,8 @@ AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
     }
     CopyRegistry(applier->GetSegmentRegistry(), registry);
     replay.value.max_replica_id = *max_replica_id;
+    replay.value.last_applied_seq = replay.value.last_included_seq;
+    replay.value.last_applied_batch_id = replay.value.last_included_batch_id;
     return replay;
 }
 

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
@@ -1,0 +1,412 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
+
+#include <algorithm>
+#include <memory>
+#include <string_view>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "crc32c.h"
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_applier.h"
+#include "ha/oplog/oplog_batch_standby_reader.h"
+#include "ha/oplog/oplog_batch_storage.h"
+#include "ha/snapshot/batch_oplog/codec.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/object/snapshot_object_store.h"
+
+namespace mooncake {
+namespace {
+
+enum class AttemptDisposition { kSuccess, kInvalid, kInfrastructure };
+
+struct AttemptResult {
+    AttemptDisposition disposition{AttemptDisposition::kInvalid};
+    ErrorCode error{ErrorCode::DESERIALIZE_FAIL};
+    BatchOpLogSnapshotRestoreResult value;
+};
+
+AttemptResult Invalid(ErrorCode error = ErrorCode::DESERIALIZE_FAIL) {
+    return {AttemptDisposition::kInvalid, error, {}};
+}
+
+AttemptResult Infrastructure(
+    ErrorCode error = ErrorCode::ETCD_OPERATION_ERROR) {
+    return {AttemptDisposition::kInfrastructure, error, {}};
+}
+
+bool IsRetryableBackendError(ErrorCode error) {
+    return error == ErrorCode::ETCD_OPERATION_ERROR ||
+           error == ErrorCode::ETCD_CTX_CANCELLED;
+}
+
+bool SameIdentity(const ha::BatchOpLogSnapshotDescriptor& descriptor,
+                  const ha::BatchOpLogSnapshotManifest& manifest) {
+    return descriptor.schema_version == manifest.schema_version &&
+           descriptor.snapshot_format == manifest.snapshot_format &&
+           descriptor.snapshot_id == manifest.snapshot_id &&
+           descriptor.last_included_seq == manifest.last_included_seq &&
+           descriptor.last_included_batch_id ==
+               manifest.last_included_batch_id &&
+           descriptor.producer_view_version == manifest.producer_view_version;
+}
+
+AttemptResult ReadVerifiedObject(SnapshotObjectStore& object_store,
+                                 const std::string& key, uint64_t expected_size,
+                                 uint32_t expected_crc,
+                                 std::vector<uint8_t>& bytes) {
+    auto inspection = object_store.InspectObject(key);
+    if (!inspection) {
+        return object_store.IsNotFoundError(inspection.error())
+                   ? Invalid()
+                   : Infrastructure();
+    }
+    if (inspection->stored_size != expected_size || expected_size == 0) {
+        return Invalid();
+    }
+    if (inspection->crc32c && *inspection->crc32c != expected_crc) {
+        return Invalid();
+    }
+
+    auto download = object_store.DownloadBuffer(key, bytes);
+    if (!download) {
+        return object_store.IsNotFoundError(download.error())
+                   ? Invalid()
+                   : Infrastructure();
+    }
+    if (bytes.size() != expected_size ||
+        Crc32cValue(bytes.data(), bytes.size()) != expected_crc) {
+        return Invalid();
+    }
+    return {AttemptDisposition::kSuccess, ErrorCode::OK, {}};
+}
+
+AttemptResult ReadDescriptorObject(SnapshotObjectStore& object_store,
+                                   const std::string& key,
+                                   std::string_view pointer_bytes) {
+    std::vector<uint8_t> bytes;
+    auto inspection = object_store.InspectObject(key);
+    if (!inspection) {
+        return object_store.IsNotFoundError(inspection.error())
+                   ? Invalid()
+                   : Infrastructure();
+    }
+    if (inspection->stored_size != pointer_bytes.size()) {
+        return Invalid();
+    }
+    auto download = object_store.DownloadBuffer(key, bytes);
+    if (!download) {
+        return object_store.IsNotFoundError(download.error())
+                   ? Invalid()
+                   : Infrastructure();
+    }
+    if (bytes.size() != pointer_bytes.size() ||
+        !std::equal(bytes.begin(), bytes.end(), pointer_bytes.begin(),
+                    pointer_bytes.end())) {
+        return Invalid();
+    }
+    return {AttemptDisposition::kSuccess, ErrorCode::OK, {}};
+}
+
+bool ValidateSegments(const std::vector<StandbySegmentInfo>& segments) {
+    std::unordered_set<std::string> endpoints;
+    for (const auto& segment : segments) {
+        if (segment.transport_endpoint.empty() ||
+            !endpoints.insert(segment.transport_endpoint).second) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void CopyRegistry(const StandbySegmentRegistry& source,
+                  StandbySegmentRegistry& destination) {
+    destination.Clear();
+    for (const auto& segment : source.GetAllSegments()) {
+        destination.OnSegmentMount(segment);
+    }
+}
+
+tl::expected<ReplicaID, ErrorCode> ScanLiveReplicaIds(
+    const StandbyMetadataStore& metadata) {
+    auto cursor = metadata.BeginSnapshotTraversal();
+    ReplicaID max_replica_id = 0;
+    while (!cursor.done()) {
+        std::vector<StandbyObjectEntry> objects;
+        if (!metadata.CopyNextSnapshotChunk(1, cursor, objects)) {
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        }
+        for (const auto& object : objects) {
+            std::unordered_set<ReplicaID> object_ids;
+            for (const auto& replica : object.metadata.replicas) {
+                if (replica.id == 0 || !object_ids.insert(replica.id).second) {
+                    return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
+                }
+                max_replica_id = std::max(max_replica_id, replica.id);
+            }
+        }
+    }
+    return max_replica_id;
+}
+
+AttemptResult ReplaySuffix(const std::string& cluster_id, HaKvBackend& backend,
+                           OpLogApplier& applier,
+                           const DurablePrefix* baseline) {
+    OpLogBatchStandbyReader reader(cluster_id, backend, applier);
+    const DurablePrefix start =
+        baseline == nullptr ? DurablePrefix{} : *baseline;
+    if (reader.SetBaselineCursor(start) != ErrorCode::OK) {
+        return Invalid(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
+    }
+
+    for (;;) {
+        auto poll = reader.PollOnce();
+        if (poll.error != ErrorCode::OK) {
+            return IsRetryableBackendError(poll.error)
+                       ? Infrastructure(poll.error)
+                       : Invalid(poll.error);
+        }
+        if (!poll.durable_prefix_present) {
+            // A missing prefix cannot prove complete history, even for an
+            // empty cluster.
+            return Invalid(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
+        }
+        const uint64_t applied = applier.GetExpectedSequenceId() - 1;
+        if (applied == poll.durable_prefix.last_seq) {
+            return {AttemptDisposition::kSuccess,
+                    ErrorCode::OK,
+                    {.last_included_seq = poll.durable_prefix.last_seq,
+                     .last_included_batch_id = poll.durable_prefix.batch_id}};
+        }
+        if (poll.applied_entries == 0) {
+            return Invalid(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
+        }
+    }
+}
+
+AttemptResult RestorePointer(
+    const std::string& cluster_id, HaKvBackend& backend,
+    SnapshotObjectStore& object_store, const std::string& snapshot_root,
+    std::string_view pointer_bytes, StandbyMetadataStore& metadata,
+    StandbySegmentRegistry& registry, OpLogApplier* supplied_applier) {
+    auto decoded_descriptor =
+        ha::DecodeBatchOpLogSnapshotDescriptor(pointer_bytes);
+    if (!decoded_descriptor) {
+        return Invalid();
+    }
+    const auto& descriptor = *decoded_descriptor;
+    const std::string expected_manifest_key =
+        ha::BuildBatchOpLogSnapshotManifestKey(snapshot_root,
+                                               descriptor.snapshot_id);
+    if (descriptor.manifest_key != expected_manifest_key) {
+        return Invalid();
+    }
+    const std::string descriptor_key = ha::BuildBatchOpLogSnapshotDescriptorKey(
+        snapshot_root, descriptor.snapshot_id);
+    if (descriptor_key.empty()) {
+        return Invalid();
+    }
+
+    auto read_descriptor =
+        ReadDescriptorObject(object_store, descriptor_key, pointer_bytes);
+    if (read_descriptor.disposition != AttemptDisposition::kSuccess) {
+        return read_descriptor;
+    }
+
+    std::vector<uint8_t> manifest_bytes;
+    auto read_manifest = ReadVerifiedObject(
+        object_store, descriptor.manifest_key, descriptor.manifest_size,
+        descriptor.manifest_crc32c, manifest_bytes);
+    if (read_manifest.disposition != AttemptDisposition::kSuccess) {
+        return read_manifest;
+    }
+    auto decoded_manifest = ha::DecodeBatchOpLogSnapshotManifest(
+        std::string_view(reinterpret_cast<const char*>(manifest_bytes.data()),
+                         manifest_bytes.size()));
+    std::vector<uint8_t>().swap(manifest_bytes);
+    if (!decoded_manifest || !SameIdentity(descriptor, *decoded_manifest)) {
+        return Invalid();
+    }
+    const auto& manifest = *decoded_manifest;
+    const std::string expected_segments_key =
+        ha::BuildBatchOpLogSnapshotSegmentsKey(snapshot_root,
+                                               descriptor.snapshot_id);
+    if (descriptor.manifest_key != expected_manifest_key ||
+        manifest.segments.key != expected_segments_key) {
+        return Invalid();
+    }
+
+    std::vector<uint8_t> segments_bytes;
+    auto read_segments = ReadVerifiedObject(
+        object_store, manifest.segments.key, manifest.segments.stored_size,
+        manifest.segments.crc32c, segments_bytes);
+    if (read_segments.disposition != AttemptDisposition::kSuccess) {
+        return read_segments;
+    }
+    auto decoded_segments = DecodeBatchOpLogSnapshotSegments(segments_bytes);
+    std::vector<uint8_t>().swap(segments_bytes);
+    if (!decoded_segments || !ValidateSegments(*decoded_segments)) {
+        return Invalid();
+    }
+
+    std::unique_ptr<OpLogApplier> owned_applier;
+    OpLogApplier* applier = supplied_applier;
+    if (applier == nullptr) {
+        owned_applier = std::make_unique<OpLogApplier>(&metadata, cluster_id);
+        applier = owned_applier.get();
+    }
+    applier->LoadSegmentRegistry(*decoded_segments);
+    const DurablePrefix baseline{.batch_id = descriptor.last_included_batch_id,
+                                 .last_seq = descriptor.last_included_seq};
+    applier->Recover(baseline.last_seq);
+
+    for (size_t i = 0; i < manifest.object_chunks.size(); ++i) {
+        const auto& chunk = manifest.object_chunks[i];
+        const std::string expected_key =
+            ha::BuildBatchOpLogSnapshotObjectChunkKey(
+                snapshot_root, descriptor.snapshot_id, i);
+        if (chunk.chunk_index != i || chunk.key != expected_key) {
+            return Invalid();
+        }
+        std::vector<uint8_t> chunk_bytes;
+        auto read_chunk =
+            ReadVerifiedObject(object_store, chunk.key, chunk.stored_size,
+                               chunk.crc32c, chunk_bytes);
+        if (read_chunk.disposition != AttemptDisposition::kSuccess) {
+            return read_chunk;
+        }
+        auto decoded_chunk = DecodeBatchOpLogSnapshotObjectChunk(
+            chunk_bytes, i, chunk.object_count);
+        if (!decoded_chunk) {
+            return Invalid();
+        }
+        for (const auto& entry : decoded_chunk->objects) {
+            if (entry.key.empty() || !TenantId(entry.tenant_id).IsValid()) {
+                return Invalid();
+            }
+            std::unordered_set<ReplicaID> object_ids;
+            for (const auto& replica : entry.metadata.replicas) {
+                if (replica.id == 0 || !object_ids.insert(replica.id).second) {
+                    return Invalid();
+                }
+            }
+            if (!metadata.RestoreMetadata(entry.tenant_id, entry.key,
+                                          entry.metadata)) {
+                return Invalid();
+            }
+        }
+    }
+
+    auto suffix = ReplaySuffix(cluster_id, backend, *applier, &baseline);
+    if (suffix.disposition != AttemptDisposition::kSuccess) {
+        return suffix;
+    }
+    auto live_max_replica_id = ScanLiveReplicaIds(metadata);
+    if (!live_max_replica_id) {
+        return Invalid(live_max_replica_id.error());
+    }
+    CopyRegistry(applier->GetSegmentRegistry(), registry);
+    return {AttemptDisposition::kSuccess,
+            ErrorCode::OK,
+            {.last_included_seq = descriptor.last_included_seq,
+             .last_included_batch_id = descriptor.last_included_batch_id,
+             .producer_view_version = descriptor.producer_view_version,
+             .max_replica_id = *live_max_replica_id}};
+}
+
+AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
+                                   HaKvBackend& backend,
+                                   StandbyMetadataStore& metadata,
+                                   StandbySegmentRegistry& registry,
+                                   OpLogApplier* supplied_applier) {
+    std::unique_ptr<OpLogApplier> owned_applier;
+    OpLogApplier* applier = supplied_applier;
+    if (applier == nullptr) {
+        owned_applier = std::make_unique<OpLogApplier>(&metadata, cluster_id);
+        applier = owned_applier.get();
+    }
+    applier->Recover(0);
+    applier->LoadSegmentRegistry({});
+    OpLogBatchStorage storage(cluster_id, backend);
+    DurablePrefix durable_prefix;
+    const ErrorCode init_error = storage.InitDurablePrefix(durable_prefix);
+    if (init_error != ErrorCode::OK) {
+        return IsRetryableBackendError(init_error) ? Infrastructure(init_error)
+                                                   : Invalid(init_error);
+    }
+    auto replay = ReplaySuffix(cluster_id, backend, *applier, nullptr);
+    if (replay.disposition != AttemptDisposition::kSuccess) {
+        return replay;
+    }
+    auto max_replica_id = ScanLiveReplicaIds(metadata);
+    if (!max_replica_id) {
+        return Invalid(max_replica_id.error());
+    }
+    CopyRegistry(applier->GetSegmentRegistry(), registry);
+    replay.value.max_replica_id = *max_replica_id;
+    return replay;
+}
+
+}  // namespace
+
+BatchOpLogSnapshotProvider::BatchOpLogSnapshotProvider(
+    std::string cluster_id, HaKvBackend& backend,
+    SnapshotObjectStore& object_store, std::string snapshot_root)
+    : cluster_id_(std::move(cluster_id)),
+      backend_(backend),
+      object_store_(object_store),
+      snapshot_root_(std::move(snapshot_root)) {}
+
+tl::expected<BatchOpLogSnapshotRestoreResult, ErrorCode>
+BatchOpLogSnapshotProvider::RestoreBaseline(StandbyMetadataStore& metadata,
+                                            StandbySegmentRegistry& registry,
+                                            OpLogApplier* applier) {
+    metadata.Clear();
+    registry.Clear();
+    if (!NormalizeAndValidateClusterId(cluster_id_) || cluster_id_.empty() ||
+        snapshot_root_.empty()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    for (const std::string& pointer_key :
+         {ha::BuildBatchOpLogSnapshotLatestKey(cluster_id_),
+          ha::BuildBatchOpLogSnapshotFallbackKey(cluster_id_)}) {
+        std::string pointer_bytes;
+        const ErrorCode pointer_error =
+            backend_.Get(pointer_key, pointer_bytes);
+        if (pointer_error == ErrorCode::ETCD_KEY_NOT_EXIST) {
+            continue;
+        }
+        if (pointer_error != ErrorCode::OK) {
+            return tl::make_unexpected(pointer_error);
+        }
+
+        auto attempt =
+            RestorePointer(cluster_id_, backend_, object_store_, snapshot_root_,
+                           pointer_bytes, metadata, registry, applier);
+        if (attempt.disposition == AttemptDisposition::kSuccess) {
+            return attempt.value;
+        }
+        metadata.Clear();
+        registry.Clear();
+        if (applier != nullptr) {
+            applier->Recover(0);
+            applier->LoadSegmentRegistry({});
+        }
+        if (attempt.disposition == AttemptDisposition::kInfrastructure) {
+            return tl::make_unexpected(attempt.error);
+        }
+    }
+
+    auto full_replay = RestoreCompleteOpLog(cluster_id_, backend_, metadata,
+                                            registry, applier);
+    if (full_replay.disposition != AttemptDisposition::kSuccess) {
+        metadata.Clear();
+        registry.Clear();
+        return tl::make_unexpected(full_replay.error);
+    }
+    return full_replay.value;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -275,6 +275,8 @@ ErrorCode HotStandbyService::LoadBatchOpLogSnapshotBaselineLocked(
     batch_snapshot_baseline_ =
         DurablePrefix{.batch_id = restored->last_applied_batch_id,
                       .last_seq = restored->last_applied_seq};
+    applied_seq_id_.store(baseline_seq_id, std::memory_order_release);
+    primary_seq_id_.store(baseline_seq_id, std::memory_order_release);
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -13,6 +13,7 @@
 #include "ha/oplog/oplog_batch_standby_reader.h"
 #include "ha/oplog/oplog_test_failpoint.h"
 #include "ha/oplog/oplog_types.h"
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
 
 namespace mooncake {
 
@@ -84,6 +85,7 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     }
     batch_standby_reader_.reset();
     batch_standby_kv_backend_.reset();
+    batch_snapshot_baseline_.reset();
 
     last_error_.store(ErrorCode::OK, std::memory_order_release);
 
@@ -158,6 +160,9 @@ ErrorCode HotStandbyService::PrepareBootstrapBaselineLocked(
 
     oplog_applier_ =
         std::make_unique<OpLogApplier>(metadata_store_.get(), cluster_id_);
+    if (batch_oplog_snapshot_provider_ && config_.enable_snapshot_bootstrap) {
+        return LoadBatchOpLogSnapshotBaselineLocked(baseline_seq_id);
+    }
     if (!config_.enable_oplog_following) {
         if (metadata_store_ && metadata_store_->GetKeyCount() > 0) {
             LOG(INFO) << "Snapshot-only restart discards local metadata and "
@@ -249,6 +254,30 @@ ErrorCode HotStandbyService::LoadSnapshotBaselineLocked(
     return ErrorCode::OK;
 }
 
+ErrorCode HotStandbyService::LoadBatchOpLogSnapshotBaselineLocked(
+    uint64_t& baseline_seq_id) {
+    baseline_seq_id = 0;
+    auto temporary_metadata = std::make_unique<StandbyMetadataStore>();
+    auto temporary_applier =
+        std::make_unique<OpLogApplier>(temporary_metadata.get(), cluster_id_);
+    StandbySegmentRegistry temporary_registry;
+    auto restored = batch_oplog_snapshot_provider_->RestoreBaseline(
+        *temporary_metadata, temporary_registry, temporary_applier.get());
+    if (!restored) {
+        return restored.error();
+    }
+
+    // The provider has already replayed the suffix in temporary state. The
+    // running reader/applier starts from that proven final sequence.
+    metadata_store_ = std::move(temporary_metadata);
+    oplog_applier_ = std::move(temporary_applier);
+    baseline_seq_id = oplog_applier_->GetExpectedSequenceId() - 1;
+    batch_snapshot_baseline_ =
+        DurablePrefix{.batch_id = restored->last_included_batch_id,
+                      .last_seq = restored->last_included_seq};
+    return ErrorCode::OK;
+}
+
 ErrorCode HotStandbyService::StartOplogFollowingLocked(
     uint64_t baseline_seq_id) {
     (void)baseline_seq_id;
@@ -259,6 +288,13 @@ ErrorCode HotStandbyService::StartOplogFollowingLocked(
     }
     batch_standby_reader_ = std::make_unique<OpLogBatchStandbyReader>(
         cluster_id_, *batch_standby_kv_backend_, *oplog_applier_);
+    if (batch_snapshot_baseline_) {
+        const ErrorCode cursor_error =
+            batch_standby_reader_->SetBaselineCursor(*batch_snapshot_baseline_);
+        if (cursor_error != ErrorCode::OK) {
+            return cursor_error;
+        }
+    }
 
     state_machine_.ProcessEvent(StandbyEvent::SYNC_COMPLETE);
     replication_loop_running_.store(true, std::memory_order_release);
@@ -496,7 +532,8 @@ ErrorCode HotStandbyService::Promote() {
 
     LOG(INFO) << "Promoting Standby to Primary. Applied seq_id: "
               << current_applied_seq_id << ", lag: " << status.lag_entries
-              << " entries" << ", state: " << StandbyStateToString(GetState());
+              << " entries"
+              << ", state: " << StandbyStateToString(GetState());
 
     auto internal_err = PromoteLockedInternal(current_applied_seq_id);
     if (internal_err != ErrorCode::OK) {
@@ -755,6 +792,12 @@ void HotStandbyService::SetSnapshotProvider(
     } else {
         snapshot_provider_ = std::make_unique<NoopSnapshotProvider>();
     }
+}
+
+void HotStandbyService::SetBatchOpLogSnapshotProvider(
+    std::unique_ptr<BatchOpLogSnapshotProvider> provider) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    batch_oplog_snapshot_provider_ = std::move(provider);
 }
 
 void HotStandbyService::ReplicationLoop() {

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -273,8 +273,8 @@ ErrorCode HotStandbyService::LoadBatchOpLogSnapshotBaselineLocked(
     oplog_applier_ = std::move(temporary_applier);
     baseline_seq_id = oplog_applier_->GetExpectedSequenceId() - 1;
     batch_snapshot_baseline_ =
-        DurablePrefix{.batch_id = restored->last_included_batch_id,
-                      .last_seq = restored->last_included_seq};
+        DurablePrefix{.batch_id = restored->last_applied_batch_id,
+                      .last_seq = restored->last_applied_seq};
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -170,6 +170,8 @@ add_ha_test(batch_oplog_snapshot_codec_test
             ha/snapshot/batch_oplog/codec_test.cpp)
 add_ha_test(batch_oplog_snapshot_writer_test
             ha/snapshot/batch_oplog/writer_test.cpp)
+add_ha_test(batch_oplog_snapshot_provider_test
+            ha/snapshot/batch_oplog/provider_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_standby_reader_test.cpp
@@ -108,6 +108,28 @@ TEST(OpLogBatchStandbyReaderTest, MissingPrefixWaitsWithoutLegacyFallback) {
     EXPECT_EQ(1u, applier.GetExpectedSequenceId());
 }
 
+TEST(OpLogBatchStandbyReaderTest, ResumesAfterSnapshotBatchCursor) {
+    FakeHaKvBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildBatchRecordKey("clusterA", 2),
+                          EncodeOpLogBatchRecord(MakeBatch(2, 2, 2))));
+
+    MockMetadataStore metadata_store;
+    OpLogApplier applier(&metadata_store, "clusterA");
+    applier.Recover(1);
+    OpLogBatchStandbyReader reader("clusterA", backend, applier);
+    ASSERT_EQ(ErrorCode::OK,
+              reader.SetBaselineCursor({.batch_id = 1, .last_seq = 1}));
+
+    const auto result = reader.PollOnce();
+    EXPECT_EQ(ErrorCode::OK, result.error);
+    EXPECT_EQ(1u, result.applied_entries);
+    EXPECT_EQ(3u, applier.GetExpectedSequenceId());
+}
+
 TEST(OpLogBatchStandbyReaderTest, MissingPrefixAfterObservationFailsClosed) {
     FakeHaKvBackend backend;
     ASSERT_EQ(ErrorCode::OK,

--- a/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
+++ b/mooncake-store/tests/ha/oplog/oplog_batch_storage_test.cpp
@@ -327,12 +327,33 @@ TEST(OpLogBatchStorageTest, RejectsLegacyEntry) {
 
 TEST(OpLogBatchStorageTest, RejectsLegacySnapshotSidecar) {
     FakeHaKvBackend backend;
+    for (const std::string_view key :
+         {"compaction_floor", "fallback", "latest", "maintenance"}) {
+        ASSERT_EQ(ErrorCode::OK,
+                  backend.Put("/oplog/clusterA/snapshot/" + std::string(key),
+                              "control"));
+    }
     ASSERT_EQ(ErrorCode::OK,
               backend.Put("/oplog/clusterA/snapshot/old/sequence_id", "42"));
     OpLogBatchStorage storage("clusterA", backend);
 
     DurablePrefix prefix;
     EXPECT_NE(ErrorCode::OK, storage.InitDurablePrefix(prefix));
+}
+
+TEST(OpLogBatchStorageTest, AllowsBatchSnapshotControlKeys) {
+    FakeHaKvBackend backend;
+    for (const std::string_view key :
+         {"compaction_floor", "fallback", "latest", "maintenance"}) {
+        ASSERT_EQ(ErrorCode::OK,
+                  backend.Put("/oplog/clusterA/snapshot/" + std::string(key),
+                              "control"));
+    }
+    OpLogBatchStorage storage("clusterA", backend);
+
+    DurablePrefix prefix;
+    EXPECT_EQ(ErrorCode::OK, storage.InitDurablePrefix(prefix));
+    EXPECT_EQ((DurablePrefix{.batch_id = 0, .last_seq = 0}), prefix);
 }
 
 TEST(OpLogBatchStorageTest, InitDurablePrefixFailsClosedWhenBatchesExist) {

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
@@ -1,0 +1,137 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string_view>
+#include <vector>
+
+#include "crc32c.h"
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_codec.h"
+#include "ha/snapshot/batch_oplog/codec.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
+
+namespace mooncake::test {
+namespace {
+
+class EmptyBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        values_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view begin, std::string_view end, size_t limit,
+                    std::vector<KvPair>& output) override {
+        output.clear();
+        for (const auto& [key, value] : values_) {
+            if (key >= begin && key < end &&
+                (limit == 0 || output.size() < limit)) {
+                output.push_back({key, value});
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+
+    ErrorCode Txn(const KvTxn& txn) override {
+        for (const auto& put : txn.puts) {
+            values_[put.key] = put.value;
+        }
+        return ErrorCode::OK;
+    }
+
+   private:
+    std::map<std::string, std::string> values_;
+};
+
+}  // namespace
+
+TEST(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
+    EmptyBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n05-provider-test");
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+
+    auto result = provider.RestoreBaseline(metadata, registry);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(0u, result->last_included_seq);
+    EXPECT_EQ(0u, result->last_included_batch_id);
+    EXPECT_EQ(0u, metadata.GetKeyCount());
+    EXPECT_TRUE(registry.GetAllSegments().empty());
+}
+
+TEST(BatchOpLogSnapshotProviderTest, UsesFallbackWhenLatestIsCorrupt) {
+    const std::string root = "/tmp/mooncake-n05-provider-fallback";
+    LocalFileSnapshotObjectStore object_store(root);
+    EmptyBackend backend;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+
+    const std::string snapshot_id = "0-7";
+    const std::string segments_key =
+        ha::BuildBatchOpLogSnapshotSegmentsKey("snapshots", snapshot_id);
+    const auto segments = EncodeBatchOpLogSnapshotSegments({});
+    ASSERT_TRUE(object_store.UploadBuffer(segments_key, segments));
+    ha::BatchOpLogSnapshotManifest manifest;
+    manifest.snapshot_id = snapshot_id;
+    manifest.segments = {
+        .key = segments_key,
+        .stored_size = segments.size(),
+        .crc32c = Crc32cValue(segments.data(), segments.size())};
+    const std::string manifest_key =
+        ha::BuildBatchOpLogSnapshotManifestKey("snapshots", snapshot_id);
+    const std::string manifest_bytes =
+        ha::EncodeBatchOpLogSnapshotManifest(manifest);
+    ASSERT_TRUE(object_store.UploadString(manifest_key, manifest_bytes));
+
+    ha::BatchOpLogSnapshotDescriptor descriptor;
+    descriptor.snapshot_id = snapshot_id;
+    descriptor.manifest_key = manifest_key;
+    descriptor.manifest_size = manifest_bytes.size();
+    descriptor.manifest_crc32c =
+        Crc32cValue(manifest_bytes.data(), manifest_bytes.size());
+    const std::string descriptor_bytes =
+        ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
+    const std::string descriptor_key =
+        ha::BuildBatchOpLogSnapshotDescriptorKey("snapshots", snapshot_id);
+    ASSERT_TRUE(object_store.UploadString(descriptor_key, descriptor_bytes));
+
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put(ha::BuildBatchOpLogSnapshotLatestKey("clusterA"), "{}"));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("clusterA"),
+                          descriptor_bytes));
+
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+    auto result = provider.RestoreBaseline(metadata, registry);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(0u, result->last_included_seq);
+    EXPECT_EQ(0u, metadata.GetKeyCount());
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
@@ -61,6 +61,26 @@ class EmptyBackend final : public HaKvBackend {
 
 }  // namespace
 
+TEST(BatchOpLogSnapshotProviderTest, AllAbsentNamespaceIsAnEmptyBaseline) {
+    EmptyBackend backend;
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n05-provider-all-absent");
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+
+    auto result = provider.RestoreBaseline(metadata, registry);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(0u, result->last_applied_seq);
+    EXPECT_EQ(0u, result->last_applied_batch_id);
+    std::string prefix;
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Get(BuildDurablePrefixKey("clusterA"), prefix));
+    EXPECT_EQ(EncodeDurablePrefix({.batch_id = 0, .last_seq = 0}), prefix);
+}
+
 TEST(BatchOpLogSnapshotProviderTest, EmptyCompleteHistoryIsAValidBaseline) {
     EmptyBackend backend;
     ASSERT_EQ(ErrorCode::OK,
@@ -203,6 +223,48 @@ TEST(BatchOpLogSnapshotProviderTest, ReturnsFinalCursorAfterSuffixReplay) {
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(1u, result->last_included_seq);
     EXPECT_EQ(1u, result->last_included_batch_id);
+    EXPECT_EQ(2u, result->last_applied_seq);
+    EXPECT_EQ(2u, result->last_applied_batch_id);
+}
+
+TEST(BatchOpLogSnapshotProviderTest,
+     ReplaysCompleteHistoryAfterBothPointersAreInvalid) {
+    const std::string root = "/tmp/mooncake-n05-provider-complete-oplog";
+    LocalFileSnapshotObjectStore object_store(root);
+    EmptyBackend backend;
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put(ha::BuildBatchOpLogSnapshotLatestKey("clusterA"), "{}"));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend.Put(ha::BuildBatchOpLogSnapshotFallbackKey("clusterA"), "{}"));
+
+    for (uint64_t id = 1; id <= 2; ++id) {
+        OpLogEntry entry;
+        entry.sequence_id = id;
+        entry.op_type = OpType::REMOVE;
+        entry.tenant_id = "tenant";
+        entry.object_key = "key-" + std::to_string(id);
+        OpLogBatchRecord batch;
+        batch.batch_id = id;
+        batch.first_seq = id;
+        batch.last_seq = id;
+        batch.entries.push_back(std::move(entry));
+        ASSERT_EQ(ErrorCode::OK,
+                  backend.Put(BuildBatchRecordKey("clusterA", id),
+                              EncodeOpLogBatchRecord(batch)));
+    }
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
+
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+    auto result = provider.RestoreBaseline(metadata, registry);
+
+    ASSERT_TRUE(result.has_value());
     EXPECT_EQ(2u, result->last_applied_seq);
     EXPECT_EQ(2u, result->last_applied_batch_id);
 }

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/provider_test.cpp
@@ -4,11 +4,13 @@
 
 #include <map>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "crc32c.h"
 #include "ha/kv/ha_kv_backend.h"
 #include "ha/oplog/oplog_batch_codec.h"
+#include "ha/oplog/oplog_batch_types.h"
 #include "ha/snapshot/batch_oplog/codec.h"
 #include "ha/snapshot/batch_oplog/metadata.h"
 #include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
@@ -132,6 +134,77 @@ TEST(BatchOpLogSnapshotProviderTest, UsesFallbackWhenLatestIsCorrupt) {
     ASSERT_TRUE(result.has_value());
     EXPECT_EQ(0u, result->last_included_seq);
     EXPECT_EQ(0u, metadata.GetKeyCount());
+}
+
+TEST(BatchOpLogSnapshotProviderTest, ReturnsFinalCursorAfterSuffixReplay) {
+    const std::string root = "/tmp/mooncake-n05-provider-suffix";
+    LocalFileSnapshotObjectStore object_store(root);
+    EmptyBackend backend;
+
+    OpLogBatchRecord suffix_batch;
+    suffix_batch.batch_id = 2;
+    suffix_batch.first_seq = 2;
+    suffix_batch.last_seq = 2;
+    OpLogEntry suffix_entry;
+    suffix_entry.sequence_id = 2;
+    suffix_entry.op_type = OpType::REMOVE;
+    suffix_entry.tenant_id = "tenant";
+    suffix_entry.object_key = "suffix-key";
+    suffix_batch.entries.push_back(std::move(suffix_entry));
+    ASSERT_EQ(ErrorCode::OK, backend.Put(BuildBatchRecordKey("clusterA", 2),
+                                         EncodeOpLogBatchRecord(suffix_batch)));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(BuildDurablePrefixKey("clusterA"),
+                          EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
+
+    const std::string snapshot_id = "1-7";
+    const auto segments = EncodeBatchOpLogSnapshotSegments({});
+    const std::string segments_key =
+        ha::BuildBatchOpLogSnapshotSegmentsKey("snapshots", snapshot_id);
+    ASSERT_TRUE(object_store.UploadBuffer(segments_key, segments));
+
+    ha::BatchOpLogSnapshotManifest manifest;
+    manifest.snapshot_id = snapshot_id;
+    manifest.last_included_seq = 1;
+    manifest.last_included_batch_id = 1;
+    manifest.segments = {
+        .key = segments_key,
+        .stored_size = segments.size(),
+        .crc32c = Crc32cValue(segments.data(), segments.size())};
+    const std::string manifest_bytes =
+        ha::EncodeBatchOpLogSnapshotManifest(manifest);
+    const std::string manifest_key =
+        ha::BuildBatchOpLogSnapshotManifestKey("snapshots", snapshot_id);
+    ASSERT_TRUE(object_store.UploadString(manifest_key, manifest_bytes));
+
+    ha::BatchOpLogSnapshotDescriptor descriptor;
+    descriptor.snapshot_id = snapshot_id;
+    descriptor.last_included_seq = 1;
+    descriptor.last_included_batch_id = 1;
+    descriptor.manifest_key = manifest_key;
+    descriptor.manifest_size = manifest_bytes.size();
+    descriptor.manifest_crc32c =
+        Crc32cValue(manifest_bytes.data(), manifest_bytes.size());
+    const std::string descriptor_bytes =
+        ha::EncodeBatchOpLogSnapshotDescriptor(descriptor);
+    const std::string descriptor_key =
+        ha::BuildBatchOpLogSnapshotDescriptorKey("snapshots", snapshot_id);
+    ASSERT_TRUE(object_store.UploadString(descriptor_key, descriptor_bytes));
+    ASSERT_EQ(ErrorCode::OK,
+              backend.Put(ha::BuildBatchOpLogSnapshotLatestKey("clusterA"),
+                          descriptor_bytes));
+
+    BatchOpLogSnapshotProvider provider("clusterA", backend, object_store,
+                                        "snapshots");
+    StandbyMetadataStore metadata;
+    StandbySegmentRegistry registry;
+    auto result = provider.RestoreBaseline(metadata, registry);
+
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(1u, result->last_included_seq);
+    EXPECT_EQ(1u, result->last_included_batch_id);
+    EXPECT_EQ(2u, result->last_applied_seq);
+    EXPECT_EQ(2u, result->last_applied_batch_id);
 }
 
 }  // namespace mooncake::test


### PR DESCRIPTION
## Description

This PR implements PR-N05 of the standby snapshot and bounded OpLog retention RFC (#3167).

It adds a batch-OpLog-specific snapshot bootstrap path that:

- restores candidates in the fixed order: `latest`, `fallback`, then proven complete OpLog history;
- verifies pointer and object-store `descriptor.json` bytes are identical;
- validates manifest, segments, and object chunks using size, CRC32C, snapshot identity, cursor, chunk index, and object count;
- rejects duplicate objects, zero or duplicate per-object `ReplicaID` values, invalid tenant IDs, and inconsistent cursors;
- distinguishes invalid snapshot candidates from infrastructure failures, so backend timeouts and connection failures do not silently fall back;
- restores and replays the suffix in temporary standby state, installing it into `HotStandbyService` only after the full restore succeeds;
- seeds `OpLogBatchStandbyReader` with the snapshot batch cursor and requires batch 1 / sequence 1 when proving complete OpLog history.

The new provider and tests are isolated under `ha/snapshot/batch_oplog/`. The legacy snapshot provider, catalog fallback, scheduler, pruning, and production configuration are unchanged.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] New feature

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B /tmp/mooncake-n05-build \
  -DCMAKE_BUILD_TYPE=Debug \
  -DBUILD_UNIT_TESTS=ON \
  -DSTORE_USE_ETCD=ON \
  -DUSE_ETCD=OFF \
  -DUSE_HTTP=ON \
  -DUSE_UB=OFF \
  -DUSE_CUDA=OFF

cmake --build /tmp/mooncake-n05-build -j32

ctest --test-dir /tmp/mooncake-n05-build --output-on-failure \
  -R 'batch_oplog_snapshot_provider_test|oplog_batch_standby_reader_test|batch_oplog_snapshot_types_test|batch_oplog_snapshot_codec_test|batch_oplog_snapshot_writer_test|hot_standby_snapshot_bootstrap_test'
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done

The complete build finished successfully. All six N05 and adjacent snapshot /
standby test targets passed.

A full `ctest -j32` run completed with 107/141 targets passing. The remaining 34 failures require capabilities unavailable in the sandbox, mainly TCP/UDS socket binding, runtime service stacks, or in-source test-data paths. None of the N05-related targets failed.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not applicable because production configuration and
      user-facing wiring are outside PR-N05
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: RFC #3167 covers this design

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with implementation, code inspection, test development, build validation, and drafting this PR description. The human submitter is responsible for reviewing and understanding every changed line before merge.