### PR TITLE
[Refactor][Store] Distinguish new segment registration from segment remount (#3560)

### DIFF
--- a/docs/source/design/store/mooncake-store.md
+++ b/docs/source/design/store/mooncake-store.md
@@ -168,8 +168,9 @@ service MasterService {
   // Remove objects matching a regex
   rpc RemoveByRegex(RemoveByRegexRequest) returns (RemoveByRegexResponse);
 
-  // Storage node (Client) registers a storage segment
-  rpc MountSegment(MountSegmentRequest) returns (MountSegmentResponse);
+  // Storage node (Client) registers new segments or reconciles its full
+  // segment snapshot after the Master requests a remount
+  rpc UpdateSegments(UpdateSegmentsRequest) returns (UpdateSegmentsResponse);
 
   // Storage node (Client) unregisters a storage segment
   rpc UnmountSegment(UnmountSegmentRequest) returns (UnmountSegmentResponse);
@@ -323,21 +324,47 @@ message RemoveByRegexResponse {
 - **Response**: RemoveByRegexResponse, which contains a status_code and the number of objects that were removed, removed_count.
 - **Description**: Used to delete all objects and their corresponding replicas for keys that match the specified regular expression. Similar to the Remove interface, this is a metadata operation where the Master Service marks the status of all matched object replicas as removed.
 
-9. MountSegment
+9. UpdateSegments
 
 ```protobuf
-message MountSegmentRequest {
-  required uint64 buffer = 1;       // Starting address of the space
-  required uint64 size = 2;         // Size of the space
-  required string segment_name = 3; // Storage segment name
+enum SegmentRegistrationIntent {
+  NEW = 0;
+  REMOUNT = 1;
 }
 
-message MountSegmentResponse {
-  required int32 status_code = 1;
+enum SegmentUpdateRequestIntent {
+  REGISTER = 0;
+  RECONCILE = 1;
+}
+
+message SegmentUpdate {
+  required Segment segment = 1;
+  required SegmentRegistrationIntent intent = 2;
+}
+
+message UpdateSegmentsRequest {
+  required UUID client_id = 1;
+  required SegmentUpdateRequestIntent request_intent = 2;
+  repeated SegmentUpdate segments = 3;
+}
+
+message SegmentUpdateResult {
+  required UUID segment_id = 1;
+  required int32 error_code = 2;
+}
+
+message UpdateSegmentsResponse {
+  required ClientStatus client_status = 1;
+  repeated SegmentUpdateResult results = 2;
 };
 ```
 
-The storage node (Client) allocates a segment of memory and, after calling `TransferEngine::registerLocalMemory` to complete local mounting, calls this interface to mount the allocated continuous address space to the Master Service for allocation.
+After registering memory locally with `TransferEngine`, a storage node sends a
+`REGISTER` request containing `NEW` segments. A client whose heartbeat reports
+`NEED_REMOUNT` sends one `RECONCILE` request containing its complete pending
+snapshot: newly created segments use `NEW`, while segments known before the
+Master lost state use `REMOUNT`. Only a successful reconciliation confirms the
+client snapshot and changes its status to `OK`.
 
 10. UnmountSegment
 
@@ -357,15 +384,15 @@ When the space needs to be released, this interface is used to remove the previo
 
 The Master Service needs to maintain mappings related to buffer allocators and object metadata to efficiently manage memory resources and precisely control replica states in multi-replica scenarios. Additionally, the Master Service uses read-write locks to protect critical data structures, ensuring data consistency and security in multi-threaded environments. The following are the interfaces maintained by the Master Service for storage space information:
 
-- MountSegment
+- UpdateSegments
 
 ```C++
-tl::expected<void, ErrorCode> MountSegment(uint64_t buffer,
-                                          uint64_t size,
-                                          const std::string& segment_name);
+tl::expected<UpdateSegmentsResponse, ErrorCode> UpdateSegments(
+    const UpdateSegmentsRequest& request);
 ```
 
-The storage node (Client) registers the storage segment space with the Master Service.
+The storage node (Client) incrementally registers new segment space or
+reconciles its complete segment snapshot with the Master Service.
 
 - UnmountSegment
 

--- a/mooncake-pg/tests/test_pg_elastic.py
+++ b/mooncake-pg/tests/test_pg_elastic.py
@@ -864,6 +864,7 @@ def _run_p2p_ping_pong(
 
 def _recovery_p2p_worker(
     ctx: MooncakePGWorkerContext,
+    pre_failure_barrier: mp.Barrier,
     broken_exited: mp.Event,
     start_recovery: mp.Event,
     graceful_group_destroy: bool,
@@ -875,6 +876,11 @@ def _recovery_p2p_worker(
         device = ctx.init_group(rank=logical_rank)
         backend = ctx.get_backend()
         _run_p2p_ping_pong(ctx, device, logical_rank)
+        # Local completion does not mean the peer has consumed its final ack.
+        # Finish the healthy round on both ranks before changing the group epoch
+        # or exiting, so failure injection cannot invalidate that exchange.
+        ctx.synchronize()
+        pre_failure_barrier.wait(timeout=30.0)
 
         if logical_rank == BROKEN_RANK:
             if graceful_group_destroy:
@@ -1283,11 +1289,13 @@ class _ElasticMixin:
     def _run_recovery_p2p(self, graceful_group_destroy: bool) -> None:
         recovery_world_size = 2
         spawn_ctx = mp.get_context("spawn")
+        pre_failure_barrier = spawn_ctx.Barrier(recovery_world_size)
         broken_exited = spawn_ctx.Event()
         start_recovery = spawn_ctx.Event()
 
         rows = self.spawn_backend_and_collect(
             _recovery_p2p_worker,
+            pre_failure_barrier,
             broken_exited,
             start_recovery,
             graceful_group_destroy,

--- a/mooncake-store/benchmarks/batch_get_replica_bench.cpp
+++ b/mooncake-store/benchmarks/batch_get_replica_bench.cpp
@@ -97,10 +97,22 @@ class SegmentClient {
         segment_.base = segment_base;
         segment_.size = segment_size;
         segment_.te_endpoint = name;
-        auto mount_ec = master_client_.MountSegment(segment_);
-        if (!mount_ec.has_value()) {
+        mooncake::UpdateSegmentsRequest mount_request;
+        mount_request.request_intent =
+            mooncake::SegmentUpdateRequestIntent::REGISTER;
+        mount_request.segments.emplace_back(
+            segment_, mooncake::SegmentRegistrationIntent::NEW);
+        auto mount_result = master_client_.UpdateSegments(mount_request);
+        if (!mount_result.has_value() || mount_result->results.size() != 1 ||
+            mount_result->results[0].error_code != mooncake::ErrorCode::OK) {
+            auto error = mount_result.has_value()
+                             ? mooncake::ErrorCode::INTERNAL_ERROR
+                             : mount_result.error();
+            if (mount_result.has_value() && mount_result->results.size() == 1) {
+                error = mount_result->results[0].error_code;
+            }
             throw std::runtime_error("Failed to mount segment " + name +
-                                     ", ec=" + toString(mount_ec.error()));
+                                     ", ec=" + toString(error));
         }
     }
 
@@ -132,8 +144,16 @@ class SegmentClient {
                 mooncake::ClientStatus::NEED_REMOUNT &&
             !remount_future_.valid()) {
             remount_future_ = std::async(std::launch::async, [&]() {
-                auto remount_ec = master_client_.ReMountSegment({segment_});
-                if (!remount_ec.has_value()) {
+                mooncake::UpdateSegmentsRequest request;
+                request.request_intent =
+                    mooncake::SegmentUpdateRequestIntent::RECONCILE;
+                request.segments.emplace_back(
+                    segment_, mooncake::SegmentRegistrationIntent::REMOUNT);
+                auto result = master_client_.UpdateSegments(request);
+                if (!result.has_value() ||
+                    result->client_status != mooncake::ClientStatus::OK ||
+                    result->results.size() != 1 ||
+                    result->results[0].error_code != mooncake::ErrorCode::OK) {
                     throw std::runtime_error("Failed to remount segment");
                 }
             });

--- a/mooncake-store/benchmarks/master_bench.cpp
+++ b/mooncake-store/benchmarks/master_bench.cpp
@@ -72,10 +72,22 @@ class SegmentClient {
         segment_.base = segment_base;
         segment_.size = segment_size;
         segment_.te_endpoint = name;
-        auto mount_ec = master_client_.MountSegment(segment_);
-        if (!mount_ec.has_value()) {
+        mooncake::UpdateSegmentsRequest mount_request;
+        mount_request.request_intent =
+            mooncake::SegmentUpdateRequestIntent::REGISTER;
+        mount_request.segments.emplace_back(
+            segment_, mooncake::SegmentRegistrationIntent::NEW);
+        auto mount_result = master_client_.UpdateSegments(mount_request);
+        if (!mount_result.has_value() || mount_result->results.size() != 1 ||
+            mount_result->results[0].error_code != mooncake::ErrorCode::OK) {
+            auto error = mount_result.has_value()
+                             ? mooncake::ErrorCode::INTERNAL_ERROR
+                             : mount_result.error();
+            if (mount_result.has_value() && mount_result->results.size() == 1) {
+                error = mount_result->results[0].error_code;
+            }
             throw std::runtime_error("Failed to mount segment " + name +
-                                     ", ec=" + toString(mount_ec.error()));
+                                     ", ec=" + toString(error));
         }
     }
 
@@ -107,8 +119,16 @@ class SegmentClient {
                 mooncake::ClientStatus::NEED_REMOUNT &&
             !remount_future_.valid()) {
             remount_future_ = std::async(std::launch::async, [&]() {
-                auto remount_ec = master_client_.ReMountSegment({segment_});
-                if (!remount_ec.has_value()) {
+                mooncake::UpdateSegmentsRequest request;
+                request.request_intent =
+                    mooncake::SegmentUpdateRequestIntent::RECONCILE;
+                request.segments.emplace_back(
+                    segment_, mooncake::SegmentRegistrationIntent::REMOUNT);
+                auto result = master_client_.UpdateSegments(request);
+                if (!result.has_value() ||
+                    result->client_status != mooncake::ClientStatus::OK ||
+                    result->results.size() != 1 ||
+                    result->results[0].error_code != mooncake::ErrorCode::OK) {
                     throw std::runtime_error("Failed to remount segment");
                 }
             });

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -349,12 +349,12 @@ class Client {
         ReplicaType replica_type);
 
     /**
-     * @brief Registers local memory and queues the segment for asynchronous
-     * Master registration.
+     * @brief Registers local memory and the segment with the Master.
      * @param buffer Memory buffer to register
      * @param size Size of the buffer in bytes
-     * @return Success once local registration is accepted. Master-side
-     * registration is retried by the control-plane flusher.
+     * @return Success after incremental Master registration. If the Master
+     * requests a full reconciliation, the control-plane flusher completes it
+     * asynchronously.
      */
     tl::expected<void, ErrorCode> MountSegment(
         const void* buffer, size_t size, const std::string& protocol = "tcp",
@@ -370,8 +370,8 @@ class Client {
                                                  size_t size);
 
     /**
-     * @brief Registers local memory, queues Master registration, and returns
-     * the generated Segment UUID.
+     * @brief Registers local memory and the segment with the Master, then
+     * returns the generated Segment UUID.
      */
     tl::expected<UUID, ErrorCode> MountSegmentAndGetId(
         const void* buffer, size_t size, const std::string& protocol = "tcp",

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -349,10 +349,12 @@ class Client {
         ReplicaType replica_type);
 
     /**
-     * @brief Registers a memory segment to master for allocation
+     * @brief Registers local memory and queues the segment for asynchronous
+     * Master registration.
      * @param buffer Memory buffer to register
      * @param size Size of the buffer in bytes
-     * @return ErrorCode indicating success/failure
+     * @return Success once local registration is accepted. Master-side
+     * registration is retried by the control-plane flusher.
      */
     tl::expected<void, ErrorCode> MountSegment(
         const void* buffer, size_t size, const std::string& protocol = "tcp",
@@ -368,8 +370,8 @@ class Client {
                                                  size_t size);
 
     /**
-     * @brief Mounts a memory segment and returns its generated Segment UUID.
-     *        Logic is identical to MountSegment, but returns the segment id.
+     * @brief Registers local memory, queues Master registration, and returns
+     * the generated Segment UUID.
      */
     tl::expected<UUID, ErrorCode> MountSegmentAndGetId(
         const void* buffer, size_t size, const std::string& protocol = "tcp",
@@ -932,7 +934,7 @@ class Client {
     enum class SegmentSyncState : uint8_t {
         NEW_PENDING = 0,
         REMOUNT_PENDING,
-        ALIGNED,
+        ACTIVE,
     };
 
     struct MountedSegmentEntry {
@@ -945,11 +947,11 @@ class Client {
 
     // Mutex to protect mounted_segments_
     mutable std::mutex mounted_segments_mutex_;
+    // Serializes segment update RPCs with unmount operations. Mount only needs
+    // mounted_segments_mutex_, so newly created segments can enter the next
+    // flusher snapshot while an RPC is in flight.
+    std::mutex segment_update_mutex_;
     MountedSegmentMap mounted_segments_;
-    // True after the latest full segment reconciliation succeeds. Guarded by
-    // mounted_segments_mutex_ so mounts and NEED_REMOUNT transitions have one
-    // ordering point.
-    bool segments_aligned_with_master_{false};
 
     // Segments in graceful unmount: readable by remote peers, not allocatable
     // locally. TE MR remains registered until master confirms removal.
@@ -1006,6 +1008,9 @@ class Client {
     std::atomic<bool> leader_monitor_running_{false};
     std::thread storage_heartbeat_thread_;
     std::atomic<bool> storage_heartbeat_running_{false};
+    std::mutex storage_control_mutex_;
+    std::condition_variable storage_control_cv_;
+    std::atomic<bool> segment_flush_requested_{false};
     std::thread task_poll_thread_;
     std::atomic<bool> task_poll_running_{false};
     std::atomic<bool> last_ping_success_{false};

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -678,8 +678,8 @@ class Client {
     std::unordered_set<std::string> GetLocalEndpoints() const {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         std::unordered_set<std::string> endpoints;
-        for (const auto& [segment_id, segment] : mounted_segments_) {
-            endpoints.insert(segment.te_endpoint);
+        for (const auto& [segment_id, entry] : mounted_segments_) {
+            endpoints.insert(entry.segment.te_endpoint);
         }
         return endpoints;
     }
@@ -929,9 +929,27 @@ class Client {
     MasterClient master_client_;
     std::unique_ptr<TransferSubmitter> transfer_submitter_;
 
+    enum class SegmentSyncState : uint8_t {
+        NEW_PENDING = 0,
+        REMOUNT_PENDING,
+        ALIGNED,
+    };
+
+    struct MountedSegmentEntry {
+        Segment segment;
+        SegmentSyncState sync_state{SegmentSyncState::NEW_PENDING};
+    };
+
+    using MountedSegmentMap =
+        std::unordered_map<UUID, MountedSegmentEntry, boost::hash<UUID>>;
+
     // Mutex to protect mounted_segments_
     mutable std::mutex mounted_segments_mutex_;
-    std::unordered_map<UUID, Segment, boost::hash<UUID>> mounted_segments_;
+    MountedSegmentMap mounted_segments_;
+    // True after the latest full segment reconciliation succeeds. Guarded by
+    // mounted_segments_mutex_ so mounts and NEED_REMOUNT transitions have one
+    // ordering point.
+    bool segments_aligned_with_master_{false};
 
     // Segments in graceful unmount: readable by remote peers, not allocatable
     // locally. TE MR remains registered until master confirms removal.
@@ -946,7 +964,7 @@ class Client {
      *        Caller must hold mounted_segments_mutex_.
      */
     tl::expected<void, ErrorCode> UnmountSegmentImpl(
-        std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it);
+        MountedSegmentMap::iterator it);
 
     void StartGracefulUnmountTimer(const UUID& segment_id,
                                    uint64_t grace_period_ms);

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -947,9 +947,8 @@ class Client {
 
     // Mutex to protect mounted_segments_
     mutable std::mutex mounted_segments_mutex_;
-    // Serializes segment update RPCs with unmount operations. Mount only needs
-    // mounted_segments_mutex_, so newly created segments can enter the next
-    // flusher snapshot while an RPC is in flight.
+    // Serializes synchronous registration, background reconciliation, and
+    // unmount operations so their snapshots cannot race with each other.
     std::mutex segment_update_mutex_;
     MountedSegmentMap mounted_segments_;
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -317,11 +317,10 @@ class MasterClient {
     [[nodiscard]] std::vector<tl::expected<void, ErrorCode>> BatchRemove(
         const std::vector<std::string>& keys, bool force = false);
 
-    /**
-     * @brief Registers a segment to master for allocation
-     * @param segment Segment to register
-     * @return tl::expected<void, ErrorCode> indicating success/failure
-     */
+    [[nodiscard]] tl::expected<UpdateSegmentsResponse, ErrorCode>
+    UpdateSegments(const UpdateSegmentsRequest& request);
+
+    // Compatibility helper implemented through UpdateSegments(REGISTER).
     [[nodiscard]] tl::expected<void, ErrorCode> MountSegment(
         const Segment& segment);
 
@@ -336,14 +335,7 @@ class MasterClient {
     [[nodiscard]] tl::expected<void, ErrorCode> MountNoFSegment(
         const NoFSegment& segment);
 
-    /**
-     * @brief Re-mount segments, invoked when the client is the first time to
-     * connect to the master or the client Ping TTL is expired and need
-     * to remount. This function is idempotent. Client should retry if the
-     * return code is not ErrorCode::OK.
-     * @param updates Segments to reconcile and their per-segment intent
-     * @return tl::expected<void, ErrorCode> indicating success/failure
-     */
+    // Compatibility helper implemented through UpdateSegments(RECONCILE).
     [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
         const std::vector<SegmentUpdate>& updates);
 

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -320,10 +320,6 @@ class MasterClient {
     [[nodiscard]] tl::expected<UpdateSegmentsResponse, ErrorCode>
     UpdateSegments(const UpdateSegmentsRequest& request);
 
-    // Compatibility helper implemented through UpdateSegments(REGISTER).
-    [[nodiscard]] tl::expected<void, ErrorCode> MountSegment(
-        const Segment& segment);
-
     [[nodiscard]] tl::expected<void, ErrorCode> MountSSDSegment(
         const Segment& segment);
 
@@ -334,14 +330,6 @@ class MasterClient {
      */
     [[nodiscard]] tl::expected<void, ErrorCode> MountNoFSegment(
         const NoFSegment& segment);
-
-    // Compatibility helper implemented through UpdateSegments(RECONCILE).
-    [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
-        const std::vector<SegmentUpdate>& updates);
-
-    // Compatibility helper for callers that only issue true remounts.
-    [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
-        const std::vector<Segment>& segments);
 
     /**
      * @brief Re-mount NoF ssd segments, invoked when the client is the first

--- a/mooncake-store/include/master_client.h
+++ b/mooncake-store/include/master_client.h
@@ -341,9 +341,13 @@ class MasterClient {
      * connect to the master or the client Ping TTL is expired and need
      * to remount. This function is idempotent. Client should retry if the
      * return code is not ErrorCode::OK.
-     * @param segments Segments to remount
+     * @param updates Segments to reconcile and their per-segment intent
      * @return tl::expected<void, ErrorCode> indicating success/failure
      */
+    [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
+        const std::vector<SegmentUpdate>& updates);
+
+    // Compatibility helper for callers that only issue true remounts.
     [[nodiscard]] tl::expected<void, ErrorCode> ReMountSegment(
         const std::vector<Segment>& segments);
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -265,16 +265,21 @@ class MasterService {
         -> tl::expected<void, ErrorCode>;
 
     /**
-     * @brief Re-mount segments, invoked when the client is the first time to
-     * connect to the master or the client Ping TTL is expired and need
-     * to remount. This function is idempotent. Client should retry if the
-     * return code is not ErrorCode::OK.
+     * @brief Reconcile segment registrations after the master requests a
+     * client remount. NEW updates use ordinary idempotent registration;
+     * REMOUNT updates additionally run standby recovery. This function is
+     * idempotent. Client should retry if the return code is not ErrorCode::OK.
      * @return ErrorCode::OK means either all segments are remounted
      * successfully or the fail is not solvable by a new remount request.
      *         ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS if the segment cannot
      *         be mounted temporarily.
      *         ErrorCode::INTERNAL_ERROR if something temporary error happens.
      */
+    auto ReMountSegment(const std::vector<SegmentUpdate>& updates,
+                        const UUID& client_id) -> tl::expected<void, ErrorCode>;
+
+    // Compatibility helper for in-process callers that only issue true
+    // remounts. RPC callers should provide an explicit intent per segment.
     auto ReMountSegment(const std::vector<Segment>& segments,
                         const UUID& client_id) -> tl::expected<void, ErrorCode>;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -1011,7 +1011,7 @@ class MasterService {
         const std::vector<StandbySegmentInfo>& segments,
         size_t chunk_object_count,
         std::optional<ReplicaID> expected_max_replica_id);
-    std::vector<SegmentUpdateResult> MountNewSegments(
+    tl::expected<std::vector<SegmentUpdateResult>, ErrorCode> MountNewSegments(
         const std::vector<Segment>& segments, const UUID& client_id);
 
     std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore(

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -241,6 +241,13 @@ class MasterService {
     uint64_t GetKvClearedSuppressedForTesting() const;
 
     /**
+     * @brief Unified external entry point for incremental registration and
+     * full client segment reconciliation.
+     */
+    auto UpdateSegments(const UpdateSegmentsRequest& request)
+        -> tl::expected<UpdateSegmentsResponse, ErrorCode>;
+
+    /**
      * @brief Mount a memory segment for buffer allocation. This function is
      * idempotent.
      * @return ErrorCode::OK on success,
@@ -1004,6 +1011,8 @@ class MasterService {
         const std::vector<StandbySegmentInfo>& segments,
         size_t chunk_object_count,
         std::optional<ReplicaID> expected_max_replica_id);
+    std::vector<SegmentUpdateResult> MountNewSegments(
+        const std::vector<Segment>& segments, const UUID& client_id);
 
     std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore(
         const MasterServiceConfig& config);

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -154,14 +154,11 @@ class WrappedMasterService {
         const std::vector<std::string>& keys, bool force = false,
         const std::string& tenant_id = "default");
 
-    tl::expected<void, ErrorCode> MountSegment(const Segment& segment,
-                                               const UUID& client_id);
+    tl::expected<UpdateSegmentsResponse, ErrorCode> UpdateSegments(
+        const UpdateSegmentsRequest& request);
 
     tl::expected<void, ErrorCode> MountNoFSegment(const NoFSegment& segment,
                                                   const UUID& client_id);
-
-    tl::expected<void, ErrorCode> ReMountSegment(
-        const std::vector<SegmentUpdate>& updates, const UUID& client_id);
 
     tl::expected<void, ErrorCode> ReMountNoFSegment(
         const std::vector<NoFSegment>& segments, const UUID& client_id);

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -161,7 +161,7 @@ class WrappedMasterService {
                                                   const UUID& client_id);
 
     tl::expected<void, ErrorCode> ReMountSegment(
-        const std::vector<Segment>& segments, const UUID& client_id);
+        const std::vector<SegmentUpdate>& updates, const UUID& client_id);
 
     tl::expected<void, ErrorCode> ReMountNoFSegment(
         const std::vector<NoFSegment>& segments, const UUID& client_id);

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <optional>
+#include <vector>
 
 #include "types.h"
 #include "replica.h"
@@ -13,12 +14,21 @@ namespace mooncake {
  * @brief Describes how the master should reconcile a segment registration.
  *
  * This is request intent, not the master-side availability status of a
- * segment. The same segment is NEW when first registered with a master and
- * REMOUNT when it is registered again after master-side state is lost.
+ * segment. NEW always uses ordinary idempotent registration and never standby
+ * recovery; REMOUNT restores a segment that predates loss of Master state.
  */
 enum class SegmentRegistrationIntent : uint8_t {
     NEW = 0,
     REMOUNT = 1,
+};
+
+enum class SegmentUpdateRequestIntent : uint8_t {
+    // Incremental registration. Every item must have NEW intent and this
+    // request never confirms the client's complete segment snapshot.
+    REGISTER = 0,
+    // Full pending snapshot. NEW and REMOUNT items are both accepted, and a
+    // complete success confirms the client in ok_client_.
+    RECONCILE = 1,
 };
 
 /**
@@ -34,6 +44,28 @@ struct SegmentUpdate {
         : segment(segment_param), intent(intent_param) {}
 };
 YLT_REFL(SegmentUpdate, segment, intent);
+
+struct UpdateSegmentsRequest {
+    UUID client_id{};
+    SegmentUpdateRequestIntent request_intent{
+        SegmentUpdateRequestIntent::REGISTER};
+    std::vector<SegmentUpdate> segments;
+};
+YLT_REFL(UpdateSegmentsRequest, client_id, request_intent, segments);
+
+struct SegmentUpdateResult {
+    UUID segment_id{};
+    ErrorCode error_code{ErrorCode::OK};
+};
+YLT_REFL(SegmentUpdateResult, segment_id, error_code);
+
+struct UpdateSegmentsResponse {
+    // Master-side status after handling the request. REGISTER may succeed per
+    // segment while still returning NEED_REMOUNT for the client as a whole.
+    ClientStatus client_status{ClientStatus::NEED_REMOUNT};
+    std::vector<SegmentUpdateResult> results;
+};
+YLT_REFL(UpdateSegmentsResponse, client_status, results);
 
 struct ObjectMeta {
     std::string key;

--- a/mooncake-store/include/rpc_types.h
+++ b/mooncake-store/include/rpc_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 
 #include "types.h"
@@ -7,6 +8,32 @@
 #include "task_manager.h"
 
 namespace mooncake {
+
+/**
+ * @brief Describes how the master should reconcile a segment registration.
+ *
+ * This is request intent, not the master-side availability status of a
+ * segment. The same segment is NEW when first registered with a master and
+ * REMOUNT when it is registered again after master-side state is lost.
+ */
+enum class SegmentRegistrationIntent : uint8_t {
+    NEW = 0,
+    REMOUNT = 1,
+};
+
+/**
+ * @brief A segment descriptor paired with its reconciliation intent.
+ */
+struct SegmentUpdate {
+    Segment segment;
+    SegmentRegistrationIntent intent{SegmentRegistrationIntent::NEW};
+
+    SegmentUpdate() = default;
+    SegmentUpdate(const Segment& segment_param,
+                  SegmentRegistrationIntent intent_param)
+        : segment(segment_param), intent(intent_param) {}
+};
+YLT_REFL(SegmentUpdate, segment, intent);
 
 struct ObjectMeta {
     std::string key;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -3676,6 +3676,8 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
     }
 
     UUID segment_id;
+    Segment segment;
+    std::unique_lock<std::mutex> update_lock(segment_update_mutex_);
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
 
@@ -3702,7 +3704,6 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             return tl::unexpected(ErrorCode::INVALID_PARAMS);
         }
 
-        Segment segment;
         segment.id = generate_uuid();
         segment.name = local_hostname_;
         segment.base = reinterpret_cast<uintptr_t>(buffer);
@@ -3716,17 +3717,58 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
         }
 
         segment_id = segment.id;
-        // Local registration owns the buffer immediately. Master registration
-        // is performed by the single-flight control-plane flusher, so a Master
-        // outage does not lose this segment or require the caller to recreate
-        // it.
         mounted_segments_[segment_id] = {segment,
                                          SegmentSyncState::NEW_PENDING};
     }
 
+    UpdateSegmentsRequest request;
+    request.client_id = client_id_;
+    request.request_intent = SegmentUpdateRequestIntent::REGISTER;
+    request.segments.emplace_back(segment, SegmentRegistrationIntent::NEW);
+    auto mount_result = master_client_.UpdateSegments(request);
+
+    ErrorCode mount_error = ErrorCode::OK;
+    if (!mount_result) {
+        mount_error = mount_result.error();
+    } else if (mount_result->results.size() != 1 ||
+               mount_result->results.front().segment_id != segment_id) {
+        mount_error = ErrorCode::INTERNAL_ERROR;
+    } else {
+        mount_error = mount_result->results.front().error_code;
+    }
+
+    if (mount_error != ErrorCode::OK) {
+        LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
+                   << " size=" << size << ", error=" << mount_error;
+        {
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            mounted_segments_.erase(segment_id);
+        }
+        int rc = transfer_engine_->unregisterLocalMemory((void*)buffer);
+        if (rc != 0 && rc != ERR_ADDRESS_NOT_REGISTERED) {
+            LOG(ERROR) << "rollback_register_local_memory_failed base="
+                       << buffer << " size=" << size << ", error=" << rc;
+        }
+        return tl::unexpected(mount_error);
+    }
+
+    const bool need_reconcile =
+        mount_result->client_status == ClientStatus::NEED_REMOUNT;
+    if (!need_reconcile) {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+        auto entry = mounted_segments_.find(segment_id);
+        if (entry != mounted_segments_.end() &&
+            entry->second.sync_state == SegmentSyncState::NEW_PENDING) {
+            entry->second.sync_state = SegmentSyncState::ACTIVE;
+        }
+    }
+
+    update_lock.unlock();
     EnsureStorageControlPlaneStarted();
-    segment_flush_requested_.store(true);
-    storage_control_cv_.notify_one();
+    if (need_reconcile) {
+        segment_flush_requested_.store(true);
+        storage_control_cv_.notify_one();
+    }
     return segment_id;
 }
 
@@ -4916,6 +4958,7 @@ void Client::StorageHeartbeatThreadMain() {
     };
 
     auto mark_need_remount = [this]() {
+        std::lock_guard<std::mutex> update_lock(segment_update_mutex_);
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         for (auto& [segment_id, entry] : mounted_segments_) {
             if (entry.sync_state == SegmentSyncState::ACTIVE) {

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -478,7 +478,7 @@ Client::~Client() {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
         mounted_segments_copy.reserve(mounted_segments_.size());
         for (auto& entry : mounted_segments_) {
-            mounted_segments_copy.emplace_back(entry.second);
+            mounted_segments_copy.emplace_back(entry.second.segment);
         }
         for (auto& entry : gracefully_unmounting_segments_) {
             gracefully_unmounting_segments_copy.emplace_back(entry.second);
@@ -693,6 +693,18 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
 ErrorCode Client::SwitchLeader(const ha::MasterView& target_view) {
     std::lock_guard<std::mutex> lock(leader_switch_mutex_);
 
+    const bool leader_changed =
+        current_master_view_.has_value() &&
+        (target_view.view_version != current_master_view_->view_version ||
+         target_view.leader_address != current_master_view_->leader_address);
+    std::unique_lock<std::mutex> segment_lock(mounted_segments_mutex_,
+                                              std::defer_lock);
+    if (leader_changed) {
+        // Establish a barrier between mounts accepted by the old and new
+        // leaders. New mounts cannot be classified until the switch finishes.
+        segment_lock.lock();
+    }
+
     if (current_master_view_.has_value()) {
         const auto& current_view = current_master_view_.value();
         if (target_view.view_version < current_view.view_version) {
@@ -714,6 +726,17 @@ ErrorCode Client::SwitchLeader(const ha::MasterView& target_view) {
 
     current_master_view_ = target_view;
     last_ping_success_.store(true);
+    if (leader_changed) {
+        segments_aligned_with_master_ = false;
+        for (auto& [segment_id, entry] : mounted_segments_) {
+            if (entry.sync_state != SegmentSyncState::REMOUNT_PENDING) {
+                // NEW is relative to the leader that accepted MountSegment.
+                // Any entry that predates this switch is a remount for the new
+                // leader, regardless of whether the previous full sync ran.
+                entry.sync_state = SegmentSyncState::REMOUNT_PENDING;
+            }
+        }
+    }
     return ErrorCode::OK;
 }
 
@@ -3616,8 +3639,9 @@ tl::expected<void, ErrorCode> Client::MountSegment(
 }
 
 tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
-    std::unordered_map<UUID, Segment, boost::hash<UUID>>::iterator it) {
-    auto unmount_result = master_client_.UnmountSegment(it->second.id);
+    MountedSegmentMap::iterator it) {
+    auto& segment = it->second.segment;
+    auto unmount_result = master_client_.UnmountSegment(segment.id);
     if (!unmount_result) {
         ErrorCode err = unmount_result.error();
         LOG(ERROR) << "Failed to unmount segment from master: "
@@ -3626,7 +3650,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
     }
 
     int rc = transfer_engine_->unregisterLocalMemory(
-        reinterpret_cast<void*>(it->second.base));
+        reinterpret_cast<void*>(segment.base));
     if (rc != 0) {
         LOG(ERROR) << "Failed to unregister transfer buffer with transfer "
                       "engine ret is "
@@ -3649,8 +3673,9 @@ tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
 
     for (auto it = mounted_segments_.begin(); it != mounted_segments_.end();
          ++it) {
-        if (it->second.base == reinterpret_cast<uintptr_t>(buffer) &&
-            it->second.size == size) {
+        const auto& mounted = it->second.segment;
+        if (mounted.base == reinterpret_cast<uintptr_t>(buffer) &&
+            mounted.size == size) {
             segment = it;
             break;
         }
@@ -3677,7 +3702,7 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
 
         // Check if the segment overlaps with any existing segment
         for (auto& it : mounted_segments_) {
-            auto& mtseg = it.second;
+            auto& mtseg = it.second.segment;
             uintptr_t l1 = reinterpret_cast<uintptr_t>(mtseg.base);
             uintptr_t r1 = reinterpret_cast<uintptr_t>(mtseg.size) + l1;
             uintptr_t l2 = reinterpret_cast<uintptr_t>(buffer);
@@ -3720,7 +3745,12 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
         }
 
         segment_id = segment.id;
-        mounted_segments_[segment_id] = segment;
+        // Keep a successful ordinary mount as NEW_PENDING until a subsequent
+        // Ping confirms that the same master still considers the client OK, or
+        // until it participates in an explicit reconciliation request. This
+        // preserves NEW across the race between MountSegment and NEED_REMOUNT.
+        mounted_segments_[segment_id] = {segment,
+                                         SegmentSyncState::NEW_PENDING};
     }
 
     EnsureStorageControlPlaneStarted();
@@ -3750,7 +3780,8 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentById(
         return tl::unexpected(err);
     }
 
-    gracefully_unmounting_segments_.emplace(segment->first, segment->second);
+    gracefully_unmounting_segments_.emplace(segment->first,
+                                            segment->second.segment);
     if (cleanup_callback) {
         graceful_unmount_cleanup_callbacks_[segment->first] =
             std::move(cleanup_callback);
@@ -4910,15 +4941,31 @@ void Client::StorageHeartbeatThreadMain() {
         // unmounted successfully first, and then remounted again in
         // this thread.
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-        std::vector<Segment> segments;
-        for (auto it : mounted_segments_) {
-            auto& segment = it.second;
-            segments.emplace_back(segment);
+        std::vector<SegmentUpdate> updates;
+        updates.reserve(mounted_segments_.size());
+        for (const auto& [segment_id, entry] : mounted_segments_) {
+            switch (entry.sync_state) {
+                case SegmentSyncState::NEW_PENDING:
+                    updates.emplace_back(entry.segment,
+                                         SegmentRegistrationIntent::NEW);
+                    break;
+                case SegmentSyncState::REMOUNT_PENDING:
+                    updates.emplace_back(entry.segment,
+                                         SegmentRegistrationIntent::REMOUNT);
+                    break;
+                case SegmentSyncState::ALIGNED:
+                    break;
+            }
         }
-        auto remount_result = master_client_.ReMountSegment(segments);
+        auto remount_result = master_client_.ReMountSegment(updates);
         if (!remount_result) {
             ErrorCode err = remount_result.error();
             LOG(ERROR) << "Failed to remount segments: " << err;
+        } else {
+            for (auto& [segment_id, entry] : mounted_segments_) {
+                entry.sync_state = SegmentSyncState::ALIGNED;
+            }
+            segments_aligned_with_master_ = true;
         }
         // Re-publish Transfer Engine segment descriptors to the HTTP
         // metadata server.  When Master (which hosts the HTTP metadata
@@ -4977,8 +5024,30 @@ void Client::StorageHeartbeatThreadMain() {
             ping_fail_count = 0;
             last_ping_success_.store(true);
             auto& ping_response = ping_result.value();
+            if (ping_response.client_status == ClientStatus::OK) {
+                std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+                if (segments_aligned_with_master_) {
+                    for (auto& [segment_id, entry] : mounted_segments_) {
+                        if (entry.sync_state == SegmentSyncState::NEW_PENDING) {
+                            entry.sync_state = SegmentSyncState::ALIGNED;
+                        }
+                    }
+                }
+            }
             if (ping_response.client_status == ClientStatus::NEED_REMOUNT &&
                 !remount_segment_future.valid()) {
+                {
+                    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+                    if (segments_aligned_with_master_) {
+                        for (auto& [segment_id, entry] : mounted_segments_) {
+                            if (entry.sync_state == SegmentSyncState::ALIGNED) {
+                                entry.sync_state =
+                                    SegmentSyncState::REMOUNT_PENDING;
+                            }
+                        }
+                        segments_aligned_with_master_ = false;
+                    }
+                }
                 // Ensure at most one remount segment thread is running
                 remount_segment_future =
                     std::async(std::launch::async, remount_segment);
@@ -5116,8 +5185,8 @@ tl::expected<Replica::Descriptor, ErrorCode> Client::GetPreferredReplica(
     std::unordered_set<std::string> local_endpoints;
     {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-        for (const auto& [segment_id, segment] : mounted_segments_) {
-            local_endpoints.insert(segment.te_endpoint);
+        for (const auto& [segment_id, entry] : mounted_segments_) {
+            local_endpoints.insert(entry.segment.te_endpoint);
         }
     }
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -450,6 +450,7 @@ Client::~Client() {
     }
 
     storage_heartbeat_running_ = false;
+    storage_control_cv_.notify_all();
     if (storage_heartbeat_thread_.joinable()) {
         storage_heartbeat_thread_.join();
     }
@@ -693,18 +694,6 @@ ErrorCode Client::ConnectToMaster(const std::string& master_server_entry) {
 ErrorCode Client::SwitchLeader(const ha::MasterView& target_view) {
     std::lock_guard<std::mutex> lock(leader_switch_mutex_);
 
-    const bool leader_changed =
-        current_master_view_.has_value() &&
-        (target_view.view_version != current_master_view_->view_version ||
-         target_view.leader_address != current_master_view_->leader_address);
-    std::unique_lock<std::mutex> segment_lock(mounted_segments_mutex_,
-                                              std::defer_lock);
-    if (leader_changed) {
-        // Establish a barrier between mounts accepted by the old and new
-        // leaders. New mounts cannot be classified until the switch finishes.
-        segment_lock.lock();
-    }
-
     if (current_master_view_.has_value()) {
         const auto& current_view = current_master_view_.value();
         if (target_view.view_version < current_view.view_version) {
@@ -726,17 +715,6 @@ ErrorCode Client::SwitchLeader(const ha::MasterView& target_view) {
 
     current_master_view_ = target_view;
     last_ping_success_.store(true);
-    if (leader_changed) {
-        segments_aligned_with_master_ = false;
-        for (auto& [segment_id, entry] : mounted_segments_) {
-            if (entry.sync_state != SegmentSyncState::REMOUNT_PENDING) {
-                // NEW is relative to the leader that accepted MountSegment.
-                // Any entry that predates this switch is a remount for the new
-                // leader, regardless of whether the previous full sync ran.
-                entry.sync_state = SegmentSyncState::REMOUNT_PENDING;
-            }
-        }
-    }
     return ErrorCode::OK;
 }
 
@@ -3668,6 +3646,7 @@ tl::expected<void, ErrorCode> Client::UnmountSegmentImpl(
 
 tl::expected<void, ErrorCode> Client::UnmountSegment(const void* buffer,
                                                      size_t size) {
+    std::lock_guard<std::mutex> update_lock(segment_update_mutex_);
     std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
     auto segment = mounted_segments_.end();
 
@@ -3736,30 +3715,25 @@ tl::expected<UUID, ErrorCode> Client::MountSegmentAndGetId(
             segment.te_endpoint = local_hostname_;
         }
 
-        auto mount_result = master_client_.MountSegment(segment);
-        if (!mount_result) {
-            ErrorCode err = mount_result.error();
-            LOG(ERROR) << "mount_segment_to_master_failed base=" << buffer
-                       << " size=" << size << ", error=" << err;
-            return tl::unexpected(err);
-        }
-
         segment_id = segment.id;
-        // Keep a successful ordinary mount as NEW_PENDING until a subsequent
-        // Ping confirms that the same master still considers the client OK, or
-        // until it participates in an explicit reconciliation request. This
-        // preserves NEW across the race between MountSegment and NEED_REMOUNT.
+        // Local registration owns the buffer immediately. Master registration
+        // is performed by the single-flight control-plane flusher, so a Master
+        // outage does not lose this segment or require the caller to recreate
+        // it.
         mounted_segments_[segment_id] = {segment,
                                          SegmentSyncState::NEW_PENDING};
     }
 
     EnsureStorageControlPlaneStarted();
+    segment_flush_requested_.store(true);
+    storage_control_cv_.notify_one();
     return segment_id;
 }
 
 tl::expected<void, ErrorCode> Client::UnmountSegmentById(
     const UUID& segment_id, uint64_t grace_period_ms,
     std::function<void(const UUID&)> cleanup_callback) {
+    std::lock_guard<std::mutex> update_lock(segment_update_mutex_);
     std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
     auto segment = mounted_segments_.find(segment_id);
     if (segment == mounted_segments_.end()) {
@@ -4926,55 +4900,40 @@ void Client::ExecuteTask(const ClientTask& client_task) {
 }
 
 void Client::StorageHeartbeatThreadMain() {
-    // How many failed pings before reconnecting via the HA coordinator
     const int max_ping_fail_count = 3;
-    // How long to wait for next ping after success
     const int success_ping_interval_ms = 1000;
-    // How long to wait for next ping after failure
     const int fail_ping_interval_ms = 1000;
-    // Increment after a ping failure, reset after a ping success
     int ping_fail_count = 0;
 
-    auto remount_segment = [this]() {
-        // This lock must be held until the remount rpc is finished,
-        // otherwise there will be corner cases, e.g., a segment is
-        // unmounted successfully first, and then remounted again in
-        // this thread.
+    auto wait_for_next_cycle = [this](int interval_ms) {
+        std::unique_lock<std::mutex> lock(storage_control_mutex_);
+        storage_control_cv_.wait_for(
+            lock, std::chrono::milliseconds(interval_ms), [this] {
+                return !storage_heartbeat_running_.load() ||
+                       segment_flush_requested_.load();
+            });
+        segment_flush_requested_.store(false);
+    };
+
+    auto mark_need_remount = [this]() {
         std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-        std::vector<SegmentUpdate> updates;
-        updates.reserve(mounted_segments_.size());
-        for (const auto& [segment_id, entry] : mounted_segments_) {
-            switch (entry.sync_state) {
-                case SegmentSyncState::NEW_PENDING:
-                    updates.emplace_back(entry.segment,
-                                         SegmentRegistrationIntent::NEW);
-                    break;
-                case SegmentSyncState::REMOUNT_PENDING:
-                    updates.emplace_back(entry.segment,
-                                         SegmentRegistrationIntent::REMOUNT);
-                    break;
-                case SegmentSyncState::ALIGNED:
-                    break;
+        for (auto& [segment_id, entry] : mounted_segments_) {
+            if (entry.sync_state == SegmentSyncState::ACTIVE) {
+                entry.sync_state = SegmentSyncState::REMOUNT_PENDING;
             }
         }
-        auto remount_result = master_client_.ReMountSegment(updates);
-        if (!remount_result) {
-            ErrorCode err = remount_result.error();
-            LOG(ERROR) << "Failed to remount segments: " << err;
-        } else {
-            for (auto& [segment_id, entry] : mounted_segments_) {
-                entry.sync_state = SegmentSyncState::ALIGNED;
-            }
-            segments_aligned_with_master_ = true;
-        }
-        // Re-publish Transfer Engine segment descriptors to the HTTP
-        // metadata server.  When Master (which hosts the HTTP metadata
-        // server in the same process) is killed and restarted, all
-        // in-memory KV entries are lost.  ReMountSegment above only
-        // restores Master-side allocation state; it does NOT write back
-        // the transport-level segment descriptors.  Without this, remote
-        // peers get HTTP 404 when querying our segment descriptor and
-        // data transfers fail.
+    };
+
+    auto has_remount_pending = [this]() {
+        std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+        return std::any_of(mounted_segments_.begin(), mounted_segments_.end(),
+                           [](const auto& item) {
+                               return item.second.sync_state ==
+                                      SegmentSyncState::REMOUNT_PENDING;
+                           });
+    };
+
+    auto republish_transfer_metadata = [this]() {
         auto metadata = transfer_engine_->getMetadata();
         if (metadata) {
             int rc = metadata->updateLocalSegmentDesc();
@@ -5000,62 +4959,138 @@ void Client::StorageHeartbeatThreadMain() {
                 rpc_meta_publish_pending_.store(false);
             }
         }
-        // Note: LOCAL_DISK segment remount is NOT done here.
-        // It is handled by FileStorage::Heartbeat() when it detects
-        // SEGMENT_NOT_FOUND, which also triggers ScanMeta to
-        // re-register offloaded object metadata.
     };
-    // Use another thread to remount segments to avoid blocking the ping
-    // thread
-    std::future<void> remount_segment_future;
 
-    while (storage_heartbeat_running_.load()) {
-        // Join the remount segment thread if it is ready
-        if (remount_segment_future.valid() &&
-            remount_segment_future.wait_for(std::chrono::seconds(0)) ==
-                std::future_status::ready) {
-            remount_segment_future = std::future<void>();
-        }
-
-        // Ping master
-        auto ping_result = master_client_.Ping();
-        if (ping_result) {
-            // Reset ping failure count
-            ping_fail_count = 0;
-            last_ping_success_.store(true);
-            auto& ping_response = ping_result.value();
-            if (ping_response.client_status == ClientStatus::OK) {
-                std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-                if (segments_aligned_with_master_) {
-                    for (auto& [segment_id, entry] : mounted_segments_) {
-                        if (entry.sync_state == SegmentSyncState::NEW_PENDING) {
-                            entry.sync_state = SegmentSyncState::ALIGNED;
-                        }
-                    }
+    auto flush_new_segments = [this]() -> std::optional<ClientStatus> {
+        std::lock_guard<std::mutex> update_lock(segment_update_mutex_);
+        UpdateSegmentsRequest request;
+        request.client_id = client_id_;
+        request.request_intent = SegmentUpdateRequestIntent::REGISTER;
+        {
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            request.segments.reserve(mounted_segments_.size());
+            for (const auto& [segment_id, entry] : mounted_segments_) {
+                if (entry.sync_state == SegmentSyncState::NEW_PENDING) {
+                    request.segments.emplace_back(
+                        entry.segment, SegmentRegistrationIntent::NEW);
                 }
             }
-            if (ping_response.client_status == ClientStatus::NEED_REMOUNT &&
-                !remount_segment_future.valid()) {
-                {
-                    std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
-                    if (segments_aligned_with_master_) {
-                        for (auto& [segment_id, entry] : mounted_segments_) {
-                            if (entry.sync_state == SegmentSyncState::ALIGNED) {
-                                entry.sync_state =
-                                    SegmentSyncState::REMOUNT_PENDING;
-                            }
-                        }
-                        segments_aligned_with_master_ = false;
-                    }
+        }
+        if (request.segments.empty()) {
+            return std::nullopt;
+        }
+
+        auto result = master_client_.UpdateSegments(request);
+        if (!result) {
+            LOG(ERROR) << "Failed to register new segments: " << result.error();
+            return std::nullopt;
+        }
+
+        if (result->client_status == ClientStatus::OK) {
+            std::unordered_map<UUID, ErrorCode, boost::hash<UUID>> results;
+            results.reserve(result->results.size());
+            for (const auto& update_result : result->results) {
+                results[update_result.segment_id] = update_result.error_code;
+                if (update_result.error_code != ErrorCode::OK) {
+                    LOG(ERROR) << "Failed to register segment "
+                               << UuidToString(update_result.segment_id) << ": "
+                               << update_result.error_code;
                 }
-                // Ensure at most one remount segment thread is running
-                remount_segment_future =
-                    std::async(std::launch::async, remount_segment);
-            } else if (segment_desc_publish_pending_.load() &&
-                       !remount_segment_future.valid()) {
-                // Previous remount succeeded but updateLocalSegmentDesc()
-                // failed (e.g. transient HTTP error).  Retry it directly
-                // without re-running ReMountSegment.
+            }
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            for (const auto& update : request.segments) {
+                auto entry = mounted_segments_.find(update.segment.id);
+                auto update_result = results.find(update.segment.id);
+                if (entry != mounted_segments_.end() &&
+                    entry->second.sync_state == SegmentSyncState::NEW_PENDING &&
+                    update_result != results.end() &&
+                    update_result->second == ErrorCode::OK) {
+                    entry->second.sync_state = SegmentSyncState::ACTIVE;
+                }
+            }
+        }
+        return result->client_status;
+    };
+
+    auto reconcile_segments = [this, &republish_transfer_metadata]() {
+        std::lock_guard<std::mutex> update_lock(segment_update_mutex_);
+        UpdateSegmentsRequest request;
+        request.client_id = client_id_;
+        request.request_intent = SegmentUpdateRequestIntent::RECONCILE;
+        {
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            request.segments.reserve(mounted_segments_.size());
+            for (const auto& [segment_id, entry] : mounted_segments_) {
+                if (entry.sync_state == SegmentSyncState::NEW_PENDING) {
+                    request.segments.emplace_back(
+                        entry.segment, SegmentRegistrationIntent::NEW);
+                } else if (entry.sync_state ==
+                           SegmentSyncState::REMOUNT_PENDING) {
+                    request.segments.emplace_back(
+                        entry.segment, SegmentRegistrationIntent::REMOUNT);
+                }
+            }
+        }
+
+        auto result = master_client_.UpdateSegments(request);
+        if (!result) {
+            LOG(ERROR) << "Failed to reconcile segments: " << result.error();
+            return false;
+        }
+        const bool all_succeeded =
+            result->client_status == ClientStatus::OK &&
+            result->results.size() == request.segments.size() &&
+            std::all_of(result->results.begin(), result->results.end(),
+                        [](const auto& update_result) {
+                            return update_result.error_code == ErrorCode::OK;
+                        });
+        if (!all_succeeded) {
+            LOG(ERROR) << "Master did not confirm the complete segment "
+                          "snapshot";
+            return false;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mounted_segments_mutex_);
+            for (const auto& update : request.segments) {
+                auto entry = mounted_segments_.find(update.segment.id);
+                if (entry == mounted_segments_.end()) {
+                    continue;
+                }
+                const auto expected_state =
+                    update.intent == SegmentRegistrationIntent::NEW
+                        ? SegmentSyncState::NEW_PENDING
+                        : SegmentSyncState::REMOUNT_PENDING;
+                if (entry->second.sync_state == expected_state) {
+                    entry->second.sync_state = SegmentSyncState::ACTIVE;
+                }
+            }
+        }
+        republish_transfer_metadata();
+        return true;
+    };
+
+    while (storage_heartbeat_running_.load()) {
+        bool need_reconcile = has_remount_pending();
+        if (!need_reconcile) {
+            auto register_status = flush_new_segments();
+            if (register_status == ClientStatus::NEED_REMOUNT) {
+                mark_need_remount();
+                need_reconcile = true;
+            }
+        }
+
+        auto ping_result = master_client_.Ping();
+        if (ping_result) {
+            ping_fail_count = 0;
+            last_ping_success_.store(true);
+            if (ping_result->client_status == ClientStatus::NEED_REMOUNT) {
+                mark_need_remount();
+                need_reconcile = true;
+            }
+            if (need_reconcile) {
+                (void)reconcile_segments();
+            } else if (segment_desc_publish_pending_.load()) {
                 auto metadata = transfer_engine_->getMetadata();
                 if (metadata) {
                     int rc = metadata->updateLocalSegmentDesc();
@@ -5069,10 +5104,7 @@ void Client::StorageHeartbeatThreadMain() {
                         segment_desc_publish_pending_.store(false);
                     }
                 }
-            } else if (rpc_meta_publish_pending_.load() &&
-                       !remount_segment_future.valid()) {
-                // Previous remount succeeded but rePublishRpcMetaEntry()
-                // failed.  Retry it directly.
+            } else if (rpc_meta_publish_pending_.load()) {
                 auto metadata = transfer_engine_->getMetadata();
                 if (metadata) {
                     int rc = metadata->rePublishRpcMetaEntry(local_hostname_);
@@ -5088,8 +5120,7 @@ void Client::StorageHeartbeatThreadMain() {
                 }
             }
 
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(success_ping_interval_ms));
+            wait_for_next_cycle(success_ping_interval_ms);
             continue;
         }
 
@@ -5097,8 +5128,7 @@ void Client::StorageHeartbeatThreadMain() {
         last_ping_success_.store(false);
         if (ping_fail_count < max_ping_fail_count) {
             LOG(ERROR) << "Failed to ping master";
-            std::this_thread::sleep_for(
-                std::chrono::milliseconds(fail_ping_interval_ms));
+            wait_for_next_cycle(fail_ping_interval_ms);
             continue;
         }
 
@@ -5111,14 +5141,12 @@ void Client::StorageHeartbeatThreadMain() {
             if (!current_view) {
                 LOG(ERROR) << "Failed to get new master view: "
                            << toString(current_view.error());
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(fail_ping_interval_ms));
+                wait_for_next_cycle(fail_ping_interval_ms);
                 continue;
             }
             if (!current_view.value().has_value()) {
                 LOG(WARNING) << "No active master view is published yet";
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(fail_ping_interval_ms));
+                wait_for_next_cycle(fail_ping_interval_ms);
                 continue;
             }
 
@@ -5127,8 +5155,7 @@ void Client::StorageHeartbeatThreadMain() {
             if (err != ErrorCode::OK) {
                 LOG(ERROR) << "Failed to connect to master "
                            << next_view.leader_address << ": " << toString(err);
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(fail_ping_interval_ms));
+                wait_for_next_cycle(fail_ping_interval_ms);
                 continue;
             }
 
@@ -5143,18 +5170,13 @@ void Client::StorageHeartbeatThreadMain() {
             if (err != ErrorCode::OK) {
                 LOG(ERROR) << "Reconnect failed to " << current_master_address
                            << ": " << toString(err);
-                std::this_thread::sleep_for(
-                    std::chrono::milliseconds(fail_ping_interval_ms));
+                wait_for_next_cycle(fail_ping_interval_ms);
                 continue;
             }
             LOG(INFO) << "Reconnected to master " << current_master_address;
             last_ping_success_.store(true);
             ping_fail_count = 0;
         }
-    }
-    // Explicitly wait for the remount segment thread to finish
-    if (remount_segment_future.valid()) {
-        remount_segment_future.wait();
     }
 }
 

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -143,18 +143,13 @@ struct RpcNameTraits<&WrappedMasterService::BatchRemove> {
 };
 
 template <>
-struct RpcNameTraits<&WrappedMasterService::MountSegment> {
-    static constexpr const char* value = "MountSegment";
+struct RpcNameTraits<&WrappedMasterService::UpdateSegments> {
+    static constexpr const char* value = "UpdateSegments";
 };
 
 template <>
 struct RpcNameTraits<&WrappedMasterService::MountNoFSegment> {
     static constexpr const char* value = "MountNoFSegment";
-};
-
-template <>
-struct RpcNameTraits<&WrappedMasterService::ReMountSegment> {
-    static constexpr const char* value = "ReMountSegment";
 };
 
 template <>
@@ -797,17 +792,38 @@ std::vector<tl::expected<void, ErrorCode>> MasterClient::BatchRemove(
     return result;
 }
 
-tl::expected<void, ErrorCode> MasterClient::MountSegment(
-    const Segment& segment) {
-    ScopedVLogTimer timer(1, "MasterClient::MountSegment");
-    timer.LogRequest("base=", segment.base, ", size=", segment.size,
-                     ", name=", segment.name, ", id=", segment.id,
-                     ", client_id=", client_id_);
+tl::expected<UpdateSegmentsResponse, ErrorCode> MasterClient::UpdateSegments(
+    const UpdateSegmentsRequest& request) {
+    ScopedVLogTimer timer(1, "MasterClient::UpdateSegments");
+    timer.LogRequest(
+        "segments_num=", request.segments.size(),
+        ", request_intent=", static_cast<int>(request.request_intent),
+        ", client_id=", client_id_);
 
-    auto result = invoke_rpc<&WrappedMasterService::MountSegment, void>(
-        segment, client_id_);
+    auto wire_request = request;
+    wire_request.client_id = client_id_;
+    auto result = invoke_rpc<&WrappedMasterService::UpdateSegments,
+                             UpdateSegmentsResponse>(wire_request);
     timer.LogResponseExpected(result);
     return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::MountSegment(
+    const Segment& segment) {
+    UpdateSegmentsRequest request;
+    request.request_intent = SegmentUpdateRequestIntent::REGISTER;
+    request.segments.emplace_back(segment, SegmentRegistrationIntent::NEW);
+    auto result = UpdateSegments(request);
+    if (!result) {
+        return tl::unexpected(result.error());
+    }
+    if (result->results.size() != 1) {
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (result->results.front().error_code != ErrorCode::OK) {
+        return tl::unexpected(result->results.front().error_code);
+    }
+    return {};
 }
 
 tl::expected<void, ErrorCode> MasterClient::MountNoFSegment(
@@ -825,14 +841,23 @@ tl::expected<void, ErrorCode> MasterClient::MountNoFSegment(
 
 tl::expected<void, ErrorCode> MasterClient::ReMountSegment(
     const std::vector<SegmentUpdate>& updates) {
-    ScopedVLogTimer timer(1, "MasterClient::ReMountSegment");
-    timer.LogRequest("segments_num=", updates.size(),
-                     ", client_id=", client_id_);
-
-    auto result = invoke_rpc<&WrappedMasterService::ReMountSegment, void>(
-        updates, client_id_);
-    timer.LogResponseExpected(result);
-    return result;
+    UpdateSegmentsRequest request;
+    request.request_intent = SegmentUpdateRequestIntent::RECONCILE;
+    request.segments = updates;
+    auto result = UpdateSegments(request);
+    if (!result) {
+        return tl::unexpected(result.error());
+    }
+    if (result->client_status != ClientStatus::OK ||
+        result->results.size() != updates.size()) {
+        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    for (const auto& update_result : result->results) {
+        if (update_result.error_code != ErrorCode::OK) {
+            return tl::unexpected(update_result.error_code);
+        }
+    }
+    return {};
 }
 
 tl::expected<void, ErrorCode> MasterClient::ReMountSegment(

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -808,24 +808,6 @@ tl::expected<UpdateSegmentsResponse, ErrorCode> MasterClient::UpdateSegments(
     return result;
 }
 
-tl::expected<void, ErrorCode> MasterClient::MountSegment(
-    const Segment& segment) {
-    UpdateSegmentsRequest request;
-    request.request_intent = SegmentUpdateRequestIntent::REGISTER;
-    request.segments.emplace_back(segment, SegmentRegistrationIntent::NEW);
-    auto result = UpdateSegments(request);
-    if (!result) {
-        return tl::unexpected(result.error());
-    }
-    if (result->results.size() != 1) {
-        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-    if (result->results.front().error_code != ErrorCode::OK) {
-        return tl::unexpected(result->results.front().error_code);
-    }
-    return {};
-}
-
 tl::expected<void, ErrorCode> MasterClient::MountNoFSegment(
     const NoFSegment& segment) {
     ScopedVLogTimer timer(1, "MasterClient::MountNofSegment");
@@ -837,37 +819,6 @@ tl::expected<void, ErrorCode> MasterClient::MountNoFSegment(
         segment, client_id_);
     timer.LogResponseExpected(result);
     return result;
-}
-
-tl::expected<void, ErrorCode> MasterClient::ReMountSegment(
-    const std::vector<SegmentUpdate>& updates) {
-    UpdateSegmentsRequest request;
-    request.request_intent = SegmentUpdateRequestIntent::RECONCILE;
-    request.segments = updates;
-    auto result = UpdateSegments(request);
-    if (!result) {
-        return tl::unexpected(result.error());
-    }
-    if (result->client_status != ClientStatus::OK ||
-        result->results.size() != updates.size()) {
-        return tl::unexpected(ErrorCode::INTERNAL_ERROR);
-    }
-    for (const auto& update_result : result->results) {
-        if (update_result.error_code != ErrorCode::OK) {
-            return tl::unexpected(update_result.error_code);
-        }
-    }
-    return {};
-}
-
-tl::expected<void, ErrorCode> MasterClient::ReMountSegment(
-    const std::vector<Segment>& segments) {
-    std::vector<SegmentUpdate> updates;
-    updates.reserve(segments.size());
-    for (const auto& segment : segments) {
-        updates.emplace_back(segment, SegmentRegistrationIntent::REMOUNT);
-    }
-    return ReMountSegment(updates);
 }
 
 tl::expected<void, ErrorCode> MasterClient::ReMountNoFSegment(

--- a/mooncake-store/src/master_client.cpp
+++ b/mooncake-store/src/master_client.cpp
@@ -824,15 +824,25 @@ tl::expected<void, ErrorCode> MasterClient::MountNoFSegment(
 }
 
 tl::expected<void, ErrorCode> MasterClient::ReMountSegment(
-    const std::vector<Segment>& segments) {
+    const std::vector<SegmentUpdate>& updates) {
     ScopedVLogTimer timer(1, "MasterClient::ReMountSegment");
-    timer.LogRequest("segments_num=", segments.size(),
+    timer.LogRequest("segments_num=", updates.size(),
                      ", client_id=", client_id_);
 
     auto result = invoke_rpc<&WrappedMasterService::ReMountSegment, void>(
-        segments, client_id_);
+        updates, client_id_);
     timer.LogResponseExpected(result);
     return result;
+}
+
+tl::expected<void, ErrorCode> MasterClient::ReMountSegment(
+    const std::vector<Segment>& segments) {
+    std::vector<SegmentUpdate> updates;
+    updates.reserve(segments.size());
+    for (const auto& segment : segments) {
+        updates.emplace_back(segment, SegmentRegistrationIntent::REMOUNT);
+    }
+    return ReMountSegment(updates);
 }
 
 tl::expected<void, ErrorCode> MasterClient::ReMountNoFSegment(

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -913,63 +913,116 @@ MasterService::DeleteTenantQuotaPolicy(const TenantId& tenant_id) {
     return GetTenantQuotaSnapshot(tenant_id);
 }
 
-auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
-    -> tl::expected<void, ErrorCode> {
-    ErrorCode mount_result = ErrorCode::OK;
+std::vector<SegmentUpdateResult> MasterService::MountNewSegments(
+    const std::vector<Segment>& segments, const UUID& client_id) {
+    std::vector<SegmentUpdateResult> results;
+    results.reserve(segments.size());
+    if (segments.empty()) {
+        return results;
+    }
+
+    bool mounted_new_segment = false;
     {
         std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
         ScopedSegmentAccess segment_access =
             segment_manager_.getSegmentAccess();
 
-        // Tell the client monitor thread to start timing for this client. To
-        // avoid the following undesired situations, this message must be sent
-        // after locking the segment mutex and before the mounting operation
-        // completes:
-        // 1. Sending the message before the lock: the client expires and
-        // unmouting invokes before this mounting are completed, which prevents
-        // this segment being able to be unmounted forever;
-        // 2. Sending the message after mounting the segment: After mounting
-        // this segment, when trying to push id to the queue, the queue is
-        // already full. However, at this point, the message must be sent,
-        // otherwise this client cannot be monitored and expired.
-        {
-            PodUUID pod_client_id;
-            pod_client_id.first = client_id.first;
-            pod_client_id.second = client_id.second;
-            if (!client_ping_queue_.push(pod_client_id)) {
-                LOG(ERROR) << "segment_name=" << segment.name
-                           << ", error=client_ping_queue_full";
-                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+        PodUUID pod_client_id{client_id.first, client_id.second};
+        if (!client_ping_queue_.push(pod_client_id)) {
+            LOG(ERROR) << "client_id=" << client_id
+                       << ", error=client_ping_queue_full";
+            for (const auto& segment : segments) {
+                results.push_back({segment.id, ErrorCode::INTERNAL_ERROR});
             }
+            return results;
         }
 
-        LOG(INFO) << "client_id=" << client_id
-                  << ", action=mount_segment, segment_name=" << segment.name;
-
-        auto err = segment_access.MountSegment(segment, client_id);
-        if (err == ErrorCode::SEGMENT_ALREADY_EXISTS) {
-            // Return OK because this is an idempotent operation
-            mount_result = err;
-        } else if (err != ErrorCode::OK) {
-            return tl::make_unexpected(err);
+        for (const auto& segment : segments) {
+            LOG(INFO) << "client_id=" << client_id
+                      << ", action=mount_segment, segment_name="
+                      << segment.name;
+            auto error = segment_access.MountSegment(segment, client_id);
+            if (error == ErrorCode::SEGMENT_ALREADY_EXISTS) {
+                error = ErrorCode::OK;
+            } else if (error == ErrorCode::OK) {
+                mounted_new_segment = true;
+            }
+            results.push_back({segment.id, error});
         }
     }
 
-    if (enable_oplog_ && ordered_oplog_writer_) {
-        SegmentMountOp op;
-        op.segment_name = segment.name;
-        op.transport_endpoint = segment.te_endpoint;
-        op.capacity = segment.size;
-        op.is_memory_segment = true;
-        op.file_path.clear();
-        auto bytes = struct_pack::serialize(op);
-        PersistSegmentOpForHAOrEnqueue("MountSegment", OpType::SEGMENT_MOUNT,
-                                       segment.te_endpoint,
-                                       std::string(bytes.begin(), bytes.end()));
+    for (size_t i = 0; i < segments.size(); ++i) {
+        if (results[i].error_code != ErrorCode::OK) {
+            continue;
+        }
+        const auto& segment = segments[i];
+        if (enable_oplog_ && ordered_oplog_writer_) {
+            SegmentMountOp op;
+            op.segment_name = segment.name;
+            op.transport_endpoint = segment.te_endpoint;
+            op.capacity = segment.size;
+            op.is_memory_segment = true;
+            op.file_path.clear();
+            auto bytes = struct_pack::serialize(op);
+            PersistSegmentOpForHAOrEnqueue(
+                "MountSegment", OpType::SEGMENT_MOUNT, segment.te_endpoint,
+                std::string(bytes.begin(), bytes.end()));
+        }
+        UpdateClientHostId(client_id, segment.host_id);
     }
-    UpdateClientHostId(client_id, segment.host_id);
-    if (mount_result == ErrorCode::OK) {
+    if (mounted_new_segment) {
         RecomputeTenantEffectiveQuotas();
+    }
+    return results;
+}
+
+auto MasterService::UpdateSegments(const UpdateSegmentsRequest& request)
+    -> tl::expected<UpdateSegmentsResponse, ErrorCode> {
+    UpdateSegmentsResponse response;
+    if (request.request_intent == SegmentUpdateRequestIntent::REGISTER) {
+        std::vector<Segment> segments;
+        segments.reserve(request.segments.size());
+        for (const auto& update : request.segments) {
+            if (update.intent != SegmentRegistrationIntent::NEW) {
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            segments.push_back(update.segment);
+        }
+
+        response.results = MountNewSegments(segments, request.client_id);
+        {
+            std::shared_lock<std::shared_mutex> lock(client_mutex_);
+            response.client_status = ok_client_.contains(request.client_id)
+                                         ? ClientStatus::OK
+                                         : ClientStatus::NEED_REMOUNT;
+        }
+        return response;
+    }
+
+    if (request.request_intent != SegmentUpdateRequestIntent::RECONCILE) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    auto reconcile_result = ReMountSegment(request.segments, request.client_id);
+    if (!reconcile_result) {
+        return tl::make_unexpected(reconcile_result.error());
+    }
+    response.client_status = ClientStatus::OK;
+    response.results.reserve(request.segments.size());
+    for (const auto& update : request.segments) {
+        response.results.push_back({update.segment.id, ErrorCode::OK});
+    }
+    return response;
+}
+
+auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    auto results = MountNewSegments({segment}, client_id);
+    if (results.size() != 1) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    if (results.front().error_code != ErrorCode::OK) {
+        return tl::make_unexpected(results.front().error_code);
     }
     return {};
 }
@@ -1038,14 +1091,26 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
                                    const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     std::vector<Segment> segments;
+    std::vector<Segment> new_segments;
+    std::vector<Segment> remount_segments;
     segments.reserve(updates.size());
+    new_segments.reserve(updates.size());
+    remount_segments.reserve(updates.size());
     for (const auto& update : updates) {
         segments.push_back(update.segment);
+        if (update.intent == SegmentRegistrationIntent::NEW) {
+            new_segments.push_back(update.segment);
+        } else if (update.intent == SegmentRegistrationIntent::REMOUNT) {
+            remount_segments.push_back(update.segment);
+        }
     }
 
     {
         std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
         std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+        if (ok_client_.erase(client_id) != 0) {
+            MasterMetricManager::instance().dec_active_clients();
+        }
         for (const auto& segment : segments) {
             if (!segment.host_id.empty()) {
                 client_host_id_[client_id] = segment.host_id;
@@ -1076,13 +1141,6 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
                 }
             }
         }
-        if (ok_client_.contains(client_id)) {
-            LOG(WARNING) << "client_id=" << client_id
-                         << ", warn=client_already_remounted";
-            // Return OK because this is an idempotent operation
-            return {};
-        }
-
         struct SegmentRestore {
             Segment segment;
             std::shared_ptr<BufferAllocatorBase> old_allocator;
@@ -1153,39 +1211,48 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
 
-            for (const auto& update : updates) {
-                const auto& segment = update.segment;
-                if (update.intent == SegmentRegistrationIntent::NEW) {
-                    remount_error =
-                        segment_access.MountSegment(segment, client_id);
-                    if (remount_error == ErrorCode::SEGMENT_ALREADY_EXISTS) {
-                        remount_error = ErrorCode::OK;
-                    }
-                } else {
-                    remount_error = segment_access.ReMountSegment(
-                        std::vector<Segment>{segment}, client_id);
+            for (const auto& segment : new_segments) {
+                remount_error = segment_access.MountSegment(segment, client_id);
+                if (remount_error == ErrorCode::SEGMENT_ALREADY_EXISTS) {
+                    remount_error = ErrorCode::OK;
                 }
                 if (remount_error != ErrorCode::OK) {
                     break;
                 }
+            }
+            if (remount_error == ErrorCode::OK) {
+                remount_error =
+                    segment_access.ReMountSegment(remount_segments, client_id);
+            }
 
-                auto allocator = segment_access.GetAllocator(segment.id);
-                Segment authoritative;
-                if (!allocator ||
-                    !segment_access.GetSegment(segment.id, authoritative)) {
-                    remount_error = ErrorCode::INTERNAL_ERROR;
-                    break;
+            if (remount_error == ErrorCode::OK) {
+                for (const auto& segment : segments) {
+                    auto allocator = segment_access.GetAllocator(segment.id);
+                    Segment authoritative;
+                    if (!allocator ||
+                        !segment_access.GetSegment(segment.id, authoritative)) {
+                        remount_error = ErrorCode::INTERNAL_ERROR;
+                        break;
+                    }
                 }
-                if (update.intent != SegmentRegistrationIntent::REMOUNT) {
-                    continue;
+            }
+            if (remount_error == ErrorCode::OK) {
+                for (const auto& segment : remount_segments) {
+                    auto allocator = segment_access.GetAllocator(segment.id);
+                    Segment authoritative;
+                    if (!allocator ||
+                        !segment_access.GetSegment(segment.id, authoritative)) {
+                        remount_error = ErrorCode::INTERNAL_ERROR;
+                        break;
+                    }
+                    restores.push_back({std::move(authoritative),
+                                        std::move(allocator),
+                                        nullptr,
+                                        {},
+                                        {},
+                                        {},
+                                        0});
                 }
-                restores.push_back({std::move(authoritative),
-                                    std::move(allocator),
-                                    nullptr,
-                                    {},
-                                    {},
-                                    {},
-                                    0});
             }
         }
         if (remount_error != ErrorCode::OK) {
@@ -1353,7 +1420,7 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
                 std::chrono::milliseconds(default_kv_lease_ttl_));
         }
 
-        // Change the client status to OK
+        // Only a complete reconcile confirms the client snapshot.
         ok_client_.insert(client_id);
         MasterMetricManager::instance().inc_active_clients();
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -913,8 +913,9 @@ MasterService::DeleteTenantQuotaPolicy(const TenantId& tenant_id) {
     return GetTenantQuotaSnapshot(tenant_id);
 }
 
-std::vector<SegmentUpdateResult> MasterService::MountNewSegments(
-    const std::vector<Segment>& segments, const UUID& client_id) {
+tl::expected<std::vector<SegmentUpdateResult>, ErrorCode>
+MasterService::MountNewSegments(const std::vector<Segment>& segments,
+                                const UUID& client_id) {
     std::vector<SegmentUpdateResult> results;
     results.reserve(segments.size());
     if (segments.empty()) {
@@ -931,10 +932,7 @@ std::vector<SegmentUpdateResult> MasterService::MountNewSegments(
         if (!client_ping_queue_.push(pod_client_id)) {
             LOG(ERROR) << "client_id=" << client_id
                        << ", error=client_ping_queue_full";
-            for (const auto& segment : segments) {
-                results.push_back({segment.id, ErrorCode::INTERNAL_ERROR});
-            }
-            return results;
+            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
 
         for (const auto& segment : segments) {
@@ -989,7 +987,11 @@ auto MasterService::UpdateSegments(const UpdateSegmentsRequest& request)
             segments.push_back(update.segment);
         }
 
-        response.results = MountNewSegments(segments, request.client_id);
+        auto mount_result = MountNewSegments(segments, request.client_id);
+        if (!mount_result) {
+            return tl::make_unexpected(mount_result.error());
+        }
+        response.results = std::move(mount_result.value());
         {
             std::shared_lock<std::shared_mutex> lock(client_mutex_);
             response.client_status = ok_client_.contains(request.client_id)
@@ -1018,11 +1020,14 @@ auto MasterService::UpdateSegments(const UpdateSegmentsRequest& request)
 auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
     auto results = MountNewSegments({segment}, client_id);
-    if (results.size() != 1) {
+    if (!results) {
+        return tl::make_unexpected(results.error());
+    }
+    if (results->size() != 1) {
         return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
     }
-    if (results.front().error_code != ErrorCode::OK) {
-        return tl::make_unexpected(results.front().error_code);
+    if (results->front().error_code != ErrorCode::OK) {
+        return tl::make_unexpected(results->front().error_code);
     }
     return {};
 }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1026,6 +1026,23 @@ ErrorCode MasterService::ValidateStandbyRemountSegment(
 auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                                    const UUID& client_id)
     -> tl::expected<void, ErrorCode> {
+    std::vector<SegmentUpdate> updates;
+    updates.reserve(segments.size());
+    for (const auto& segment : segments) {
+        updates.emplace_back(segment, SegmentRegistrationIntent::REMOUNT);
+    }
+    return ReMountSegment(updates, client_id);
+}
+
+auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
+                                   const UUID& client_id)
+    -> tl::expected<void, ErrorCode> {
+    std::vector<Segment> segments;
+    segments.reserve(updates.size());
+    for (const auto& update : updates) {
+        segments.push_back(update.segment);
+    }
+
     {
         std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
         std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
@@ -1037,14 +1054,23 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
         }
         {
             auto segment_access = segment_manager_.getSegmentAccess();
-            for (const auto& segment : segments) {
-                auto standby_validation =
-                    ValidateStandbyRemountSegment(segment);
-                if (standby_validation != ErrorCode::OK) {
-                    return tl::make_unexpected(standby_validation);
+            for (const auto& update : updates) {
+                switch (update.intent) {
+                    case SegmentRegistrationIntent::NEW:
+                        break;
+                    case SegmentRegistrationIntent::REMOUNT: {
+                        auto standby_validation =
+                            ValidateStandbyRemountSegment(update.segment);
+                        if (standby_validation != ErrorCode::OK) {
+                            return tl::make_unexpected(standby_validation);
+                        }
+                        break;
+                    }
+                    default:
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                 }
-                auto validation =
-                    segment_access.ValidateRemountSegment(segment, client_id);
+                auto validation = segment_access.ValidateRemountSegment(
+                    update.segment, client_id);
                 if (validation != ErrorCode::OK) {
                     return tl::make_unexpected(validation);
                 }
@@ -1067,7 +1093,7 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
             uint64_t imported_size{0};
         };
         std::vector<SegmentRestore> restores;
-        restores.reserve(segments.size());
+        restores.reserve(updates.size());
         std::vector<bool> segment_existed(segments.size());
         auto rollback_new_segments = [&] {
             ScopedSegmentAccess segment_access =
@@ -1127,24 +1153,39 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
 
-            remount_error = segment_access.ReMountSegment(segments, client_id);
-            if (remount_error == ErrorCode::OK) {
-                for (const auto& segment : segments) {
-                    auto allocator = segment_access.GetAllocator(segment.id);
-                    Segment authoritative;
-                    if (!allocator ||
-                        !segment_access.GetSegment(segment.id, authoritative)) {
-                        remount_error = ErrorCode::INTERNAL_ERROR;
-                        break;
+            for (const auto& update : updates) {
+                const auto& segment = update.segment;
+                if (update.intent == SegmentRegistrationIntent::NEW) {
+                    remount_error =
+                        segment_access.MountSegment(segment, client_id);
+                    if (remount_error == ErrorCode::SEGMENT_ALREADY_EXISTS) {
+                        remount_error = ErrorCode::OK;
                     }
-                    restores.push_back({std::move(authoritative),
-                                        std::move(allocator),
-                                        nullptr,
-                                        {},
-                                        {},
-                                        {},
-                                        0});
+                } else {
+                    remount_error = segment_access.ReMountSegment(
+                        std::vector<Segment>{segment}, client_id);
                 }
+                if (remount_error != ErrorCode::OK) {
+                    break;
+                }
+
+                auto allocator = segment_access.GetAllocator(segment.id);
+                Segment authoritative;
+                if (!allocator ||
+                    !segment_access.GetSegment(segment.id, authoritative)) {
+                    remount_error = ErrorCode::INTERNAL_ERROR;
+                    break;
+                }
+                if (update.intent != SegmentRegistrationIntent::REMOUNT) {
+                    continue;
+                }
+                restores.push_back({std::move(authoritative),
+                                    std::move(allocator),
+                                    nullptr,
+                                    {},
+                                    {},
+                                    {},
+                                    0});
             }
         }
         if (remount_error != ErrorCode::OK) {
@@ -1155,8 +1196,9 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
         bool unsupported_cxl = false;
         std::unordered_set<ObjectMetadata*> affected_objects;
         bool any_standby_kept_alive = std::any_of(
-            segments.begin(), segments.end(), [this](const Segment& segment) {
-                return standby_accounted_memory_bytes_.contains(segment.name);
+            restores.begin(), restores.end(), [this](const auto& restore) {
+                return standby_accounted_memory_bytes_.contains(
+                    restore.segment.name);
             });
         for (size_t shard_index = 0;
              any_standby_kept_alive && shard_index < kNumShards;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1108,15 +1108,6 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
     {
         std::unique_lock<std::shared_mutex> client_lock(client_mutex_);
         std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
-        if (ok_client_.erase(client_id) != 0) {
-            MasterMetricManager::instance().dec_active_clients();
-        }
-        for (const auto& segment : segments) {
-            if (!segment.host_id.empty()) {
-                client_host_id_[client_id] = segment.host_id;
-                break;
-            }
-        }
         {
             auto segment_access = segment_manager_.getSegmentAccess();
             for (const auto& update : updates) {
@@ -1420,9 +1411,20 @@ auto MasterService::ReMountSegment(const std::vector<SegmentUpdate>& updates,
                 std::chrono::milliseconds(default_kv_lease_ttl_));
         }
 
-        // Only a complete reconcile confirms the client snapshot.
-        ok_client_.insert(client_id);
-        MasterMetricManager::instance().inc_active_clients();
+        for (const auto& segment : segments) {
+            if (!segment.host_id.empty()) {
+                client_host_id_[client_id] = segment.host_id;
+                break;
+            }
+        }
+
+        // Only a complete reconcile confirms the client snapshot. Keep an
+        // already healthy client healthy if validation or reconciliation
+        // fails; client_mutex_ prevents observers from seeing an in-progress
+        // reconcile.
+        if (ok_client_.insert(client_id).second) {
+            MasterMetricManager::instance().inc_active_clients();
+        }
     }
 
     if (enable_oplog_ && ordered_oplog_writer_) {

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -931,18 +931,33 @@ std::vector<tl::expected<void, ErrorCode>> WrappedMasterService::BatchRemove(
     return results;
 }
 
-tl::expected<void, ErrorCode> WrappedMasterService::MountSegment(
-    const Segment& segment, const UUID& client_id) {
+tl::expected<UpdateSegmentsResponse, ErrorCode>
+WrappedMasterService::UpdateSegments(const UpdateSegmentsRequest& request) {
     return execute_rpc(
-        "MountSegment",
-        [&] { return master_service_.MountSegment(segment, client_id); },
+        "UpdateSegments",
+        [&] { return master_service_.UpdateSegments(request); },
         [&](auto& timer) {
-            timer.LogRequest("base=", segment.base, ", size=", segment.size,
-                             ", segment_name=", segment.name,
-                             ", id=", segment.id);
+            timer.LogRequest(
+                "segments_count=", request.segments.size(),
+                ", request_intent=", static_cast<int>(request.request_intent),
+                ", client_id=", request.client_id);
         },
-        [] { MasterMetricManager::instance().inc_mount_segment_requests(); },
-        [] { MasterMetricManager::instance().inc_mount_segment_failures(); });
+        [&] {
+            if (request.request_intent ==
+                SegmentUpdateRequestIntent::REGISTER) {
+                MasterMetricManager::instance().inc_mount_segment_requests();
+            } else {
+                MasterMetricManager::instance().inc_remount_segment_requests();
+            }
+        },
+        [&] {
+            if (request.request_intent ==
+                SegmentUpdateRequestIntent::REGISTER) {
+                MasterMetricManager::instance().inc_mount_segment_failures();
+            } else {
+                MasterMetricManager::instance().inc_remount_segment_failures();
+            }
+        });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::MountNoFSegment(
@@ -962,19 +977,6 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountNoFSegment(
         [] {
             MasterMetricManager::instance().inc_mount_nof_segment_failures();
         });
-}
-
-tl::expected<void, ErrorCode> WrappedMasterService::ReMountSegment(
-    const std::vector<SegmentUpdate>& updates, const UUID& client_id) {
-    return execute_rpc(
-        "ReMountSegment",
-        [&] { return master_service_.ReMountSegment(updates, client_id); },
-        [&](auto& timer) {
-            timer.LogRequest("segments_count=", updates.size(),
-                             ", client_id=", client_id);
-        },
-        [] { MasterMetricManager::instance().inc_remount_segment_requests(); },
-        [] { MasterMetricManager::instance().inc_remount_segment_failures(); });
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::ReMountNoFSegment(
@@ -1794,11 +1796,9 @@ void RegisterRpcService(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::BatchRemove>(
         &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::MountSegment>(
+    server.register_handler<&mooncake::WrappedMasterService::UpdateSegments>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::MountNoFSegment>(
-        &wrapped_master_service);
-    server.register_handler<&mooncake::WrappedMasterService::ReMountSegment>(
         &wrapped_master_service);
     server.register_handler<&mooncake::WrappedMasterService::ReMountNoFSegment>(
         &wrapped_master_service);

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -965,12 +965,12 @@ tl::expected<void, ErrorCode> WrappedMasterService::MountNoFSegment(
 }
 
 tl::expected<void, ErrorCode> WrappedMasterService::ReMountSegment(
-    const std::vector<Segment>& segments, const UUID& client_id) {
+    const std::vector<SegmentUpdate>& updates, const UUID& client_id) {
     return execute_rpc(
         "ReMountSegment",
-        [&] { return master_service_.ReMountSegment(segments, client_id); },
+        [&] { return master_service_.ReMountSegment(updates, client_id); },
         [&](auto& timer) {
-            timer.LogRequest("segments_count=", segments.size(),
+            timer.LogRequest("segments_count=", updates.size(),
                              ", client_id=", client_id);
         },
         [] { MasterMetricManager::instance().inc_remount_segment_requests(); },

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -139,6 +139,7 @@ set_tests_properties(object_checksum_client_test
                      PROPERTIES ENVIRONMENT "MOONCAKE_STORE_CHECKSUM=1")
 add_store_test(rpc_timeout_test rpc_timeout_test.cpp)
 add_store_test(rpc_timeout_config_test rpc_timeout_config_test.cpp)
+add_store_test(update_segments_rpc_test update_segments_rpc_test.cpp)
 if(USE_CXL)
   add_store_test(cxl_client_integration_test cxl_client_integration_test.cpp)
 endif()

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -18,6 +18,7 @@
 #include "master_admin_service.h"
 #include "master_config.h"
 #include "rpc_service.h"
+#include "segment_update_test_utils.h"
 #include "tenant_quota_policy_store.h"
 #include "types.h"
 #include "utils.h"
@@ -538,7 +539,8 @@ TEST_F(MasterAdminServerTest, TenantQuotaAdminLifecycleEndpoints) {
     segment.base = 0x600000000;
     segment.size = 2000;
     UUID client_id = generate_uuid();
-    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(*service, segment, client_id).has_value());
 
     int port = getFreeTcpPort();
     MasterAdminServer admin(static_cast<uint16_t>(port), false);
@@ -707,7 +709,7 @@ class MasterAdminServerWithServiceTest : public ::testing::Test {
         segment_.base = 0x300000000;
         segment_.size = 8 * 1024 * 1024;
         UUID client_id = generate_uuid();
-        (void)service_->MountSegment(segment_, client_id);
+        (void)RegisterNewSegmentForTest(*service_, segment_, client_id);
 
         ReplicateConfig cfg;
         cfg.replica_num = 1;
@@ -875,7 +877,7 @@ TEST_F(MasterAdminServerWithServiceTest,
     s.name = seg;
     s.base = 0x600000000;
     s.size = 4 * 1024 * 1024;
-    (void)service_->MountSegment(s, generate_uuid());
+    (void)RegisterNewSegmentForTest(*service_, s, generate_uuid());
 
     std::string body = R"({"segments":[")" + seg + R"("]})";
     auto resp = HttpPostJson("/api/v1/drain_jobs", body);
@@ -913,7 +915,7 @@ TEST_F(MasterAdminServerWithServiceTest, QueryDrainJobReturnsCreatedJob) {
     s.name = seg;
     s.base = 0x700000000;
     s.size = 4 * 1024 * 1024;
-    (void)service_->MountSegment(s, generate_uuid());
+    (void)RegisterNewSegmentForTest(*service_, s, generate_uuid());
 
     std::string body = R"({"segments":[")" + seg + R"("]})";
     auto create_resp = HttpPostJson("/api/v1/drain_jobs", body);
@@ -960,7 +962,7 @@ TEST_F(MasterAdminServerWithServiceTest, CancelDrainJobSucceeds) {
     s.name = seg;
     s.base = 0x800000000;
     s.size = 4 * 1024 * 1024;
-    (void)service_->MountSegment(s, generate_uuid());
+    (void)RegisterNewSegmentForTest(*service_, s, generate_uuid());
 
     std::string body = R"({"segments":[")" + seg + R"("]})";
     auto create_resp = HttpPostJson("/api/v1/drain_jobs", body);
@@ -1088,7 +1090,7 @@ TEST_F(MasterAdminServerWithServiceTest, DrainJobFullLifecycle) {
     s.name = seg;
     s.base = 0x900000000;
     s.size = 4 * 1024 * 1024;
-    (void)service_->MountSegment(s, generate_uuid());
+    (void)RegisterNewSegmentForTest(*service_, s, generate_uuid());
 
     std::string body = R"({"segments":[")" + seg + R"("]})";
     auto create_resp = HttpPostJson("/api/v1/drain_jobs", body);
@@ -1190,14 +1192,16 @@ TEST_F(MasterAdminServerTest, MultipleSegmentsAndKeys) {
     seg1.name = "seg_alpha";
     seg1.base = 0x400000000;
     seg1.size = 8 * 1024 * 1024;
-    ASSERT_TRUE(service->MountSegment(seg1, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(*service, seg1, client_id).has_value());
 
     Segment seg2;
     seg2.id = generate_uuid();
     seg2.name = "seg_beta";
     seg2.base = 0x500000000;
     seg2.size = 4 * 1024 * 1024;
-    ASSERT_TRUE(service->MountSegment(seg2, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(*service, seg2, client_id).has_value());
 
     ReplicateConfig cfg;
     cfg.replica_num = 1;
@@ -1281,7 +1285,8 @@ TEST_F(MasterAdminServerTest, BatchQueryKeysReturnsLocalDiskReplicaInfo) {
     segment.name = "ld_segment";
     segment.base = 0x600000000;
     segment.size = 8 * 1024 * 1024;
-    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(*service, segment, client_id).has_value());
     ASSERT_TRUE(service->MountLocalDiskSegment(client_id, true).has_value());
 
     const std::string key = "ld_only_key";

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -15,6 +15,7 @@
 #include "master_service.h"
 #include "segment.h"
 #include "rpc_service.h"
+#include "segment_update_test_utils.h"
 #include "types.h"
 #include "master_config.h"
 #include "master_metric_manager.h"
@@ -161,8 +162,8 @@ TEST_F(MasterMetricsTest, BasicRequestTest) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    // Test MountSegment request
-    auto mount_result = service_.MountSegment(segment, client_id);
+    // Test UpdateSegments(REGISTER) request
+    auto mount_result = RegisterNewSegmentForTest(service_, segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
     ASSERT_EQ(metrics.get_allocated_mem_size(), 0);
     ASSERT_EQ(metrics.get_total_mem_capacity(), kSegmentSize);
@@ -295,7 +296,8 @@ TEST_F(MasterMetricsTest, ServiceTeardownReleasesSegmentCapacity) {
         service_config.default_kv_lease_ttl = 100;
         service_config.enable_metric_reporting = false;
         WrappedMasterService service(service_config);
-        ASSERT_TRUE(service.MountSegment(segment, client_id).has_value());
+        ASSERT_TRUE(
+            RegisterNewSegmentForTest(service, segment, client_id).has_value());
         ASSERT_EQ(metrics.get_total_mem_capacity(),
                   capacity_before + static_cast<int64_t>(segment.size));
         ASSERT_EQ(metrics.get_segment_total_mem_capacity(segment.name),
@@ -469,7 +471,7 @@ TEST_F(MasterMetricsTest, CalcCacheStatsTest) {
     const double base_valid_get_rate =
         base_stats.at(CacheHitStat::VALID_GET_RATE);
 
-    auto mount_result = service_.MountSegment(segment, client_id);
+    auto mount_result = RegisterNewSegmentForTest(service_, segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
     auto put_start_result1 =
         service_.PutStart(client_id, key, value_length, config);
@@ -616,7 +618,8 @@ TEST_F(MasterMetricsTest, AdminServerRoutesServiceEndpointsWhenAvailable) {
     segment.base = 0x300000000;
     segment.size = 8 * 1024 * 1024;
     UUID client_id = generate_uuid();
-    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(*service, segment, client_id).has_value());
     ReplicateConfig config;
     config.replica_num = 1;
     constexpr size_t kAllocationSize = 4096;
@@ -735,7 +738,7 @@ TEST_F(MasterMetricsTest, BatchRequestTest) {
     config.replica_num = 1;
 
     // Mount segment
-    auto mount_result = service_.MountSegment(segment, client_id);
+    auto mount_result = RegisterNewSegmentForTest(service_, segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
 
     // Test BatchExistKey request (should all return false initially)
@@ -1062,7 +1065,7 @@ TEST_F(MasterMetricsTest, SsdOffloadCacheHitAndTotalConsistent) {
     const int64_t base_file_cache_nums = metrics.get_file_cache_nums();
 
     // Step 1: Mount segment and create a completed MEMORY replica.
-    auto mount_result = service_.MountSegment(segment, client_id);
+    auto mount_result = RegisterNewSegmentForTest(service_, segment, client_id);
     ASSERT_TRUE(mount_result.has_value());
     auto put_start_result =
         service_.PutStart(client_id, key, value_length, config);

--- a/mooncake-store/tests/master_service_group_test.cpp
+++ b/mooncake-store/tests/master_service_group_test.cpp
@@ -1,5 +1,6 @@
 #include "master_service_test_fixture.h"
 #include "rpc_service.h"
+#include "segment_update_test_utils.h"
 
 #include <glog/logging.h>
 
@@ -100,7 +101,8 @@ TEST_F(MasterServiceTest, WrappedBatchPutStartMixedGroupIdsPreservesOrder) {
 
     Segment segment = MakeSegment("wrapped_batch_group_segment");
     const UUID client_id = generate_uuid();
-    ASSERT_TRUE(service_.MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(service_, segment, client_id).has_value());
 
     const std::vector<std::string> keys = {
         "wrapped_batch_grouped_a",

--- a/mooncake-store/tests/master_service_test.cpp
+++ b/mooncake-store/tests/master_service_test.cpp
@@ -25,6 +25,7 @@
 
 #include <unistd.h>
 
+#include "segment_update_test_utils.h"
 #include "tenant_quota_policy_store.h"
 #include "types.h"
 #include "utils.h"
@@ -2661,7 +2662,8 @@ TEST_F(MasterServiceTest, WrappedBatchExistKeyUsesTenantAwareBatchPath) {
 
     Segment segment = MakeSegment("wrapped_batch_exist_segment");
     const UUID client_id = generate_uuid();
-    ASSERT_TRUE(service_.MountSegment(segment, client_id).has_value());
+    ASSERT_TRUE(
+        RegisterNewSegmentForTest(service_, segment, client_id).has_value());
 
     ReplicateConfig config;
     config.replica_num = 1;

--- a/mooncake-store/tests/segment_update_test_utils.h
+++ b/mooncake-store/tests/segment_update_test_utils.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+
+#include "rpc_types.h"
+#include "types.h"
+
+namespace mooncake {
+
+template <typename Service>
+auto RegisterNewSegmentsForTest(Service& service,
+                                const std::vector<Segment>& segments,
+                                const UUID& client_id) {
+    UpdateSegmentsRequest request;
+    request.client_id = client_id;
+    request.request_intent = SegmentUpdateRequestIntent::REGISTER;
+    request.segments.reserve(segments.size());
+    for (const auto& segment : segments) {
+        request.segments.emplace_back(segment, SegmentRegistrationIntent::NEW);
+    }
+    return service.UpdateSegments(request);
+}
+
+template <typename Service>
+auto RegisterNewSegmentForTest(Service& service, const Segment& segment,
+                               const UUID& client_id) {
+    return RegisterNewSegmentsForTest(service, std::vector<Segment>{segment},
+                                      client_id);
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/update_segments_rpc_test.cpp
+++ b/mooncake-store/tests/update_segments_rpc_test.cpp
@@ -1,0 +1,227 @@
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "master_client.h"
+#include "rpc_types.h"
+#include "test_server_helpers.h"
+#include "types.h"
+#include "utils.h"
+
+namespace mooncake::testing {
+
+class UpdateSegmentsRpcTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("UpdateSegmentsRpcTest");
+        FLAGS_logtostderr = 1;
+
+        InProcMasterConfig config;
+        ASSERT_TRUE(master_.Start(config));
+    }
+
+    static void TearDownTestSuite() {
+        master_.Stop();
+        google::ShutdownGoogleLogging();
+    }
+
+    static Segment MakeSegment(const std::string& name,
+                               uintptr_t base = 0x300000000) {
+        Segment segment;
+        segment.id = generate_uuid();
+        segment.name = name;
+        segment.base = base;
+        segment.size = 16 * 1024 * 1024;
+        segment.protocol = "tcp";
+        segment.te_endpoint = name;
+        return segment;
+    }
+
+    static UpdateSegmentsRequest MakeRequest(
+        SegmentUpdateRequestIntent request_intent,
+        std::vector<SegmentUpdate> segments = {}) {
+        UpdateSegmentsRequest request;
+        request.request_intent = request_intent;
+        request.segments = std::move(segments);
+        return request;
+    }
+
+    static void Connect(MasterClient& client) {
+        ASSERT_EQ(client.Connect(master_.master_address()), ErrorCode::OK);
+    }
+
+    inline static InProcMaster master_;
+};
+
+TEST_F(UpdateSegmentsRpcTest, RegisterNewMountsWithoutConfirmingSnapshot) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+    const Segment segment = MakeSegment("update_register_new");
+
+    auto response = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::REGISTER,
+                    {{segment, SegmentRegistrationIntent::NEW}}));
+
+    ASSERT_TRUE(response.has_value());
+    EXPECT_EQ(response->client_status, ClientStatus::NEED_REMOUNT);
+    ASSERT_EQ(response->results.size(), 1);
+    EXPECT_EQ(response->results[0].segment_id, segment.id);
+    EXPECT_EQ(response->results[0].error_code, ErrorCode::OK);
+
+    auto status = client.QuerySegmentStatusById(segment.id);
+    ASSERT_TRUE(status.has_value());
+    EXPECT_EQ(*status, SegmentStatus::OK);
+
+    auto ping = client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::NEED_REMOUNT);
+}
+
+TEST_F(UpdateSegmentsRpcTest, RegisterRejectsRemountIntentAtomically) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+    const Segment new_segment = MakeSegment("update_illegal_register_new");
+    const Segment remount_segment =
+        MakeSegment("update_illegal_register_remount", 0x310000000);
+
+    auto response = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::REGISTER,
+                    {{new_segment, SegmentRegistrationIntent::NEW},
+                     {remount_segment, SegmentRegistrationIntent::REMOUNT}}));
+
+    ASSERT_FALSE(response.has_value());
+    EXPECT_EQ(response.error(), ErrorCode::INVALID_PARAMS);
+    EXPECT_FALSE(client.QuerySegmentStatusById(new_segment.id).has_value());
+    EXPECT_FALSE(client.QuerySegmentStatusById(remount_segment.id).has_value());
+}
+
+TEST_F(UpdateSegmentsRpcTest,
+       ReconcileDispatchesMixedSnapshotAndConfirmsClient) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+    const Segment existing = MakeSegment("update_mixed_existing");
+    const Segment new_segment = MakeSegment("update_mixed_new", 0x310000000);
+
+    auto registration = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::REGISTER,
+                    {{existing, SegmentRegistrationIntent::NEW}}));
+    ASSERT_TRUE(registration.has_value());
+    ASSERT_EQ(registration->results.size(), 1);
+    ASSERT_EQ(registration->results[0].error_code, ErrorCode::OK);
+
+    auto reconciliation = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::RECONCILE,
+                    {{existing, SegmentRegistrationIntent::REMOUNT},
+                     {new_segment, SegmentRegistrationIntent::NEW}}));
+
+    ASSERT_TRUE(reconciliation.has_value());
+    EXPECT_EQ(reconciliation->client_status, ClientStatus::OK);
+    ASSERT_EQ(reconciliation->results.size(), 2);
+    EXPECT_EQ(reconciliation->results[0].segment_id, existing.id);
+    EXPECT_EQ(reconciliation->results[0].error_code, ErrorCode::OK);
+    EXPECT_EQ(reconciliation->results[1].segment_id, new_segment.id);
+    EXPECT_EQ(reconciliation->results[1].error_code, ErrorCode::OK);
+    auto existing_status = client.QuerySegmentStatusById(existing.id);
+    ASSERT_TRUE(existing_status.has_value());
+    EXPECT_EQ(*existing_status, SegmentStatus::OK);
+    auto new_status = client.QuerySegmentStatusById(new_segment.id);
+    ASSERT_TRUE(new_status.has_value());
+    EXPECT_EQ(*new_status, SegmentStatus::OK);
+
+    auto ping = client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::OK);
+}
+
+TEST_F(UpdateSegmentsRpcTest, EmptyReconcileConfirmsEmptyClient) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+
+    auto response = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::RECONCILE));
+
+    ASSERT_TRUE(response.has_value());
+    EXPECT_EQ(response->client_status, ClientStatus::OK);
+    EXPECT_TRUE(response->results.empty());
+    auto ping = client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::OK);
+}
+
+TEST_F(UpdateSegmentsRpcTest, RegisterOnHealthyClientKeepsClientHealthy) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+    ASSERT_TRUE(
+        client
+            .UpdateSegments(MakeRequest(SegmentUpdateRequestIntent::RECONCILE))
+            .has_value());
+    const Segment segment = MakeSegment("update_healthy_incremental");
+
+    auto response = client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::REGISTER,
+                    {{segment, SegmentRegistrationIntent::NEW}}));
+
+    ASSERT_TRUE(response.has_value());
+    EXPECT_EQ(response->client_status, ClientStatus::OK);
+    ASSERT_EQ(response->results.size(), 1);
+    EXPECT_EQ(response->results[0].error_code, ErrorCode::OK);
+    auto ping = client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::OK);
+}
+
+TEST_F(UpdateSegmentsRpcTest, FailedReconcileKeepsHealthyClientHealthy) {
+    MasterClient healthy_client(generate_uuid());
+    MasterClient owner_client(generate_uuid());
+    Connect(healthy_client);
+    Connect(owner_client);
+    ASSERT_TRUE(
+        healthy_client
+            .UpdateSegments(MakeRequest(SegmentUpdateRequestIntent::RECONCILE))
+            .has_value());
+
+    const Segment foreign_segment = MakeSegment("update_foreign_owner");
+    auto registration = owner_client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::REGISTER,
+                    {{foreign_segment, SegmentRegistrationIntent::NEW}}));
+    ASSERT_TRUE(registration.has_value());
+    ASSERT_EQ(registration->results.size(), 1);
+    ASSERT_EQ(registration->results[0].error_code, ErrorCode::OK);
+
+    const Segment pending_new =
+        MakeSegment("update_failed_reconcile_new", 0x310000000);
+    auto reconciliation = healthy_client.UpdateSegments(
+        MakeRequest(SegmentUpdateRequestIntent::RECONCILE,
+                    {{pending_new, SegmentRegistrationIntent::NEW},
+                     {foreign_segment, SegmentRegistrationIntent::REMOUNT}}));
+
+    ASSERT_FALSE(reconciliation.has_value());
+    EXPECT_EQ(reconciliation.error(), ErrorCode::INVALID_PARAMS);
+    EXPECT_FALSE(
+        healthy_client.QuerySegmentStatusById(pending_new.id).has_value());
+    auto ping = healthy_client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::OK);
+}
+
+TEST_F(UpdateSegmentsRpcTest, UnknownRequestIntentIsRejected) {
+    MasterClient client(generate_uuid());
+    Connect(client);
+    auto request = MakeRequest(SegmentUpdateRequestIntent::REGISTER);
+    request.request_intent = static_cast<SegmentUpdateRequestIntent>(255);
+
+    auto response = client.UpdateSegments(request);
+
+    ASSERT_FALSE(response.has_value());
+    EXPECT_EQ(response.error(), ErrorCode::INVALID_PARAMS);
+    auto ping = client.Ping();
+    ASSERT_TRUE(ping.has_value());
+    EXPECT_EQ(ping->client_status, ClientStatus::NEED_REMOUNT);
+}
+
+}  // namespace mooncake::testing

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -41,9 +41,7 @@ def _shm_name_to_path(name):
 
 def _unblock_shutdown_signals():
     try:
-        signal.pthread_sigmask(
-            signal.SIG_UNBLOCK, {signal.SIGINT, signal.SIGTERM}
-        )
+        signal.pthread_sigmask(signal.SIG_UNBLOCK, {signal.SIGINT, signal.SIGTERM})
     except AttributeError:
         pass
 
@@ -126,9 +124,7 @@ class MooncakeStoreService:
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         )
 
-    async def start_store_service(
-        self, max_wait_time: float = 60, shutdown_event=None
-    ):
+    async def start_store_service(self, max_wait_time: float = 60, shutdown_event=None):
         """
         Start the store service with retry mechanism.
 
@@ -191,9 +187,7 @@ class MooncakeStoreService:
                     # chance to publish a shutdown requested while it ran.
                     await asyncio.sleep(0)
                     if shutdown_event.is_set():
-                        logging.info(
-                            "Store startup cancelled by shutdown request"
-                        )
+                        logging.info("Store startup cancelled by shutdown request")
                         await self.stop()
                         return False
 
@@ -228,9 +222,7 @@ class MooncakeStoreService:
                                 shutdown_event.wait(),
                                 timeout=actual_sleep_time,
                             )
-                            logging.info(
-                                "Store startup cancelled by shutdown request"
-                            )
+                            logging.info("Store startup cancelled by shutdown request")
                             return False
                         except asyncio.TimeoutError:
                             pass

--- a/mooncake-wheel/mooncake/mooncake_store_service.py
+++ b/mooncake-wheel/mooncake/mooncake_store_service.py
@@ -310,7 +310,7 @@ class MooncakeStoreService:
                     previous_segment_ids = list(self.mounted_segment_ids)
                     # /api/reconfigure binds through store.mount_segment ->
                     # MooncakeDistributedStore.mount_segment -> RealClient::mountSegment
-                    # -> Client::MountSegmentAndGetId -> MasterClient::MountSegment,
+                    # -> Client::MountSegmentAndGetId -> MasterClient::UpdateSegments,
                     # the standard allocator path: each mount mints a fresh UUID
                     # and the duplicate check is UUID-keyed. That path never calls
                     # MountNoFSegment or enters ScopedNoFSegmentAccess, so the NoF

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -319,7 +319,9 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         # subsequent same-path detection keeps working.
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/old")
 
-    async def test_reconfigure_decode_same_path_remount_failure_keeps_previous_segments(self):
+    async def test_reconfigure_decode_same_path_remount_failure_keeps_previous_segments(
+        self,
+    ):
         # A remount to the SAME path that fails to mount must not destroy the
         # still-healthy previous segments: the node keeps serving from them and
         # stays in decode mode (make-before-break). Same-path MBB is safe here
@@ -397,7 +399,9 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(self.service.current_mode, "decode")
         self.assertEqual(self.service.last_mount_info["path"], "/dev/shm/new")
 
-    async def test_reconfigure_decode_partial_unmount_failure_keeps_only_failed_ids(self):
+    async def test_reconfigure_decode_partial_unmount_failure_keeps_only_failed_ids(
+        self,
+    ):
         # New mount succeeds, but retiring the previous segments only PARTIALLY
         # fails. unmount_segment reports the first error for a batch, so the old
         # ids must be unmounted individually; mounted_segment_ids must then hold
@@ -1077,9 +1081,7 @@ class StoreServiceShutdownTest(unittest.IsolatedAsyncioTestCase):
             await self.service.stop()
 
         self.assertIsNone(self.service.store)
-        self.assertTrue(
-            any("close returned 7" in message for message in logs.output)
-        )
+        self.assertTrue(any("close returned 7" in message for message in logs.output))
         await self.service.stop()
         store.close.assert_called_once_with()
 

--- a/mooncake-wheel/tests/test_mooncake_store_service_api.py
+++ b/mooncake-wheel/tests/test_mooncake_store_service_api.py
@@ -323,7 +323,7 @@ class StoreServiceApiTest(unittest.IsolatedAsyncioTestCase):
         # A remount to the SAME path that fails to mount must not destroy the
         # still-healthy previous segments: the node keeps serving from them and
         # stays in decode mode (make-before-break). Same-path MBB is safe here
-        # because /api/reconfigure binds through MasterClient::MountSegment,
+        # because /api/reconfigure binds through MasterClient::UpdateSegments,
         # which mints a fresh UUID per mount and does not enter the NoF
         # te_endpoint-dedup path, so old and new cannot collide on the same path.
         old_id = "00000000-0000-0000-0000-000000000001"


### PR DESCRIPTION
## Description

Closes #3560.

This refactors memory-segment registration and remount handling into a unified
`UpdateSegments` RPC.

Key Changes:

- The new protocol distinguishes:

  - Request-level intent:
    - `REGISTER` for incremental registration.
    - `RECONCILE` for a complete client segment snapshot.
  - Per-segment intent:
    - `NEW` for newly created segments.
    - `REMOUNT` for segments that existed before the Master lost state.

- The client now tracks each segment as `NEW_PENDING`, `REMOUNT_PENDING`, or
`ACTIVE`. 

- The wire RPC changes from `MountSegment`/`ReMountSegment` to `UpdateSegments`,
so Client and Master binaries must be upgraded together.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Refactor

## How Has This Been Tested?

**Test commands:**

```bash
# Unit tests
ctest --test-dir build \
  -R '^(update_segments_rpc_test|master_service_test|master_metrics_test|master_admin_server_test)$' \
  --output-on-failure \
  --no-tests=error

# Client and reconnect integration coverage
ctest --test-dir build \
  -R '^(client_integration_test|client_tcp_local_memcpy_test|pybind_client_test|non_ha_reconnect_test|task_integration_test)$' \
  --parallel 5 \
  --output-on-failure \
  --no-tests=error

# Python API tests
python3 mooncake-wheel/tests/test_mooncake_store_service_api.py
```

Test results:

- [x] Unit tests pass — all directly affected C++ tests passed (4/4),
  including all 7 cases in update_segments_rpc_test.

- [x] Integration tests pass — client, reconnect, local-copy, pybind, and task
  integration targets passed (5/5).

- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using ./scripts/code_format.sh
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed RFC issue #3560

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex assisted with reviewing the diff, checking synchronization and
failure-handling paths, running formatting and pre-commit checks, updating the
design documentation, executing the focused and full test suites, and comparing
the Python failures against main. The human submitter reviewed the resulting
changes and remains responsible for them.