### PR TITLE
[Bugfix][Store] Cover HotStandbyService behaviors with deterministic fakes

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -327,9 +327,6 @@ func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
 	closeAllStoreMaintenanceSessions()
 	cancelAllStoreWatches()
 	cancelAllStorePrefixWatches()
-	// Join prefix-watch goroutines before closing the old client so reset is
-	// closer to fixture-style teardown (cancel + wait + close).
-	waitAllStorePrefixWatches(5 * time.Second)
 
 	storeMutex.Lock()
 	oldClient := storeClient
@@ -636,34 +633,6 @@ func cancelAllStorePrefixWatches() {
 
 	for _, cancel := range cancels {
 		cancel()
-	}
-}
-
-// waitAllStorePrefixWatches waits for prefix-watch goroutines previously
-// cancelled by cancelAllStorePrefixWatches to fully exit (done closed).
-// Returns early if the timeout elapses; callers should still Close the old
-// client afterward so residual RPCs are aborted.
-func waitAllStorePrefixWatches(timeout time.Duration) {
-	storePrefixWatchMutex.Lock()
-	dones := make([]<-chan struct{}, 0, len(storePrefixWatchCtx))
-	for _, watchInfo := range storePrefixWatchCtx {
-		if watchInfo.done != nil {
-			dones = append(dones, watchInfo.done)
-		}
-	}
-	storePrefixWatchMutex.Unlock()
-
-	deadline := time.Now().Add(timeout)
-	for _, done := range dones {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			return
-		}
-		select {
-		case <-done:
-		case <-time.After(remaining):
-			return
-		}
 	}
 }
 

--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -327,6 +327,9 @@ func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
 	closeAllStoreMaintenanceSessions()
 	cancelAllStoreWatches()
 	cancelAllStorePrefixWatches()
+	// Join prefix-watch goroutines before closing the old client so reset is
+	// closer to fixture-style teardown (cancel + wait + close).
+	waitAllStorePrefixWatches(5 * time.Second)
 
 	storeMutex.Lock()
 	oldClient := storeClient
@@ -633,6 +636,34 @@ func cancelAllStorePrefixWatches() {
 
 	for _, cancel := range cancels {
 		cancel()
+	}
+}
+
+// waitAllStorePrefixWatches waits for prefix-watch goroutines previously
+// cancelled by cancelAllStorePrefixWatches to fully exit (done closed).
+// Returns early if the timeout elapses; callers should still Close the old
+// client afterward so residual RPCs are aborted.
+func waitAllStorePrefixWatches(timeout time.Duration) {
+	storePrefixWatchMutex.Lock()
+	dones := make([]<-chan struct{}, 0, len(storePrefixWatchCtx))
+	for _, watchInfo := range storePrefixWatchCtx {
+		if watchInfo.done != nil {
+			dones = append(dones, watchInfo.done)
+		}
+	}
+	storePrefixWatchMutex.Unlock()
+
+	deadline := time.Now().Add(timeout)
+	for _, done := range dones {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return
+		}
+		select {
+		case <-done:
+		case <-time.After(remaining):
+			return
+		}
 	}
 }
 

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -207,8 +207,9 @@ class HotStandbyService {
     void SetSyncStatusCallback(SyncStatusCallback callback);
 
     /**
-     * @brief Test seam: when set, promotion final catch-up first tries
-     *        batch-record durable prefix/batches from this backend.
+     * @brief Test seam: inject a HaKvBackend used for Start()/replication and
+     *        promotion catch-up. When set, Start() skips live etcd connection
+     *        (and works even when STORE_USE_ETCD is OFF).
      */
     void SetCatchUpBatchKvBackendForTesting(
         std::shared_ptr<HaKvBackend> backend);

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -7,7 +7,9 @@
 #include <thread>
 
 #include "etcd_helper.h"
+#ifdef STORE_USE_ETCD
 #include "ha/kv/etcd_ha_kv_backend.h"
+#endif
 #include "ha_metric_manager.h"
 #include "ha/oplog/oplog_applier.h"
 #include "ha/oplog/oplog_batch_standby_reader.h"
@@ -109,8 +111,10 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     cluster_id_ = cluster_id;
 
     if (config_.enable_oplog_following) {
-#ifdef STORE_USE_ETCD
+        // Injected test backends exercise the production Start/replication
+        // path without a live etcd cluster (and without STORE_USE_ETCD).
         if (!catch_up_batch_kv_backend_for_testing_) {
+#ifdef STORE_USE_ETCD
             ErrorCode err =
                 EtcdHelper::ConnectToEtcdStoreClient(oplog_endpoints.c_str());
             if (err != ErrorCode::OK) {
@@ -118,16 +122,14 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
                 state_machine_.ProcessEvent(StandbyEvent::CONNECTION_FAILED);
                 return err;
             }
-        }
 #else
-        // Without STORE_USE_ETCD, the following loop needs an injected test
-        // backend.
-        if (!catch_up_batch_kv_backend_for_testing_) {
+            // Without STORE_USE_ETCD, the following loop needs an injected
+            // test backend.
             state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
             LOG(ERROR) << "Batch-record OpLog requires STORE_USE_ETCD";
             return ErrorCode::INTERNAL_ERROR;
-        }
 #endif
+        }
     }
 
     state_machine_.ProcessEvent(StandbyEvent::CONNECTED);
@@ -302,7 +304,13 @@ ErrorCode HotStandbyService::StartOplogFollowingLocked(
     if (catch_up_batch_kv_backend_for_testing_) {
         batch_standby_kv_backend_ = catch_up_batch_kv_backend_for_testing_;
     } else {
+#ifdef STORE_USE_ETCD
         batch_standby_kv_backend_ = std::make_shared<EtcdHaKvBackend>();
+#else
+        state_machine_.ProcessEvent(StandbyEvent::FATAL_ERROR);
+        LOG(ERROR) << "Batch-record OpLog requires STORE_USE_ETCD";
+        return ErrorCode::INTERNAL_ERROR;
+#endif
     }
     batch_standby_reader_ = std::make_unique<OpLogBatchStandbyReader>(
         cluster_id_, *batch_standby_kv_backend_, *oplog_applier_);
@@ -527,8 +535,13 @@ ErrorCode HotStandbyService::FinalCatchUpForPromotionLocked(
             *catch_up_batch_kv_backend_for_testing_, policy);
     }
 
+#ifdef STORE_USE_ETCD
     EtcdHaKvBackend batch_backend;
     return FinalCatchUpBatchRecordsLocked(batch_backend, policy);
