### PR TITLE
[Store] RFC: Tenant-first object-level metadata locking

### DIFF
--- a/rfc-object-directory-read-path-optimization.md
+++ b/rfc-object-directory-read-path-optimization.md
@@ -1,0 +1,213 @@
+# [RFC][Store]: Group Directory Object-Route Read-Path Optimization
+
+## Summary
+
+This RFC replaces only `GroupDirectory`'s private object-route implementation.
+It preserves the ownership, group, object lock, quota, HA, offload, and eviction
+semantics defined by
+[Tenant-First Object-Level Metadata Locking](rfc-object-level-metadata-locking.md).
+
+```mermaid
+flowchart LR
+    subgraph CORE["Locked reference"]
+        C1["WithObjects"] --> C2["route shared lock"]
+        C2 --> C3["copy aliasing owner per key"]
+        C3 --> C4["object lock"]
+    end
+
+    subgraph FAST["Optimized route"]
+        F1["WithObjects"] --> F2["one request epoch"]
+        F2 --> F3["atomic immutable bucket"]
+        F3 --> F4["borrow ObjectEntry*"]
+        F4 --> F5["object lock"]
+    end
+
+    CORE ==>|"same GroupDirectory API"| FAST
+```
+
+For the representative 32-key batch read/write 1:1 workload, the optimized path
+measured 59.71 M key ops/s versus 42.73 for main's shard layout and 35.11 for
+the locked-owning reference.
+
+```text
+M key ops/s
+
+Main shard       42.73  █████████████████
+Locked owning    35.11  ██████████████
+Epoch bucket     59.71  ████████████████████████
+```
+
+## Scope
+
+| Goals | Non-goals |
+| --- | --- |
+| Remove route locks from synchronous reads | Changing `Tenant -> GroupDirectory -> Object` ownership |
+| Avoid per-key `shared_ptr` copies | Lock-free `ObjectState` mutation |
+| Enter one epoch per point request or batch | Changing group, eviction, quota, HA, or offload semantics |
+| Publish one small immutable route bucket | Making group catalogs/member sets lock-free |
+| Preserve `WithObject(s)`, `Pin`, `VisitHandles`, and matched unlink | Dynamic route resizing in the first version |
+
+Tenant-registry COW remains independent and uses its own epoch domain.
+
+## Proposed Route
+
+```cpp
+class ObjectRouteIndex {
+    // Singleton: normal ObjectEntry owner.
+    // Explicit member: aliasing owner whose control block owns GroupEntry.
+    using EntryOwner = std::shared_ptr<ObjectEntry>;
+    using BucketSnapshot = OwningStringMap<EntryOwner>;
+
+    struct Bucket {
+        std::atomic<const BucketSnapshot*> current;
+    };
+
+  public:
+    template <class Fn> auto WithObject(std::string_view, Fn&&) const;
+    template <class Fn> auto WithObjects(KeySpan, Fn&&) const;
+    ObjectHandle Pin(std::string_view) const;
+    void VisitHandles(const HandleVisitor&) const;
+    void Publish(std::string key, EntryOwner);
+    bool EraseIfMatch(std::string_view, ObjectId, const ObjectEntry*);
+
+  private:
+    EpochDomain& epochs_;
+    std::array<Bucket, kObjectBucketCount> buckets_;
+    std::array<std::mutex, kObjectWriterStripeCount> writers_;
+};
+```
+
+Each immutable bucket owns its lookup strings and entry owners. For an explicit
+member, `.get()` points directly to `ObjectEntry` while the control block keeps
+the whole `GroupEntry` alive.
+
+### Read path
+
+```mermaid
+sequenceDiagram
+    participant R as RPC/batch
+    participant D as GroupDirectory
+    participant B as Route bucket
+    participant E as ObjectEntry
+
+    R->>D: WithObjects(keys)
+    D->>D: enter epoch once
+    loop each key
+        D->>B: atomic load + string_view lookup
+        B-->>D: borrowed ObjectEntry*
+        D->>E: object lock + lifecycle validation
+    end
+    D->>D: leave epoch after callback
+```
+
+The callback-scoped access object, state references, raw pointers, and epoch
+guard cannot escape. `Pin` copies a strong aliasing handle only for work that
+must outlive the callback.
+
+### Route publication
+
+Create or matched unlink:
+
+1. lock the writer stripe for the object key;
+2. load and copy only its route bucket;
+3. apply `Publish` or `EraseIfMatch(ObjectId, pointer)`;
+4. publish the new snapshot with release semantics;
+5. retire the old snapshot after an epoch grace period.
+
+Group creation, membership, lifecycle, and teardown remain under the core
+`GroupDirectory` protocol. Empty buckets share one immutable snapshot. Bucket
+and writer-stripe counts are fixed in the first version and selected from
+memory and membership-churn measurements.
+
+### Eviction integration
+
+Eviction keeps strong handles and the core group-aware commit protocol:
+
+| Operation | Locked reference | Epoch bucket |
+| --- | --- | --- |
+| `WithObject(s)` | Copy owner under route lock | Borrow under one request epoch |
+| `Pin` | Copy owner under route lock | Copy owner from protected snapshot |
+| `VisitHandles` | Copy bounded chunks under route lock | Copy emitted handles under short per-chunk epochs |
+| Publish/unlink | Route exclusive lock | Copy/publish one bucket, retire old bucket |
+
+A census never holds one epoch across the entire object population. Ranking,
+group deduplication, group/object lock order, HA, and cleanup remain outside the
+route implementation.
+
+## Performance Evidence
+
+Measurements are pinned medians on AMD EPYC 7742/GCC 11.4 with 16 threads and
+64-byte keys. Microbenchmarks exclude tenant lookup, RPC, quota, external work,
+real reclamation, and eviction execution.
+
+### Flat group route versus two-level lookup
+
+The optimized two-level baseline performs object-key -> group followed by a
+second string-key member lookup. The flat route returns an aliasing object
+handle in one hash lookup.
+
+| Workload | Two-level | Flat alias | Change |
+| --- | ---: | ---: | ---: |
+| Point reads, group size 32 | 21.84 Mops/s | **29.17 Mops/s** | +33.6% |
+| Same-group batch R/W 1:1, 32 keys | 43.39 | **50.34** | +16.0% |
+| Cross-group batch R/W 1:1, 32 keys | 25.83 | **39.85** | +54.3% |
+
+Same-group results remained 16-27% faster for group sizes 8-128. For group size
+32, flat p50/p99 batch latency was 7.46/11.05 us versus 9.69/13.96 us. At one
+million objects, flat RSS was 571.1 MB versus 685.3 MB, a 16.7% reduction,
+primarily because group membership uses numeric `ObjectId`s instead of a second
+owning string-key map.
+
+These measurements use the locked flat route and validate its shape and
+aliasing lifetime cost. They do not validate publication, teardown, or eviction.
+
+### Epoch route versus current and locked reference
+
+`shard` models main's 1,024 shard locks, `owning` models the locked reference,
+and `epoch_cow` models the optimized read path with prepublished snapshots.
+
+| Workload | Main `shard` | Locked `owning` | `epoch_cow` | Epoch vs main |
+| --- | ---: | ---: | ---: | ---: |
+| Point reads | **55.10** | 32.81 | 44.85 | -18.6% |
+| Batch R/W 1:1, 32 keys | 42.73 | 35.11 | **59.71** | +39.7% |
+| Forced shard collision, batch R/W 1:1 | 2.12 | 33.66 | **55.58** | 26.3x |
+
+For the 32-key batch workload, epoch read/write p99 was 8.58/9.87 us versus
+14.01/18.67 us on main. Pure point reads remain slower than main, so the design
+is gated on the production-weighted batch mix rather than claimed as a universal
+QPS improvement.
+
+## Costs and Gates
+
+The route retains two safe object-key owners: the canonical entry key and the
+lookup key. Additional costs are bucket pointers, writer stripes, copied bucket
+nodes during membership changes, retired snapshots, and one epoch participant
+per registered execution context.
+
+An old route snapshot can pin an entire explicit group through an aliasing
+owner. Stalled-reader age and retired bytes must therefore be observable and
+bounded. Create/delete bucket copying remains the main unmeasured write cost.
+
+| Gate | Acceptance criterion |
+| --- | --- |
+| Production batch R/W 1:1 | At least 20% throughput gain at representative batch sizes and threads |
+| Point reads | No more than 20% regression versus main |
+| Membership churn | Report create/delete throughput, p99, copied bytes, and retired bytes |
+| Explicit groups | Run same/cross-group lookup plus publication, teardown, and eviction at representative group sizes |
+| Reclamation | Bounded retired memory, stalled-reader diagnostics, and clean shutdown |
+| Eviction | No correctness regression; report foreground p99 and census CPU at million-object scale |
+| Memory | Report bytes/tenant and RSS/million objects for selected bucket/stripe counts |
+
+## Implementation
+
+1. Establish the core `GroupDirectory` API and lifetime tests.
+2. Add a process-wide object-route epoch domain with stalled-reader and retired
+   memory diagnostics.
+3. Replace locked route shards with immutable buckets and writer stripes.
+4. Implement scoped borrowing while preserving `Pin`, `VisitHandles`, publish,
+   and matched-unlink behavior.
+5. Run TSan/ASan, membership-churn, group, eviction, memory, and production-mix
+   gates; then delete the locked route implementation.
+
+The locked reference does not need to be enabled as a separate production
+intermediate, and no compatibility mode or dual representation is retained.

