### PR TITLE
[TENT] Cache metrics label cells to remove hot-path lock contention

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metrics/cached_metric.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/cached_metric.h
@@ -1,0 +1,197 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "ylt/metric.hpp"
+
+namespace mooncake {
+namespace tent {
+namespace metrics {
+
+// Movable acquire/release cell-pointer slot. std::atomic is not movable, so
+// it cannot live in a resizeable vector; moves only happen while the vector
+// is being built (before any recording).
+class CellSlot {
+   public:
+    CellSlot() = default;
+    CellSlot(const CellSlot&) = delete;
+    CellSlot& operator=(const CellSlot&) = delete;
+    CellSlot(CellSlot&& other) noexcept
+        : cell_(other.cell_.load(std::memory_order_relaxed)) {}
+    CellSlot& operator=(CellSlot&& other) noexcept {
+        cell_.store(other.cell_.load(std::memory_order_relaxed),
+                    std::memory_order_relaxed);
+        return *this;
+    }
+
+    std::atomic<int64_t>* load() const {
+        return cell_.load(std::memory_order_acquire);
+    }
+    void store(std::atomic<int64_t>* c) {
+        cell_.store(c, std::memory_order_release);
+    }
+
+   private:
+    std::atomic<std::atomic<int64_t>*> cell_{nullptr};
+};
+
+// Metrics primitives with pre-resolved label cells. ylt's dynamic counter
+// inc() / histogram observe() take a mutex-protected map lookup per call, and
+// because TENT labels come from small fixed enums, all updates for a label
+// land on the same shard mutex. These primitives resolve the atomic cell
+// backing a label once and cache it in a per-label-index slot, reducing the
+// steady-state update to relaxed atomic adds.
+//
+// Labels are never erased by TentMetrics, so resolved cells stay valid for
+// the process lifetime. Slot publication uses release/acquire, so
+// concurrent first-use resolutions are race free.
+
+template <uint8_t N>
+class CachedDynamicCounter
+    : public ylt::metric::basic_dynamic_counter<int64_t, N> {
+   public:
+    using Base = ylt::metric::basic_dynamic_counter<int64_t, N>;
+    using Label = std::array<std::string, N>;
+
+    // label_domain_size: number of distinct label values ever recorded; the
+    // caller maps each label to a stable index < this size.
+    CachedDynamicCounter(std::string name, std::string help,
+                         std::array<std::string, N> labels_name,
+                         size_t label_domain_size)
+        : Base(std::move(name), std::move(help), std::move(labels_name)),
+          slots_(label_domain_size) {}
+
+    // Resolve (creating on first use) the atomic cell backing a label.
+    std::atomic<int64_t>* resolve(const Label& label) {
+        auto cell = Base::try_emplace(label).first;
+        return &cell->value;
+    }
+
+    // Increment via the cached cell; make_label runs only on first use.
+    template <typename LabelFn>
+    void incCached(size_t label_index, LabelFn&& make_label,
+                   int64_t value = 1) {
+        std::atomic<int64_t>* cell = slots_[label_index].load();
+        if (cell == nullptr) [[unlikely]] {
+            cell = resolve(make_label());
+            slots_[label_index].store(cell);
+        }
+        cell->fetch_add(value, std::memory_order_relaxed);
+    }
+
+   private:
+    std::vector<CellSlot> slots_;
+};
+
+// Histogram composed of CachedDynamicCounter buckets and a sum counter.
+// Same bucketing semantics as ylt's basic_dynamic_histogram (inclusive upper
+// bounds, trailing +Inf bucket), but observe goes through cached cells.
+template <uint8_t N>
+class CachedDynamicHistogram {
+   public:
+    using Label = std::array<std::string, N>;
+    using Counter = CachedDynamicCounter<N>;
+
+    CachedDynamicHistogram(const std::string& name, const std::string& help,
+                           const std::vector<double>& boundaries,
+                           const std::array<std::string, N>& labels_name,
+                           size_t label_domain_size)
+        : name_(name),
+          help_(help),
+          labels_name_(labels_name),
+          boundaries_(boundaries),
+          sum_(std::make_unique<Counter>(name + "_sum", help, labels_name,
+                                         label_domain_size)) {
+        for (size_t i = 0; i < boundaries_.size() + 1; ++i) {
+            buckets_.push_back(std::make_unique<Counter>(
+                name, help, labels_name, label_domain_size));
+        }
+        bucket_slots_.resize(label_domain_size * buckets_.size());
+        sum_slots_.resize(label_domain_size);
+    }
+
+    // Observation via cached bucket and sum cells.
+    template <typename LabelFn>
+    void observeCached(size_t label_index, LabelFn&& make_label,
+                       int64_t value) {
+        const size_t bucket = bucketIndex(value);
+        const size_t slot = label_index * buckets_.size() + bucket;
+        std::atomic<int64_t>* cell = bucket_slots_[slot].load();
+        if (cell == nullptr) [[unlikely]] {
+            cell = buckets_[bucket]->resolve(make_label());
+            bucket_slots_[slot].store(cell);
+        }
+        cell->fetch_add(1, std::memory_order_relaxed);
+
+        std::atomic<int64_t>* sum_cell = sum_slots_[label_index].load();
+        if (sum_cell == nullptr) [[unlikely]] {
+            sum_cell = sum_->resolve(make_label());
+            sum_slots_[label_index].store(sum_cell);
+        }
+        sum_cell->fetch_add(value, std::memory_order_relaxed);
+    }
+
+    // Scrape-time accessors, typed as the ylt base for copy()/value().
+    std::vector<ylt::metric::basic_dynamic_counter<int64_t, N>*>
+    bucketCounters() const {
+        std::vector<ylt::metric::basic_dynamic_counter<int64_t, N>*> counters;
+        counters.reserve(buckets_.size());
+        for (auto& bucket : buckets_) {
+            counters.push_back(bucket.get());
+        }
+        return counters;
+    }
+
+    ylt::metric::basic_dynamic_counter<int64_t, N>* sumCounter() {
+        return sum_.get();
+    }
+
+    const std::string& name() const { return name_; }
+    const std::string& help() const { return help_; }
+    const std::array<std::string, N>& labelsName() const {
+        return labels_name_;
+    }
+    const std::vector<double>& boundaries() const { return boundaries_; }
+
+   private:
+    // Index of the first boundary >= value (ylt bucketing); values above the
+    // last boundary land in the trailing +Inf bucket.
+    size_t bucketIndex(int64_t value) const {
+        return static_cast<size_t>(std::distance(
+            boundaries_.begin(),
+            std::lower_bound(boundaries_.begin(), boundaries_.end(), value)));
+    }
+
+    std::string name_;
+    std::string help_;
+    std::array<std::string, N> labels_name_;
+    std::vector<double> boundaries_;
+    std::vector<std::unique_ptr<Counter>> buckets_;
+    std::unique_ptr<Counter> sum_;
+    std::vector<CellSlot> bucket_slots_;
+    std::vector<CellSlot> sum_slots_;
+};
+
+}  // namespace metrics
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -25,6 +25,7 @@
 
 #include "tent/common/status.h"
 #include "tent/common/types.h"
+#include "tent/metrics/cached_metric.h"
 #include "tent/metrics/config_loader.h"
 
 // Compile-time metrics enable/disable switch
@@ -56,6 +57,11 @@ constexpr size_t kPrometheusBufferSize = 4096;
  * - Optional periodic logging of metrics summary
  * - Compile-time disable option (TENT_METRICS_ENABLED=0) for zero overhead
  * - Runtime disable option via setEnabled(false) for minimal overhead
+ *
+ * Hot-path counters and histograms record through pre-resolved label cells
+ * (see cached_metric.h): TransportType and Request::OpCode label domains are
+ * small fixed enums, so each label's atomic cell is resolved once and cached,
+ * turning the steady-state update into relaxed atomic adds with no locks.
  */
 class TentMetrics {
    public:
@@ -194,42 +200,58 @@ class TentMetrics {
     static inline const std::array<std::string, 2> kAttemptLabels{"transport",
                                                                   "operation"};
 
+    // Hot-path metrics record through pre-resolved label cells (see
+    // cached_metric.h). Label domain sizes: TransportType has
+    // kNumTransportTypes values; attempt metrics are additionally labeled by
+    // the 2-valued Request::OpCode.
+    static constexpr size_t kTransportDomain =
+        static_cast<size_t>(kNumTransportTypes);
+    static constexpr size_t kAttemptDomain = kTransportDomain * 2;
+
+    // Stable slot indices into the cached-cell label domain.
+    static size_t transportSlot(TransportType tp) {
+        return static_cast<size_t>(tp);
+    }
+    static size_t attemptSlot(TransportType tp, Request::OpCode op) {
+        return static_cast<size_t>(tp) * 2 + (op == Request::READ ? 0u : 1u);
+    }
+
     // Per-transport counters (label: transport). Values are int64_t.
-    ylt::metric::basic_dynamic_counter<int64_t, 1> read_bytes_total_{
-        "tent_read_bytes_total", "Total bytes read via TENT", kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> write_bytes_total_{
+    metrics::CachedDynamicCounter<1> read_bytes_total_{
+        "tent_read_bytes_total", "Total bytes read via TENT", kTransportLabel,
+        kTransportDomain};
+    metrics::CachedDynamicCounter<1> write_bytes_total_{
         "tent_write_bytes_total", "Total bytes written via TENT",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> read_requests_total_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> read_requests_total_{
         "tent_read_requests_total", "Total read requests via TENT",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> write_requests_total_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> write_requests_total_{
         "tent_write_requests_total", "Total write requests via TENT",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> read_failures_total_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> read_failures_total_{
         "tent_read_failures_total", "Total read failures via TENT",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> write_failures_total_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> write_failures_total_{
         "tent_write_failures_total", "Total write failures via TENT",
-        kTransportLabel};
-    // Failover counter has two labels (from, to) so failover flows are
-    // queryable as e.g. tent_transport_failover_total{from="rdma",to="tcp"}.
+        kTransportLabel, kTransportDomain};
+    // Failover is a rare event and its label domain is the cross product of
+    // transports, so it stays on the plain locked path.
     ylt::metric::basic_dynamic_counter<int64_t, 2> failover_total_{
         "tent_transport_failover_total",
         "Total cross-transport failover events", kFailoverLabels};
-    ylt::metric::basic_dynamic_counter<int64_t, 2> transport_attempts_total_{
+    metrics::CachedDynamicCounter<2> transport_attempts_total_{
         "tent_transport_attempts_total",
         "Total physical transport attempts submitted for execution",
-        kAttemptLabels};
-    ylt::metric::basic_dynamic_counter<int64_t, 2>
-        transport_attempt_failures_total_{
-            "tent_transport_attempt_failures_total",
-            "Physical transport attempts that terminated with FAILED",
-            kAttemptLabels};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> deadline_infeasible_total_{
+        kAttemptLabels, kAttemptDomain};
+    metrics::CachedDynamicCounter<2> transport_attempt_failures_total_{
+        "tent_transport_attempt_failures_total",
+        "Physical transport attempts that terminated with FAILED",
+        kAttemptLabels, kAttemptDomain};
+    metrics::CachedDynamicCounter<1> deadline_infeasible_total_{
         "tent_deadline_infeasible_total",
         "Transfers whose deadline was already in the past at submit",
-        kTransportLabel};
+        kTransportLabel, kTransportDomain};
     // Label-less: quarantine is a batch-lifecycle event, not a per-transport
     // one (a batch may hold SubBatches on several transports).
     ylt::metric::counter_t quarantined_batches_total_{
@@ -237,124 +259,73 @@ class TentMetrics {
         "Batches abandoned by lazyFreeBatch after repeated failed reclaim "
         "attempts; reclaimed only at engine teardown"};
 
-    // Histograms - paired with their bucket boundaries in a single vector so
-    // the two cannot drift out of sync (ylt histogram doesn't expose its
-    // boundaries publicly, so we hold them alongside the pointer).
-    // Each entry also carries a parallel counter used to track the per-label
-    // sum, because ylt's basic_dynamic_histogram keeps sum_ private with no
-    // public accessor — without this counter, _sum could only be emitted as 0
-    // in the Prometheus endpoint, breaking _sum / _count queries.
-    // Only N=1 (per-transport) histograms live here; the N=2
-    // transport_attempt_latency_ histogram is serialized separately (see
-    // getPrometheusMetrics / getJsonMetrics) via the same templated helpers.
-    struct HistogramEntry {
-        ylt::metric::basic_dynamic_histogram<int64_t, 1>* h;
-        const std::vector<double>* boundaries;
-        ylt::metric::basic_dynamic_counter<int64_t, 1>* sum;
-    };
-    std::vector<HistogramEntry> histograms_;
-
     // Latency histograms use microseconds (us) as unit
     // Default buckets: 100us, 500us, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s
     static inline const std::vector<double> kLatencyBuckets{
         100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> read_latency_{
-        "tent_read_latency_us", "Read latency distribution in microseconds",
-        kLatencyBuckets, kTransportLabel};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> write_latency_{
-        "tent_write_latency_us", "Write latency distribution in microseconds",
-        kLatencyBuckets, kTransportLabel};
     // Size histograms for request size distribution (in bytes)
     // Default buckets: 1KB, 4KB, 16KB, 64KB, 256KB, 1MB, 4MB, 16MB, 64MB,
     // 256MB, 1GB
     static inline const std::vector<double> kSizeBuckets{
         1024,    4096,     16384,    65536,     262144,    1048576,
         4194304, 16777216, 67108864, 268435456, 1073741824};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> read_size_{
-        "tent_read_size_bytes", "Read request size distribution in bytes",
-        kSizeBuckets, kTransportLabel};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> write_size_{
-        "tent_write_size_bytes", "Write request size distribution in bytes",
-        kSizeBuckets, kTransportLabel};
-
     // Deadline feasibility ratio (MLU) distribution for transfers that carried
     // a deadline. Stored in per-mille (MLU x 1000) so the histogram can use
     // integer observe() like the others; the 1000 boundary is MLU == 1.0, the
     // feasible/infeasible line (< 1000 met the deadline, >= 1000 missed it).
     static inline const std::vector<double> kMluPerMilleBuckets{
         100, 250, 500, 750, 900, 1000, 1250, 1500, 2000, 5000};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> deadline_mlu_{
-        "tent_deadline_mlu_permille",
-        "Deadline feasibility ratio (MLU x 1000) distribution",
-        kMluPerMilleBuckets, kTransportLabel};
-
     // Causal chain stage latency histograms (microseconds)
     // Buckets span 10us to 500ms to capture both fast RDMA and slower TCP.
     static inline const std::vector<double> kStageBuckets{
         10, 50, 100, 500, 1000, 5000, 10000, 50000, 100000, 500000};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_queue_wait_{
+
+    // Histograms are composed of cached-cell counters: one counter per bucket
+    // plus a sum counter. The sum is part of the histogram itself, so no
+    // parallel standalone sum counter is needed.
+    metrics::CachedDynamicHistogram<1> read_latency_{
+        "tent_read_latency_us", "Read latency distribution in microseconds",
+        kLatencyBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> write_latency_{
+        "tent_write_latency_us", "Write latency distribution in microseconds",
+        kLatencyBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> read_size_{
+        "tent_read_size_bytes", "Read request size distribution in bytes",
+        kSizeBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> write_size_{
+        "tent_write_size_bytes", "Write request size distribution in bytes",
+        kSizeBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> deadline_mlu_{
+        "tent_deadline_mlu_permille",
+        "Deadline feasibility ratio (MLU x 1000) distribution",
+        kMluPerMilleBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> stage_queue_wait_{
         "tent_stage_queue_wait_us",
         "Causal chain: queue wait latency in microseconds", kStageBuckets,
-        kTransportLabel};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_dispatch_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> stage_dispatch_{
         "tent_stage_dispatch_us",
         "Causal chain: dispatch latency in microseconds", kStageBuckets,
-        kTransportLabel};
-    ylt::metric::basic_dynamic_histogram<int64_t, 1> stage_transport_{
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<1> stage_transport_{
         "tent_stage_transport_us",
         "Causal chain: transport execution latency in microseconds",
-        kStageBuckets, kTransportLabel};
-    ylt::metric::basic_dynamic_histogram<int64_t, 2> transport_attempt_latency_{
+        kStageBuckets, kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicHistogram<2> transport_attempt_latency_{
         "tent_transport_attempt_latency_us",
         "Observed physical transport attempt latency in microseconds",
-        kLatencyBuckets, kAttemptLabels};
+        kLatencyBuckets, kAttemptLabels, kAttemptDomain};
 
-    // Parallel counters tracking per-label sum for each histogram. ylt's
-    // basic_dynamic_histogram keeps sum_ private with no public accessor, so
-    // we maintain these alongside observe() calls and read them back via
-    // copy() in the Prometheus serializer. Each counter's str_name is the
-    // histogram name suffixed with "_sum" so it emits as <name>_sum{...} in
-    // Prometheus output.
-    ylt::metric::basic_dynamic_counter<int64_t, 1> read_latency_sum_{
-        "tent_read_latency_us_sum",
-        "Sum of read latency observations (microseconds)", kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> write_latency_sum_{
-        "tent_write_latency_us_sum",
-        "Sum of write latency observations (microseconds)", kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> read_size_sum_{
-        "tent_read_size_bytes_sum", "Sum of read request sizes (bytes)",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> write_size_sum_{
-        "tent_write_size_bytes_sum", "Sum of write request sizes (bytes)",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> deadline_mlu_sum_{
-        "tent_deadline_mlu_permille_sum",
-        "Sum of deadline MLU (permille) observations", kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> stage_queue_wait_sum_{
-        "tent_stage_queue_wait_us_sum",
-        "Sum of queue wait latency observations (microseconds)",
-        kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> stage_dispatch_sum_{
-        "tent_stage_dispatch_us_sum",
-        "Sum of dispatch latency observations (microseconds)", kTransportLabel};
-    ylt::metric::basic_dynamic_counter<int64_t, 1> stage_transport_sum_{
-        "tent_stage_transport_us_sum",
-        "Sum of transport execution latency observations (microseconds)",
-        kTransportLabel};
-    // Parallel sum counter for the N=2 transport-attempt latency histogram
-    // (labels: transport, operation). Same rationale as the N=1 sum counters
-    // above — ylt keeps the histogram's sum_ private.
-    ylt::metric::basic_dynamic_counter<int64_t, 2>
-        transport_attempt_latency_sum_{"tent_transport_attempt_latency_us_sum",
-                                       "Sum of physical transport attempt "
-                                       "latency observations (microseconds)",
-                                       kAttemptLabels};
+    // Per-transport (N=1) histograms for unified serialization; the N=2
+    // transport_attempt_latency_ histogram is serialized separately (see
+    // getPrometheusMetrics / getJsonMetrics) via the same templated helpers.
+    std::vector<metrics::CachedDynamicHistogram<1>*> histograms_;
 
     // Helper to register all metrics to the vectors
     void registerMetrics();
 
-    // Serialize a single histogram in Prometheus text format. Walks the
-    // same get_bucket_counts() / copy() data the JSON path uses, so the two
+    // Serialize a single histogram in Prometheus text format. Walks the same
+    // bucket-counter / sum-counter data the JSON path uses, so the two
     // endpoints can never drift. Unlike ylt's serialize(), this never
     // silently drops a histogram that has observed >=1 sample — even when
     // every observation landed in the first bucket (which makes sum_==0
@@ -362,17 +333,11 @@ class TentMetrics {
     // # HELP / # TYPE header with it). Reachable in production when
     // sub-microsecond latencies truncate to 0 under int64_t observation.
     //
-    // `boundaries` is the compile-time bucket boundary vector paired with
-    // the histogram in HistogramEntry. The caller (getPrometheusMetrics)
-    // emits the # HELP / # TYPE header so the format stays identical to ylt.
     // Templated over label arity N so both the per-transport (N=1) histograms
     // and the transport-attempt (N=2) histogram share one implementation.
     template <uint8_t N>
-    void serializeHistogramPrometheus(
-        ylt::metric::basic_dynamic_histogram<int64_t, N>* hist,
-        const std::vector<double>& boundaries,
-        ylt::metric::basic_dynamic_counter<int64_t, N>& sum,
-        std::string& out) const;
+    void serializeHistogramPrometheus(metrics::CachedDynamicHistogram<N>& hist,
+                                      std::string& out) const;
 #endif  // TENT_METRICS_ENABLED
 };
 

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -209,7 +209,8 @@ void TentMetrics::registerMetrics() {
     // Register all counters as base metric_t* pointers so that counters with
     // different label arities (N=1 per-transport, N=2 failover from→to and
     // transport-attempt operation labels) share one vector for Prometheus
-    // serialize().
+    // serialize(). CachedDynamicCounter is-a basic_dynamic_counter, so its
+    // ylt serialize() output is unchanged.
     counters_ = {
         &read_bytes_total_,
         &write_bytes_total_,
@@ -224,22 +225,13 @@ void TentMetrics::registerMetrics() {
         &quarantined_batches_total_,
     };
 
-    // Register the N=1 per-transport histograms with their bucket boundaries
-    // and parallel sum counters. Each entry keeps the histogram, its
-    // compile-time boundaries, and its sum counter in sync so both the
-    // Prometheus and JSON serializers cannot mislabel buckets or drop _sum.
+    // Register the N=1 per-transport histograms for unified serialization.
     // The N=2 transport_attempt_latency_ histogram is serialized separately
     // (it can't share this N=1-typed vector); see getPrometheusMetrics /
     // getJsonMetrics.
     histograms_ = {
-        {&read_latency_, &kLatencyBuckets, &read_latency_sum_},
-        {&write_latency_, &kLatencyBuckets, &write_latency_sum_},
-        {&read_size_, &kSizeBuckets, &read_size_sum_},
-        {&write_size_, &kSizeBuckets, &write_size_sum_},
-        {&deadline_mlu_, &kMluPerMilleBuckets, &deadline_mlu_sum_},
-        {&stage_queue_wait_, &kStageBuckets, &stage_queue_wait_sum_},
-        {&stage_dispatch_, &kStageBuckets, &stage_dispatch_sum_},
-        {&stage_transport_, &kStageBuckets, &stage_transport_sum_},
+        &read_latency_, &write_latency_,    &read_size_,      &write_size_,
+        &deadline_mlu_, &stage_queue_wait_, &stage_dispatch_, &stage_transport_,
     };
 }
 
@@ -248,16 +240,19 @@ void TentMetrics::recordReadCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
-    read_bytes_total_.inc(label, static_cast<int64_t>(bytes));
-    read_requests_total_.inc(label);
+    const size_t slot = transportSlot(tp);
+    // The label is only constructed on the first use of this slot (cache
+    // miss); the steady state is a relaxed atomic add.
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
     auto bytes_val = static_cast<int64_t>(bytes);
-    read_size_.observe(label, bytes_val);
-    read_size_sum_.inc(label, bytes_val);
+    read_bytes_total_.incCached(slot, label, bytes_val);
+    read_requests_total_.incCached(slot, label);
+    read_size_.observeCached(slot, label, bytes_val);
     if (latency_seconds > 0.0) {
         int64_t latency_us = static_cast<int64_t>(latency_seconds * 1000000.0);
-        read_latency_.observe(label, latency_us);
-        read_latency_sum_.inc(label, latency_us);
+        read_latency_.observeCached(slot, label, latency_us);
     }
 }
 
@@ -266,16 +261,17 @@ void TentMetrics::recordWriteCompleted(TransportType tp, size_t bytes,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
 
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
-    write_bytes_total_.inc(label, static_cast<int64_t>(bytes));
-    write_requests_total_.inc(label);
+    const size_t slot = transportSlot(tp);
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
     auto bytes_val = static_cast<int64_t>(bytes);
-    write_size_.observe(label, bytes_val);
-    write_size_sum_.inc(label, bytes_val);
+    write_bytes_total_.incCached(slot, label, bytes_val);
+    write_requests_total_.incCached(slot, label);
+    write_size_.observeCached(slot, label, bytes_val);
     if (latency_seconds > 0.0) {
         int64_t latency_us = static_cast<int64_t>(latency_seconds * 1000000.0);
-        write_latency_.observe(label, latency_us);
-        write_latency_sum_.inc(label, latency_us);
+        write_latency_.observeCached(slot, label, latency_us);
     }
 }
 
@@ -283,17 +279,20 @@ void TentMetrics::recordDeadlineMLU(TransportType tp, double mlu) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (mlu < 0.0) return;
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
+    const size_t slot = transportSlot(tp);
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
     auto mlu_permille = static_cast<int64_t>(mlu * 1000.0);
-    deadline_mlu_.observe(label, mlu_permille);
-    deadline_mlu_sum_.inc(label, mlu_permille);
+    deadline_mlu_.observeCached(slot, label, mlu_permille);
 }
 
 void TentMetrics::recordDeadlineInfeasible(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    deadline_infeasible_total_.inc(
-        std::array<std::string, 1>{transportTypeName(tp)});
+    deadline_infeasible_total_.incCached(transportSlot(tp), [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    });
 }
 
 void TentMetrics::recordBatchQuarantined() {
@@ -307,20 +306,20 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     if (latency_us < 0.0) return;
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
+    const size_t slot = transportSlot(tp);
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
     int64_t val = static_cast<int64_t>(latency_us);
     switch (stage) {
         case Stage::QueueWait:
-            stage_queue_wait_.observe(label, val);
-            stage_queue_wait_sum_.inc(label, val);
+            stage_queue_wait_.observeCached(slot, label, val);
             break;
         case Stage::Dispatch:
-            stage_dispatch_.observe(label, val);
-            stage_dispatch_sum_.inc(label, val);
+            stage_dispatch_.observeCached(slot, label, val);
             break;
         case Stage::Transport:
-            stage_transport_.observe(label, val);
-            stage_transport_sum_.inc(label, val);
+            stage_transport_.observeCached(slot, label, val);
             break;
     }
 }
@@ -328,23 +327,31 @@ void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
 void TentMetrics::recordReadFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
-    read_failures_total_.inc(label);
-    read_requests_total_.inc(label);
+    const size_t slot = transportSlot(tp);
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
+    read_failures_total_.incCached(slot, label);
+    read_requests_total_.incCached(slot, label);
 }
 
 void TentMetrics::recordWriteFailed(TransportType tp) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 1>{transportTypeName(tp)};
-    write_failures_total_.inc(label);
-    write_requests_total_.inc(label);
+    const size_t slot = transportSlot(tp);
+    auto label = [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    };
+    write_failures_total_.incCached(slot, label);
+    write_requests_total_.incCached(slot, label);
 }
 
 void TentMetrics::recordTransportFailover(TransportType from,
                                           TransportType to) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
+    // Rare event on a large (transport × transport) label domain: plain
+    // locked path, no cached cells.
     failover_total_.inc(std::array<std::string, 2>{transportTypeName(from),
                                                    transportTypeName(to)});
 }
@@ -353,8 +360,11 @@ void TentMetrics::recordTransportAttemptStarted(TransportType tp,
                                                 Request::OpCode operation) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    transport_attempts_total_.inc(std::array<std::string, 2>{
-        transportTypeName(tp), operationName(operation)});
+    const size_t slot = attemptSlot(tp, operation);
+    transport_attempts_total_.incCached(slot, [tp, operation] {
+        return std::array<std::string, 2>{transportTypeName(tp),
+                                          operationName(operation)};
+    });
 }
 
 void TentMetrics::recordTransportAttemptFinished(TransportType tp,
@@ -363,15 +373,17 @@ void TentMetrics::recordTransportAttemptFinished(TransportType tp,
                                                  double latency_us) {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
-    auto label = std::array<std::string, 2>{transportTypeName(tp),
-                                            operationName(operation)};
+    const size_t slot = attemptSlot(tp, operation);
+    auto label = [tp, operation] {
+        return std::array<std::string, 2>{transportTypeName(tp),
+                                          operationName(operation)};
+    };
     if (status == FAILED) {
-        transport_attempt_failures_total_.inc(label);
+        transport_attempt_failures_total_.incCached(slot, label);
     }
     if (latency_us >= 0.0) {
         auto latency_val = static_cast<int64_t>(latency_us);
-        transport_attempt_latency_.observe(label, latency_val);
-        transport_attempt_latency_sum_.inc(label, latency_val);
+        transport_attempt_latency_.observeCached(slot, label, latency_val);
     }
 }
 
@@ -400,15 +412,12 @@ std::string TentMetrics::getPrometheusMetrics() {
         // walks get_bucket_counts() directly and is unaffected, which is why
         // /metrics/json reported count=4846 while /metrics omitted the metric
         // entirely. Using the same bucket-walk here closes that drift.
-        for (const auto& entry : histograms_) {
-            serializeHistogramPrometheus(entry.h, *entry.boundaries, *entry.sum,
-                                         result);
+        for (const auto& hist : histograms_) {
+            serializeHistogramPrometheus(*hist, result);
         }
         // N=2 transport-attempt latency histogram (labels: transport,
         // operation) goes through the same helper, instantiated for N=2.
-        serializeHistogramPrometheus(&transport_attempt_latency_,
-                                     kLatencyBuckets,
-                                     transport_attempt_latency_sum_, result);
+        serializeHistogramPrometheus(transport_attempt_latency_, result);
 
         return result;
     } catch (const std::exception& e) {
@@ -430,44 +439,39 @@ int64_t sumCounterValues(CounterPtr counter) {
 }
 
 template <uint8_t N>
-void serializeHistogramToJson(
-    nlohmann::json& root,
-    ylt::metric::basic_dynamic_histogram<int64_t, N>* hist,
-    const std::vector<double>& boundaries,
-    ylt::metric::basic_dynamic_counter<int64_t, N>* sum) {
-    auto bucket_counts = hist->get_bucket_counts();
+void serializeHistogramToJson(nlohmann::json& root,
+                              metrics::CachedDynamicHistogram<N>& hist) {
+    auto bucket_counters = hist.bucketCounters();
+    const auto& boundaries = hist.boundaries();
     int64_t total_count = 0;
     int64_t total_sum = 0;
     nlohmann::json buckets_obj;
-    for (size_t i = 0; i < bucket_counts.size(); ++i) {
-        int64_t bucket_total = sumCounterValues(bucket_counts[i]);
+    for (size_t i = 0; i < bucket_counters.size(); ++i) {
+        int64_t bucket_total = sumCounterValues(bucket_counters[i]);
         total_count += bucket_total;
         if (i < boundaries.size()) {
             buckets_obj[std::to_string(static_cast<int64_t>(boundaries[i]))] =
                 bucket_total;
         }
     }
-    // ylt keeps the histogram's sum_ private, so read the parallel sum counter
-    // maintained alongside each observe() call (matches the Prometheus path).
-    for (auto& e : sum->copy()) {
+    // The sum counter is maintained by the histogram itself (one add per
+    // observe), matching the Prometheus path.
+    for (auto& e : hist.sumCounter()->copy()) {
         total_sum += e->value.load();
     }
     nlohmann::json hist_obj;
     hist_obj["count"] = total_count;
     hist_obj["sum"] = total_sum;
     hist_obj["buckets"] = buckets_obj;
-    root[hist->str_name()] = hist_obj;
+    root[hist.name()] = hist_obj;
 }
 }  // namespace
 
 template <uint8_t N>
 void TentMetrics::serializeHistogramPrometheus(
-    ylt::metric::basic_dynamic_histogram<int64_t, N>* hist,
-    const std::vector<double>& boundaries,
-    ylt::metric::basic_dynamic_counter<int64_t, N>& sum,
-    std::string& out) const {
-    // Walk the same data the JSON path uses (get_bucket_counts() + copy()),
-    // so the two endpoints cannot drift. Unlike ylt's serialize() this never
+    metrics::CachedDynamicHistogram<N>& hist, std::string& out) const {
+    // Walk the same bucket-counter / sum-counter data the JSON path uses, so
+    // the two endpoints cannot drift. Unlike ylt's serialize() this never
     // silently drops a histogram that has observed >=1 sample: ylt clears its
     // output string (taking the # HELP / # TYPE header with it) whenever
     // every label combo has sum_==0, which is reachable in production when
@@ -476,10 +480,11 @@ void TentMetrics::serializeHistogramPrometheus(
     // Templated over label arity N: the per-transport histograms are N=1 and
     // the transport-attempt latency histogram is N=2. For N=1 the emitted
     // text is byte-identical to the original single-label implementation.
-    auto bucket_counts = hist->get_bucket_counts();
-    if (bucket_counts.empty()) return;
+    auto bucket_counters = hist.bucketCounters();
+    if (bucket_counters.empty()) return;
 
-    const auto& label_names = hist->labels_name();
+    const auto& boundaries = hist.boundaries();
+    const auto& label_names = hist.labelsName();
 
     // A unique key per label tuple, used to dedup combos and look up the sum.
     auto combo_key = [](const std::array<std::string, N>& lv) {
@@ -499,16 +504,15 @@ void TentMetrics::serializeHistogramPrometheus(
         }
     };
 
-    // Build the union of label combos across ALL buckets. ylt's observe()
-    // increments exactly one bucket per observation (the bucket containing
-    // the value), so no single bucket sees every combo: e.g. queue_wait
-    // (sub-us -> bucket[0]) and transport_us (>=100us -> higher buckets) live
-    // in disjoint buckets. ylt itself uses sum_->copy() for this, but sum_ is
-    // private. Unioning across buckets gives the same set without needing sum_.
+    // Build the union of label combos across ALL buckets. A bucket counter
+    // only sees a combo after that combo has been observed in that bucket,
+    // so no single bucket sees every combo: e.g. queue_wait (sub-us ->
+    // bucket[0]) and transport_us (>=100us -> higher buckets) live in
+    // disjoint buckets. Unioning across buckets recovers the full set.
     std::vector<const std::array<std::string, N>*> label_combos;
     std::unordered_set<std::string> seen;
-    for (auto& bc : bucket_counts) {
-        for (auto& e : bc->copy()) {
+    for (auto* bucket_counter : bucket_counters) {
+        for (auto& e : bucket_counter->copy()) {
             if (seen.insert(combo_key(e->label)).second) {
                 label_combos.push_back(&e->label);
             }
@@ -518,15 +522,13 @@ void TentMetrics::serializeHistogramPrometheus(
 
     // Pre-compute per-combo total counts so we can (a) skip totally-empty
     // combos and (b) decide whether to emit the # HELP / # TYPE header at
-    // all. This mirrors ylt's "emit head only if value_map non-empty" but
-    // uses bucket counts instead of sum, so a combo with sum==0 but real
-    // observations is still emitted.
+    // all. A combo with sum==0 but real observations is still emitted.
     std::vector<std::pair<const std::array<std::string, N>*, int64_t>>
         active_combos;
     for (auto* labels_value : label_combos) {
         int64_t total_count = 0;
-        for (auto& bc : bucket_counts) {
-            total_count += bc->value(*labels_value);
+        for (auto* bucket_counter : bucket_counters) {
+            total_count += bucket_counter->value(*labels_value);
         }
         if (total_count > 0) {
             active_combos.emplace_back(labels_value, total_count);
@@ -534,17 +536,16 @@ void TentMetrics::serializeHistogramPrometheus(
     }
     if (active_combos.empty()) return;
 
-    // Read back the per-combo sum from the parallel counter. ylt's histogram
-    // keeps sum_ private with no accessor, so we maintain a separate counter
-    // incremented alongside each observe() call. copy() returns a vector of
+    // Read back the per-combo sum from the histogram's sum counter
+    // (maintained alongside each observe() call). copy() returns a vector of
     // {label, value} pairs; build a lookup map for O(1) access per combo.
     std::unordered_map<std::string, int64_t> sum_by_combo;
-    for (auto& e : sum.copy()) {
+    for (auto& e : hist.sumCounter()->copy()) {
         sum_by_combo[combo_key(e->label)] = e->value.load();
     }
 
-    const std::string& name = hist->str_name();
-    const std::string help_str{hist->help()};
+    const std::string& name = hist.name();
+    const std::string help_str{hist.help()};
 
     // Emit the header once per metric (matches ylt's serialize_head()).
     out.append("# HELP ").append(name).append(" ").append(help_str).append(
@@ -553,8 +554,8 @@ void TentMetrics::serializeHistogramPrometheus(
 
     for (auto& [labels_value, total_count] : active_combos) {
         int64_t cumulative = 0;
-        for (size_t i = 0; i < bucket_counts.size(); ++i) {
-            cumulative += bucket_counts[i]->value(*labels_value);
+        for (size_t i = 0; i < bucket_counters.size(); ++i) {
+            cumulative += bucket_counters[i]->value(*labels_value);
             out.append(name).append("_bucket{");
             append_labels(out, *labels_value);
             out.append(",");
@@ -568,9 +569,9 @@ void TentMetrics::serializeHistogramPrometheus(
             out.append(std::to_string(cumulative)).append("\n");
         }
 
-        // _sum: read from the parallel counter maintained alongside each
-        // observe() call. Falls back to 0 if the combo is not yet in the
-        // counter (should not happen for active combos, but defensive).
+        // _sum: read from the sum counter maintained by each observe() call.
+        // Falls back to 0 if the combo is not yet in the counter (should not
+        // happen for active combos, but defensive).
         int64_t total_sum = 0;
         auto it = sum_by_combo.find(combo_key(*labels_value));
         if (it != sum_by_combo.end()) {
@@ -618,28 +619,18 @@ std::string TentMetrics::getJsonMetrics() {
             static_cast<int64_t>(quarantined_batches_total_.value());
 
         // Histograms: sum bucket counts across all transport labels. The
-        // templated helper also reads back the parallel sum counter so the
+        // templated helper also reads back the histogram's sum counter so the
         // JSON endpoint emits "sum" alongside "count" (and stays in sync with
         // the Prometheus endpoint).
-        serializeHistogramToJson(root, &read_latency_, kLatencyBuckets,
-                                 &read_latency_sum_);
-        serializeHistogramToJson(root, &write_latency_, kLatencyBuckets,
-                                 &write_latency_sum_);
-        serializeHistogramToJson(root, &read_size_, kSizeBuckets,
-                                 &read_size_sum_);
-        serializeHistogramToJson(root, &write_size_, kSizeBuckets,
-                                 &write_size_sum_);
-        serializeHistogramToJson(root, &deadline_mlu_, kMluPerMilleBuckets,
-                                 &deadline_mlu_sum_);
-        serializeHistogramToJson(root, &stage_queue_wait_, kStageBuckets,
-                                 &stage_queue_wait_sum_);
-        serializeHistogramToJson(root, &stage_dispatch_, kStageBuckets,
-                                 &stage_dispatch_sum_);
-        serializeHistogramToJson(root, &stage_transport_, kStageBuckets,
-                                 &stage_transport_sum_);
-        serializeHistogramToJson(root, &transport_attempt_latency_,
-                                 kLatencyBuckets,
-                                 &transport_attempt_latency_sum_);
+        serializeHistogramToJson(root, read_latency_);
+        serializeHistogramToJson(root, write_latency_);
+        serializeHistogramToJson(root, read_size_);
+        serializeHistogramToJson(root, write_size_);
+        serializeHistogramToJson(root, deadline_mlu_);
+        serializeHistogramToJson(root, stage_queue_wait_);
+        serializeHistogramToJson(root, stage_dispatch_);
+        serializeHistogramToJson(root, stage_transport_);
+        serializeHistogramToJson(root, transport_attempt_latency_);
 
         return root.dump(2);  // Pretty print with 2-space indent
     } catch (const std::exception& e) {

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -934,6 +934,98 @@ TEST_F(MetricsRecordingTest, BucketsAreCompileTimeDefaults) {
         << "latency buckets must be the compile-time defaults";
 }
 
+// Concurrency guard for the cached-cell hot path: several threads hammering
+// overlapping (transport, operation) labels must produce exactly the summed
+// counts — including the first-use window where multiple threads resolve the
+// same label cell concurrently. Exercises every hot-path metric family
+// (per-transport counters, N=2 attempt counters/histogram, stage histograms).
+TEST_F(MetricsRecordingTest, ConcurrentRecordsAcrossTransportsAreExact) {
+    constexpr int kThreads = 8;
+    constexpr int kIters = 2000;
+    constexpr size_t kBytes = 4096;
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+
+    std::vector<std::thread> threads;
+    for (int t = 0; t < kThreads; ++t) {
+        threads.emplace_back([t] {
+            for (int i = 0; i < kIters; ++i) {
+                // Even threads write to rdma, odd threads to nvlink, so both
+                // transports' cells are resolved concurrently.
+                TransportType tp = (t % 2 == 0) ? RDMA : NVLINK;
+                Request::OpCode op =
+                    (i % 2 == 0) ? Request::WRITE : Request::READ;
+                TentMetrics::instance().recordTransportAttemptStarted(tp, op);
+                TentMetrics::instance().recordTransportAttemptFinished(
+                    tp, op, TransferStatusEnum::COMPLETED, 150.0);
+                if (op == Request::WRITE) {
+                    TentMetrics::instance().recordWriteCompleted(tp, kBytes,
+                                                                 0.002);
+                } else {
+                    TentMetrics::instance().recordReadCompleted(tp, kBytes,
+                                                                0.002);
+                }
+                TentMetrics::instance().recordStageLatency(
+                    TentMetrics::Stage::Transport, tp, 120.0);
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    auto after = MetricsSnapshot(TentMetrics::instance());
+    const int64_t total = kThreads * kIters;  // all attempts
+    const int64_t writes = total / 2;         // half the iterations
+    const int64_t bytes = writes * static_cast<int64_t>(kBytes);
+
+    EXPECT_EQ(after.counter("tent_write_bytes_total") -
+                  before.counter("tent_write_bytes_total"),
+              bytes);
+    EXPECT_EQ(after.counter("tent_read_bytes_total") -
+                  before.counter("tent_read_bytes_total"),
+              bytes);
+    EXPECT_EQ(after.counter("tent_write_requests_total") -
+                  before.counter("tent_write_requests_total"),
+              writes);
+    EXPECT_EQ(after.counter("tent_read_requests_total") -
+                  before.counter("tent_read_requests_total"),
+              writes);
+    EXPECT_EQ(after.counter("tent_transport_attempts_total") -
+                  before.counter("tent_transport_attempts_total"),
+              total);
+    EXPECT_EQ(after.histogramCount("tent_transport_attempt_latency_us") -
+                  before.histogramCount("tent_transport_attempt_latency_us"),
+              total);
+    EXPECT_EQ(after.histogramCount("tent_write_latency_us") -
+                  before.histogramCount("tent_write_latency_us"),
+              writes);
+    EXPECT_EQ(after.histogramCount("tent_stage_transport_us") -
+                  before.histogramCount("tent_stage_transport_us"),
+              total);
+    // Per-label Prometheus series must also be exact: 4 threads per transport,
+    // half of their iterations are writes.
+    const double per_transport_bytes =
+        static_cast<double>(kThreads / 2) * (kIters / 2) * kBytes;
+    EXPECT_EQ(after.series("tent_write_bytes_total{transport=\"rdma\"}") -
+                  before.series("tent_write_bytes_total{transport=\"rdma\"}"),
+              per_transport_bytes);
+    EXPECT_EQ(after.series("tent_write_bytes_total{transport=\"nvlink\"}") -
+                  before.series("tent_write_bytes_total{transport=\"nvlink\"}"),
+              per_transport_bytes);
+    EXPECT_EQ(after.series("tent_transport_attempts_total{transport=\"nvlink\","
+                           "operation=\"read\"}") -
+                  before.series("tent_transport_attempts_total{transport="
+                                "\"nvlink\",operation=\"read\"}"),
+              static_cast<double>(kThreads / 2) * (kIters / 2));
+    EXPECT_EQ(after.counter("tent_write_failures_total") -
+                  before.counter("tent_write_failures_total"),
+              0);
+    EXPECT_EQ(after.counter("tent_read_failures_total") -
+                  before.counter("tent_read_failures_total"),
+              0);
+}
+
 // ---------------------------------------------------------------------------
 // L2 HTTP integration: scrape the real /metrics, /metrics/json, /health
 // endpoints via coro_http_client and assert on status + body. Validates the


### PR DESCRIPTION
## Description

TENT's hot-path metrics (per-transport counters, attempt counters,
latency/size/stage histograms) were recorded through yalantinglibs'
dynamic metrics, whose `inc()`/`observe()` take a mutex-protected map
lookup on every update. The map is sharded by label hash, and TENT
labels come from small fixed enums (`TransportType`, `OpCode`), so all
updates for a given label land on the same shard mutex. After #3648
removed the engine-level global lock, this metrics layer became the
next serialization point: tebench 4K/1 with metrics enabled plateaued
(~170k ops/s flat at t>=4, latency growing with thread count —
47us@t=8, 88us@t=16) while `TENT_METRICS_ENABLED=false` reached ~490k.

Since the label domains are compile-time-known enums, this change
resolves each label's atomic cell once and caches the pointer in a
per-label-index slot, reducing the steady-state update to relaxed
atomic adds:

- New `tent/include/tent/metrics/cached_metric.h`:
  `CachedDynamicCounter<N>` exposes `resolve()` and `incCached()`
  (a relaxed `fetch_add` on the cached cell); `CachedDynamicHistogram<N>`
  is composed of cached-cell bucket counters plus the sum counter,
  replacing ylt's dynamic histograms and the parallel standalone sum
  counters (the sum becomes part of the histogram).
- `TentMetrics` slots N=1 metrics by `TransportType` and N=2 attempt
  metrics by (transport, operation), resolving cells lazily with
  race-free publication (release/acquire; concurrent first-use
  resolutions produce the same cell). Labels are never erased, so
  resolved cells stay valid for the process lifetime. The rare
  failover counter keeps the plain locked path.
- Prometheus/JSON output is unchanged (same custom serializers, now
  walking the histogram's own bucket/sum counters).

Performance, tebench 4K/1 write, local pair (same machine,
back-to-back runs; a background load was present, so the comparison is
relative, not absolute):

| threads | before (metrics on) | after (metrics on) | after (metrics off) | on/off gap |
|---|---|---|---|---|
| 1  | 127k ops/s / 7.9us | 138k / 7.2us | 139k / 7.2us | -0.7% |
| 4  | 142k | 323k | 323k | 0% |
| 8  | 170k / 47.2us | 478k / 16.7us | 488k / 16.4us | -2.0% |
| 16 | 181k / 88.4us | 663k / 24.1us | 682k / 23.5us | -2.8% |

Metrics recording is now effectively free: the on/off gap shrinks
from ~30% to <3%, and the thread-count latency blow-up is gone.

Follow-up work (kept out of this PR): failure-reason label and
in-flight gauges for production diagnosis, per-rank metrics port
wiring in the sglang integration.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S mooncake-transfer-engine -B build-tent -DCMAKE_BUILD_TYPE=Release \
      -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON -DYLT_ENABLE_IBV=ON -DWITH_STORE=OFF
cmake --build build-tent -j16
# all tent test binaries (see mooncake-transfer-engine/tent/tests/)
for t in build-tent/tent/tests/*_test; do $t || exit 1; done
# benchmark (target in one shell, initiator in another)
build-tent/benchmark/tebench --backend=tent
build-tent/benchmark/tebench --backend=tent --target_seg_name=<seg> \
    --seg_type=DRAM --op_type=write --start_block_size=4096 --max_block_size=4096 \
    --start_batch_size=1 --max_batch_size=1 --start_num_threads=1 --max_num_threads=16 --duration=3
```

**Test results:**
- [x] Unit tests pass — all 40 tent test binaries pass, including
  `tent_metrics_recording_test` (18 pre-existing + 1 new concurrency
  test asserting exact counts when 8 threads resolve and update
  overlapping label cells), `tent_progress_worker_test` (22/22),
  `tent_engine_failover_e2e_test` (17/17)
- [x] Manual testing done — tebench matrix above; Prometheus/JSON
  endpoint output verified byte-compatible by the existing
  serialization assertions in `metrics_recording_test`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — no user-facing config/behavior change
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — 485 added LOC, contained to the metrics subsystem, no interface changes

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (AI coding assistant) assisted with implementation, testing,
and benchmarking under human direction. Every changed line has been
reviewed by the submitter, who can defend the change end-to-end.