### PR TITLE
[TENT] Derive per-NIC bandwidth from the negotiated port speed

### DIFF
--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -263,14 +263,18 @@ All slice spraying parameters are configurable via the configuration file:
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `default_bandwidth_gbps` | float | `400.0` | Default NIC bandwidth when topology info unavailable |
+| `default_bandwidth_gbps` | float | `400.0` | NIC bandwidth assumed when the port speed is unknown or out of range |
 | `min_bandwidth_gbps` | float | `10.0` | Minimum valid NIC bandwidth (Gbps) |
 | `max_bandwidth_gbps` | float | `800.0` | Maximum valid NIC bandwidth (Gbps) |
 
 **Notes**:
-- These constants define the valid range and default for device bandwidth
-- Used in EWMA calculations and theoretical bandwidth estimation
-- If a device's reported bandwidth is outside [min, max], default_bandwidth is used
+- Each device's bandwidth is read from the speed and width its port
+  negotiated (`ibv_query_port`), so a 100G and a 400G NIC in the same host
+  start from different theoretical rates
+- The theoretical rate seeds the EWMA and bounds it to
+  `[ewma_min_multiplier, ewma_max_multiplier]` times that rate
+- If a device's port speed cannot be read or is outside [min, max],
+  `default_bandwidth_gbps` is used and a warning is logged
 
 ## Usage Examples
 

--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -280,7 +280,9 @@ All slice spraying parameters are configurable via the configuration file:
   excluded from device selection and from the aggregate bandwidth the
   admission queue's deadline predictor reads. The default speed applies
   only to a usable NIC whose speed could not be determined. `PORT_ERR`
-  marks a device unavailable and `PORT_ACTIVE` restores it
+  marks a device unavailable and `PORT_ACTIVE` restores it; both are
+  matched against the port the context opened, since a device's async
+  events cover every port of that device
 - The link speed is re-read on `IBV_EVENT_PORT_ACTIVE`, and on
   `IBV_EVENT_DEVICE_SPEED_CHANGE` where rdma-core (>= 62) provides it. If
   the speed changed -- a 400G link returning at 100G, or a VF over LAG

--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -275,6 +275,12 @@ All slice spraying parameters are configurable via the configuration file:
   `[ewma_min_multiplier, ewma_max_multiplier]` times that rate
 - If a device's port speed cannot be read or is outside [min, max],
   `default_bandwidth_gbps` is used and a warning is logged
+- A NIC that cannot carry traffic -- its context was never constructed,
+  `construct()` failed, or its port is down -- is marked unavailable: it is
+  excluded from device selection and from the aggregate bandwidth the
+  admission queue's deadline predictor reads. The default speed applies
+  only to a usable NIC whose speed could not be determined. `PORT_ERR`
+  marks a device unavailable and `PORT_ACTIVE` restores it
 
 ## Usage Examples
 

--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -281,6 +281,11 @@ All slice spraying parameters are configurable via the configuration file:
   admission queue's deadline predictor reads. The default speed applies
   only to a usable NIC whose speed could not be determined. `PORT_ERR`
   marks a device unavailable and `PORT_ACTIVE` restores it
+- The link speed is re-read on `IBV_EVENT_PORT_ACTIVE`, and on
+  `IBV_EVENT_DEVICE_SPEED_CHANGE` where rdma-core (>= 62) provides it. If
+  the speed changed -- a 400G link returning at 100G, or a VF over LAG
+  losing a PF -- the device's EWMA is re-seeded and its clamp re-derived; a
+  link that returns at the same speed keeps its learned estimate
 
 ## Usage Examples
 

--- a/mooncake-common/include/ib_link_speed.h
+++ b/mooncake-common/include/ib_link_speed.h
@@ -1,0 +1,75 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MOONCAKE_IB_LINK_SPEED_H_
+#define MOONCAKE_IB_LINK_SPEED_H_
+
+namespace mooncake {
+
+// Per-lane signalling rate for an ibv_port_attr::active_speed encoding
+// (see ibv_query_port(3)). Returns 0 for an encoding that is not known.
+inline double ibLaneSpeedGbps(int active_speed) {
+    switch (active_speed) {
+        case 1:
+            return 2.5;  // SDR
+        case 2:
+            return 5.0;  // DDR
+        case 4:
+            return 10.0;  // QDR
+        case 8:
+            return 10.0;  // FDR10
+        case 16:
+            return 14.0;  // FDR
+        case 32:
+            return 25.0;  // EDR
+        case 64:
+            return 50.0;  // HDR
+        case 128:
+            return 100.0;  // NDR
+        case 256:
+            return 200.0;  // XDR
+        default:
+            return 0.0;
+    }
+}
+
+// Lane count for an ibv_port_attr::active_width encoding. Returns 0 for an
+// encoding that is not known.
+inline int ibLinkWidthLanes(int active_width) {
+    switch (active_width) {
+        case 1:
+            return 1;
+        case 2:
+            return 4;
+        case 4:
+            return 8;
+        case 8:
+            return 12;
+        case 16:
+            return 2;
+        default:
+            return 0;
+    }
+}
+
+// Link speed in Gbps from the raw ibv_port_attr encodings, or 0 when either
+// encoding is unknown so the caller can fall back explicitly rather than
+// scheduling against a guessed rate.
+inline double ibLinkSpeedGbps(int active_speed, int active_width) {
+    return ibLaneSpeedGbps(active_speed) * ibLinkWidthLanes(active_width);
+}
+
+}  // namespace mooncake
+
+#endif  // MOONCAKE_IB_LINK_SPEED_H_

--- a/mooncake-common/tests/CMakeLists.txt
+++ b/mooncake-common/tests/CMakeLists.txt
@@ -28,3 +28,8 @@ foreach(parser_test ascii_string bool_parser environment_value_parser
                                                    gtest_main pthread)
   add_test(NAME ${parser_test}_test COMMAND ${parser_test}_test)
 endforeach()
+
+add_executable(ib_link_speed_test ib_link_speed_test.cpp)
+target_link_libraries(ib_link_speed_test PUBLIC mooncake_common gtest
+                                                gtest_main pthread)
+add_test(NAME ib_link_speed_test COMMAND ib_link_speed_test)

