### PR TITLE
[MUSA] Backport YLT include propagation to v0.3.13

### DIFF
--- a/mooncake-pg/src/CMakeLists.txt
+++ b/mooncake-pg/src/CMakeLists.txt
@@ -25,6 +25,14 @@ elseif(USE_MUSA OR USE_MACA)
       "${_pg_device_depfile}"
       "-I${CMAKE_CURRENT_SOURCE_DIR}/../include"
       "-I${CMAKE_CURRENT_SOURCE_DIR}/../../mooncake-transfer-engine/include")
+  # mcc/mxcc run outside a CMake compile target, so linked target usage
+  # requirements do not reach this custom command automatically.
+  get_target_property(_pg_ylt_include_dirs yalantinglibs
+                      INTERFACE_INCLUDE_DIRECTORIES)
+  foreach(_pg_ylt_include_dir IN LISTS _pg_ylt_include_dirs)
+    list(APPEND _pg_device_flags
+         "$<$<BOOL:${_pg_ylt_include_dir}>:-I${_pg_ylt_include_dir}>")
+  endforeach()
   set(_pg_device_dependencies
       "${_pg_device_source}"
       "${CMAKE_CURRENT_SOURCE_DIR}/../include/mooncake_worker_kernels.cuh"


### PR DESCRIPTION
## Description

Backport #3691 to `release/v0.3.13`.

This propagates yalantinglibs interface include directories to the standalone
PG device compiler command used by MUSA and MACA builds. The change is an
unchanged cherry-pick of commit `2d840282613746779d11ed66965e802254da4f0d`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

This is an unchanged cherry-pick of the commit merged through #3691.

**Test commands:**
```bash
git diff --check origin/release/v0.3.13...HEAD
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: the cherry-pick applied without conflicts and the
      resulting diff passes `git diff --check`.

`pre-commit` was not available in the current environment.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex identified the latest release branch, cherry-picked the existing commit,
performed the validation described above, and prepared this pull request.