### PR TITLE
[Bugfix][TENT] Add non-blocking try_push to BoundedMPSCQueue and fail slices on queue full (#3636)

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
@@ -49,8 +49,7 @@ struct BoundedMPSCQueue {
         Cell *cell = &buffer[pos % Capacity];
 
         uint64_t seq = cell->sequence.load(std::memory_order_acquire);
-        intptr_t dif =
-            static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
+        intptr_t dif = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
         if (dif == 0) {
             if (tail.compare_exchange_weak(pos, pos + 1,
                                            std::memory_order_acq_rel,

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
@@ -43,6 +43,26 @@ struct BoundedMPSCQueue {
 
     ~BoundedMPSCQueue() = default;
 
+    bool try_push(T &slice_list) {
+        if (slice_list.num_slices == 0) return true;
+        uint64_t pos = tail.load(std::memory_order_relaxed);
+        Cell *cell = &buffer[pos % Capacity];
+
+        uint64_t seq = cell->sequence.load(std::memory_order_acquire);
+        intptr_t dif =
+            static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
+        if (dif == 0) {
+            if (tail.compare_exchange_weak(pos, pos + 1,
+                                           std::memory_order_acq_rel,
+                                           std::memory_order_relaxed)) {
+                cell->data = slice_list;
+                cell->sequence.store(pos + 1, std::memory_order_release);
+                return true;
+            }
+        }
+        return false;
+    }
+
     void push(T &slice_list) {
         while (!try_push(slice_list)) {
             std::this_thread::yield();

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -41,7 +41,7 @@ class Workers {
     friend class RdmaTransportTestPeer;
 
    public:
-    static constexpr size_t kCapacity = 1024 * 8;
+    static constexpr size_t kCapacity = 1024 * 64;
     using BoundedSliceQueue = BoundedMPSCQueue<RdmaSliceList, kCapacity>;
 
    public:

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -585,7 +585,22 @@ Status RdmaTransport::submitTransferTasks(
     for (int i = 0; i < num_workers; ++i) {
         if (slice_lists[i].first) {
             rdma_batch->slice_chain.push_back(slice_lists[i].first);
-            workers_->submit(slice_lists[i], i);
+            Status submit_st = workers_->submit(slice_lists[i], i);
+            if (!submit_st.ok()) {
+                // The slices were allocated and attached to the task, but the
+                // initial submit was rejected (queue full). Without this check
+                // the batch would stay PENDING forever: nothing queued it and
+                // nothing marked it failed. Cancel the task so its slices are
+                // drained (CANCELED) and the batch can be retried. See #3636.
+                RdmaTask* rejected_task = slice_lists[i].first->task;
+                LOG(WARNING) << "Initial submit rejected for worker " << i
+                             << ": " << submit_st.message()
+                             << ", canceling task " << rejected_task;
+                workers_->cancel(rejected_task);
+                return Status::TooManyRequests(
+                    "Initial slice submit rejected (worker queue full)"
+                    LOC_MARK);
+            }
         }
     }
     return Status::OK();

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -598,8 +598,8 @@ Status RdmaTransport::submitTransferTasks(
                              << ", canceling task " << rejected_task;
                 workers_->cancel(rejected_task);
                 return Status::TooManyRequests(
-                    "Initial slice submit rejected (worker queue full)"
-                    LOC_MARK);
+                    "Initial slice submit rejected (worker queue "
+                    "full)" LOC_MARK);
             }
         }
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -356,7 +356,16 @@ Status Workers::submit(RdmaSliceList& slice_list, int worker_id) {
         priority = slice_list.first->priority;
     }
 
-    worker.queues[priority].push(slice_list);
+    // Use try_push to avoid blocking when queue is full. If the queue is full,
+    // return an error so the caller can fail the slice immediately instead of
+    // spinning indefinitely. This prevents livelock when the worker thread
+    // itself tries to re-enqueue retried slices into a full queue.
+    if (!worker.queues[priority].try_push(slice_list)) {
+        LOG(WARNING) << "Worker " << worker_id << " queue full (capacity "
+                     << Workers::kCapacity << "), rejecting slice";
+        return Status(Status::Code::kTooManyRequests,
+                      "Worker submit queue is full, cannot accept more slices");
+    }
     if (!worker.inflight_slices.fetch_add(slice_list.num_slices)) {
         std::lock_guard<std::mutex> lock(worker.mutex);
         if (worker.in_suspend) worker.cv.notify_all();
@@ -766,8 +775,19 @@ void Workers::asyncPostSend() {
                     updateSliceStatus(slice, FAILED);
                     discountFromOwner(worker, slice);
                 } else {
-                    // The re-submit moves the count to the lane it lands on.
-                    submitFromTick(worker, slice);
+                    releaseSliceQuota(slice);
+                    // The worker must never block on enqueue: if the queue is
+                    // full, fail the slice immediately rather than spinning.
+                    // Spinning here wedges the worker (it stops popping its own
+                    // queue) and livelocks the whole engine. See #3636/#3637.
+                    Status st = submit(slice);
+                    if (!st.ok()) {
+                        LOG(WARNING)
+                            << "Slice " << slice
+                            << " failed: re-enqueue rejected ("
+                            << st.message() << ")";
+                        updateSliceStatus(slice, FAILED);
+                    }
                 }
             }
             continue;
@@ -796,6 +816,7 @@ void Workers::asyncPostSend() {
             [&](RdmaSlice* posted) { markPosted(worker, posted, post_ts); });
         for (int id = 0; id < num_submitted; ++id) {
             auto slice = slices[id];
+<<<<<<< HEAD
             if (!slice->failed) continue;
             // Rejected by the hardware: it never went on the wire, so take
             // back what the hook put in place.
@@ -814,6 +835,36 @@ void Workers::asyncPostSend() {
                 disableEndpoint(slice);
                 updateSliceStatus(slice, FAILED);
                 discountFromOwner(worker, slice);
+=======
+            if (slice->failed) {
+                releaseSliceQuota(slice);
+                if (slice->task->cancel_requested.load(
+                        std::memory_order_acquire)) {
+                    updateSliceStatus(slice, CANCELED);
+                    worker.inflight_slices.fetch_sub(1);
+                    continue;
+                }
+                slice->retry_count++;
+                if (slice->retry_count >=
+                    transport_->params_->workers.max_retry_count) {
+                    LOG(WARNING)
+                        << "Slice " << slice << " failed: retry count exceeded";
+                    disableEndpoint(slice);
+                    updateSliceStatus(slice, FAILED);
+                } else {
+                    // Non-blocking re-enqueue: never wedge the worker on a
+                    // full queue. Fail the slice instead. See #3636/#3637.
+                    Status st = submit(slice);
+                    if (!st.ok()) {
+                        LOG(WARNING)
+                            << "Slice " << slice
+                            << " failed: re-enqueue rejected ("
+                            << st.message() << ")";
+                        updateSliceStatus(slice, FAILED);
+                    }
+                }
+                worker.inflight_slices.fetch_sub(1);
+>>>>>>> d96993a ([Bugfix][TENT] Add non-blocking try_push to BoundedMPSCQueue and fail slices on queue full (#3636))
             } else {
                 submitFromTick(worker, slice);
             }
@@ -1119,9 +1170,118 @@ void Workers::asyncPollCq() {
         int nr_poll = cq->poll(kPollCount, wc);
         if (nr_poll < 0) continue;
         auto poll_ts = getCurrentTimeInNano();
+<<<<<<< HEAD
         for (int i = 0; i < nr_poll; ++i)
             handleCompletion(worker, *context, wc[i], poll_ts,
                              i + 1 == nr_poll);
+=======
+        for (int i = 0; i < nr_poll; ++i) {
+            auto slice = (RdmaSlice*)wc[i].wr_id;
+            worker.inflight_slice_set.erase(slice);
+            auto ep = slice->ep_weak_ptr.lock();
+            double enqueue_lat =
+                (slice->submit_ts - slice->enqueue_ts) / 1000.0;
+            double inflight_lat = (poll_ts - slice->submit_ts) / 1000.0;
+            double overall_lat_sec = (poll_ts - slice->enqueue_ts) / 1e9;
+            releaseSliceQuota(slice, overall_lat_sec);
+            if (slice->word != PENDING) continue;
+            if (!ep) {
+                updateSliceStatus(slice, FAILED);
+                num_slices++;
+                continue;
+            }
+            if (wc[i].status != IBV_WC_SUCCESS) {
+                if (wc[i].status != IBV_WC_WR_FLUSH_ERR) {
+                    // TE handles them automatically
+                    LOG(INFO) << "Detected error WQE for slice " << slice
+                              << " (opcode: " << slice->task->request.opcode
+                              << ", source_addr: " << (void*)slice->source_addr
+                              << ", dest_addr: " << (void*)slice->target_addr
+                              << ", length: " << slice->length
+                              << ", local_nic: " << context->name()
+                              << "): " << ibv_wc_status_str(wc[i].status);
+                }
+                // GPUDirect reachability learning: a protection/access error
+                // on a GPU buffer means the chosen NIC cannot P2P-DMA to that
+                // GPU (ibv_reg_mr succeeded but the PCIe path is unusable).
+                // Record it so selection avoids that NIC and converges onto a
+                // reachable rail instead of exhausting retries. The local side
+                // (source NIC -> source GPU) surfaces as LOC_PROT; the remote
+                // side (target NIC -> target GPU) as REM_ACCESS or, for a
+                // remote GDR-read failure, REM_OP (observed on strict fabrics).
+                bool local_gdr_err = (wc[i].status == IBV_WC_LOC_PROT_ERR);
+                bool remote_gdr_err = (wc[i].status == IBV_WC_REM_ACCESS_ERR ||
+                                       wc[i].status == IBV_WC_REM_OP_ERR);
+                if (local_gdr_err && slice->source_gpu_ordinal >= 0 &&
+                    slice->source_nic_name) {
+                    GdrReachability::instance().reportLocalFailure(
+                        slice->source_nic_name, slice->source_gpu_ordinal);
+                } else if (remote_gdr_err && slice->target_gpu_ordinal >= 0 &&
+                           slice->target_nic_name && slice->target_machine_id) {
+                    GdrReachability::instance().reportRemoteFailure(
+                        *slice->target_machine_id, slice->target_nic_name,
+                        slice->target_gpu_ordinal);
+                }
+                slice->retry_count++;
+                if (slice->retry_count >=
+                    transport_->params_->workers.max_retry_count) {
+                    LOG(WARNING)
+                        << "Slice " << slice << " failed: retry count exceeded";
+                    num_slices += ep->acknowledge(slice, FAILED);
+                    disableEndpoint(slice);
+                } else {
+                    num_slices += ep->acknowledge(slice, PENDING);
+                    disableEndpoint(slice);
+                    if (slice->task->cancel_requested.load(
+                            std::memory_order_acquire)) {
+                        updateSliceStatus(slice, CANCELED);
+                    } else {
+                        // Non-blocking re-enqueue: never wedge the worker on a
+                        // full queue. Fail the slice instead. See #3636/#3637.
+                        Status st = submit(slice);
+                        if (!st.ok()) {
+                            LOG(WARNING)
+                                << "Slice " << slice
+                                << " failed: re-enqueue rejected ("
+                                << st.message() << ")";
+                            updateSliceStatus(slice, FAILED);
+                        }
+                    }
+                }
+            } else {
+                num_slices += ep->acknowledge(slice, COMPLETED);
+                // A successful GPU transfer re-admits any learned GDR
+                // unreachability for the (GPU, NIC) pair(s) it used, so a
+                // transient exclusion (or a recovered path) heals. Skipped
+                // entirely until something has actually been excluded.
+                if (GdrReachability::hasAnyExclusion()) {
+                    auto& gdr = GdrReachability::instance();
+                    if (slice->source_gpu_ordinal >= 0 &&
+                        slice->source_nic_name)
+                        gdr.reportLocalSuccess(slice->source_nic_name,
+                                               slice->source_gpu_ordinal);
+                    if (slice->target_gpu_ordinal >= 0 &&
+                        slice->target_nic_name && slice->target_machine_id)
+                        gdr.reportRemoteSuccess(*slice->target_machine_id,
+                                                slice->target_nic_name,
+                                                slice->target_gpu_ordinal);
+                }
+                // A successful transfer proves this rail is healthy; clear
+                // any accumulated error count so a previously-cooled-down
+                // rail can be used again without waiting for the full
+                // cooldown to expire. The monitor pointer is resolved once
+                // in generatePostPath, so no map lookup is needed here.
+                if (auto* rail = slice->rail_monitor; rail && rail->ready())
+                    rail->markRecovered(slice->source_dev_id,
+                                        slice->target_dev_id);
+                worker.perf.inflight_lat.add(inflight_lat);
+                worker.perf.enqueue_lat.add(enqueue_lat);
+            }
+        }
+    }
+    if (num_slices) {
+        worker.inflight_slices.fetch_sub(num_slices);
+>>>>>>> d96993a ([Bugfix][TENT] Add non-blocking try_push to BoundedMPSCQueue and fail slices on queue full (#3636))
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -782,10 +782,9 @@ void Workers::asyncPostSend() {
                     // queue) and livelocks the whole engine. See #3636/#3637.
                     Status st = submit(slice);
                     if (!st.ok()) {
-                        LOG(WARNING)
-                            << "Slice " << slice
-                            << " failed: re-enqueue rejected ("
-                            << st.message() << ")";
+                        LOG(WARNING) << "Slice " << slice
+                                     << " failed: re-enqueue rejected ("
+                                     << st.message() << ")";
                         updateSliceStatus(slice, FAILED);
                     }
                 }
@@ -856,10 +855,9 @@ void Workers::asyncPostSend() {
                     // full queue. Fail the slice instead. See #3636/#3637.
                     Status st = submit(slice);
                     if (!st.ok()) {
-                        LOG(WARNING)
-                            << "Slice " << slice
-                            << " failed: re-enqueue rejected ("
-                            << st.message() << ")";
+                        LOG(WARNING) << "Slice " << slice
+                                     << " failed: re-enqueue rejected ("
+                                     << st.message() << ")";
                         updateSliceStatus(slice, FAILED);
                     }
                 }
@@ -1240,10 +1238,9 @@ void Workers::asyncPollCq() {
                         // full queue. Fail the slice instead. See #3636/#3637.
                         Status st = submit(slice);
                         if (!st.ok()) {
-                            LOG(WARNING)
-                                << "Slice " << slice
-                                << " failed: re-enqueue rejected ("
-                                << st.message() << ")";
+                            LOG(WARNING) << "Slice " << slice
+                                         << " failed: re-enqueue rejected ("
+                                         << st.message() << ")";
                             updateSliceStatus(slice, FAILED);
                         }
                     }


### PR DESCRIPTION
Fixes #3636 and #3637.

## Summary

A full bounded worker queue could make BoundedMPSCQueue::push() spin forever. A worker retrying into the same queue it must drain could therefore wedge all RDMA progress.

Initial multi-worker submission also needs atomic admission. If an earlier worker observes and posts its list before a later queue rejects, asynchronous cancellation can overlap fallback and freeSubBatch(), allowing late CQ completions to reference freed slices.

## Fix

- Keep non-blocking try_push() for retry paths and return backpressure instead of spinning.
- Keep a large worker queue capacity to avoid rejection during normal bursts.
- Add queue try_reserve(), commit(), and cancel_reservation() operations.
- Add Workers::admitBatch():
  - reserve one cell in every target worker queue before publishing any real list;
  - if any reservation fails, publish only default empty placeholders for earlier reservations and return TooManyRequests;
  - after every reservation succeeds, establish ownership and inflight accounting for all lists, then commit the real lists and wake workers.
- Route RdmaTransport::submitTransferTasks() through admitBatch() rather than per-worker submit followed by asynchronous cancellation.
- Restore current upstream worker completion/retry lifecycle and remove accidentally committed conflict markers and duplicate queue methods.

No real slice list is visible to a worker on the rejection path, so no WR can be posted and no cancellation/CQ drain is required before fallback frees the sub-batch.

## Testing

- clang-format-20 --dry-run --Werror passes on all five changed C++ files.
- git diff --check passes and no merge-conflict markers remain.
- A standalone reservation regression passes:
  - reserved entries remain invisible until commit;
  - a later-queue rejection cancels earlier reservations by publishing only empty entries;
  - no real batch entry becomes visible on rejection.
- On a B200 GPU pod, USE_TENT=ON, USE_CUDA=OFF production build completes 245/245 targets, including the changed workers.cpp and rdma_transport.cpp.
- GitHub check-paths is green; remaining CTest/build/wheel/TENT jobs for head e9c337f are pending runner capacity.
