### PR TITLE
[TENT] Guard RDMA worker latency samples behind latency logging flag

### DIFF
--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -735,8 +735,10 @@ void Workers::asyncPollCq() {
                 if (auto* rail = slice->rail_monitor; rail && rail->ready())
                     rail->markRecovered(slice->source_dev_id,
                                         slice->target_dev_id);
-                worker.perf.inflight_lat.add(inflight_lat);
-                worker.perf.enqueue_lat.add(enqueue_lat);
+                if (transport_->params_->workers.show_latency_info) {
+                    worker.perf.inflight_lat.add(inflight_lat);
+                    worker.perf.enqueue_lat.add(enqueue_lat);
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Fix an RDMA worker perf sampling issue where `enqueue_lat` and `inflight_lat` samples were appended even when `show_latency_info` was disabled by default. Since those vectors are only cleared by the latency logging path, the default configuration could retain completed-task latency samples unnecessarily.

This change only records those samples when latency logging is enabled.

Also audited other TENT vector usages for similar default-disabled perf/sample accumulation patterns; no other matching issue was found.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check -- mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
cmake --build build --target tent_xport_rdma -j2
pre-commit run --files mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
```

**Test results:**
- [x] Manual testing done
- [x] `git diff --check` passed
- [x] `tent_xport_rdma` build passed
- [ ] Pre-commit passed

Pre-commit could not be completed because `pre-commit` is not installed in the current environment.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to inspect TENT vector/perf usage, make the RDMA worker guard change, and prepare this PR summary. The human submitter should review and validate the final diff before submission.