### PR TITLE
[Store] Add NUMA-aware DRAM placement

### DIFF
--- a/mooncake-integration/store/store_py.cpp
+++ b/mooncake-integration/store/store_py.cpp
@@ -1932,6 +1932,21 @@ PYBIND11_MODULE(store, m) {
         .def_readwrite("preferred_segment", &ReplicateConfig::preferred_segment)
         .def_readwrite("prefer_alloc_in_same_node",
                        &ReplicateConfig::prefer_alloc_in_same_node)
+        .def_property(
+            "preferred_numa_node",
+            [](const ReplicateConfig &config) -> py::object {
+                if (!config.preferred_numa_node.has_value()) {
+                    return py::none();
+                }
+                return py::int_(config.preferred_numa_node.value());
+            },
+            [](ReplicateConfig &config, const py::object &value) {
+                if (value.is_none()) {
+                    config.preferred_numa_node.reset();
+                } else {
+                    config.preferred_numa_node = value.cast<int32_t>();
+                }
+            })
         .def_readwrite("data_type", &ReplicateConfig::data_type)
         .def_readwrite("group_ids", &ReplicateConfig::group_ids)
         .def("__str__", [](const ReplicateConfig &config) {

--- a/mooncake-integration/store/store_py_internal.h
+++ b/mooncake-integration/store/store_py_internal.h
@@ -865,6 +865,7 @@ bool is_default_replicate_config(const ReplicateConfig &config) {
            config.dfs_replica_num == 0 &&
            config.soft_pin_action == SoftPinAction::PRESERVE &&
            !config.soft_pin_ttl_ms.has_value() && !config.with_hard_pin &&
+           !config.preferred_numa_node.has_value() &&
            config.preferred_segments.empty() &&
            config.preferred_segment.empty() &&
            !config.prefer_alloc_in_same_node && !config.group_ids.has_value();

--- a/mooncake-store/include/allocation_strategy.h
+++ b/mooncake-store/include/allocation_strategy.h
@@ -194,7 +194,8 @@ class AllocationStrategy {
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY) = 0;
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1) = 0;
 
     virtual tl::expected<std::vector<Replica>, ErrorCode> Allocate(
         const ScopedAllocatorAccess& placement, const size_t slice_length,
@@ -203,7 +204,8 @@ class AllocationStrategy {
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY);
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1);
 
     /**
      * @brief Allocate one replica from the specified segment.
@@ -249,7 +251,8 @@ class RandomAllocationStrategy : public AllocationStrategy {
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1) override {
         // Validate input parameters
         if (slice_length == 0 || replica_num == 0) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
@@ -270,8 +273,8 @@ class RandomAllocationStrategy : public AllocationStrategy {
                 return tl::make_unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
             }
 
-            auto buffer =
-                allocateSingle(allocator_manager, names[0], slice_length);
+            auto buffer = allocateSingle(allocator_manager, names[0],
+                                         slice_length, preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -291,7 +294,7 @@ class RandomAllocationStrategy : public AllocationStrategy {
             }
 
             auto buffer = allocateSingle(allocator_manager, preferred_segment,
-                                         slice_length);
+                                         slice_length, preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -322,8 +325,8 @@ class RandomAllocationStrategy : public AllocationStrategy {
                 continue;
             }
 
-            auto buffer =
-                allocateSingle(allocator_manager, names[index], slice_length);
+            auto buffer = allocateSingle(allocator_manager, names[index],
+                                         slice_length, preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -364,7 +367,7 @@ class RandomAllocationStrategy : public AllocationStrategy {
 
     std::unique_ptr<AllocatedBuffer> allocateSingle(
         const AllocatorManager& allocator_manager, const std::string& name,
-        const size_t slice_length) {
+        const size_t slice_length, const int32_t preferred_numa_node = -1) {
         const auto allocators = allocator_manager.getAllocators(name);
         if (allocators == nullptr || allocators->size() == 0) {
             return nullptr;
@@ -376,14 +379,24 @@ class RandomAllocationStrategy : public AllocationStrategy {
             return (*allocators)[0]->allocate(slice_length);
         }
 
-        // Randomly select a start point to distribute
-        // allocations across all segments
-        // Select a start segment to place the replica.
-        size_t seg_offset = randomIndex(num_segs);
-        for (size_t i = 0; i < num_segs; i++) {  // only allocate one replica
-            auto& allocator = (*allocators)[(i + seg_offset) % num_segs];
-            if (auto buffer = allocator->allocate(slice_length)) {
-                return buffer;
+        // Randomize within locality tiers, then prefer matching NUMA domains,
+        // unknown legacy domains, and finally known mismatches.
+        const size_t seg_offset = randomIndex(num_segs);
+        for (int tier = 0; tier < (preferred_numa_node >= 0 ? 3 : 1); ++tier) {
+            for (size_t i = 0; i < num_segs; ++i) {
+                auto& allocator = (*allocators)[(i + seg_offset) % num_segs];
+                const int32_t numa_node = allocator->getNumaNode();
+                const int allocator_tier =
+                    preferred_numa_node < 0 ? 0
+                                            : (numa_node == preferred_numa_node
+                                                   ? 0
+                                                   : (numa_node < 0 ? 1 : 2));
+                if (allocator_tier != tier) {
+                    continue;
+                }
+                if (auto buffer = allocator->allocate(slice_length)) {
+                    return buffer;
+                }
             }
         }
 
@@ -407,7 +420,8 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
         const size_t replica_num,
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
-        const ReplicaType replica_type, ScoreFn&& score) {
+        const ReplicaType replica_type, const int32_t preferred_numa_node,
+        ScoreFn&& score) {
         if (slice_length == 0 || replica_num == 0) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }
@@ -427,7 +441,7 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
                 continue;
             }
             auto buffer = allocateSingle(allocator_manager, preferred_segment,
-                                         slice_length);
+                                         slice_length, preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -468,7 +482,8 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
                 break;
             }
             const auto& name = names[candidate.name_idx];
-            auto buffer = allocateSingle(allocator_manager, name, slice_length);
+            auto buffer = allocateSingle(allocator_manager, name, slice_length,
+                                         preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -492,7 +507,8 @@ class RankedAllocationStrategy : public RandomAllocationStrategy {
                 used_segments.contains(name)) {
                 continue;
             }
-            auto buffer = allocateSingle(allocator_manager, name, slice_length);
+            auto buffer = allocateSingle(allocator_manager, name, slice_length,
+                                         preferred_numa_node);
             if (buffer) {
                 replicas.emplace_back(std::move(buffer),
                                       ReplicaStatus::PROCESSING, replica_type);
@@ -520,10 +536,12 @@ class FreeRatioFirstAllocationStrategy final : public RankedAllocationStrategy {
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1) override {
         return AllocateRanked(
             allocator_manager, slice_length, replica_num, preferred_segments,
-            excluded_segments, replica_type, [&](const std::string& name) {
+            excluded_segments, replica_type, preferred_numa_node,
+            [&](const std::string& name) {
                 return GetSegmentFreeRatio(allocator_manager, name);
             });
     }
@@ -568,7 +586,8 @@ class SsdFreeRatioFirstAllocationStrategy final
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY) override;
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1) override;
 
     using RandomAllocationStrategy::Allocate;
 
@@ -586,7 +605,9 @@ class CxlAllocationStrategy : public AllocationStrategy {
             std::vector<std::string>(),
         const std::set<std::string>& excluded_segments =
             std::set<std::string>(),
-        const ReplicaType replica_type = ReplicaType::MEMORY) override {
+        const ReplicaType replica_type = ReplicaType::MEMORY,
+        const int32_t preferred_numa_node = -1) override {
+        (void)preferred_numa_node;
         if (slice_length == 0 || replica_num == 0) {
             return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
         }

--- a/mooncake-store/include/allocator.h
+++ b/mooncake-store/include/allocator.h
@@ -120,6 +120,9 @@ class BufferAllocatorBase {
     virtual std::string getSegmentName() const = 0;
     virtual std::string getTransportEndpoint() const = 0;
 
+    [[nodiscard]] int32_t getNumaNode() const noexcept { return numa_node_; }
+    void SetNumaNode(int32_t numa_node) noexcept { numa_node_ = numa_node; }
+
     /**
      * Returns the largest free region available in this allocator.
      * For CacheLib allocators, this returns kAllocatorUnknownFreeSpace as an
@@ -151,6 +154,7 @@ class BufferAllocatorBase {
 
    private:
     std::atomic_size_t cur_size_{0};
+    int32_t numa_node_{-1};
     std::unique_ptr<StorageUsageRegistration> usage_registration_;
 };
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -339,6 +339,7 @@ class MasterService {
         uint64_t size_bytes{0};
         std::string te_endpoint;
         std::string protocol;
+        int32_t numa_node{-1};
         SegmentStatus status{SegmentStatus::UNDEFINED};
         uint64_t allocator_used_bytes{0};
         uint64_t allocator_capacity_bytes{0};

--- a/mooncake-store/include/replica.h
+++ b/mooncake-store/include/replica.h
@@ -117,6 +117,7 @@ struct ReplicateConfig {
     std::vector<std::string>
         preferred_nof_segments{};  // Preferred NoF segments for allocation
     bool prefer_alloc_in_same_node{false};
+    struct_pack::compatible<int32_t, 1> preferred_numa_node;
     ObjectDataType data_type{ObjectDataType::UNKNOWN};
     std::string host_id{};
     // Optional per-key routing group IDs. Empty string keeps that key
@@ -146,6 +147,8 @@ struct ReplicateConfig {
             os << "default";
         }
         os << ", with_hard_pin: " << config.with_hard_pin
+           << ", preferred_numa_node: "
+           << config.preferred_numa_node.value_or(-1)
            << ", preferred_segments: [";
         for (size_t i = 0; i < config.preferred_segments.size(); ++i) {
             os << config.preferred_segments[i];

--- a/mooncake-store/include/types.h
+++ b/mooncake-store/include/types.h
@@ -439,9 +439,11 @@ struct Segment {
     std::string te_endpoint{};
     std::string protocol;
     std::string host_id{};
+    struct_pack::compatible<int32_t, 1> numa_node;
     Segment() = default;
 };
-YLT_REFL(Segment, id, name, base, size, te_endpoint, protocol, host_id);
+YLT_REFL(Segment, id, name, base, size, te_endpoint, protocol, host_id,
+         numa_node);
 
 /**
  * @brief Allocation strategy type for segment allocation

--- a/mooncake-store/src/allocation_strategy.cpp
+++ b/mooncake-store/src/allocation_strategy.cpp
@@ -10,9 +10,10 @@ tl::expected<std::vector<Replica>, ErrorCode> AllocationStrategy::Allocate(
     const size_t replica_num,
     const std::vector<std::string>& preferred_segments,
     const std::set<std::string>& excluded_segments,
-    const ReplicaType replica_type) {
+    const ReplicaType replica_type, const int32_t preferred_numa_node) {
     return Allocate(placement.getAllocatorManager(), slice_length, replica_num,
-                    preferred_segments, excluded_segments, replica_type);
+                    preferred_segments, excluded_segments, replica_type,
+                    preferred_numa_node);
 }
 
 tl::expected<std::vector<Replica>, ErrorCode>
@@ -21,11 +22,12 @@ SsdFreeRatioFirstAllocationStrategy::Allocate(
     const size_t replica_num,
     const std::vector<std::string>& preferred_segments,
     const std::set<std::string>& excluded_segments,
-    const ReplicaType replica_type) {
+    const ReplicaType replica_type, const int32_t preferred_numa_node) {
     const auto& allocator_manager = placement.getAllocatorManager();
     return AllocateRanked(
         allocator_manager, slice_length, replica_num, preferred_segments,
-        excluded_segments, replica_type, [&](const std::string& name) {
+        excluded_segments, replica_type, preferred_numa_node,
+        [&](const std::string& name) {
             auto client_id = placement.GetOwnerClientId(name);
             if (!client_id) {
                 return 1.0;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3532,6 +3532,20 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
         segment.size = size;
         segment.protocol = protocol;
         segment.host_id = host_id_;
+        constexpr std::string_view kCpuLocationPrefix = "cpu:";
+        if (location.starts_with(kCpuLocationPrefix)) {
+            try {
+                size_t parsed = 0;
+                const auto node = std::stoi(
+                    location.substr(kCpuLocationPrefix.size()), &parsed);
+                if (node >= 0 &&
+                    parsed == location.size() - kCpuLocationPrefix.size()) {
+                    segment.numa_node = node;
+                }
+            } catch (const std::exception&) {
+                VLOG(1) << "Ignore invalid CPU memory location: " << location;
+            }
+        }
         if (metadata_connstring_ == P2PHANDSHAKE) {
             segment.te_endpoint = transfer_engine_->getLocalIpAndPort();
         } else {

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -694,14 +694,15 @@ struct HttpSegmentDetailItem {
     std::string size_human;
     std::string te_endpoint;
     std::string protocol;
+    int32_t numa_node{-1};
     std::string status;
     uint64_t allocator_used_bytes{0};
     uint64_t allocator_capacity_bytes{0};
     double allocator_usage_percent{0.0};
 };
 YLT_REFL(HttpSegmentDetailItem, segment_name, segment_id, client_id,
-         base_address, size_bytes, size_human, te_endpoint, protocol, status,
-         allocator_used_bytes, allocator_capacity_bytes,
+         base_address, size_bytes, size_human, te_endpoint, protocol, numa_node,
+         status, allocator_used_bytes, allocator_capacity_bytes,
          allocator_usage_percent);
 
 struct HttpSegmentsDetailResponse {
@@ -740,6 +741,7 @@ void MasterAdminServer::HandleGetSegmentsDetail(
 
             item.te_endpoint = info.te_endpoint;
             item.protocol = info.protocol;
+            item.numa_node = info.numa_node;
             item.status = EnumToString(info.status);
             item.allocator_used_bytes = info.allocator_used_bytes;
             item.allocator_capacity_bytes = info.allocator_capacity_bytes;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2938,6 +2938,7 @@ auto MasterService::GetSegmentsDetail()
         info.size_bytes = segment.size;
         info.te_endpoint = segment.te_endpoint;
         info.protocol = segment.protocol;
+        info.numa_node = segment.numa_node.value_or(-1);
 
         // Query segment status
         segment_access.GetSegmentStatusByName(segment.name, info.status);
@@ -4097,7 +4098,8 @@ auto MasterService::AllocateAndInsertMetadata(
 
         auto allocation_result = allocation_strategy_->Allocate(
             allocator_access, value_length, config.replica_num,
-            preferred_segments, std::set<std::string>(), ReplicaType::MEMORY);
+            preferred_segments, std::set<std::string>(), ReplicaType::MEMORY,
+            config.preferred_numa_node.value_or(-1));
 
         if (!allocation_result.has_value()) {
             VLOG(1) << "Failed to allocate replicas for key=" << key

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -955,7 +955,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         std::vector<int> seg_numa_nodes;
         if (protocol == "rdma") {
             seg_numa_nodes = client_->GetNicNumaNodes();
-            if (seg_numa_nodes.size() > 1) {
+            if (!seg_numa_nodes.empty()) {
                 std::string nodes_str;
                 for (size_t i = 0; i < seg_numa_nodes.size(); ++i) {
                     if (i) nodes_str += ",";
@@ -963,10 +963,18 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                 }
                 LOG(INFO) << "NUMA-segmented mode: NIC NUMA nodes=["
                           << nodes_str << "]";
-            } else {
-                seg_numa_nodes.clear();
             }
         }
+        if (!seg_numa_nodes.empty()) {
+            const size_t per_node_limit =
+                align_up((global_segment_size + seg_numa_nodes.size() - 1) /
+                             seg_numa_nodes.size(),
+                         alignment);
+            if (!split_limit.has_value() || per_node_limit < *split_limit) {
+                split_limit = per_node_limit;
+            }
+        }
+        size_t next_numa_node = 0;
 
         const bool parallel_hugetlb_population =
             protocol == "rdma" && should_use_hugepage;
@@ -986,15 +994,15 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
             std::string seg_location = kWildcardLocation;
 
             if (!seg_numa_nodes.empty()) {
-                // NUMA-segmented allocation: contiguous VMA, per-region binding
-                size_t page_sz = should_use_hugepage
-                                     ? get_hugepage_size_from_env()
-                                     : static_cast<size_t>(getpagesize());
-                mapped_size =
-                    align_up(segment_size, page_sz * seg_numa_nodes.size());
-                ptr = allocate_buffer_numa_segments(mapped_size, seg_numa_nodes,
+                const int numa_node =
+                    seg_numa_nodes[next_numa_node++ % seg_numa_nodes.size()];
+                const size_t page_sz = should_use_hugepage
+                                           ? get_hugepage_size_from_env()
+                                           : static_cast<size_t>(getpagesize());
+                mapped_size = align_up(segment_size, page_sz);
+                ptr = allocate_buffer_numa_segments(mapped_size, {numa_node},
                                                     page_sz);
-                seg_location = buildSegmentsLocation(page_sz, seg_numa_nodes);
+                seg_location = "cpu:" + std::to_string(numa_node);
             } else if (should_use_hugepage) {
                 mapped_size =
                     align_up(segment_size, get_hugepage_size_from_env());

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -269,6 +269,7 @@ ErrorCode ScopedSegmentAccess::MountSegment(const Segment& segment,
         return ErrorCode::INVALID_PARAMS;
     }
 
+    allocator->SetNumaNode(segment.numa_node.value_or(-1));
     allocator->AttachUsageTracker(segment_manager_->usage_tracker_);
     segment_manager_->allocator_manager_.addAllocator(segment.name, allocator);
     segment_manager_->client_segments_[client_id].push_back(segment.id);
@@ -288,6 +289,16 @@ ErrorCode ScopedSegmentAccess::ReMountSegment(
         auto validation = ValidateRemountSegment(segment, client_id);
         if (validation != ErrorCode::OK) {
             return validation;
+        }
+        auto mounted = segment_manager_->mounted_segments_.find(segment.id);
+        if (mounted != segment_manager_->mounted_segments_.end() &&
+            !mounted->second.segment.numa_node.has_value() &&
+            segment.numa_node.has_value()) {
+            mounted->second.segment.numa_node = segment.numa_node;
+            if (mounted->second.buf_allocator) {
+                mounted->second.buf_allocator->SetNumaNode(
+                    segment.numa_node.value());
+            }
         }
         ErrorCode err = MountSegment(segment, client_id);
         if (err == ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS ||
@@ -332,7 +343,9 @@ ErrorCode ScopedSegmentAccess::ValidateRemountSegment(
         authoritative.size != segment.size ||
         authoritative.te_endpoint != segment.te_endpoint ||
         authoritative.protocol != segment.protocol ||
-        authoritative.host_id != segment.host_id) {
+        authoritative.host_id != segment.host_id ||
+        (authoritative.numa_node.has_value() && segment.numa_node.has_value() &&
+         authoritative.numa_node.value() != segment.numa_node.value())) {
         return ErrorCode::INVALID_PARAMS;
     }
     return ErrorCode::OK;

--- a/mooncake-store/src/serialize/serializer.cpp
+++ b/mooncake-store/src/serialize/serializer.cpp
@@ -869,9 +869,9 @@ tl::expected<void, SerializationError> Serializer<MountedSegment>::serialize(
     // Use array structure for packing, more efficient
     // Format: [segment_id, segment_name, segment_base, segment_size,
     // te_endpoint, status, has_buffer_allocator, buffer_allocator_data,
-    // host_id]
+    // host_id, numa_node]
 
-    packer.pack_array(9);
+    packer.pack_array(10);
 
     // Serialize Segment info
     packer.pack(UuidToString(mounted_segment.segment.id));
@@ -895,6 +895,7 @@ tl::expected<void, SerializationError> Serializer<MountedSegment>::serialize(
                 return tl::unexpected(result.error());
             }
             packer.pack(mounted_segment.segment.host_id);
+            packer.pack(mounted_segment.segment.numa_node.value_or(-1));
             return {};
         }
     }
@@ -902,6 +903,7 @@ tl::expected<void, SerializationError> Serializer<MountedSegment>::serialize(
     packer.pack(false);  // Mark no valid buffer allocator exists
     packer.pack_nil();
     packer.pack(mounted_segment.segment.host_id);
+    packer.pack(mounted_segment.segment.numa_node.value_or(-1));
     return {};
 }
 
@@ -960,6 +962,16 @@ Serializer<MountedSegment>::deserialize(const msgpack::object &obj) {
         }
         if (obj.via.array.size >= 9) {
             mounted_segment.segment.host_id = array[8].as<std::string>();
+        }
+        if (obj.via.array.size >= 10) {
+            const auto numa_node = array[9].as<int32_t>();
+            if (numa_node >= 0) {
+                mounted_segment.segment.numa_node = numa_node;
+            }
+        }
+        if (mounted_segment.buf_allocator) {
+            mounted_segment.buf_allocator->SetNumaNode(
+                mounted_segment.segment.numa_node.value_or(-1));
         }
     } catch (const std::exception &e) {
         return tl::unexpected(SerializationError(

--- a/mooncake-store/tests/allocation_strategy_test.cpp
+++ b/mooncake-store/tests/allocation_strategy_test.cpp
@@ -115,6 +115,54 @@ TEST_F(AllocationStrategyTest, EmptyAllocatorsMap) {
     EXPECT_EQ(result.error(), ErrorCode::NO_AVAILABLE_HANDLE);
 }
 
+TEST_F(AllocationStrategyTest, PreferredNumaNodeSelectsMatchingAllocator) {
+    AllocatorManager allocator_manager;
+    auto node0 = std::make_shared<OffsetBufferAllocator>("host", 0x100000000ULL,
+                                                         64 * MiB, "node0");
+    auto node1 = std::make_shared<OffsetBufferAllocator>("host", 0x110000000ULL,
+                                                         64 * MiB, "node1");
+    node0->SetNumaNode(0);
+    node1->SetNumaNode(1);
+    allocator_manager.addAllocator("host", node0);
+    allocator_manager.addAllocator("host", node1);
+
+    auto result = strategy_->Allocate(allocator_manager, 1024, 1, {}, {},
+                                      ReplicaType::MEMORY, 1);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->size(), 1u);
+    EXPECT_EQ(result->front()
+                  .get_descriptor()
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              "node1");
+}
+
+TEST_F(AllocationStrategyTest, PreferredNumaNodeFallsBackToUnknownAllocator) {
+    AllocatorManager allocator_manager;
+    auto matching = std::make_shared<OffsetBufferAllocator>(
+        "host", 0x100000000ULL, 64 * MiB, "matching");
+    auto unknown = std::make_shared<OffsetBufferAllocator>(
+        "host", 0x110000000ULL, 64 * MiB, "unknown");
+    auto mismatch = std::make_shared<OffsetBufferAllocator>(
+        "host", 0x120000000ULL, 64 * MiB, "mismatch");
+    matching->SetNumaNode(1);
+    mismatch->SetNumaNode(0);
+    allocator_manager.addAllocator("host", matching);
+    allocator_manager.addAllocator("host", unknown);
+    allocator_manager.addAllocator("host", mismatch);
+    auto occupied = matching->allocate(matching->capacity());
+    ASSERT_NE(occupied, nullptr);
+
+    auto result = strategy_->Allocate(allocator_manager, 1024, 1, {}, {},
+                                      ReplicaType::MEMORY, 1);
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result->front()
+                  .get_descriptor()
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              "unknown");
+}
+
 // Test preferred segment behavior with empty allocators (non-parameterized)
 TEST_F(AllocationStrategyTest, PreferredSegmentWithEmptyAllocators) {
     AllocatorManager allocator_manager;

--- a/mooncake-store/tests/master_service_tenant_quota_test.cpp
+++ b/mooncake-store/tests/master_service_tenant_quota_test.cpp
@@ -71,11 +71,12 @@ class BlockingAllocationStrategy final : public AllocationStrategy {
         const size_t replica_num,
         const std::vector<std::string>& preferred_segments,
         const std::set<std::string>& excluded_segments,
-        const ReplicaType replica_type) override {
+        const ReplicaType replica_type,
+        const int32_t preferred_numa_node = -1) override {
         BlockOnce();
         return delegate_.Allocate(allocator_manager, slice_length, replica_num,
                                   preferred_segments, excluded_segments,
-                                  replica_type);
+                                  replica_type, preferred_numa_node);
     }
 
     tl::expected<Replica, ErrorCode> AllocateFrom(

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -190,6 +190,33 @@ TEST_F(SegmentTest, MountSegmentSuccess) {
     ValidateMountedSegment(segment_manager, segment, client_id);
 }
 
+TEST_F(SegmentTest, MountSegmentCopiesNumaNodeToAllocator) {
+    SegmentManager segment_manager(BufferAllocatorType::OFFSET);
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "numa_segment";
+    segment.size = 16 * 1024 * 1024;
+    segment.base = 0x100000000;
+    segment.numa_node = 1;
+    const UUID client_id = generate_uuid();
+
+    auto segment_access = segment_manager.getSegmentAccess();
+    ASSERT_EQ(segment_access.MountSegment(segment, client_id), ErrorCode::OK);
+    auto allocator = segment_access.GetAllocator(segment.id);
+    ASSERT_NE(allocator, nullptr);
+    EXPECT_EQ(allocator->getNumaNode(), 1);
+
+    Segment conflicting = segment;
+    conflicting.numa_node = 0;
+    EXPECT_EQ(segment_access.ValidateRemountSegment(conflicting, client_id),
+              ErrorCode::INVALID_PARAMS);
+
+    Segment legacy = segment;
+    legacy.numa_node.reset();
+    EXPECT_EQ(segment_access.ValidateRemountSegment(legacy, client_id),
+              ErrorCode::OK);
+}
+
 TEST_F(SegmentTest, MemoryUsageSnapshotTracksMountedAllocatorState) {
     SegmentManager segment_manager(BufferAllocatorType::OFFSET);
     constexpr size_t kSegmentSize = 16 * 1024 * 1024;

--- a/mooncake-store/tests/serializer_test.cpp
+++ b/mooncake-store/tests/serializer_test.cpp
@@ -175,6 +175,7 @@ TEST_F(SerializerTest, MountedSegmentSerializationPreservesHostId) {
     original.segment.size = 1024 * 1024;
     original.segment.te_endpoint = "segment_host1";
     original.segment.host_id = "host1";
+    original.segment.numa_node = 1;
     original.status = SegmentStatus::OK;
 
     msgpack::sbuffer buffer;
@@ -189,6 +190,8 @@ TEST_F(SerializerTest, MountedSegmentSerializationPreservesHostId) {
     EXPECT_EQ(restored->segment.id, original.segment.id);
     EXPECT_EQ(restored->segment.name, original.segment.name);
     EXPECT_EQ(restored->segment.host_id, original.segment.host_id);
+    ASSERT_TRUE(restored->segment.numa_node.has_value());
+    EXPECT_EQ(restored->segment.numa_node.value(), 1);
     EXPECT_EQ(restored->status, original.status);
 }
 
@@ -214,6 +217,7 @@ TEST_F(SerializerTest, MountedSegmentDeserializesLegacyFormatWithoutHostId) {
     EXPECT_EQ(restored->segment.id, segment_id);
     EXPECT_EQ(restored->segment.name, "legacy_segment");
     EXPECT_TRUE(restored->segment.host_id.empty());
+    EXPECT_FALSE(restored->segment.numa_node.has_value());
     EXPECT_EQ(restored->status, SegmentStatus::OK);
 }
 


### PR DESCRIPTION
## Description

Implements the end-to-end NUMA-aware DRAM allocation and placement path proposed in #3653.

- carries optional NUMA locality on mounted Segments and request placement hints using compatible fields
- splits auto-allocated RDMA Store memory into homogeneous NUMA-bound Segments and registers each with `cpu:N` locality
- ranks allocators within a logical segment as exact NUMA match, unknown locality, then cross-NUMA fallback
- preserves legacy clients and 8/9-element mounted-Segment snapshots
- validates immutable known locality on remount and enriches legacy unknown locality on a compatible remount
- exposes Segment NUMA locality through the admin detail API and Python `ReplicateConfig`

This intentionally keeps the existing logical segment-name failure domain and composes NUMA ordering inside it, so explicit preferred/excluded segments and replica separation are unchanged.

Overlap with draft #3529: this change is based on current `main` and extends `AllocatorManager`/`BufferAllocatorBase`. If #3529 lands first, the locality field and tiering should move to its concrete placement-target/`PlacementIndex` layer; the wire and snapshot compatibility pieces remain applicable.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target \
  allocation_strategy_test serializer_test segment_test \
  master_service_tenant_quota_test -j12

./allocation_strategy_test
./serializer_test
./segment_test
./master_service_tenant_quota_test

./scripts/code_format.sh --staged --check
pre-commit run --files <changed files>
```

**Test results:**
- [x] Unit tests pass (122 tests: allocation strategy 66, serializer 7, segment 19, tenant quota 30)
- [x] Integration tests pass (dual-container Soft-RoCE Store E2E)
- [x] Manual testing done (full relevant C++ targets compile in the RDMA development container)

Synthetic tests cover exact-NUMA selection, unknown-locality fallback, allocator locality propagation, conflicting remount rejection, and legacy snapshot decoding.

Functional Store E2E was run on two containers (`10.99.0.11` / `10.99.0.12`) over shared Soft-RoCE `rxe0` with P2P handshake metadata:

- mounted 16 MiB `cpu:0`, 32 MiB `cpu:1`, and 16 MiB unknown-locality DRAM Segments
- wrote four 12 MiB objects with preferences `0, 1, 0, 0`
- verified allocation addresses landed in order on NUMA 0, NUMA 1, unknown-locality fallback, then known NUMA 1 mismatch fallback after the preferred/unknown allocators were exhausted
- read all four objects from the second container over RDMA and verified every payload byte (`READER_OK`)
- confirmed `/get_segments_detail` reports Segment locality as `0`, `1`, and `-1`

This is a functional Soft-RoCE loop test. It does not claim physical NIC DMA locality or NUMA performance validation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (the design is documented in RFC #3653; no separate user guide exists yet)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (#3653; this patch is below 500 LOC)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (OpenAI Codex assisted with implementation, test coverage, validation, and PR preparation; the human submitter must review and be able to defend every changed line.)
