### PR TITLE
[TENT] Wake progress worker on RDMA task completion

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -51,6 +51,8 @@ using RdmaTaskStorage = Slab<RdmaTask>;
 struct RdmaTask {
     int num_slices;
     Request request;
+    BatchID progress_batch_id{0};
+    std::function<void(BatchID)> notify_progress;
     // Resolved by TransportSelector and copied from RdmaSubBatch. The
     // per-slice path runs later on worker threads, so it must carry the same
     // device policy as the aggregate allocation path.
@@ -148,7 +150,11 @@ static inline void updateSliceStatus(RdmaSlice* slice,
                 ? COMPLETED
                 : task->first_error;
         if (final_st == PENDING) final_st = FAILED;
-        __sync_bool_compare_and_swap(&task->status_word, PENDING, final_st);
+        if (__sync_bool_compare_and_swap(&task->status_word, PENDING,
+                                         final_st)) {
+            if (task->notify_progress)
+                task->notify_progress(task->progress_batch_id);
+        }
     }
     task->deref();
 }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -464,6 +464,8 @@ Status RdmaTransport::submitTransferTasks(
         auto* task = RdmaTaskStorage::Get().allocate();
         rdma_batch->task_list.push_back(task);
         task->request = request;
+        task->progress_batch_id = batch->progress_batch_id;
+        task->notify_progress = batch->notify_progress;
         task->device_mask = rdma_batch->device_mask;
         task->qp_pool = rdma_batch->qp_pool;  // RFC #2568 step 3
         task->num_slices = 0;

--- a/mooncake-transfer-engine/tent/tests/rdma_cancel_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_cancel_test.cpp
@@ -28,6 +28,8 @@ TEST(RdmaCancelTest, PartialCancellationWaitsForPostedSlices) {
     task.success_slices.store(0);
     task.resolved_slices.store(0);
     task.first_error = PENDING;
+    int notifications = 0;
+    task.notify_progress = [&](BatchID) { ++notifications; };
     // Two slice references plus the batch reference. updateSliceStatus drops
     // one reference per resolved slice; the stack object is never deallocated.
     task.ref_count.store(3);
@@ -44,11 +46,13 @@ TEST(RdmaCancelTest, PartialCancellationWaitsForPostedSlices) {
     updateSliceStatus(&canceled, CANCELED);
     EXPECT_EQ(task.status_word, PENDING);
     EXPECT_EQ(task.transferred_bytes, 0u);
+    EXPECT_EQ(notifications, 0);
 
     updateSliceStatus(&posted, COMPLETED);
     EXPECT_EQ(task.status_word, CANCELED);
     EXPECT_EQ(task.transferred_bytes, 8192u);
     EXPECT_EQ(task.resolved_slices.load(), 2);
+    EXPECT_EQ(notifications, 1);
 }
 
 TEST(RdmaCancelTest, FullyPostedTaskMayStillComplete) {
@@ -61,6 +65,8 @@ TEST(RdmaCancelTest, FullyPostedTaskMayStillComplete) {
     task.first_error = PENDING;
     task.cancel_requested.store(true);
     task.ref_count.store(2);
+    int notifications = 0;
+    task.notify_progress = [&](BatchID) { ++notifications; };
 
     RdmaSlice posted{};
     posted.task = &task;
@@ -70,6 +76,10 @@ TEST(RdmaCancelTest, FullyPostedTaskMayStillComplete) {
 
     EXPECT_EQ(task.status_word, COMPLETED);
     EXPECT_EQ(task.transferred_bytes, 4096u);
+    EXPECT_EQ(notifications, 1);
+
+    updateSliceStatus(&posted, COMPLETED);
+    EXPECT_EQ(notifications, 1);
 }
 
 }  // namespace


### PR DESCRIPTION
## Description
  - [#2199](https://github.com/kvcache-ai/Mooncake/pull/2199) introduced `ProgressWorker` to advance batch progress and trigger failover without requiring continuous caller polling.
  - [#2562](https://github.com/kvcache-ai/Mooncake/pull/2562) added a progress  callback to `Transport::SubBatch` and wired the TCP, SHM and io_uring completion paths to invoke it. The callback wakes `ProgressWorker`, which also refills the local runtime queue dispatch window.
  - [#2733](https://github.com/kvcache-ai/Mooncake/pull/2733) reused the same callback for the TPU transport.



RDMA tasks did not retain or invoke this progress callback. Consequently, `ProgressWorker` could not react immediately when an RDMA task completed or  failed.

  This PR propagates the callback from `RdmaSubBatch` to each `RdmaTask` and  invokes it once when the task first reaches a terminal state.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?
The tests verify that a multi-slice task is not notified early, a terminal task is notified once, and repeated status updates do not generate duplicate  notifications.




**Test commands:**
  ```bash
  cmake -S . -B build
 cmake --build build  --target rdma_cancel_test tent_xport_rdma  tent_runtime_queue_dispatch_test tent_progress_worker_test
  ctest --test-dir build --output-on-failure    -R '^(rdma_cancel_test|tent_runtime_queue_dispatch_test|tent_progress_worker_test)$'

```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)
codex was used to update the unit tests.