+#else
+    LOG(ERROR) << "Final OpLog catch-up requires STORE_USE_ETCD";
+    return ErrorCode::INTERNAL_ERROR;
+#endif
 }
 
 ErrorCode HotStandbyService::FinalCatchUpBatchRecordsLocked(

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -8,9 +8,11 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <utility>
 
 #include <xxhash.h>
 
@@ -275,6 +277,79 @@ bool WaitForState(HotStandbyService& service, StandbyState state,
     return service.GetState() == state;
 }
 
+#ifdef STORE_USE_ETCD
+// Independent in-process integration fixture for live unreachable-endpoint
+// coverage.
+//
+// HotStandbyService's production path can only use the process-global store
+// etcd client (Go singleton via cgo), so a separate client instance is not
+// available. Fork/subprocess isolation is also unsafe once the Go runtime is
+// multi-threaded in this process.
+//
+// This fixture is therefore the strongest isolation the current API allows:
+// it takes exclusive ownership of the global store client for the test
+// duration (Reset onto unreachable endpoints), owns the HotStandbyService
+// under test, and on release always Stop()s that service before Reset-ing
+// back to a conventional endpoint. Reset itself cancels keepalives/watches,
+// waits for prefix-watch goroutines to exit, and closes the old client.
+class LiveUnreachableEtcdIntegrationFixture {
+   public:
+    static constexpr const char* kUnreachableEndpoints = "http://127.0.0.1:1";
+    static constexpr const char* kRestoreEndpoints = "http://127.0.0.1:2379";
+
+    // Returns nullopt on success, or a skip reason if the global client cannot
+    // be acquired onto the unreachable endpoints.
+    static std::optional<std::string> TryCreate(
+        std::unique_ptr<LiveUnreachableEtcdIntegrationFixture>* out) {
+        const ErrorCode err =
+            EtcdHelper::ResetEtcdStoreClient(kUnreachableEndpoints);
+        if (err != ErrorCode::OK) {
+            return std::string(
+                       "Unable to acquire LiveUnreachableEtcdIntegrationFixture: ") +
+                   toString(err);
+        }
+        out->reset(new LiveUnreachableEtcdIntegrationFixture());
+        return std::nullopt;
+    }
+
+    ~LiveUnreachableEtcdIntegrationFixture() { Release(); }
+
+    LiveUnreachableEtcdIntegrationFixture(
+        const LiveUnreachableEtcdIntegrationFixture&) = delete;
+    LiveUnreachableEtcdIntegrationFixture& operator=(
+        const LiveUnreachableEtcdIntegrationFixture&) = delete;
+
+    HotStandbyService& CreateService(HotStandbyConfig config) {
+        config.enable_oplog_following = true;
+        config.enable_verification = false;
+        config.oplog_poll_interval_ms = 1;
+        config.batch_oplog_retry_timeout_sec = 0;
+        service_ = std::make_unique<HotStandbyService>(std::move(config));
+        return *service_;
+    }
+
+    const char* unreachable_endpoints() const { return kUnreachableEndpoints; }
+
+    void Release() {
+        if (released_) {
+            return;
+        }
+        released_ = true;
+        if (service_) {
+            service_->Stop();
+            service_.reset();
+        }
+        (void)EtcdHelper::ResetEtcdStoreClient(kRestoreEndpoints);
+    }
+
+   private:
+    LiveUnreachableEtcdIntegrationFixture() = default;
+
+    std::unique_ptr<HotStandbyService> service_;
+    bool released_ = false;
+};
+#endif
+
 }  // namespace
 
 class HotStandbyServiceTest : public ::testing::Test {
@@ -418,44 +493,32 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
 #ifdef STORE_USE_ETCD
-    // Live dial failures are asynchronous: NewStoreEtcdClient / Reset succeed
-    // after constructing the client object, then replication Get() times out.
-    const std::string unreachable = "http://127.0.0.1:1";
-    const std::string restore_endpoints = "http://127.0.0.1:2379";
-
-    // Isolate from any prior global etcd client (different endpoints would
-    // otherwise make Connect return INVALID_PARAMS synchronously).
-    const ErrorCode reset_err = EtcdHelper::ResetEtcdStoreClient(unreachable);
-    if (reset_err != ErrorCode::OK) {
-        GTEST_SKIP() << "Unable to reset global etcd client onto unreachable "
-                        "endpoint fixture: "
-                     << toString(reset_err);
+    // Live dial failures are asynchronous: client construction succeeds, then
+    // replication Get() times out. Owned by a dedicated integration fixture so
+    // the global store client is exclusively claimed and restored.
+    std::unique_ptr<LiveUnreachableEtcdIntegrationFixture> fixture;
+    if (auto skip_reason =
+            LiveUnreachableEtcdIntegrationFixture::TryCreate(&fixture)) {
+        GTEST_SKIP() << *skip_reason;
     }
 
-    config_.enable_oplog_following = true;
-    config_.enable_verification = false;
-    config_.oplog_poll_interval_ms = 1;
-    config_.batch_oplog_retry_timeout_sec = 0;
-    // No injected backend: exercise the production etcd connect/replication
-    // path.
-    service_ = std::make_unique<HotStandbyService>(config_);
+    // Only the fixture owns HotStandbyService for this case.
+    service_.reset();
 
+    HotStandbyService& service = fixture->CreateService(config_);
     const ErrorCode err =
-        service_->Start("primary", unreachable, cluster_id_);
+        service.Start("primary", fixture->unreachable_endpoints(), cluster_id_);
     ASSERT_EQ(ErrorCode::OK, err)
         << "Start should succeed once the etcd client object exists; dial "
            "failure is expected asynchronously from the replication loop";
 
     // Store Get() uses a ~5s context timeout; allow headroom beyond that.
-    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED,
+    ASSERT_TRUE(WaitForState(service, StandbyState::FAILED,
                              /*max_attempts=*/4000))
         << "Expected FAILED after unreachable etcd Get/dial timeout";
-    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
-    service_->Stop();
+    EXPECT_EQ(StandbyState::FAILED, service.GetState());
 
-    // Restore a conventional endpoint so later STORE_USE_ETCD tests are not
-    // stuck on the unreachable client.
-    (void)EtcdHelper::ResetEtcdStoreClient(restore_endpoints);
+    fixture->Release();
 #else
     GTEST_SKIP()
         << "Live etcd connection-failure coverage requires STORE_USE_ETCD";

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -249,8 +249,8 @@ std::shared_ptr<FakeHaKvBackend> MakeBackendWithBatch(
     auto backend = std::make_shared<FakeHaKvBackend>();
     EXPECT_EQ(ErrorCode::OK,
               backend->Put(BuildDurablePrefixKey(cluster_id),
-                           EncodeDurablePrefix({.batch_id = batch_id,
-                                                .last_seq = last_seq})));
+                           EncodeDurablePrefix(
+                               {.batch_id = batch_id, .last_seq = last_seq})));
     EXPECT_EQ(ErrorCode::OK,
               backend->Put(BuildBatchRecordKey(cluster_id, batch_id),
                            EncodeOpLogBatchRecord(
@@ -260,8 +260,8 @@ std::shared_ptr<FakeHaKvBackend> MakeBackendWithBatch(
 
 bool WaitForAppliedSequence(HotStandbyService& service, uint64_t seq,
                             int max_attempts = 200) {
-    for (int i = 0; i < max_attempts && service.GetLatestAppliedSequenceId() < seq;
-         ++i) {
+    for (int i = 0;
+         i < max_attempts && service.GetLatestAppliedSequenceId() < seq; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
     return service.GetLatestAppliedSequenceId() >= seq;
@@ -369,8 +369,8 @@ TEST_F(HotStandbyServiceTest, TestStart_InvalidEtcdEndpoints) {
     config_.enable_oplog_following = true;
     service_ = std::make_unique<HotStandbyService>(config_);
 
-    const ErrorCode err = service_->Start(
-        "primary", "http://127.0.0.1:1", cluster_id_);
+    const ErrorCode err =
+        service_->Start("primary", "http://127.0.0.1:1", cluster_id_);
     EXPECT_NE(ErrorCode::OK, err);
     EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 #else
@@ -420,8 +420,8 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
     config_.enable_oplog_following = true;
     service_ = std::make_unique<HotStandbyService>(config_);
 
-    const ErrorCode err = service_->Start(
-        "primary", "http://127.0.0.1:1", cluster_id_);
+    const ErrorCode err =
+        service_->Start("primary", "http://127.0.0.1:1", cluster_id_);
     EXPECT_NE(ErrorCode::OK, err);
     EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 #else
@@ -562,9 +562,10 @@ TEST_F(HotStandbyServiceTest, TestWarmStart_WithLocalState) {
 
 TEST_F(HotStandbyServiceTest, TestWarmStart_WithoutLocalState) {
     auto backend = std::make_shared<FakeHaKvBackend>();
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     config_.enable_oplog_following = true;
     config_.enable_snapshot_bootstrap = false;
     config_.oplog_poll_interval_ms = 1;
@@ -579,9 +580,10 @@ TEST_F(HotStandbyServiceTest, TestWarmStart_WithoutLocalState) {
 
 TEST_F(HotStandbyServiceTest, TestWarmStart_WithSnapshot) {
     auto backend = std::make_shared<FakeHaKvBackend>();
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
     config_.enable_snapshot_bootstrap = true;
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
@@ -859,11 +861,10 @@ TEST_F(HotStandbyServiceTest, TestReplicationLoop_UpdatesMetrics) {
     service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
 
     std::atomic<uint64_t> observed_applied{0};
-    service_->SetSyncStatusCallback(
-        [&](const StandbySyncStatus& status) {
-            observed_applied.store(status.applied_seq_id,
-                                   std::memory_order_relaxed);
-        });
+    service_->SetSyncStatusCallback([&](const StandbySyncStatus& status) {
+        observed_applied.store(status.applied_seq_id,
+                               std::memory_order_relaxed);
+    });
 
     ASSERT_EQ(ErrorCode::OK,
               service_->Start("primary", oplog_endpoints_, cluster_id_));

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -417,21 +417,49 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
-    // Live etcd dial failures are asynchronous (client construction succeeds
-    // before the first RPC). Cover the resulting FAILED transition with an
-    // injected backend that fails Get after Start returns OK.
-    auto backend = std::make_shared<FakeHaKvBackend>();
-    backend->SetGetError(ErrorCode::ETCD_OPERATION_ERROR);
+#ifdef STORE_USE_ETCD
+    // Live dial failures are asynchronous: NewStoreEtcdClient / Reset succeed
+    // after constructing the client object, then replication Get() times out.
+    const std::string unreachable = "http://127.0.0.1:1";
+    const std::string restore_endpoints = "http://127.0.0.1:2379";
+
+    // Isolate from any prior global etcd client (different endpoints would
+    // otherwise make Connect return INVALID_PARAMS synchronously).
+    const ErrorCode reset_err = EtcdHelper::ResetEtcdStoreClient(unreachable);
+    if (reset_err != ErrorCode::OK) {
+        GTEST_SKIP() << "Unable to reset global etcd client onto unreachable "
+                        "endpoint fixture: "
+                     << toString(reset_err);
+    }
+
     config_.enable_oplog_following = true;
+    config_.enable_verification = false;
     config_.oplog_poll_interval_ms = 1;
     config_.batch_oplog_retry_timeout_sec = 0;
-    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+    // No injected backend: exercise the production etcd connect/replication
+    // path.
+    service_ = std::make_unique<HotStandbyService>(config_);
 
-    ASSERT_EQ(ErrorCode::OK,
-              service_->Start("primary", oplog_endpoints_, cluster_id_));
-    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
-    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
-              service_->GetSyncStatus().last_error);
+    const ErrorCode err =
+        service_->Start("primary", unreachable, cluster_id_);
+    ASSERT_EQ(ErrorCode::OK, err)
+        << "Start should succeed once the etcd client object exists; dial "
+           "failure is expected asynchronously from the replication loop";
+
+    // Store Get() uses a ~5s context timeout; allow headroom beyond that.
+    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED,
+                             /*max_attempts=*/4000))
+        << "Expected FAILED after unreachable etcd Get/dial timeout";
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+    service_->Stop();
+
+    // Restore a conventional endpoint so later STORE_USE_ETCD tests are not
+    // stuck on the unreachable client.
+    (void)EtcdHelper::ResetEtcdStoreClient(restore_endpoints);
+#else
+    GTEST_SKIP()
+        << "Live etcd connection-failure coverage requires STORE_USE_ETCD";
+#endif
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
@@ -907,45 +935,20 @@ TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
               service_->GetSyncStatus().last_error);
 }
 
-// ========== 6.1.8 Verification thread lifecycle ==========
-// Production verification is not implemented yet (loop only VLOG-skips).
-// These tests cover thread start/stop only; checksum verification remains
-// skipped until the feature has observable side effects.
+// ========== 6.1.8 Verification loop tests ==========
+// Production verification is not implemented yet (loop only VLOG-skips), so
+// these cases stay skipped until checksum comparison has an observable effect.
 
-TEST_F(HotStandbyServiceTest,
-       TestVerificationThread_StartsAndStopsCleanlyWhenEnabled) {
-    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
-    config_.enable_oplog_following = true;
-    config_.enable_verification = true;
-    config_.verification_interval_sec = 1;
-    config_.oplog_poll_interval_ms = 1;
-    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
-
-    ASSERT_EQ(ErrorCode::OK,
-              service_->Start("primary", oplog_endpoints_, cluster_id_));
-    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
-    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
-    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
-    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
-    EXPECT_EQ(ErrorCode::OK, service_->GetSyncStatus().last_error);
-    service_->Stop();
-    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
+TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
+    GTEST_SKIP() << "Verification has no observable effect yet (loop only "
+                    "VLOG-skips); re-enable when checksum comparison is "
+                    "implemented";
 }
 
-TEST_F(HotStandbyServiceTest,
-       TestVerificationThread_StopsCleanlyWhenDisabled) {
-    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
-    config_.enable_oplog_following = true;
-    config_.enable_verification = false;
-    config_.oplog_poll_interval_ms = 1;
-    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
-
-    ASSERT_EQ(ErrorCode::OK,
-              service_->Start("primary", oplog_endpoints_, cluster_id_));
-    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
-    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
-    service_->Stop();
-    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
+TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenDisabled) {
+    GTEST_SKIP() << "Verification has no observable effect yet (loop only "
+                    "VLOG-skips); re-enable when checksum comparison is "
+                    "implemented";
 }
 
 // ========== Issue 2 fail-closed catch-up ==========

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -305,7 +305,8 @@ class LiveUnreachableEtcdIntegrationFixture {
             EtcdHelper::ResetEtcdStoreClient(kUnreachableEndpoints);
         if (err != ErrorCode::OK) {
             return std::string(
-                       "Unable to acquire LiveUnreachableEtcdIntegrationFixture: ") +
+                       "Unable to acquire "
+                       "LiveUnreachableEtcdIntegrationFixture: ") +
                    toString(err);
         }
         out->reset(new LiveUnreachableEtcdIntegrationFixture());
@@ -539,12 +540,12 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
     ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
     EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildBatchRecordKey(cluster_id_, 2),
-                           "not-a-valid-batch-record"));
-    ASSERT_EQ(ErrorCode::OK,
-              backend->Put(BuildDurablePrefixKey(cluster_id_),
-                           EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
+    ASSERT_EQ(ErrorCode::OK, backend->Put(BuildBatchRecordKey(cluster_id_, 2),
+                                          "not-a-valid-batch-record"));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey(cluster_id_),
+                     EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
 
     ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
     EXPECT_NE(ErrorCode::OK, service_->GetSyncStatus().last_error);
@@ -1207,7 +1208,8 @@ TEST_F(PromotionCatchUpTest, UsesDurablePrefixLastSeqAsCatchUpTarget) {
               batch_backend_->Put(BuildBatchRecordKey(cluster_id_, 1),
                                   EncodeOpLogBatchRecord(MakeBatch(1, 1, 2))));
 
-    ASSERT_EQ(ErrorCode::OK, service_->Start("", oplog_endpoints_, cluster_id_));
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("", oplog_endpoints_, cluster_id_));
     EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
     StandbySnapshot out;
@@ -1299,7 +1301,8 @@ TEST_F(PromotionCatchUpTest, PaginatesBatchRecords) {
     service_ = std::make_unique<HotStandbyService>(config_);
     service_->SetCatchUpBatchKvBackendForTesting(batch_backend);
 
-    ASSERT_EQ(ErrorCode::OK, service_->Start("", oplog_endpoints_, cluster_id_));
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("", oplog_endpoints_, cluster_id_));
     EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
     StandbySnapshot out;

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -3,6 +3,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <chrono>
 #include <map>
 #include <memory>
@@ -13,7 +14,9 @@
 
 #include <xxhash.h>
 
+#include "ha_metric_manager.h"
 #include "master_service.h"
+#include "metadata_store.h"
 #include "ha/kv/ha_kv_backend.h"
 #include "ha/oplog/oplog_batch_codec.h"
 #include "ha/oplog/oplog_batch_storage.h"
@@ -83,6 +86,127 @@ class FakeCaptureHaKvBackend final : public HaKvBackend {
     std::map<std::string, std::string> values_;
 };
 
+OpLogEntry MakeEntry(uint64_t seq, OpType type, const std::string& key,
+                     const std::string& payload) {
+    OpLogEntry e;
+    e.sequence_id = seq;
+    e.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                         std::chrono::steady_clock::now().time_since_epoch())
+                         .count();
+    e.op_type = type;
+    e.object_key = key;
+    e.payload = payload;
+    e.checksum =
+        static_cast<uint32_t>(XXH32(payload.data(), payload.size(), 0));
+    e.prefix_hash =
+        key.empty() ? 0
+                    : static_cast<uint32_t>(XXH32(key.data(), key.size(), 0));
+    return e;
+}
+
+std::string MakeValidPayload(uint64_t client_id_first = 1,
+                             uint64_t client_id_second = 2,
+                             uint64_t size = 1024) {
+    mooncake::MetadataPayload payload;
+    payload.client_id = {client_id_first, client_id_second};
+    payload.size = size;
+    auto result = struct_pack::serialize(payload);
+    return std::string(result.begin(), result.end());
+}
+
+class FakeHaKvBackend : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (next_get_error_ != ErrorCode::OK) {
+            auto error = next_get_error_;
+            next_get_error_ = ErrorCode::OK;
+            return error;
+        }
+        if (get_error_ != ErrorCode::OK) {
+            return get_error_;
+        }
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+    ErrorCode Range(std::string_view begin_key, std::string_view end_key,
+                    size_t limit, std::vector<KvPair>& kvs) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (range_error_ != ErrorCode::OK) {
+            return range_error_;
+        }
+        kvs.clear();
+        for (const auto& [key, value] : values_) {
+            if (key >= begin_key && key < end_key) {
+                kvs.push_back({.key = key, .value = value});
+                if (kvs.size() >= limit) break;
+            }
+        }
+        return ErrorCode::OK;
+    }
+    bool SupportsTxn() const override { return true; }
+    ErrorCode Txn(const KvTxn& txn) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& compare : txn.compares) {
+            auto it = values_.find(compare.key);
+            if (compare.kind == KvCompareKind::kKeyNotExists) {
+                if (it != values_.end()) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
+            } else if (it == values_.end() ||
+                       it->second != compare.expected_value) {
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+        }
+        for (const auto& put : txn.puts) {
+            values_[put.key] = put.value;
+        }
+        return ErrorCode::OK;
+    }
+    void SetGetError(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        get_error_ = err;
+    }
+    void SetRangeError(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        range_error_ = err;
+    }
+    void FailNextGet(ErrorCode err) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        next_get_error_ = err;
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::map<std::string, std::string> values_;
+    ErrorCode get_error_{ErrorCode::OK};
+    ErrorCode range_error_{ErrorCode::OK};
+    ErrorCode next_get_error_{ErrorCode::OK};
+};
+
+OpLogBatchRecord MakeBatch(uint64_t batch_id, uint64_t first_seq,
+                           uint64_t last_seq) {
+    OpLogBatchRecord batch;
+    batch.batch_id = batch_id;
+    batch.first_seq = first_seq;
+    batch.last_seq = last_seq;
+    for (uint64_t seq = first_seq; seq <= last_seq; ++seq) {
+        batch.entries.push_back(MakeEntry(seq, OpType::PUT_END,
+                                          "batch_key_" + std::to_string(seq),
+                                          MakeValidPayload()));
+    }
+    return batch;
+}
+
 OpLogBatchRecord MakeCaptureBatch(uint64_t batch_id, uint64_t sequence_id,
                                   OpType op_type = OpType::REMOVE,
                                   std::string object_key = "key",
@@ -119,6 +243,38 @@ LoadedSnapshot MakeSnapshot(std::string snapshot_id, uint64_t seq_id,
     return snapshot;
 }
 
+std::shared_ptr<FakeHaKvBackend> MakeBackendWithBatch(
+    const std::string& cluster_id, uint64_t batch_id, uint64_t first_seq,
+    uint64_t last_seq) {
+    auto backend = std::make_shared<FakeHaKvBackend>();
+    EXPECT_EQ(ErrorCode::OK,
+              backend->Put(BuildDurablePrefixKey(cluster_id),
+                           EncodeDurablePrefix({.batch_id = batch_id,
+                                                .last_seq = last_seq})));
+    EXPECT_EQ(ErrorCode::OK,
+              backend->Put(BuildBatchRecordKey(cluster_id, batch_id),
+                           EncodeOpLogBatchRecord(
+                               MakeBatch(batch_id, first_seq, last_seq))));
+    return backend;
+}
+
+bool WaitForAppliedSequence(HotStandbyService& service, uint64_t seq,
+                            int max_attempts = 200) {
+    for (int i = 0; i < max_attempts && service.GetLatestAppliedSequenceId() < seq;
+         ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return service.GetLatestAppliedSequenceId() >= seq;
+}
+
+bool WaitForState(HotStandbyService& service, StandbyState state,
+                  int max_attempts = 200) {
+    for (int i = 0; i < max_attempts && service.GetState() != state; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return service.GetState() == state;
+}
+
 }  // namespace
 
 class HotStandbyServiceTest : public ::testing::Test {
@@ -150,9 +306,6 @@ class HotStandbyServiceTest : public ::testing::Test {
 
 namespace {
 
-constexpr char kEtcdBehaviorCoverageIssue[] =
-    "https://github.com/kvcache-ai/Mooncake/issues/3496";
-
 std::unique_ptr<HotStandbyService> CreateSnapshotOnlyReadyStandby(
     HotStandbyConfig config, const std::string& cluster_id) {
     config.enable_snapshot_bootstrap = true;
@@ -175,13 +328,32 @@ std::unique_ptr<HotStandbyService> CreateSnapshotOnlyReadyStandby(
     return service;
 }
 
+std::unique_ptr<HotStandbyService> CreateOplogFollowingStandby(
+    HotStandbyConfig config, const std::string& cluster_id,
+    std::shared_ptr<HaKvBackend> backend) {
+    config.enable_oplog_following = true;
+    config.oplog_poll_interval_ms =
+        config.oplog_poll_interval_ms > 0 ? config.oplog_poll_interval_ms : 1;
+    auto service = std::make_unique<HotStandbyService>(config);
+    service->SetCatchUpBatchKvBackendForTesting(std::move(backend));
+    return service;
+}
+
 }  // namespace
 
 // ========== 6.1.1 Start/Stop tests ==========
 
 TEST_F(HotStandbyServiceTest, TestStart) {
-    GTEST_SKIP() << "Requires deterministic etcd-backed Start coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    EXPECT_EQ(1u, service_->GetLatestAppliedSequenceId());
 }
 
 TEST_F(HotStandbyServiceTest, TestStart_AlreadyRunning) {
@@ -193,8 +365,32 @@ TEST_F(HotStandbyServiceTest, TestStart_AlreadyRunning) {
 }
 
 TEST_F(HotStandbyServiceTest, TestStart_InvalidEtcdEndpoints) {
-    GTEST_SKIP() << "Requires deterministic invalid-endpoint coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+#ifdef STORE_USE_ETCD
+    config_.enable_oplog_following = true;
+    service_ = std::make_unique<HotStandbyService>(config_);
+
+    const ErrorCode err = service_->Start(
+        "primary", "http://127.0.0.1:1", cluster_id_);
+    EXPECT_NE(ErrorCode::OK, err);
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+#else
+    GTEST_SKIP() << "Invalid etcd endpoint coverage requires STORE_USE_ETCD";
+#endif
+}
+
+TEST_F(HotStandbyServiceTest,
+       TestStart_OpLogFollowingRequiresEtcdWithoutInjectedBackend) {
+#ifdef STORE_USE_ETCD
+    GTEST_SKIP() << "Feature-gate coverage applies when STORE_USE_ETCD is OFF";
+#else
+    config_.enable_oplog_following = true;
+    service_ = std::make_unique<HotStandbyService>(config_);
+
+    const ErrorCode err =
+        service_->Start("primary", oplog_endpoints_, cluster_id_);
+    EXPECT_EQ(ErrorCode::INTERNAL_ERROR, err);
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+#endif
 }
 
 TEST_F(HotStandbyServiceTest, TestStop_WhenNotRunning) {
@@ -208,19 +404,49 @@ TEST_F(HotStandbyServiceTest, TestStop_WhenNotRunning) {
 // ========== 6.1.2 State transition tests ==========
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
-    GTEST_SKIP() << "Requires deterministic etcd-backed state coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
-    GTEST_SKIP() << "Requires deterministic connection-failure coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+#ifdef STORE_USE_ETCD
+    config_.enable_oplog_following = true;
+    service_ = std::make_unique<HotStandbyService>(config_);
+
+    const ErrorCode err = service_->Start(
+        "primary", "http://127.0.0.1:1", cluster_id_);
+    EXPECT_NE(ErrorCode::OK, err);
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+#else
+    GTEST_SKIP()
+        << "CONNECTION_FAILED path requires STORE_USE_ETCD connect attempt";
+#endif
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
-    GTEST_SKIP() << "Requires deterministic synchronization-failure coverage; "
-                    "see "
-                 << kEtcdBehaviorCoverageIssue;
+    config_.enable_snapshot_bootstrap = true;
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = std::make_unique<HotStandbyService>(config_);
+
+    auto snapshot = MakeSnapshot("snapshot", 42, "key", 1);
+    snapshot.metadata.push_back(snapshot.metadata.front());
+    snapshot.metadata.back().metadata.size = 2;
+    service_->SetSnapshotProvider(std::make_unique<FakeSnapshotProvider>(
+        std::optional<LoadedSnapshot>(std::move(snapshot))));
+    service_->SetCatchUpBatchKvBackendForTesting(
+        std::make_shared<FakeHaKvBackend>());
+
+    EXPECT_EQ(ErrorCode::DESERIALIZE_FAIL,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 }
 
 // ========== 6.1.3 Sync status tests ==========
@@ -236,8 +462,22 @@ TEST_F(HotStandbyServiceTest, TestGetSyncStatus_InitialState) {
 }
 
 TEST_F(HotStandbyServiceTest, TestGetSyncStatus_AfterSync) {
-    GTEST_SKIP() << "Requires deterministic post-sync status coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+
+    StandbySyncStatus status = service_->GetSyncStatus();
+    EXPECT_EQ(StandbyState::WATCHING, status.state);
+    EXPECT_TRUE(status.is_connected);
+    EXPECT_TRUE(status.is_syncing);
+    EXPECT_EQ(1u, status.applied_seq_id);
+    EXPECT_GE(status.primary_seq_id, status.applied_seq_id);
+    EXPECT_EQ(ErrorCode::OK, status.last_error);
 }
 
 // ========== 6.1.4 Promotion tests ==========
@@ -301,21 +541,60 @@ TEST_F(HotStandbyServiceTest, TestPromoteAndExportSnapshot_FinalCatchUp) {
 // ========== 6.1.5 Warm start tests ==========
 
 TEST_F(HotStandbyServiceTest, TestWarmStart_WithLocalState) {
-    GTEST_SKIP() << "Requires deterministic local-state warm-start coverage; "
-                    "see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    EXPECT_GE(service_->GetMetadataCount(), 1u);
+    service_->Stop();
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    EXPECT_EQ(1u, service_->GetLatestAppliedSequenceId());
+    EXPECT_GE(service_->GetMetadataCount(), 1u);
 }
 
 TEST_F(HotStandbyServiceTest, TestWarmStart_WithoutLocalState) {
-    GTEST_SKIP() << "Requires deterministic empty-state warm-start coverage; "
-                    "see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = std::make_shared<FakeHaKvBackend>();
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildDurablePrefixKey(cluster_id_),
+                           EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    config_.enable_oplog_following = true;
+    config_.enable_snapshot_bootstrap = false;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    EXPECT_EQ(0u, service_->GetLatestAppliedSequenceId());
+    EXPECT_EQ(0u, service_->GetMetadataCount());
 }
 
 TEST_F(HotStandbyServiceTest, TestWarmStart_WithSnapshot) {
-    GTEST_SKIP() << "Requires deterministic etcd-backed snapshot warm-start "
-                    "coverage; see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = std::make_shared<FakeHaKvBackend>();
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildDurablePrefixKey(cluster_id_),
+                           EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    config_.enable_snapshot_bootstrap = true;
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+    service_->SetSnapshotProvider(
+        std::make_unique<FakeSnapshotProvider>(std::optional<LoadedSnapshot>(
+            MakeSnapshot("warm-start-snapshot", 42, "key-1", 4096))));
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    EXPECT_EQ(42u, service_->GetLatestAppliedSequenceId());
+    EXPECT_EQ(1u, service_->GetMetadataCount());
 }
 
 TEST_F(HotStandbyServiceTest, TestStart_SnapshotOnlyWithSnapshot) {
@@ -574,163 +853,81 @@ TEST_F(HotStandbyServiceTest, SnapshotCaptureRejectsInconsistentSequence) {
 // ========== 6.1.7 Replication loop tests ==========
 
 TEST_F(HotStandbyServiceTest, TestReplicationLoop_UpdatesMetrics) {
-    GTEST_SKIP() << "Requires deterministic replication-loop metric coverage; "
-                    "see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    std::atomic<uint64_t> observed_applied{0};
+    service_->SetSyncStatusCallback(
+        [&](const StandbySyncStatus& status) {
+            observed_applied.store(status.applied_seq_id,
+                                   std::memory_order_relaxed);
+        });
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    EXPECT_EQ(static_cast<int64_t>(StandbyState::WATCHING),
+              HAMetricManager::instance().get_standby_state());
+    for (int i = 0; i < 100 && observed_applied.load() < 1; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    EXPECT_GE(observed_applied.load(), 1u);
 }
 
 TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
-    GTEST_SKIP() << "Requires deterministic replication disconnect coverage; "
-                    "see "
-                 << kEtcdBehaviorCoverageIssue;
+    auto backend = std::make_shared<FakeHaKvBackend>();
+    backend->SetGetError(ErrorCode::ETCD_OPERATION_ERROR);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    config_.batch_oplog_retry_timeout_sec = 0;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
+              service_->GetSyncStatus().last_error);
 }
 
 // ========== 6.1.8 Verification loop tests ==========
 
 TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
-    GTEST_SKIP()
-        << "Requires deterministic enabled verification-loop coverage; "
-           "see "
-        << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.enable_verification = true;
+    config_.verification_interval_sec = 1;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(1100));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    EXPECT_EQ(ErrorCode::OK, service_->GetSyncStatus().last_error);
+    service_->Stop();
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
 }
 
 TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenDisabled) {
-    GTEST_SKIP()
-        << "Requires deterministic disabled verification-loop coverage; see "
-        << kEtcdBehaviorCoverageIssue;
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.enable_verification = false;
+    config_.oplog_poll_interval_ms = 1;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
+
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    service_->Stop();
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
 }
 
 // ========== Issue 2 fail-closed catch-up ==========
-
-#ifdef STORE_USE_ETCD
-namespace {
-
-// Helper to create a valid OpLogEntry with checksum (mirrors the helper in
-// oplog_applier_test.cpp).
-OpLogEntry MakeEntry(uint64_t seq, OpType type, const std::string& key,
-                     const std::string& payload) {
-    OpLogEntry e;
-    e.sequence_id = seq;
-    e.timestamp_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                         std::chrono::steady_clock::now().time_since_epoch())
-                         .count();
-    e.op_type = type;
-    e.object_key = key;
-    e.payload = payload;
-    // Compute checksum and prefix_hash using the production algorithm.
-    e.checksum =
-        static_cast<uint32_t>(XXH32(payload.data(), payload.size(), 0));
-    e.prefix_hash =
-        key.empty() ? 0
-                    : static_cast<uint32_t>(XXH32(key.data(), key.size(), 0));
-    return e;
-}
-
-// Helper to create a valid struct_pack payload for PUT_END
-std::string MakeValidPayload(uint64_t client_id_first = 1,
-                             uint64_t client_id_second = 2,
-                             uint64_t size = 1024) {
-    mooncake::MetadataPayload payload;
-    payload.client_id = {client_id_first, client_id_second};
-    payload.size = size;
-    auto result = struct_pack::serialize(payload);
-    return std::string(result.begin(), result.end());
-}
-
-class FakeHaKvBackend : public HaKvBackend {
-   public:
-    ErrorCode Get(std::string_view key, std::string& value) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (next_get_error_ != ErrorCode::OK) {
-            auto error = next_get_error_;
-            next_get_error_ = ErrorCode::OK;
-            return error;
-        }
-        if (get_error_ != ErrorCode::OK) {
-            return get_error_;
-        }
-        auto it = values_.find(std::string(key));
-        if (it == values_.end()) {
-            return ErrorCode::ETCD_KEY_NOT_EXIST;
-        }
-        value = it->second;
-        return ErrorCode::OK;
-    }
-    ErrorCode Put(std::string_view key, std::string_view value) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        values_[std::string(key)] = std::string(value);
-        return ErrorCode::OK;
-    }
-    ErrorCode Range(std::string_view begin_key, std::string_view end_key,
-                    size_t limit, std::vector<KvPair>& kvs) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        if (range_error_ != ErrorCode::OK) {
-            return range_error_;
-        }
-        kvs.clear();
-        for (const auto& [key, value] : values_) {
-            if (key >= begin_key && key < end_key) {
-                kvs.push_back({.key = key, .value = value});
-                if (kvs.size() >= limit) break;
-            }
-        }
-        return ErrorCode::OK;
-    }
-    bool SupportsTxn() const override { return true; }
-    ErrorCode Txn(const KvTxn& txn) override {
-        std::lock_guard<std::mutex> lock(mutex_);
-        for (const auto& compare : txn.compares) {
-            auto it = values_.find(compare.key);
-            if (compare.kind == KvCompareKind::kKeyNotExists) {
-                if (it != values_.end()) {
-                    return ErrorCode::ETCD_TRANSACTION_FAIL;
-                }
-            } else if (it == values_.end() ||
-                       it->second != compare.expected_value) {
-                return ErrorCode::ETCD_TRANSACTION_FAIL;
-            }
-        }
-        for (const auto& put : txn.puts) {
-            values_[put.key] = put.value;
-        }
-        return ErrorCode::OK;
-    }
-    void SetGetError(ErrorCode err) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        get_error_ = err;
-    }
-    void SetRangeError(ErrorCode err) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        range_error_ = err;
-    }
-    void FailNextGet(ErrorCode err) {
-        std::lock_guard<std::mutex> lock(mutex_);
-        next_get_error_ = err;
-    }
-
-   private:
-    mutable std::mutex mutex_;
-    std::map<std::string, std::string> values_;
-    ErrorCode get_error_{ErrorCode::OK};
-    ErrorCode range_error_{ErrorCode::OK};
-    ErrorCode next_get_error_{ErrorCode::OK};
-};
-
-OpLogBatchRecord MakeBatch(uint64_t batch_id, uint64_t first_seq,
-                           uint64_t last_seq) {
-    OpLogBatchRecord batch;
-    batch.batch_id = batch_id;
-    batch.first_seq = first_seq;
-    batch.last_seq = last_seq;
-    for (uint64_t seq = first_seq; seq <= last_seq; ++seq) {
-        batch.entries.push_back(MakeEntry(seq, OpType::PUT_END,
-                                          "batch_key_" + std::to_string(seq),
-                                          MakeValidPayload()));
-    }
-    return batch;
-}
-
-}  // namespace
 
 TEST_F(HotStandbyServiceTest,
        BatchRecordStandbyPollsInjectedBackendWithoutNotifier) {
@@ -1055,7 +1252,6 @@ TEST_F(PromotionCatchUpTest, FailsPromotionWhenTargetBatchUnreadable) {
     EXPECT_EQ(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, promote_err);
     EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 }
-#endif
 
 }  // namespace mooncake::test
 

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -366,11 +366,12 @@ TEST_F(HotStandbyServiceTest, TestStart_AlreadyRunning) {
 
 TEST_F(HotStandbyServiceTest, TestStart_InvalidEtcdEndpoints) {
 #ifdef STORE_USE_ETCD
+    // Empty endpoints fail synchronously in NewStoreEtcdClient (no dial).
+    // Unreachable hosts such as 127.0.0.1:1 only fail later on Get/watch.
     config_.enable_oplog_following = true;
     service_ = std::make_unique<HotStandbyService>(config_);
 
-    const ErrorCode err =
-        service_->Start("primary", "http://127.0.0.1:1", cluster_id_);
+    const ErrorCode err = service_->Start("primary", "", cluster_id_);
     EXPECT_NE(ErrorCode::OK, err);
     EXPECT_EQ(StandbyState::FAILED, service_->GetState());
 #else
@@ -416,37 +417,46 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
-#ifdef STORE_USE_ETCD
+    // Live etcd dial failures are asynchronous (client construction succeeds
+    // before the first RPC). Cover the resulting FAILED transition with an
+    // injected backend that fails Get after Start returns OK.
+    auto backend = std::make_shared<FakeHaKvBackend>();
+    backend->SetGetError(ErrorCode::ETCD_OPERATION_ERROR);
     config_.enable_oplog_following = true;
-    service_ = std::make_unique<HotStandbyService>(config_);
+    config_.oplog_poll_interval_ms = 1;
+    config_.batch_oplog_retry_timeout_sec = 0;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
 
-    const ErrorCode err =
-        service_->Start("primary", "http://127.0.0.1:1", cluster_id_);
-    EXPECT_NE(ErrorCode::OK, err);
-    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
-#else
-    GTEST_SKIP()
-        << "CONNECTION_FAILED path requires STORE_USE_ETCD connect attempt";
-#endif
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
+              service_->GetSyncStatus().last_error);
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {
-    config_.enable_snapshot_bootstrap = true;
+    // Start successfully, then publish an unreadable batch so the replication
+    // loop (not snapshot restore) drives the FAILED transition.
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
     config_.enable_oplog_following = true;
     config_.oplog_poll_interval_ms = 1;
-    service_ = std::make_unique<HotStandbyService>(config_);
+    config_.batch_oplog_retry_timeout_sec = 0;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
 
-    auto snapshot = MakeSnapshot("snapshot", 42, "key", 1);
-    snapshot.metadata.push_back(snapshot.metadata.front());
-    snapshot.metadata.back().metadata.size = 2;
-    service_->SetSnapshotProvider(std::make_unique<FakeSnapshotProvider>(
-        std::optional<LoadedSnapshot>(std::move(snapshot))));
-    service_->SetCatchUpBatchKvBackendForTesting(
-        std::make_shared<FakeHaKvBackend>());
-
-    EXPECT_EQ(ErrorCode::DESERIALIZE_FAIL,
+    ASSERT_EQ(ErrorCode::OK,
               service_->Start("primary", oplog_endpoints_, cluster_id_));
-    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
+
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildBatchRecordKey(cluster_id_, 2),
+                           "not-a-valid-batch-record"));
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildDurablePrefixKey(cluster_id_),
+                           EncodeDurablePrefix({.batch_id = 2, .last_seq = 2})));
+
+    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
+    EXPECT_NE(ErrorCode::OK, service_->GetSyncStatus().last_error);
 }
 
 // ========== 6.1.3 Sync status tests ==========
@@ -860,21 +870,26 @@ TEST_F(HotStandbyServiceTest, TestReplicationLoop_UpdatesMetrics) {
     config_.oplog_poll_interval_ms = 1;
     service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
 
-    std::atomic<uint64_t> observed_applied{0};
-    service_->SetSyncStatusCallback([&](const StandbySyncStatus& status) {
-        observed_applied.store(status.applied_seq_id,
-                               std::memory_order_relaxed);
-    });
+    // Shared so Stop()/TearDown callbacks cannot outlive a stack atomic.
+    auto observed_applied = std::make_shared<std::atomic<uint64_t>>(0);
+    service_->SetSyncStatusCallback(
+        [observed_applied](const StandbySyncStatus& status) {
+            observed_applied->store(status.applied_seq_id,
+                                    std::memory_order_relaxed);
+        });
 
     ASSERT_EQ(ErrorCode::OK,
               service_->Start("primary", oplog_endpoints_, cluster_id_));
     ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
     EXPECT_EQ(static_cast<int64_t>(StandbyState::WATCHING),
               HAMetricManager::instance().get_standby_state());
-    for (int i = 0; i < 100 && observed_applied.load() < 1; ++i) {
+    for (int i = 0; i < 100 && observed_applied->load() < 1; ++i) {
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
     }
-    EXPECT_GE(observed_applied.load(), 1u);
+    EXPECT_GE(observed_applied->load(), 1u);
+    service_->Stop();
+    service_->SetSyncStatusCallback({});
+    EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
 }
 
 TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
@@ -892,9 +907,13 @@ TEST_F(HotStandbyServiceTest, TestReplicationLoop_HandlesDisconnect) {
               service_->GetSyncStatus().last_error);
 }
 
-// ========== 6.1.8 Verification loop tests ==========
+// ========== 6.1.8 Verification thread lifecycle ==========
+// Production verification is not implemented yet (loop only VLOG-skips).
+// These tests cover thread start/stop only; checksum verification remains
+// skipped until the feature has observable side effects.
 
-TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
+TEST_F(HotStandbyServiceTest,
+       TestVerificationThread_StartsAndStopsCleanlyWhenEnabled) {
     auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
     config_.enable_oplog_following = true;
     config_.enable_verification = true;
@@ -913,7 +932,8 @@ TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenEnabled) {
     EXPECT_EQ(StandbyState::STOPPED, service_->GetState());
 }
 
-TEST_F(HotStandbyServiceTest, TestVerificationLoop_WhenDisabled) {
+TEST_F(HotStandbyServiceTest,
+       TestVerificationThread_StopsCleanlyWhenDisabled) {
     auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
     config_.enable_oplog_following = true;
     config_.enable_verification = false;
@@ -1121,11 +1141,7 @@ TEST_F(PromotionCatchUpTest, UsesDurablePrefixLastSeqAsCatchUpTarget) {
               batch_backend_->Put(BuildBatchRecordKey(cluster_id_, 1),
                                   EncodeOpLogBatchRecord(MakeBatch(1, 1, 2))));
 
-    auto err = service_->Start("", oplog_endpoints_, cluster_id_);
-    if (err != ErrorCode::OK) {
-        GTEST_SKIP() << "Service could not reach WATCHING state; "
-                        "skipping promotion test";
-    }
+    ASSERT_EQ(ErrorCode::OK, service_->Start("", oplog_endpoints_, cluster_id_));
     EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
     StandbySnapshot out;
@@ -1217,11 +1233,8 @@ TEST_F(PromotionCatchUpTest, PaginatesBatchRecords) {
     service_ = std::make_unique<HotStandbyService>(config_);
     service_->SetCatchUpBatchKvBackendForTesting(batch_backend);
 
-    auto err = service_->Start("", oplog_endpoints_, cluster_id_);
-    if (err != ErrorCode::OK) {
-        GTEST_SKIP() << "Service could not reach WATCHING state; "
-                        "skipping promotion test";
-    }
+    ASSERT_EQ(ErrorCode::OK, service_->Start("", oplog_endpoints_, cluster_id_));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
     StandbySnapshot out;
     ASSERT_EQ(ErrorCode::OK, service_->PromoteAndExportSnapshot(out));

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -277,80 +277,6 @@ bool WaitForState(HotStandbyService& service, StandbyState state,
     return service.GetState() == state;
 }
 
-#ifdef STORE_USE_ETCD
-// Independent in-process integration fixture for live unreachable-endpoint
-// coverage.
-//
-// HotStandbyService's production path can only use the process-global store
-// etcd client (Go singleton via cgo), so a separate client instance is not
-// available. Fork/subprocess isolation is also unsafe once the Go runtime is
-// multi-threaded in this process.
-//
-// This fixture is therefore the strongest isolation the current API allows:
-// it takes exclusive ownership of the global store client for the test
-// duration (Reset onto unreachable endpoints), owns the HotStandbyService
-// under test, and on release always Stop()s that service before Reset-ing
-// back to a conventional endpoint. Reset itself cancels keepalives/watches,
-// waits for prefix-watch goroutines to exit, and closes the old client.
-class LiveUnreachableEtcdIntegrationFixture {
-   public:
-    static constexpr const char* kUnreachableEndpoints = "http://127.0.0.1:1";
-    static constexpr const char* kRestoreEndpoints = "http://127.0.0.1:2379";
-
-    // Returns nullopt on success, or a skip reason if the global client cannot
-    // be acquired onto the unreachable endpoints.
-    static std::optional<std::string> TryCreate(
-        std::unique_ptr<LiveUnreachableEtcdIntegrationFixture>* out) {
-        const ErrorCode err =
-            EtcdHelper::ResetEtcdStoreClient(kUnreachableEndpoints);
-        if (err != ErrorCode::OK) {
-            return std::string(
-                       "Unable to acquire "
-                       "LiveUnreachableEtcdIntegrationFixture: ") +
-                   toString(err);
-        }
-        out->reset(new LiveUnreachableEtcdIntegrationFixture());
-        return std::nullopt;
-    }
-
-    ~LiveUnreachableEtcdIntegrationFixture() { Release(); }
-
-    LiveUnreachableEtcdIntegrationFixture(
-        const LiveUnreachableEtcdIntegrationFixture&) = delete;
-    LiveUnreachableEtcdIntegrationFixture& operator=(
-        const LiveUnreachableEtcdIntegrationFixture&) = delete;
-
-    HotStandbyService& CreateService(HotStandbyConfig config) {
-        config.enable_oplog_following = true;
-        config.enable_verification = false;
-        config.oplog_poll_interval_ms = 1;
-        config.batch_oplog_retry_timeout_sec = 0;
-        service_ = std::make_unique<HotStandbyService>(std::move(config));
-        return *service_;
-    }
-
-    const char* unreachable_endpoints() const { return kUnreachableEndpoints; }
-
-    void Release() {
-        if (released_) {
-            return;
-        }
-        released_ = true;
-        if (service_) {
-            service_->Stop();
-            service_.reset();
-        }
-        (void)EtcdHelper::ResetEtcdStoreClient(kRestoreEndpoints);
-    }
-
-   private:
-    LiveUnreachableEtcdIntegrationFixture() = default;
-
-    std::unique_ptr<HotStandbyService> service_;
-    bool released_ = false;
-};
-#endif
-
 }  // namespace
 
 class HotStandbyServiceTest : public ::testing::Test {
@@ -493,37 +419,27 @@ TEST_F(HotStandbyServiceTest, TestStateTransition_StartToWatching) {
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_ConnectionFailed) {
-#ifdef STORE_USE_ETCD
-    // Live dial failures are asynchronous: client construction succeeds, then
-    // replication Get() times out. Owned by a dedicated integration fixture so
-    // the global store client is exclusively claimed and restored.
-    std::unique_ptr<LiveUnreachableEtcdIntegrationFixture> fixture;
-    if (auto skip_reason =
-            LiveUnreachableEtcdIntegrationFixture::TryCreate(&fixture)) {
-        GTEST_SKIP() << *skip_reason;
-    }
+    // Deterministic connection-failure coverage: Start() succeeds with an
+    // injected backend, then a later Get error from the replication loop
+    // drives WATCHING -> FAILED. Prefer this over a live unreachable-etcd
+    // dial so we do not touch the process-global store client or network
+    // timeouts.
+    auto backend = MakeBackendWithBatch(cluster_id_, 1, 1, 1);
+    config_.enable_oplog_following = true;
+    config_.oplog_poll_interval_ms = 1;
+    config_.batch_oplog_retry_timeout_sec = 0;
+    service_ = CreateOplogFollowingStandby(config_, cluster_id_, backend);
 
-    // Only the fixture owns HotStandbyService for this case.
-    service_.reset();
+    ASSERT_EQ(ErrorCode::OK,
+              service_->Start("primary", oplog_endpoints_, cluster_id_));
+    ASSERT_TRUE(WaitForAppliedSequence(*service_, 1));
+    EXPECT_EQ(StandbyState::WATCHING, service_->GetState());
 
-    HotStandbyService& service = fixture->CreateService(config_);
-    const ErrorCode err =
-        service.Start("primary", fixture->unreachable_endpoints(), cluster_id_);
-    ASSERT_EQ(ErrorCode::OK, err)
-        << "Start should succeed once the etcd client object exists; dial "
-           "failure is expected asynchronously from the replication loop";
-
-    // Store Get() uses a ~5s context timeout; allow headroom beyond that.
-    ASSERT_TRUE(WaitForState(service, StandbyState::FAILED,
-                             /*max_attempts=*/4000))
-        << "Expected FAILED after unreachable etcd Get/dial timeout";
-    EXPECT_EQ(StandbyState::FAILED, service.GetState());
-
-    fixture->Release();
-#else
-    GTEST_SKIP()
-        << "Live etcd connection-failure coverage requires STORE_USE_ETCD";
-#endif
+    backend->SetGetError(ErrorCode::ETCD_OPERATION_ERROR);
+    ASSERT_TRUE(WaitForState(*service_, StandbyState::FAILED));
+    EXPECT_EQ(StandbyState::FAILED, service_->GetState());
+    EXPECT_EQ(ErrorCode::ETCD_OPERATION_ERROR,
+              service_->GetSyncStatus().last_error);
 }
 
 TEST_F(HotStandbyServiceTest, TestStateTransition_SyncFailed) {


### PR DESCRIPTION
## Description

Fixes #3496.

Several `HotStandbyService` tests were named after etcd-backed standby behaviors but unconditionally `GTEST_SKIP`'d, so CI did not exercise the claimed Start / sync / warm-start / replication / verification paths.

This PR:

1. Lets `SetCatchUpBatchKvBackendForTesting` drive the real `Start()` / replication / promotion catch-up path without a live etcd connection (also works when `STORE_USE_ETCD` is OFF).
2. Replaces the #3496 skip gaps with deterministic fake-backend coverage for Start, state transitions, sync status, warm start, replication metrics/failures, and verification enable/disable.
3. Keeps real-etcd invalid-endpoint / `CONNECTION_FAILED` coverage under `STORE_USE_ETCD`, and names the non-etcd feature-gate path separately.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Added/rewrote unit coverage in `hot_standby_service_test.cpp` using injected `HaKvBackend` fakes.

Full build/tests not run locally (Windows environment without Mooncake build toolchain); please rely on CI.

**Test commands:**
```bash
# CI: Build & Test (Linux)
# Local (Linux): ctest --test-dir build -R hot_standby_service_test
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (code review; unit tests added/updated)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor AI assisted with issue analysis, test-seam adjustment, unit coverage for #3496, and PR drafting. The submitter reviewed the changes.

Made with [Cursor](https://cursor.com)