--- a/mooncake-common/tests/ib_link_speed_test.cpp
+++ b/mooncake-common/tests/ib_link_speed_test.cpp
@@ -1,0 +1,64 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ib_link_speed.h"
+
+#include <gtest/gtest.h>
+
+namespace mooncake {
+namespace {
+
+struct LinkSpeedCase {
+    int active_speed;
+    int active_width;
+    double expected_gbps;
+};
+
+// active_speed / active_width are the raw ibv_port_attr encodings from
+// ibv_query_port(3): speed is the per-lane rate, width is the lane count.
+TEST(IbLinkSpeedTest, ConvertsPortAttrEncodingsToGbps) {
+    const LinkSpeedCase cases[] = {
+        {1, 1, 2.5},      // SDR x1
+        {2, 2, 20.0},     // DDR x4
+        {4, 2, 40.0},     // QDR x4
+        {8, 2, 40.0},     // FDR10 x4
+        {16, 2, 56.0},    // FDR x4
+        {32, 2, 100.0},   // EDR x4  (ConnectX-4/5 100G)
+        {64, 2, 200.0},   // HDR x4  (ConnectX-6 200G)
+        {128, 2, 400.0},  // NDR x4 (ConnectX-7 400G)
+        {256, 2, 800.0},  // XDR x4
+        {32, 16, 50.0},   // EDR x2
+        {64, 1, 50.0},    // HDR x1
+        {64, 4, 400.0},   // HDR x8
+        {32, 8, 300.0},   // EDR x12
+    };
+    for (const auto& c : cases) {
+        EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(c.active_speed, c.active_width),
+                         c.expected_gbps)
+            << "speed=" << c.active_speed << " width=" << c.active_width;
+    }
+}
+
+// An encoding the table does not know must not be guessed at: 0 tells the
+// caller the speed is unknown so it can fall back explicitly.
+TEST(IbLinkSpeedTest, UnknownEncodingsReportZero) {
+    EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(0, 2), 0.0);   // speed unset
+    EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(32, 0), 0.0);  // width unset
+    EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(3, 2), 0.0);   // not a speed bit
+    EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(32, 3), 0.0);  // not a width bit
+    EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(-1, 2), 0.0);  // classic TE default
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/src/CMakeLists.txt
@@ -2,6 +2,18 @@ file(GLOB ENGINE_SOURCES "*.cpp" "shared_segment/*.cpp")
 set(TRANSFER_METADATA_PLUGIN_SOURCES config.cpp transfer_metadata_plugin.cpp)
 list(REMOVE_ITEM ENGINE_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/config.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/transfer_metadata_plugin.cpp")
+# ibv_port_attr::active_speed is a uint8_t and reads 0 for XDR (encoding 256);
+# newer rdma-core adds active_speed_ex to carry it. TENT probes the same cache
+# variable in tent/src; this definition covers the classic RdmaContext under
+# transport/ so both decode the port speed the same way.
+include(CheckStructHasMember)
+check_struct_has_member(
+  "struct ibv_port_attr" active_speed_ex infiniband/verbs.h
+  HAVE_IBV_ACTIVE_SPEED_EX LANGUAGE CXX)
+if(HAVE_IBV_ACTIVE_SPEED_EX)
+  add_compile_definitions(HAVE_IBV_ACTIVE_SPEED_EX)
+endif()
+
 add_subdirectory(common)
 add_subdirectory(transport)
 

--- a/mooncake-transfer-engine/src/show_links.cpp
+++ b/mooncake-transfer-engine/src/show_links.cpp
@@ -16,7 +16,8 @@
 
 #include <json/json.h>
 
-#include <algorithm>
+#include "ib_link_speed.h"
+
 #include <sstream>
 
 #include "transfer_engine_impl.h"
@@ -64,64 +65,9 @@ static bool hasTransportDetails(const NicDiagInfo& nic) {
     return nic.gid_index >= 0;
 }
 
+// Truncated to whole Gbps so the diagnostic output keeps its integer shape.
 static int computeSpeedGbps(int active_speed, int active_width) {
-    if (active_width <= 0) return 0;
-
-    int lane_gbps = 0;
-    switch (active_speed) {
-        case 1:
-            lane_gbps = 2;
-            break;
-        case 2:
-            lane_gbps = 5;
-            break;
-        case 4:
-            lane_gbps = 10;
-            break;
-        case 8:
-            lane_gbps = 10;
-            break;
-        case 16:
-            lane_gbps = 14;
-            break;
-        case 32:
-            lane_gbps = 25;
-            break;
-        case 64:
-            lane_gbps = 50;
-            break;
-        case 128:
-            lane_gbps = 100;
-            break;
-        case 256:
-            lane_gbps = 200;
-            break;
-        default:
-            lane_gbps = std::max(0, active_speed);
-            break;
-    }
-    int lanes = 1;
-    switch (active_width) {
-        case 1:
-            lanes = 1;
-            break;
-        case 2:
-            lanes = 4;
-            break;
-        case 4:
-            lanes = 8;
-            break;
-        case 8:
-            lanes = 12;
-            break;
-        case 16:
-            lanes = 2;
-            break;
-        default:
-            lanes = 1;
-            break;
-    }
-    return lane_gbps * lanes;
+    return static_cast<int>(ibLinkSpeedGbps(active_speed, active_width));
 }
 
 std::string buildShowLinksJson(TransferEngineImpl* impl) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -1421,6 +1421,12 @@ int RdmaContext::openRdmaDevice(const std::string &device_name, uint8_t port,
         lid_ = attr.lid;
         active_mtu_ = attr.active_mtu;
         active_speed_ = attr.active_speed;
+#ifdef HAVE_IBV_ACTIVE_SPEED_EX
+        // XDR (encoding 256) overflows the uint8_t field above, which then
+        // reads 0; the extended field carries it on rdma-core builds that
+        // have one.
+        if (attr.active_speed_ex) active_speed_ = attr.active_speed_ex;
+#endif
         active_width_ = attr.active_width;
         {
             std::lock_guard<std::mutex> guard(gid_lock_);

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -167,6 +167,9 @@ struct TransferStatus {
     size_t transferred_bytes;
 };
 
+// One RDMA NIC's load snapshot. Only NICs currently able to carry traffic
+// are reported: a NIC whose context failed to construct or whose port is
+// down is omitted rather than listed with a meaningless bandwidth.
 struct NicLoadStats {
     std::string device_name;
     uint64_t inflight_bytes{0};

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -207,6 +207,7 @@ int tent_register_memory_batch_ex(tent_engine_t engine, void** addrs,
 int tent_task_status_list(tent_engine_t engine, tent_batch_id_t batch_id,
                           tent_status_t* statuses, size_t* count);
 
+// Only NICs currently able to carry traffic are reported (see NicLoadStats).
 struct tent_nic_load_stat {
     char device_name[64];
     uint64_t inflight_bytes;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -110,7 +110,8 @@ class RdmaContext {
 
     ibv_pd *nativePD() const { return native_pd_; }
 
-    uint8_t portNum() const { return params_->device.port; }
+    // The one port this context opened; 0 for a slot that never constructed.
+    uint8_t portNum() const { return params_ ? params_->device.port : 0; }
 
     // Negotiated port speed in Gbps, 0 when it could not be determined.
     double linkSpeedGbps() const;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -115,6 +115,13 @@ class RdmaContext {
     // Negotiated port speed in Gbps, 0 when it could not be determined.
     double linkSpeedGbps() const;
 
+    // Re-read the port's negotiated speed and width from the hardware, so
+    // linkSpeedGbps() reflects a renegotiated link. Called from the monitor
+    // thread on IBV_EVENT_PORT_ACTIVE / IBV_EVENT_DEVICE_SPEED_CHANGE.
+    // Returns -1 and leaves the cached values untouched if no device is
+    // open or the query fails.
+    int refreshPortAttributes();
+
     int eventFd() const { return event_fd_; }
 
     RdmaCQ *cq(int index);
@@ -131,6 +138,8 @@ class RdmaContext {
 
    private:
     int openDevice(const std::string &device_name, uint8_t port);
+    // Decode one ibv_query_port result into active_speed_/active_width_.
+    void recordPortSpeed(const ibv_port_attr &port_attr);
 
     // Release every resource currently owned by this context. This is
     // intentionally state-independent so it can clean up a partially completed
@@ -154,8 +163,11 @@ class RdmaContext {
     std::vector<ibv_comp_channel *> comp_channel_;
 
     uint16_t lid_ = 0;
-    int active_speed_ = 0;
-    int active_width_ = 0;
+    // Set by openDevice() and refreshed by refreshPortAttributes() on the
+    // monitor thread. Today every runtime reader is that same thread;
+    // atomic so a reader added elsewhere stays well-defined.
+    std::atomic<int> active_speed_{0};
+    std::atomic<int> active_width_{0};
     int gid_index_ = -1;
     ibv_gid gid_;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -112,6 +112,9 @@ class RdmaContext {
 
     uint8_t portNum() const { return params_->device.port; }
 
+    // Negotiated port speed in Gbps, 0 when it could not be determined.
+    double linkSpeedGbps() const;
+
     int eventFd() const { return event_fd_; }
 
     RdmaCQ *cq(int index);
@@ -151,6 +154,8 @@ class RdmaContext {
     std::vector<ibv_comp_channel *> comp_channel_;
 
     uint16_t lid_ = 0;
+    int active_speed_ = 0;
+    int active_width_ = 0;
     int gid_index_ = -1;
     ibv_gid gid_;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -30,11 +30,6 @@
 namespace mooncake {
 namespace tent {
 
-// Bandwidth constants (Gbps)
-static constexpr double kDefaultBwGbps = 400.0;
-static constexpr double kMinBwGbps = 10.0;
-static constexpr double kMaxBwGbps = 800.0;
-
 class SharedSlotManager;
 
 /**
@@ -93,12 +88,6 @@ class DeviceSelector {
         double getEwmaBandwidth() const {
             return ewma_bandwidth_bps.load(std::memory_order_relaxed);
         }
-
-        double getTheoreticalBandwidth() const {
-            if (bw_gbps >= kMinBwGbps && bw_gbps <= kMaxBwGbps)
-                return bw_gbps * 1e9 / 8.0;
-            return kDefaultBwGbps * 1e9 / 8.0;
-        }
     };
 
    public:
@@ -109,6 +98,12 @@ class DeviceSelector {
     DeviceSelector &operator=(const DeviceSelector &) = delete;
 
     Status loadTopology(std::shared_ptr<Topology> &local_topology);
+
+    // Record the link speed ibv_query_port reported for dev_id and re-seed
+    // its EWMA from it. A value outside [min, max]_bandwidth_gbps (including
+    // 0 = unknown) falls back to default_bandwidth_gbps. Call after
+    // setSchedulingParams and before any traffic.
+    Status setDeviceBandwidth(int dev_id, double gbps);
 
     std::shared_ptr<Topology> getTopology() const { return local_topology_; }
 
@@ -188,10 +183,11 @@ class DeviceSelector {
         double ewma_min_multiplier = 0.1;   // 10% of theoretical
         double ewma_max_multiplier = 10.0;  // 1000% of theoretical
 
-        // Default bandwidth (Gbps) when topology info unavailable
-        double default_bandwidth_gbps = 400.0;  // Default NIC bandwidth
-        double min_bandwidth_gbps = 10.0;       // Minimum valid NIC bandwidth
-        double max_bandwidth_gbps = 800.0;      // Maximum valid NIC bandwidth
+        // Bandwidth (Gbps) assumed for a device whose link speed is unknown
+        // or outside [min, max]
+        double default_bandwidth_gbps = 400.0;
+        double min_bandwidth_gbps = 10.0;   // Minimum valid NIC bandwidth
+        double max_bandwidth_gbps = 800.0;  // Maximum valid NIC bandwidth
 
         // Shared slot rotation interval (milliseconds)
         int slot_rotation_interval_ms = 2;
@@ -213,6 +209,10 @@ class DeviceSelector {
     std::shared_ptr<SharedSlotManager> slot_manager_;
     bool smart_selection_enabled_ = true;
     SchedulingParams sched_params_;
+
+    // Bytes/s the device is rated for: bw_gbps when it is inside the
+    // configured [min, max], default_bandwidth_gbps otherwise.
+    double theoreticalBandwidth(const DeviceInfo &dev) const;
 
     Status buildCandidates(const Topology::MemEntry *entry,
                            uint64_t slice_bytes, uint64_t device_mask,

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -63,8 +63,17 @@ class DeviceSelector {
 
     struct DeviceInfo {
         int dev_id;
-        double bw_gbps;
+        // Negotiated link speed in Gbps. setDeviceBandwidth() may rewrite it
+        // after traffic has started while workers read it in release(), so
+        // it is atomic.
+        std::atomic<double> bw_gbps{0.0};
         int numa_id;
+        // False for a NIC that cannot carry traffic: context never
+        // constructed, or port down. Excluded from candidate construction
+        // and from every aggregate; the bandwidth fields are meaningless
+        // while false. Fits the alignment hole after numa_id, so the padding
+        // below still puts inflight_bytes on its own cache line.
+        std::atomic<bool> available{true};
         uint64_t padding0[5];
         std::atomic<uint64_t> inflight_bytes{0};
         uint64_t padding1[7];
@@ -100,10 +109,20 @@ class DeviceSelector {
     Status loadTopology(std::shared_ptr<Topology> &local_topology);
 
     // Record the link speed ibv_query_port reported for dev_id and re-seed
-    // its EWMA from it. A value outside [min, max]_bandwidth_gbps (including
-    // 0 = unknown) falls back to default_bandwidth_gbps. Call after
-    // setSchedulingParams and before any traffic.
+    // its EWMA from it, replacing whatever was learned and re-deriving the
+    // clamp. A value outside [min, max]_bandwidth_gbps (including 0 =
+    // unknown) falls back to default_bandwidth_gbps. Call after
+    // setSchedulingParams; may be called again at runtime when the link
+    // renegotiates.
     Status setDeviceBandwidth(int dev_id, double gbps);
+
+    // Mark dev_id able (or unable) to carry traffic. Unavailable devices are
+    // never selected and do not count toward the aggregate bandwidth. May be
+    // called from the monitor thread while workers allocate; readers see the
+    // flag on their next allocate/aggregate.
+    Status setDeviceAvailable(int dev_id, bool available);
+    // False for an unknown device.
+    bool isDeviceAvailable(int dev_id) const;
 
     std::shared_ptr<Topology> getTopology() const { return local_topology_; }
 
@@ -213,6 +232,13 @@ class DeviceSelector {
     // Bytes/s the device is rated for: bw_gbps when it is inside the
     // configured [min, max], default_bandwidth_gbps otherwise.
     double theoreticalBandwidth(const DeviceInfo &dev) const;
+
+    // Known to the selector and currently able to carry traffic.
+    bool usable(int dev_id) const {
+        auto it = devices_.find(dev_id);
+        return it != devices_.end() &&
+               it->second.available.load(std::memory_order_relaxed);
+    }
 
     Status buildCandidates(const Topology::MemEntry *entry,
                            uint64_t slice_bytes, uint64_t device_mask,

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -82,7 +82,9 @@ class Workers {
     // failure load.
     void reclaimEndpoints();
 
-    int handleContextEvents(std::shared_ptr<RdmaContext>& context);
+    // dev_id is the NicID (context_set_ index), which is also the
+    // DeviceSelector id, so port events can flip that device's availability.
+    int handleContextEvents(int dev_id, std::shared_ptr<RdmaContext>& context);
 
     Status generatePostPath(RdmaSlice* slice);
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -86,6 +86,14 @@ class Workers {
     // DeviceSelector id, so port events can flip that device's availability.
     int handleContextEvents(int dev_id, std::shared_ptr<RdmaContext>& context);
 
+    // The decision half of handleContextEvents, kept apart from
+    // ibv_get_async_event/ibv_ack_async_event so a synthesized event can
+    // drive it in tests. Port events (PORT_ERR/PORT_ACTIVE) name their port;
+    // a device's async fd delivers them for every port of the device, and a
+    // context opens exactly one, so events for another port are ignored.
+    void applyContextEvent(int dev_id, RdmaContext& context,
+                           const ibv_async_event& event);
+
     // Re-read the link speed after a port event and re-seed the selector if
     // it changed; a link that returns at the same speed keeps what it
     // learned.

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -86,6 +86,11 @@ class Workers {
     // DeviceSelector id, so port events can flip that device's availability.
     int handleContextEvents(int dev_id, std::shared_ptr<RdmaContext>& context);
 
+    // Re-read the link speed after a port event and re-seed the selector if
+    // it changed; a link that returns at the same speed keeps what it
+    // learned.
+    void refreshLinkSpeed(int dev_id, RdmaContext& context);
+
     Status generatePostPath(RdmaSlice* slice);
 
    private:

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -61,6 +61,18 @@ if(IBVERBS_LIB AND IBVERBS_INCLUDE)
   target_compile_definitions(tent_interface INTERFACE USE_RDMA)
   target_include_directories(tent_interface INTERFACE ${IBVERBS_INCLUDE})
   target_link_libraries(tent_interface INTERFACE ${IBVERBS_LIB})
+  # ibv_port_attr::active_speed is a uint8_t and reads 0 for XDR (encoding 256);
+  # newer rdma-core adds active_speed_ex to carry it.
+  include(CheckStructHasMember)
+  set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE})
+  check_struct_has_member(
+    "struct ibv_port_attr" active_speed_ex infiniband/verbs.h
+    HAVE_IBV_ACTIVE_SPEED_EX LANGUAGE CXX)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  if(HAVE_IBV_ACTIVE_SPEED_EX)
+    target_compile_definitions(tent_interface
+                               INTERFACE HAVE_IBV_ACTIVE_SPEED_EX)
+  endif()
 else()
   message(STATUS "RDMA: Disabled")
 endif()

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -73,6 +73,19 @@ if(IBVERBS_LIB AND IBVERBS_INCLUDE)
     target_compile_definitions(tent_interface
                                INTERFACE HAVE_IBV_ACTIVE_SPEED_EX)
   endif()
+  # IBV_EVENT_DEVICE_SPEED_CHANGE (rdma-core >= 62) reports a port speed change
+  # without a link flap. It is an enumerator, so probe by compiling.
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_INCLUDES ${IBVERBS_INCLUDE})
+  check_cxx_source_compiles(
+    "#include <infiniband/verbs.h>
+     int main() { return IBV_EVENT_DEVICE_SPEED_CHANGE == IBV_EVENT_PORT_ACTIVE; }"
+    HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE)
+  unset(CMAKE_REQUIRED_INCLUDES)
+  if(HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE)
+    target_compile_definitions(tent_interface
+                               INTERFACE HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE)
+  endif()
 else()
   message(STATUS "RDMA: Disabled")
 endif()

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -850,19 +850,39 @@ int RdmaContext::openDevice(const std::string& device_name, uint8_t port) {
 
     native_context_ = context.release();
     lid_ = port_attr.lid;
-    active_speed_ = port_attr.active_speed;
+    recordPortSpeed(port_attr);
+    return 0;
+}
+
+void RdmaContext::recordPortSpeed(const ibv_port_attr& port_attr) {
+    int speed = port_attr.active_speed;
 #ifdef HAVE_IBV_ACTIVE_SPEED_EX
     // XDR (encoding 256) overflows the uint8_t field above, which then
     // reads 0; the extended field carries it on rdma-core builds that have
     // one.
-    if (port_attr.active_speed_ex) active_speed_ = port_attr.active_speed_ex;
+    if (port_attr.active_speed_ex) speed = port_attr.active_speed_ex;
 #endif
-    active_width_ = port_attr.active_width;
+    active_speed_.store(speed, std::memory_order_relaxed);
+    active_width_.store(port_attr.active_width, std::memory_order_relaxed);
+}
+
+int RdmaContext::refreshPortAttributes() {
+    if (!native_context_) return -1;
+    ibv_port_attr port_attr;
+    if (verbs_.ibv_query_port_default(native_context_, params_->device.port,
+                                      &port_attr)) {
+        PLOG(WARNING) << "Failed to re-query port "
+                      << static_cast<int>(params_->device.port) << " on "
+                      << device_name_;
+        return -1;
+    }
+    recordPortSpeed(port_attr);
     return 0;
 }
 
 double RdmaContext::linkSpeedGbps() const {
-    return ibLinkSpeedGbps(active_speed_, active_width_);
+    return ibLinkSpeedGbps(active_speed_.load(std::memory_order_relaxed),
+                           active_width_.load(std::memory_order_relaxed));
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -35,6 +35,7 @@
 #include <cuda_runtime.h>
 #endif
 
+#include "ib_link_speed.h"
 #include "tent/common/status.h"
 #include "tent/transport/rdma/endpoint_store.h"
 
@@ -849,7 +850,19 @@ int RdmaContext::openDevice(const std::string& device_name, uint8_t port) {
 
     native_context_ = context.release();
     lid_ = port_attr.lid;
+    active_speed_ = port_attr.active_speed;
+#ifdef HAVE_IBV_ACTIVE_SPEED_EX
+    // XDR (encoding 256) overflows the uint8_t field above, which then
+    // reads 0; the extended field carries it on rdma-core builds that have
+    // one.
+    if (port_attr.active_speed_ex) active_speed_ = port_attr.active_speed_ex;
+#endif
+    active_width_ = port_attr.active_width;
     return 0;
+}
+
+double RdmaContext::linkSpeedGbps() const {
+    return ibLinkSpeedGbps(active_speed_, active_width_);
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -391,6 +391,10 @@ Status DeviceSelector::getNicLoadStats(std::vector<NicLoadStats>& stats) const {
     // devices_ is populated during topology load and remains stable while
     // transfers update the per-device atomic counters below.
     for (const auto& [dev_id, dev] : devices_) {
+        // Same rule as the aggregate: a NIC that cannot carry traffic has
+        // no meaningful load or bandwidth to report, and with zero inflight
+        // it would score as the best NIC of the lot.
+        if (!dev.available.load(std::memory_order_relaxed)) continue;
         std::string device_name = local_topology_->getNicName(dev_id);
         if (device_name.empty()) device_name = std::to_string(dev_id);
         stats.push_back(NicLoadStats{

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -18,6 +18,8 @@
 #include "tent/common/utils/random.h"
 #include "tent/common/utils/os.h"
 
+#include <glog/logging.h>
+
 #include <algorithm>
 #include <iostream>
 #include <iomanip>
@@ -31,13 +33,39 @@ Status DeviceSelector::loadTopology(std::shared_ptr<Topology>& local_topology) {
         if (!entry || entry->type != Topology::NIC_RDMA) continue;
         DeviceInfo& info = devices_[dev_id];
         info.dev_id = dev_id;
-        info.bw_gbps = kDefaultBwGbps;
+        info.bw_gbps = 0.0;  // unknown until setDeviceBandwidth
         info.numa_id = entry->numa_node;
-        info.ewma_bandwidth_bps.store(info.getTheoreticalBandwidth(),
+        info.ewma_bandwidth_bps.store(theoreticalBandwidth(info),
                                       std::memory_order_relaxed);
     }
     // Initialize device base priorities after all devices are loaded
     fillDevicePriorities();
+    return Status::OK();
+}
+
+double DeviceSelector::theoreticalBandwidth(const DeviceInfo& dev) const {
+    const auto& p = sched_params_;
+    double gbps = dev.bw_gbps;
+    if (gbps < p.min_bandwidth_gbps || gbps > p.max_bandwidth_gbps)
+        gbps = p.default_bandwidth_gbps;
+    return gbps * 1e9 / 8.0;
+}
+
+Status DeviceSelector::setDeviceBandwidth(int dev_id, double gbps) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end())
+        return Status::InvalidArgument("device not found");
+    auto& dev = it->second;
+    const auto& p = sched_params_;
+    if (gbps < p.min_bandwidth_gbps || gbps > p.max_bandwidth_gbps) {
+        LOG(WARNING) << "Device " << local_topology_->getNicName(dev_id)
+                     << " link speed " << gbps << " Gbps is "
+                     << (gbps <= 0.0 ? "unknown" : "outside the valid range")
+                     << ", assuming " << p.default_bandwidth_gbps << " Gbps";
+    }
+    dev.bw_gbps = gbps;
+    dev.ewma_bandwidth_bps.store(theoreticalBandwidth(dev),
+                                 std::memory_order_relaxed);
     return Status::OK();
 }
 
@@ -333,7 +361,7 @@ Status DeviceSelector::release(int dev_id, uint64_t length, double latency) {
     double new_ewma = alpha * current_ewma + (1.0 - alpha) * observed_bw;
 
     // Clamp to [min_multiplier, max_multiplier] of theoretical bandwidth
-    double theoretical_bw = dev.getTheoreticalBandwidth();
+    double theoretical_bw = theoreticalBandwidth(dev);
     new_ewma = std::max(
         sched_params_.ewma_min_multiplier * theoretical_bw,
         std::min(sched_params_.ewma_max_multiplier * theoretical_bw, new_ewma));

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -33,7 +33,7 @@ Status DeviceSelector::loadTopology(std::shared_ptr<Topology>& local_topology) {
         if (!entry || entry->type != Topology::NIC_RDMA) continue;
         DeviceInfo& info = devices_[dev_id];
         info.dev_id = dev_id;
-        info.bw_gbps = 0.0;  // unknown until setDeviceBandwidth
+        info.bw_gbps.store(0.0, std::memory_order_relaxed);  // unknown
         info.numa_id = entry->numa_node;
         info.ewma_bandwidth_bps.store(theoreticalBandwidth(info),
                                       std::memory_order_relaxed);
@@ -45,7 +45,7 @@ Status DeviceSelector::loadTopology(std::shared_ptr<Topology>& local_topology) {
 
 double DeviceSelector::theoreticalBandwidth(const DeviceInfo& dev) const {
     const auto& p = sched_params_;
-    double gbps = dev.bw_gbps;
+    double gbps = dev.bw_gbps.load(std::memory_order_relaxed);
     if (gbps < p.min_bandwidth_gbps || gbps > p.max_bandwidth_gbps)
         gbps = p.default_bandwidth_gbps;
     return gbps * 1e9 / 8.0;
@@ -63,10 +63,24 @@ Status DeviceSelector::setDeviceBandwidth(int dev_id, double gbps) {
                      << (gbps <= 0.0 ? "unknown" : "outside the valid range")
                      << ", assuming " << p.default_bandwidth_gbps << " Gbps";
     }
-    dev.bw_gbps = gbps;
+    dev.bw_gbps.store(gbps, std::memory_order_relaxed);
+    // A worker completing between these two stores clamps the old EWMA
+    // against the new rate once; the seed below overwrites it.
     dev.ewma_bandwidth_bps.store(theoreticalBandwidth(dev),
                                  std::memory_order_relaxed);
     return Status::OK();
+}
+
+Status DeviceSelector::setDeviceAvailable(int dev_id, bool available) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end())
+        return Status::InvalidArgument("device not found");
+    it->second.available.store(available, std::memory_order_relaxed);
+    return Status::OK();
+}
+
+bool DeviceSelector::isDeviceAvailable(int dev_id) const {
+    return usable(dev_id);
 }
 
 Status DeviceSelector::enableSharedQuota(const std::string& shm_name) {
@@ -113,7 +127,7 @@ Status DeviceSelector::allocate(uint64_t total_length, uint32_t num_slices,
             thread_local std::vector<int> tl_eligible;
             tl_eligible.clear();
             for (int dev_id : entry->device_list[rank]) {
-                if (!devices_.count(dev_id)) continue;
+                if (!usable(dev_id)) continue;
                 if ((device_mask & (1ULL << dev_id)) == 0) continue;
                 tl_eligible.push_back(dev_id);
             }
@@ -195,7 +209,7 @@ Status DeviceSelector::buildCandidates(const Topology::MemEntry* entry,
     // First pass: filter by device priority (QoS filtering)
     for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
         for (int dev_id : entry->device_list[rank]) {
-            if (!devices_.count(dev_id)) continue;
+            if (!usable(dev_id)) continue;
             if ((device_mask & (1ULL << dev_id)) == 0) continue;
             // QoS: Get device's current priority slot (local, per-process)
             // Device accepts request if dev_priority >= request_priority
@@ -208,11 +222,12 @@ Status DeviceSelector::buildCandidates(const Topology::MemEntry* entry,
         }
     }
 
-    // If no devices after filtering, fallback to all devices
+    // If no devices after priority filtering, fall back to every usable
+    // device. Availability is not a QoS filter and is never relaxed here.
     if (candidates.empty()) {
         for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
             for (int dev_id : entry->device_list[rank]) {
-                if (!devices_.count(dev_id)) continue;
+                if (!usable(dev_id)) continue;
                 if ((device_mask & (1ULL << dev_id)) == 0) continue;
                 add_candidate(dev_id, rank);
             }
@@ -430,6 +445,7 @@ int DeviceSelector::getDevicePriority(int dev_id) const {
 double DeviceSelector::getAggregateEwmaBandwidth() const {
     double total = 0.0;
     for (const auto& [id, dev] : devices_) {
+        if (!dev.available.load(std::memory_order_relaxed)) continue;
         total += dev.getEwmaBandwidth();
     }
     return total > 0.0 ? total : -1.0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -853,11 +853,36 @@ int Workers::handleContextEvents(int dev_id,
         LOG(WARNING) << "Action: " << context->name() << " down";
     } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
         context->resume();
+        // The link may have renegotiated while down: re-seed before the
+        // device becomes selectable so no worker scores it on the old rate.
+        refreshLinkSpeed(dev_id, *context);
         device_selector_->setDeviceAvailable(dev_id, true);
         LOG(WARNING) << "Action: " << context->name() << " up";
+#ifdef HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE
+    } else if (event.event_type == IBV_EVENT_DEVICE_SPEED_CHANGE) {
+        // rdma-core >= 62: a port speed changed without a link flap (e.g. a
+        // VF over LAG losing a PF). Device-level, so the event names no
+        // port; each context opens exactly one, so re-query that one.
+        refreshLinkSpeed(dev_id, *context);
+#endif
     }
     ibv_ack_async_event(&event);
     return 0;
+}
+
+void Workers::refreshLinkSpeed(int dev_id, RdmaContext& context) {
+    if (!device_selector_) return;
+    const double before = context.linkSpeedGbps();
+    if (context.refreshPortAttributes() != 0) return;  // already logged
+    const double after = context.linkSpeedGbps();
+    // Both values decode from the same integer encodings, so exact
+    // comparison is meaningful. A speed that can no longer be read (0)
+    // counts as a change: setDeviceBandwidth() then falls back to the
+    // configured default and warns, the same as at startup.
+    if (after == before) return;
+    LOG(WARNING) << context.name() << " link speed " << before << " -> "
+                 << after << " Gbps, re-seeding its bandwidth estimate";
+    device_selector_->setDeviceBandwidth(dev_id, after);
 }
 
 void Workers::reclaimEndpoints() {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -836,38 +836,71 @@ int Workers::handleContextEvents(int dev_id,
     LOG(WARNING) << "Received context async event "
                  << ibv_event_type_str(event.event_type) << " for context "
                  << context->name();
-    if (event.event_type == IBV_EVENT_QP_FATAL ||
-        event.event_type == IBV_EVENT_WQ_FATAL) {
-        auto endpoint = (RdmaEndPoint*)event.element.qp->qp_context;
-        context->endpointStore()->remove(endpoint);
-    } else if (event.event_type == IBV_EVENT_CQ_ERR) {
-        context->pause();
-        context->resume();
-        LOG(WARNING) << "Action: " << context->name() << " restarted";
-    } else if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
-               event.event_type == IBV_EVENT_PORT_ERR) {
-        context->pause();
-        // Out of selection and out of the aggregate until the port returns;
-        // its EWMA cannot learn anything while no traffic flows.
-        device_selector_->setDeviceAvailable(dev_id, false);
-        LOG(WARNING) << "Action: " << context->name() << " down";
-    } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
-        context->resume();
-        // The link may have renegotiated while down: re-seed before the
-        // device becomes selectable so no worker scores it on the old rate.
-        refreshLinkSpeed(dev_id, *context);
-        device_selector_->setDeviceAvailable(dev_id, true);
-        LOG(WARNING) << "Action: " << context->name() << " up";
-#ifdef HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE
-    } else if (event.event_type == IBV_EVENT_DEVICE_SPEED_CHANGE) {
-        // rdma-core >= 62: a port speed changed without a link flap (e.g. a
-        // VF over LAG losing a PF). Device-level, so the event names no
-        // port; each context opens exactly one, so re-query that one.
-        refreshLinkSpeed(dev_id, *context);
-#endif
-    }
+    applyContextEvent(dev_id, *context, event);
     ibv_ack_async_event(&event);
     return 0;
+}
+
+void Workers::applyContextEvent(int dev_id, RdmaContext& context,
+                                const ibv_async_event& event) {
+    switch (event.event_type) {
+        case IBV_EVENT_QP_FATAL:
+        case IBV_EVENT_WQ_FATAL: {
+            auto endpoint = (RdmaEndPoint*)event.element.qp->qp_context;
+            context.endpointStore()->remove(endpoint);
+            break;
+        }
+        case IBV_EVENT_CQ_ERR:
+            context.pause();
+            context.resume();
+            LOG(WARNING) << "Action: " << context.name() << " restarted";
+            break;
+        case IBV_EVENT_DEVICE_FATAL:
+            // Device-scoped: every port is gone.
+            context.pause();
+            device_selector_->setDeviceAvailable(dev_id, false);
+            LOG(WARNING) << "Action: " << context.name() << " down";
+            break;
+        case IBV_EVENT_PORT_ERR:
+        case IBV_EVENT_PORT_ACTIVE: {
+            if (event.element.port_num != context.portNum()) {
+                LOG(INFO) << context.name() << ": ignoring "
+                          << ibv_event_type_str(event.event_type)
+                          << " for port " << event.element.port_num
+                          << " (this context uses port "
+                          << static_cast<int>(context.portNum()) << ")";
+                break;
+            }
+            if (event.event_type == IBV_EVENT_PORT_ERR) {
+                context.pause();
+                // Out of selection and out of the aggregate until the port
+                // returns; its EWMA cannot learn anything while no traffic
+                // flows.
+                device_selector_->setDeviceAvailable(dev_id, false);
+                LOG(WARNING) << "Action: " << context.name() << " down";
+            } else {
+                context.resume();
+                // The link may have renegotiated while down: re-seed before
+                // the device becomes selectable so no worker scores it on
+                // the old rate.
+                refreshLinkSpeed(dev_id, context);
+                device_selector_->setDeviceAvailable(dev_id, true);
+                LOG(WARNING) << "Action: " << context.name() << " up";
+            }
+            break;
+        }
+#ifdef HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE
+        case IBV_EVENT_DEVICE_SPEED_CHANGE:
+            // rdma-core >= 62: a port speed changed without a link flap
+            // (e.g. a VF over LAG losing a PF). Device-level, so the event
+            // names no port; each context opens exactly one, so re-query
+            // that one.
+            refreshLinkSpeed(dev_id, context);
+            break;
+#endif
+        default:
+            break;
+    }
 }
 
 void Workers::refreshLinkSpeed(int dev_id, RdmaContext& context) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -188,16 +188,34 @@ Workers::Workers(RdmaTransport* transport)
 
     device_selector_->setSchedulingParams(params);
 
-    // Seed each device's bandwidth from the speed its port negotiated.
-    // context_set_ is indexed by NicID, the same id the selector uses; an
-    // inert slot (NIC skipped at init) has no port to read, so leave it on
-    // the configured default without logging a second warning for it.
+    // Seed each device from its context. context_set_ is indexed by NicID,
+    // the same id the selector uses. Three cases:
+    //   - no usable context (DEVICE_UNINIT: initializeContexts() replaced a
+    //     failed construct() with an inert slot; DEVICE_DISABLED handled the
+    //     same way defensively): the NIC cannot carry traffic, so it gets no
+    //     bandwidth at all -- not the default -- and leaves candidate
+    //     selection and the aggregate.
+    //   - port down at open (DEVICE_PAUSED): seeded from whatever the port
+    //     reports (possibly 0, i.e. the default), but unavailable until
+    //     IBV_EVENT_PORT_ACTIVE.
+    //   - DEVICE_ENABLED: seeded from the negotiated speed, or the configured
+    //     default (with a warning) when the speed could not be read.
     for (size_t dev_id = 0; dev_id < transport_->context_set_.size();
          ++dev_id) {
+        const auto* nic = transport_->local_topology_->getNicEntry(dev_id);
+        // Only NIC_RDMA entries have a selector slot (see loadTopology()).
+        if (!nic || nic->type != Topology::NIC_RDMA) continue;
         const auto& context = transport_->context_set_[dev_id];
-        if (!context || context->status() == RdmaContext::DEVICE_UNINIT)
+        const auto status =
+            context ? context->status() : RdmaContext::DEVICE_UNINIT;
+        if (status == RdmaContext::DEVICE_UNINIT ||
+            status == RdmaContext::DEVICE_DISABLED) {
+            device_selector_->setDeviceAvailable(dev_id, false);
             continue;
+        }
         device_selector_->setDeviceBandwidth(dev_id, context->linkSpeedGbps());
+        device_selector_->setDeviceAvailable(
+            dev_id, status == RdmaContext::DEVICE_ENABLED);
     }
 
     // ============================================================
@@ -811,7 +829,8 @@ void Workers::workerThread(int thread_id) {
     }
 }
 
-int Workers::handleContextEvents(std::shared_ptr<RdmaContext>& context) {
+int Workers::handleContextEvents(int dev_id,
+                                 std::shared_ptr<RdmaContext>& context) {
     ibv_async_event event;
     if (ibv_get_async_event(context->nativeContext(), &event) < 0) return -1;
     LOG(WARNING) << "Received context async event "
@@ -828,9 +847,13 @@ int Workers::handleContextEvents(std::shared_ptr<RdmaContext>& context) {
     } else if (event.event_type == IBV_EVENT_DEVICE_FATAL ||
                event.event_type == IBV_EVENT_PORT_ERR) {
         context->pause();
+        // Out of selection and out of the aggregate until the port returns;
+        // its EWMA cannot learn anything while no traffic flows.
+        device_selector_->setDeviceAvailable(dev_id, false);
         LOG(WARNING) << "Action: " << context->name() << " down";
     } else if (event.event_type == IBV_EVENT_PORT_ACTIVE) {
         context->resume();
+        device_selector_->setDeviceAvailable(dev_id, true);
         LOG(WARNING) << "Action: " << context->name() << " up";
     }
     ibv_ack_async_event(&event);
@@ -863,7 +886,9 @@ void Workers::monitorThread() {
             last_reclaim_time = current_time;
         }
 
-        for (auto& context : transport_->context_set_) {
+        for (size_t dev_id = 0; dev_id < transport_->context_set_.size();
+             ++dev_id) {
+            auto& context = transport_->context_set_[dev_id];
             struct epoll_event event;
             if (context->eventFd() < 0) continue;
             int num_events = epoll_wait(context->eventFd(), &event, 1, 100);
@@ -874,7 +899,7 @@ void Workers::monitorThread() {
             if (num_events == 0) continue;
             if (!(event.events & EPOLLIN)) continue;
             if (event.data.fd == context->nativeContext()->async_fd)
-                handleContextEvents(context);
+                handleContextEvents(static_cast<int>(dev_id), context);
         }
     }
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -179,13 +179,26 @@ Workers::Workers(RdmaTransport* transport)
     // ============================================================
 
     params.default_bandwidth_gbps =
-        conf->get("transports/rdma/default_bandwidth_gbps", 400.0);
-    params.min_bandwidth_gbps =
-        conf->get("transports/rdma/min_bandwidth_gbps", 10.0);
-    params.max_bandwidth_gbps =
-        conf->get("transports/rdma/max_bandwidth_gbps", 800.0);
+        conf->get("transports/rdma/default_bandwidth_gbps",
+                  params.default_bandwidth_gbps);
+    params.min_bandwidth_gbps = conf->get("transports/rdma/min_bandwidth_gbps",
+                                          params.min_bandwidth_gbps);
+    params.max_bandwidth_gbps = conf->get("transports/rdma/max_bandwidth_gbps",
+                                          params.max_bandwidth_gbps);
 
     device_selector_->setSchedulingParams(params);
+
+    // Seed each device's bandwidth from the speed its port negotiated.
+    // context_set_ is indexed by NicID, the same id the selector uses; an
+    // inert slot (NIC skipped at init) has no port to read, so leave it on
+    // the configured default without logging a second warning for it.
+    for (size_t dev_id = 0; dev_id < transport_->context_set_.size();
+         ++dev_id) {
+        const auto& context = transport_->context_set_[dev_id];
+        if (!context || context->status() == RdmaContext::DEVICE_UNINIT)
+            continue;
+        device_selector_->setDeviceBandwidth(dev_id, context->linkSpeedGbps());
+    }
 
     // ============================================================
     // Shared Memory Configuration

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -214,6 +214,13 @@ target_include_directories(tent_endpoint_store_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_endpoint_store_test COMMAND tent_endpoint_store_test)
 
+add_executable(tent_device_selector_test device_selector_test.cpp)
+target_link_libraries(tent_device_selector_test PRIVATE gtest gtest_main
+                                                        tent_link_group)
+target_include_directories(tent_device_selector_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_device_selector_test COMMAND tent_device_selector_test)
+
 add_executable(tent_rdma_transport_test rdma_transport_test.cpp)
 target_link_libraries(tent_rdma_transport_test PRIVATE gtest gtest_main
                                                        tent_link_group ibverbs)

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -20,6 +20,8 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 namespace mooncake {
 namespace tent {
@@ -108,6 +110,140 @@ TEST(DeviceSelectorBandwidthTest, EwmaClampScalesWithLinkSpeed) {
     observe(*sel, 1e3);
     observe(*sel, 1e3);
     EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 0.3125e9);
+}
+
+// ---------------------------------------------------------------------------
+// Availability: a NIC that cannot carry traffic (context never constructed,
+// construct() failed, port down) must not be a selection candidate and must
+// not count toward the aggregate the admission queue reads.
+// ---------------------------------------------------------------------------
+
+constexpr int kDev0 = 0;
+constexpr int kDev1 = 1;
+
+// Two RDMA NICs, both rank-0 for "cpu:0".
+std::shared_ptr<Topology> twoRdmaNics() {
+    auto topo = std::make_shared<Topology>();
+    for (const char* name : {"mlx5_0", "mlx5_1"}) {
+        Topology::NicEntry nic;
+        nic.name = name;
+        nic.type = Topology::NIC_RDMA;
+        nic.numa_node = 0;
+        topo->nic_list_.push_back(nic);
+    }
+    Topology::MemEntry mem;
+    mem.name = "cpu:0";
+    mem.type = Topology::MEM_HOST;
+    mem.numa_node = 0;
+    mem.device_list[0] = {kDev0, kDev1};
+    topo->mem_list_.push_back(mem);
+    return topo;
+}
+
+std::unique_ptr<DeviceSelector> makeTwoNicSelector(
+    const DeviceSelector::SchedulingParams& params = {}) {
+    auto topo = twoRdmaNics();
+    auto sel = std::make_unique<DeviceSelector>();
+    EXPECT_TRUE(sel->loadTopology(topo).ok());
+    sel->setSchedulingParams(params);
+    EXPECT_TRUE(sel->setDeviceBandwidth(kDev0, 100.0).ok());
+    EXPECT_TRUE(sel->setDeviceBandwidth(kDev1, 100.0).ok());
+    return sel;
+}
+
+// Allocate `rounds` single-slice requests and return how many landed on each
+// device, releasing each so inflight never skews the next choice.
+std::pair<int, int> countAllocations(DeviceSelector& sel, int rounds) {
+    std::pair<int, int> hits{0, 0};
+    for (int i = 0; i < rounds; ++i) {
+        int dev = -1;
+        if (!sel.allocate(kMiB, "cpu:0", dev).ok()) continue;
+        if (dev == kDev0) ++hits.first;
+        if (dev == kDev1) ++hits.second;
+        sel.release(dev, kMiB, 0.0);
+    }
+    return hits;
+}
+
+TEST(DeviceSelectorAvailabilityTest, DevicesStartAvailable) {
+    auto sel = makeTwoNicSelector();
+    EXPECT_TRUE(sel->isDeviceAvailable(kDev0));
+    EXPECT_TRUE(sel->isDeviceAvailable(kDev1));
+    EXPECT_FALSE(sel->isDeviceAvailable(7));  // unknown device
+    EXPECT_FALSE(sel->setDeviceAvailable(7, false).ok());
+}
+
+TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceLeavesAggregate) {
+    auto sel = makeTwoNicSelector();
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 25e9);
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 12.5e9);
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, true).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 25e9);
+}
+
+TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceIsNeverAllocated) {
+    auto sel = makeTwoNicSelector();
+    auto both = countAllocations(*sel, 64);
+    ASSERT_GT(both.first, 0);
+    ASSERT_GT(both.second, 0);  // sanity: both are picked when available
+
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
+    auto smart = countAllocations(*sel, 64);
+    EXPECT_EQ(smart.first, 64);
+    EXPECT_EQ(smart.second, 0);
+
+    sel->setSmartSelection(false);  // round-robin path has its own loop
+    auto rr = countAllocations(*sel, 64);
+    EXPECT_EQ(rr.first, 64);
+    EXPECT_EQ(rr.second, 0);
+}
+
+TEST(DeviceSelectorAvailabilityTest, AllDevicesUnavailable) {
+    auto sel = makeTwoNicSelector();
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev0, false).ok());
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
+    int dev = -1;
+    EXPECT_FALSE(sel->allocate(kMiB, "cpu:0", dev).ok());
+    // No usable bandwidth: the admission queue must not drop on it.
+    EXPECT_LT(sel->getAggregateEwmaBandwidth(), 0.0);
+}
+
+TEST(DeviceSelectorAvailabilityTest, PriorityFallbackKeepsUnavailableOut) {
+    // Priority filtering can reject every candidate, after which
+    // buildCandidates falls back to "all devices". That fallback must still
+    // honor availability.
+    DeviceSelector::SchedulingParams params;
+    params.enable_priority_filtering = true;
+    params.local_rotation_interval_us = 0;  // fixed priorities: dev0=0, dev1=1
+    auto sel = makeTwoNicSelector(params);
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
+    // Device priorities are 0 and 1, so request priority 2 rejects both in
+    // the first pass; the fallback must then offer dev0 only.
+    for (int i = 0; i < 16; ++i) {
+        std::vector<int> dev_ids;
+        ASSERT_TRUE(sel->allocate(kMiB, 1, kMiB, "cpu:0", dev_ids, 2).ok());
+        ASSERT_EQ(dev_ids, std::vector<int>{kDev0});
+        sel->release(kDev0, kMiB, 0.0);
+    }
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev0, false).ok());
+    std::vector<int> dev_ids;
+    EXPECT_FALSE(sel->allocate(kMiB, 1, kMiB, "cpu:0", dev_ids, 2).ok());
+}
+
+// The reviewer's scenario for a link that renegotiates lower: the learned
+// EWMA and the clamp derived from the old speed must both be replaced.
+TEST(DeviceSelectorBandwidthTest, ReseedOnLinkSpeedChangeReleasesStaleClamp) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 400.0).ok());
+    for (int i = 0; i < 64; ++i) observe(*sel, 45e9);
+    ASSERT_NEAR(sel->getAggregateEwmaBandwidth(), 45e9, 45e9 * 0.02);
+
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 3.125e9);
+    for (int i = 0; i < 64; ++i) observe(*sel, 3.1e9);
+    // With the 400G clamp still in place this would sit at the 5 GB/s floor.
+    EXPECT_NEAR(sel->getAggregateEwmaBandwidth(), 3.1e9, 3.1e9 * 0.02);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -1,0 +1,115 @@
+// Copyright 2025 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// DeviceSelector bandwidth calibration: the per-device link speed must drive
+// the EWMA seed and clamp instead of a one-size-fits-all constant.
+
+#include "tent/transport/rdma/quota.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+constexpr int kDev = 0;
+constexpr uint64_t kMiB = 1ull << 20;
+
+std::shared_ptr<Topology> oneRdmaNic() {
+    auto topo = std::make_shared<Topology>();
+    Topology::NicEntry nic;
+    nic.name = "mlx5_0";
+    nic.type = Topology::NIC_RDMA;
+    nic.numa_node = 0;
+    topo->nic_list_.push_back(nic);
+    return topo;
+}
+
+// A selector over one RDMA NIC, with scheduling params applied the way
+// Workers does it (topology first, then params).
+std::unique_ptr<DeviceSelector> makeSelector(
+    const DeviceSelector::SchedulingParams& params = {}) {
+    auto topo = oneRdmaNic();
+    auto sel = std::make_unique<DeviceSelector>();
+    EXPECT_TRUE(sel->loadTopology(topo).ok());
+    sel->setSchedulingParams(params);
+    return sel;
+}
+
+// Feed one completion whose observed bandwidth is `bytes_per_sec`.
+void observe(DeviceSelector& sel, double bytes_per_sec) {
+    ASSERT_TRUE(sel.release(kDev, kMiB, kMiB / bytes_per_sec).ok());
+}
+
+TEST(DeviceSelectorBandwidthTest, LinkSpeedSeedsEwma) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    // 25 Gbps = 3.125 GB/s, before a single byte has moved.
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 3.125e9);
+}
+
+TEST(DeviceSelectorBandwidthTest, UnknownLinkSpeedUsesConfiguredDefault) {
+    DeviceSelector::SchedulingParams params;
+    params.default_bandwidth_gbps = 100.0;
+    auto sel = makeSelector(params);
+    // 0 = the transport could not read the port speed.
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 0.0).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 12.5e9);
+}
+
+TEST(DeviceSelectorBandwidthTest, OutOfRangeLinkSpeedUsesConfiguredDefault) {
+    DeviceSelector::SchedulingParams params;
+    params.default_bandwidth_gbps = 100.0;
+    params.min_bandwidth_gbps = 10.0;
+    params.max_bandwidth_gbps = 800.0;
+    auto sel = makeSelector(params);
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 5.0).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 12.5e9);
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 1600.0).ok());
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 12.5e9);
+}
+
+TEST(DeviceSelectorBandwidthTest, UnknownDeviceIsRejected) {
+    auto sel = makeSelector();
+    EXPECT_FALSE(sel->setDeviceBandwidth(7, 100.0).ok());
+}
+
+// The bug this file exists for: with theoretical bandwidth fixed at 400 Gbps
+// the EWMA floor was 5 GB/s everywhere, so a 25G link (3.1 GB/s measured)
+// could never learn its real rate.
+TEST(DeviceSelectorBandwidthTest, EwmaLearnsRealRateOn25GLink) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    const double measured = 3.1e9;
+    for (int i = 0; i < 64; ++i) observe(*sel, measured);
+    EXPECT_NEAR(sel->getAggregateEwmaBandwidth(), measured, measured * 0.02);
+}
+
+TEST(DeviceSelectorBandwidthTest, EwmaClampScalesWithLinkSpeed) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    // One absurd sample: the ceiling must be 10x the 25G link, not 10x 400G.
+    observe(*sel, 1e13);
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 31.25e9);
+    // And absurdly slow ones: the floor is 0.1x the 25G link.
+    observe(*sel, 1e3);
+    observe(*sel, 1e3);
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 0.3125e9);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -182,6 +182,28 @@ TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceLeavesAggregate) {
     EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 25e9);
 }
 
+// getNicLoadStats() is the load signal upper layers score NICs with
+// (#2996, for #2516). A NIC that cannot carry traffic must not appear in it
+// at all: its seed is meaningless and, with zero inflight, would look like
+// the best NIC of the lot -- the same bad pick the aggregate avoids.
+TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceLeavesLoadStats) {
+    auto sel = makeTwoNicSelector();
+    std::vector<NicLoadStats> stats;
+    ASSERT_TRUE(sel->getNicLoadStats(stats).ok());
+    ASSERT_EQ(stats.size(), 2u);
+
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
+    stats.clear();
+    ASSERT_TRUE(sel->getNicLoadStats(stats).ok());
+    ASSERT_EQ(stats.size(), 1u);
+    EXPECT_EQ(stats[0].device_name, "mlx5_0");
+
+    ASSERT_TRUE(sel->setDeviceAvailable(kDev1, true).ok());
+    stats.clear();
+    ASSERT_TRUE(sel->getNicLoadStats(stats).ok());
+    EXPECT_EQ(stats.size(), 2u);
+}
+
 TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceIsNeverAllocated) {
     auto sel = makeTwoNicSelector();
     auto both = countAllocations(*sel, 64);

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -331,6 +331,17 @@ TEST(RdmaNicIndexAlignmentTest, FailedContextIsUnavailableToSelector) {
     EXPECT_LT(selector->getAggregateEwmaBandwidth(), 0.0);
 }
 
+// refreshPortAttributes() is called from the monitor thread on port events.
+// On a slot that never opened a device it must fail cleanly and leave the
+// (zero) speed alone rather than touch a null ibv_context.
+TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {
+    RdmaTransport transport;
+    RdmaContext context(transport);
+    ASSERT_EQ(context.status(), RdmaContext::DEVICE_UNINIT);
+    EXPECT_EQ(context.refreshPortAttributes(), -1);
+    EXPECT_DOUBLE_EQ(context.linkSpeedGbps(), 0.0);
+}
+
 TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {
     if (!hasRdmaDevice()) GTEST_SKIP() << "no RDMA device detected";
 

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -67,6 +67,14 @@ class RdmaTransportTestPeer {
         return std::make_unique<Workers>(&transport);
     }
 
+    // Drives the decision half of handleContextEvents with a synthesized
+    // event, bypassing ibv_get_async_event/ibv_ack_async_event.
+    static void applyContextEvent(Workers& workers, int dev_id,
+                                  RdmaContext& context,
+                                  const ibv_async_event& event) {
+        workers.applyContextEvent(dev_id, context, event);
+    }
+
     static const RdmaContextSet& contextSet(const RdmaTransport& transport) {
         return transport.context_set_;
     }
@@ -334,6 +342,81 @@ TEST(RdmaNicIndexAlignmentTest, FailedContextIsUnavailableToSelector) {
 // refreshPortAttributes() is called from the monitor thread on port events.
 // On a slot that never opened a device it must fail cleanly and leave the
 // (zero) speed alone rather than touch a null ibv_context.
+// Port events carry the port they concern, and a device's async fd delivers
+// events for every port of that device. A context opens exactly one port, so
+// an event for another port must not touch its availability. These run on an
+// inert context: pause()/resume() are no-ops there and the decision under
+// test is the selector flip.
+class RdmaContextEventTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        topology_ = std::make_shared<Topology>();
+        ASSERT_TRUE(topology_
+                        ->parse(R"({"nics":[
+                            {"name":"mc-tcp-0","type":1,"numa_node":0},
+                            {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                        .ok());
+        RdmaTransportTestPeer::bindTopology(transport_, topology_);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_NE(selector_, nullptr);
+        // Init marked the failed context unavailable; pretend it recovered so
+        // the flips below are observable.
+        ASSERT_TRUE(selector_->setDeviceAvailable(kDev, true).ok());
+    }
+
+    RdmaContext& context() {
+        return *RdmaTransportTestPeer::contextSet(transport_)[kDev];
+    }
+
+    void fire(ibv_event_type type, int port_num) {
+        ibv_async_event event{};
+        event.event_type = type;
+        event.element.port_num = port_num;
+        RdmaTransportTestPeer::applyContextEvent(*workers_, kDev, context(),
+                                                 event);
+    }
+
+    int ourPort() { return context().portNum(); }
+    int otherPort() { return ourPort() + 1; }
+
+    static constexpr int kDev = 1;
+    std::shared_ptr<Topology> topology_;
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+};
+
+TEST_F(RdmaContextEventTest, PortErrAndPortActiveFlipAvailability) {
+    fire(IBV_EVENT_PORT_ERR, ourPort());
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+    EXPECT_LT(selector_->getAggregateEwmaBandwidth(), 0.0);
+    fire(IBV_EVENT_PORT_ACTIVE, ourPort());
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+    EXPECT_GT(selector_->getAggregateEwmaBandwidth(), 0.0);
+}
+
+TEST_F(RdmaContextEventTest, EventsForAnotherPortAreIgnored) {
+    fire(IBV_EVENT_PORT_ERR, otherPort());
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+
+    fire(IBV_EVENT_PORT_ERR, ourPort());
+    ASSERT_FALSE(selector_->isDeviceAvailable(kDev));
+    fire(IBV_EVENT_PORT_ACTIVE, otherPort());
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST_F(RdmaContextEventTest, DeviceFatalMarksUnavailableRegardlessOfPort) {
+    fire(IBV_EVENT_DEVICE_FATAL, otherPort());  // device-scoped: no port
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST_F(RdmaContextEventTest, CqErrLeavesAvailabilityAlone) {
+    fire(IBV_EVENT_CQ_ERR, ourPort());
+    EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+}
+
 TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {
     RdmaTransport transport;
     RdmaContext context(transport);

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -61,6 +61,12 @@ class RdmaTransportTestPeer {
         return transport.initializeContexts();
     }
 
+    // Constructs Workers (which seeds the DeviceSelector from context_set_)
+    // without starting any threads.
+    static std::unique_ptr<Workers> makeWorkers(RdmaTransport& transport) {
+        return std::make_unique<Workers>(&transport);
+    }
+
     static const RdmaContextSet& contextSet(const RdmaTransport& transport) {
         return transport.context_set_;
     }
@@ -297,6 +303,32 @@ TEST(RdmaNicIndexAlignmentTest, ContextSetKeepsOneSlotWhenConstructFails) {
               static_cast<size_t>(0));
     expectInertContextPerNic(RdmaTransportTestPeer::contextSet(transport),
                              topology->getNicCount());
+}
+
+// A NIC whose construct() failed is still an RDMA entry in the topology, so
+// loadTopology() gives it a DeviceSelector slot. Workers must mark it
+// unavailable: it can carry no traffic, so it must be neither a selection
+// candidate nor part of the aggregate bandwidth the admission queue reads --
+// the configured default speed is for usable NICs only.
+TEST(RdmaNicIndexAlignmentTest, FailedContextIsUnavailableToSelector) {
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                    .ok());
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport),
+              static_cast<size_t>(0));
+
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    auto* selector = workers->getDeviceSelector();
+    ASSERT_NE(selector, nullptr);
+    EXPECT_FALSE(selector->isDeviceAvailable(1));
+    // Nothing usable: no bandwidth to predict with, rather than 400G of it.
+    EXPECT_LT(selector->getAggregateEwmaBandwidth(), 0.0);
 }
 
 TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {

--- a/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_context_reprobe_test.cpp
@@ -29,6 +29,7 @@
 #include "error.h"
 #include "rdma_test_peers.h"
 #include "transfer_metadata.h"
+#include "ib_link_speed.h"
 #include "transport/rdma_transport/rdma_context.h"
 #include "transport/rdma_transport/rdma_transport.h"
 
@@ -55,6 +56,10 @@ struct FakeVerbsDevice {
     ibv_device *device_list[2] = {&device, nullptr};
     ibv_context context = {};
     size_t alloc_pd_calls = 0;
+    // Reported by the interposed ibv_query_port.
+    uint8_t active_speed = 0;
+    uint8_t active_width = 0;
+    uint32_t active_speed_ex = 0;
 };
 
 FakeVerbsDevice fake_verbs;
@@ -66,6 +71,9 @@ class FakeVerbsDeviceScope {
         fake_verbs.context = {};
         fake_verbs.context.num_comp_vectors = num_comp_vectors;
         fake_verbs.alloc_pd_calls = 0;
+        fake_verbs.active_speed = 0;
+        fake_verbs.active_width = 0;
+        fake_verbs.active_speed_ex = 0;
     }
 
     ~FakeVerbsDeviceScope() { fake_verbs.enabled = false; }
@@ -112,6 +120,11 @@ int ibv_query_port(ibv_context *context, uint8_t,
     port_attr->state = IBV_PORT_ACTIVE;
     port_attr->lid = 1;
     port_attr->active_mtu = IBV_MTU_4096;
+    port_attr->active_speed = fake_verbs.active_speed;
+    port_attr->active_width = fake_verbs.active_width;
+#ifdef HAVE_IBV_ACTIVE_SPEED_EX
+    port_attr->active_speed_ex = fake_verbs.active_speed_ex;
+#endif
     return 0;
 }
 
@@ -195,6 +208,50 @@ TEST_F(RdmaContextConstructionTest, LogsPortNumberAsIntegerNotCharacter) {
 
     EXPECT_NE(log.find("on port 1 with GID"), std::string::npos) << log;
     EXPECT_EQ(log.find(std::string("on port \x01")), std::string::npos) << log;
+}
+
+// openRdmaDevice() records the negotiated speed before construct() goes on
+// to validate completion vectors, so a device with none lets the recorded
+// values be inspected without allocating anything.
+TEST_F(RdmaContextConstructionTest, RecordsNegotiatedPortSpeedAndWidth) {
+#ifdef __linux__
+    FakeVerbsDeviceScope fake_device(/*num_comp_vectors=*/0);
+    fake_verbs.active_speed = 64;  // HDR, 50 Gb/s per lane
+    fake_verbs.active_width = 2;   // 4x
+
+    EXPECT_EQ(context_->construct(1, 1, /*port=*/1, /*gid_index=*/0),
+              ERR_CONTEXT);
+    EXPECT_EQ(context_->activeSpeed(), 64);
+    EXPECT_EQ(context_->activeWidth(), 2);
+    EXPECT_DOUBLE_EQ(
+        ibLinkSpeedGbps(context_->activeSpeed(), context_->activeWidth()),
+        200.0);
+    RdmaContextTestPeer::disableContextForTeardown(*context_);
+#else
+    GTEST_SKIP() << "Requires Linux libibverbs symbol interposition";
+#endif
+}
+
+// XDR's encoding (256) does not fit ibv_port_attr::active_speed (uint8_t),
+// which reads 0; rdma-core carries it in active_speed_ex. show_links must
+// report 800 Gbps for XDR 4x, not 0.
+TEST_F(RdmaContextConstructionTest, PrefersActiveSpeedExForXdr) {
+#if defined(__linux__) && defined(HAVE_IBV_ACTIVE_SPEED_EX)
+    FakeVerbsDeviceScope fake_device(/*num_comp_vectors=*/0);
+    fake_verbs.active_speed = 0;       // what the uint8_t field reads for XDR
+    fake_verbs.active_speed_ex = 256;  // XDR
+    fake_verbs.active_width = 2;       // 4x
+
+    EXPECT_EQ(context_->construct(1, 1, /*port=*/1, /*gid_index=*/0),
+              ERR_CONTEXT);
+    EXPECT_EQ(context_->activeSpeed(), 256);
+    EXPECT_DOUBLE_EQ(
+        ibLinkSpeedGbps(context_->activeSpeed(), context_->activeWidth()),
+        800.0);
+    RdmaContextTestPeer::disableContextForTeardown(*context_);
+#else
+    GTEST_SKIP() << "Requires Linux and ibv_port_attr::active_speed_ex";
+#endif
 }
 
 TEST_F(RdmaContextConstructionTest,


### PR DESCRIPTION
Description

  DeviceSelector stamped every RDMA device with a constant 400 Gbps and nothing ever overwrote it, so the "theoretical bandwidth" was 50 GB/s for every NIC. That value seeds the EWMA the smart selector scores with and bounds it to [0.1x, 10x] = [5, 500] GB/s regardless of the real link. A 25G NIC (~3.1 GB/s measured) sits below that floor, so the clamp pins its EWMA at 5 GB/s and it never learns its real rate; on hosts mixing link speeds the selector keeps steering slices at the slow NIC. The same number feeds getAggregateEwmaBandwidth(), used by the admission queue's deadline-drop predictor. The default/min/max_bandwidth_gbps config knobs were read into SchedulingParams but never consulted.

  - RdmaContext::openDevice keeps active_speed/active_width from the ibv_query_port it already issues; new linkSpeedGbps(). XDR (encoding 256) overflows the legacy uint8_t field, so CMake probes for ibv_port_attr::active_speed_ex (HAVE_IBV_ACTIVE_SPEED_EX) and prefers it when present.
  - New DeviceSelector::setDeviceBandwidth(): validates the speed against the configured [min, max], falls back to default_bandwidth_gbps with a warning when unknown (0) or out of range, and re-seeds the EWMA. theoreticalBandwidth() now reads SchedulingParams, so the config knobs take effect. The kDefaultBwGbps/kMinBwGbps/kMaxBwGbps constants are dropped; SchedulingParams is the single source and Workers uses its defaults as the config fallback.
  - Workers seeds each device from its context status: a context that never constructed (`DEVICE_UNINIT`/`DISABLED`) is marked **unavailable** and gets no bandwidth at all; a port down at open (`DEVICE_PAUSED`) is seeded but unavailable until `PORT_ACTIVE`; `DEVICE_ENABLED` is seeded from the negotiated speed. `DeviceSelector::setDeviceAvailable()` excludes a device from candidate construction (both passes, both modes) and from the aggregate bandwidth the admission queue's deadline predictor reads; all-unavailable yields -1, which switches the drop predictor off. `handleContextEvents` flips availability on `PORT_ERR`/`DEVICE_FATAL`/`PORT_ACTIVE`. The configured default is applied only to a usable NIC whose speed could not be read. (review: failed contexts were left at 400G in the aggregate and stayed selection candidates)
  - The link speed is re-read on `IBV_EVENT_PORT_ACTIVE` and, behind a CMake probe (`HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE`, rdma-core >= 62), on `IBV_EVENT_DEVICE_SPEED_CHANGE`; `RdmaContext::refreshPortAttributes()` re-issues `ibv_query_port`, and `Workers::refreshLinkSpeed()` re-seeds through `setDeviceBandwidth()` only when the speed actually changed, before the device becomes selectable again. (review: a link returning at a lower speed kept the old seed and clamp)
  - The speed/width decoding table is lifted from show_links.cpp into mooncake-common/include/ib_link_speed.h so classic TE and TENT share one copy. The classic RdmaContext now also prefers `ibv_port_attr::active_speed_ex` (same `HAVE_IBV_ACTIVE_SPEED_EX` probe, in `src/CMakeLists.txt` for the classic tree), so show_links reports 800 Gbps for XDR 4x instead of 0. (review)
  - Port events are matched against the port the context opened: a device's async fd delivers `PORT_ERR`/`PORT_ACTIVE` for every port of that device, so on a multi-port HCA a flap on an unused port no longer pauses the context or drops it from selection. The decision half of `handleContextEvents` is now `applyContextEvent()`, so a synthesized event can drive it in tests. (review)
  - `getNicLoadStats()` reports only NICs able to carry traffic, the same rule as the aggregate; the C struct is unchanged (C ABI, consumed by the Rust binding via FFI). (review)

  No public API or wire format changes. Not related to #1974 (classic TE GPU↔NIC PCI ranking).

  Module

  - [x] Transfer Engine (mooncake-transfer-engine)
  - [ ] Mooncake Store (mooncake-store)
  - [ ] Reshard (mooncake-reshard)
  - [ ] Mooncake EP (mooncake-ep)
  - [ ] Mooncake PG (mooncake-pg)
  - [ ] Integration (mooncake-integration)
  - [ ] P2P Store (mooncake-p2p-store)
  - [ ] Python Wheel (mooncake-wheel)
  - [x] Common (mooncake-common)
  - [ ] Mooncake RL (mooncake-rl)
  - [ ] CI/CD
  - [x] Docs
  - [ ] Other

  Type of Change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Documentation update
  - [ ] Performance improvement
  - [ ] Other

  How Has This Been Tested?

  Test commands:
  cd build
  cmake --build . --target ib_link_speed_test tent_device_selector_test tent_rdma_transport_test tent_qos_contract_test bw_arbitration_test rdma_context_reprobe_test
  ctest -R 'ib_link_speed_test|tent_device_selector_test|tent_rdma_transport_test|tent_qos_contract_test|bw_arbitration_test|rdma_context_reprobe_test' --output-on-failure

  Test results:
  - [x] Unit tests pass — 100% tests passed, 0 tests failed out of 6 (Ubuntu 22.04, rdma-core 39, no RNIC)
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  New tests, both written first and observed failing on the unpatched tree:
  - ib_link_speed_test — SDR…XDR × 1x/2x/4x/8x/12x encoding table; unknown encodings report 0.
  - tent_device_selector_test — link speed seeds the EWMA; unknown / out-of-range speed falls back to the configured default; unknown device is rejected; a 25G link learns 3.1 GB/s instead of being pinned at 5 GB/s; the clamp ceiling and floor scale with the link speed; re-seeding after a 400G→25G change releases the stale clamp; unavailable devices leave the aggregate and are never allocated (smart and round-robin), all-unavailable yields DeviceNotFound and a negative aggregate, and the priority fallback offers only available devices.
  - tent_rdma_transport_test — a context whose construct() failed is unavailable to the selector after Workers construction and contributes nothing to the aggregate (hardware-free via RdmaTransportTestPeer); refreshPortAttributes() on an inert context is rejected and leaves the speed at 0; synthesized `PORT_ERR`/`PORT_ACTIVE` for the opened port flip availability and the aggregate, events for another port are ignored in both directions, `DEVICE_FATAL` applies regardless of port, `CQ_ERR` leaves availability alone.
  - tent_device_selector_test — unavailable devices leave getNicLoadStats() and return when restored.
  - rdma_context_reprobe_test (classic, interposed ibv_query_port) — the negotiated speed/width are recorded (HDR 4x → 200 Gbps); with `active_speed_ex` = 256 and `active_speed` = 0, activeSpeed() is 256 and the shared table yields 800 Gbps. The XDR case is skipped where the header lacks the field (CI's rdma-core 39); it was run RED→GREEN against a verbs.h copy with the field added.

  Manual: the HAVE_IBV_ACTIVE_SPEED_EX branch was compile-checked against a copy of verbs.h with the field added, and the CMake probe confirmed to report yes/no against headers with/without it; the HAVE_IBV_EVENT_DEVICE_SPEED_CHANGE branch was syntax-checked with the enumerator injected (CI's rdma-core 39 predates it). Not covered without hardware: openDevice populating the fields from a real port, and the PORT_ERR/PORT_ACTIVE/DEVICE_SPEED_CHANGE events reaching handleContextEvents (the last also needs rdma-core >= 62 + Linux 7.0 + mlx5).

  Checklist
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue (N/A, ~370 LOC incl. tests)

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)