--- a/rfc-object-level-metadata-locking.md
+++ b/rfc-object-level-metadata-locking.md
@@ -1,0 +1,278 @@
+# [RFC][Store]: Tenant-First Object-Level Metadata Locking
+
+## Summary
+
+Move metadata ownership from global shards to tenants and move the mutation
+boundary from one shard lock to one object lock.
+
+```mermaid
+flowchart LR
+    subgraph BEFORE["Current"]
+        S["MetadataShard[1024]"] --> L["one shard lock"]
+        L --> M["many tenants + objects + task maps"]
+    end
+
+    subgraph AFTER["Proposed"]
+        R["TenantRegistry<br/>COW snapshots"] --> T["TenantState"]
+        T --> Q["TenantQuotaHandle"]
+        T --> G["GroupDirectory"]
+        G --> I["ObjectRouteIndex[N]<br/>key -> aliasing ObjectHandle"]
+        G --> MG["explicit GroupEntry<br/>1..N objects"]
+        G --> SG["implicit singleton group"]
+        MG --> O["ObjectEntry<br/>object lock + state"]
+        SG --> O
+        I -. "one key lookup -> ObjectEntry*" .-> O
+    end
+
+    BEFORE ==>|"invert ownership; narrow mutation lock"| AFTER
+```
+
+| Concern | Current | Proposed |
+| --- | --- | --- |
+| Ownership | Global shards contain fragments of many tenants | `TenantState -> GroupDirectory -> ObjectEntry` |
+| Mutation | One shard lock covers unrelated objects | One lock per `ObjectEntry` |
+| Group | Separate object-to-group and member maps | One tenant-local `GroupDirectory` |
+| Lookup | Shard routing is also the lifetime boundary | One flat object route pins the owning object/group |
+| Eviction | Scan and mutate under broad shard locks | Handle census, group-aware commit, matched unlink |
+
+The expected architectural win is isolation and a clear ownership model. The
+simple locked route defined here is the correctness baseline. Epoch/COW route
+optimization is specified separately in
+[Group Directory Object-Route Read-Path Optimization](rfc-object-directory-read-path-optimization.md).
+
+## Scope
+
+| Goals | Non-goals |
+| --- | --- |
+| Put `TenantState` at the outer semantic boundary | Lock-free object business state |
+| Make `GroupDirectory` the only tenant-local object container | Changing the external `group_id` contract |
+| Allow unrelated objects to mutate concurrently | Concurrent conflicting mutations of one object |
+| Make erase/recreate and async work lifetime-safe | Dynamic route-shard resizing |
+| Preserve quota, group, HA, offload, and eviction semantics | A dual representation or compatibility mode |
+
+## Data Model
+
+Every object belongs to one logical group:
+
+- a non-empty external `group_id` resolves to an explicit `GroupEntry`;
+- an empty external `group_id` is an implicit singleton group;
+- singleton state is physically collapsed into `ObjectEntry`, so it adds no
+  group allocation or group lock;
+- an explicit `GroupEntry` owns all member objects and destroys them together.
+
+The logical hierarchy does not add a second lookup:
+
+```text
+logical ownership: Tenant -> GroupDirectory -> GroupEntry -> ObjectEntry
+point lookup:       tenant + object key -> one route hash -> ObjectEntry*
+                                             └── owner pins GroupEntry
+```
+
+The core C++ shape is:
+
+```cpp
+struct TenantInstanceId { uint64_t value; };
+struct GroupId { uint64_t value; };
+struct ObjectId { uint64_t value; };
+struct ObjectToken { TenantInstanceId tenant; ObjectId object; };
+
+class ObjectEntry;
+class GroupEntry;
+
+class ObjectHandle {
+    std::shared_ptr<TenantState> tenant_;
+    // Singleton: owns ObjectEntry.
+    // Explicit member: aliases GroupEntry ownership but points to ObjectEntry.
+    std::shared_ptr<ObjectEntry> entry_;
+};
+
+class GroupEntry {
+    const GroupId id_;
+    const std::string name_;
+    std::atomic<GroupLifecycle> lifecycle_;
+    mutable SharedMutex mutex_;
+    std::unordered_map<ObjectId, std::unique_ptr<ObjectEntry>> members_
+        GUARDED_BY(mutex_);
+};
+
+class ObjectEntry {
+    const ObjectId id_;
+    const GroupId group_id_;
+    GroupEntry* const explicit_group_;  // null for singleton
+    const std::string key_;
+    mutable SharedMutex mutex_;
+    ObjectLifecycle lifecycle_ GUARDED_BY(mutex_);
+    ObjectState state_ GUARDED_BY(mutex_);  // metadata + runtime tasks
+};
+
+class GroupDirectory {
+    using ObjectOwner = std::shared_ptr<ObjectEntry>;
+    struct RouteShard {
+        SharedMutex mutex;
+        OwningStringMap<ObjectOwner> objects;
+    };
+
+    std::array<RouteShard, kObjectRouteShardCount> routes_;
+    SharedMutex group_catalog_mutex_;
+    OwningStringMap<std::shared_ptr<GroupEntry>> groups_by_name_;
+    std::unordered_map<GroupId, std::shared_ptr<GroupEntry>> groups_by_id_;
+    std::array<std::mutex, kLifecycleStripeCount> lifecycle_stripes_;
+
+    template <class Fn> auto WithObject(std::string_view, Fn&&) const;
+    template <class Fn> auto WithObjects(KeySpan, Fn&&) const;
+    ObjectHandle Pin(std::string_view) const;
+    void VisitHandles(const HandleVisitor&) const;
+    bool EraseIfMatch(std::string_view, ObjectId, const ObjectEntry*);
+};
+
+class TenantState {
+    const TenantId id_;
+    const TenantInstanceId instance_id_;
+    std::atomic<TenantLifecycle> lifecycle_;
+    TenantQuotaHandle quota_;
+    GroupDirectory groups_;
+};
+```
+
+For an explicit member, the route stores the standard aliasing form
+`shared_ptr<ObjectEntry>(group_owner, member_ptr)`. One route lookup therefore
+returns the member directly while keeping the whole group alive. A
+`GroupHandle` can be derived in O(1) from the immutable back-pointer; point
+operations neither perform a second hash lookup nor take the group lock.
+
+`WithObject(s)` is callback-scoped and exposes no raw pointer or state reference
+to its caller. Work that outlives the callback uses a strong `ObjectHandle` or a
+weak handle plus `ObjectToken`. Tenant generation, group lifecycle, `ObjectId`,
+and object lifecycle fence unregister, erase, recreate, and delayed callbacks.
+
+Stored object keys remain owning strings with transparent `string_view` lookup.
+The route owns one safe lookup key and `ObjectEntry` owns the canonical key.
+Explicit group names are stored per group, while member objects store only a
+numeric `GroupId`.
+
+### Read-mostly tenant registry and quota
+
+`TenantRegistry` uses sharded immutable COW snapshots. A reader enters the
+registry epoch, loads one snapshot, copies a strong `TenantHandle`, and leaves
+the epoch. Registration and matching-generation removal copy only one registry
+shard. Snapshot keys are owning strings.
+
+`TenantHandle::quota()` returns the existing stable quota account. Charge and
+release use its atomic protocol; policy updates use existing quota-table locks.
+They do not mutate `TenantRegistry` or `GroupDirectory`.
+
+## Access and Locking
+
+```mermaid
+sequenceDiagram
+    participant R as RPC/batch
+    participant TR as TenantRegistry
+    participant G as GroupDirectory
+    participant E as ObjectEntry
+
+    R->>TR: Lookup(tenant_id)
+    TR-->>R: strong TenantHandle
+    R->>G: WithObject(key)
+    G-->>R: aliasing owner; route lock released
+    R->>E: object lock + lifecycle validation
+    E-->>R: value result
+```
+
+| Lock | Protects | Boundary |
+| --- | --- | --- |
+| Tenant-registry writer | One tenant snapshot shard | Never includes tenant work or teardown drain |
+| Object route | Key membership and handle acquisition | Released before group/object locks |
+| Group catalog | Explicit group name/ID lookup | Released before group/object locks |
+| Explicit group | Membership and group transaction | Then member objects in canonical key order |
+| Object | One object's metadata and tasks | Never includes directory change or external I/O |
+
+Allocator, filesystem, queue, event, and network work run without registry or
+directory locks. Timer/retry indexes are also never nested with object locks.
+
+### Lifecycle
+
+| Operation | Protocol |
+| --- | --- |
+| Create | Serialize the key, create/join its group, build the owning or aliasing handle, then publish the route |
+| Singleton erase | Mark object removing, matched-unlink its route, clean up off-lock |
+| Explicit group erase | Mark group removing, matched-unlink every member route, clean up the group off-lock |
+| Tenant teardown | Close admission, unregister the matching generation, then drain handles |
+| Async callback | Upgrade weak handle and revalidate tenant, group, object ID/version, and lifecycle |
+
+Partially published objects remain `kCreating`; removing objects/groups remain
+`kRemoving`. Lookup accepts only `kActive`. A retained handle preserves memory,
+not logical validity.
+
+## Eviction
+
+Eviction is the largest migration area because current shard locks implicitly
+provide scan stability, object lifetime, group serialization, auxiliary-map
+consistency, and erase serialization.
+
+```mermaid
+flowchart LR
+    C["current shard scan<br/>mutate + erase"] ==>|"make guarantees explicit"| V["route census<br/>copy handles in chunks"]
+    V --> G["derive + deduplicate groups"]
+    G --> P["candidate snapshot"]
+    P --> K["group then object locks<br/>revalidate + commit"]
+    K --> U["matched route unlink"]
+    U --> X["external cleanup off-lock"]
+```
+
+The target protocol is:
+
+1. `VisitHandles` copies bounded chunks under route shared locks.
+2. Candidate selection runs after route locks are released.
+3. Candidates derive `GroupHandle`; repeated `GroupId`s are deduplicated.
+4. An explicit group is locked before its member objects in canonical order;
+   singleton eviction locks only its object.
+5. HA reservation happens before metadata locks. Commit revalidates generation,
+   IDs, version, lease, pin state, and lifecycle.
+6. Membership teardown is group-wide. Member routes use matched unlink so stale
+   work cannot erase a recreated object.
+7. Offload, allocator, durable callbacks, and event publication run off-lock.
+
+Global, tenant-quota, NoF, and DFS eviction reuse the same census and commit
+kernel with different selection predicates. The implementation must first
+extract this kernel on the current shard layout before changing ownership.
+
+## Expected Impact
+
+| Area | Expected benefit | Cost |
+| --- | --- | --- |
+| Distinct object writes | Independent object locks | More lock objects and checks |
+| Tenant isolation | No cross-tenant object-mutation lock | Tenant plus object-route lookup |
+| Group operations | One ownership and lifetime unit | Canonical multi-object locking |
+| Tenant eviction | Direct tenant-local census | Explicit handle lifetime |
+| Identity memory | Group name once; numeric member IDs | Two safe object-key owners |
+
+The explicit-group microbenchmark measured the flat alias route 16-54% faster
+than a two-level group/member lookup and 16.7% lower RSS at one million objects.
+The simple locked route can still regress uniform singleton workloads versus
+main; production enablement therefore requires the companion performance RFC
+or equivalent end-to-end evidence.
+
+## Implementation and Validation
+
+1. Add lock metrics and extract the common eviction commit kernel on the
+   current representation.
+2. Consolidate metadata and per-key runtime maps into `ObjectEntry`.
+3. Add `TenantRegistry`, `TenantState`, `GroupDirectory`, handles, IDs, and
+   lifecycle fencing.
+4. Convert point/batch, create/erase, group, eviction, HA/offload, snapshot, and
+   admin paths to the new API.
+5. Delete global shard ownership, `object_group_ids_`, per-shard
+   `group_members`, parallel per-key maps, and migration adapters.
+
+| Gate | Acceptance criterion |
+| --- | --- |
+| Lifetime | TSan/ASan coverage for lookup, erase/recreate, group teardown, and delayed callbacks |
+| Locking | Distinct colliding objects progress; canonical group/object ordering has no deadlock |
+| Eviction | Existing ranking, HA, group, quota, accounting, NoF, and DFS behavior is preserved |
+| Foreground impact | Report Get/PutEnd throughput and p99 during million-object eviction |
+| Memory | Report bytes/tenant and RSS/million objects, including group-size distribution |
+| Fast path | Meet the companion RFC gates or equivalent production-weighted evidence |
+
+One authoritative metadata representation exists in every phase. The locked
+reference and optimized route may land in one change series; no feature flag,
+dual-write path, or compatibility representation is introduced.


