### PR TITLE
TENT: flush a peer's pooled RPC connections when one of them fails

### DIFF
--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -43,29 +43,52 @@ struct RpcHandlerScope {
 
 class ClientPool {
    public:
-    std::unique_ptr<coro_rpc_client> acquire() {
+    struct Lease {
+        std::unique_ptr<coro_rpc_client> client;
+        // Which generation the client was drawn from. Flushing is keyed on
+        // this: see clearIfCurrent().
+        uint64_t generation = 0;
+    };
+
+    Lease acquire() {
         std::lock_guard<std::mutex> guard(lock_);
         if (!idle_clients_.empty()) {
             auto client = std::move(idle_clients_.back());
             idle_clients_.pop_back();
-            return client;
+            return Lease{std::move(client), generation_};
         }
-        return nullptr;
+        return Lease{nullptr, generation_};
     }
 
+    // A client is only released after a call succeeded on it, which proves it
+    // is alive, so it goes back regardless of which generation it came from.
     void release(std::unique_ptr<coro_rpc_client> client) {
         if (!client) return;
         std::lock_guard<std::mutex> guard(lock_);
         idle_clients_.push_back(std::move(client));
     }
 
+    // Drop every idle client, but only on behalf of a caller that is still
+    // looking at the generation it drew from. Several callers notice a peer
+    // restart at once; without this, the second one to fail would throw away
+    // the connections the first one has already re-established, and the pool
+    // would churn for as long as stale clients keep surfacing.
+    void clearIfCurrent(uint64_t generation) {
+        std::lock_guard<std::mutex> guard(lock_);
+        if (generation != generation_) return;
+        ++generation_;
+        idle_clients_.clear();
+    }
+
     void clear() {
         std::lock_guard<std::mutex> guard(lock_);
+        ++generation_;
         idle_clients_.clear();
     }
 
    private:
     std::mutex lock_;
+    uint64_t generation_ = 0;
     std::vector<std::unique_ptr<coro_rpc_client>> idle_clients_;
 };
 
@@ -187,6 +210,26 @@ std::shared_ptr<ClientPool> CoroRpcAgent::getOrCreatePool(
     return it->second;
 }
 
+namespace {
+
+// True when the failure came back from the peer as a reply, which means the
+// connection carried a full round trip and is still usable. Every other
+// failure leaves the connection in an unknown state.
+bool peerAnswered(coro_rpc::errc ec) {
+    switch (ec) {
+        case coro_rpc::errc::rpc_throw_exception:
+        case coro_rpc::errc::function_not_registered:
+        case coro_rpc::errc::invalid_rpc_arguments:
+        case coro_rpc::errc::invalid_rpc_result:
+        case coro_rpc::errc::message_too_large:
+            return true;
+        default:
+            return false;
+    }
+}
+
+}  // namespace
+
 Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
     std::string server_addr, int func_id, std::string request) {
     if (tl_inside_rpc_handler) {
@@ -197,7 +240,10 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
     }
 
     auto pool = getOrCreatePool(server_addr);
-    ClientLease lease{pool->acquire(), pool, false};
+    auto acquired = pool->acquire();
+    const uint64_t generation = acquired.generation;
+    ClientLease lease{std::move(acquired.client), pool, false};
+    const bool from_pool = lease.client != nullptr;
 
     if (!lease.client) {
         lease.client = std::make_unique<coro_rpc_client>(
@@ -219,6 +265,21 @@ Lazy<std::pair<Status, std::string>> CoroRpcAgent::callCoroutine(
 
     if (!call_result.has_value()) {
         lease.broken = true;
+        // An idle pooled connection only learns that its peer restarted when
+        // it is next used, and every other connection pooled for that peer is
+        // just as stale. Discarding only this one leaves the rest to fail the
+        // same way, one wasted attempt each, and callers above get few
+        // attempts: TcpTransport allows max_retry_count, so a peer that is
+        // already back up can still fail a transfer outright. Drop the whole
+        // pool instead, so the next attempt starts from a fresh connection.
+        //
+        // Only for failures that leave the connection unusable. If the peer
+        // answered -- a handler exception, an unknown function id, a rejected
+        // argument -- the socket is fine, and so are the connections the other
+        // callers of this address are holding.
+        if (from_pool && !peerAnswered(call_result.error().code)) {
+            pool->clearIfCurrent(generation);
+        }
         auto msg = "Failed to call RPC function. server: " + server_addr +
                    ", func_id: " + std::to_string(func_id) +
                    ", message: " + std::string{call_result.error().msg};

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -491,3 +491,15 @@ if(USE_TPU)
     PRIVATE MOCK_TPU_PJRT_LIB="$<TARGET_FILE:mock_tpu_pjrt>")
   add_test(NAME tent_tpu_transport_test COMMAND tent_tpu_transport_test)
 endif()
+
+# A peer restart invalidates every connection pooled for it; one failed call
+# must flush the whole pool. Loopback only, no NIC required.
+add_executable(tent_rpc_reconnect_test rpc_reconnect_test.cpp)
+target_link_libraries(tent_rpc_reconnect_test PRIVATE gtest gtest_main
+                                                      tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_rpc_reconnect_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_rpc_reconnect_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_rpc_reconnect_test COMMAND tent_rpc_reconnect_test)

--- a/mooncake-transfer-engine/tent/tests/rpc_reconnect_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rpc_reconnect_test.cpp
@@ -1,0 +1,269 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A peer restart invalidates every connection pooled for that peer, not just
+// the one that happens to notice first. These tests pin what a failed pooled
+// call does to the rest of the pool.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "tent/rpc/rpc.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+using namespace std::chrono_literals;
+using std::chrono::steady_clock;
+
+constexpr int kEchoFunc = 5001;
+constexpr int kBarrierFunc = 5002;
+constexpr int kThrowFunc = 5003;
+constexpr int kSideEffectThenThrowFunc = 5004;
+
+// Counts how many times the peer actually ran the handler.
+std::atomic<int> g_side_effects{0};
+
+// How many connections the burst below parks in the pool. Two is what these
+// tests need: enough to tell a whole-pool flush from a single-client discard,
+// and low enough that the burst is genuinely concurrent on any offload pool.
+constexpr int kPooled = 2;
+
+std::atomic<int> g_in_flight{0};
+
+class RpcReconnectTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        g_in_flight.store(0);
+        g_side_effects.store(0);
+    }
+
+    void StartServer(uint16_t port) {
+        server_ = std::make_unique<CoroRpcAgent>();
+        ASSERT_TRUE(server_
+                        ->registerFunction(kEchoFunc,
+                                           [](const std::string_view& request,
+                                              std::string& response) {
+                                               response = std::string(request);
+                                           })
+                        .ok());
+        // Parks until the whole burst has arrived, so the calls are genuinely
+        // concurrent and cannot share one pooled connection.
+        ASSERT_TRUE(
+            server_
+                ->registerFunction(
+                    kBarrierFunc,
+                    [](const std::string_view& request, std::string& response) {
+                        g_in_flight.fetch_add(1);
+                        auto deadline = steady_clock::now() + 3s;
+                        while (g_in_flight.load() < kPooled &&
+                               steady_clock::now() < deadline) {
+                            std::this_thread::sleep_for(1ms);
+                        }
+                        response = std::string(request);
+                    },
+                    /*offload=*/true)
+                .ok());
+        // Runs a side effect and only then fails, standing in for the
+        // control-plane handlers that mutate state before something goes
+        // wrong on the way back.
+        ASSERT_TRUE(
+            server_
+                ->registerFunction(kSideEffectThenThrowFunc,
+                                   [](const std::string_view&, std::string&) {
+                                       g_side_effects.fetch_add(1);
+                                       throw std::runtime_error(
+                                           "after the side effect");
+                                   })
+                .ok());
+        // Fails on the server side, with the connection intact.
+        ASSERT_TRUE(server_
+                        ->registerFunction(
+                            kThrowFunc,
+                            [](const std::string_view&, std::string&) {
+                                throw std::runtime_error("handler failed");
+                            })
+                        .ok());
+        uint16_t requested = port;
+        port_ = port;
+        ASSERT_TRUE(server_->start(port_).ok());
+        // start() takes the port by reference and picks a random one if the
+        // bind fails. A silent change would move the pool key and make these
+        // tests pass without exercising anything.
+        if (requested != 0) ASSERT_EQ(port_, requested) << "port drifted";
+        addr_ = "127.0.0.1:" + std::to_string(port_);
+    }
+
+    void StopServer() { server_.reset(); }
+
+    // The server destructor joins its io threads, so the port is free when
+    // this returns; the sleep lets the client sockets see the FIN first, so
+    // "stale" is deterministic rather than racing the restart.
+    void RestartServerSamePort() {
+        StopServer();
+        std::this_thread::sleep_for(100ms);
+        g_in_flight.store(0);
+        StartServer(port_);
+    }
+
+    // Parks kPooled concurrent calls in the server, so the client has to open
+    // one connection each and pools all of them.
+    void FillPool(CoroRpcAgent& client) {
+        std::atomic<int> ok_count{0};
+        std::vector<std::thread> burst;
+        for (int i = 0; i < kPooled; ++i) {
+            burst.emplace_back([&] {
+                std::string response;
+                if (client.call(addr_, kBarrierFunc, "warm", response).ok()) {
+                    ok_count.fetch_add(1);
+                }
+            });
+        }
+        for (auto& t : burst) t.join();
+        ASSERT_EQ(ok_count.load(), kPooled) << "burst did not fill the pool";
+    }
+
+    std::unique_ptr<CoroRpcAgent> server_;
+    uint16_t port_ = 0;
+    std::string addr_;
+};
+
+// The point of the change. After a restart every pooled connection is stale.
+// The first call to use one fails - a socket only reports the peer's death
+// when it is written to - but that single failure must take the rest of the
+// pool with it, so the next call connects fresh and succeeds. Without the
+// flush the caller pays one failed call per stale connection, and the retry
+// budget above (TcpTransport: max_retry_count) runs out before the pool does.
+TEST_F(RpcReconnectTest, StalePoolIsFlushedSoTheNextCallSucceeds) {
+    StartServer(0);
+    CoroRpcAgent client;
+    ASSERT_NO_FATAL_FAILURE(FillPool(client));
+
+    RestartServerSamePort();
+
+    std::string response;
+    auto first = client.call(addr_, kEchoFunc, "after-restart", response);
+    EXPECT_FALSE(first.ok()) << "expected the stale connection to fail";
+
+    response.clear();
+    auto second = client.call(addr_, kEchoFunc, "after-restart", response);
+    EXPECT_TRUE(second.ok()) << second.ToString();
+    EXPECT_EQ(response, "after-restart");
+}
+
+// Guard, not a regression test: it passes with and without the flush, because
+// a flushed pool simply reconnects. It is here to pin the behaviour a reviewer
+// would ask about - a failure the peer replied with says nothing about the
+// connection, and the pool is shared with every other caller of this address,
+// so a throwing handler must not cost them their connections.
+TEST_F(RpcReconnectTest, HandlerFailureLeavesThePoolAlone) {
+    StartServer(0);
+    CoroRpcAgent client;
+    ASSERT_NO_FATAL_FAILURE(FillPool(client));
+
+    std::string response;
+    EXPECT_FALSE(client.call(addr_, kThrowFunc, "boom", response).ok());
+
+    // The pooled connections are still good, and the server is still up.
+    for (int i = 0; i < kPooled; ++i) {
+        response.clear();
+        auto status = client.call(addr_, kEchoFunc, "still-fine", response);
+        EXPECT_TRUE(status.ok()) << status.ToString();
+        EXPECT_EQ(response, "still-fine");
+    }
+}
+
+// Guard, not a regression test: a peer that is genuinely gone must keep
+// failing, so the flush cannot turn an unreachable server into a false
+// success or a retry storm.
+TEST_F(RpcReconnectTest, DeadPeerStillFails) {
+    StartServer(0);
+    CoroRpcAgent client;
+    ASSERT_NO_FATAL_FAILURE(FillPool(client));
+
+    StopServer();
+
+    std::string response;
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_FALSE(client.call(addr_, kEchoFunc, "gone", response).ok());
+    }
+}
+
+// A failed call is reported, not retried. Several RPCs share this path and
+// mutate remote state - Pin acquires a stage buffer, Unpin releases one,
+// Delegate starts a transfer, Notify runs a user callback - and an
+// unsuccessful result does not tell us the peer skipped the handler: the
+// error code for "never sent" and for "ran, but the reply was lost" is the
+// same io_error. Retrying here would turn those into at-least-once.
+TEST_F(RpcReconnectTest, AFailedCallIsNotRetried) {
+    StartServer(0);
+    CoroRpcAgent client;
+    ASSERT_NO_FATAL_FAILURE(FillPool(client));
+
+    std::string response;
+    EXPECT_FALSE(
+        client.call(addr_, kSideEffectThenThrowFunc, "once", response).ok());
+    EXPECT_EQ(g_side_effects.load(), 1)
+        << "the peer ran the handler " << g_side_effects.load() << " times";
+}
+
+// Several callers notice the same restart at once. Each flushes at most the
+// generation it drew from, so the connection one caller has already
+// re-established is not thrown away by another's later failure, and every
+// caller recovers on its next attempt.
+//
+// Guard, not a regression test: what the generation changes is how many
+// reconnects happen, and the agent exposes no connection count to assert on.
+// What is checked here is the part that is observable - nobody is left
+// permanently broken.
+TEST_F(RpcReconnectTest, ConcurrentStaleCallsAllRecover) {
+    StartServer(0);
+    CoroRpcAgent client;
+    ASSERT_NO_FATAL_FAILURE(FillPool(client));
+
+    RestartServerSamePort();
+
+    constexpr int kCallers = 4;
+    auto round = [&](const char* payload) {
+        std::atomic<int> ok_count{0};
+        std::vector<std::thread> callers;
+        for (int i = 0; i < kCallers; ++i) {
+            callers.emplace_back([&] {
+                std::string response;
+                if (client.call(addr_, kEchoFunc, payload, response).ok() &&
+                    response == payload) {
+                    ok_count.fetch_add(1);
+                }
+            });
+        }
+        for (auto& t : callers) t.join();
+        return ok_count.load();
+    };
+
+    // The first round draws the stale connections; some or all of it fails.
+    (void)round("first");
+    // By the second round every caller is on a fresh connection.
+    EXPECT_EQ(round("second"), kCallers);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake


### PR DESCRIPTION
## Description

An idle pooled RPC connection only learns that its peer restarted when it is next used, and that first use fails. Discarding just that one client left every other connection pooled for the same peer equally stale, so the caller paid one failed call per stale connection. `TcpTransport` retries a bounded number of times (`max_retry_count`), so a peer that was already back up could still fail a transfer outright, and notifications, which have no retry above this layer, were dropped.

Drop the whole pool for that address instead, so the next attempt starts from a fresh connection.

This deliberately does not retry the failed call in place. `Pin`, `Unpin`, `Delegate` and `Notify` share this path and mutate remote state, and the error tells us nothing about whether the peer ran the handler: ylt reports both "never sent" and "ran, but the reply was lost" as `io_error`. Recovery stays with the layer that already owns it and knows whether its operation is safe to repeat.

The flush is skipped when the failure came back from the peer as a reply — a handler exception, an unknown function id, a rejected argument. The connection carried a full round trip in those cases, so it is fine, and so are the ones other callers of the same address are holding.

The pool also carries a generation. A client is handed out with the generation it came from, and a failure only flushes if that is still the current one. Several callers notice the same restart at once; without this the second one to fail would throw away the connections the first one has already re-established, and the pool would churn for as long as stale clients keep surfacing.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON ..
ninja && ctest --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`rpc_reconnect_test`, all on loopback with no NIC:

- `StalePoolIsFlushedSoTheNextCallSucceeds` — a concurrent burst parks two connections in the pool, the peer restarts on the same port, and the call after the first (unavoidable) failure has to succeed. Fails without the flush.
- `AFailedCallIsNotRetried` — the peer runs a side effect and only then fails; it must have run exactly once. Fails against a version that retries, reporting two executions.
- `HandlerFailureLeavesThePoolAlone`, `DeadPeerStillFails`, `ConcurrentStaleCallsAllRecover` — guards for behaviour that must not change. They pass either way, and their comments say so rather than implying otherwise.

Manual testing on a server with RDMA hardware (8×H20, 5×RoCE): full TENT suite 31/31, the new test 5/5 consecutive runs, and a negative control — this change removed from `rpc.cpp`, only that test rebuilt — fails there as required.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

On the pre-commit box: every hook passes on the changed files except `cmake-format`, which rewrites 57 lines of pre-existing content in `tent/tests/CMakeLists.txt` — `main` is already not clean under the pinned v0.6.13. Reformatting it here would bury a 12-line addition in unrelated churn, so I left it alone. The CI format gate (clang-format 20, changed lines only) passes.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used while investigating the failure mode and while drafting the tests and this description. I have reviewed every changed line and can defend the change end to end.
