### PR TITLE
[TransferEngine] Log batchTransferSync failure paths

### DIFF
--- a/mooncake-integration/transfer_engine/transfer_engine_py.cpp
+++ b/mooncake-integration/transfer_engine/transfer_engine_py.cpp
@@ -584,7 +584,11 @@ int TransferEnginePy::batchTransferSync(
             handle = handle_map_[target_hostname];
         } else {
             handle = engine_->openSegment(target_hostname);
-            if (handle == (Transport::SegmentHandle)-1) return -1;
+            if (handle == (Transport::SegmentHandle)-1) {
+                LOG(ERROR) << "batchTransferSync: openSegment failed for "
+                           << target_hostname;
+                return -1;
+            }
             handle_map_[target_hostname] = handle;
         }
     }
@@ -626,6 +630,10 @@ int TransferEnginePy::batchTransferSync(
                       TransferMetadata::NotifyDesc{notify->name, notify->msg})
                 : engine_->submitTransfer(batch_id, entries);
         if (!s.ok()) {
+            LOG(ERROR) << "batchTransferSync: submitTransfer failed for "
+                       << target_hostname << " (batch of " << batch_size
+                       << " requests, " << total_length
+                       << " bytes): " << s.ToString();
             engine_->freeBatchID(batch_id);
             Status segment_status = engine_->CheckSegmentStatus(handle);
             if (!segment_status.ok()) {
@@ -650,6 +658,10 @@ int TransferEnginePy::batchTransferSync(
                 engine_->freeBatchID(batch_id);
                 return 0;
             } else if (status.s == TransferStatusEnum::FAILED) {
+                LOG(ERROR) << "batchTransferSync: transfer FAILED for "
+                           << target_hostname << " (batch of " << batch_size
+                           << " requests, " << total_length
+                           << " bytes) on retry " << retry << "/" << max_retry;
                 engine_->freeBatchID(batch_id);
                 already_freed = true;
                 completed = true;
@@ -673,6 +685,9 @@ int TransferEnginePy::batchTransferSync(
             }
         }
     }
+    LOG(ERROR) << "batchTransferSync: all " << max_retry
+               << " retries exhausted for " << target_hostname << " (batch of "
+               << batch_size << " requests, " << total_length << " bytes)";
     return -1;
 }
 


### PR DESCRIPTION
## Description

`batchTransferSync()` returned `-1` silently from three failure paths and logged nothing when a transfer ended `FAILED`:

1. `openSegment()` failure for the target host
2. `submitTransfer()` failure (with only a follow-up `CheckSegmentStatus` warning, nothing about the submit itself)
3. All `max_retry` attempts exhausted
4. (also) a transfer polling out as `FAILED` — silently retried with no log

A failed KV transfer therefore surfaced to callers (e.g. sglang PD
disaggregation) as an opaque `-1` with nothing in the engine log. We hit
this while debugging the TENT NVLink transport recently: the transfer
failure that took down same-machine PD transfers produced **zero**
diagnostics at this layer, which made the failure look like a mystery.
Each path now logs with target host, batch size, total length and retry
context.

No behavior change — log lines only.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [x] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [x] Other (observability)

## How Has This Been Tested?

**Test commands:**
```bash
# full build of the branch
cmake --build build-tent -j8

# TENT test suite on the integrated branch this change was split from
# (this commit is a pure log-lines delta of that branch)
cd build-tent/mooncake-transfer-engine/tent/tests && ctest -j8
```

**Test results:**
- [x] Unit tests pass (full TENT suite 44/44 on the integrated branch; this PR adds no logic)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: exercised in a same-machine PD disaggregation
  debugging session (sglang prefill/decode + TENT engine); the log lines
  compile and link into the deployed `engine.so` used in GPU e2e runs.
  The specific failure paths fire only under transfer failure, which the
  accompanying transport fixes eliminate — so they are expected to be
  silent in healthy runs, and to carry the context above when they do fire.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — N/A, no doc surface
- [ ] I have added tests to prove my changes are effective — deliberately
      not adding tests: the change adds log lines to pybind failure paths
      with no behavioral delta; unit-testing them would require mocking the
      whole engine binding for zero coverage value
- [ ] For changes >500 LOC: I have filed an RFC issue — N/A, 16 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (Claude) assisted with the change and this PR description; the
analysis of the silent-failure paths came out of a same-machine PD
disaggregation debugging session. The human submitter has reviewed every
changed line and can defend the change end-to-end.