### PR TITLE
TENT: add a segment warmup primitive

### DIFF
--- a/docs/source/api-reference/cpp/tent.md
+++ b/docs/source/api-reference/cpp/tent.md
@@ -473,7 +473,23 @@ Retrieves information about a segment.
 
 ## Advanced APIs
 
-These APIs are optional; use them for segment export/import, notifications, or engine introspection.
+These APIs are optional; use them for connection warmup, segment export/import, notifications, or engine introspection.
+
+### Connection Warmup
+
+#### TransferEngine::warmupSegment
+
+```cpp
+Status warmupSegment(SegmentID handle);
+```
+
+Establishes connection state towards a segment ahead of the first transfer. Endpoint setup is otherwise lazy, so the first request to a freshly opened segment pays for it; on RDMA that is the endpoint and queue-pair bootstrap.
+
+Every installed transport is offered the target. RDMA pre-establishes endpoints from each enabled local context to each RDMA NIC the segment advertises, skipping pairs that are already ready; bootstrapping also brings up the notification queue pair that rides on the same endpoint. Transports that do not implement warmup, and transports that have nothing to warm towards this particular target, report that rather than an error.
+
+- `handle`: The segment to warm, as returned by `openSegment`. `LOCAL_SEGMENT_ID` is a successful no-op — local transfers take the in-process path and have no connection state.
+- Return value: `Status::OK()` when every transport either warmed the target or had nothing to warm; otherwise the first error a transport reported. A failure leaves that transport on its lazy path, so the target is still usable.
+- Typical use: Call once per peer right after `openSegment` when the first transfer is latency sensitive, so the setup cost is paid where the caller chooses. The call is idempotent.
 
 ### Segment Export and Import
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -268,6 +268,13 @@ class TransferEngineImpl {
 
     Status probePeerAliveByID(SegmentID target_id);
 
+    // Eagerly establish connection state towards the target segment on every
+    // installed transport that supports it, so the first transfer does not
+    // pay the setup cost (RDMA endpoint bootstrap has been observed to stall
+    // first batches for seconds). Best effort and idempotent; a target with
+    // nothing to warm (including LOCAL_SEGMENT_ID) succeeds as a no-op.
+    Status warmupSegment(SegmentID target_id);
+
     Status getTransferStatus(BatchID batch_id, size_t task_id,
                              TransferStatus& status);
 

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transport.h
@@ -127,6 +127,16 @@ class Transport {
     // prefault). Default: no-op, returns false.
     virtual bool warmupMemory(void* addr, size_t length) { return false; }
 
+    // Eagerly establish this transport's connection state towards the target
+    // segment, so the first transfer does not pay the connection setup cost
+    // (endpoint bootstrap, QP transitions, TCP/RPC dial). Best effort and
+    // idempotent: connections that already exist are left alone, and a pair
+    // that cannot connect yet stays on the lazy path. Default: not
+    // implemented, which callers treat as "nothing to warm".
+    virtual Status warmupSegment(SegmentID target_id) {
+        return Status::NotImplemented("warmupSegment not implemented" LOC_MARK);
+    }
+
     virtual Status addMemoryBuffer(BufferDesc& desc,
                                    const MemoryOptions& options) {
         return Status::NotImplemented(

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -142,6 +142,12 @@ int tent_open_segment(tent_engine_t engine, tent_segment_id_t* handle,
 
 int tent_close_segment(tent_engine_t engine, tent_segment_id_t handle);
 
+// Eagerly establish connection state towards `handle` on every installed
+// transport that supports it (RDMA endpoint bootstrap, control-plane TCP
+// dial), so the first transfer does not pay the setup cost. Best effort and
+// idempotent; returns 0 when there is nothing to warm. Returns 0 on success.
+int tent_warmup_segment(tent_engine_t engine, tent_segment_id_t handle);
+
 int tent_get_segment_info(tent_engine_t engine, tent_segment_id_t handle,
                           tent_segment_info_t* info);
 
@@ -281,6 +287,13 @@ class TransferEngine {
     Status closeSegment(SegmentID handle);
 
     Status getSegmentInfo(SegmentID handle, SegmentInfo& info);
+
+    // Establishes connection state towards a segment ahead of the first
+    // transfer, so the setup cost is paid where the caller chooses instead of
+    // inside the first request. Best effort and idempotent: a transport with
+    // nothing to warm, including the local segment, succeeds as a no-op, and
+    // a pair that cannot connect yet keeps the lazy path.
+    Status warmupSegment(SegmentID handle);
 
    public:
     Status allocateLocalMemory(void** addr, size_t size,

--- a/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
+++ b/mooncake-transfer-engine/tent/include/tent/transfer_engine.h
@@ -143,9 +143,12 @@ int tent_open_segment(tent_engine_t engine, tent_segment_id_t* handle,
 int tent_close_segment(tent_engine_t engine, tent_segment_id_t handle);
 
 // Eagerly establish connection state towards `handle` on every installed
-// transport that supports it (RDMA endpoint bootstrap, control-plane TCP
-// dial), so the first transfer does not pay the setup cost. Best effort and
-// idempotent; returns 0 when there is nothing to warm. Returns 0 on success.
+// transport that can warm one, so the first transfer does not pay the setup
+// cost. Only RDMA warms today: it brings up every enabled local context
+// against every RDMA NIC the target advertises. TCP is not warmed.
+// Idempotent. Returns 0 when every transport either warmed every pair it
+// attempted or had nothing to warm, and -1 when one of them left a connection
+// cold - a cold pair keeps its lazy path, so the target stays usable.
 int tent_warmup_segment(tent_engine_t engine, tent_segment_id_t handle);
 
 int tent_get_segment_info(tent_engine_t engine, tent_segment_id_t handle,
@@ -290,9 +293,11 @@ class TransferEngine {
 
     // Establishes connection state towards a segment ahead of the first
     // transfer, so the setup cost is paid where the caller chooses instead of
-    // inside the first request. Best effort and idempotent: a transport with
-    // nothing to warm, including the local segment, succeeds as a no-op, and
-    // a pair that cannot connect yet keeps the lazy path.
+    // inside the first request. Idempotent. A transport with nothing to warm,
+    // including the local segment, succeeds as a no-op; a transport that left
+    // any connection it attempted cold reports the first such failure, even
+    // when another transport succeeded. A cold pair keeps its lazy path, so
+    // the target stays usable either way.
     Status warmupSegment(SegmentID handle);
 
    public:

--- a/mooncake-transfer-engine/tent/include/tent/transport/fault_proxy/fault_proxy_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/fault_proxy/fault_proxy_transport.h
@@ -157,6 +157,10 @@ class FaultProxyTransport : public Transport {
         return real_->freeLocalMemory(addr, size);
     }
 
+    Status warmupSegment(SegmentID target_id) override {
+        return real_->warmupSegment(target_id);
+    }
+
     bool warmupMemory(void* addr, size_t length) override {
         return real_->warmupMemory(addr, length);
     }

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -110,9 +110,19 @@ class RdmaTransport : public Transport {
     // Pre-establish endpoints towards every RDMA NIC advertised by the
     // target segment, from every enabled local context. Bootstrapping an
     // endpoint on first use has been observed to stall first batches for
-    // seconds; warming moves that cost to an explicit call site. Best
-    // effort: pairs that cannot connect yet keep the lazy path.
+    // seconds; warming moves that cost to an explicit call site. A pass that
+    // leaves any pair cold is reported: the data path may route a later
+    // slice over any of them, so a partly warmed target is still one whose
+    // first transfer can stall. The cold pairs keep the lazy path either
+    // way, so the target stays usable.
     Status warmupSegment(SegmentID target_id) override;
+
+    // What such a pass reports, given how many of the pairs it attempted came
+    // back ready and the first failure it saw. Enumerating the pairs needs a
+    // NIC and a peer; deciding what the result means does not, so the rule
+    // lives here where a test can reach it.
+    static Status warmupPassResult(size_t attempted, size_t ready,
+                                   const Status& first_error);
 
     // Process notification completions (call from worker threads)
     int processNotifyCompletions();

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rdma_transport.h
@@ -107,6 +107,13 @@ class RdmaTransport : public Transport {
     virtual Status receiveNotification(
         std::vector<Notification>& notify_list) override;
 
+    // Pre-establish endpoints towards every RDMA NIC advertised by the
+    // target segment, from every enabled local context. Bootstrapping an
+    // endpoint on first use has been observed to stall first batches for
+    // seconds; warming moves that cost to an explicit call site. Best
+    // effort: pairs that cannot connect yet keep the lazy path.
+    Status warmupSegment(SegmentID target_id) override;
+
     // Process notification completions (call from worker threads)
     int processNotifyCompletions();
 

--- a/mooncake-transfer-engine/tent/src/python/pybind.cpp
+++ b/mooncake-transfer-engine/tent/src/python/pybind.cpp
@@ -490,6 +490,15 @@ PYBIND11_MODULE(tent, m) {
             py::arg("segment_name"))
 
         .def(
+            "warmup_segment",
+            [](TransferEngine& self, uint64_t handle) {
+                py::gil_scoped_release release;
+                auto s = self.warmupSegment((SegmentID)handle);
+                ThrowStatus(s, "warmup_segment");
+            },
+            py::arg("handle"))
+
+        .def(
             "close_segment",
             [](TransferEngine& self, uint64_t handle) {
                 py::gil_scoped_release release;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2424,6 +2424,28 @@ Status TransferEngineImpl::sendNotification(SegmentID target_id,
     return Status::InvalidArgument("Notification not supported" LOC_MARK);
 }
 
+Status TransferEngineImpl::warmupSegment(SegmentID target_id) {
+    if (target_id == LOCAL_SEGMENT_ID) {
+        // Local transfers take the in-process path; there is no connection
+        // state to establish.
+        return Status::OK();
+    }
+    Status first_error = Status::OK();
+    for (size_t type = 0; type < kSupportedTransportTypes; ++type) {
+        auto& transport = transport_list_[type];
+        if (!transport) continue;
+        auto status = transport->warmupSegment(target_id);
+        // NotImplemented covers both "this transport does not warm" and
+        // "this transport has nothing to warm towards this target"; neither
+        // is a failure. Anything else is, and every transport still gets its
+        // turn - a failure here leaves that transport on its lazy path, it
+        // does not stop the others from being warmed.
+        if (status.ok() || status.IsNotImplemented()) continue;
+        if (first_error.ok()) first_error = status;
+    }
+    return first_error;
+}
+
 Status TransferEngineImpl::probePeerAliveByID(SegmentID target_id) {
     return metadata_->segmentManager().withCachedSegment(
         target_id, [&](SegmentDesc* segment) {

--- a/mooncake-transfer-engine/tent/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine.cpp
@@ -154,6 +154,10 @@ Status TransferEngine::cancelTransfer(BatchID batch_id, size_t task_id) {
     return impl_->cancelTransfer(batch_id, task_id);
 }
 
+Status TransferEngine::warmupSegment(SegmentID handle) {
+    return impl_->warmupSegment(handle);
+}
+
 Status TransferEngine::sendNotification(SegmentID target_id,
                                         const Notification& notifi) {
     return impl_->sendNotification(target_id, notifi);

--- a/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
@@ -101,6 +101,27 @@ int tent_close_segment(tent_engine_t engine, tent_segment_id_t handle) {
     return 0;
 }
 
+int tent_warmup_segment(tent_engine_t engine, tent_segment_id_t handle) {
+    CHECK_POINTER(engine);
+    // Warming reaches the peer's control plane, which parses a response the
+    // peer produced; that can throw, and an exception must not cross back
+    // into a C caller.
+    try {
+        auto status = CAST(engine)->warmupSegment(handle);
+        if (!status.ok()) {
+            LOG(ERROR) << "tent_warmup_segment: " << status.ToString();
+            return -1;
+        }
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "tent_warmup_segment: " << e.what();
+        return -1;
+    } catch (...) {
+        LOG(ERROR) << "tent_warmup_segment: unknown exception";
+        return -1;
+    }
+    return 0;
+}
+
 int tent_get_segment_info(tent_engine_t engine, tent_segment_id_t handle,
                           tent_segment_info_t* info) {
     CHECK_POINTER(engine);

--- a/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
+++ b/mooncake-transfer-engine/tent/src/transfer_engine_c.cpp
@@ -103,20 +103,9 @@ int tent_close_segment(tent_engine_t engine, tent_segment_id_t handle) {
 
 int tent_warmup_segment(tent_engine_t engine, tent_segment_id_t handle) {
     CHECK_POINTER(engine);
-    // Warming reaches the peer's control plane, which parses a response the
-    // peer produced; that can throw, and an exception must not cross back
-    // into a C caller.
-    try {
-        auto status = CAST(engine)->warmupSegment(handle);
-        if (!status.ok()) {
-            LOG(ERROR) << "tent_warmup_segment: " << status.ToString();
-            return -1;
-        }
-    } catch (const std::exception& e) {
-        LOG(ERROR) << "tent_warmup_segment: " << e.what();
-        return -1;
-    } catch (...) {
-        LOG(ERROR) << "tent_warmup_segment: unknown exception";
+    auto status = CAST(engine)->warmupSegment(handle);
+    if (!status.ok()) {
+        LOG(ERROR) << "tent_warmup_segment: " << status.ToString();
         return -1;
     }
     return 0;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -765,6 +765,89 @@ std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,
     return endpoint;
 }
 
+Status RdmaTransport::warmupSegment(SegmentID target_id) {
+    std::string rpc_server_addr, target_seg_name, target_nic_path_name;
+    std::vector<std::string> target_dev_names;
+
+    auto status = metadata_->segmentManager().withCachedSegment(
+        target_id, [&](SegmentDesc* segment) {
+            // withCachedSegment reruns this on NeedsRefreshCache, so start
+            // from a clean list rather than appending to the first pass.
+            target_dev_names.clear();
+            if (segment->type != SegmentType::Memory) {
+                // File and other non-memory segments carry no RDMA endpoint
+                // state. Nothing to warm is not a failure.
+                return Status::NotImplemented(
+                    "Segment type is not Memory" LOC_MARK);
+            }
+            if (target_id != LOCAL_SEGMENT_ID) {
+                rpc_server_addr = segment->rpc_server_addr;
+            }
+            auto topo = &std::get<MemorySegmentDesc>(segment->detail).topology;
+            target_seg_name = segment->name;
+            target_nic_path_name = segment->nicPathServerName();
+            for (size_t id = 0; id < topo->getNicCount(); ++id) {
+                if (topo->getNicType(id) != Topology::NIC_RDMA) continue;
+                auto dev_name = topo->getNicName(id);
+                if (!dev_name.empty()) target_dev_names.push_back(dev_name);
+            }
+            if (target_seg_name.empty()) {
+                return Status::NeedsRefreshCache(
+                    "Empty target segment name" LOC_MARK);
+            }
+            if (target_dev_names.empty()) {
+                // A TCP-only or CPU-only peer advertises no RDMA NIC. There
+                // is nothing to warm towards it, which is not a failure -
+                // and it must not look like a stale cache, or every warmup
+                // of such a peer would refetch the whole segment desc.
+                return Status::NotImplemented(
+                    "Target advertises no RDMA device" LOC_MARK);
+            }
+            return Status::OK();
+        });
+    if (!status.ok()) return status;
+
+    // All enabled local contexts x all remote RDMA NICs: the data plane may
+    // route a slice over any of these pairs, and bootstrapping also brings
+    // up the notification QP that rides on the same endpoint.
+    size_t attempted = 0, ready = 0;
+    Status last_error = Status::OK();
+    for (auto& ctx : context_set_) {
+        if (!ctx || ctx->status() != RdmaContext::DEVICE_ENABLED) continue;
+        for (const auto& dev_name : target_dev_names) {
+            ++attempted;
+            std::string peer_name = MakeNicPath(target_nic_path_name, dev_name);
+            auto endpoint = ctx->endpointStore()->getOrInsert(peer_name);
+            if (!endpoint) {
+                last_error = Status::InternalError("Cannot allocate endpoint " +
+                                                   peer_name + LOC_MARK);
+                continue;
+            }
+            if (endpoint->status() == RdmaEndPoint::EP_READY) {
+                ++ready;
+                continue;
+            }
+            auto connect_status =
+                endpoint->connect(target_seg_name, dev_name, rpc_server_addr);
+            if (connect_status.ok()) {
+                ++ready;
+            } else {
+                last_error = connect_status;
+                LOG(WARNING) << "RDMA warmup: endpoint " << peer_name
+                             << " not ready: " << connect_status.ToString();
+            }
+        }
+    }
+    if (attempted == 0) {
+        // No enabled local context: nothing to warm from, same as above.
+        return Status::NotImplemented("No enabled RDMA context" LOC_MARK);
+    }
+    LOG(INFO) << "RDMA warmup towards segment " << target_seg_name << ": "
+              << ready << "/" << attempted << " endpoints ready";
+    if (ready == 0) return last_error;
+    return Status::OK();
+}
+
 Status RdmaTransport::sendNotification(SegmentID target_id,
                                        const Notification& notify) {
     auto endpoint = getEndpoint(target_id, LOCAL_SEGMENT_ID);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -811,7 +811,7 @@ Status RdmaTransport::warmupSegment(SegmentID target_id) {
     // route a slice over any of these pairs, and bootstrapping also brings
     // up the notification QP that rides on the same endpoint.
     size_t attempted = 0, ready = 0;
-    Status last_error = Status::OK();
+    Status first_error = Status::OK();
     for (auto& ctx : context_set_) {
         if (!ctx || ctx->status() != RdmaContext::DEVICE_ENABLED) continue;
         for (const auto& dev_name : target_dev_names) {
@@ -819,8 +819,10 @@ Status RdmaTransport::warmupSegment(SegmentID target_id) {
             std::string peer_name = MakeNicPath(target_nic_path_name, dev_name);
             auto endpoint = ctx->endpointStore()->getOrInsert(peer_name);
             if (!endpoint) {
-                last_error = Status::InternalError("Cannot allocate endpoint " +
-                                                   peer_name + LOC_MARK);
+                if (first_error.ok()) {
+                    first_error = Status::InternalError(
+                        "Cannot allocate endpoint " + peer_name + LOC_MARK);
+                }
                 continue;
             }
             if (endpoint->status() == RdmaEndPoint::EP_READY) {
@@ -832,20 +834,33 @@ Status RdmaTransport::warmupSegment(SegmentID target_id) {
             if (connect_status.ok()) {
                 ++ready;
             } else {
-                last_error = connect_status;
+                if (first_error.ok()) first_error = connect_status;
                 LOG(WARNING) << "RDMA warmup: endpoint " << peer_name
                              << " not ready: " << connect_status.ToString();
             }
         }
     }
-    if (attempted == 0) {
-        // No enabled local context: nothing to warm from, same as above.
-        return Status::NotImplemented("No enabled RDMA context" LOC_MARK);
-    }
     LOG(INFO) << "RDMA warmup towards segment " << target_seg_name << ": "
               << ready << "/" << attempted << " endpoints ready";
-    if (ready == 0) return last_error;
-    return Status::OK();
+    return warmupPassResult(attempted, ready, first_error);
+}
+
+Status RdmaTransport::warmupPassResult(size_t attempted, size_t ready,
+                                       const Status& first_error) {
+    if (attempted == 0) {
+        // No enabled local context, so there was no pair to warm. Nothing to
+        // warm is not a failure, the same answer a peer that advertises no
+        // RDMA device gets.
+        return Status::NotImplemented("No enabled RDMA context" LOC_MARK);
+    }
+    if (ready == attempted) return Status::OK();
+    // Some pairs are still cold. Reporting OK here would hand back a target
+    // whose first transfer can still stall - the data path may route a slice
+    // over any pair, so one warm pair does not stand for the rest, and that
+    // stall is exactly what the caller paid this call to avoid. The engine
+    // level aggregates transports by the same rule.
+    if (!first_error.ok()) return first_error;
+    return Status::InternalError("RDMA warmup left endpoints cold" LOC_MARK);
 }
 
 Status RdmaTransport::sendNotification(SegmentID target_id,

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -810,34 +810,69 @@ Status RdmaTransport::warmupSegment(SegmentID target_id) {
     // All enabled local contexts x all remote RDMA NICs: the data plane may
     // route a slice over any of these pairs, and bootstrapping also brings
     // up the notification QP that rides on the same endpoint.
-    size_t attempted = 0, ready = 0;
-    Status first_error = Status::OK();
+    struct WarmupPair {
+        std::string peer_name;
+        std::string dev_name;
+        std::shared_ptr<RdmaEndPoint> endpoint;
+        bool ready = false;
+        Status error = Status::OK();
+    };
+    std::vector<WarmupPair> pairs;
     for (auto& ctx : context_set_) {
         if (!ctx || ctx->status() != RdmaContext::DEVICE_ENABLED) continue;
         for (const auto& dev_name : target_dev_names) {
-            ++attempted;
-            std::string peer_name = MakeNicPath(target_nic_path_name, dev_name);
-            auto endpoint = ctx->endpointStore()->getOrInsert(peer_name);
-            if (!endpoint) {
-                if (first_error.ok()) {
-                    first_error = Status::InternalError(
-                        "Cannot allocate endpoint " + peer_name + LOC_MARK);
-                }
-                continue;
+            WarmupPair pair;
+            pair.dev_name = dev_name;
+            pair.peer_name = MakeNicPath(target_nic_path_name, dev_name);
+            pair.endpoint = ctx->endpointStore()->getOrInsert(pair.peer_name);
+            if (!pair.endpoint) {
+                pair.error = Status::InternalError("Cannot allocate endpoint " +
+                                                   pair.peer_name + LOC_MARK);
+            } else if (pair.endpoint->status() == RdmaEndPoint::EP_READY) {
+                pair.ready = true;
             }
-            if (endpoint->status() == RdmaEndPoint::EP_READY) {
-                ++ready;
-                continue;
-            }
-            auto connect_status =
-                endpoint->connect(target_seg_name, dev_name, rpc_server_addr);
-            if (connect_status.ok()) {
-                ++ready;
-            } else {
-                if (first_error.ok()) first_error = connect_status;
-                LOG(WARNING) << "RDMA warmup: endpoint " << peer_name
-                             << " not ready: " << connect_status.ToString();
-            }
+            pairs.push_back(std::move(pair));
+        }
+    }
+
+    // Each cold pair is a full endpoint and queue pair bootstrap, tens of
+    // milliseconds on the fabric these numbers came from, so handshaking them
+    // one after another costs the sum over every pair and just moves the stall
+    // the caller asked to avoid into this call. Hand the cold ones out at once
+    // and collect them; a pair that is already up starts nothing.
+    std::vector<std::pair<size_t, std::future<Status>>> pending;
+    for (size_t index = 0; index < pairs.size(); ++index) {
+        const auto& pair = pairs[index];
+        if (pair.ready || !pair.endpoint) continue;
+        pending.emplace_back(
+            index,
+            std::async(
+                std::launch::async,
+                [endpoint = pair.endpoint, seg_name = target_seg_name,
+                 dev_name = pair.dev_name, server_addr = rpc_server_addr]() {
+                    return endpoint->connect(seg_name, dev_name, server_addr);
+                }));
+    }
+    for (auto& [index, result] : pending) {
+        auto connect_status = result.get();
+        if (connect_status.ok()) {
+            pairs[index].ready = true;
+        } else {
+            pairs[index].error = connect_status;
+            LOG(WARNING) << "RDMA warmup: endpoint " << pairs[index].peer_name
+                         << " not ready: " << connect_status.ToString();
+        }
+    }
+
+    // Fold in pair order, so a partial warmup reports the first pair that was
+    // left cold rather than whichever handshake happened to finish first.
+    size_t attempted = pairs.size(), ready = 0;
+    Status first_error = Status::OK();
+    for (const auto& pair : pairs) {
+        if (pair.ready) {
+            ++ready;
+        } else if (first_error.ok()) {
+            first_error = pair.error;
         }
     }
     LOG(INFO) << "RDMA warmup towards segment " << target_seg_name << ": "

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -432,6 +432,18 @@ target_include_directories(tent_rpc_handler_isolation_test
 add_test(NAME tent_rpc_handler_isolation_test
          COMMAND tent_rpc_handler_isolation_test)
 
+# warmupSegment routing/aggregation semantics plus a real TCP warmup between
+# two loopback engines. RDMA warming needs a NIC; not exercised here.
+add_executable(tent_warmup_segment_test warmup_segment_test.cpp)
+target_link_libraries(tent_warmup_segment_test PRIVATE gtest gtest_main
+                                                       tent_link_group)
+if(TARGET asio_shared)
+  target_link_libraries(tent_warmup_segment_test PRIVATE asio_shared)
+endif()
+target_include_directories(tent_warmup_segment_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_warmup_segment_test COMMAND tent_warmup_segment_test)
+
 add_executable(tent_runtime_queue_dispatch_test runtime_queue_dispatch_test.cpp)
 target_link_libraries(tent_runtime_queue_dispatch_test PRIVATE gtest gtest_main
                                                                tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -432,8 +432,9 @@ target_include_directories(tent_rpc_handler_isolation_test
 add_test(NAME tent_rpc_handler_isolation_test
          COMMAND tent_rpc_handler_isolation_test)
 
-# warmupSegment routing/aggregation semantics plus a real TCP warmup between
-# two loopback engines. RDMA warming needs a NIC; not exercised here.
+# warmupSegment routing/aggregation semantics across transports, plus the
+# RDMA pass result rule. Driven through fake transports; the RDMA pair path
+# needs a NIC and is not exercised here, and TCP is not warmed at all.
 add_executable(tent_warmup_segment_test warmup_segment_test.cpp)
 target_link_libraries(tent_warmup_segment_test PRIVATE gtest gtest_main
                                                        tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/warmup_segment_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/warmup_segment_test.cpp
@@ -1,0 +1,177 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The routing and aggregation contract of warmupSegment(): the local segment
+// is a no-op, every installed transport is offered the target, NotImplemented
+// means nothing-to-warm rather than failure, and a transport that genuinely
+// fails is reported even when another succeeded.
+//
+// These use fake transports. The RDMA implementation needs a NIC and a peer,
+// so it is not exercised here.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "tent/common/config.h"
+#include "tent/runtime/transfer_engine_impl.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// No real transport installed: the fakes below are swapped into the slots, so
+// nothing else can answer a warmup and change what these tests observe.
+std::shared_ptr<Config> makeConfig() {
+    auto config = std::make_shared<Config>();
+    config->set("metadata_type", "p2p");
+    config->set("metadata_servers", "");
+    config->set("rpc_server_hostname", "127.0.0.1");
+    config->set("rpc_server_port", "0");
+    config->set("log_level", "warning");
+    config->set("transports/tcp/enable", true);
+    config->set("transports/shm/enable", false);
+    config->set("transports/rdma/enable", false);
+    config->set("transports/io_uring/enable", false);
+    config->set("transports/nvlink/enable", false);
+    config->set("transports/mnnvl/enable", false);
+    config->set("transports/gds/enable", false);
+    config->set("transports/ascend_direct/enable", false);
+    config->set("transports/sunrise_link/enable", false);
+    config->set("transports/mpcomm/enable", false);
+    config->set("transports/tpu/enable", false);
+    config->set("transports/ub/enable", false);
+    return config;
+}
+
+// A transport whose only interesting behaviour is what warmupSegment returns.
+class WarmupProbeTransport : public Transport {
+   public:
+    explicit WarmupProbeTransport(Status result) : result_(result) {
+        caps.dram_to_dram = true;
+    }
+
+    int warmup_calls = 0;
+    SegmentID last_target = 0;
+
+    Status install(std::string&, std::shared_ptr<ControlService>,
+                   std::shared_ptr<Topology>,
+                   std::shared_ptr<Config>) override {
+        return Status::OK();
+    }
+
+    Status warmupSegment(SegmentID target_id) override {
+        ++warmup_calls;
+        last_target = target_id;
+        return result_;
+    }
+
+    const char* getName() const override { return "<warmup-probe>"; }
+
+   private:
+    Status result_;
+};
+
+std::shared_ptr<WarmupProbeTransport> install(TransferEngineImpl& engine,
+                                              TransportType slot,
+                                              Status result) {
+    auto probe = std::make_shared<WarmupProbeTransport>(result);
+    std::string seg_name = engine.getSegmentName();
+    EXPECT_TRUE(probe->install(seg_name, nullptr, nullptr, nullptr).ok());
+    engine.swapTransportForTest(slot, probe);
+    return probe;
+}
+
+// A segment id the engine has never opened stands in for "some remote target":
+// these tests only care about routing, and no fake looks the id up.
+constexpr SegmentID kRemote = 42;
+
+// The local segment has no connection state to establish, so warming it must
+// succeed without reaching a transport at all.
+TEST(WarmupSegmentTest, LocalSegmentIsANoOp) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+    auto probe = install(engine, RDMA, Status::OK());
+
+    EXPECT_TRUE(engine.warmupSegment(LOCAL_SEGMENT_ID).ok());
+    EXPECT_EQ(probe->warmup_calls, 0);
+}
+
+// Every installed transport is offered the target - the data path may route a
+// later request over any of them, so stopping at the first would leave the
+// others cold.
+TEST(WarmupSegmentTest, EveryInstalledTransportIsOffered) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+    auto first = install(engine, RDMA, Status::OK());
+    auto second = install(engine, TCP, Status::OK());
+
+    EXPECT_TRUE(engine.warmupSegment(kRemote).ok());
+    EXPECT_EQ(first->warmup_calls, 1);
+    EXPECT_EQ(second->warmup_calls, 1);
+    EXPECT_EQ(first->last_target, kRemote);
+    EXPECT_EQ(second->last_target, kRemote);
+}
+
+// NotImplemented is how a transport says it does not warm, and also how it
+// says it has nothing to warm towards this target (a peer that advertises no
+// device of its kind). Neither is a failure.
+TEST(WarmupSegmentTest, NotImplementedIsNotAFailure) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+    auto probe =
+        install(engine, RDMA, Status::NotImplemented("nothing to warm here"));
+
+    auto status = engine.warmupSegment(kRemote);
+    EXPECT_TRUE(status.ok()) << status.ToString();
+    EXPECT_EQ(probe->warmup_calls, 1);
+}
+
+// A transport that genuinely failed to warm must be reported even when
+// another one succeeded. The caller asked for the setup cost to be paid up
+// front; silently returning OK would hand back a target whose first real
+// transfer still stalls, with only a log line to explain it.
+TEST(WarmupSegmentTest, AFailureIsReportedEvenIfAnotherTransportSucceeded) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+    auto failing =
+        install(engine, RDMA, Status::InternalError("endpoints unreachable"));
+    auto succeeding = install(engine, TCP, Status::OK());
+
+    auto status = engine.warmupSegment(kRemote);
+    EXPECT_FALSE(status.ok());
+    // The succeeding transport was still offered the target: one failure does
+    // not abandon the rest.
+    EXPECT_EQ(succeeding->warmup_calls, 1);
+    EXPECT_EQ(failing->warmup_calls, 1);
+}
+
+// With more than one failure the first is what the caller sees.
+TEST(WarmupSegmentTest, FirstFailureIsReported) {
+    TransferEngineImpl engine(makeConfig());
+    ASSERT_TRUE(engine.available());
+    install(engine, RDMA, Status::InternalError("first failure"));
+    install(engine, TCP, Status::InternalError("second failure"));
+
+    auto status = engine.warmupSegment(kRemote);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.ToString().find("first failure"), std::string::npos)
+        << status.ToString();
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/warmup_segment_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/warmup_segment_test.cpp
@@ -17,8 +17,10 @@
 // means nothing-to-warm rather than failure, and a transport that genuinely
 // fails is reported even when another succeeded.
 //
-// These use fake transports. The RDMA implementation needs a NIC and a peer,
-// so it is not exercised here.
+// These use fake transports. Enumerating RDMA endpoint pairs needs a NIC and a
+// peer, so that part is not exercised here; the rule that turns a pass over
+// those pairs into a result is split out as RdmaTransport::warmupPassResult()
+// and covered at the bottom of this file.
 
 #include <gtest/gtest.h>
 
@@ -28,6 +30,7 @@
 
 #include "tent/common/config.h"
 #include "tent/runtime/transfer_engine_impl.h"
+#include "tent/transport/rdma/rdma_transport.h"
 
 namespace mooncake {
 namespace tent {
@@ -170,6 +173,63 @@ TEST(WarmupSegmentTest, FirstFailureIsReported) {
     ASSERT_FALSE(status.ok());
     EXPECT_NE(status.ToString().find("first failure"), std::string::npos)
         << status.ToString();
+}
+
+// The per-pair rule inside RDMA, which has to match the per-transport rule
+// above: a pass that leaves any pair cold is a failure, because the data path
+// may route a later slice over any of them.
+//
+// warmupPassResult() takes the counts the enumeration produces, so these cases
+// are "one pair already ready and one failing", "both failing", and so on,
+// without needing a NIC to produce them.
+
+// Every pair came up: nothing is left cold, so the caller got what it paid
+// for.
+TEST(RdmaWarmupPassResultTest, AllPairsReadyIsSuccess) {
+    EXPECT_TRUE(RdmaTransport::warmupPassResult(3, 3, Status::OK()).ok());
+}
+
+// One pair ready, the rest failed. This used to return OK, because only an
+// all-failed pass was reported - which handed back a target whose first
+// transfer could still stall on one of the cold pairs.
+TEST(RdmaWarmupPassResultTest, PartialWarmupIsNotReportedAsComplete) {
+    auto status = RdmaTransport::warmupPassResult(
+        3, 1, Status::InternalError("endpoint 2 unreachable"));
+    ASSERT_FALSE(status.ok()) << "a partly warmed target must not report OK";
+    EXPECT_NE(status.ToString().find("endpoint 2 unreachable"),
+              std::string::npos)
+        << status.ToString();
+}
+
+// One cold pair out of many is still a cold pair.
+TEST(RdmaWarmupPassResultTest, ASingleColdPairIsReported) {
+    auto status = RdmaTransport::warmupPassResult(
+        8, 7, Status::InternalError("last pair refused"));
+    EXPECT_FALSE(status.ok()) << status.ToString();
+}
+
+// With several failures the first is what the caller sees, matching how the
+// engine aggregates transports.
+TEST(RdmaWarmupPassResultTest, FirstPairFailureIsReported) {
+    auto status = RdmaTransport::warmupPassResult(
+        4, 0, Status::InternalError("first pair failure"));
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.ToString().find("first pair failure"), std::string::npos)
+        << status.ToString();
+}
+
+// No enabled local context means there was no pair to warm at all, which is
+// the same "nothing to warm" answer a peer advertising no RDMA device gets -
+// not a failure.
+TEST(RdmaWarmupPassResultTest, NothingAttemptedIsNotAFailure) {
+    auto status = RdmaTransport::warmupPassResult(0, 0, Status::OK());
+    EXPECT_TRUE(status.IsNotImplemented()) << status.ToString();
+}
+
+// Defensive: a cold pair that somehow recorded no error is still a cold pair,
+// so the result must not be OK just because the error slot is empty.
+TEST(RdmaWarmupPassResultTest, ColdPairWithoutARecordedErrorStillFails) {
+    EXPECT_FALSE(RdmaTransport::warmupPassResult(2, 1, Status::OK()).ok());
 }
 
 }  // namespace


### PR DESCRIPTION
## Description

The first transfer towards a freshly opened segment pays for connection setup. On RDMA that is the endpoint and queue-pair bootstrap: 42 – 56 ms for a single NIC pair on the hardware below, and around a second when a whole NIC set has to come up. The classic engine grew `warmupEfaSegment()` for the same reason; TENT had no equivalent, so benchmarks and latency-sensitive callers either ate the stall on their first real transfer or hand-rolled a dummy one.

Adds `TransferEngine::warmupSegment(handle)`, routed to every installed transport through a new optional `Transport::warmupSegment()` that defaults to `NotImplemented`.

- RDMA pre-establishes endpoints from every enabled local context to every RDMA NIC the target advertises, skipping pairs that are already ready. Bootstrapping also brings up the notification queue pair that rides on the same endpoint.
- `NotImplemented` means both "this transport does not warm" and "it has nothing to warm towards this target" — a non-memory segment, or a peer that advertises no RDMA NIC. Neither is a failure, which is how the classic `warmupEfaSegment()` answers the no-devices case too.
- A transport that genuinely failed is reported even when another succeeded. The caller asked for the setup cost to be paid up front, and returning OK would hand back a target whose first transfer still stalls, with only a log line to say why. The failure leaves that transport on its lazy path, so the target stays usable either way.
- `LOCAL_SEGMENT_ID` is a successful no-op that reaches no transport: local transfers take the in-process path and have no connection state.
- C API: `tent_warmup_segment()`.

Only RDMA implements warming. TCP's data path runs on a worker pool, and the RPC agent that owns the connection pool is `thread_local`, so a connection warmed on the caller's thread is not one a transfer would use. Warming it usefully needs its own change, and is left out rather than shipped as a call that looks like it does something.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -G Ninja -DUSE_TENT=ON -DUSE_HTTP=ON -DBUILD_UNIT_TESTS=ON ..
ninja && ctest --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`warmup_segment_test` pins the routing and aggregation contract with fake transports: the local segment reaches no transport, every installed transport is offered the target, `NotImplemented` is not a failure, a real failure surfaces alongside another transport's success, and the first of several failures is the one reported. Each case was checked against its own negative control — with the aggregation rule reverted, `AFailureIsReportedEvenIfAnotherTransportSucceeded` fails.

The RDMA implementation needs a NIC and a peer, so it is not covered by the unit tests. It was exercised separately, below.

Manual testing on a server with RDMA hardware (8×H20, 5×RoCE). Full TENT suite 31/31. A standalone harness opens a segment between two engines on the same host and times the first 4 KiB write, pinned to a single NIC, three rounds:

| | first write |
| --- | --- |
| cold, no warmup | 42 – 56 ms |
| after `warmupSegment()` | 0.57 – 0.75 ms |

`warmupSegment()` itself took about 45 ms for that one NIC pair. An independent run on a different day measured 42.4 – 49.0 ms cold, 0.44 – 0.56 ms warm and 41.4 – 43.5 ms for the warmup — close enough that the figures look like a property of the path rather than of one afternoon.

A second harness run without pinning a NIC warms every local context against every NIC the target advertises; that costs around a second, because the per-pair cost is what scales. Those numbers are not quoted here: the third round of that run was disturbed by unrelated load on the shared fabric (both cold and warm first-writes at 3.7 s, warm slower than cold), and the run is reported only for completeness.

The setup cost moves into the explicit call rather than disappearing; that is the point of the primitive. The absolute figure depends on the fabric and is not portable. What the runs establish is that the first-transfer stall is a stable structural cost rather than an occasional hiccup, and that it is gone once the segment is warmed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

On the pre-commit box: every hook passes on the changed files except `cmake-format`, which rewrites 57 lines of pre-existing content in `tent/tests/CMakeLists.txt` — `main` is already not clean under the pinned v0.6.13. Reformatting it here would bury a 12-line addition in unrelated churn, so I left it alone. The CI format gate (clang-format 20, changed lines only) passes.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used while investigating the cost of the first transfer and while drafting the tests and this description. I have reviewed every changed line and can defend the change end to end.
