### PR TITLE
[Bugfix][TE] Restore fork state on memory unregister to prevent VMA exhaustion (#3639)

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -641,20 +641,20 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
     if (iter == memory_region_map_.end()) {
         return 0;
     }
+    // Cache addr/length before ibv_dereg_mr: the MR is freed by dereg_mr, so
+    // reading mr->length (or the cached region length) afterwards is a use-
+    // after-free. We restore fork state on the same range to undo the
+    // MADV_DONTFORK applied at register time (see issue #3639).
+    void *region_addr = iter->second.addr;
+    size_t region_length = iter->second.mr->length;
     if (ibv_dereg_mr(iter->second.mr)) {
         LOG(ERROR) << "Failed to unregister memory " << addr;
         return ERR_CONTEXT;
     }
-    // Restore mergeability after ibv_dereg_mr. ibv_reg_mr calls
-    // madvise(MADV_DONTFORK) on the registered range when fork protection
-    // is active; failing to undo this on unregister leaves VMAs permanently
-    // split, exhausting vm.max_map_count under high register/unregister churn.
-    // See issue #3639.
-    void *region_addr = iter->second.addr;
-    size_t region_length = iter->second.mr->length;
     if (madvise(region_addr, region_length, MADV_DOFORK) != 0) {
         PLOG(WARNING) << "Failed to restore fork state for memory region at "
-                      << region_addr << " (" << region_length << " bytes)";
+                      << region_addr << " (" << region_length
+                      << " bytes), deregister already succeeded";
     }
     memory_region_map_.erase(iter);
     return 0;

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <netinet/in.h>
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -643,6 +644,17 @@ int RdmaContext::unregisterMemoryRegion(void *addr) {
     if (ibv_dereg_mr(iter->second.mr)) {
         LOG(ERROR) << "Failed to unregister memory " << addr;
         return ERR_CONTEXT;
+    }
+    // Restore mergeability after ibv_dereg_mr. ibv_reg_mr calls
+    // madvise(MADV_DONTFORK) on the registered range when fork protection
+    // is active; failing to undo this on unregister leaves VMAs permanently
+    // split, exhausting vm.max_map_count under high register/unregister churn.
+    // See issue #3639.
+    void *region_addr = iter->second.addr;
+    size_t region_length = iter->second.mr->length;
+    if (madvise(region_addr, region_length, MADV_DOFORK) != 0) {
+        PLOG(WARNING) << "Failed to restore fork state for memory region at "
+                      << region_addr << " (" << region_length << " bytes)";
     }
     memory_region_map_.erase(iter);
     return 0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <sys/epoll.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -628,6 +629,16 @@ int RdmaContext::unregisterMemReg(MemReg id) {
         const void* end = static_cast<const char*>(entry->addr) + entry->length;
         LOG(ERROR) << "Failed to unregister memory from " << entry->addr
                    << " to " << end << " in RDMA device " << device_name_;
+        return -1;
+    }
+    // Restore mergeability after ibv_dereg_mr. ibv_reg_mr calls
+    // madvise(MADV_DONTFORK) on the registered range when fork protection
+    // is active; failing to undo this on unregister leaves VMAs permanently
+    // split, exhausting vm.max_map_count under high register/unregister churn.
+    // See issue #3639.
+    if (madvise(entry->addr, entry->length, MADV_DOFORK) != 0) {
+        PLOG(WARNING) << "Failed to restore fork state for memory region at "
+                      << entry->addr << " (" << entry->length << " bytes)";
     }
 
     return 0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -623,7 +623,7 @@ int RdmaContext::unregisterMemReg(MemReg id) {
     auto entry = (ibv_mr*)id;
     // Cache addr/length before ibv_dereg_mr: entry is freed by dereg_mr, so
     // reading entry->addr/entry->length afterwards is a use-after-free.
-    void *region_addr = entry->addr;
+    void* region_addr = entry->addr;
     size_t region_length = entry->length;
     mr_set_mutex_.lock();
     mr_set_.erase(entry);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -621,13 +621,17 @@ int RdmaContext::unregisterMemReg(MemReg id) {
         return -1;
     }
     auto entry = (ibv_mr*)id;
+    // Cache addr/length before ibv_dereg_mr: entry is freed by dereg_mr, so
+    // reading entry->addr/entry->length afterwards is a use-after-free.
+    void *region_addr = entry->addr;
+    size_t region_length = entry->length;
     mr_set_mutex_.lock();
     mr_set_.erase(entry);
     mr_set_mutex_.unlock();
 
     if (verbs_.ibv_dereg_mr(entry)) {
-        const void* end = static_cast<const char*>(entry->addr) + entry->length;
-        LOG(ERROR) << "Failed to unregister memory from " << entry->addr
+        const void* end = static_cast<const char*>(region_addr) + region_length;
+        LOG(ERROR) << "Failed to unregister memory from " << region_addr
                    << " to " << end << " in RDMA device " << device_name_;
         return -1;
     }
@@ -636,9 +640,10 @@ int RdmaContext::unregisterMemReg(MemReg id) {
     // is active; failing to undo this on unregister leaves VMAs permanently
     // split, exhausting vm.max_map_count under high register/unregister churn.
     // See issue #3639.
-    if (madvise(entry->addr, entry->length, MADV_DOFORK) != 0) {
+    if (madvise(region_addr, region_length, MADV_DOFORK) != 0) {
         PLOG(WARNING) << "Failed to restore fork state for memory region at "
-                      << entry->addr << " (" << entry->length << " bytes)";
+                      << region_addr << " (" << region_length
+                      << " bytes), deregister already succeeded";
     }
 
     return 0;


### PR DESCRIPTION
Fixes #3639.

## Summary
`ibv_reg_mr` unconditionally calls `madvise(MADV_DONTFORK)` on registered ranges when `ibv_fork_init()` has been called (which `RdmaContext` does at startup). The corresponding unregister path never issued `MADV_DOFORK`, so VMAs remained permanently split even after the MR was destroyed. Under high register/unregister churn with varying sizes (e.g. per-request buffer registration in multimodal serving), this exhausts `vm.max_map_count` and causes all subsequent `ibv_reg_mr` / `ibv_create_qp` calls to fail with `ENOMEM`.

## Root Cause
1. `RdmaContext` calls `ibv_fork_init()` at startup
2. `ibv_reg_mr` calls `madvise(range, MADV_DONTFORK)` on every registration
3. `unregisterMemoryRegion()` destroys the MR but never calls `madvise(range, MADV_DOFORK)`
4. `VM_DONTCOPY` persists; VMA splits never heal, even after memory is freed

## Fix
Call `madvise(addr, len, MADV_DOFORK)` after successful `ibv_dereg_mr` in both:
- `mooncake-transfer-engine/src/transport/rdma_transport/rdma_context.cpp` (`RdmaContext::unregisterMemoryRegion`)
- `mooncake-transfer-engine/tent/src/transport/rdma/context.cpp` (`RdmaContext::unregisterMemReg`)

Failure to restore is logged as a warning (non-fatal) — the deregister itself already succeeded.

## Suggested Fix from Issue
Implements option 1 from the issue (restore mergeability on unregister). Option 2 (make fork protection opt-out via env var) is a separate enhancement.

## Verification
- Built `mooncake_transfer_engine` on the Beijing H200 box with g++-11
- All `storage_backend_test` tests still pass (98/99, same pre-existing failure)
- Manual verification: confirmed `madvise` and `MADV_DOFORK` are available via `<sys/mman.h>`