### PR DESCRIPTION
## Description

This PR adds two focused RFCs for evolving Mooncake Store metadata from shard-level locking to tenant-first ownership and object-level locking:

- Core RFC: tenant -> GroupDirectory -> Group -> Object ownership, lock boundaries, lifecycle, and evict revalidation.
- Follow-up RFC: optional COW/epoch read-path optimization, justified by batch read/write benchmarks and kept separate from the correctness change.

Both documents put the before/after data structure and lock diagrams first so the proposal and expected contention reduction are visible at a glance.

Related work and scope boundaries:

- Complements #3589: that PR decouples current object routing from group semantics; this RFC defines the longer-term ownership, group-lifetime, and object-lock model.
- Complements #3593: that PR bounds write-lock holds for stale-handle sweeps in the existing shard model; this RFC specifies the target lock granularity and evict protocol.
- Tenant quota hot-path accounting remains separate from #3157.
- Eviction candidate indexing/full-scan optimization remains separate from #2560.

No production code changes are included.

## Module

- [ ] Transfer Engine (mooncake-transfer-engine)
- [x] Mooncake Store (mooncake-store)
- [ ] Reshard (mooncake-reshard)
- [ ] Mooncake EP (mooncake-ep)
- [ ] Mooncake PG (mooncake-pg)
- [ ] Integration (mooncake-integration)
- [ ] P2P Store (mooncake-p2p-store)
- [ ] Python Wheel (mooncake-wheel)
- [ ] Common (mooncake-common)
- [ ] Mooncake RL (mooncake-rl)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Test commands:

    pre-commit run --files rfc-object-level-metadata-locking.md rfc-object-directory-read-path-optimization.md

Test results:

- [x] Pre-commit hooks pass.
- [x] Markdown diff check passes.
- [x] Runtime tests are not applicable because this PR changes design documents only.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using ./scripts/code_format.sh (N/A: no source-code changes)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation
- [ ] I have added tests to prove my changes are effective (N/A: RFC-only PR)
- [ ] For changes >500 LOC: I have filed an RFC issue (N/A: 491 added lines, consisting of the RFCs themselves)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Codex assisted with drafting, Mermaid visualizations, benchmark interpretation, and iterative editing. The submitter reviewed the design decisions and final RFC content.