### PR TITLE
[TENT] Keep the worker from blocking on its own submit queue

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
@@ -57,11 +57,9 @@ struct BoundedMPSCQueue {
         Cell *cell = &buffer[pos % Capacity];
 
         uint64_t seq = cell->sequence.load(std::memory_order_acquire);
-        intptr_t dif =
-            static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
+        intptr_t dif = static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
         if (dif != 0) return false;
-        if (!tail.compare_exchange_weak(pos, pos + 1,
-                                        std::memory_order_acq_rel,
+        if (!tail.compare_exchange_weak(pos, pos + 1, std::memory_order_acq_rel,
                                         std::memory_order_relaxed)) {
             return false;
         }

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
@@ -43,27 +43,31 @@ struct BoundedMPSCQueue {
     ~BoundedMPSCQueue() = default;
 
     void push(T &slice_list) {
-        if (slice_list.num_slices == 0) return;
-        uint64_t pos;
-        while (true) {
-            pos = tail.load(std::memory_order_relaxed);
-            Cell *cell = &buffer[pos % Capacity];
-
-            uint64_t seq = cell->sequence.load(std::memory_order_acquire);
-            intptr_t dif =
-                static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
-            if (dif == 0) {
-                if (tail.compare_exchange_weak(pos, pos + 1,
-                                               std::memory_order_acq_rel,
-                                               std::memory_order_relaxed)) {
-                    cell->data = slice_list;
-                    cell->sequence.store(pos + 1, std::memory_order_release);
-                    return;
-                }
-            } else if (dif < 0) {
-                std::this_thread::yield();
-            }
+        while (!try_push(slice_list)) {
+            std::this_thread::yield();
         }
+    }
+
+    // Non-blocking push: returns false when the queue is full. The worker
+    // thread re-enqueues through this so a full queue parks the entry in a
+    // local overflow instead of wedging the only consumer (issue #3637).
+    bool try_push(T &slice_list) {
+        if (slice_list.num_slices == 0) return true;
+        uint64_t pos = tail.load(std::memory_order_relaxed);
+        Cell *cell = &buffer[pos % Capacity];
+
+        uint64_t seq = cell->sequence.load(std::memory_order_acquire);
+        intptr_t dif =
+            static_cast<intptr_t>(seq) - static_cast<intptr_t>(pos);
+        if (dif != 0) return false;
+        if (!tail.compare_exchange_weak(pos, pos + 1,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_relaxed)) {
+            return false;
+        }
+        cell->data = slice_list;
+        cell->sequence.store(pos + 1, std::memory_order_release);
+        return true;
     }
 
     T pop() {

--- a/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/concurrent/bounded_mpsc_queue.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <thread>
 #include <unordered_set>
+#include <vector>
 
 namespace mooncake {
 namespace tent {

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -222,7 +222,9 @@ class Workers {
         // Tick-internal re-enqueues that found their target queue full
         // (target priority, entry). Parked items stay counted in
         // inflight_slices, which both keeps the accounting continuous and
-        // keeps the worker from suspending while a flush is pending.
+        // keeps the worker from suspending while they are pending. The
+        // asyncPostSend drain consumes this list before the shared queues,
+        // so parked entries can never starve behind contending producers.
         std::vector<std::pair<int, RdmaSliceList>> requeue_overflow;
 
         // Values are held via unique_ptr so that map rehashing does not
@@ -238,9 +240,8 @@ class Workers {
 
     // Tick-internal re-enqueue: the worker thread must never block on its own
     // queue (issue #3637), so these park into requeue_overflow on a full queue
-    // and the flush retries on the next tick.
+    // and the asyncPostSend drain consumes them first.
     void submitFromTick(WorkerContext& worker, RdmaSlice* slice);
-    void flushTickOverflow(WorkerContext& worker);
 
     WorkerContext* worker_context_;
     uint64_t slice_timeout_ns_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -219,6 +219,12 @@ class Workers {
         // Next time to check for priority promotions (nanoseconds)
         uint64_t next_promotion_check_ns = 0;
 
+        // Tick-internal re-enqueues that found their target queue full
+        // (target priority, entry). Parked items stay counted in
+        // inflight_slices, which both keeps the accounting continuous and
+        // keeps the worker from suspending while a flush is pending.
+        std::vector<std::pair<int, RdmaSliceList>> requeue_overflow;
+
         // Values are held via unique_ptr so that map rehashing does not
         // invalidate pointers into RailMonitor stored on in-flight slices
         // (see RdmaSlice::rail_monitor).
@@ -229,6 +235,12 @@ class Workers {
 
     // Promote timed-out low priority requests to higher priority queues
     void promoteTimedOutRequests(WorkerContext& worker);
+
+    // Tick-internal re-enqueue: the worker thread must never block on its own
+    // queue (issue #3637), so these park into requeue_overflow on a full queue
+    // and the flush retries on the next tick.
+    void submitFromTick(WorkerContext& worker, RdmaSlice* slice);
+    void flushTickOverflow(WorkerContext& worker);
 
     WorkerContext* worker_context_;
     uint64_t slice_timeout_ns_;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -273,6 +273,37 @@ Status Workers::submit(RdmaSlice* slice) {
     return submit(slice_list);
 }
 
+void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
+    RdmaSliceList slice_list;
+    slice_list.first = slice;
+    slice_list.num_slices = 1;
+    int priority = PRIO_HIGH;
+    if (slice && slice->task) {
+        priority = slice->priority;
+    }
+    // The worker must never block on its own queue (issue #3637): a full
+    // queue parks the slice in requeue_overflow and the next tick retries.
+    // Either way it stays counted as inflight, which keeps the worker from
+    // suspending while a parked flush is pending.
+    if (!worker.queues[priority].try_push(slice_list)) {
+        worker.requeue_overflow.emplace_back(priority, slice_list);
+    }
+    worker.inflight_slices.fetch_add(1);
+}
+
+void Workers::flushTickOverflow(WorkerContext& worker) {
+    auto& overflow = worker.requeue_overflow;
+    if (overflow.empty()) return;
+    auto it = overflow.begin();
+    while (it != overflow.end()) {
+        if (worker.queues[it->first].try_push(it->second)) {
+            it = overflow.erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 Status Workers::cancel(RdmaTask* task) {
     if (!task) return Status::InvalidArgument("Invalid RDMA task" LOC_MARK);
     if (task->cancel_requested.exchange(true, std::memory_order_acq_rel)) {
@@ -461,7 +492,7 @@ void Workers::asyncPostSend() {
                     updateSliceStatus(slice, FAILED);
                 } else {
                     releaseSliceQuota(slice);
-                    submit(slice);
+                    submitFromTick(worker, slice);
                 }
                 worker.inflight_slices.fetch_sub(1);
             }
@@ -529,7 +560,7 @@ void Workers::asyncPostSend() {
                     disableEndpoint(slice);
                     updateSliceStatus(slice, FAILED);
                 } else {
-                    submit(slice);
+                    submitFromTick(worker, slice);
                 }
                 worker.inflight_slices.fetch_sub(1);
             } else {
@@ -559,6 +590,15 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
         worker.queues[from].pop(drained);
         if (drained.empty()) return false;
 
+        // The worker must never block on its own queue: a full target parks
+        // the entry in requeue_overflow and the next tick retries (issue
+        // #3637). Parked entries stay counted as inflight throughout.
+        auto requeue = [&](int target, RdmaSliceList& slice_list) {
+            if (!worker.queues[target].try_push(slice_list)) {
+                worker.requeue_overflow.emplace_back(target, slice_list);
+            }
+        };
+
         if (!priority_promotion_per_entry_) {
             auto* slice = drained.front().first;
             const bool head_timed_out = slice && slice->enqueue_ts > 0 &&
@@ -566,7 +606,7 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
                                         (current_ts - slice->enqueue_ts) >=
                                             priority_promotion_timeout_ns_;
             for (auto& slice_list : drained) {
-                worker.queues[head_timed_out ? to : from].push(slice_list);
+                requeue(head_timed_out ? to : from, slice_list);
             }
             return head_timed_out;
         }
@@ -582,8 +622,7 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
             enqueue_ts, current_ts, priority_promotion_timeout_ns_);
 
         if (!decision.promoted_any()) {
-            for (auto& slice_list : drained)
-                worker.queues[from].push(slice_list);
+            for (auto& slice_list : drained) requeue(from, slice_list);
             return false;
         }
 
@@ -592,7 +631,7 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
             if (idx < drained.size()) promote[idx] = true;
         }
         for (size_t i = 0; i < drained.size(); ++i) {
-            worker.queues[promote[i] ? to : from].push(drained[i]);
+            requeue(promote[i] ? to : from, drained[i]);
         }
         return true;
     };
@@ -706,7 +745,7 @@ void Workers::asyncPollCq() {
                             std::memory_order_acquire)) {
                         updateSliceStatus(slice, CANCELED);
                     } else {
-                        submit(slice);
+                        submitFromTick(worker, slice);
                     }
                 }
             } else {
@@ -775,6 +814,7 @@ void Workers::workerThread(int thread_id) {
         if (inflight_slices ||
             current_ts - grace_ts <
                 transport_->params_->workers.grace_period_ns) {
+            flushTickOverflow(worker);
             asyncPostSend();
             asyncPollCq();
             if (inflight_slices) grace_ts = current_ts;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -291,19 +291,6 @@ void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
     worker.inflight_slices.fetch_add(1);
 }
 
-void Workers::flushTickOverflow(WorkerContext& worker) {
-    auto& overflow = worker.requeue_overflow;
-    if (overflow.empty()) return;
-    auto it = overflow.begin();
-    while (it != overflow.end()) {
-        if (worker.queues[it->first].try_push(it->second)) {
-            it = overflow.erase(it);
-        } else {
-            ++it;
-        }
-    }
-}
-
 Status Workers::cancel(RdmaTask* task) {
     if (!task) return Status::InvalidArgument("Invalid RDMA task" LOC_MARK);
     if (task->cancel_requested.exchange(true, std::memory_order_acq_rel)) {
@@ -426,9 +413,21 @@ void Workers::asyncPostSend() {
     // Promote timed-out low priority requests
     promoteTimedOutRequests(worker);
 
-    // Priority selection: HIGH -> MEDIUM -> LOW
+    // Priority selection: HIGH -> MEDIUM -> LOW. The worker-local overflow is
+    // drained before the shared queues, so a parked retry can never starve
+    // behind producers that keep refilling freed slots (issue #3637).
+    auto& overflow = worker.requeue_overflow;
     for (int prio = PRIO_HIGH; prio < kNumPriorityLevels; ++prio) {
         if (shared_quota && !shared_quota->canSend(prio)) continue;
+        for (auto it = overflow.begin(); it != overflow.end();) {
+            if (it->first == prio) {
+                result.push_back(it->second);
+                it = overflow.erase(it);
+            } else {
+                ++it;
+            }
+        }
+        if (!result.empty()) break;
         worker.queues[prio].pop(result);
         if (!result.empty()) break;
     }
@@ -814,7 +813,6 @@ void Workers::workerThread(int thread_id) {
         if (inflight_slices ||
             current_ts - grace_ts <
                 transport_->params_->workers.grace_period_ns) {
-            flushTickOverflow(worker);
             asyncPostSend();
             asyncPollCq();
             if (inflight_slices) grace_ts = current_ts;

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -84,6 +84,13 @@ target_include_directories(promotion_policy_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME promotion_policy_test COMMAND promotion_policy_test)
 
+add_executable(bounded_mpsc_queue_test bounded_mpsc_queue_test.cpp)
+target_link_libraries(bounded_mpsc_queue_test PRIVATE tent_common gtest
+                                                      gtest_main)
+target_include_directories(bounded_mpsc_queue_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME bounded_mpsc_queue_test COMMAND bounded_mpsc_queue_test)
+
 add_executable(rdma_cancel_test rdma_cancel_test.cpp ../src/runtime/slab.cpp)
 target_link_libraries(rdma_cancel_test PRIVATE tent_common gtest gtest_main)
 target_include_directories(rdma_cancel_test

--- a/mooncake-transfer-engine/tent/tests/bounded_mpsc_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/bounded_mpsc_queue_test.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Regression coverage for issue #3637: a full queue used to spin push()
+// forever, so a worker re-enqueueing its own slices could wedge the only
+// consumer. try_push must report fullness instead, and the tick overflow
+// pattern (park, pop, flush) must keep every entry deliverable.
+
+#include "tent/common/concurrent/bounded_mpsc_queue.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// The queue is generic over T and only touches num_slices, so a stand-in keeps
+// this test buildable without the RDMA transport headers.
+struct SliceList {
+    void* first = nullptr;
+    int num_slices = 0;
+};
+
+using Queue = BoundedMPSCQueue<SliceList, 8>;
+
+SliceList entry(int n) {
+    SliceList list;
+    list.num_slices = n;
+    return list;
+}
+
+TEST(BoundedMPSCQueueTest, TryPushReportsFullInsteadOfSpinning) {
+    Queue queue;
+    for (int i = 0; i < 8; ++i) {
+        auto item = entry(1);
+        ASSERT_TRUE(queue.try_push(item));
+    }
+    auto extra = entry(1);
+    EXPECT_FALSE(queue.try_push(extra));
+}
+
+TEST(BoundedMPSCQueueTest, PopDrainsInOrderAfterFull) {
+    Queue queue;
+    for (int i = 1; i <= 8; ++i) {
+        auto item = entry(i);
+        ASSERT_TRUE(queue.try_push(item));
+    }
+    for (int i = 1; i <= 8; ++i) {
+        EXPECT_EQ(queue.pop().num_slices, i);
+    }
+    // Empty pop returns a zero-initialized entry.
+    EXPECT_EQ(queue.pop().num_slices, 0);
+}
+
+TEST(BoundedMPSCQueueTest, OverflowParkPopFlushKeepsEveryEntry) {
+    Queue queue;
+    for (int i = 0; i < 8; ++i) {
+        auto item = entry(1);
+        ASSERT_TRUE(queue.try_push(item));
+    }
+    // The tick path: a full queue parks the entry and the flush retries once
+    // space frees up.
+    std::vector<SliceList> overflow;
+    auto parked = entry(7);
+    ASSERT_FALSE(queue.try_push(parked));
+    overflow.push_back(parked);
+    EXPECT_EQ(queue.pop().num_slices, 1);
+    auto it = overflow.begin();
+    while (it != overflow.end()) {
+        if (queue.try_push(*it)) {
+            it = overflow.erase(it);
+        } else {
+            ++it;
+        }
+    }
+    EXPECT_TRUE(overflow.empty());
+}
+
+TEST(BoundedMPSCQueueTest, PushStillAcceptsAndEmptyPushIsANoop) {
+    Queue queue;
+    auto empty = entry(0);
+    queue.push(empty);  // returns immediately for an empty list
+    auto item = entry(3);
+    queue.push(item);
+    EXPECT_EQ(queue.pop().num_slices, 3);
+    EXPECT_EQ(queue.pop().num_slices, 0);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/bounded_mpsc_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/bounded_mpsc_queue_test.cpp
@@ -14,8 +14,9 @@
 //
 // Regression coverage for issue #3637: a full queue used to spin push()
 // forever, so a worker re-enqueueing its own slices could wedge the only
-// consumer. try_push must report fullness instead, and the tick overflow
-// pattern (park, pop, flush) must keep every entry deliverable.
+// consumer. try_push must report fullness instead, and the worker-local
+// overflow must drain before the shared queue so parked entries cannot
+// starve behind contending producers.
 
 #include "tent/common/concurrent/bounded_mpsc_queue.h"
 
@@ -65,27 +66,37 @@ TEST(BoundedMPSCQueueTest, PopDrainsInOrderAfterFull) {
     EXPECT_EQ(queue.pop().num_slices, 0);
 }
 
-TEST(BoundedMPSCQueueTest, OverflowParkPopFlushKeepsEveryEntry) {
+TEST(BoundedMPSCQueueTest, ParkedEntryIsDrainedBeforeContendingProducers) {
+    // Model the production drain order: the worker consumes its local overflow
+    // before popping the shared queue, so a parked retry makes progress even
+    // while producers keep refilling freed slots (review feedback on #3683).
     Queue queue;
     for (int i = 0; i < 8; ++i) {
         auto item = entry(1);
         ASSERT_TRUE(queue.try_push(item));
     }
-    // The tick path: a full queue parks the entry and the flush retries once
-    // space frees up.
     std::vector<SliceList> overflow;
     auto parked = entry(7);
     ASSERT_FALSE(queue.try_push(parked));
     overflow.push_back(parked);
-    EXPECT_EQ(queue.pop().num_slices, 1);
-    auto it = overflow.begin();
-    while (it != overflow.end()) {
-        if (queue.try_push(*it)) {
-            it = overflow.erase(it);
-        } else {
-            ++it;
-        }
+
+    // First tick drains the shared queue fully; a producer instantly refills.
+    std::vector<SliceList> first_batch;
+    queue.pop(first_batch);
+    ASSERT_EQ(first_batch.size(), 8u);
+    auto fresh = entry(9);
+    ASSERT_TRUE(queue.try_push(fresh));
+
+    // Second tick: overflow first, then the shared queue.
+    std::vector<SliceList> batch;
+    for (auto it = overflow.begin(); it != overflow.end();) {
+        batch.push_back(*it);
+        it = overflow.erase(it);
     }
+    queue.pop(batch);
+    ASSERT_EQ(batch.size(), 2u);
+    EXPECT_EQ(batch[0].num_slices, 7);
+    EXPECT_EQ(batch[1].num_slices, 9);
     EXPECT_TRUE(overflow.empty());
 }
 


### PR DESCRIPTION
## Description

Fixes #3637.

`BoundedMPSCQueue::push()` spins with `yield()` when the queue is full and has no failure exit. The TENT worker thread calls `push()` on its own priority queues when re-enqueueing retried slices and when promoting entries between levels, so once a queue fills during a sustained failure period the worker wedges itself: it stops popping, every producer then spins in `push()`, and the engine cannot recover even after the underlying RDMA problem clears.

This adds a non-blocking `try_push` and routes every tick-internal re-enqueue through it. A full queue now parks the entry in a per-worker overflow list that the next tick flushes first, so the worker keeps draining and the producer-side spin keeps its exit. Parked entries stay counted as inflight, which keeps the accounting continuous and keeps the worker from suspending while a flush is pending. The external `submit()` path is unchanged; producer backpressure semantics are untouched.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
# new deterministic regression test (no RDMA stack needed)
ctest -R bounded_mpsc_queue_test --output-on-failure
```

**Test results:**
- [x] Unit tests pass — `bounded_mpsc_queue_test` (4 cases: full-queue try_push reports instead of spinning, FIFO drain after full, the park/pop/flush overflow pattern, push noop on empty list). Built and run locally on macOS against the header-only queue.
- [ ] Integration tests pass (if applicable) — the RDMA transport does not build on this machine (no rdma-core headers), so the workers.cpp compile is left to CI.
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass (the cmake-format hook rewrites unrelated blocks of `tent/tests/CMakeLists.txt` even on pristine main, so those were left out)
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Drafted with Kimi K3 assistance. The invariants this change relies on (the worker never blocks on its own queue; inflight accounting is unchanged: re-enqueue +1 and the call-site -1 net to zero, same as the old submit path) were re-verified against the code before submission.