### PR TITLE
[Build] Propagate YLT includes to PG device compiler

### DIFF
--- a/mooncake-pg/src/CMakeLists.txt
+++ b/mooncake-pg/src/CMakeLists.txt
@@ -25,6 +25,14 @@ elseif(USE_MUSA OR USE_MACA)
       "${_pg_device_depfile}"
       "-I${CMAKE_CURRENT_SOURCE_DIR}/../include"
       "-I${CMAKE_CURRENT_SOURCE_DIR}/../../mooncake-transfer-engine/include")
+  # mcc/mxcc run outside a CMake compile target, so linked target usage
+  # requirements do not reach this custom command automatically.
+  get_target_property(_pg_ylt_include_dirs yalantinglibs
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  foreach(_pg_ylt_include_dir IN LISTS _pg_ylt_include_dirs)
+    list(APPEND _pg_device_flags
+         "$<$<BOOL:${_pg_ylt_include_dir}>:-I${_pg_ylt_include_dir}>")
+  endforeach()
   set(_pg_device_dependencies
       "${_pg_device_source}"
       "${CMAKE_CURRENT_SOURCE_DIR}/../include/mooncake_worker_kernels.cuh"


### PR DESCRIPTION
## Description

Fix the MUSA PG device compilation failure where `mcc` cannot find `ylt/util/expected.hpp` after #3537 migrated yalantinglibs from a system installation to CMake FetchContent.

The MUSA/MACA device object is compiled by a hand-written `add_custom_command`, so usage requirements from `yalantinglibs::yalantinglibs` do not reach that compiler invocation. This change reads the dependency target include directories and appends the non-empty build-time paths to the custom compiler flags.

Failing nightly job: https://github.com/kvcache-ai/Mooncake/actions/runs/32870688235/job/97876675893

No overlapping open issue or pull request was found.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check HEAD^
pre-commit run --files mooncake-pg/src/CMakeLists.txt
```

A minimal CMake configure/generate smoke check also verified that the target include directories become independent `-I` arguments and that the empty install-interface expression does not leave a bare `-I`.

The MUSA project build was not run because the local environment does not provide the MUSA toolchain.

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done as described above

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable: no C/C++ files changed)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: internal build fix)
- [ ] I have added tests to prove my changes are effective (covered by the existing nightly MUSA build)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable: 8-line fix)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped inspect the GitHub Actions failure, trace the regression to the YLT FetchContent migration, implement the CMake include propagation, and run the static checks. The human submitter is responsible for reviewing and defending the change.