### PR TITLE
[Bugfix] Isolate Mooncake Store test data directories

### DIFF
--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -50,7 +50,8 @@ class FileStorageTest : public ::testing::Test {
         UnsetEnv("MOONCAKE_DISK_EVICTION_LOW_WATERMARK_RATIO");
         UnsetEnv("MOONCAKE_OFFLOAD_USE_URING");
         UnsetEnv("MOONCAKE_USE_URING");
-        data_path = std::filesystem::current_path().string() + "/data";
+        data_path = (std::filesystem::current_path() / "file_storage_test_data")
+                        .string();
         fs::create_directories(data_path);
         for (const auto& entry : fs::directory_iterator(data_path)) {
             std::error_code ec;

--- a/mooncake-store/tests/storage_backend_test.cpp
+++ b/mooncake-store/tests/storage_backend_test.cpp
@@ -179,7 +179,9 @@ class StorageBackendTest : public ::testing::Test {
     void SetUp() override {
         google::InitGoogleLogging("StorageBackendTest");
         FLAGS_logtostderr = true;
-        data_path = std::filesystem::current_path().string() + "/data";
+        data_path =
+            (std::filesystem::current_path() / "storage_backend_test_data")
+                .string();
         // Remove all leftover files and subdirectories from previous runs
         if (fs::exists(data_path)) {
             for (const auto& entry : fs::directory_iterator(data_path)) {
@@ -658,16 +660,6 @@ TEST_F(StorageBackendTest, LargeNumberOfIds_NoOverflowInLifetime) {
 }
 
 TEST_F(StorageBackendTest, OrphanedBucketFileCleanup) {
-    std::string data_path = std::filesystem::current_path().string() + "/data";
-    fs::create_directories(data_path);
-
-    // Clean up any existing files
-    for (const auto& entry : fs::directory_iterator(data_path)) {
-        if (entry.is_regular_file()) {
-            fs::remove(entry.path());
-        }
-    }
-
     FileStorageConfig config;
     config.storage_filepath = data_path;
     BucketBackendConfig bucket_config;


### PR DESCRIPTION
## Description

Fix: [nightly coverage failure](https://github.com/kvcache-ai/Mooncake/actions/runs/32749394762/job/97665029093)

`storage_backend_test` and `file_storage_test` previously shared the same
`data` directory. When CTest ran them in parallel, one test fixture could
remove `kv_cache.meta.tmp` while `storage_backend_test` was persisting its
checkpoint, causing the subsequent rename to fail with `ENOENT`.

This change:

- Gives the two test binaries separate data directories.
- Makes `OrphanedBucketFileCleanup` reuse the directory managed by the
  `StorageBackendTest` fixture.
- Prevents parallel test cleanup from deleting another test's files.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The failure was reproduced on the original code by repeatedly running
`file_storage_test` concurrently with
`StorageBackendTest.OffsetAllocatorStorageBackend_Persist_OversizedKeyRejected`.
It reproduced the same missing `kv_cache.meta.tmp` rename and assertion failure
reported by the nightly job.

After the fix, the same concurrent test completed 200 iterations without any
rename failures.

**Test commands:**

```bash
cmake --build build \
  --target storage_backend_test file_storage_test \
  -j"$(nproc)"

./file_storage_test \
  --gtest_filter=FileStorageTest.IsEnableOffloading \
  --gtest_repeat=-1 &

./storage_backend_test \
  --gtest_filter=StorageBackendTest.OffsetAllocatorStorageBackend_Persist_OversizedKeyRejected \
  --gtest_repeat=200
```

**Test results:**

- [x] Focused regression test passes
- [x] Manual concurrent testing completed
- [ ] Full integration tests pass

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted the changed C++ files with `clang-format-20`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is not applicable
- [x] I have verified the change against the reproduced failure
- [x] RFC is not applicable because the change is under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex was used to analyze the nightly failure, reproduce the parallel test
directory race, implement the test isolation change, and run focused regression
testing. The human submitter has reviewed the changes and is responsible for
the final submission.