### PR TITLE
[Bugfix][Store] OffsetAllocatorStorageBackend: fix misleading O_DIRECT claim (#3611)

### DIFF
--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -3908,7 +3908,11 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
         // Get data file path
         data_file_path_ = GetDataFilePath();
 
-        // Open/truncate data file in read-write mode
+        // OffsetAllocatorStorageBackend uses buffered I/O (no O_DIRECT):
+        // the vector_read/vector_write hot path does not enforce 4096-byte
+        // alignment on buffers, lengths, or offsets, so enabling O_DIRECT
+        // would cause EINVAL on every I/O operation.  Pass use_direct_io=false
+        // to UringFile to avoid the misleading "O_DIRECT mode enabled" log.
         int flags = O_CLOEXEC | O_RDWR | O_CREAT | O_TRUNC;
         int raw_fd = open(data_file_path_.c_str(), flags, 0644);
         if (raw_fd < 0) {
@@ -3932,7 +3936,7 @@ tl::expected<void, ErrorCode> OffsetAllocatorStorageBackend::Init() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
+                data_file_path_, fd_guard.release(), 32, false);  // buffered I/O, not O_DIRECT
         } else
 #endif
         {
@@ -4719,7 +4723,7 @@ OffsetAllocatorStorageBackend::TryRecoverFromMetadata() {
 #ifdef USE_URING
         if (file_storage_config_.use_uring) {
             data_file_ = std::make_shared<UringFile>(
-                data_file_path_, fd_guard.release(), 32, true);
+                data_file_path_, fd_guard.release(), 32, false);  // buffered I/O
         } else
 #endif
         {
@@ -5639,7 +5643,7 @@ void OffsetAllocatorStorageBackend::RemoveAll() {
 #ifdef USE_URING
             if (file_storage_config_.use_uring) {
                 data_file_ =
-                    std::make_shared<UringFile>(data_file_path_, fd, 32, true);
+                    std::make_shared<UringFile>(data_file_path_, fd, 32, false);  // buffered I/O
             } else
 #endif
             {


### PR DESCRIPTION
Fixes #3611.

## Summary
`OffsetAllocatorStorageBackend` passed `use_direct_io = true` to `UringFile`, but the fd was opened without `O_DIRECT` and the vector I/O hot path has no alignment handling. This made the log line `[UringFile] O_DIRECT mode enabled for <file>` misleading: all I/O was actually buffered through the page cache.

This PR changes the three `OffsetAllocatorStorageBackend` construction sites to pass `use_direct_io = false`, matching the real behavior and avoiding the misleading log.

## Affected code paths
- `mooncake-store/src/storage_backend.cpp`
  - `OffsetAllocatorStorageBackend::Init()`
  - `OffsetAllocatorStorageBackend::TryRecoverFromMetadata()`
  - `OffsetAllocatorStorageBackend::RemoveAll()`

## Root cause
- `open()` never set `O_DIRECT`
- `vector_read` / `vector_write` never checked `use_direct_io_`
- the only code paths that would respect `use_direct_io_` are scalar methods not used by this backend

## Fix
Pass `use_direct_io = false` in all three `OffsetAllocatorStorageBackend` `UringFile` constructions and add a comment explaining why buffered I/O is the correct behavior here.

## Verification
- Built `storage_backend_test` on the Beijing H200 box with g++-11.
- Ran the full `storage_backend_test` suite: **98/99 pass**.
- The one remaining failure (`AdaptorWatermarkEvictionNotifiesRecoveredKeysAfterRestart`) is pre-existing and unrelated to this change; it lives in `FilePerKeyStorageBackend`, not `OffsetAllocatorStorageBackend`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)