### PR TITLE
[TENT] Remove global lock serialization on per-batch hot paths

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -303,8 +303,12 @@ class TransferEngineImpl {
     // Test-only hook: how many batches are still alive. Lets a test assert
     // that a failed transfer released its batch rather than leaking it.
     size_t aliveBatchCountForTest() {
-        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-        return alive_batches_.size();
+        size_t count = 0;
+        for (auto& shard : batch_shards_) {
+            std::lock_guard<std::recursive_mutex> lk(shard.mtx);
+            count += shard.alive_batches.size();
+        }
+        return count;
     }
 
     // Test-only hook: how many undrained staging batches the ProxyManager
@@ -445,11 +449,6 @@ class TransferEngineImpl {
         MemoryOptions options;
     };
 
-    struct BatchSet {
-        std::unordered_set<Batch*> active;
-        std::vector<Batch*> freelist;
-    };
-
     // Staging resources that ProxyManager could not drain before its shutdown
     // deadline. Their slices may still be written by transport workers, so
     // nothing here may be freed before transport_list_ is reset (which joins
@@ -492,8 +491,6 @@ class TransferEngineImpl {
         transport_list_;
     std::unique_ptr<SegmentTracker> local_segment_tracker_;
 
-    BatchSet batch_set_;
-
     std::vector<AllocatedMemory> allocated_memory_;
     std::mutex mutex_;
 
@@ -514,16 +511,67 @@ class TransferEngineImpl {
     size_t dispatch_inflight_bytes_{0};
     uint64_t next_batch_token_{1};
 
-    // Guards alive_batches_ and serializes pollTaskStatus /
-    // updateTaskStatusAfterPoll / lazyFreeBatch against the optional
-    // ProgressWorker thread. Recursive because freeBatch -> lazyFreeBatch ->
-    // getTransferStatus can re-enter on the same thread. See issue #2116.
+    // Serializes engine-global progress: runtime queue, lazyFreeBatch
+    // freelist, and ProgressWorker. Recursive because freeBatch ->
+    // lazyFreeBatch -> getTransferStatus can re-enter. See issue #2116.
     std::recursive_mutex progress_mutex_;
-    std::unordered_set<BatchID> alive_batches_;
     // Guarded by progress_mutex_. Emptied (abandoned on purpose) at the end of
     // deconstruct(), after the transports have been destroyed.
     DeferredStageTeardown deferred_stage_teardown_;
     std::unique_ptr<ProgressWorker> progress_worker_;
+
+    // Per-batch hot paths (poll / free / retain) lock only the shard for
+    // that BatchID instead of progress_mutex_, so N threads polling N
+    // independent batches do not serialize.
+    //
+    // Exception: enable_runtime_queue=true keeps those paths on
+    // progress_mutex_ because queued_owners_ / dispatch window are
+    // engine-global. The runtime queue is off by default.
+    //
+    // The batch registry (alive / active membership) lives INSIDE the same
+    // shard: membership changes and lookups are O(1) set ops taken while
+    // already holding the shard lock, so no separate global registry lock
+    // sits on the poll/alloc/free hot path.
+    //
+    // Lock order (never reversed):
+    //   progress_mutex_ -> shard
+    // With the runtime queue enabled, hot paths hold progress_mutex_ and
+    // take the shard only for membership ops:
+    //   progress_mutex_ -> shard (membership only)
+    static constexpr size_t kBatchLockShards = 64;
+    struct BatchShard {
+        std::recursive_mutex mtx;
+        std::unordered_set<Batch*> active_batches;
+        std::unordered_set<BatchID> alive_batches;
+    };
+    BatchShard& batchShard(BatchID batch_id) {
+        return batch_shards_[reinterpret_cast<uintptr_t>(batch_id) %
+                             kBatchLockShards];
+    }
+    std::recursive_mutex& batchShardMutex(BatchID batch_id) {
+        return batchShard(batch_id).mtx;
+    }
+    std::recursive_mutex& progressLockFor(BatchID batch_id) {
+        if (runtime_queue_config_.enabled) return progress_mutex_;
+        return batchShardMutex(batch_id);
+    }
+    // Caller must hold progressLockFor(batch_id). In default mode that is
+    // the shard itself, so the membership check is a lock-free read under
+    // an already-held lock. In queue mode the caller holds progress_mutex_
+    // and we take the shard briefly (progress -> shard order is allowed).
+    bool isBatchAlive(BatchID batch_id) {
+        BatchShard& shard = batchShard(batch_id);
+        if (runtime_queue_config_.enabled) {
+            std::lock_guard<std::recursive_mutex> lk(shard.mtx);
+            return shard.alive_batches.count(batch_id) != 0;
+        }
+        return shard.alive_batches.count(batch_id) != 0;
+    }
+    std::array<BatchShard, kBatchLockShards> batch_shards_;
+    // Deferred-free queue, guarded by progress_mutex_. Only used when the
+    // fast path cannot free inline (tasks still in flight, runtime refs,
+    // or runtime queue enabled).
+    std::vector<Batch*> batch_freelist_;
 };
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -553,11 +553,17 @@ Status TransferEngineImpl::deconstruct() {
             }
             Slab<Batch>::Get().deallocate(batch);
         };
-        for (auto& batch : batch_set_.active) release_batch(batch);
-        for (auto& batch : batch_set_.freelist) release_batch(batch);
-        batch_set_.active.clear();
-        batch_set_.freelist.clear();
-        alive_batches_.clear();
+        // Registry state is sharded; collect members under each shard.
+        // Shutdown is quiesced (progress_mutex_ held, no pollers expected),
+        // so a brief per-shard lock per batch is sufficient.
+        for (auto& shard : batch_shards_) {
+            std::lock_guard<std::recursive_mutex> shard_lk(shard.mtx);
+            for (auto* batch : shard.active_batches) release_batch(batch);
+            shard.active_batches.clear();
+            shard.alive_batches.clear();
+        }
+        for (auto* batch : batch_freelist_) release_batch(batch);
+        batch_freelist_.clear();
     }
 
     // Now safe to destroy transports (workers join here)
