### PR TITLE
[Store] Add version support to real_client and its HTTP service

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -1150,7 +1150,7 @@ the positional overload.
   data is stored under `MOONCAKE_DFS_ROOT_DIR`, but this separate directory is
   still validated during FileStorage initialization.
 - `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
-- `enable_client_http_server` (bool): Enable the client-local `/health`, `/metrics`, and `/metrics/summary` HTTP endpoints. Defaults to `False`.
+- `enable_client_http_server` (bool): Enable the client-local `/health`, `/metrics`, `/metrics/summary`, and `/version` HTTP endpoints. Defaults to `False`.
 - `client_http_port` (int): Port for the client-local HTTP endpoints. Defaults to `9300`.
 
 **Store segment pinned memory:** CUDA-enabled builds can register Store-managed

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -947,7 +947,7 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
 | `ssd_offload_path` | str | empty | *(advanced)* FileStorage path; with the distributed backend, DFS data uses `MOONCAKE_DFS_ROOT_DIR` |
 | `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
-| `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `client_http_port` | int | `9300` | Client-side HTTP endpoint port, used only when `enable_client_http_server=true` |
 
 ```{note}
@@ -978,7 +978,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
 | `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | FileStorage path; DFS shard data uses `MOONCAKE_DFS_ROOT_DIR` with the distributed backend |
 | `MOONCAKE_TENANT_ID` | `tenant_id` | `default` | Tenant identifier |
-| `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `MOONCAKE_CLIENT_HTTP_PORT` | `client_http_port` | `9300` | Client-side HTTP endpoint port |
 | `MOONCAKE_CONFIG_PATH` | — | unset | Path to a JSON config file (takes precedence over the variables above) |
 
@@ -1047,7 +1047,7 @@ mooncake_client \
 | `--tenant_id` | `default` | Tenant identifier |
 | `--enable_offload` | `false` | Enable client-side SSD offload |
 | `--start_offload_rpc_server` | `true` | Start the offload RPC server for dummy clients |
-| `--enable_http_server` | `false` | Enable client-side `/health`, `/metrics`, and `/metrics/summary` endpoints |
+| `--enable_http_server` | `false` | Enable client-side `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `--http_port` | `9300` | Client-side HTTP endpoint port |
 
 ### Client HTTP Health and Metrics Endpoint
@@ -1075,6 +1075,7 @@ For `mooncake_store_service`, use `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER=true` and 
 | `GET /health` | Client health check |
 | `GET /metrics` | Prometheus-format client metrics |
 | `GET /metrics/summary` | Human-readable client metrics summary |
+| `GET /version` | Client version, JSON `{"version":"..."}` |
 
 ```{note}
 `MC_STORE_CLIENT_METRIC` controls whether client metrics are collected. If the client HTTP server is enabled but `MC_STORE_CLIENT_METRIC=0`, `/metrics` and `/metrics/summary` return HTTP 503 with `metrics not available`.

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -12,6 +12,7 @@
 #include <unordered_set>
 #include <vector>
 #include <ylt/metric/counter.hpp>
+#include <ylt/metric/gauge.hpp>
 #include <ylt/metric/histogram.hpp>
 #include <ylt/metric/summary.hpp>
 #include "environ.h"
