### PR TITLE
[TENT] Add task failure reason counter and in-flight gauges

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -138,12 +138,15 @@ class TentMetrics {
     // In-flight transport attempts (gauge): incremented when an attempt is
     // submitted, decremented when it finishes. Reflects how much work is
     // sitting in the engine right now — a persistently high or stuck value
-    // is the signature of a stalled pipeline.
+    // is the signature of a stalled pipeline. Gauge updates are paired
+    // add/sub operations, so they execute whenever initialized and ignore
+    // setEnabled(): skipping one half of a pair across an enable/disable
+    // transition would permanently corrupt the gauge.
     void recordInflightAttemptStarted(TransportType tp);
     void recordInflightAttemptFinished(TransportType tp);
 
     // Registered buffer bytes per transport (gauge), maintained on
-    // register/unregisterLocalMemory.
+    // register/unregisterLocalMemory. Same pairing rule as above.
     void recordRegisteredBufferBytes(TransportType tp, int64_t delta);
 
     enum class Stage {

--- a/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
+++ b/mooncake-transfer-engine/tent/include/tent/metrics/tent_metrics.h
@@ -124,6 +124,28 @@ class TentMetrics {
     // are parked until shutdown and the last reclaim error is in the log.
     void recordBatchQuarantined();
 
+    // Why a task failed. "submit" failures were observed synchronously at
+    // submission (the transport rejected the request); "poll" failures were
+    // observed by polling after the request had been accepted; timeout and
+    // canceled come from the terminal status itself.
+    enum class TaskFailureReason { Submit, Poll, Timeout, Canceled };
+
+    // Record a task-level failure with its reason. Additive to the legacy
+    // read/write_failures_total counters (which stay label-compatible); also
+    // the only failure metric that records TIMEOUT/CANCELED outcomes.
+    void recordTaskFailure(TransportType tp, TaskFailureReason reason);
+
+    // In-flight transport attempts (gauge): incremented when an attempt is
+    // submitted, decremented when it finishes. Reflects how much work is
+    // sitting in the engine right now — a persistently high or stuck value
+    // is the signature of a stalled pipeline.
+    void recordInflightAttemptStarted(TransportType tp);
+    void recordInflightAttemptFinished(TransportType tp);
+
+    // Registered buffer bytes per transport (gauge), maintained on
+    // register/unregisterLocalMemory.
+    void recordRegisteredBufferBytes(TransportType tp, int64_t delta);
+
     enum class Stage {
         QueueWait,
         Dispatch,
@@ -199,6 +221,8 @@ class TentMetrics {
                                                                    "to"};
     static inline const std::array<std::string, 2> kAttemptLabels{"transport",
                                                                   "operation"};
+    static inline const std::array<std::string, 2> kTaskFailureLabels{
+        "transport", "reason"};
 
     // Hot-path metrics record through pre-resolved label cells (see
     // cached_metric.h). Label domain sizes: TransportType has
@@ -207,6 +231,7 @@ class TentMetrics {
     static constexpr size_t kTransportDomain =
         static_cast<size_t>(kNumTransportTypes);
     static constexpr size_t kAttemptDomain = kTransportDomain * 2;
+    static constexpr size_t kTaskFailureDomain = kTransportDomain * 4;
 
     // Stable slot indices into the cached-cell label domain.
     static size_t transportSlot(TransportType tp) {
@@ -214,6 +239,9 @@ class TentMetrics {
     }
     static size_t attemptSlot(TransportType tp, Request::OpCode op) {
         return static_cast<size_t>(tp) * 2 + (op == Request::READ ? 0u : 1u);
+    }
+    static size_t taskFailureSlot(TransportType tp, TaskFailureReason reason) {
+        return static_cast<size_t>(tp) * 4 + static_cast<size_t>(reason);
     }
 
     // Per-transport counters (label: transport). Values are int64_t.
@@ -248,6 +276,13 @@ class TentMetrics {
         "tent_transport_attempt_failures_total",
         "Physical transport attempts that terminated with FAILED",
         kAttemptLabels, kAttemptDomain};
+    // Task-level failures with a reason label, so Grafana can alert on the
+    // failure signature (submit vs poll vs timeout vs canceled) without log
+    // scraping. Additive to the legacy read/write_failures_total counters.
+    metrics::CachedDynamicCounter<2> task_failures_total_{
+        "tent_task_failures_total",
+        "Task-level failures by terminal transport and failure reason",
+        kTaskFailureLabels, kTaskFailureDomain};
     metrics::CachedDynamicCounter<1> deadline_infeasible_total_{
         "tent_deadline_infeasible_total",
         "Transfers whose deadline was already in the past at submit",
@@ -258,6 +293,18 @@ class TentMetrics {
         "tent_quarantined_batches_total",
         "Batches abandoned by lazyFreeBatch after repeated failed reclaim "
         "attempts; reclaimed only at engine teardown"};
+
+    // Gauges, backed by cached cells and updated with add/sub. Serialized as
+    // Prometheus gauges (current value per label), NOT via the counters_
+    // vector.
+    metrics::CachedDynamicCounter<1> inflight_attempts_{
+        "tent_inflight_attempts",
+        "In-flight transport attempts (submitted, not yet finished)",
+        kTransportLabel, kTransportDomain};
+    metrics::CachedDynamicCounter<1> registered_buffer_bytes_{
+        "tent_registered_buffer_bytes", "Registered local buffer bytes",
+        kTransportLabel, kTransportDomain};
+    std::vector<metrics::CachedDynamicCounter<1>*> gauges_;
 
     // Latency histograms use microseconds (us) as unit
     // Default buckets: 100us, 500us, 1ms, 5ms, 10ms, 50ms, 100ms, 500ms, 1s
@@ -320,6 +367,11 @@ class TentMetrics {
     // transport_attempt_latency_ histogram is serialized separately (see
     // getPrometheusMetrics / getJsonMetrics) via the same templated helpers.
     std::vector<metrics::CachedDynamicHistogram<1>*> histograms_;
+
+    // Serialize a gauge backed by a cached-cell counter: emits the current
+    // value per label with # TYPE ... gauge.
+    void serializeGaugePrometheus(metrics::CachedDynamicCounter<1>& gauge,
+                                  std::string& out) const;
 
     // Helper to register all metrics to the vectors
     void registerMetrics();

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -84,6 +84,14 @@ struct TaskInfo {
     std::chrono::steady_clock::time_point attempt_post_time{};
     TransportType attempt_type{UNSPEC};
     bool attempt_active{false};
+    // Failure attribution for tent_task_failures_total (first failure wins):
+    // -1 = none, 0 = submit-stage, 1 = poll-stage. Set where the failure
+    // originates and never overwritten, so a poll-observed failure stays
+    // "poll" even when a later failover resubmit is synchronously rejected.
+    // Invariant for integrators: mark submit failures before any recovery
+    // attempt, so a task that recovers and later fails at poll still
+    // attributes its root cause to submit.
+    int8_t failure_stage{-1};
 
     TaskInfo() = default;
 
@@ -105,7 +113,8 @@ struct TaskInfo {
           post_time(other.post_time),
           attempt_post_time(other.attempt_post_time),
           attempt_type(other.attempt_type),
-          attempt_active(other.attempt_active) {}
+          attempt_active(other.attempt_active),
+          failure_stage(other.failure_stage) {}
 
     TaskInfo(TaskInfo&& other) noexcept
         : type(other.type),
@@ -125,7 +134,8 @@ struct TaskInfo {
           post_time(other.post_time),
           attempt_post_time(other.attempt_post_time),
           attempt_type(other.attempt_type),
-          attempt_active(other.attempt_active) {}
+          attempt_active(other.attempt_active),
+          failure_stage(other.failure_stage) {}
 
     TaskInfo& operator=(const TaskInfo& other) {
         if (this != &other) {
@@ -149,6 +159,7 @@ struct TaskInfo {
             attempt_post_time = other.attempt_post_time;
             attempt_type = other.attempt_type;
             attempt_active = other.attempt_active;
+            failure_stage = other.failure_stage;
         }
         return *this;
     }
@@ -175,6 +186,7 @@ struct TaskInfo {
             attempt_post_time = other.attempt_post_time;
             attempt_type = other.attempt_type;
             attempt_active = other.attempt_active;
+            failure_stage = other.failure_stage;
         }
         return *this;
     }

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -35,6 +35,20 @@ namespace {
 const char* operationName(Request::OpCode operation) {
     return operation == Request::READ ? "read" : "write";
 }
+
+const char* taskFailureReasonName(TentMetrics::TaskFailureReason reason) {
+    switch (reason) {
+        case TentMetrics::TaskFailureReason::Submit:
+            return "submit";
+        case TentMetrics::TaskFailureReason::Poll:
+            return "poll";
+        case TentMetrics::TaskFailureReason::Timeout:
+            return "timeout";
+        case TentMetrics::TaskFailureReason::Canceled:
+            return "canceled";
+    }
+    return "unknown";
+}
 }  // namespace
 
 Status TentMetrics::initialize(const MetricsConfig& config) {
@@ -195,6 +209,7 @@ void TentMetrics::shutdown() {
     // Clear metric vectors
     counters_.clear();
     histograms_.clear();
+    gauges_.clear();
 
     // Reset bound port so httpPort() returns 0 after shutdown, not a stale
     // port from a previous initialization. Without this, a re-initialize
@@ -221,8 +236,14 @@ void TentMetrics::registerMetrics() {
         &failover_total_,
         &transport_attempts_total_,
         &transport_attempt_failures_total_,
+        &task_failures_total_,
         &deadline_infeasible_total_,
         &quarantined_batches_total_,
+    };
+
+    gauges_ = {
+        &inflight_attempts_,
+        &registered_buffer_bytes_,
     };
 
     // Register the N=1 per-transport histograms for unified serialization.
@@ -299,6 +320,41 @@ void TentMetrics::recordBatchQuarantined() {
     if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
         return;
     quarantined_batches_total_.inc();
+}
+
+void TentMetrics::recordTaskFailure(TransportType tp,
+                                    TaskFailureReason reason) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    task_failures_total_.incCached(taskFailureSlot(tp, reason), [tp, reason] {
+        return std::array<std::string, 2>{transportTypeName(tp),
+                                          taskFailureReasonName(reason)};
+    });
+}
+
+void TentMetrics::recordInflightAttemptStarted(TransportType tp) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    inflight_attempts_.incCached(transportSlot(tp), [tp] {
+        return std::array<std::string, 1>{transportTypeName(tp)};
+    });
+}
+
+void TentMetrics::recordInflightAttemptFinished(TransportType tp) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    inflight_attempts_.incCached(
+        transportSlot(tp),
+        [tp] { return std::array<std::string, 1>{transportTypeName(tp)}; }, -1);
+}
+
+void TentMetrics::recordRegisteredBufferBytes(TransportType tp, int64_t delta) {
+    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
+        return;
+    registered_buffer_bytes_.incCached(
+        transportSlot(tp),
+        [tp] { return std::array<std::string, 1>{transportTypeName(tp)}; },
+        delta);
 }
 
 void TentMetrics::recordStageLatency(Stage stage, TransportType tp,
@@ -418,6 +474,11 @@ std::string TentMetrics::getPrometheusMetrics() {
         // N=2 transport-attempt latency histogram (labels: transport,
         // operation) goes through the same helper, instantiated for N=2.
         serializeHistogramPrometheus(transport_attempt_latency_, result);
+
+        // Gauges: current value per label.
+        for (auto* gauge : gauges_) {
+            serializeGaugePrometheus(*gauge, result);
+        }
 
         return result;
     } catch (const std::exception& e) {
@@ -587,6 +648,29 @@ void TentMetrics::serializeHistogramPrometheus(
     }
 }
 
+void TentMetrics::serializeGaugePrometheus(
+    metrics::CachedDynamicCounter<1>& gauge, std::string& out) const {
+    auto cells = gauge.copy();
+    if (cells.empty()) return;
+    const std::string& name = gauge.str_name();
+    out.append("# HELP ")
+        .append(name)
+        .append(" ")
+        .append(gauge.help())
+        .append("\n");
+    out.append("# TYPE ").append(name).append(" gauge\n");
+    for (auto& e : cells) {
+        out.append(name)
+            .append("{")
+            .append(gauge.labels_name()[0])
+            .append("=\"")
+            .append(e->label[0])
+            .append("\"} ")
+            .append(std::to_string(e->value.load(std::memory_order_relaxed)))
+            .append("\n");
+    }
+}
+
 std::string TentMetrics::getJsonMetrics() {
     if (!initialized_) return "{}";
 
@@ -617,6 +701,14 @@ std::string TentMetrics::getJsonMetrics() {
             sumCounterValues(&deadline_infeasible_total_);
         root[quarantined_batches_total_.str_name()] =
             static_cast<int64_t>(quarantined_batches_total_.value());
+
+        // Gauges: aggregate across transport labels (total in-flight attempts
+        // / total registered bytes). Per-transport breakdown is via the
+        // Prometheus endpoint.
+        root[inflight_attempts_.str_name()] =
+            sumCounterValues(&inflight_attempts_);
+        root[registered_buffer_bytes_.str_name()] =
+            sumCounterValues(&registered_buffer_bytes_);
 
         // Histograms: sum bucket counts across all transport labels. The
         // templated helper also reads back the histogram's sum counter so the
@@ -711,6 +803,10 @@ void TentMetrics::recordTransportAttemptFinished(TransportType, Request::OpCode,
 void TentMetrics::recordDeadlineMLU(TransportType, double) {}
 void TentMetrics::recordDeadlineInfeasible(TransportType) {}
 void TentMetrics::recordBatchQuarantined() {}
+void TentMetrics::recordTaskFailure(TransportType, TaskFailureReason) {}
+void TentMetrics::recordInflightAttemptStarted(TransportType) {}
+void TentMetrics::recordInflightAttemptFinished(TransportType) {}
+void TentMetrics::recordRegisteredBufferBytes(TransportType, int64_t) {}
 void TentMetrics::recordStageLatency(Stage, TransportType, double) {}
 
 std::string TentMetrics::getPrometheusMetrics() {

--- a/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
+++ b/mooncake-transfer-engine/tent/src/metrics/tent_metrics.cpp
@@ -332,25 +332,27 @@ void TentMetrics::recordTaskFailure(TransportType tp,
     });
 }
 
+// Gauge updates below deliberately ignore runtime_enabled_: gauges track
+// engine state through paired add/sub operations (attempt start/finish,
+// register/unregister), and skipping one half of a pair across a
+// setEnabled() transition would permanently corrupt the value. Counters and
+// histograms are samples and may be dropped while disabled; gauges are not.
 void TentMetrics::recordInflightAttemptStarted(TransportType tp) {
-    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
-        return;
+    if (!initialized_) return;
     inflight_attempts_.incCached(transportSlot(tp), [tp] {
         return std::array<std::string, 1>{transportTypeName(tp)};
     });
 }
 
 void TentMetrics::recordInflightAttemptFinished(TransportType tp) {
-    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
-        return;
+    if (!initialized_) return;
     inflight_attempts_.incCached(
         transportSlot(tp),
         [tp] { return std::array<std::string, 1>{transportTypeName(tp)}; }, -1);
 }
 
 void TentMetrics::recordRegisteredBufferBytes(TransportType tp, int64_t delta) {
-    if (!initialized_ || !runtime_enabled_.load(std::memory_order_relaxed))
-        return;
+    if (!initialized_) return;
     registered_buffer_bytes_.incCached(
         transportSlot(tp),
         [tp] { return std::array<std::string, 1>{transportTypeName(tp)}; },

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -843,6 +843,14 @@ Status TransferEngineImpl::registerLocalMemory(std::vector<void*> addr_list,
                 auto s = transport_list_[type]->addMemoryBuffer(descs, options);
                 if (!s.ok()) LOG(WARNING) << s.ToString();
             }
+            // desc.transports lists the transports that actually registered
+            // the buffer (each transport appends itself on success).
+            for (auto& desc : descs) {
+                for (auto type : desc.transports) {
+                    TentMetrics::instance().recordRegisteredBufferBytes(
+                        type, static_cast<int64_t>(desc.length));
+                }
+            }
             return Status::OK();
         });
     if (!status.ok()) return status;
@@ -861,6 +869,10 @@ Status TransferEngineImpl::unregisterLocalMemory(void* addr, size_t size) {
             for (auto type : desc.transports) {
                 auto status = transport_list_[type]->removeMemoryBuffer(desc);
                 if (!status.ok()) LOG(WARNING) << status.ToString();
+            }
+            for (auto type : desc.transports) {
+                TentMetrics::instance().recordRegisteredBufferBytes(
+                    type, -static_cast<int64_t>(desc.length));
             }
             return Status::OK();
         });
@@ -885,6 +897,10 @@ Status TransferEngineImpl::unregisterLocalMemory(
                 for (auto type : desc.transports) {
                     auto s = transport_list_[type]->removeMemoryBuffer(desc);
                     if (!s.ok()) LOG(WARNING) << s.ToString();
+                }
+                for (auto type : desc.transports) {
+                    TentMetrics::instance().recordRegisteredBufferBytes(
+                        type, -static_cast<int64_t>(desc.length));
                 }
                 return Status::OK();
             });
@@ -1879,11 +1895,16 @@ Status TransferEngineImpl::commitPreparedSubmit(
             auto status = transport->submitTransferTasks(sub_batch, requests);
             if (!status.ok()) {
                 auto attempt_end = std::chrono::steady_clock::now();
+                // failure_stage must be marked in this first segment, before
+                // any recovery/failover attempt on the failure: a task that
+                // recovers and later fails at poll must still attribute its
+                // root cause to submit.
                 for (const auto physical_task_id : group) {
                     for (const auto public_task_id :
                          public_tasks_by_physical_owner.at(physical_task_id)) {
-                        finishTransportAttempt(batch->task_list[public_task_id],
-                                               FAILED, attempt_end);
+                        auto& task = batch->task_list[public_task_id];
+                        if (task.failure_stage < 0) task.failure_stage = 0;
+                        finishTransportAttempt(task, FAILED, attempt_end);
                     }
                 }
                 // Recover by failing over to the remaining candidate
@@ -2106,6 +2127,7 @@ Status TransferEngineImpl::dispatchQueuedOwner(QueueOwnerId owner_id) {
     startTransportAttempt(task, task.type, std::chrono::steady_clock::now());
     auto status = transport->submitTransferTasks(sub_batch, {task.request});
     if (!status.ok()) {
+        if (task.failure_stage < 0) task.failure_stage = 0;
         finishTransportAttempt(task, FAILED, std::chrono::steady_clock::now());
         // Submit-stage failover: walk the remaining candidate transports
         // before giving up (the queued path dispatches one owner task at a
@@ -2410,6 +2432,7 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     startTransportAttempt(task, type, std::chrono::steady_clock::now());
     auto status = transport->submitTransferTasks(sub_batch, {task.request});
     if (!status.ok()) {
+        if (task.failure_stage < 0) task.failure_stage = 0;
         finishTransportAttempt(task, FAILED, std::chrono::steady_clock::now());
     }
     return status;
@@ -2472,6 +2495,14 @@ void TransferEngineImpl::updateTaskStatusAfterPoll(Batch* batch, size_t task_id,
                                                    bool allow_failover) {
     auto& task = batch->task_list[task_id];
     task.status = task_status.s;
+    // First-failure attribution: a terminal failure observed by polling marks
+    // the poll stage. Submit-stage failures were already marked at their
+    // origin and are not overwritten (a poll failure followed by a rejected
+    // failover resubmit still counts as poll).
+    if (task_status.s == FAILED || task_status.s == TIMEOUT ||
+        task_status.s == CANCELED) {
+        if (task.failure_stage < 0) task.failure_stage = 1;
+    }
     if (!allow_failover || task.cancel_requested || task_status.s != FAILED ||
         task.type == UNSPEC)
         return;
@@ -2850,6 +2881,35 @@ void TransferEngineImpl::recordTaskCompletionMetrics(
 #if TENT_METRICS_ENABLED
     if (prev_status == PENDING && new_status != PENDING && !task.derived) {
         auto end_time = std::chrono::steady_clock::now();
+        // Failure reason: task.failure_stage marks where the first failure
+        // originated (0 = submit, 1 = poll), set at the failure site — a
+        // poll-observed failure stays "poll" even when the failover resubmit
+        // is synchronously rejected. TIMEOUT/CANCELED come from the status
+        // itself and were previously not recorded anywhere.
+        if (new_status == FAILED || new_status == TIMEOUT ||
+            new_status == CANCELED) {
+            TentMetrics::TaskFailureReason reason;
+            if (new_status == TIMEOUT) {
+                reason = TentMetrics::TaskFailureReason::Timeout;
+            } else if (new_status == CANCELED) {
+                reason = TentMetrics::TaskFailureReason::Canceled;
+            } else if (task.failure_stage == 0) {
+                reason = TentMetrics::TaskFailureReason::Submit;
+            } else if (task.failure_stage == 1) {
+                reason = TentMetrics::TaskFailureReason::Poll;
+            } else {
+                // Unmarked path: an attempt still in flight means the
+                // failure was observed by polling.
+                reason = task.attempt_active
+                             ? TentMetrics::TaskFailureReason::Poll
+                             : TentMetrics::TaskFailureReason::Submit;
+            }
+            // Prefer the attempt transport: task.type may already be UNSPEC
+            // after a submit-stage failure.
+            TransportType failure_tp =
+                task.attempt_type != UNSPEC ? task.attempt_type : task.type;
+            TentMetrics::instance().recordTaskFailure(failure_tp, reason);
+        }
         finishTransportAttempt(task, new_status, end_time);
         auto start_time = task.start_time;
         if (start_time.time_since_epoch().count() > 0) {
@@ -2951,6 +3011,7 @@ void TransferEngineImpl::startTransportAttempt(
 #if TENT_METRICS_ENABLED
     TentMetrics::instance().recordTransportAttemptStarted(type,
                                                           task.request.opcode);
+    TentMetrics::instance().recordInflightAttemptStarted(type);
 #else
     (void)type;
 #endif
@@ -2962,6 +3023,10 @@ void TransferEngineImpl::finishTransportAttempt(
     if (!task.attempt_active) return;
     task.attempt_active = false;
 #if TENT_METRICS_ENABLED
+    // Decrement before the early return below so the in-flight gauge stays
+    // symmetric with recordInflightAttemptStarted() for every attempt that
+    // actually started.
+    TentMetrics::instance().recordInflightAttemptFinished(task.attempt_type);
     auto post_time = task.attempt_post_time;
     if (post_time.time_since_epoch().count() == 0) return;
     double latency_us =

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -1152,6 +1152,114 @@ TEST_F(MetricsRecordingTest, ConcurrentRecordsAcrossTransportsAreExact) {
               0);
 }
 
+// Task failure with reason="submit": a synchronously rejected submit fails
+// the attempt at the submit site, so recordTaskCompletionMetrics sees
+// attempt_active == false. The counter must attribute the failure to the
+// attempt transport (rdma) even though task.type is UNSPEC by then — the
+// attribution leak the reason counter must not reproduce.
+TEST_F(MetricsRecordingTest, SubmitFailureRecordsTaskFailureWithSubmitReason) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA, /*force_fail=*/false,
+                                                /*force_submit_fail=*/true);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xCD);
+    auto before_register = MetricsSnapshot(TentMetrics::instance());
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kLen).ok());
+    auto after_register = MetricsSnapshot(TentMetrics::instance());
+    EXPECT_EQ(after_register.series(
+                  "tent_registered_buffer_bytes{transport=\"rdma\"}") -
+                  before_register.series(
+                      "tent_registered_buffer_bytes{transport=\"rdma\"}"),
+              static_cast<double>(kLen));
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    ASSERT_TRUE(
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)}).ok());
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::FAILED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(
+        after.series(
+            "tent_task_failures_total{transport=\"rdma\",reason=\"submit"
+            "\"}") -
+            before.series("tent_task_failures_total{transport=\"rdma\",reason="
+                          "\"submit\"}"),
+        1);
+    EXPECT_EQ(
+        after.series(
+            "tent_task_failures_total{transport=\"rdma\",reason=\"poll\"}") -
+            before.series(
+                "tent_task_failures_total{transport=\"rdma\",reason=\""
+                "poll\"}"),
+        0);
+    // In-flight gauge returns to zero after the terminal failure.
+    EXPECT_EQ(after.counter("tent_inflight_attempts") -
+                  before.counter("tent_inflight_attempts"),
+              0);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kLen).ok());
+    auto after_unregister = MetricsSnapshot(TentMetrics::instance());
+    EXPECT_EQ(after_unregister.series(
+                  "tent_registered_buffer_bytes{transport=\"rdma\"}"),
+              0);
+}
+
+// Task failure with reason="poll": the transport accepted the request and
+// reported FAILED from getTransferStatus, so the attempt is still active when
+// recordTaskCompletionMetrics runs.
+TEST_F(MetricsRecordingTest, PollFailureRecordsTaskFailureWithPollReason) {
+    auto cfg = makeMetricsTestConfig();
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    auto fake = std::make_shared<FakeTransport>(RDMA, /*force_fail=*/true,
+                                                /*force_submit_fail=*/false);
+    installFakeRdma(engine, fake);
+
+    constexpr size_t kLen = 4096;
+    std::vector<uint8_t> buf(kLen, 0xAB);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), kLen).ok());
+
+    BatchID batch = engine.allocateBatch(4);
+    ASSERT_NE(batch, (BatchID)0);
+
+    auto before = MetricsSnapshot(TentMetrics::instance());
+    ASSERT_TRUE(
+        engine.submitTransfer(batch, {makeLocalWrite(buf.data(), kLen)}).ok());
+    ASSERT_EQ(pollUntilTerminal(engine, batch, 0), TransferStatusEnum::FAILED);
+    auto after = MetricsSnapshot(TentMetrics::instance());
+
+    EXPECT_EQ(
+        after.series(
+            "tent_task_failures_total{transport=\"rdma\",reason=\"poll\"}") -
+            before.series(
+                "tent_task_failures_total{transport=\"rdma\",reason=\""
+                "poll\"}"),
+        1);
+    EXPECT_EQ(
+        after.series(
+            "tent_task_failures_total{transport=\"rdma\",reason=\"submit"
+            "\"}") -
+            before.series("tent_task_failures_total{transport=\"rdma\",reason="
+                          "\"submit\"}"),
+        0);
+    EXPECT_EQ(after.counter("tent_inflight_attempts") -
+                  before.counter("tent_inflight_attempts"),
+              0);
+
+    EXPECT_TRUE(engine.freeBatch(batch).ok());
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kLen).ok());
+}
+
 // ---------------------------------------------------------------------------
 // L2 HTTP integration: scrape the real /metrics, /metrics/json, /health
 // endpoints via coro_http_client and assert on status + body. Validates the

--- a/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/metrics_recording_test.cpp
@@ -1260,6 +1260,53 @@ TEST_F(MetricsRecordingTest, PollFailureRecordsTaskFailureWithPollReason) {
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kLen).ok());
 }
 
+// Gauges must stay symmetric across setEnabled() transitions: the runtime
+// switch governs statistical sampling, not state tracking. Skipping one half
+// of a paired add/sub would permanently corrupt the gauge (review feedback).
+TEST_F(MetricsRecordingTest, InflightGaugeSurvivesEnableToggle) {
+    auto& m = TentMetrics::instance();
+    auto before = MetricsSnapshot(m);
+
+    // Enabled at start, disabled before finish.
+    TentMetrics::setEnabled(true);
+    m.recordInflightAttemptStarted(RDMA);
+    TentMetrics::setEnabled(false);
+    m.recordInflightAttemptFinished(RDMA);
+
+    // Disabled at start, enabled before finish (reverse straddle).
+    m.recordInflightAttemptStarted(RDMA);
+    TentMetrics::setEnabled(true);
+    m.recordInflightAttemptFinished(RDMA);
+
+    auto after = MetricsSnapshot(m);
+    EXPECT_EQ(after.counter("tent_inflight_attempts") -
+                  before.counter("tent_inflight_attempts"),
+              0);
+    EXPECT_EQ(after.series("tent_inflight_attempts{transport=\"rdma\"}") -
+                  before.series("tent_inflight_attempts{transport=\"rdma\"}"),
+              0);
+}
+
+TEST_F(MetricsRecordingTest, RegisteredBytesGaugeSurvivesEnableToggle) {
+    auto& m = TentMetrics::instance();
+    auto before = MetricsSnapshot(m);
+
+    TentMetrics::setEnabled(true);
+    m.recordRegisteredBufferBytes(RDMA, 4096);
+    TentMetrics::setEnabled(false);
+    m.recordRegisteredBufferBytes(RDMA, -4096);
+    TentMetrics::setEnabled(true);
+
+    auto after = MetricsSnapshot(m);
+    EXPECT_EQ(after.counter("tent_registered_buffer_bytes") -
+                  before.counter("tent_registered_buffer_bytes"),
+              0);
+    EXPECT_EQ(
+        after.series("tent_registered_buffer_bytes{transport=\"rdma\"}") -
+            before.series("tent_registered_buffer_bytes{transport=\"rdma\"}"),
+        0);
+}
+
 // ---------------------------------------------------------------------------
 // L2 HTTP integration: scrape the real /metrics, /metrics/json, /health
 // endpoints via coro_http_client and assert on status + body. Validates the


### PR DESCRIPTION
## Description

Follow-up to #3677 (stacked on `tent/metrics-cell-cache`, merge after it).
Adds three metrics aimed at production diagnosis, all recorded through the
cached label cells (no locks on the hot path):

- **`tent_task_failures_total{transport, reason}`** — task-level failures
  with reason `submit` / `poll` / `timeout` / `canceled`. Motivation: in the
  CI incident that motivated this, hundreds of failures collapsed into a
  single `write_failures_total{transport="..."}` counter with no way to
  tell whether ops died at submission or in flight without log scraping.
  - `TaskInfo.failure_stage` marks where the **first** failure originated,
    set at the submit-rejection sites (commitPreparedSubmit /
    dispatchQueuedOwner / resubmitTransferTask) and at poll observation
    (updateTaskStatusAfterPoll), first-set-wins. A poll-observed failure
    stays `poll` even when the failover resubmit is synchronously
    rejected — the root cause, not the last bookkeeping event.
  - Transport attribution uses `attempt_type` (captured at attempt start),
    so a submit-stage failure still attributes to the real transport even
    though `task.type` is UNSPEC by then.
  - TIMEOUT/CANCELED outcomes were previously not recorded as failures
    anywhere; they are now.
  - Additive: the legacy `read/write_failures_total` counters are
    unchanged, so existing dashboards keep working.
- **`tent_inflight_attempts{transport}`** (gauge) — incremented on attempt
  submit, decremented on attempt finish. Shows how much transfer work is
  sitting in the engine right now; a persistently high or stuck value is
  the signature of a stalled pipeline (previously required log scraping
  plus Little's law to detect).
- **`tent_registered_buffer_bytes{transport}`** (gauge) — maintained on
  register/unregisterLocalMemory from `desc.transports` (the transports
  that actually registered), pairing with the failure counters to answer
  "registered but not moving".

All labels are small-cardinality enums (4 reasons, transport enum), per
the metrics label-domain constraint.

## Performance

tebench 4K/1 write, local pair, same back-to-back conditions as #3677
(background load present; comparisons are relative):

| threads | this PR, metrics on | this PR, metrics off | on/off gap | #3677 only, metrics on |
|---|---|---|---|---|
| 1  | 137k ops/s / 7.3µs | 137k / 7.3µs | 0%    | 138k / 7.2µs |
| 2  | 171k               | 175k               | -2.3% | 178k |
| 4  | 316k               | 324k               | -2.5% | 323k |
| 8  | 480k / 16.7µs      | 498k / 16.1µs      | -3.6% | 478k / 16.7µs |
| 16 | 669k / 23.9µs      | 669k / 23.9µs      | 0%    | 663k / 24.1µs |

With metrics enabled, this PR is indistinguishable from #3677 alone
(within run-to-run variance), and the metrics on/off gap stays within
the <5% acceptance bound. The only hot-path addition is the in-flight
gauge's pair of relaxed atomic adds per attempt; the failure-reason
counter and registered-bytes gauge are off the hot path.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S mooncake-transfer-engine -B build-tent -DCMAKE_BUILD_TYPE=Release \
      -DUSE_TENT=ON -DTENT_METRICS_ENABLED=ON -DYLT_ENABLE_IBV=ON -DWITH_STORE=OFF
cmake --build build-tent -j16
for t in build-tent/tent/tests/*_test; do $t || exit 1; done
```

**Test results:**
- [x] Unit tests pass — all 40 tent test binaries pass; two new tests in
  `tent_metrics_recording_test` cover submit-attributed and poll-attributed
  task failures (including the poll-failure-followed-by-rejected-failover
  path, which initially misattributed as submit and is exactly what
  `failure_stage` fixes), in-flight returning to zero after terminal
  states, and registered bytes rising on register and returning to zero on
  unregister
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done — reason series asserted via the Prometheus
  text output; gauge serialization covered by the JSON/Prometheus snapshot
  helpers

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable) — metric names are self-documenting via # HELP
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue — 329 added LOC, additive metrics only

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

CodeBuddy (AI coding assistant) assisted with implementation, testing, and
benchmarking under human direction. Every changed line has been reviewed
by the submitter, who can defend the change end-to-end.