@@ -894,31 +900,86 @@ BatchID TransferEngineImpl::allocateBatch(size_t batch_size) {
     batch->max_size = batch_size;
     batch->task_list.reserve(batch_size);
     BatchID batch_id = (BatchID)batch;
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    batch_set_.active.insert(batch);
-    alive_batches_.insert(batch_id);
+    // Registry insert under the batch's own shard; no global lock.
+    {
+        BatchShard& shard = batchShard(batch_id);
+        std::lock_guard<std::recursive_mutex> lk(shard.mtx);
+        shard.active_batches.insert(batch);
+        shard.alive_batches.insert(batch_id);
+    }
     return batch_id;
 }
 
 Status TransferEngineImpl::freeBatch(BatchID batch_id) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
-        return Status::InvalidArgument("Batch is not alive" LOC_MARK);
-    if (runtime_queue_config_.enabled && batch->queue_token != 0) {
-        auto retire_status = retireQueueForBatch(batch);
-        if (!retire_status.ok() && !retire_status.IsInvalidEntry()) {
-            return retire_status;
+    // Fast path (queue off, no refs, tasks terminal): free under the batch
+    // shard only. tebench / sglang take this path. Shard is released before
+    // the deferred path takes progress_mutex_ (lock-order safety).
+    bool already_requested = false;
+    bool deferred = false;
+    {
+        std::lock_guard<std::recursive_mutex> shard_lk(
+            progressLockFor(batch_id));
+        if (!isBatchAlive(batch_id))
+            return Status::InvalidArgument("Batch is not alive" LOC_MARK);
+        if (!runtime_queue_config_.enabled && batch->runtime_refs == 0 &&
+            !batch->free_requested) {
+            // Only free inline when the final poll succeeds and reports a
+            // terminal state. A poll error defers the batch instead of
+            // failing freeBatch(): the lazy sweep retries, rate-limits and
+            // eventually quarantines a permanently stuck batch.
+            TransferStatus overall_status;
+            auto status = getTransferStatus(batch_id, overall_status);
+            if (status.ok() && overall_status.s != PENDING) {
+                for (size_t type = 0; type < kSupportedTransportTypes;
+                     ++type) {
+                    auto& transport = transport_list_[type];
+                    auto& sub_batch = batch->sub_batch[type];
+                    if (transport && sub_batch)
+                        transport->freeSubBatch(sub_batch);
+                }
+                {
+                    BatchShard& shard = batchShard(batch_id);
+                    std::lock_guard<std::recursive_mutex> shard_reg_lk(
+                        shard.mtx);
+                    shard.active_batches.erase(batch);
+                    shard.alive_batches.erase(batch_id);
+                }
+                Slab<Batch>::Get().deallocate(batch);
+                return Status::OK();
+            }
         }
+        already_requested = batch->free_requested;
+        batch->free_requested = true;
+        deferred = true;
     }
-    if (batch->free_requested) {
+
+    if (deferred) {
+        std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+        if (!isBatchAlive(batch_id)) {
+            // We marked free_requested; another thread already reaped it.
+            return Status::OK();
+        }
+        if (runtime_queue_config_.enabled && batch->queue_token != 0) {
+            auto retire_status = retireQueueForBatch(batch);
+            if (!retire_status.ok() && !retire_status.IsInvalidEntry()) {
+                return retire_status;
+            }
+        }
+        if (!already_requested) {
+            // First free request: accepted unconditionally; the lazy sweep
+            // result is dropped (retry/quarantine happens in background).
+            batch_freelist_.push_back(batch);
+            lazyFreeBatch();
+            return Status::OK();
+        }
+        // Re-free of an already-requested batch: surface the sweep status —
+        // callers polling a stuck batch observe the reclaim error until the
+        // batch is quarantined or reclaimed.
         CHECK_STATUS(lazyFreeBatch());
         return Status::OK();
     }
-    batch->free_requested = true;
-    batch_set_.freelist.push_back(batch);
-    lazyFreeBatch();
     return Status::OK();
 }
 
@@ -933,61 +994,82 @@ Status TransferEngineImpl::lazyFreeBatch() {
     // also logged here, rate-limited, or a permanently stuck batch would be
     // re-polled forever without a trace.
     Status first_error = Status::OK();
-    for (auto it = batch_set_.freelist.begin();
-         it != batch_set_.freelist.end();) {
+    for (auto it = batch_freelist_.begin(); it != batch_freelist_.end();) {
         auto& batch = *it;
-        if (batch->runtime_refs > 0 || batch->reclaim_abandoned) {
+        if (batch->reclaim_abandoned) {
             it++;
             continue;
         }
-        TransferStatus overall_status;
-        auto status = getTransferStatus((BatchID)batch, overall_status);
-        if (status.ok() && overall_status.s == PENDING) {
-            batch->reclaim_failures = 0;
-            it++;
-            continue;
-        }
-        if (status.ok() && runtime_queue_config_.enabled &&
-            batch->queue_token != 0) {
-            status = retireQueueForBatch(batch);
-        }
-        if (!status.ok()) {
-            if (++batch->reclaim_failures >= kMaxReclaimAttempts) {
-                batch->reclaim_abandoned = true;
-                TENT_RECORD_BATCH_QUARANTINED();
-                LOG(ERROR) << "lazyFreeBatch: batch " << batch << " failed "
-                           << batch->reclaim_failures
-                           << " consecutive reclaim attempts; giving up until "
-                              "engine teardown reclaims it unconditionally. "
-                              "Last error: "
-                           << status.ToString();
-            } else {
-                LOG_EVERY_N(WARNING, 100)
-                    << "lazyFreeBatch: batch " << batch
-                    << " cannot be reclaimed yet, left in freelist: "
-                    << status.ToString();
+        BatchID batch_id = (BatchID)batch;
+        // Hold the shard through deallocate so a poller waiting on the
+        // same shard cannot observe a dangling Batch*. runtime_refs is
+        // read under the shard because retain/release mutate it there.
+        {
+            std::lock_guard<std::recursive_mutex> shard_lk(
+                progressLockFor(batch_id));
+            if (!isBatchAlive(batch_id)) {
+                // Another thread already reaped this batch.
+                it = batch_freelist_.erase(it);
+                continue;
             }
-            if (first_error.ok()) first_error = status;
-            it++;
-            continue;
+            if (batch->runtime_refs > 0) {
+                it++;
+                continue;
+            }
+            TransferStatus overall_status;
+            auto status = getTransferStatus(batch_id, overall_status);
+            if (status.ok() && overall_status.s == PENDING) {
+                batch->reclaim_failures = 0;
+                it++;
+                continue;
+            }
+            if (status.ok() && runtime_queue_config_.enabled &&
+                batch->queue_token != 0) {
+                status = retireQueueForBatch(batch);
+            }
+            if (!status.ok()) {
+                if (++batch->reclaim_failures >= kMaxReclaimAttempts) {
+                    batch->reclaim_abandoned = true;
+                    TENT_RECORD_BATCH_QUARANTINED();
+                    LOG(ERROR) << "lazyFreeBatch: batch " << batch << " failed "
+                               << batch->reclaim_failures
+                               << " consecutive reclaim attempts; giving up "
+                                  "until engine teardown reclaims it "
+                                  "unconditionally. Last error: "
+                               << status.ToString();
+                } else {
+                    LOG_EVERY_N(WARNING, 100)
+                        << "lazyFreeBatch: batch " << batch
+                        << " cannot be reclaimed yet, left in freelist: "
+                        << status.ToString();
+                }
+                if (first_error.ok()) first_error = status;
+                it++;
+                continue;
+            }
+            for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
+                auto& transport = transport_list_[type];
+                auto& sub_batch = batch->sub_batch[type];
+                if (transport && sub_batch) transport->freeSubBatch(sub_batch);
+            }
+            {
+                BatchShard& shard = batchShard(batch_id);
+                std::lock_guard<std::recursive_mutex> shard_reg_lk(
+                    shard.mtx);
+                shard.active_batches.erase(batch);
+                shard.alive_batches.erase(batch_id);
+            }
+            Slab<Batch>::Get().deallocate(batch);
         }
-        for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
-            auto& transport = transport_list_[type];
-            auto& sub_batch = batch->sub_batch[type];
-            if (transport && sub_batch) transport->freeSubBatch(sub_batch);
-        }
-        batch_set_.active.erase(batch);
-        alive_batches_.erase((BatchID)batch);
-        Slab<Batch>::Get().deallocate(batch);
-        it = batch_set_.freelist.erase(it);
+        it = batch_freelist_.erase(it);
     }
     return first_error;
 }
 
 Status TransferEngineImpl::retainBatch(BatchID batch_id, Batch*& batch) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id)) {
+    std::lock_guard<std::recursive_mutex> shard_lk(progressLockFor(batch_id));
+    if (!isBatchAlive(batch_id)) {
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     }
     batch = (Batch*)batch_id;
@@ -1000,12 +1082,19 @@ Status TransferEngineImpl::retainBatch(BatchID batch_id, Batch*& batch) {
 
 Status TransferEngineImpl::releaseBatch(Batch* batch) {
     if (!batch) return Status::InvalidArgument("Invalid batch" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (batch->runtime_refs == 0) {
-        return Status::InternalError("Batch runtime ref underflow" LOC_MARK);
+    // Refcount under the batch lock; deferred free runs on the global path
+    // after that lock is released (lock-order safety).
+    bool deferred_free = false;
+    {
+        std::lock_guard<std::recursive_mutex> shard_lk(
+            progressLockFor((BatchID)batch));
+        if (batch->runtime_refs == 0) {
+            return Status::InternalError("Batch runtime ref underflow" LOC_MARK);
+        }
+        --batch->runtime_refs;
+        deferred_free = (batch->runtime_refs == 0 && batch->free_requested);
     }
-    --batch->runtime_refs;
-    if (batch->runtime_refs == 0 && batch->free_requested) {
+    if (deferred_free) {
         CHECK_STATUS(lazyFreeBatch());
     }
     return Status::OK();
@@ -1017,16 +1106,18 @@ void TransferEngineImpl::adoptDeferredStageTeardown(
     std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     for (auto batch_id : deferred.batches) {
         Batch* batch = (Batch*)batch_id;
-        // Detach from the normal lifecycle: an undrained batch sits in
-        // batch_set_.active, batch_set_.freelist (free_requested, still
-        // referenced) and alive_batches_, so the sweep in deconstruct() would
-        // hand its SubBatch/Slice objects back to the Slab while a transport
-        // worker can still write their status.
-        batch_set_.active.erase(batch);
-        auto it = std::find(batch_set_.freelist.begin(),
-                            batch_set_.freelist.end(), batch);
-        if (it != batch_set_.freelist.end()) batch_set_.freelist.erase(it);
-        alive_batches_.erase(batch_id);
+        // Detach from the normal lifecycle: an undrained batch sits in its
+        // shard's active_batches / alive_batches and possibly
+        // batch_freelist_ (free_requested, still referenced), so the sweep
+        // in deconstruct() would hand its SubBatch/Slice objects back to
+        // the Slab while a transport worker can still write their status.
+        BatchShard& shard = batchShard(batch_id);
+        std::lock_guard<std::recursive_mutex> shard_lk(shard.mtx);
+        shard.active_batches.erase(batch);
+        shard.alive_batches.erase(batch_id);
+        auto it =
+            std::find(batch_freelist_.begin(), batch_freelist_.end(), batch);
+        if (it != batch_freelist_.end()) batch_freelist_.erase(it);
         deferred_stage_teardown_.batches.push_back(batch_id);
     }
     deferred_stage_teardown_.stage_buffers.insert(
@@ -1931,8 +2022,9 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
 }
 
 Status TransferEngineImpl::refillDispatchWindow() {
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
+    // Queue is off by default; skip the global lock on the poll hot path.
     if (!runtime_queue_config_.enabled) return Status::OK();
+    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
     if (dispatch_inflight_owners_ >=
             runtime_queue_config_.max_dispatch_owners ||
         dispatch_inflight_bytes_ >= runtime_queue_config_.max_dispatch_bytes) {
@@ -1970,7 +2062,7 @@ Status TransferEngineImpl::progressRuntimeQueue() {
         auto& queued = queued_it->second;
         if (!queued.in_dispatch_window) continue;
         auto* batch = queued.batch;
-        if (!batch || !alive_batches_.count((BatchID)batch)) continue;
+        if (!batch || !isBatchAlive((BatchID)batch)) continue;
         if (queued.owner_task_id >= batch->task_list.size()) {
             return Status::InternalError(
                 "queued owner task id out of range" LOC_MARK);
@@ -2106,8 +2198,8 @@ Status TransferEngineImpl::submitTransfer(
 
 Status TransferEngineImpl::cancelTransfer(BatchID batch_id, size_t task_id) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id)) {
+    std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
+    if (!isBatchAlive(batch_id)) {
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     }
     auto* batch = reinterpret_cast<Batch*>(batch_id);
@@ -2303,8 +2395,8 @@ Status TransferEngineImpl::receiveNotification(
 Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
                                              TransferStatus& task_status) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
+    if (!isBatchAlive(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     if (task_id >= batch->task_list.size())
@@ -2364,8 +2456,8 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
 Status TransferEngineImpl::getTransferStatus(
     BatchID batch_id, std::vector<TransferStatus>& status_list) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
+    if (!isBatchAlive(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     Batch* batch = (Batch*)(batch_id);
     status_list.clear();
@@ -2381,8 +2473,8 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                                           TransferStatus& overall_status,
                                           bool allow_failover) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
-    std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-    if (!alive_batches_.count(batch_id))
+    std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
+    if (!isBatchAlive(batch_id))
         return Status::InvalidArgument("Batch is not alive" LOC_MARK);
     CHECK_STATUS(refillDispatchWindow());
     Batch* batch = (Batch*)(batch_id);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -932,8 +932,7 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
             TransferStatus overall_status;
             auto status = getTransferStatus(batch_id, overall_status);
             if (status.ok() && overall_status.s != PENDING) {
-                for (size_t type = 0; type < kSupportedTransportTypes;
-                     ++type) {
+                for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
                     auto& transport = transport_list_[type];
                     auto& sub_batch = batch->sub_batch[type];
                     if (transport && sub_batch)
@@ -1054,8 +1053,7 @@ Status TransferEngineImpl::lazyFreeBatch() {
             }
             {
                 BatchShard& shard = batchShard(batch_id);
-                std::lock_guard<std::recursive_mutex> shard_reg_lk(
-                    shard.mtx);
+                std::lock_guard<std::recursive_mutex> shard_reg_lk(shard.mtx);
                 shard.active_batches.erase(batch);
                 shard.alive_batches.erase(batch_id);
             }
@@ -1089,7 +1087,8 @@ Status TransferEngineImpl::releaseBatch(Batch* batch) {
         std::lock_guard<std::recursive_mutex> shard_lk(
             progressLockFor((BatchID)batch));
         if (batch->runtime_refs == 0) {
-            return Status::InternalError("Batch runtime ref underflow" LOC_MARK);
+            return Status::InternalError(
+                "Batch runtime ref underflow" LOC_MARK);
         }
         --batch->runtime_refs;
         deferred_free = (batch->runtime_refs == 0 && batch->free_requested);

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1572,8 +1572,9 @@ TEST(ProgressLockShard, ConcurrentIndependentBatchPolls) {
                             ++failures;
                             return;
                         }
-                        if (!engine.submitTransfer(
-                                     batch_id, {makeLocalWriteReq(ptr, kBufLen)})
+                        if (!engine
+                                 .submitTransfer(batch_id, {makeLocalWriteReq(
+                                                               ptr, kBufLen)})
                                  .ok()) {
                             ++failures;
                             (void)engine.freeBatch(batch_id);
@@ -1614,7 +1615,8 @@ TEST(ProgressLockShard, PollRacesWithFreeSameBatch) {
     BatchID batch_id = engine.allocateBatch(1);
     ASSERT_NE(batch_id, (BatchID)0);
     ASSERT_TRUE(
-        engine.submitTransfer(batch_id, {makeLocalWriteReq(buf.data(), kBufLen)})
+        engine
+            .submitTransfer(batch_id, {makeLocalWriteReq(buf.data(), kBufLen)})
             .ok());
 
     std::atomic<bool> stop{false};
@@ -1679,9 +1681,10 @@ TEST(ProgressLockShard, RuntimeQueuePollAndFreeDoesNotDeadlock) {
     for (int i = 0; i < kBatches; ++i) {
         BatchID batch_id = engine.allocateBatch(1);
         ASSERT_NE(batch_id, (BatchID)0);
-        ASSERT_TRUE(engine.submitTransfer(
-                             batch_id, {makeLocalWriteReq(
-                                           buf.data() + i * kBufLen, kBufLen)})
+        ASSERT_TRUE(engine
+                        .submitTransfer(batch_id,
+                                        {makeLocalWriteReq(
+                                            buf.data() + i * kBufLen, kBufLen)})
                         .ok());
         batches.push_back(batch_id);
     }
@@ -1710,7 +1713,6 @@ TEST(ProgressLockShard, RuntimeQueuePollAndFreeDoesNotDeadlock) {
 
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
 }
-
 
 }  // namespace
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -1499,6 +1500,217 @@ TEST(BatchLifecycle, PermanentlyStuckBatchIsQuarantinedNotRetriedForever) {
               2)
         << "teardown must reclaim the quarantined batch";
 }
+
+void installFakeRdmaAndTcp(TransferEngineImpl& engine,
+                           const std::shared_ptr<FakeTransport>& fake_rdma,
+                           const std::shared_ptr<FakeTransport>& fake_tcp) {
+    std::string seg = engine.getSegmentName();
+    ASSERT_TRUE(fake_rdma->install(seg, nullptr, nullptr).ok());
+    ASSERT_TRUE(fake_tcp->install(seg, nullptr, nullptr).ok());
+    engine.swapTransportForTest(RDMA, fake_rdma);
+    engine.swapTransportForTest(TCP, fake_tcp);
+}
+
+Request makeLocalWriteReq(uint8_t* ptr, size_t length) {
+    Request req;
+    req.opcode = Request::WRITE;
+    req.source = ptr;
+    req.target_id = LOCAL_SEGMENT_ID;
+    req.target_offset = reinterpret_cast<uint64_t>(ptr);
+    req.length = length;
+    return req;
+}
+
+template <typename Fn>
+void runOrAbortOnTimeout(Fn&& fn, std::chrono::milliseconds timeout,
+                         const char* what) {
+    std::promise<void> done;
+    auto fut = done.get_future();
+    std::thread worker([&] {
+        fn();
+        done.set_value();
+    });
+    if (fut.wait_for(timeout) != std::future_status::ready) {
+        worker.detach();
+        ADD_FAILURE() << what << " timed out (likely deadlock)";
+        std::_Exit(1);
+    }
+    worker.join();
+}
+
+// ---------------------------------------------------------------------------
+// Lock-sharding: independent batches poll concurrently; poll vs free of the
+// same batch is well-defined; runtime-queue path must not invert lock order.
+// ---------------------------------------------------------------------------
+
+TEST(ProgressLockShard, ConcurrentIndependentBatchPolls) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    constexpr int kThreads = 8;
+    constexpr int kIters = 50;
+    std::vector<uint8_t> buf(kBufLen * kThreads, 0x5A);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    std::atomic<int> failures{0};
+    runOrAbortOnTimeout(
+        [&] {
+            std::vector<std::thread> threads;
+            threads.reserve(kThreads);
+            for (int t = 0; t < kThreads; ++t) {
+                threads.emplace_back([&, t] {
+                    uint8_t* ptr = buf.data() + t * kBufLen;
+                    for (int i = 0; i < kIters; ++i) {
+                        BatchID batch_id = engine.allocateBatch(1);
+                        if (!batch_id) {
+                            ++failures;
+                            return;
+                        }
+                        if (!engine.submitTransfer(
+                                     batch_id, {makeLocalWriteReq(ptr, kBufLen)})
+                                 .ok()) {
+                            ++failures;
+                            (void)engine.freeBatch(batch_id);
+                            return;
+                        }
+                        TransferStatus status{};
+                        if (!engine.getTransferStatus(batch_id, status).ok() ||
+                            status.s != TransferStatusEnum::COMPLETED) {
+                            ++failures;
+                            (void)engine.freeBatch(batch_id);
+                            return;
+                        }
+                        if (!engine.freeBatch(batch_id).ok()) ++failures;
+                    }
+                });
+            }
+            for (auto& th : threads) th.join();
+        },
+        std::chrono::seconds(10), "ConcurrentIndependentBatchPolls");
+
+    EXPECT_EQ(failures.load(), 0);
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
+TEST(ProgressLockShard, PollRacesWithFreeSameBatch) {
+    auto cfg = makeMinimalP2PConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake_rdma = std::make_shared<FakeTransport>(RDMA);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    std::vector<uint8_t> buf(kBufLen, 0x11);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kBufLen).ok());
+
+    BatchID batch_id = engine.allocateBatch(1);
+    ASSERT_NE(batch_id, (BatchID)0);
+    ASSERT_TRUE(
+        engine.submitTransfer(batch_id, {makeLocalWriteReq(buf.data(), kBufLen)})
+            .ok());
+
+    std::atomic<bool> stop{false};
+    std::atomic<int> invalid_after_free{0};
+    std::atomic<int> unexpected{0};
+    runOrAbortOnTimeout(
+        [&] {
+            std::thread poller([&] {
+                TransferStatus status{};
+                while (!stop.load(std::memory_order_acquire)) {
+                    auto st = engine.getTransferStatus(batch_id, status);
+                    if (st.ok()) continue;
+                    if (st.IsInvalidArgument()) {
+                        ++invalid_after_free;
+                        return;
+                    }
+                    ++unexpected;
+                    return;
+                }
+            });
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+            EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+            stop.store(true, std::memory_order_release);
+            poller.join();
+        },
+        std::chrono::seconds(10), "PollRacesWithFreeSameBatch");
+
+    EXPECT_EQ(unexpected.load(), 0);
+    TransferStatus status{};
+    EXPECT_TRUE(engine.getTransferStatus(batch_id, status).IsInvalidArgument());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
+}
+
+TEST(ProgressLockShard, RuntimeQueuePollAndFreeDoesNotDeadlock) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_runtime_queue", true);
+    cfg->set("runtime_queue/max_outstanding_owners", 16UL);
+    cfg->set("runtime_queue/max_outstanding_bytes", 1UL << 20);
+    cfg->set("runtime_queue/max_dispatch_owners", 4UL);
+    cfg->set("runtime_queue/max_dispatch_bytes", 1UL << 20);
+    cfg->set("runtime_queue/staging_owner_reserve", 0UL);
+    cfg->set("runtime_queue/staging_byte_reserve", 0UL);
+    cfg->set("runtime_queue/progress_fallback_interval_us", 50000UL);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto pending_poll = [](const Request&, int) {
+        return TransferStatus{TransferStatusEnum::PENDING, 0};
+    };
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{}, pending_poll);
+    auto fake_tcp = std::make_shared<FakeTransport>(TCP);
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    constexpr int kBatches = 8;
+    std::vector<uint8_t> buf(kBufLen * kBatches, 0x22);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    std::vector<BatchID> batches;
+    batches.reserve(kBatches);
+    for (int i = 0; i < kBatches; ++i) {
+        BatchID batch_id = engine.allocateBatch(1);
+        ASSERT_NE(batch_id, (BatchID)0);
+        ASSERT_TRUE(engine.submitTransfer(
+                             batch_id, {makeLocalWriteReq(
+                                           buf.data() + i * kBufLen, kBufLen)})
+                        .ok());
+        batches.push_back(batch_id);
+    }
+
+    runOrAbortOnTimeout(
+        [&] {
+            std::atomic<bool> stop{false};
+            std::vector<std::thread> pollers;
+            pollers.reserve(kBatches);
+            for (int i = 0; i < kBatches; ++i) {
+                pollers.emplace_back([&, i] {
+                    TransferStatus status{};
+                    while (!stop.load(std::memory_order_acquire)) {
+                        (void)engine.getTransferStatus(batches[i], status);
+                    }
+                });
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            for (auto batch_id : batches) {
+                EXPECT_TRUE(engine.freeBatch(batch_id).ok());
+            }
+            stop.store(true, std::memory_order_release);
+            for (auto& th : pollers) th.join();
+        },
+        std::chrono::seconds(10), "RuntimeQueuePollAndFreeDoesNotDeadlock");
+
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
 
 }  // namespace
 }  // namespace tent


### PR DESCRIPTION
## Description

**Problem.** TENT throughput does not scale with caller threads. In `tebench` (4KiB/1 write), the op rate is flat at ~140k ops/s from 4 to 16 threads while per-op latency grows linearly with thread count (55us at 8 threads, 113us at 16) — the classic M/D/1 signature of a single serialized server. Under the same workload the classic engine reaches 474k ops/s at 8 threads with flat latency. The engine effectively degrades to one core no matter how many threads submit, poll, or free batches.

**Root cause.** `TransferEngineImpl::progress_mutex_` serializes every per-batch operation: `submitTransfer`, `getTransferStatus`, `freeBatch`. Sharding that mutex alone is not sufficient — the batch registry (`alive_batches_` / active set) sits behind a single global mutex taken on *every poll*, which reintroduces the same serialization (measured at ~5.9k cycles per poll at 8 threads with rdtsc section counters).

**Solution.** Give each batch a complete lock domain: 64 `BatchShard`s keyed by BatchID, each owning both its recursive mutex *and* its slice of the batch registry.

- Poll / free / retain lock only the batch's shard. Membership checks become O(1) set lookups under the already-held shard lock — no global lock remains on the hot path.
- Lock order is `progress_mutex_ -> shard`, never reversed. With `enable_runtime_queue=true`, hot paths stay on `progress_mutex_` (queue state is engine-global) and take the shard only for membership ops.
- `freeBatch` fast path (runtime queue off, no refs, tasks terminal) frees inline under the shard and holds it through deallocation, so a concurrent poller can never observe a dangling `Batch*`. A poll error defers the batch to the lazy sweep (retry / quarantine) instead of failing the call, preserving the semantics of the recent reclaim rework on main.

**Results.** All numbers below were measured the same day, on the same machine pair, with the same `tebench` parameters and `TENT_METRICS_ENABLED=OFF` at build time; "before" is `main` without this change, "classic" is the classic engine from the same revision.

Local, RDMA loopback (ops/s):

| Threads | 1 | 2 | 4 | 8 | 16 |
|---|---|---|---|---|---|
| before | 112k | 142k | 161k | 145k | 142k |
| **after** | 112k | 170k | 329k | **464k** | **673k** |
| classic | 104k | 117k | 280k | 474k | 975k |

Cross-machine RDMA (ops/s):

| Threads | 1 | 2 | 4 | 8 | 16 |
|---|---|---|---|---|---|
| before | 62k | 87k | 118k | 135k | 138k |
| **after** | 61k | 94k | 190k | **322k** | **512k** |
| classic | 65k | 120k | 242k | 470k | 852k |

Single-thread latency is unchanged (9.0us local / 16.2us cross). At 8 threads the fix delivers **3.2x local / 2.4x cross-machine** and reaches classic parity locally (464k vs 474k); 8-thread latency drops from 55us to 17.3us. 256KiB transfers sustain 52.6 GB/s at 8 threads. A further gap to classic remains at 16 threads and cross-machine (60–70%); that residual is in transport-level per-op overhead and the completion model, not the engine lock domain, and is left for follow-up work.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -B build-tent -DCMAKE_BUILD_TYPE=Release -DUSE_TENT=ON -DTENT_METRICS_ENABLED=OFF -DWITH_STORE=OFF
cmake --build build-tent --target tent_progress_worker_test tebench
./build-tent/mooncake-transfer-engine/tent/tests/tent_progress_worker_test
```

**Test results:**
- [x] Unit tests pass — 22/22 in `tent_progress_worker_test`, including 3 new concurrency tests: `ConcurrentIndependentBatchPolls` (8 threads poll+free independent batches), `PollRacesWithFreeSameBatch` (poll vs free of one batch returns OK or InvalidArgument, never crashes), `RuntimeQueuePollAndFreeDoesNotDeadlock`
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below) — full `tebench` matrix on the same machine pair: before/after/classic × local/cross-machine × 1–16 threads × 4KiB ops, plus 256KiB ops; methodology and numbers in Description

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (GLM) assisted with root-cause profiling (rdtsc section counters), implementing the sharded registry, resolving rebase conflicts against the reclaim rework on main, and running the benchmark matrix. Every changed line has been reviewed and is understood by the human submitter.