@@ -658,6 +659,10 @@ struct ClientMetric {
     MasterClientMetric master_client_metric;
     TransferOperationMetric transfer_operation_metric;
     SsdMetric ssd_metric;
+    // Constant gauge carrying the client version as a label, following the
+    // Prometheus "info metric" convention:
+    //   mooncake_client_version_info{version="..."} 1
+    ylt::metric::gauge_t version_info;
 
     /**
      * @brief Creates a ClientMetric instance based on environment variables

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -7,10 +7,17 @@
 
 #include "bool_parser.h"
 #include "integer_parser.h"
+#include "version.h"
 
 namespace mooncake {
 
 namespace {
+
+std::map<std::string, std::string> withVersionLabel(
+    std::map<std::string, std::string> labels) {
+    labels.emplace("version", MOONCAKE_DISPLAY_VERSION);
+    return labels;
+}
 
 bool parseMetricsEnabled() {
     const char* metric_env = std::getenv("MC_STORE_CLIENT_METRIC");
@@ -71,6 +78,9 @@ ClientMetric::ClientMetric(uint64_t interval_seconds,
       master_client_metric(labels),
       transfer_operation_metric(labels),
       ssd_metric(labels),
+      version_info("mooncake_client_version_info",
+                   "Mooncake store client version information",
+                   withVersionLabel(labels)),
       should_stop_metrics_thread_(false),
       metrics_interval_seconds_(interval_seconds),
       bandwidth_reporting_enabled_(bandwidth_reporting_enabled),
@@ -79,6 +89,8 @@ ClientMetric::ClientMetric(uint64_t interval_seconds,
         static_cast<uint64_t>(transfer_metric.total_read_bytes.value()),
         static_cast<uint64_t>(transfer_metric.total_write_bytes.value()),
         std::chrono::steady_clock::now()};
+    // Constant value 1; the payload is the "version" label.
+    version_info.update(1);
     if (metrics_interval_seconds_ > 0) {
         StartMetricsReportingThread();
     }
@@ -110,6 +122,7 @@ std::unique_ptr<ClientMetric> ClientMetric::Create(
 }
 
 void ClientMetric::serialize(std::string& str) {
+    version_info.serialize(str);
     transfer_metric.serialize(str);
     if (master_rpc_metrics_enabled_) {
         master_client_metric.serialize(str);
@@ -121,6 +134,7 @@ void ClientMetric::serialize(std::string& str) {
 std::string ClientMetric::summary_metrics() {
     std::stringstream ss;
     ss << "Client Metrics Summary\n";
+    ss << "Version: " << MOONCAKE_DISPLAY_VERSION << "\n";
     ss << transfer_metric.summary_metrics(bandwidth_reporting_enabled_);
     ss << "\n";
     if (master_rpc_metrics_enabled_) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -29,6 +29,7 @@
 #include "mutex.h"
 #include "types.h"
 #include "utils.h"
+#include "version.h"
 #include "rpc_types.h"
 #include "file_storage.h"
 #include "device/accelerator_registry.h"
@@ -1924,6 +1925,14 @@ int RealClient::start_http_server(int port) {
             }
             resp.add_header("Content-Type", "text/plain");
             resp.set_status_and_content(status_type::ok, std::move(*result));
+        });
+
+    http_server_->set_http_handler<GET>(
+        "/version", [](coro_http_request &req, coro_http_response &resp) {
+            std::string body = std::string("{\"version\":\"") +
+                               MOONCAKE_DISPLAY_VERSION + "\"}";
+            resp.add_header("Content-Type", "application/json");
+            resp.set_status_and_content(status_type::ok, std::move(body));
         });
 
     auto ec = http_server_->async_start();

--- a/mooncake-store/src/real_client_main.cpp
+++ b/mooncake-store/src/real_client_main.cpp
@@ -6,6 +6,7 @@
 #include "common.h"
 #include "config.h"
 #include "real_client.h"
+#include "version.h"
 
 using namespace mooncake;
 
@@ -110,6 +111,7 @@ int main(int argc, char *argv[]) {
     // spawning threads, leading to missing signal processing.
     mooncake::ResourceTracker::getInstance();
 
+    gflags::SetVersionString(mooncake::MOONCAKE_DISPLAY_VERSION);
     gflags::ParseCommandLineFlags(&argc, &argv, true);
     if (!FLAGS_log_dir.empty()) {
         google::InitGoogleLogging(argv[0]);

--- a/mooncake-store/tests/client_metrics_test.cpp
+++ b/mooncake-store/tests/client_metrics_test.cpp
@@ -14,6 +14,7 @@
 #include "real_client.h"
 #include "test_server_helpers.h"
 #include "utils.h"
+#include "version.h"
 
 namespace mooncake::test {
 namespace {
@@ -262,6 +263,20 @@ TEST_F(ClientMetricsTest, CompareWithSerializedMetrics) {
                 summary.find("No data") != std::string::npos);
 }
 
+TEST_F(ClientMetricsTest, MetricsIncludeVersionInfo) {
+    ClientMetric metrics;
+
+    std::string serialized;
+    metrics.serialize(serialized);
+    EXPECT_NE(serialized.find("mooncake_client_version_info{version=\"" +
+                              std::string(MOONCAKE_DISPLAY_VERSION) + "\"} 1"),
+              std::string::npos);
+
+    std::string summary = metrics.summary_metrics();
+    EXPECT_NE(summary.find(std::string("Version: ") + MOONCAKE_DISPLAY_VERSION),
+              std::string::npos);
+}
+
 TEST_F(ClientMetricsTest, HybridHistogramSerializesEachLabelOnce) {
     ylt::metric::hybrid_histogram_1t histogram(
         "request_latency", "Request latency", {10.0, 20.0}, {}, {"route"});
@@ -437,11 +452,28 @@ TEST_F(ClientMetricsTest, HttpMetricsEndpointsReturnData) {
         FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/metrics");
     EXPECT_EQ(metrics.status, 200);
     EXPECT_EQ(metrics.body.find("metrics not available"), std::string::npos);
+    // The client attaches extra static labels (e.g. client_mode), so only
+    // check for the metric name and the version label.
+    EXPECT_NE(metrics.body.find("mooncake_client_version_info{"),
+              std::string::npos);
+    EXPECT_NE(metrics.body.find("version=\"" +
+                                std::string(MOONCAKE_DISPLAY_VERSION) + "\""),
+              std::string::npos);
 
     auto summary = FetchUrl("http://127.0.0.1:" + std::to_string(http_port) +
                             "/metrics/summary");
     EXPECT_EQ(summary.status, 200);
     EXPECT_NE(summary.body.find("Client Metrics Summary"), std::string::npos);
+    EXPECT_NE(
+        summary.body.find(std::string("Version: ") + MOONCAKE_DISPLAY_VERSION),
+        std::string::npos);
+
+    auto version =
+        FetchUrl("http://127.0.0.1:" + std::to_string(http_port) + "/version");
+    EXPECT_EQ(version.status, 200);
+    EXPECT_NE(version.body.find("{\"version\":\"" +
+                                std::string(MOONCAKE_DISPLAY_VERSION) + "\"}"),
+              std::string::npos);
 
     EXPECT_EQ(client->tearDownAll(), 0);
 }


### PR DESCRIPTION
## Description

`mooncake_master` already supports `--version` via `gflags::SetVersionString(mooncake::MOONCAKE_DISPLAY_VERSION)` (`mooncake-store/src/master.cpp`). This PR mirrors that in the `real_client` binary and exposes the version through the client HTTP service and metrics, as requested for deployments:

- `mooncake_client --version` prints the display version (pyproject version + short git hash from the generated `version.h`).
- `GET /version` on the client HTTP server returns `{"version":"..."}`.
- `GET /metrics` includes `mooncake_client_version_info{version="..."} 1`, following the Prometheus info-metric convention. Instance labels (e.g. `client_mode`, `cluster_id`) are preserved alongside the `version` label.
- `GET /metrics/summary` includes a `Version:` line.

Scope note: the issue targets `real_client` and its HTTP service. The master admin HTTP server and master metrics are left unchanged; master keeps its existing `--version` support. Happy to add the same `/version` endpoint and info metric to the master in a follow-up if desired.

Docs: updated the three places that list the client HTTP endpoints and the endpoint table in the deployment guide.

Closes #3617

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Built with `-DBUILD_UNIT_TESTS=ON -DUSE_HTTP=ON` (gcc 11, Ubuntu 22.04 aarch64).

**Test commands:**
```bash
./mooncake_client --version
# mooncake_client version 0.3.13 (git: b46235d)

# with a local master running and
# ./mooncake_client ... --enable_http_server=true --http_port 19300
curl http://127.0.0.1:19300/version
# {"version":"0.3.13 (git: b46235d)"}

curl http://127.0.0.1:19300/metrics | grep -B1 mooncake_client_version_info
# # HELP mooncake_client_version_info Mooncake store client version information
# # TYPE mooncake_client_version_info gauge
# mooncake_client_version_info{client_mode="real",version="0.3.13 (git: b46235d)"} 1

curl http://127.0.0.1:19300/metrics/summary | head -2
# Client Metrics Summary
# Version: 0.3.13 (git: b46235d)

./client_metrics_test
# [  PASSED  ] 17 tests.
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`client_metrics_test` (17 tests, includes a new `MetricsIncludeVersionInfo` test and new assertions in `HttpMetricsEndpointsReturnData` for `/version` and the version metric) passes. Manual run of `mooncake_master` + `mooncake_client` with the HTTP server enabled verified all three endpoints as shown above.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Drafted with Claude Code (implementation, tests, and verification runs). The human submitter reviewed every changed line and takes responsibility for the change.