### PR TITLE
[TENT] Preserve per-request RDMA selection policy

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -129,6 +129,13 @@ class DeviceSelector {
     Status allocate(uint64_t length, const std::string &location,
                     int &chosen_dev_id);
 
+    // Allocate one device for the per-slice path. Small requests do not go
+    // through the aggregate allocator, but must still honor the request
+    // priority and transport policy's device mask. Keep the three-argument
+    // overload above for source and binary compatibility.
+    Status allocate(uint64_t length, const std::string &location,
+                    int &chosen_dev_id, int priority, uint64_t device_mask);
+
     Status release(int dev_id, uint64_t length, double latency);
 
     Status getNicLoadStats(std::vector<NicLoadStats> &stats) const;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -51,6 +51,10 @@ using RdmaTaskStorage = Slab<RdmaTask>;
 struct RdmaTask {
     int num_slices;
     Request request;
+    // Resolved by TransportSelector and copied from RdmaSubBatch. The
+    // per-slice path runs later on worker threads, so it must carry the same
+    // device policy as the aggregate allocation path.
+    uint64_t device_mask{~0ULL};
     // Named QP pool this task's slices should use (RFC #2568 step 3). Empty =
     // no pool selected: slices spray across all data QPs as before. Resolved
     // from SelectionResult.qp_pool at task creation.

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1276,13 +1276,12 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         if (last.req.transport_hint != curr.req.transport_hint) {
             return false;
         }
-        // These fields affect transport selection or scheduling. Merging
+        // These fields affect transport selection. Merging
         // requests with different values would silently apply the first
         // request's policy to the whole combined transfer.
         if (last.req.priority != curr.req.priority ||
             last.req.policy_name != curr.req.policy_name ||
-            last.req.intent_type != curr.req.intent_type ||
-            last.req.deadline_ns != curr.req.deadline_ns) {
+            last.req.intent_type != curr.req.intent_type) {
             return false;
         }
         if (!last.boundary.source_key || !curr.boundary.source_key ||
@@ -1568,10 +1567,6 @@ Status TransferEngineImpl::commitPreparedSubmit(
             "batch public task capacity exceeded" LOC_MARK);
     }
 
-    std::vector<size_t> task_id_list[kSupportedTransportTypes];
-    // task_id_list also contains derived public tasks created by request
-    // merging. Keep a parallel list of physical owners so requests can be
-    // grouped with the policy that will be copied into their transport task.
     std::vector<size_t> physical_task_id_list[kSupportedTransportTypes];
     std::unordered_map<size_t, TaskInfo> merged_task_id_map;
 
@@ -1591,7 +1586,6 @@ Status TransferEngineImpl::commitPreparedSubmit(
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
             if (task.type != UNSPEC) {
-                task_id_list[task.type].push_back(task_id);
                 auto owner_it =
                     owner_task_id_by_merged_task.find(merged_task_id);
                 if (owner_it != owner_task_id_by_merged_task.end()) {
@@ -1653,7 +1647,6 @@ Status TransferEngineImpl::commitPreparedSubmit(
 
         task.sub_task_id = -1;
         task.derived = false;
-        task_id_list[task.type].push_back(task_id);
         physical_task_id_list[task.type].push_back(task_id);
         owner_task_id_by_merged_task[merged_task_id] = task_id;
         public_tasks_by_physical_owner[task_id].push_back(task_id);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -25,6 +25,7 @@
 #include <random>
 #include <stdexcept>
 #include <thread>
+#include <unordered_set>
 
 #include "tent/common/config.h"
 #include "tent/common/status.h"
@@ -1275,6 +1276,15 @@ MergeResult mergeRequests(const std::vector<Request>& requests,
         if (last.req.transport_hint != curr.req.transport_hint) {
             return false;
         }
+        // These fields affect transport selection or scheduling. Merging
+        // requests with different values would silently apply the first
+        // request's policy to the whole combined transfer.
+        if (last.req.priority != curr.req.priority ||
+            last.req.policy_name != curr.req.policy_name ||
+            last.req.intent_type != curr.req.intent_type ||
+            last.req.deadline_ns != curr.req.deadline_ns) {
+            return false;
+        }
         if (!last.boundary.source_key || !curr.boundary.source_key ||
             !last.boundary.target_key || !curr.boundary.target_key) {
             return false;
@@ -1558,14 +1568,19 @@ Status TransferEngineImpl::commitPreparedSubmit(
             "batch public task capacity exceeded" LOC_MARK);
     }
 
-    std::vector<Request> classified_request_list[kSupportedTransportTypes];
     std::vector<size_t> task_id_list[kSupportedTransportTypes];
+    // task_id_list also contains derived public tasks created by request
+    // merging. Keep a parallel list of physical owners so requests can be
+    // grouped with the policy that will be copied into their transport task.
+    std::vector<size_t> physical_task_id_list[kSupportedTransportTypes];
     std::unordered_map<size_t, TaskInfo> merged_task_id_map;
 
     batch->task_list.insert(batch->task_list.end(), prepared.tasks.size(),
                             TaskInfo{});
 
-    std::unordered_map<TransportType, size_t> next_sub_task_id;
+    std::unordered_map<size_t, size_t> owner_task_id_by_merged_task;
+    std::unordered_map<size_t, std::vector<size_t>>
+        public_tasks_by_physical_owner;
     for (const auto& task_plan : prepared.tasks) {
         size_t task_id = task_plan.task_id;
         size_t merged_task_id = task_plan.merged_task_index;
@@ -1575,7 +1590,15 @@ Status TransferEngineImpl::commitPreparedSubmit(
         if (merged_task_id_map.count(merged_task_id)) {
             task = merged_task_id_map[merged_task_id];
             task.derived = true;
-            if (task.type != UNSPEC) task_id_list[task.type].push_back(task_id);
+            if (task.type != UNSPEC) {
+                task_id_list[task.type].push_back(task_id);
+                auto owner_it =
+                    owner_task_id_by_merged_task.find(merged_task_id);
+                if (owner_it != owner_task_id_by_merged_task.end()) {
+                    public_tasks_by_physical_owner[owner_it->second].push_back(
+                        task_id);
+                }
+            }
             continue;
         }
 
@@ -1628,47 +1651,89 @@ Status TransferEngineImpl::commitPreparedSubmit(
             attachProgressNotifier(batch, batch->sub_batch[task.type]);
         }
 
-        if (!next_sub_task_id.count(task.type))
-            next_sub_task_id[task.type] = batch->sub_batch[task.type]->size();
-        size_t sub_task_id = next_sub_task_id[task.type];
-        next_sub_task_id[task.type]++;
-
-        classified_request_list[task.type].push_back(merged_request);
-        task.sub_task_id = sub_task_id;
+        task.sub_task_id = -1;
         task.derived = false;
         task_id_list[task.type].push_back(task_id);
+        physical_task_id_list[task.type].push_back(task_id);
+        owner_task_id_by_merged_task[merged_task_id] = task_id;
+        public_tasks_by_physical_owner[task_id].push_back(task_id);
         merged_task_id_map[merged_task_id] = task;
     }
 
     for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
-        if (classified_request_list[type].empty()) continue;
+        if (physical_task_id_list[type].empty()) continue;
         auto& transport = transport_list_[type];
         auto& sub_batch = batch->sub_batch[type];
 
-        // Set device_mask on SubBatch for RDMA transport
-        if (type == RDMA && !task_id_list[type].empty()) {
-            // Use the device_mask from the first task (we assume all tasks in
-            // this batch should have the same policy)
-            sub_batch->device_mask =
-                batch->task_list[task_id_list[type][0]].device_mask;
-            sub_batch->qp_pool =
-                batch->task_list[task_id_list[type][0]].qp_pool;
+        // SubBatch carries one policy per submit call. Requests using the
+        // same transport may still resolve to different device masks or QP
+        // pools, so RDMA owners must be submitted in homogeneous groups.
+        // RdmaTransport copies these scalar fields into each RdmaTask before
+        // returning, so groups can safely share one SubBatch.
+        std::vector<std::vector<size_t>> submit_groups;
+        if (type == RDMA) {
+            std::map<std::pair<uint64_t, std::string>, size_t>
+                group_by_policy;
+            for (const auto task_id : physical_task_id_list[type]) {
+                const auto& task = batch->task_list[task_id];
+                auto key = std::make_pair(task.device_mask, task.qp_pool);
+                auto [it, inserted] =
+                    group_by_policy.emplace(std::move(key),
+                                            submit_groups.size());
+                if (inserted) submit_groups.emplace_back();
+                submit_groups[it->second].push_back(task_id);
+            }
+        } else {
+            submit_groups.push_back(physical_task_id_list[type]);
         }
 
-        auto attempt_start = std::chrono::steady_clock::now();
-        for (auto& task_id : task_id_list[type]) {
-            startTransportAttempt(batch->task_list[task_id],
-                                  static_cast<TransportType>(type),
-                                  attempt_start);
-        }
-        auto status = transport->submitTransferTasks(
-            sub_batch, classified_request_list[type]);
-        if (!status.ok()) {
-            auto attempt_end = std::chrono::steady_clock::now();
-            for (auto& task_id : task_id_list[type]) {
-                finishTransportAttempt(batch->task_list[task_id], FAILED,
-                                       attempt_end);
-                batch->task_list[task_id].type = UNSPEC;
+        for (const auto& group : submit_groups) {
+            if (group.empty()) continue;
+
+            // A synchronous failure is allowed to return without appending
+            // anything to the SubBatch. Resolve IDs from the actual current
+            // size for each group so a failed earlier group cannot leave a gap
+            // in the IDs assigned to a later successful group. Propagate the
+            // physical ID to every merged public alias before submission so
+            // synchronous failure handling still sees a consistent mapping.
+            int next_sub_task_id = static_cast<int>(sub_batch->size());
+            for (const auto physical_task_id : group) {
+                for (const auto public_task_id :
+                     public_tasks_by_physical_owner.at(physical_task_id)) {
+                    batch->task_list[public_task_id].sub_task_id =
+                        next_sub_task_id;
+                }
+                ++next_sub_task_id;
+            }
+
+            if (type == RDMA) {
+                const auto& first_task = batch->task_list[group.front()];
+                sub_batch->device_mask = first_task.device_mask;
+                sub_batch->qp_pool = first_task.qp_pool;
+            }
+
+            std::vector<Request> requests;
+            requests.reserve(group.size());
+            for (const auto task_id : group)
+                requests.push_back(batch->task_list[task_id].request);
+
+            auto attempt_start = std::chrono::steady_clock::now();
+            for (const auto task_id : group) {
+                startTransportAttempt(batch->task_list[task_id],
+                                      static_cast<TransportType>(type),
+                                      attempt_start);
+            }
+            auto status = transport->submitTransferTasks(sub_batch, requests);
+            if (!status.ok()) {
+                auto attempt_end = std::chrono::steady_clock::now();
+                for (const auto physical_task_id : group) {
+                    for (const auto public_task_id :
+                         public_tasks_by_physical_owner.at(physical_task_id)) {
+                        auto& task = batch->task_list[public_task_id];
+                        finishTransportAttempt(task, FAILED, attempt_end);
+                        task.type = UNSPEC;
+                    }
+                }
             }
         }
     }
@@ -1824,7 +1889,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     auto route = resolveTransport(task.request, 0);
     task.type = route.transport;
     task.device_mask = route.device_mask;
-    if (route.qp_pool) task.qp_pool = *route.qp_pool;
+    task.qp_pool = route.qp_pool.value_or("");
     if (task.type == UNSPEC) {
         return finishQueuedOwner(owner_id, FAILED);
     }
@@ -2152,6 +2217,12 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
         attachProgressNotifier(batch, batch->sub_batch[type]);
     }
     auto& sub_batch = batch->sub_batch[type];
+    task.device_mask = result.device_mask;
+    task.qp_pool = result.qp_pool.value_or("");
+    if (type == RDMA) {
+        sub_batch->device_mask = task.device_mask;
+        sub_batch->qp_pool = task.qp_pool;
+    }
     task.sub_task_id = sub_batch->size();
     task.type = type;
     startTransportAttempt(task, type, std::chrono::steady_clock::now());

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1672,14 +1672,12 @@ Status TransferEngineImpl::commitPreparedSubmit(
         // returning, so groups can safely share one SubBatch.
         std::vector<std::vector<size_t>> submit_groups;
         if (type == RDMA) {
-            std::map<std::pair<uint64_t, std::string>, size_t>
-                group_by_policy;
+            std::map<std::pair<uint64_t, std::string>, size_t> group_by_policy;
             for (const auto task_id : physical_task_id_list[type]) {
                 const auto& task = batch->task_list[task_id];
                 auto key = std::make_pair(task.device_mask, task.qp_pool);
-                auto [it, inserted] =
-                    group_by_policy.emplace(std::move(key),
-                                            submit_groups.size());
+                auto [it, inserted] = group_by_policy.emplace(
+                    std::move(key), submit_groups.size());
                 if (inserted) submit_groups.emplace_back();
                 submit_groups[it->second].push_back(task_id);
             }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -292,8 +292,15 @@ void DeviceSelector::selectMultiPath(const std::vector<Candidate>& candidates,
 
 Status DeviceSelector::allocate(uint64_t length, const std::string& location,
                                 int& chosen_dev_id) {
+    return allocate(length, location, chosen_dev_id, PRIO_HIGH, ~0ULL);
+}
+
+Status DeviceSelector::allocate(uint64_t length, const std::string& location,
+                                int& chosen_dev_id, int priority,
+                                uint64_t device_mask) {
     std::vector<int> slice_dev_ids;
-    Status status = allocate(length, 1, length, location, slice_dev_ids, ~0ULL);
+    Status status = allocate(length, 1, length, location, slice_dev_ids,
+                             priority, device_mask);
     if (!status.ok()) return status;
     if (slice_dev_ids.empty()) {
         return Status::DeviceNotFound("allocation failed");

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -464,6 +464,7 @@ Status RdmaTransport::submitTransferTasks(
         auto* task = RdmaTaskStorage::Get().allocate();
         rdma_batch->task_list.push_back(task);
         task->request = request;
+        task->device_mask = rdma_batch->device_mask;
         task->qp_pool = rdma_batch->qp_pool;  // RFC #2568 step 3
         task->num_slices = 0;
         task->status_word = PENDING;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -924,7 +924,8 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
     auto& worker = worker_context_[tl_wid];
     if (slice->source_dev_id < 0) {
         CHECK_STATUS(device_selector_->allocate(
-            slice->length, source.buffer->location, slice->source_dev_id));
+            slice->length, source.buffer->location, slice->source_dev_id,
+            slice->priority, slice->task->device_mask));
         slice->quota_charged = true;
     }
 
@@ -1080,12 +1081,15 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
             : &getOrCreateRail(worker.rails, target.segment->machine_id);
     size_t start =
         static_cast<size_t>(slice->last_fallback_idx + 1) % total_combos;
+    const uint64_t device_mask = slice->task->device_mask;
     for (size_t k = 0; k < total_combos; ++k) {
         size_t idx = (start + k) % total_combos;
         size_t src_idx = idx / dst_total;
         size_t dst_idx = idx % dst_total;
         int sdev = getDeviceByFlatIndex(source, src_idx);
         int tdev = getDeviceByFlatIndex(target, dst_idx);
+        if (sdev < 0 || sdev >= 64 || (device_mask & (1ULL << sdev)) == 0)
+            continue;
         bool reachable = same_machine ? (sdev == tdev)  // loopback is safe
                                       : rail_mon->available(sdev, tdev);
 

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -181,9 +181,10 @@ TEST(DeviceSelectorTest, PerSliceAllocationHonorsPolicy) {
         DeviceSelector selector;
         ASSERT_TRUE(selector.loadTopology(topology).ok());
         int chosen_device = -1;
-        ASSERT_TRUE(selector.allocate(4096, "cpu:0", chosen_device,
-                                       PRIO_HIGH, 1ULL << 1)
-                        .ok());
+        ASSERT_TRUE(
+            selector
+                .allocate(4096, "cpu:0", chosen_device, PRIO_HIGH, 1ULL << 1)
+                .ok());
         EXPECT_EQ(chosen_device, 1);
     }
 
@@ -200,8 +201,9 @@ TEST(DeviceSelectorTest, PerSliceAllocationHonorsPolicy) {
         selector.setSchedulingParams(params);
 
         int chosen_device = -1;
-        ASSERT_TRUE(selector.allocate(4096, "cpu:0", chosen_device,
-                                       PRIO_LOW, (1ULL << 1) | (1ULL << 2))
+        ASSERT_TRUE(selector
+                        .allocate(4096, "cpu:0", chosen_device, PRIO_LOW,
+                                  (1ULL << 1) | (1ULL << 2))
                         .ok());
         EXPECT_EQ(chosen_device, 2);
     }

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -32,6 +32,7 @@
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/context.h"
 #include "tent/transport/rdma/params.h"
+#include "tent/transport/rdma/quota.h"
 #include "tent/transport/rdma/rdma_transport.h"
 #include "tent/transport/rdma/workers.h"
 
@@ -120,6 +121,27 @@ std::shared_ptr<Config> makeRdmaConfig() {
     return config;
 }
 
+std::shared_ptr<Topology> topologyWithRdmaNics(size_t count) {
+    auto topology = std::make_shared<Topology>();
+    for (size_t i = 0; i < count; ++i) {
+        Topology::NicEntry nic;
+        nic.name = "mlx5_" + std::to_string(i);
+        nic.type = Topology::NIC_RDMA;
+        nic.numa_node = 0;
+        topology->nic_list_.push_back(std::move(nic));
+    }
+
+    Topology::MemEntry memory;
+    memory.name = "cpu:0";
+    memory.type = Topology::MEM_HOST;
+    memory.numa_node = 0;
+    for (size_t i = 0; i < count; ++i) {
+        memory.device_list[0].push_back(static_cast<int>(i));
+    }
+    topology->mem_list_.push_back(std::move(memory));
+    return topology;
+}
+
 bool waitBatchDone(TransferEngine& engine, BatchID batch) {
     TransferStatus status;
     for (int i = 0; i < 10000; ++i) {
@@ -150,6 +172,39 @@ TEST(RdmaSubBatchTest, ReportsTaskCount) {
     batch.task_list.push_back(nullptr);
     batch.task_list.push_back(nullptr);
     EXPECT_EQ(batch.size(), 2);
+}
+
+TEST(DeviceSelectorTest, PerSliceAllocationHonorsPolicy) {
+    auto topology = topologyWithRdmaNics(3);
+
+    {
+        DeviceSelector selector;
+        ASSERT_TRUE(selector.loadTopology(topology).ok());
+        int chosen_device = -1;
+        ASSERT_TRUE(selector.allocate(4096, "cpu:0", chosen_device,
+                                       PRIO_HIGH, 1ULL << 1)
+                        .ok());
+        EXPECT_EQ(chosen_device, 1);
+    }
+
+    {
+        DeviceSelector selector;
+        ASSERT_TRUE(selector.loadTopology(topology).ok());
+        auto params = selector.getSchedulingParams();
+        params.device_base_priorities = {0, 1, 2};
+        params.local_rotation_interval_us = 0;
+        params.numa_tier_weights[0] = 1.0;
+        params.numa_tier_weights[1] = 1.0;
+        params.numa_tier_weights[2] = 1.0;
+        params.score_jitter_range = 0.0;
+        selector.setSchedulingParams(params);
+
+        int chosen_device = -1;
+        ASSERT_TRUE(selector.allocate(4096, "cpu:0", chosen_device,
+                                       PRIO_LOW, (1ULL << 1) | (1ULL << 2))
+                        .ok());
+        EXPECT_EQ(chosen_device, 2);
+    }
 }
 
 // context_set_ is subscripted by NicID, so it must keep one slot per NIC even

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -170,7 +170,7 @@ TEST(RequestMergeTest, MergesAdjacentRequestsWithSameTransportHint) {
     EXPECT_EQ(merged.task_lookup.at(1), 0u);
 }
 
-TEST(RequestMergeTest, KeepsDifferentSelectionAndSchedulingAttributesSplit) {
+TEST(RequestMergeTest, KeepsDifferentSelectionAttributesSplit) {
     std::array<char, 8192> source{};
     const auto source_addr =
         static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
@@ -179,7 +179,7 @@ TEST(RequestMergeTest, KeepsDifferentSelectionAndSchedulingAttributesSplit) {
         const char* name;
         void (*set_different)(Request&, Request&);
     };
-    const std::array<AttributeCase, 4> cases = {{
+    const std::array<AttributeCase, 3> cases = {{
         {"priority",
          [](Request& first, Request& second) {
              first.priority = PRIO_HIGH;
@@ -194,11 +194,6 @@ TEST(RequestMergeTest, KeepsDifferentSelectionAndSchedulingAttributesSplit) {
          [](Request& first, Request& second) {
              first.intent_type = IntentType::FOREGROUND_GET;
              second.intent_type = IntentType::MIGRATION;
-         }},
-        {"deadline_ns",
-         [](Request& first, Request& second) {
-             first.deadline_ns = 100;
-             second.deadline_ns = 200;
          }},
     }};
 
@@ -223,7 +218,7 @@ TEST(RequestMergeTest, KeepsDifferentSelectionAndSchedulingAttributesSplit) {
     }
 }
 
-TEST(RequestMergeTest, MergesMatchingSelectionAndSchedulingAttributes) {
+TEST(RequestMergeTest, MergesMatchingSelectionAttributes) {
     std::array<char, 2048> source{};
     const auto source_addr =
         static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
@@ -235,7 +230,6 @@ TEST(RequestMergeTest, MergesMatchingSelectionAndSchedulingAttributes) {
         request.priority = PRIO_LOW;
         request.policy_name = "background";
         request.intent_type = IntentType::MIGRATION;
-        request.deadline_ns = 12345;
     }
     std::vector<RequestBoundaryInfo> boundaries = {
         {makeBufferKey(source_addr, source.size()), makeBufferKey(4096, 2048)},

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -238,10 +238,8 @@ TEST(RequestMergeTest, MergesMatchingSelectionAndSchedulingAttributes) {
         request.deadline_ns = 12345;
     }
     std::vector<RequestBoundaryInfo> boundaries = {
-        {makeBufferKey(source_addr, source.size()),
-         makeBufferKey(4096, 2048)},
-        {makeBufferKey(source_addr, source.size()),
-         makeBufferKey(4096, 2048)},
+        {makeBufferKey(source_addr, source.size()), makeBufferKey(4096, 2048)},
+        {makeBufferKey(source_addr, source.size()), makeBufferKey(4096, 2048)},
     };
 
     auto merged = mergeRequests(requests, boundaries, true);

--- a/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/request_merge_test.cpp
@@ -170,6 +170,87 @@ TEST(RequestMergeTest, MergesAdjacentRequestsWithSameTransportHint) {
     EXPECT_EQ(merged.task_lookup.at(1), 0u);
 }
 
+TEST(RequestMergeTest, KeepsDifferentSelectionAndSchedulingAttributesSplit) {
+    std::array<char, 8192> source{};
+    const auto source_addr =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
+
+    struct AttributeCase {
+        const char* name;
+        void (*set_different)(Request&, Request&);
+    };
+    const std::array<AttributeCase, 4> cases = {{
+        {"priority",
+         [](Request& first, Request& second) {
+             first.priority = PRIO_HIGH;
+             second.priority = PRIO_LOW;
+         }},
+        {"policy_name",
+         [](Request& first, Request& second) {
+             first.policy_name = "foreground";
+             second.policy_name = "background";
+         }},
+        {"intent_type",
+         [](Request& first, Request& second) {
+             first.intent_type = IntentType::FOREGROUND_GET;
+             second.intent_type = IntentType::MIGRATION;
+         }},
+        {"deadline_ns",
+         [](Request& first, Request& second) {
+             first.deadline_ns = 100;
+             second.deadline_ns = 200;
+         }},
+    }};
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.name);
+        std::vector<Request> requests = {
+            makeWriteRequest(source.data(), 0, 4096, 1024),
+            makeWriteRequest(source.data(), 1024, 5120, 1024),
+        };
+        test_case.set_different(requests[0], requests[1]);
+        std::vector<RequestBoundaryInfo> boundaries = {
+            {makeBufferKey(source_addr, source.size()),
+             makeBufferKey(4096, 2048)},
+            {makeBufferKey(source_addr, source.size()),
+             makeBufferKey(4096, 2048)},
+        };
+
+        auto merged = mergeRequests(requests, boundaries, true);
+
+        ASSERT_EQ(merged.request_list.size(), 2u);
+        EXPECT_NE(merged.task_lookup.at(0), merged.task_lookup.at(1));
+    }
+}
+
+TEST(RequestMergeTest, MergesMatchingSelectionAndSchedulingAttributes) {
+    std::array<char, 2048> source{};
+    const auto source_addr =
+        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(source.data()));
+    std::vector<Request> requests = {
+        makeWriteRequest(source.data(), 0, 4096, 1024),
+        makeWriteRequest(source.data(), 1024, 5120, 1024),
+    };
+    for (auto& request : requests) {
+        request.priority = PRIO_LOW;
+        request.policy_name = "background";
+        request.intent_type = IntentType::MIGRATION;
+        request.deadline_ns = 12345;
+    }
+    std::vector<RequestBoundaryInfo> boundaries = {
+        {makeBufferKey(source_addr, source.size()),
+         makeBufferKey(4096, 2048)},
+        {makeBufferKey(source_addr, source.size()),
+         makeBufferKey(4096, 2048)},
+    };
+
+    auto merged = mergeRequests(requests, boundaries, true);
+
+    ASSERT_EQ(merged.request_list.size(), 1u);
+    EXPECT_EQ(merged.request_list[0].length, 2048u);
+    EXPECT_EQ(merged.task_lookup.at(0), merged.task_lookup.at(1));
+}
+
 TEST(RequestMergeTest, MixedHintBatchStillMergesPerHint) {
     std::array<char, 4096> source{};
     const auto source_addr =

--- a/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
@@ -389,18 +389,20 @@ TEST(TransportPolicy, SplitsRdmaSubBatchesByResolvedPolicy) {
     std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
     installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
 
-    constexpr size_t kRequestLength = 4096;
-    constexpr size_t kBufLen = 3 * kRequestLength;
+    constexpr size_t kRequestLengths[] = {1024, 2048, 3072};
+    constexpr size_t kBufLen =
+        kRequestLengths[0] + kRequestLengths[1] + kRequestLengths[2];
     std::vector<uint8_t> buf(kBufLen, 0xCC);
     ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
 
-    Request request_a0 = makeLocalWriteRequest(buf.data(), kRequestLength);
+    Request request_a0 = makeLocalWriteRequest(buf.data(), kRequestLengths[0]);
     request_a0.policy_name = "rdma-a";
-    Request request_b =
-        makeLocalWriteRequest(buf.data() + kRequestLength, kRequestLength);
+    Request request_b = makeLocalWriteRequest(buf.data() + kRequestLengths[0],
+                                              kRequestLengths[1]);
     request_b.policy_name = "rdma-b";
-    Request request_a1 =
-        makeLocalWriteRequest(buf.data() + 2 * kRequestLength, kRequestLength);
+    Request request_a1 = makeLocalWriteRequest(
+        buf.data() + kRequestLengths[0] + kRequestLengths[1],
+        kRequestLengths[2]);
     request_a1.policy_name = "rdma-a";
 
     BatchID batch_id = engine.allocateBatch(4);
@@ -423,6 +425,7 @@ TEST(TransportPolicy, SplitsRdmaSubBatchesByResolvedPolicy) {
         TransferStatus status;
         ASSERT_TRUE(engine.getTransferStatus(batch_id, task_id, status).ok());
         EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+        EXPECT_EQ(status.transferred_bytes, kRequestLengths[task_id]);
     }
 
     EXPECT_TRUE(engine.freeBatch(batch_id).ok());

--- a/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
@@ -59,6 +59,10 @@ class FakeTransport : public Transport {
     }
 
     std::atomic<int> submit_calls{0};
+    std::vector<uint64_t> submitted_device_masks;
+    std::vector<std::string> submitted_qp_pools;
+    std::vector<size_t> submitted_request_counts;
+    std::string fail_qp_pool_once;
 
     Status install(std::string&, std::shared_ptr<ControlService>,
                    std::shared_ptr<Topology>,
@@ -80,6 +84,14 @@ class FakeTransport : public Transport {
                                const std::vector<Request>& reqs) override {
         ++submit_calls;
         auto* fb = static_cast<FakeSubBatch*>(batch);
+        submitted_device_masks.push_back(fb->device_mask);
+        submitted_qp_pools.push_back(fb->qp_pool);
+        submitted_request_counts.push_back(reqs.size());
+        if (!fail_qp_pool_once.empty() &&
+            fb->qp_pool == fail_qp_pool_once) {
+            fail_qp_pool_once.clear();
+            return Status::InternalError("injected submit failure" LOC_MARK);
+        }
         for (const auto& req : reqs) {
             fb->statuses.push_back({TransferStatusEnum::COMPLETED, req.length});
             fb->task_count++;
@@ -341,6 +353,136 @@ TEST(TransportHint, MixedHintsInBatchSplitAcrossTransports) {
 
     EXPECT_EQ(fake_rdma->submit_calls.load(), 1);
     EXPECT_EQ(fake_tcp->submit_calls.load(), 1);
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// ---------------------------------------------------------------------------
+// 6. Requests using different RDMA policies must not share one scalar
+//    SubBatch policy. The A/B/A order also verifies physical task IDs after
+//    policy grouping remain aligned with the transport's append order.
+// ---------------------------------------------------------------------------
+
+TEST(TransportPolicy, SplitsRdmaSubBatchesByResolvedPolicy) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("merge_requests", true);
+    json topology;
+    topology["cpu:0"] = {{"mlx5_0"}, {"mlx5_1"}};
+    cfg->set("topology/priority_matrix", topology);
+    json policy_a;
+    policy_a["name"] = "rdma-a";
+    policy_a["segment_type"] = "memory";
+    policy_a["transports"] = {"rdma"};
+    policy_a["devices"] = {"mlx5_0"};
+    policy_a["qp_pool"] = "pool-a";
+    json policy_b;
+    policy_b["name"] = "rdma-b";
+    policy_b["segment_type"] = "memory";
+    policy_b["transports"] = {"rdma"};
+    policy_b["devices"] = {"mlx5_1"};
+    policy_b["qp_pool"] = "pool-b";
+    cfg->set("policy", json::array({policy_a, policy_b}));
+
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kRequestLength = 4096;
+    constexpr size_t kBufLen = 3 * kRequestLength;
+    std::vector<uint8_t> buf(kBufLen, 0xCC);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    Request request_a0 = makeLocalWriteRequest(
+        buf.data(), kRequestLength);
+    request_a0.policy_name = "rdma-a";
+    Request request_b = makeLocalWriteRequest(
+        buf.data() + kRequestLength, kRequestLength);
+    request_b.policy_name = "rdma-b";
+    Request request_a1 = makeLocalWriteRequest(
+        buf.data() + 2 * kRequestLength, kRequestLength);
+    request_a1.policy_name = "rdma-a";
+
+    BatchID batch_id = engine.allocateBatch(4);
+    ASSERT_TRUE(engine
+                    .submitTransfer(batch_id,
+                                    {request_a0, request_b, request_a1})
+                    .ok());
+
+    ASSERT_EQ(fake_rdma->submit_calls.load(), 2);
+    ASSERT_EQ(fake_rdma->submitted_request_counts.size(), 2u);
+    EXPECT_EQ(fake_rdma->submitted_request_counts[0], 2u);
+    EXPECT_EQ(fake_rdma->submitted_request_counts[1], 1u);
+    ASSERT_EQ(fake_rdma->submitted_device_masks.size(), 2u);
+    EXPECT_EQ(fake_rdma->submitted_device_masks[0], 1ULL);
+    EXPECT_EQ(fake_rdma->submitted_device_masks[1], 1ULL << 1);
+    ASSERT_EQ(fake_rdma->submitted_qp_pools.size(), 2u);
+    EXPECT_EQ(fake_rdma->submitted_qp_pools[0], "pool-a");
+    EXPECT_EQ(fake_rdma->submitted_qp_pools[1], "pool-b");
+
+    for (size_t task_id = 0; task_id < 3; ++task_id) {
+        TransferStatus status;
+        ASSERT_TRUE(engine.getTransferStatus(batch_id, task_id, status).ok());
+        EXPECT_EQ(status.s, TransferStatusEnum::COMPLETED);
+    }
+
+    EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+// A failed homogeneous group may return without appending any transport task.
+// The next group must derive its task ID from the SubBatch's actual size, not
+// from the number of requests the engine intended to submit.
+TEST(TransportPolicy, SyncFailureDoesNotShiftLaterGroupTaskIds) {
+    auto cfg = makeMinimalP2PConfig();
+    json topology;
+    topology["cpu:0"] = {{"mlx5_0"}, {"mlx5_1"}};
+    cfg->set("topology/priority_matrix", topology);
+    json failing_policy;
+    failing_policy["name"] = "rdma-fail";
+    failing_policy["segment_type"] = "memory";
+    failing_policy["transports"] = {"rdma"};
+    failing_policy["devices"] = {"mlx5_0"};
+    failing_policy["qp_pool"] = "pool-fail";
+    json succeeding_policy;
+    succeeding_policy["name"] = "rdma-ok";
+    succeeding_policy["segment_type"] = "memory";
+    succeeding_policy["transports"] = {"rdma"};
+    succeeding_policy["devices"] = {"mlx5_1"};
+    succeeding_policy["qp_pool"] = "pool-ok";
+    cfg->set("policy", json::array({failing_policy, succeeding_policy}));
+
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::shared_ptr<FakeTransport> fake_rdma, fake_tcp;
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+    fake_rdma->fail_qp_pool_once = "pool-fail";
+
+    constexpr size_t kRequestLength = 4096;
+    constexpr size_t kBufLen = 2 * kRequestLength;
+    std::vector<uint8_t> buf(kBufLen, 0xDD);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    Request failing = makeLocalWriteRequest(buf.data(), kRequestLength);
+    failing.policy_name = "rdma-fail";
+    Request succeeding = makeLocalWriteRequest(
+        buf.data() + kRequestLength, kRequestLength);
+    succeeding.policy_name = "rdma-ok";
+
+    BatchID batch_id = engine.allocateBatch(2);
+    ASSERT_TRUE(engine.submitTransfer(batch_id, {failing, succeeding}).ok());
+    ASSERT_EQ(fake_rdma->submit_calls.load(), 2);
+
+    TransferStatus failed_status;
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, 0, failed_status).ok());
+    EXPECT_EQ(failed_status.s, TransferStatusEnum::FAILED);
+
+    TransferStatus completed_status;
+    ASSERT_TRUE(engine.getTransferStatus(batch_id, 1, completed_status).ok());
+    EXPECT_EQ(completed_status.s, TransferStatusEnum::COMPLETED);
 
     EXPECT_TRUE(engine.freeBatch(batch_id).ok());
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());

--- a/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transport_hint_test.cpp
@@ -87,8 +87,7 @@ class FakeTransport : public Transport {
         submitted_device_masks.push_back(fb->device_mask);
         submitted_qp_pools.push_back(fb->qp_pool);
         submitted_request_counts.push_back(reqs.size());
-        if (!fail_qp_pool_once.empty() &&
-            fb->qp_pool == fail_qp_pool_once) {
+        if (!fail_qp_pool_once.empty() && fb->qp_pool == fail_qp_pool_once) {
             fail_qp_pool_once.clear();
             return Status::InternalError("injected submit failure" LOC_MARK);
         }
@@ -395,21 +394,19 @@ TEST(TransportPolicy, SplitsRdmaSubBatchesByResolvedPolicy) {
     std::vector<uint8_t> buf(kBufLen, 0xCC);
     ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
 
-    Request request_a0 = makeLocalWriteRequest(
-        buf.data(), kRequestLength);
+    Request request_a0 = makeLocalWriteRequest(buf.data(), kRequestLength);
     request_a0.policy_name = "rdma-a";
-    Request request_b = makeLocalWriteRequest(
-        buf.data() + kRequestLength, kRequestLength);
+    Request request_b =
+        makeLocalWriteRequest(buf.data() + kRequestLength, kRequestLength);
     request_b.policy_name = "rdma-b";
-    Request request_a1 = makeLocalWriteRequest(
-        buf.data() + 2 * kRequestLength, kRequestLength);
+    Request request_a1 =
+        makeLocalWriteRequest(buf.data() + 2 * kRequestLength, kRequestLength);
     request_a1.policy_name = "rdma-a";
 
     BatchID batch_id = engine.allocateBatch(4);
-    ASSERT_TRUE(engine
-                    .submitTransfer(batch_id,
-                                    {request_a0, request_b, request_a1})
-                    .ok());
+    ASSERT_TRUE(
+        engine.submitTransfer(batch_id, {request_a0, request_b, request_a1})
+            .ok());
 
     ASSERT_EQ(fake_rdma->submit_calls.load(), 2);
     ASSERT_EQ(fake_rdma->submitted_request_counts.size(), 2u);
@@ -468,8 +465,8 @@ TEST(TransportPolicy, SyncFailureDoesNotShiftLaterGroupTaskIds) {
 
     Request failing = makeLocalWriteRequest(buf.data(), kRequestLength);
     failing.policy_name = "rdma-fail";
-    Request succeeding = makeLocalWriteRequest(
-        buf.data() + kRequestLength, kRequestLength);
+    Request succeeding =
+        makeLocalWriteRequest(buf.data() + kRequestLength, kRequestLength);
     succeeding.policy_name = "rdma-ok";
 
     BatchID batch_id = engine.allocateBatch(2);


### PR DESCRIPTION
## Description

`Transport::SubBatch` carries one RDMA `device_mask` and one `qp_pool`, but a
single public submission can contain multiple requests that all select RDMA
with different policy results. `commitPreparedSubmit()` previously grouped
only by transport and copied the first task's policy to the whole RDMA
SubBatch. Later requests could therefore use the wrong NIC mask or QP pool.

This is reachable through the native TENT APIs: `tent::Request` has per-request
`priority`, `policy_name`, and `intent_type`
(`tent/include/tent/common/types.h:132-152`), the Python binding exposes them
(`tent/src/python/pybind.cpp:346-382`), and selection copies them into a
per-request `SelectionContext`
(`tent/src/runtime/transfer_engine_impl.cpp:1134-1139`) before matching the
policy (`tent/src/runtime/transport_selector.cpp:390-449`). A single native
TENT batch can therefore legitimately resolve different RDMA masks or QP pools.

This change:

- keeps requests with different selection or scheduling attributes separate
  during request merging;
- groups RDMA physical owners by resolved `(device_mask, qp_pool)` before each
  transport submission;
- assigns physical SubBatch task IDs from the actual size before each policy
  group is appended, so a synchronous failure cannot shift later groups, and
  preserves IDs for merged public aliases;
- copies the selected device mask into each `RdmaTask`, then uses it for lazy
  allocation and fallback RNIC selection while preserving request priority;
- refreshes RDMA policy metadata on queued dispatch and transport failover;
- keeps the existing three-argument `DeviceSelector::allocate()` overload and
  does not change the public `SubBatch` API.

The SubBatch API remains scalar by design. A per-request mask vector is not
needed because every `submitTransferTasks()` call is homogeneous, and the
effective mask is copied into each transport task before the SubBatch is reused
for another policy group.

This is a follow-up to the cached device-mask resolution in
[#3490](https://github.com/kvcache-ai/Mooncake/pull/3490), and is complementary
to the GPUDirect reachability and fallback handling in
[#3281](https://github.com/kvcache-ai/Mooncake/pull/3281).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B build-tent \
  -DUSE_TENT=ON -DUSE_CUDA=OFF \
  -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE=Release

cmake --build build-tent --target \
  tent_rdma_transport_test \
  tent_transport_hint_test \
  request_merge_test \
  tent_metrics_recording_test \
  tent_engine_failover_e2e_test \
  tent_runtime_queue_dispatch_test -j
ctest --test-dir build-tent/mooncake-transfer-engine/tent/tests \
  --output-on-failure \
  -R '^(tent_rdma_transport_test|tent_transport_hint_test|request_merge_test|tent_metrics_recording_test|tent_engine_failover_e2e_test|tent_runtime_queue_dispatch_test)$'
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

The six focused and adjacent regression test suites above passed. They cover
mixed-policy batching, synchronous submit failure, request merging, transport
attempt metrics, failover, and runtime-queue dispatch.

All applicable pre-commit hooks passed, including C++ formatting and codespell.

## Checklist

- [x] I have performed a self-review of my own code
- [x] The C/C++ formatting pre-commit hook passed
- [x] I have run pre-commit on the files changed in this PR
- [x] Documentation is unchanged because this is an internal bug fix
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required because this is a small bug fix

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with the implementation, testing, and writing of this
PR.