### PR TITLE
[TENT] Fix IPC relocation to not switch to the peer's device ordinal

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/status.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/status.h
@@ -42,21 +42,28 @@
     } while (0)
 
 #ifdef USE_CUDA
+#include <glog/logging.h>
+
 #define CHECK_CUDA(call)                                                      \
     do {                                                                      \
         auto err = call;                                                      \
-        if (err != cudaSuccess)                                               \
-            return Status::InternalError(std::string(#call) + ": " +          \
-                                         cudaGetErrorString(err) + LOC_MARK); \
+        if (err != cudaSuccess) {                                             \
+            auto _msg = std::string(#call) + ": " + cudaGetErrorString(err) + \
+                        LOC_MARK;                                             \
+            LOG(ERROR) << "CUDA error: " << _msg;                             \
+            return Status::InternalError(std::move(_msg));                    \
+        }                                                                     \
     } while (0)
 
-#define CHECK_CU(call)                                                        \
-    do {                                                                      \
-        auto err = call;                                                      \
-        if (err != CUDA_SUCCESS) {                                            \
-            return Status::InternalError(std::string(#call) + ": cuResult " + \
-                                         std::to_string(err) + LOC_MARK);     \
-        }                                                                     \
+#define CHECK_CU(call)                                       \
+    do {                                                     \
+        auto err = call;                                     \
+        if (err != CUDA_SUCCESS) {                           \
+            auto _msg = std::string(#call) + ": cuResult " + \
+                        std::to_string(err) + LOC_MARK;      \
+            LOG(ERROR) << "CUDA driver error: " << _msg;     \
+            return Status::InternalError(std::move(_msg));   \
+        }                                                    \
     } while (0)
 #endif
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/nvlink/nvlink_transport.h
@@ -99,6 +99,8 @@ class NVLinkTransport : public Transport {
 
     Status setPeerAccess();
 
+    friend class NVLinkTransportTestPeer;
+
    private:
     bool installed_;
     std::string local_segment_name_;

--- a/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/mnnvl/mnnvl_transport.cpp
@@ -678,9 +678,13 @@ Status MnnvlTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
                 "Requested address is not in registered CUDA buffer" LOC_MARK);
         }
 
-        int cuda_dev = 0;
-        CHECK_CUDA(cudaGetDevice(&cuda_dev));
-        cudaSetDevice(location.index());
+        // Do NOT switch to buffer->location's device index: that ordinal is
+        // the PEER's device index, relative to the peer's
+        // CUDA_VISIBLE_DEVICES. In the local process it may be an invalid
+        // ordinal, and even when numerically valid it may denote a different
+        // physical GPU. The driver calls below are device-agnostic: the VA
+        // mapping is process-wide and cuMemSetAccess grants read/write
+        // access to ALL local devices.
         if (handle_type_ == CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR) {
             auto [pid, remote_fd] = parsePidFd(buffer->mnnvl_handle);
             int local_fd = importFdFromProcess(pid, remote_fd);
@@ -718,9 +722,10 @@ Status MnnvlTransport::relocateSharedMemoryAddress(uint64_t &dest_addr,
         OpenedMnnvlEntry mnnvl_entry;
         mnnvl_entry.mnnvl_addr = mnnvl_addr;
         mnnvl_entry.length = buffer->length;
-        mnnvl_entry.cuda_id = location.index();
+        int cuda_dev = 0;
+        CHECK_CUDA(cudaGetDevice(&cuda_dev));
+        mnnvl_entry.cuda_id = cuda_dev;
         relocate_map_[target_id][buffer->addr] = mnnvl_entry;
-        cudaSetDevice(cuda_dev);
     }
 
     auto mnnvl_addr = relocate_map_[target_id][buffer->addr].mnnvl_addr;

--- a/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/nvlink/nvlink_transport.cpp
@@ -202,12 +202,21 @@ Status NVLinkTransport::submitTransferTasks(
     // Determine device for this batch and validate all requests
     int batch_device_id = -1;
     std::vector<NVLinkTask*> new_tasks;
+    // No I/O is started until startTransfer() below, so a synchronous
+    // failure must also roll back the half-appended task entries: the engine
+    // fails such tasks over to another transport, and stale never-started
+    // entries must not linger in the sub-batch (failover.md, hazard 2).
+    const size_t original_task_count = shm_batch->task_list.size();
+    auto rollback_tasks = [&shm_batch, original_task_count]() {
+        shm_batch->task_list.resize(original_task_count);
+    };
 
     for (auto& request : request_list) {
         // Find the buffer this source pointer belongs to
         BufferDesc* buf = local_segment->findBuffer(
             reinterpret_cast<uint64_t>(request.source), request.length);
         if (!buf) {
+            rollback_tasks();
             return Status::InvalidArgument(
                 "Unregistered buffer: source pointer not in any registered "
                 "buffer" LOC_MARK);
@@ -234,7 +243,10 @@ Status NVLinkTransport::submitTransferTasks(
         if (request.target_id != LOCAL_SEGMENT_ID) {
             auto status = relocateSharedMemoryAddress(
                 target_addr, request.length, request.target_id);
-            if (!status.ok()) return status;
+            if (!status.ok()) {
+                rollback_tasks();
+                return status;
+            }
         }
 
         task.target_addr = target_addr;
@@ -250,10 +262,16 @@ Status NVLinkTransport::submitTransferTasks(
             // CPU-only batch: use current CUDA device
             cudaGetDevice(&stream_device);
         }
-        CHECK_STATUS(platform_->getStreamFromPool(shm_batch->sync_stream,
-                                                  stream_device));
-        CHECK_STATUS(platform_->getStreamFromPool(shm_batch->async_stream,
-                                                  stream_device));
+        auto status =
+            platform_->getStreamFromPool(shm_batch->sync_stream, stream_device);
+        if (status.ok()) {
+            status = platform_->getStreamFromPool(shm_batch->async_stream,
+                                                  stream_device);
+        }
+        if (!status.ok()) {
+            rollback_tasks();
+            return status;
+        }
         shm_batch->stream_device_id = stream_device;
     }
 
@@ -582,16 +600,24 @@ Status NVLinkTransport::relocateSharedMemoryAddress(uint64_t& dest_addr,
         deserializeBinaryData(buffer->shm_path, output_buffer);
         cudaIpcMemHandle_t handle;
         memcpy(&handle, output_buffer.data(), sizeof(handle));
+        // Open the IPC handle on the CALLER's current device. Never switch to
+        // buffer->location's device index: that ordinal is the PEER's device
+        // index, relative to the peer's CUDA_VISIBLE_DEVICES. In the local
+        // process it may be an invalid ordinal (when the peer process sees
+        // more devices than we do), and even when numerically valid it may
+        // denote a different physical GPU. cudaIpcOpenMemHandle with
+        // cudaIpcMemLazyEnablePeerAccess is valid on the current device: the
+        // lazy flag enables peer access between the current device and the
+        // allocation's source device as needed, and subsequent copies already
+        // run cross-device via P2P (see startTransfer).
         int cuda_dev = 0;
         CHECK_CUDA(cudaGetDevice(&cuda_dev));
-        cudaSetDevice(location.index());
         CHECK_CUDA(cudaIpcOpenMemHandle(&shm_addr, handle,
                                         cudaIpcMemLazyEnablePeerAccess));
-        cudaSetDevice(cuda_dev);
         OpenedShmEntry shm_entry;
         shm_entry.shm_addr = shm_addr;
         shm_entry.length = buffer->length;
-        shm_entry.cuda_id = location.index();
+        shm_entry.cuda_id = cuda_dev;
         relocate_map_[target_id][buffer->addr] = shm_entry;
         tl_relocate_map = relocate_map_;
     }

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -181,6 +181,18 @@ target_include_directories(tent_shm_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_shm_transport_test COMMAND tent_shm_transport_test)
 
+# NOT registered via add_test: the test needs a real GPU (it opens a CUDA IPC
+# handle exported by a forked child). Run manually on a GPU box:
+#   ./tent_nvlink_transport_test --gtest_filter='NVLinkTransportTest.*'
+# Only built when CUDA is enabled: the test includes CUDA headers directly.
+if(USE_CUDA)
+  add_executable(tent_nvlink_transport_test nvlink_transport_test.cpp)
+  target_link_libraries(tent_nvlink_transport_test PRIVATE gtest gtest_main
+                                                           tent_link_group)
+  target_include_directories(tent_nvlink_transport_test
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+endif()
+
 add_executable(tent_failover_test failover_test.cpp)
 target_link_libraries(tent_failover_test PRIVATE gtest gtest_main
                                                  tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/nvlink_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/nvlink_transport_test.cpp
@@ -1,0 +1,311 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include "tent/common/config.h"
+#include "tent/common/utils/string_builder.h"
+#include "tent/runtime/control_plane.h"
+#include "tent/transport/nvlink/nvlink_transport.h"
+
+namespace mooncake {
+namespace tent {
+
+class NVLinkTransportTestPeer {
+   public:
+    static Status relocate(NVLinkTransport& transport, uint64_t& address,
+                           uint64_t length, SegmentID target_id) {
+        return transport.relocateSharedMemoryAddress(address, length,
+                                                     target_id);
+    }
+
+    static size_t mappingCount(NVLinkTransport& transport,
+                               SegmentID target_id) {
+        RWSpinlock::ReadGuard guard(transport.relocate_lock_);
+        auto it = transport.relocate_map_.find(target_id);
+        return it == transport.relocate_map_.end() ? 0 : it->second.size();
+    }
+};
+
+namespace {
+
+// A peer BufferDesc can carry a device ordinal that is invalid (or refers to
+// a different physical GPU) in the local process: ordinals are relative to
+// the PEER's CUDA_VISIBLE_DEVICES. Regression guard for the bug where
+// relocateSharedMemoryAddress switched to the peer ordinal before opening
+// the IPC handle.
+constexpr uint64_t kRemoteAddress = 0x10000000;
+constexpr size_t kBufferLength = 4096;
+constexpr uint32_t kPattern = 0x5a3c69e7;
+
+// CUDA IPC handles cannot be opened by the process that exported them, so
+// these tests obtain a handle from a forked child: the child allocates a
+// device buffer, fills it with a known pattern, exports the IPC handle and
+// stays alive (holding the allocation) until the parent is done.
+//
+// The parent must not call into CUDA before fork(): the child would inherit
+// the initialized runtime and its own CUDA calls would be unreliable. The
+// parent's first CUDA call therefore happens inside
+// relocateSharedMemoryAddress(), well after fork().
+class PeerExporter {
+   public:
+    PeerExporter() {
+        if (pipe(ready_pipe_) != 0 || pipe(stop_pipe_) != 0) return;
+
+        pid_t child = fork();
+        if (child < 0) return;
+        if (child == 0) {
+            // Child: allocate, fill, export, then block until the parent is
+            // done so the exported allocation stays alive.
+            close(ready_pipe_[0]);
+            close(stop_pipe_[1]);
+            _exit(childMain(ready_pipe_[1], stop_pipe_[0]));
+        }
+
+        close(ready_pipe_[1]);
+        close(stop_pipe_[0]);
+        child_pid_ = child;
+        valid_ = readExportResult();
+    }
+
+    ~PeerExporter() {
+        if (child_pid_ > 0) {
+            char done = 1;
+            (void)write(stop_pipe_[1], &done, sizeof(done));
+            (void)waitpid(child_pid_, nullptr, 0);
+        }
+        if (ready_pipe_[0] >= 0) close(ready_pipe_[0]);
+        if (stop_pipe_[1] >= 0) close(stop_pipe_[1]);
+    }
+
+    bool forkOk() const { return child_pid_ > 0; }
+    // 0 = handle exported fine; 1 = no CUDA device in the child.
+    int childStatus() const { return child_status_; }
+    const std::string& serializedHandle() const { return serialized_handle_; }
+
+   private:
+    static int childMain(int ready_fd, int stop_fd) {
+        int device_count = 0;
+        if (cudaGetDeviceCount(&device_count) != cudaSuccess ||
+            device_count <= 0) {
+            int32_t status = 1;
+            (void)write(ready_fd, &status, sizeof(status));
+            return 0;
+        }
+
+        void* ptr = nullptr;
+        if (cudaMalloc(&ptr, kBufferLength) != cudaSuccess) return 2;
+        std::vector<uint32_t> pattern(kBufferLength / sizeof(uint32_t),
+                                      kPattern);
+        if (cudaMemcpy(ptr, pattern.data(), kBufferLength,
+                       cudaMemcpyHostToDevice) != cudaSuccess)
+            return 3;
+        cudaIpcMemHandle_t handle;
+        if (cudaIpcGetMemHandle(&handle, ptr) != cudaSuccess) return 4;
+
+        int32_t status = 0;
+        size_t length = kBufferLength;
+        if (write(ready_fd, &status, sizeof(status)) != sizeof(status))
+            return 5;
+        if (write(ready_fd, &length, sizeof(length)) != sizeof(length))
+            return 6;
+        if (write(ready_fd, &handle, sizeof(handle)) != sizeof(handle))
+            return 7;
+
+        // Hold the allocation until the parent is done with the mapping.
+        char done = 0;
+        while (read(stop_fd, &done, sizeof(done)) < 0 && errno == EINTR) {
+        }
+        return 0;
+    }
+
+    bool readExportResult() {
+        int32_t status = -1;
+        if (read(ready_pipe_[0], &status, sizeof(status)) !=
+            (ssize_t)sizeof(status))
+            return false;
+        child_status_ = status;
+        if (status != 0) return true;  // no CUDA in child; skip, not fail
+
+        size_t length = 0;
+        cudaIpcMemHandle_t handle{};
+        if (read(ready_pipe_[0], &length, sizeof(length)) !=
+            (ssize_t)sizeof(length))
+            return false;
+        if (read(ready_pipe_[0], &handle, sizeof(handle)) !=
+            (ssize_t)sizeof(handle))
+            return false;
+        serialized_handle_ = serializeBinaryData(&handle, sizeof(handle));
+        return true;
+    }
+
+    int ready_pipe_[2]{-1, -1};
+    int stop_pipe_[2]{-1, -1};
+    pid_t child_pid_{-1};
+    int child_status_{-1};
+    std::string serialized_handle_;
+    bool valid_{false};
+
+   public:
+    bool valid() const { return valid_; }
+};
+
+Status installLocalSegmentWithIpcHandle(ControlService& metadata,
+                                        const std::string& serialized_handle,
+                                        const std::string& peer_location,
+                                        uint64_t remote_addr, size_t length) {
+    return metadata.segmentManager().updateLocal(
+        [&](SegmentDesc& segment) -> Status {
+            segment.name = "nvlink_test_segment";
+            segment.machine_id = "nvlink_test_machine";
+            segment.type = SegmentType::Memory;
+            auto& memory = std::get<MemorySegmentDesc>(segment.detail);
+            memory.buffers.clear();
+            BufferDesc buffer;
+            buffer.addr = remote_addr;
+            buffer.length = length;
+            buffer.location = peer_location;
+            buffer.shm_path = serialized_handle;
+            memory.buffers.push_back(std::move(buffer));
+            return Status::OK();
+        });
+}
+
+void verifyRelocatedData(uint64_t address, size_t length) {
+    ASSERT_LE(length, kBufferLength);
+    std::vector<uint32_t> readback(length / sizeof(uint32_t));
+    ASSERT_EQ(cudaMemcpy(readback.data(), reinterpret_cast<void*>(address),
+                         length, cudaMemcpyDeviceToHost),
+              cudaSuccess);
+    for (uint32_t value : readback) {
+        EXPECT_EQ(value, kPattern);
+    }
+}
+
+}  // namespace
+
+TEST(NVLinkTransportTest, RelocateToleratesOutOfRangePeerDeviceOrdinal) {
+    PeerExporter exporter;
+    if (!exporter.forkOk() || !exporter.valid()) {
+        GTEST_SKIP() << "Peer export failed (fork/pipe error)";
+    }
+    if (exporter.childStatus() != 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+
+    // The peer claims its buffer lives on cuda:99 — an ordinal that is out
+    // of range in this process, exactly what a peer with a larger
+    // CUDA_VISIBLE_DEVICES produces.
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    ASSERT_TRUE(installLocalSegmentWithIpcHandle(
+                    *metadata, exporter.serializedHandle(), "cuda:99",
+                    kRemoteAddress, kBufferLength)
+                    .ok());
+
+    NVLinkTransport transport;
+    std::string local_segment_name = "nvlink_test_segment";
+    ASSERT_TRUE(transport
+                    .install(local_segment_name, metadata, nullptr,
+                             std::make_shared<Config>())
+                    .ok());
+
+    uint64_t dest_addr = kRemoteAddress + 64;
+    ASSERT_TRUE(NVLinkTransportTestPeer::relocate(
+                    transport, dest_addr, kBufferLength - 64, LOCAL_SEGMENT_ID)
+                    .ok());
+    EXPECT_EQ(
+        NVLinkTransportTestPeer::mappingCount(transport, LOCAL_SEGMENT_ID), 1u);
+    // The relocated address must alias the child's allocation: dest_addr is
+    // now mapped_base + 64.
+    verifyRelocatedData(dest_addr, kBufferLength - 64);
+    ASSERT_TRUE(transport.uninstall().ok());
+}
+
+TEST(NVLinkTransportTest,
+     RelocateCachesSingleMappingForConcurrentPeersWithBogusOrdinal) {
+    PeerExporter exporter;
+    if (!exporter.forkOk() || !exporter.valid()) {
+        GTEST_SKIP() << "Peer export failed (fork/pipe error)";
+    }
+    if (exporter.childStatus() != 0) {
+        GTEST_SKIP() << "No CUDA device available";
+    }
+
+    int device_count = 0;
+    ASSERT_EQ(cudaGetDeviceCount(&device_count), cudaSuccess);
+    const std::string bogus_location =
+        "cuda:" + std::to_string(device_count + 8);
+    auto metadata = std::make_shared<ControlService>("p2p", "", nullptr);
+    ASSERT_TRUE(installLocalSegmentWithIpcHandle(
+                    *metadata, exporter.serializedHandle(), bogus_location,
+                    kRemoteAddress, kBufferLength)
+                    .ok());
+
+    NVLinkTransport transport;
+    std::string local_segment_name = "nvlink_test_segment";
+    ASSERT_TRUE(transport
+                    .install(local_segment_name, metadata, nullptr,
+                             std::make_shared<Config>())
+                    .ok());
+
+    constexpr size_t kThreadCount = 8;
+    std::atomic<size_t> ready{0};
+    std::atomic<bool> start{false};
+    std::vector<uint64_t> relocated(kThreadCount, kRemoteAddress);
+    std::vector<uint8_t> succeeded(kThreadCount, 0);
+    std::vector<std::thread> threads;
+    threads.reserve(kThreadCount);
+    for (size_t i = 0; i < kThreadCount; ++i) {
+        threads.emplace_back([&, i] {
+            ready.fetch_add(1, std::memory_order_release);
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            succeeded[i] =
+                NVLinkTransportTestPeer::relocate(
+                    transport, relocated[i], kBufferLength, LOCAL_SEGMENT_ID)
+                    .ok();
+        });
+    }
+    while (ready.load(std::memory_order_acquire) != kThreadCount) {
+        std::this_thread::yield();
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& thread : threads) thread.join();
+
+    for (uint8_t success : succeeded) EXPECT_TRUE(success);
+    for (uint64_t address : relocated) EXPECT_EQ(address, relocated.front());
+    EXPECT_EQ(
+        NVLinkTransportTestPeer::mappingCount(transport, LOCAL_SEGMENT_ID), 1u);
+    verifyRelocatedData(relocated.front(), kBufferLength);
+    ASSERT_TRUE(transport.uninstall().ok());
+}
+
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

`NVLinkTransport::relocateSharedMemoryAddress` called
`cudaSetDevice(location.index())` before `cudaIpcOpenMemHandle`, where
`location` is the **peer's** `BufferDesc` location — a device ordinal
relative to the **peer's** `CUDA_VISIBLE_DEVICES`. In the local process
that ordinal may be out of range (when the peer process sees more devices
than we do) or may denote a different physical GPU.

With per-instance `CUDA_VISIBLE_DEVICES` — a common way to partition GPUs
between prefill/decode workers — every transfer targeting the peer's
higher-numbered devices failed (invalid device ordinal) with **zero
diagnostics**: `CHECK_CUDA` returned the error silently, and the broken
device-switch sequence also left the caller's CUDA device state
inconsistent on error paths.

Fix: open the IPC handle on the **caller's current device**.
`cudaIpcMemLazyEnablePeerAccess` handles the mapping and peer access, and
the subsequent copies already run cross-device via P2P (`startTransfer`
never switches devices either).

`MnnvlTransport` had the same pattern; its driver calls are
device-agnostic (`cuMemSetAccess` grants all local devices RW), so the
switch is removed there as well.

Also included, from the same debugging session:

- **`CHECK_CUDA` / `CHECK_CU` now `LOG(ERROR)` before returning** — the
  silent early returns are exactly why this bug produced no diagnostics.
- **`NVLinkTransport::submitTransferTasks` rolls back half-appended task
  entries on synchronous failure**: no I/O has started at that point, so
  stale never-started entries must not linger in the sub-batch (also a
  prerequisite for making submit-stage failover safe).
- New `tent_nvlink_transport_test`: a real IPC handle is exported by a
  forked child (a process cannot open its own exported handle) whose
  `BufferDesc` claims an out-of-range ordinal (`cuda:99`); asserts
  relocation success, data integrity through the mapping, and
  single-mapping reuse under concurrency.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
# new unit test — NOT registered in ctest (needs a real GPU: it opens a
# CUDA IPC handle exported by a forked child). Run manually on a GPU box,
# one case per process (a fork after the parent touched CUDA leaves the
# child's runtime unusable):
./tent_nvlink_transport_test \
    --gtest_filter=NVLinkTransportTest.RelocateToleratesOutOfRangePeerDeviceOrdinal
./tent_nvlink_transport_test \
    --gtest_filter=NVLinkTransportTest.RelocateCachesSingleMappingForConcurrentPeersWithBogusOrdinal

# full TENT suite
cd build-tent/mooncake-transfer-engine/tent/tests && ctest -j8
```

**Test results:**
- [x] Unit tests pass — new test 2/2 on an 8×H20 machine (each case run in
  its own process; also skips cleanly without a GPU — the forked child
  reports no CUDA device → `GTEST_SKIP`)
- [x] Integration tests pass — full TENT suite 44/44
- [x] Manual testing done (GPU e2e, same-machine PD disaggregation, sglang
  prefill TP1 + decode TP4 with per-instance `CUDA_VISIBLE_DEVICES`
  exposing the ordinal mismatch):
  - Before: first request fails — every NVLink transfer to the peer's
    higher-numbered devices errors out with no log output
  - After: sanity probes 3/3, sustained load transfers 40+ GB over NVLink
    with zero transfer failures; NVLink-mapped memory verified by reading
    back the expected data pattern through the relocation mapping

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — N/A, no doc surface
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — N/A, 425 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (Claude) assisted with root-cause analysis (instrumented
reproducer), the fix, the fork-based test design, and this PR
description. The human submitter has reviewed every changed line and can
defend the change end-to-end.