### PR TITLE
[Docs] Add FlagCX transport README

### DIFF
--- a/docs/source/design/transfer-engine/flagcx_transport.md
+++ b/docs/source/design/transfer-engine/flagcx_transport.md
@@ -1,0 +1,318 @@
+# FlagOS FlagCX Transport
+
+## Overview
+
+[FlagCX](https://github.com/flagos-ai/FlagCX) is the cross-chip communication library in the
+FlagOS ecosystem. Mooncake's FlagCX transport connects the classic Transfer Engine to the FlagCX
+P2P Engine. Mooncake keeps its existing segment, memory-registration, batch, and completion APIs;
+the transport maps those operations to FlagCX connections and P2P read/write requests.
+
+The protocol name used by Mooncake configuration and APIs is `flagcx`. `flagos` is not a protocol
+name.
+
+> **Classic Transfer Engine only.** The FlagCX transport is implemented under
+> `mooncake-transfer-engine/src/transport/` and is not a TENT transport. Build with
+> `USE_FLAGCX=ON`, select `--backend=classic` in `tebench`, and use `flagcx` as a standalone
+> protocol.
+
+### Code Structure
+
+| Unit | Responsibility |
+|------|----------------|
+| `flagcx_transport.{h,cpp}` | Creates the P2P Engine, advertises its endpoint, registers memory, opens peer connections, submits transfers, and polls completion |
+| `flagcx_transport_internal.h` | Overflow-safe registered-range checks and descriptor-length conversion |
+| `mooncake-common/common.cmake` | Locates the external FlagCX headers and library and defines `FlagCX::flagcx` |
+| `multi_transport.cpp` | Instantiates `FlagCxTransport` when the protocol name is `flagcx` |
+
+### Transfer Pipeline
+
+1. **Initialization:** Mooncake creates a FlagCX P2P Engine and starts its RPC server.
+2. **Advertisement:** the transport obtains the FlagCX endpoint and publishes it in the local
+   Mooncake segment descriptor.
+3. **Registration:** `registerLocalMemory()` registers each local range with FlagCX and publishes
+   the corresponding Mooncake buffer descriptor.
+4. **Connection:** the first request to a remote segment reads its published FlagCX endpoint and
+   opens a connection. FlagCX caches the connection for later requests.
+5. **Submission:** Mooncake groups requests with the same target and operation, creates remote
+   descriptors, and calls the FlagCX vector read or write API.
+6. **Completion:** a Mooncake worker polls the returned FlagCX transfer ID and updates the original
+   Mooncake task when the transfer becomes terminal.
+
+---
+
+## Dependencies
+
+Build and run Mooncake with the same FlagCX installation. The prefix passed as `FLAGCX_HOME` must
+provide:
+
+- `include/flagcx_p2p.h`
+- `lib/libflagcx.so` or `lib64/libflagcx.so`
+- The accelerator runtime, communication library, and network dependencies required by the chosen
+  FlagCX backend
+
+FlagCX supports multiple accelerator backends. Choose the backend that matches the local platform;
+for example, `USE_NVIDIA=1`, `USE_METAX=1`, or `USE_MUSA=1`. See the
+[FlagCX getting-started guide](https://github.com/flagos-ai/FlagCX/blob/main/docs/getting_started.md)
+for the complete current backend list and platform prerequisites.
+
+## Build and Compile
+
+### 1. Build FlagCX
+
+```bash
+git clone https://github.com/flagos-ai/FlagCX.git
+cd FlagCX
+git submodule update --init --recursive
+
+# Replace USE_NVIDIA with the backend for the local platform.
+make USE_NVIDIA=1 -j$(nproc)
+```
+
+The default build output is suitable for an in-tree Mooncake build:
+
+```text
+FlagCX/build/include/flagcx_p2p.h
+FlagCX/build/lib/libflagcx.so
+```
+
+Alternatively, install FlagCX under a dedicated prefix:
+
+```bash
+make PREFIX=/opt/flagcx install
+```
+
+### 2. Build Mooncake
+
+From the Mooncake repository root:
+
+```bash
+cmake -S . -B build \
+  -DUSE_FLAGCX=ON \
+  -DFLAGCX_HOME=/path/to/FlagCX/build
+cmake --build build -j$(nproc)
+```
+
+For the installed layout above, use `-DFLAGCX_HOME=/opt/flagcx`. If `FLAGCX_HOME` is not passed to
+CMake, Mooncake first checks the environment variable of the same name, then defaults to
+`$HOME/FlagCX/build`.
+
+Configuration fails early if either `flagcx_p2p.h` or the FlagCX shared library cannot be found.
+A successful configuration includes a message similar to:
+
+```text
+FlagCX transport enabled, include=/path/to/FlagCX/build/include, library=/path/to/FlagCX/build/lib/libflagcx.so
+```
+
+Make the shared library and its backend dependencies visible to the dynamic linker when they are
+not installed in a system search path:
+
+```bash
+export FLAGCX_HOME=/path/to/FlagCX/build
+export LD_LIBRARY_PATH="$FLAGCX_HOME/lib:${LD_LIBRARY_PATH:-}"
+```
+
+Add the relevant Mooncake accelerator option, such as `USE_CUDA`, `USE_MUSA`, or `USE_HIP`, when
+the application also needs Mooncake to allocate or identify that accelerator's memory.
+
+---
+
+## Enabling the Transport
+
+### Python API
+
+A Mooncake Python extension built with `USE_FLAGCX=ON` accepts `flagcx` through the existing
+initialization API:
+
+```python
+engine.initialize(
+    hostname="node1",
+    metadata_server="P2PHANDSHAKE",
+    protocol="flagcx",
+    device_name="",
+)
+```
+
+The Python binding disables automatic RDMA transport discovery for this protocol and installs the
+FlagCX transport explicitly. No new Python API is required.
+
+### C++ API
+
+Applications using the classic C++ Transfer Engine can install the transport by name after engine
+initialization:
+
+```cpp
+auto* transport = engine.installTransport("flagcx", nullptr);
+if (transport == nullptr) {
+    // Mooncake was not built with USE_FLAGCX=ON, or transport setup failed.
+}
+```
+
+Continue to use the standard Transfer Engine APIs for memory registration, segment discovery,
+batch submission, and status queries.
+
+---
+
+## Run and Test
+
+### Connectivity Test with `tebench`
+
+`tebench` can validate registration, endpoint exchange, connection setup, read/write transfers,
+and completion. Both peers must use the classic backend and the `flagcx` transport. An empty
+`--target_seg_name` starts the target; setting it starts the initiator.
+
+Choose a network interface reachable by the other peer on both hosts:
+
+```bash
+export FLAGCX_SOCKET_IFNAME=eth0
+```
+
+Start the target first:
+
+```bash
+./build/mooncake-transfer-engine/benchmark/tebench \
+  --backend=classic \
+  --xport_type=flagcx \
+  --metadata_type=p2p \
+  --seg_type=DRAM \
+  --total_buffer_size=1073741824
+```
+
+The target prints a command containing its segment name. Use that value on the initiator:
+
+```bash
+./build/mooncake-transfer-engine/benchmark/tebench \
+  --backend=classic \
+  --xport_type=flagcx \
+  --metadata_type=p2p \
+  --target_seg_name=<target-segment-name> \
+  --seg_type=DRAM \
+  --total_buffer_size=1073741824 \
+  --op_type=read \
+  --start_block_size=4096 \
+  --max_block_size=67108864 \
+  --start_batch_size=1 \
+  --max_batch_size=1 \
+  --start_num_threads=1 \
+  --max_num_threads=1
+```
+
+Use `--op_type=write` to test the opposite direction. For accelerator memory, set
+`--seg_type=VRAM` and build both FlagCX and Mooncake for the accelerator platform.
+
+Useful initialization messages include:
+
+```text
+FlagCxTransport: engine up, endpoint=...
+FlagCxTransport: install OK (direct submit)
+tebench: FlagCX transport installed
+```
+
+### Hardware-Free Checks
+
+The internal range and descriptor-boundary test does not require FlagCX hardware:
+
+```bash
+ctest --test-dir build -R '^flagcx_transport_internal_test$' --output-on-failure
+```
+
+The Python source integration check verifies that the binding recognizes and installs `flagcx`:
+
+```bash
+python3 -m unittest mooncake-wheel/tests/test_transfer_engine_flagcx_source.py
+```
+
+---
+
+## Runtime Configuration
+
+FlagCX owns network-device selection and most transport tuning. The variables most relevant to the
+Mooncake integration are:
+
+| Variable | Purpose |
+|----------|---------|
+| `FLAGCX_SOCKET_IFNAME` | Selects the interface used for socket bootstrap and endpoint advertisement |
+| `FLAGCX_IB_HCA` | Selects the InfiniBand/RoCE HCA or HCA set used by FlagCX |
+| `FLAGCX_P2P_TRANSPORT=accl` | Selects the optional ACCL P2P implementation when the FlagCX build includes it |
+| `LD_LIBRARY_PATH` | Makes `libflagcx.so` and non-system backend libraries visible at run time |
+
+Set compatible values on both peers. For interface filtering syntax, GID selection, retry settings,
+and backend-specific tuning, see the
+[FlagCX environment-variable reference](https://github.com/flagos-ai/FlagCX/blob/main/docs/environment_variables.md).
+
+## Important Notes
+
+### Memory Registration Lifecycle
+
+The FlagCX connection handshake exchanges the peer's registered-memory table, and the P2P Engine
+caches established connections. Use the following lifecycle for the current Mooncake integration:
+
+1. Register every buffer that a peer may access.
+2. Establish or use the peer connection only after registration is complete.
+3. Keep those buffers registered while the connection or its transfers are active.
+4. Stop submitting work and allow outstanding work to finish before unregistering or freeing the
+   buffers.
+
+Registering a new remote buffer after a peer has already cached its connection does not refresh the
+connection's memory table. Reconnect both processes before using a changed registration set.
+
+### Deployment Scope
+
+- Use the literal protocol name `flagcx`; do not use `flagos`.
+- Use `flagcx` as a standalone protocol. Multi-protocol selection and routing are outside the
+  current integration scope.
+- Both peers must use compatible FlagCX builds and P2P backends.
+- The transport relies on FlagCX's endpoint exchange and completion behavior; it does not add a
+  separate Mooncake cancellation API.
+
+### Security and Trust
+
+Treat the FlagCX endpoint like other RDMA-capable transport endpoints. Only expose it to trusted
+peers, restrict the selected interface with network policy or host firewall rules, and register only
+the memory required by the application. P2P metadata contains information needed to access the
+registered regions and should not be published through an untrusted metadata service.
+
+## Troubleshooting
+
+### CMake Cannot Find FlagCX
+
+```text
+USE_FLAGCX=ON but flagcx_p2p.h was not found
+```
+
+Check that `FLAGCX_HOME/include/flagcx_p2p.h` exists. If the header remains only in the FlagCX
+source tree, finish the FlagCX build so its public headers are copied to `build/include`, or run its
+install target and point `FLAGCX_HOME` at that prefix.
+
+```text
+USE_FLAGCX=ON but the FlagCX library was not found
+```
+
+Check for `FLAGCX_HOME/lib/libflagcx.so` or `FLAGCX_HOME/lib64/libflagcx.so` and confirm that the
+same prefix is passed during CMake configuration.
+
+### The Executable Cannot Load `libflagcx.so`
+
+If startup reports that `libflagcx.so` or a platform backend library is missing, add their library
+directories to `LD_LIBRARY_PATH` or install them in a configured system loader path. This is a
+run-time linker issue, not a Mooncake protocol-selection issue.
+
+### The FlagCX Engine Advertises the Wrong Interface
+
+Set `FLAGCX_SOCKET_IFNAME` before starting each process. Use an interface whose advertised address
+is reachable from the peer. If InfiniBand/RoCE device selection is also ambiguous, set
+`FLAGCX_IB_HCA` consistently on both sides.
+
+### `installTransport(flagcx)` Fails
+
+Confirm all of the following:
+
+- Mooncake was configured with `USE_FLAGCX=ON`.
+- The FlagCX shared library and its platform dependencies load successfully.
+- `FLAGCX_SOCKET_IFNAME` resolves to a usable local address.
+- No other process or firewall rule prevents the FlagCX RPC server from starting.
+
+### Connection or Remote-Descriptor Creation Fails
+
+Verify that the target process is still running, the endpoint printed in the target log is reachable,
+and both peers selected compatible FlagCX P2P backends. If the target's registrations changed after
+the connection was first used, restart both processes and register all buffers before reconnecting.

--- a/docs/source/design/transfer-engine/flagcx_transport.md
+++ b/docs/source/design/transfer-engine/flagcx_transport.md
@@ -2,10 +2,11 @@
 
 ## Overview
 
-[FlagCX](https://github.com/flagos-ai/FlagCX) is the cross-chip communication library in the
-FlagOS ecosystem. Mooncake's FlagCX transport connects the classic Transfer Engine to the FlagCX
-P2P Engine. Mooncake keeps its existing segment, memory-registration, batch, and completion APIs;
-the transport maps those operations to FlagCX connections and P2P read/write requests.
+[FlagCX](https://github.com/flagos-ai/FlagCX) is the unified communication library in the FlagOS
+ecosystem for multi-vendor and cross-vendor deployments. Mooncake's FlagCX transport connects the
+classic Transfer Engine to the FlagCX P2P Engine. The integration keeps Mooncake's existing
+segment, memory-registration, batch, and completion APIs and maps them to FlagCX connections and
+P2P read/write requests.
 
 The protocol name used by Mooncake configuration and APIs is `flagcx`. `flagos` is not a protocol
 name.
@@ -42,18 +43,18 @@ name.
 
 ## Dependencies
 
-Build and run Mooncake with the same FlagCX installation. The prefix passed as `FLAGCX_HOME` must
-provide:
+Use compatible FlagCX revisions on all nodes. Each node may build the accelerator backend that
+matches its local platform. The prefix passed as `FLAGCX_HOME` must contain:
 
 - `include/flagcx_p2p.h`
 - `lib/libflagcx.so` or `lib64/libflagcx.so`
 - The accelerator runtime, communication library, and network dependencies required by the chosen
   FlagCX backend
 
-FlagCX supports multiple accelerator backends. Choose the backend that matches the local platform;
-for example, `USE_NVIDIA=1`, `USE_METAX=1`, or `USE_MUSA=1`. See the
+Choose the FlagCX backend that matches each node's local platform; for example, `USE_NVIDIA=1`,
+`USE_METAX=1`, or `USE_MUSA=1`. See the
 [FlagCX getting-started guide](https://github.com/flagos-ai/FlagCX/blob/main/docs/getting_started.md)
-for the complete current backend list and platform prerequisites.
+for the current backend list and platform prerequisites.
 
 ## Build and Compile
 
@@ -75,10 +76,11 @@ FlagCX/build/include/flagcx_p2p.h
 FlagCX/build/lib/libflagcx.so
 ```
 
-Alternatively, install FlagCX under a dedicated prefix:
+Alternatively, install FlagCX under a dedicated prefix. Installing under `/opt` normally requires
+root privileges:
 
 ```bash
-make PREFIX=/opt/flagcx install
+sudo make PREFIX=/opt/flagcx install
 ```
 
 ### 2. Build Mooncake
@@ -111,8 +113,9 @@ export FLAGCX_HOME=/path/to/FlagCX/build
 export LD_LIBRARY_PATH="$FLAGCX_HOME/lib:${LD_LIBRARY_PATH:-}"
 ```
 
-Add the relevant Mooncake accelerator option, such as `USE_CUDA`, `USE_MUSA`, or `USE_HIP`, when
-the application also needs Mooncake to allocate or identify that accelerator's memory.
+If Mooncake also needs to allocate or identify device memory, enable its matching hardware option,
+such as `USE_CUDA`, `USE_MACA`, `USE_MUSA`, `USE_HIP`, `USE_COREX`, `USE_HYGON`, or `USE_MLU`.
+See the [build guide](../../getting_started/build.md) for the options and SDK requirements.
 
 ---
 
@@ -120,8 +123,8 @@ the application also needs Mooncake to allocate or identify that accelerator's m
 
 ### Python API
 
-A Mooncake Python extension built with `USE_FLAGCX=ON` accepts `flagcx` through the existing
-initialization API:
+A Mooncake Python extension built from source with `USE_FLAGCX=ON` accepts `flagcx` through the
+existing initialization API:
 
 ```python
 engine.initialize(
@@ -138,12 +141,18 @@ FlagCX transport explicitly. No new Python API is required.
 ### C++ API
 
 Applications using the classic C++ Transfer Engine can install the transport by name after engine
-initialization:
+initialization. Keep automatic transport discovery disabled so that `flagcx` remains the standalone
+transport:
 
 ```cpp
+mooncake::TransferEngine engine(false);
+if (engine.init("P2PHANDSHAKE", "node1") != 0) {
+    return -1;
+}
+
 auto* transport = engine.installTransport("flagcx", nullptr);
 if (transport == nullptr) {
-    // Mooncake was not built with USE_FLAGCX=ON, or transport setup failed.
+    return -1;
 }
 ```
 
@@ -196,8 +205,10 @@ The target prints a command containing its segment name. Use that value on the i
   --max_num_threads=1
 ```
 
-Use `--op_type=write` to test the opposite direction. For accelerator memory, set
-`--seg_type=VRAM` and build both FlagCX and Mooncake for the accelerator platform.
+Use `--op_type=write` to test the opposite direction. The classic `tebench` VRAM allocator currently
+supports CUDA builds. For that path, add `-DUSE_CUDA=ON` when building Mooncake and run with
+`--seg_type=VRAM`. Other accelerator backends should validate device buffers through their
+application integration until `tebench` provides a matching allocator.
 
 Useful initialization messages include:
 
@@ -230,13 +241,13 @@ Mooncake integration are:
 
 | Variable | Purpose |
 |----------|---------|
-| `FLAGCX_SOCKET_IFNAME` | Selects the interface used for socket bootstrap and endpoint advertisement |
+| `FLAGCX_SOCKET_IFNAME` | Selects the interface used for socket bootstrap and endpoint advertisement; it does not select the RDMA HCA |
 | `FLAGCX_IB_HCA` | Selects the InfiniBand/RoCE HCA or HCA set used by FlagCX |
-| `FLAGCX_P2P_TRANSPORT=accl` | Selects the optional ACCL P2P implementation when the FlagCX build includes it |
+| `FLAGCX_P2P_TRANSPORT=accl` | Selects the optional ACCL P2P implementation when the FlagCX build includes it; both peers must set it |
 | `LD_LIBRARY_PATH` | Makes `libflagcx.so` and non-system backend libraries visible at run time |
 
-Set compatible values on both peers. For interface filtering syntax, GID selection, retry settings,
-and backend-specific tuning, see the
+Set `FLAGCX_SOCKET_IFNAME` and `FLAGCX_IB_HCA` for each node's local interfaces and devices. For
+interface filtering syntax, GID selection, retry settings, and backend-specific tuning, see the
 [FlagCX environment-variable reference](https://github.com/flagos-ai/FlagCX/blob/main/docs/environment_variables.md).
 
 ## Important Notes
@@ -260,7 +271,8 @@ connection's memory table. Reconnect both processes before using a changed regis
 - Use the literal protocol name `flagcx`; do not use `flagos`.
 - Use `flagcx` as a standalone protocol. Multi-protocol selection and routing are outside the
   current integration scope.
-- Both peers must use compatible FlagCX builds and P2P backends.
+- The peers may use different accelerator backends, but they must use compatible FlagCX revisions
+  and the same P2P network transport: default IBRC on both peers, or ACCL on both peers.
 - The transport relies on FlagCX's endpoint exchange and completion behavior; it does not add a
   separate Mooncake cancellation API.
 
@@ -268,8 +280,9 @@ connection's memory table. Reconnect both processes before using a changed regis
 
 Treat the FlagCX endpoint like other RDMA-capable transport endpoints. Only expose it to trusted
 peers, restrict the selected interface with network policy or host firewall rules, and register only
-the memory required by the application. P2P metadata contains information needed to access the
-registered regions and should not be published through an untrusted metadata service.
+the memory required by the application. Mooncake segment metadata exposes the endpoint and buffer
+addresses, while the FlagCX handshake exchanges the registered-region table. Do not expose either
+channel to untrusted peers.
 
 ## Troubleshooting
 
@@ -300,7 +313,7 @@ run-time linker issue, not a Mooncake protocol-selection issue.
 
 Set `FLAGCX_SOCKET_IFNAME` before starting each process. Use an interface whose advertised address
 is reachable from the peer. If InfiniBand/RoCE device selection is also ambiguous, set
-`FLAGCX_IB_HCA` consistently on both sides.
+`FLAGCX_IB_HCA` to the appropriate local HCA set on each side.
 
 ### `installTransport(flagcx)` Fails
 
@@ -309,10 +322,11 @@ Confirm all of the following:
 - Mooncake was configured with `USE_FLAGCX=ON`.
 - The FlagCX shared library and its platform dependencies load successfully.
 - `FLAGCX_SOCKET_IFNAME` resolves to a usable local address.
-- No other process or firewall rule prevents the FlagCX RPC server from starting.
+- The FlagCX log does not report a P2P Engine or RPC-server initialization error.
 
 ### Connection or Remote-Descriptor Creation Fails
 
 Verify that the target process is still running, the endpoint printed in the target log is reachable,
-and both peers selected compatible FlagCX P2P backends. If the target's registrations changed after
-the connection was first used, restart both processes and register all buffers before reconnecting.
+and both peers selected the same FlagCX P2P network transport. Check host firewall rules on the
+connection path. If the target's registrations changed after the connection was first used, restart
+both processes and register all buffers before reconnecting.

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -557,6 +557,14 @@ kunpeng_ub_transport
 sunrise_link_transport
 :::
 
+## FlagOS FlagCX Transport Component
+
+:::{toctree}
+:maxdepth: 1
+
+flagcx_transport
+:::
+
 ## MPComm Transport Component
 
 ::::{toctree}

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -9,6 +9,7 @@ Mooncake Transfer Engine supports multiple communication protocols for data tran
 | **tcp** | Standard network | General purpose, works everywhere | ✅ Primary |
 | **rdma** | RDMA-capable NIC | High-performance, low-latency | ✅ Primary |
 | **efa** | AWS EFA-capable instance | High-performance on AWS (libfabric SRD) | ✅ Primary |
+| **flagcx** | FlagCX-supported accelerator + RDMA-capable NIC | Cross-vendor P2P transfer through FlagOS FlagCX | ⚠️ Source build |
 | **nvmeof** | NVMe-oF capable storage | Direct NVMe storage access | ⚠️ Advanced |
 | **nvlink** | NVIDIA MNNVL | Inter-node GPU communication | ⚠️ Advanced |
 | **musa** | Moore Threads GPU + MTLink | Intra-node GPU IPC/P2P | ⚠️ Advanced |
@@ -167,6 +168,55 @@ cmake .. -DUSE_EFA=ON -DUSE_CUDA=ON
 - ~88% of RoCE RDMA throughput
 
 **Documentation:** See [EFA Transport](../design/transfer-engine/efa_transport.md) for build instructions, benchmarks, and tuning.
+
+### FlagOS FlagCX Transport (flagcx)
+
+**Description:** [FlagCX](https://github.com/flagos-ai/FlagCX) is the cross-chip communication
+library in the FlagOS ecosystem. Mooncake integrates its P2P Engine as a classic Transfer Engine
+transport, allowing the same Mooncake data-transfer workflow to use accelerator and network
+backends supported by the installed FlagCX build.
+
+**Use When:**
+- Deploying Mooncake on a platform supported by FlagCX
+- Using FlagCX's P2P Engine for host or accelerator memory transfers
+- Building a cross-vendor deployment around the FlagOS communication stack
+
+**Build Requirements:**
+```bash
+cmake -S . -B build \
+  -DUSE_FLAGCX=ON \
+  -DFLAGCX_HOME=/path/to/FlagCX/build
+cmake --build build -j
+```
+
+`FLAGCX_HOME` must contain `include/flagcx_p2p.h` and either `lib/libflagcx.so` or
+`lib64/libflagcx.so`. If it is omitted, Mooncake checks `$FLAGCX_HOME` and then
+`$HOME/FlagCX/build`.
+
+**Configuration:**
+```python
+engine.initialize(
+    hostname="node1",
+    metadata_server="P2PHANDSHAKE",
+    protocol="flagcx",
+    device_name=""
+)
+```
+
+```bash
+# Select the interface used by the FlagCX handshake and data path.
+export FLAGCX_SOCKET_IFNAME="eth0"
+```
+
+**Current Scope:**
+- Available through the classic Transfer Engine; it is not a TENT transport
+- Must be built from source with `USE_FLAGCX=ON`
+- Should be selected as the standalone `flagcx` protocol, not as part of a multi-protocol string
+- Buffers should be registered before the first transfer to a peer and remain registered while
+  that peer connection is active
+
+See [FlagOS FlagCX Transport](../design/transfer-engine/flagcx_transport.md) for dependency,
+build, benchmark, runtime configuration, and troubleshooting details.
 
 ## Advanced Protocols (C++ Transfer Engine)
 
@@ -427,6 +477,10 @@ export MOONCAKE_DEVICE="mlx5_0"
 export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 
+# FlagOS FlagCX (requires a USE_FLAGCX=ON source build)
+export MOONCAKE_PROTOCOL="flagcx"
+export FLAGCX_SOCKET_IFNAME="eth0"
+
 # Other configuration
 export MOONCAKE_MASTER="10.0.0.1:50051"
 export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
@@ -441,6 +495,7 @@ export MOONCAKE_LOCAL_HOSTNAME="node1"
 | Production Inference | rdma | Best performance and latency |
 | AWS Cloud (EFA instances) | efa | High performance on p5e, p6-b200, p4d, etc. |
 | Cloud Environments | tcp or rdma (if available) | Check cloud provider support |
+| FlagOS / cross-vendor accelerator clusters | flagcx | Build Mooncake against the platform's FlagCX backend |
 | Multi-tier Storage | rdma + nvmeof | Combine protocols for different layers |
 | AMD GPU Clusters | rdma + hip | Use HIP for local GPU communication |
 | Cambricon MLU Clusters | rdma | Build with `-DUSE_MLU=ON`; MLU uses the normal RDMA protocol |
@@ -484,6 +539,7 @@ If a protocol fails to initialize:
 
 - [Quick Start](quick-start.md) - Start with Mooncake integrations for serving frameworks
 - [Transfer Engine Design](../design/transfer-engine/index.md) - Detailed architecture
+- [FlagOS FlagCX Transport](../design/transfer-engine/flagcx_transport.md) - FlagCX build and usage guide
 - [Transfer Engine Benchmark](../design/transfer-engine/transfer-engine-bench-tuning.md) - Performance tuning
 - [Python API Reference](../api-reference/python/transfer-engine.md) - API documentation
 - [Deployment Guide](../deployment/mooncake-store-deployment-guide.md) - Production deployment

--- a/docs/source/getting_started/supported-protocols.md
+++ b/docs/source/getting_started/supported-protocols.md
@@ -9,7 +9,6 @@ Mooncake Transfer Engine supports multiple communication protocols for data tran
 | **tcp** | Standard network | General purpose, works everywhere | ✅ Primary |
 | **rdma** | RDMA-capable NIC | High-performance, low-latency | ✅ Primary |
 | **efa** | AWS EFA-capable instance | High-performance on AWS (libfabric SRD) | ✅ Primary |
-| **flagcx** | FlagCX-supported accelerator + RDMA-capable NIC | Cross-vendor P2P transfer through FlagOS FlagCX | ⚠️ Source build |
 | **nvmeof** | NVMe-oF capable storage | Direct NVMe storage access | ⚠️ Advanced |
 | **nvlink** | NVIDIA MNNVL | Inter-node GPU communication | ⚠️ Advanced |
 | **musa** | Moore Threads GPU + MTLink | Intra-node GPU IPC/P2P | ⚠️ Advanced |
@@ -20,6 +19,7 @@ Mooncake Transfer Engine supports multiple communication protocols for data tran
 | **ascend** | Huawei Ascend NPU | Ascend NPU communication | ⚠️ Advanced |
 | **tpu** | Google TPU (PJRT) | TPU KV-cache transfer via host-DRAM staging | 🧪 Experimental (TENT) |
 | **mpcomm** | RDMA-capable NIC(s) | Multi-NIC memory pooling with NIC/QP load balancing | ⚠️ Advanced (TENT) |
+| **flagcx** | RDMA-capable NIC(s) | Unified P2P transfer through FlagOS FlagCX | ⚠️ Advanced |
 
 ## Commonly Used Protocols (Python API)
 
@@ -168,55 +168,6 @@ cmake .. -DUSE_EFA=ON -DUSE_CUDA=ON
 - ~88% of RoCE RDMA throughput
 
 **Documentation:** See [EFA Transport](../design/transfer-engine/efa_transport.md) for build instructions, benchmarks, and tuning.
-
-### FlagOS FlagCX Transport (flagcx)
-
-**Description:** [FlagCX](https://github.com/flagos-ai/FlagCX) is the cross-chip communication
-library in the FlagOS ecosystem. Mooncake integrates its P2P Engine as a classic Transfer Engine
-transport, allowing the same Mooncake data-transfer workflow to use accelerator and network
-backends supported by the installed FlagCX build.
-
-**Use When:**
-- Deploying Mooncake on a platform supported by FlagCX
-- Using FlagCX's P2P Engine for host or accelerator memory transfers
-- Building a cross-vendor deployment around the FlagOS communication stack
-
-**Build Requirements:**
-```bash
-cmake -S . -B build \
-  -DUSE_FLAGCX=ON \
-  -DFLAGCX_HOME=/path/to/FlagCX/build
-cmake --build build -j
-```
-
-`FLAGCX_HOME` must contain `include/flagcx_p2p.h` and either `lib/libflagcx.so` or
-`lib64/libflagcx.so`. If it is omitted, Mooncake checks `$FLAGCX_HOME` and then
-`$HOME/FlagCX/build`.
-
-**Configuration:**
-```python
-engine.initialize(
-    hostname="node1",
-    metadata_server="P2PHANDSHAKE",
-    protocol="flagcx",
-    device_name=""
-)
-```
-
-```bash
-# Select the interface used by the FlagCX handshake and data path.
-export FLAGCX_SOCKET_IFNAME="eth0"
-```
-
-**Current Scope:**
-- Available through the classic Transfer Engine; it is not a TENT transport
-- Must be built from source with `USE_FLAGCX=ON`
-- Should be selected as the standalone `flagcx` protocol, not as part of a multi-protocol string
-- Buffers should be registered before the first transfer to a peer and remain registered while
-  that peer connection is active
-
-See [FlagOS FlagCX Transport](../design/transfer-engine/flagcx_transport.md) for dependency,
-build, benchmark, runtime configuration, and troubleshooting details.
 
 ## Advanced Protocols (C++ Transfer Engine)
 
@@ -435,6 +386,55 @@ so it cannot be selected through `MOONCAKE_PROTOCOL` or `transfer_engine_bench -
 See [MPComm Transport](../design/transfer-engine/mpcomm_transport.md) for the full guide,
 including selection via transport policy, tuning environment variables, and troubleshooting.
 
+### FlagOS FlagCX Transport (flagcx)
+
+**Description:** [FlagCX](https://github.com/flagos-ai/FlagCX) is the unified communication library
+in the FlagOS ecosystem for multi-vendor and cross-vendor deployments. Mooncake integrates the
+FlagCX P2P Engine as a classic Transfer Engine transport, allowing the existing Mooncake transfer
+workflow to use the accelerator and network backends provided by the local FlagCX build.
+
+**Use When:**
+- Deploying Mooncake on a platform supported by FlagCX
+- Using FlagCX's P2P Engine for accelerator memory transfers
+- Building a cross-vendor deployment around the FlagOS communication stack
+
+**Build Requirements:**
+```bash
+cmake -S . -B build \
+  -DUSE_FLAGCX=ON \
+  -DFLAGCX_HOME=/path/to/FlagCX/build
+cmake --build build -j
+```
+
+`FLAGCX_HOME` must contain `include/flagcx_p2p.h` and either `lib/libflagcx.so` or
+`lib64/libflagcx.so`. If it is omitted, Mooncake checks `$FLAGCX_HOME` and then
+`$HOME/FlagCX/build`.
+
+**Configuration:**
+```python
+engine.initialize(
+    hostname="node1",
+    metadata_server="P2PHANDSHAKE",
+    protocol="flagcx",
+    device_name=""
+)
+```
+
+```bash
+# Select the interface used for FlagCX bootstrap and endpoint advertisement.
+export FLAGCX_SOCKET_IFNAME="eth0"
+```
+
+**Current Scope:**
+- Available through the classic Transfer Engine; it is not a TENT transport
+- Must be built from source with `USE_FLAGCX=ON`
+- Should be selected as the standalone `flagcx` protocol, not as part of a multi-protocol string
+- Buffers should be registered before the first transfer to a peer and remain registered while
+  that peer connection is active
+
+See [FlagOS FlagCX Transport](../design/transfer-engine/flagcx_transport.md) for dependency,
+build, benchmark, runtime configuration, and troubleshooting details.
+
 ## Configuration Examples
 
 ### Configuration File (JSON)
@@ -477,10 +477,6 @@ export MOONCAKE_DEVICE="mlx5_0"
 export MOONCAKE_PROTOCOL="rdma"
 export MOONCAKE_DEVICE="auto-discovery"
 
-# FlagOS FlagCX (requires a USE_FLAGCX=ON source build)
-export MOONCAKE_PROTOCOL="flagcx"
-export FLAGCX_SOCKET_IFNAME="eth0"
-
 # Other configuration
 export MOONCAKE_MASTER="10.0.0.1:50051"
 export MOONCAKE_TE_META_DATA_SERVER="P2PHANDSHAKE"
@@ -495,11 +491,11 @@ export MOONCAKE_LOCAL_HOSTNAME="node1"
 | Production Inference | rdma | Best performance and latency |
 | AWS Cloud (EFA instances) | efa | High performance on p5e, p6-b200, p4d, etc. |
 | Cloud Environments | tcp or rdma (if available) | Check cloud provider support |
-| FlagOS / cross-vendor accelerator clusters | flagcx | Build Mooncake against the platform's FlagCX backend |
 | Multi-tier Storage | rdma + nvmeof | Combine protocols for different layers |
 | AMD GPU Clusters | rdma + hip | Use HIP for local GPU communication |
 | Cambricon MLU Clusters | rdma | Build with `-DUSE_MLU=ON`; MLU uses the normal RDMA protocol |
 | Ascend NPU Clusters | rdma + ascend | Use Ascend for NPU-specific operations |
+| Multi-vendor or cross-vendor clusters | flagcx | Build with `-DUSE_FLAGCX=ON`; transfers use the FlagCX P2P Engine over RDMA-capable NICs |
 
 ## Troubleshooting
 
@@ -539,7 +535,6 @@ If a protocol fails to initialize:
 
 - [Quick Start](quick-start.md) - Start with Mooncake integrations for serving frameworks
 - [Transfer Engine Design](../design/transfer-engine/index.md) - Detailed architecture
-- [FlagOS FlagCX Transport](../design/transfer-engine/flagcx_transport.md) - FlagCX build and usage guide
 - [Transfer Engine Benchmark](../design/transfer-engine/transfer-engine-bench-tuning.md) - Performance tuning
 - [Python API Reference](../api-reference/python/transfer-engine.md) - API documentation
 - [Deployment Guide](../deployment/mooncake-store-deployment-guide.md) - Production deployment


### PR DESCRIPTION
## Description

Adds documentation for the FlagOS FlagCX transport introduced in #3522.

This PR:
- Adds `flagcx` to the supported protocol overview as an advanced transport.
- Adds a complete FlagCX transport guide covering:
  - FlagCX and Mooncake build requirements
  - Python and C++ configuration
  - Classic `tebench` connectivity testing
  - Runtime network configuration
  - Memory-registration lifecycle requirements
  - Current deployment scope, security notes, and troubleshooting
- Adds the FlagCX guide to the Transfer Engine documentation navigation.
- Clarifies that Mooncake uses the protocol name `flagcx`, supports the classic Transfer Engine path, and does not introduce new Transfer Engine APIs.

This is a documentation-only change.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The documentation was built with Sphinx warnings treated as errors. The generated FlagCX page, internal links, Transfer Engine navigation entry, and sidebar were inspected.

**Test commands:**
```
cd docs
LC_ALL=C LANG=C make clean
LC_ALL=C LANG=C make html SPHINXOPTS=-W
cd ..
pre-commit run --files \
  docs/source/getting_started/supported-protocols.md \
  docs/source/design/transfer-engine/flagcx_transport.md \
  docs/source/design/transfer-engine/index.md
python3 -m unittest \
  mooncake-wheel/tests/test_transfer_engine_flagcx_source.py
git diff --check
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)
      - Sphinx build completed without warnings.
      - Generated FlagCX pages and links were inspected.
      - The FlagCX entry appears in the Transfer Engine sidebar.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex assisted with reviewing the existing Mooncake and FlagCX implementations, checking the documentation for factual consistency, refining the wording, and running documentation validation. The final changes were reviewed by the human submitter.