### PR TITLE
[TE] Add RDMA chaos runner and worker-pool failover retries

### DIFF
--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -68,6 +68,11 @@ class WorkerPool {
     void redispatch(std::vector<Transport::Slice *> &slice_list, int thread_id,
                     bool handoff_to_local_worker = false,
                     bool defer_local_redispatch = false);
+    void delayRedispatch(Transport::Slice *slice, bool handoff_to_local_worker,
+                         const char *reason);
+    void releaseReadyDelayedSlices(int thread_id);
+    bool hasDelayedSlices() const;
+    uint64_t nextDelayedSliceDueNs() const;
 
     void transferWorker(int thread_id);
 
@@ -88,6 +93,8 @@ class WorkerPool {
     void markRailFailed(const std::string &peer_nic_path,
                         bool immediate_pause = false);
     bool isRailAvailable(const std::string &peer_nic_path);
+    uint64_t peerRailPauseRemainingNs(const std::string &peer_nic_path,
+                                      uint64_t now);
 
     // Retry helper: increment retry count and return whether retry is allowed
     static bool shouldRetrySlice(Transport::Slice *slice);
@@ -156,6 +163,14 @@ class WorkerPool {
     // Rail state management: peer_nic_path -> RailState
     std::unordered_map<std::string, RailState> rail_states_;
     std::mutex rail_state_lock_;
+
+    struct DelayedSlice {
+        Transport::Slice *slice = nullptr;
+        uint64_t due_ns = 0;
+        bool handoff_to_local_worker = false;
+    };
+    mutable std::mutex delayed_slices_lock_;
+    std::vector<DelayedSlice> delayed_slices_;
 
     // Rail monitor configuration
     const static int kRailErrorThreshold = 5;  // Errors before pause

--- a/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
+++ b/mooncake-transfer-engine/include/transport/rdma_transport/worker_pool.h
@@ -116,6 +116,11 @@ class WorkerPool {
                             RdmaEndPoint *endpoint = nullptr);
 
     bool tryHandoffToAnotherLocalWorker(Transport::Slice *slice);
+    bool selectAvailablePeerRailAlternative(
+        RdmaTransport::SegmentDesc *peer_segment_desc, int buffer_id,
+        int selected_device_id, uint64_t selection_seed, int &device_id,
+        std::string &peer_nic_path);
+    static uint64_t peerRailSelectionSeed(const Transport::Slice *slice);
 
     // Only direct local completion errors charge the context breaker.
     // Submit-side all-rails-unavailable failures remain peer/rail scoped.

--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_transport.cpp
@@ -232,7 +232,14 @@ int RdmaTransport::install(std::string &local_server_name,
 }
 
 int RdmaTransport::preTouchMemory(void *addr, size_t length) {
-    if (context_list_.size() == 0) {
+    std::shared_ptr<RdmaContext> pretouch_context;
+    for (auto &context : context_list_) {
+        if (context && context->active()) {
+            pretouch_context = context;
+            break;
+        }
+    }
+    if (!pretouch_context) {
         // At least one context is required for pre-touch.
         return 0;
     }
@@ -253,9 +260,10 @@ int RdmaTransport::preTouchMemory(void *addr, size_t length) {
 
     for (size_t thread_i = 0; thread_i < num_threads; ++thread_i) {
         void *block_addr = static_cast<char *>(addr) + thread_i * block_size;
-        threads.emplace_back([this, thread_i, block_addr, block_size,
+        threads.emplace_back([pretouch_context, thread_i, block_addr,
+                              block_size,
                               &thread_results]() {
-            int ret = context_list_[0]->preTouchMemory(block_addr, block_size);
+            int ret = pretouch_context->preTouchMemory(block_addr, block_size);
             thread_results[thread_i] = ret;
         });
     }
@@ -355,6 +363,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     // (never-added) metadata, but its partial MRs still need releasing.
     auto unregisterChunkMRs = [&](void *chunk_addr) {
         for (auto &context : context_list_) {
+            if (!context) continue;
             int ret = context->unregisterMemoryRegion(chunk_addr);
             if (ret)
                 LOG(WARNING) << "Rollback: failed to unregister chunk MR at "
@@ -387,9 +396,10 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
     // which is capped at max_mr_size and would silently disable pre-touch for a
     // >=4GiB buffer). Compute once above the loop to avoid repeated
     // hardware_concurrency() OS queries per chunk.
-    const bool do_pre_touch = context_list_.size() > 0 &&
-                              std::thread::hardware_concurrency() >= 4 &&
-                              length >= (size_t)4 * 1024 * 1024 * 1024;
+    const bool do_pre_touch =
+        !std::getenv("MC_DISABLE_RDMA_PRE_TOUCH") &&
+        context_list_.size() > 0 && std::thread::hardware_concurrency() >= 4 &&
+        length >= (size_t)4 * 1024 * 1024 * 1024;
 
     for (size_t ci = 0; ci < chunks.size(); ++ci) {
         void *chunk_addr = chunks[ci].first;
@@ -434,6 +444,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
             const int ar = access_rights;  // Local copy for lambda capture
 
             for (size_t i = 0; i < context_list_.size(); ++i) {
+                if (!context_list_[i]) continue;
                 reg_threads.emplace_back([this, &ret_codes, chunk_dmabuf_exp, i,
                                           chunk_addr, chunk_len, ar]() {
                     ret_codes[i] = context_list_[i]->registerMemoryRegion(
@@ -457,6 +468,7 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
             }
         } else {
             for (size_t i = 0; i < context_list_.size(); ++i) {
+                if (!context_list_[i]) continue;
                 int ret = context_list_[i]->registerMemoryRegion(
                     chunk_addr, chunk_len, access_rights, chunk_dmabuf_exp);
                 if (ret) {
@@ -489,9 +501,10 @@ int RdmaTransport::registerLocalMemoryInternal(void *addr, size_t length,
         // Collect per-context keys for THIS chunk (address-range lookup).
         BufferDesc buffer_desc;
         for (auto &context : context_list_) {
-            buffer_desc.lkey.push_back(context->lkey(chunk_addr));
+            buffer_desc.lkey.push_back(context ? context->lkey(chunk_addr) : 0);
             if (remote_accessible)
-                buffer_desc.rkey.push_back(context->rkey(chunk_addr));
+                buffer_desc.rkey.push_back(context ? context->rkey(chunk_addr)
+                                                   : 0);
         }
         buffer_desc.name = resolved_name;
         buffer_desc.addr = (uint64_t)chunk_addr;
@@ -584,6 +597,7 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
             threads.reserve(context_list_.size());
             std::vector<int> ret_codes(context_list_.size(), 0);
             for (size_t i = 0; i < context_list_.size(); ++i) {
+                if (!context_list_[i]) continue;
                 threads.emplace_back([this, &ret_codes, i, &chunk_addrs]() {
                     for (uint64_t ca : chunk_addrs) {
                         int ret = context_list_[i]->unregisterMemoryRegion(
@@ -598,6 +612,7 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
         } else {
             for (uint64_t ca : chunk_addrs)
                 for (auto &context : context_list_) {
+                    if (!context) continue;
                     int ret = context->unregisterMemoryRegion(
                         reinterpret_cast<void *>(ca));
                     if (ret) {
@@ -634,6 +649,7 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
         std::vector<int> ret_codes(context_list_.size(), 0);
 
         for (size_t i = 0; i < context_list_.size(); ++i) {
+            if (!context_list_[i]) continue;
             unreg_threads.emplace_back([this, &ret_codes, i, addr]() {
                 ret_codes[i] = context_list_[i]->unregisterMemoryRegion(addr);
             });
@@ -652,6 +668,7 @@ int RdmaTransport::unregisterLocalMemoryInternal(void *addr,
         }
     } else {
         for (size_t i = 0; i < context_list_.size(); ++i) {
+            if (!context_list_[i]) continue;
             int ret = context_list_[i]->unregisterMemoryRegion(addr);
             if (ret) {
                 LOG(ERROR) << "Failed to unregister memory region with context "
@@ -916,11 +933,15 @@ Status RdmaTransport::submitTransferTask(
                 retry_cnt = request.advise_retry_cnt;
             bool found_device = false;
             if (request_buffer_id >= 0 && request_device_id >= 0) {
-                auto &request_context = context_list_[request_device_id];
-                if (request_context && request_context->active()) {
-                    found_device = true;
-                    buffer_id = request_buffer_id;
-                    device_id = request_device_id;
+                const auto request_device_index =
+                    static_cast<size_t>(request_device_id);
+                if (request_device_index < context_list_.size()) {
+                    auto &request_context = context_list_[request_device_index];
+                    if (request_context && request_context->active()) {
+                        found_device = true;
+                        buffer_id = request_buffer_id;
+                        device_id = request_device_id;
+                    }
                 }
             }
             while (retry_cnt < kMaxRetryCount && !found_device) {
@@ -928,10 +949,12 @@ Status RdmaTransport::submitTransferTask(
                                  (uint64_t)slice->source_addr, slice->length,
                                  buffer_id, device_id, retry_cnt++))
                     continue;
-                assert(device_id >= 0 &&
-                       static_cast<size_t>(device_id) < context_list_.size());
+                if (device_id < 0 ||
+                    static_cast<size_t>(device_id) >= context_list_.size()) {
+                    continue;
+                }
                 auto &context = context_list_[device_id];
-                assert(context.get());
+                if (!context) continue;
                 if (!context->active()) continue;
                 assert(buffer_id >= 0 &&
                        static_cast<size_t>(buffer_id) <
@@ -952,6 +975,13 @@ Status RdmaTransport::submitTransferTask(
                     std::to_string(reinterpret_cast<uintptr_t>(source_addr)));
             } else {
                 auto &context = context_list_[device_id];
+                if (!context) {
+                    fail_task_and_cleanup(task, slice, current_task_index);
+                    LOG(ERROR) << "Device " << device_id << " is unavailable";
+                    return Status::InvalidArgument(
+                        "Device " + std::to_string(device_id) +
+                        " is unavailable");
+                }
                 if (!context->active()) {
                     fail_task_and_cleanup(task, slice, current_task_index);
                     LOG(ERROR) << "Device " << device_id << " is not active";
@@ -1057,7 +1087,9 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
     int index = 0;
     for (auto &entry : local_topology_->getHcaList()) {
         if (entry == local_nic_name) {
-            context = context_list_[index];
+            if (static_cast<size_t>(index) < context_list_.size()) {
+                context = context_list_[index];
+            }
             break;
         }
         index++;
@@ -1105,7 +1137,10 @@ int RdmaTransport::onSetupRdmaConnections(const HandShakeDesc &peer_desc,
 
 int RdmaTransport::initializeRdmaResources() {
     auto hca_list = local_topology_->getHcaList();
-    for (auto &device_name : hca_list) {
+    context_list_.clear();
+    context_list_.resize(hca_list.size());
+    for (size_t i = 0; i < hca_list.size(); ++i) {
+        auto &device_name = hca_list[i];
         auto context = std::make_shared<RdmaContext>(*this, device_name);
         auto &config = globalConfig();
         size_t cq_per_ctx = config.num_cq_per_ctx;
@@ -1120,19 +1155,18 @@ int RdmaTransport::initializeRdmaResources() {
             config.gid_index, config.max_cqe, config.max_ep_per_ctx);
         if (ret) {
             local_topology_->disableDevice(device_name);
-            LOG(WARNING) << "Disable device " << device_name;
-            // Keep context_list_ index-aligned with getHcaList(): both it and
-            // BufferDesc::lkey are subscripted by the HCA index, which
-            // disableDevice() leaves in place. Dropping a slot would make a
-            // later device_id name the wrong RNIC or run off the end. A
-            // never-constructed context is an inert placeholder; the partially
-            // built one is released so it does not pin an open uverbs fd.
+            LOG(WARNING)
+                << "Disable RDMA device " << device_name
+                << " after context construction failed: context_index=" << i
+                << ", ret=" << ret
+                << ". The inactive placeholder preserves device index "
+                   "alignment.";
             auto placeholder =
                 std::make_shared<RdmaContext>(*this, device_name);
             placeholder->set_active(false);
-            context_list_.push_back(std::move(placeholder));
+            context_list_[i] = std::move(placeholder);
         } else {
-            context_list_.push_back(context);
+            context_list_[i] = context;
         }
     }
     if (local_topology_->empty()) {

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -399,32 +399,16 @@ int WorkerPool::submitPostSend(
 
         // If selected rail is paused, try alternative devices
         if (!isRailAvailable(peer_nic_path)) {
-            bool found = false;
-            for (size_t alt_dev_id = 0;
-                 alt_dev_id < peer_segment_desc->devices.size(); ++alt_dev_id) {
-                if (alt_dev_id == (size_t)device_id ||
-                    alt_dev_id >=
-                        peer_segment_desc->buffers[buffer_id].rkey.size()) {
-                    continue;
-                }
-                auto alt_path =
-                    MakeNicPath(peer_segment_desc->nicPathServerName(),
-                                peer_segment_desc->devices[alt_dev_id].name);
-                if (isRailAvailable(alt_path)) {
-                    device_id = alt_dev_id;
-                    slice->rdma.dest_rkey =
-                        peer_segment_desc->buffers[buffer_id].rkey[device_id];
-                    peer_nic_path = alt_path;
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
+            if (!selectAvailablePeerRailAlternative(
+                    peer_segment_desc.get(), buffer_id, device_id,
+                    peerRailSelectionSeed(slice), device_id, peer_nic_path)) {
                 slice->peer_nic_path = peer_nic_path;
                 delayRedispatch(slice, false, "all peer rails unavailable");
                 submitted_slice_count++;
                 continue;
             }
+            slice->rdma.dest_rkey =
+                peer_segment_desc->buffers[buffer_id].rkey[device_id];
         }
 
         slice->peer_nic_path = peer_nic_path;
@@ -1142,29 +1126,10 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                 MakeNicPath(peer_segment_desc->nicPathServerName(),
                             peer_segment_desc->devices[device_id].name);
             if (!isRailAvailable(peer_nic_path)) {
-                bool found = false;
-                for (size_t alt_dev_id = 0;
-                     alt_dev_id < peer_segment_desc->devices.size();
-                     ++alt_dev_id) {
-                    if (alt_dev_id == (size_t)device_id ||
-                        alt_dev_id >=
-                            peer_segment_desc->buffers[buffer_id].rkey.size()) {
-                        continue;
-                    }
-                    auto alt_path = MakeNicPath(
-                        peer_segment_desc->nicPathServerName(),
-                        peer_segment_desc->devices[alt_dev_id].name);
-                    if (isRailAvailable(alt_path)) {
-                        device_id = alt_dev_id;
-                        slice->rdma.dest_rkey =
-                            peer_segment_desc->buffers[buffer_id]
-                                .rkey[device_id];
-                        peer_nic_path = alt_path;
-                        found = true;
-                        break;
-                    }
-                }
-                if (!found) {
+                if (!selectAvailablePeerRailAlternative(
+                        peer_segment_desc.get(), buffer_id, device_id,
+                        peerRailSelectionSeed(slice), device_id,
+                        peer_nic_path)) {
                     LOG(ERROR)
                         << "Worker: Delaying redispatch because all peer "
                            "rails are paused for target "
@@ -1175,6 +1140,8 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                     delayRedispatch(slice, false, "all peer rails paused");
                     continue;
                 }
+                slice->rdma.dest_rkey =
+                    peer_segment_desc->buffers[buffer_id].rkey[device_id];
             }
             slice->peer_nic_path = peer_nic_path;
             if (globalConfig().log_rdma_slice_affinity) {
@@ -1520,6 +1487,8 @@ void WorkerPool::maybeActivateRecoveredContext() {
 
 bool WorkerPool::hasAvailablePeerRailAlternative(
     Transport::Slice *slice, const std::string &failed_peer_path) {
+    if (!slice) return false;
+
     auto peer_segment_desc =
         context_.engine().meta()->getSegmentDescByID(slice->target_id, false);
     if (!peer_segment_desc) return false;
@@ -1552,6 +1521,53 @@ bool WorkerPool::hasAvailablePeerRailAlternative(
     return false;
 }
 
+bool WorkerPool::selectAvailablePeerRailAlternative(
+    RdmaTransport::SegmentDesc *peer_segment_desc, int buffer_id,
+    int selected_device_id, uint64_t selection_seed, int &device_id,
+    std::string &peer_nic_path) {
+    if (!peer_segment_desc || buffer_id < 0 ||
+        buffer_id >= static_cast<int>(peer_segment_desc->buffers.size()) ||
+        peer_segment_desc->devices.empty()) {
+        return false;
+    }
+
+    const auto &rkeys = peer_segment_desc->buffers[buffer_id].rkey;
+    const size_t device_count = peer_segment_desc->devices.size();
+    const size_t start = selection_seed % device_count;
+    const auto server_name = peer_segment_desc->nicPathServerName();
+
+    for (size_t checked = 0; checked < device_count; ++checked) {
+        const size_t alt_dev_id = (start + checked) % device_count;
+        if (alt_dev_id == static_cast<size_t>(selected_device_id) ||
+            alt_dev_id >= rkeys.size()) {
+            continue;
+        }
+
+        auto alt_path = MakeNicPath(
+            server_name, peer_segment_desc->devices[alt_dev_id].name);
+        if (!isRailAvailable(alt_path)) continue;
+
+        device_id = static_cast<int>(alt_dev_id);
+        peer_nic_path = std::move(alt_path);
+        return true;
+    }
+
+    return false;
+}
+
+uint64_t WorkerPool::peerRailSelectionSeed(const Transport::Slice *slice) {
+    if (!slice) return 0;
+
+    uint64_t seed = static_cast<uint64_t>(slice->target_id);
+    seed ^= slice->rdma.dest_addr + 0x9e3779b97f4a7c15ull + (seed << 6) +
+            (seed >> 2);
+    seed ^= static_cast<uint64_t>(slice->length) + 0x9e3779b97f4a7c15ull +
+            (seed << 6) + (seed >> 2);
+    seed ^= static_cast<uint64_t>(slice->rdma.retry_cnt) +
+            0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
+    return seed;
+}
+
 void WorkerPool::refreshPublishedLocalTopology() {
     std::lock_guard<std::mutex> guard(context_.engine().local_desc_lock_);
     auto desc =
@@ -1561,6 +1577,7 @@ void WorkerPool::refreshPublishedLocalTopology() {
     auto updated_desc = std::make_shared<RdmaTransport::SegmentDesc>(*desc);
     updated_desc->topology = *context_.engine().local_topology_;
     for (const auto &context : context_.engine().context_list_) {
+        if (!context) continue;
         if (context->active()) continue;
         updated_desc->topology.disableDevice(context->deviceName());
     }

--- a/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/worker_pool.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <chrono>
 #include <condition_variable>
 #include <exception>
@@ -37,6 +38,42 @@
 // #define CONFIG_CACHE_ENDPOINT
 
 namespace mooncake {
+
+constexpr uint64_t kDelayedRedispatchMinBackoffNs = 100000000ull;   // 100 ms
+constexpr uint64_t kDelayedRedispatchMaxBackoffNs = 2000000000ull;  // 2 seconds
+constexpr uint64_t kDelayedRedispatchWakeCapNs = 100000000ull;      // 100 ms
+
+static uint64_t delayedRedispatchMaxWaitNs() {
+    const uint64_t pause_ns =
+        globalConfig().rdma_rail_pause_seconds * 1000000000ull;
+    return std::max<uint64_t>(120000000000ull, pause_ns * 4);
+}
+
+static uint64_t delayedRedispatchJitterNs(Transport::Slice *slice,
+                                          uint64_t window_ns) {
+    if (!slice || window_ns == 0) return 0;
+    auto value = reinterpret_cast<uintptr_t>(slice) >> 4;
+    value ^= static_cast<uintptr_t>(slice->target_id) * 0x9e3779b97f4a7c15ull;
+    return static_cast<uint64_t>(value % window_ns);
+}
+
+static uint64_t delayedRedispatchBackoffNs(Transport::Slice *slice,
+                                           uint64_t now) {
+    uint64_t delay_ns = kDelayedRedispatchMinBackoffNs;
+    if (slice && slice->ts > 0 && now > static_cast<uint64_t>(slice->ts)) {
+        const uint64_t elapsed_ns = now - static_cast<uint64_t>(slice->ts);
+        uint64_t scale =
+            std::max<uint64_t>(1, elapsed_ns / kDelayedRedispatchMinBackoffNs);
+        while (scale > 1 && delay_ns < kDelayedRedispatchMaxBackoffNs) {
+            delay_ns <<= 1;
+            scale >>= 1;
+        }
+        delay_ns = std::min(delay_ns, kDelayedRedispatchMaxBackoffNs);
+    }
+
+    const uint64_t jitter_window = std::max<uint64_t>(1, delay_ns / 4);
+    return delay_ns + delayedRedispatchJitterNs(slice, jitter_window);
+}
 
 static std::string resolveBufferLocation(
     const TransferMetadata::BufferDesc &buffer, uint64_t offset) {
@@ -383,7 +420,9 @@ int WorkerPool::submitPostSend(
                 }
             }
             if (!found) {
-                slice->markFailed();  // All rails unavailable
+                slice->peer_nic_path = peer_nic_path;
+                delayRedispatch(slice, false, "all peer rails unavailable");
+                submitted_slice_count++;
                 continue;
             }
         }
@@ -422,6 +461,100 @@ void WorkerPool::enqueuePreparedSlices(const SliceList &slice_list,
         std::lock_guard<std::mutex> lock(cond_mutex_);
         cond_var_.notify_all();
     }
+}
+
+void WorkerPool::delayRedispatch(Transport::Slice *slice,
+                                 bool handoff_to_local_worker,
+                                 const char *reason) {
+    if (!slice) return;
+
+    const uint64_t now = static_cast<uint64_t>(getCurrentTimeInNano());
+    if (slice->ts <= 0) slice->ts = static_cast<int64_t>(now);
+    const uint64_t first_wait_ns = static_cast<uint64_t>(slice->ts);
+    if (now > first_wait_ns &&
+        now - first_wait_ns > delayedRedispatchMaxWaitNs()) {
+        LOG(ERROR) << "Worker: Giving up delayed redispatch after "
+                   << (now - first_wait_ns) / 1000000ull
+                   << " ms, reason=" << reason
+                   << ", target=" << slice->target_id
+                   << ", peer_nic=" << slice->peer_nic_path
+                   << ", local_nic=" << context_.deviceName();
+        slice->markFailed();
+        processed_slice_count_++;
+        return;
+    }
+
+    uint64_t delay_ns = delayedRedispatchBackoffNs(slice, now);
+    const uint64_t rail_pause_remaining_ns =
+        peerRailPauseRemainingNs(slice->peer_nic_path, now);
+    if (rail_pause_remaining_ns > 0) {
+        const uint64_t pause_jitter_ns =
+            delayedRedispatchJitterNs(slice, kDelayedRedispatchMinBackoffNs);
+        delay_ns =
+            std::max(delay_ns, rail_pause_remaining_ns + pause_jitter_ns);
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(delayed_slices_lock_);
+        delayed_slices_.push_back(
+            {slice, now + delay_ns, handoff_to_local_worker});
+    }
+    if (parked_worker_count_.load(std::memory_order_acquire) > 0) {
+        std::lock_guard<std::mutex> lock(cond_mutex_);
+        cond_var_.notify_all();
+    }
+    VLOG(1) << "Worker: delayed redispatch for target " << slice->target_id
+            << ", reason=" << reason << ", local_nic=" << context_.deviceName()
+            << ", peer_nic=" << slice->peer_nic_path
+            << ", delay_ms=" << delay_ns / 1000000ull;
+}
+
+bool WorkerPool::hasDelayedSlices() const {
+    std::lock_guard<std::mutex> lock(delayed_slices_lock_);
+    return !delayed_slices_.empty();
+}
+
+uint64_t WorkerPool::nextDelayedSliceDueNs() const {
+    std::lock_guard<std::mutex> lock(delayed_slices_lock_);
+    uint64_t next_due_ns = 0;
+    for (const auto &entry : delayed_slices_) {
+        if (entry.due_ns == 0) continue;
+        if (next_due_ns == 0 || entry.due_ns < next_due_ns)
+            next_due_ns = entry.due_ns;
+    }
+    return next_due_ns;
+}
+
+void WorkerPool::releaseReadyDelayedSlices(int thread_id) {
+    const uint64_t now = static_cast<uint64_t>(getCurrentTimeInNano());
+    std::vector<DelayedSlice> ready;
+    {
+        std::lock_guard<std::mutex> lock(delayed_slices_lock_);
+        if (delayed_slices_.empty()) return;
+
+        std::vector<DelayedSlice> pending;
+        pending.reserve(delayed_slices_.size());
+        for (auto &entry : delayed_slices_) {
+            if (entry.due_ns <= now)
+                ready.push_back(entry);
+            else
+                pending.push_back(entry);
+        }
+        delayed_slices_.swap(pending);
+    }
+    if (ready.empty()) return;
+
+    SliceList remote_retry;
+    SliceList local_retry;
+    for (auto &entry : ready) {
+        if (!entry.slice) continue;
+        if (!context_.active() || entry.handoff_to_local_worker)
+            local_retry.push_back(entry.slice);
+        else
+            remote_retry.push_back(entry.slice);
+    }
+    if (!remote_retry.empty()) redispatch(remote_retry, thread_id, false);
+    if (!local_retry.empty()) redispatch(local_retry, thread_id, true);
 }
 
 int WorkerPool::submitPreparedPostSend(
@@ -590,7 +723,11 @@ void WorkerPool::performPostSend(int thread_id) {
         // deadline; only a genuine connection/QP failure can arm or extend it.
         if (!isRailAvailable(entry.first) ||
             context_.isConnectPaused(entry.first)) {
-            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            for (auto &slice : entry.second) {
+                if (!slice) continue;
+                slice->peer_nic_path = entry.first;
+                delayRedispatch(slice, false, "peer rail is paused");
+            }
             entry.second.clear();
             continue;
         }
@@ -606,7 +743,11 @@ void WorkerPool::performPostSend(int thread_id) {
             context_.endpoint(entry.first, cqIndexForPostingThread(thread_id));
 #endif
         if (!endpoint) {
-            for (auto &slice : entry.second) failed_slice_list.push_back(slice);
+            for (auto &slice : entry.second) {
+                if (!slice) continue;
+                slice->peer_nic_path = entry.first;
+                delayRedispatch(slice, false, "endpoint unavailable");
+            }
             entry.second.clear();
             continue;
         }
@@ -668,6 +809,11 @@ void WorkerPool::performPostSend(int thread_id) {
                     if (!has_peer_alternative && local_context_inactive &&
                         tryHandoffToAnotherLocalWorker(slice)) {
                         processed_slice_count_++;
+                    } else if (!has_peer_alternative &&
+                               !local_context_inactive) {
+                        slice->peer_nic_path = entry.first;
+                        delayRedispatch(slice, false,
+                                        "endpoint setup failed transiently");
                     } else {
                         failed_slice_list.push_back(slice);
                     }
@@ -684,8 +830,12 @@ void WorkerPool::performPostSend(int thread_id) {
                 markRailFailed(entry.first, true);
                 redispatch_counter_++;
                 context_.deleteEndpointByPtr(endpoint.get());
-                for (auto &slice : entry.second)
-                    failed_slice_list.push_back(slice);
+                for (auto &slice : entry.second) {
+                    if (!slice) continue;
+                    slice->peer_nic_path = entry.first;
+                    delayRedispatch(slice, false,
+                                    "timed out waiting for ready ACK");
+                }
                 entry.second.clear();
             }
             continue;
@@ -962,9 +1112,9 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                 }
                 // A local RNIC failure cannot be repaired by keeping this
                 // worker/context and changing the remote rail. If no other
-                // local worker can take the slice, fail it immediately.
-                slice->markFailed();
-                processed_slice_count_++;
+                // local worker can take the slice yet, wait for local rail
+                // recovery before declaring every local path gone.
+                delayRedispatch(slice, true, "no alternate local RNIC");
                 continue;
             }
 
@@ -982,8 +1132,8 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                            << "dest_addr=" << (void *)slice->rdma.dest_addr
                            << ", length=" << slice->length
                            << ", retry_cnt=" << slice->rdma.retry_cnt;
-                slice->markFailed();
-                processed_slice_count_++;
+                delayRedispatch(slice, false,
+                                "peer segment unavailable or no target RNIC");
                 continue;
             }
             slice->rdma.dest_rkey =
@@ -1016,13 +1166,13 @@ void WorkerPool::redispatch(std::vector<Transport::Slice *> &slice_list,
                 }
                 if (!found) {
                     LOG(ERROR)
-                        << "Worker: Cannot redispatch slice because all peer "
+                        << "Worker: Delaying redispatch because all peer "
                            "rails are paused for target "
                         << slice->target_id
                         << ", selected peer=" << peer_nic_path
                         << ", retry_cnt=" << slice->rdma.retry_cnt;
-                    slice->markFailed();
-                    processed_slice_count_++;
+                    slice->peer_nic_path = peer_nic_path;
+                    delayRedispatch(slice, false, "all peer rails paused");
                     continue;
                 }
             }
@@ -1146,12 +1296,13 @@ void WorkerPool::transferWorker(int thread_id) {
     const static uint64_t kWaitPeriodInNano = 100000000;  // 100ms
     uint64_t last_wait_ts = getCurrentTimeInNano();
     while (workers_running_.load(std::memory_order_relaxed)) {
+        releaseReadyDelayedSlices(thread_id);
         auto processed_slice_count =
             processed_slice_count_.load(std::memory_order_relaxed);
         auto submitted_slice_count =
             submitted_slice_count_.load(std::memory_order_relaxed);
         if (processed_slice_count == submitted_slice_count &&
-            !hasOutstandingCq(thread_id)) {
+            !hasOutstandingCq(thread_id) && !hasDelayedSlices()) {
             uint64_t curr_wait_ts = getCurrentTimeInNano();
             if (curr_wait_ts - last_wait_ts > kWaitPeriodInNano) {
                 std::unique_lock<std::mutex> lock(cond_mutex_);
@@ -1161,7 +1312,7 @@ void WorkerPool::transferWorker(int thread_id) {
                 // producers that submit after it will notify this worker.
                 if (processed_slice_count_.load(std::memory_order_relaxed) ==
                         submitted_slice_count_.load() &&
-                    !hasOutstandingCq(thread_id)) {
+                    !hasOutstandingCq(thread_id) && !hasDelayedSlices()) {
                     cond_var_.wait_for(lock, std::chrono::seconds(1));
                 }
                 parked_worker_count_.fetch_sub(1, std::memory_order_acq_rel);
@@ -1173,6 +1324,15 @@ void WorkerPool::transferWorker(int thread_id) {
 #ifndef USE_FAKE_POST_SEND
         performPollCq(thread_id);
 #endif
+        const uint64_t next_delayed_due_ns = nextDelayedSliceDueNs();
+        if (next_delayed_due_ns > 0) {
+            const uint64_t now = static_cast<uint64_t>(getCurrentTimeInNano());
+            if (next_delayed_due_ns > now) {
+                const uint64_t sleep_ns = std::min(next_delayed_due_ns - now,
+                                                   kDelayedRedispatchWakeCapNs);
+                std::this_thread::sleep_for(std::chrono::nanoseconds(sleep_ns));
+            }
+        }
         last_wait_ts = getCurrentTimeInNano();
     }
 }
@@ -1612,6 +1772,23 @@ bool WorkerPool::isRailAvailable(const std::string &peer_nic_path) {
         return true;
     }
     return false;
+}
+
+uint64_t WorkerPool::peerRailPauseRemainingNs(const std::string &peer_nic_path,
+                                              uint64_t now) {
+    if (peer_nic_path.empty()) return 0;
+
+    std::lock_guard<std::mutex> lock(rail_state_lock_);
+    auto it = rail_states_.find(peer_nic_path);
+    if (it == rail_states_.end()) return 0;
+    auto &state = it->second;
+    if (state.pause_until_ns == 0) return 0;
+    if (now >= state.pause_until_ns) {
+        state.error_count = 0;
+        state.pause_until_ns = 0;
+        return 0;
+    }
+    return state.pause_until_ns - now;
 }
 
 // Unified retry logic: increment retry count and return whether retry is

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -14,6 +14,12 @@ target_link_libraries(rdma_transport_test PUBLIC transfer_engine gflags::gflags
                                                  glog::glog)
 # add_test(NAME rdma_transport_test COMMAND rdma_transport_test)
 
+add_executable(rdma_transport_chaos_test
+               ${WORKSPACE}/rdma_transport_chaos_test.cpp)
+target_link_libraries(rdma_transport_chaos_test PUBLIC transfer_engine
+                                                       gflags::gflags
+                                                       glog::glog)
+
 add_executable(transport_uint_test ${WORKSPACE}/transport_uint_test.cpp)
 target_link_libraries(transport_uint_test PUBLIC transfer_engine gtest
                                                  gtest_main)

--- a/mooncake-transfer-engine/tests/rdma_transport_chaos_test.cpp
+++ b/mooncake-transfer-engine/tests/rdma_transport_chaos_test.cpp
@@ -1,0 +1,407 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Dedicated large correctness test for manual RDMA chaos runs.
+//
+// How to run:
+// etcd --listen-client-urls http://0.0.0.0:2379 --advertise-client-urls
+// http://10.0.0.1:2379
+// ./rdma_transport_chaos_test --mode=target  --metadata_server=127.0.0.1:2379
+//   --local_server_name=127.0.0.2:12345 --device_name=erdma_0
+// ./rdma_transport_chaos_test --metadata_server=127.0.0.1:2379
+//   --segment_id=127.0.0.2:12345 --local_server_name=127.0.0.3:12346
+//   --device_name=erdma_1
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <sys/time.h>
+
+#include <algorithm>
+#include <cstring>
+#include <cstdlib>
+#include <fstream>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "transfer_engine.h"
+#include "transport/transport.h"
+#include "common.h"
+
+#include "cuda_alike.h"
+#if defined(USE_CUDA) && defined(USE_NVMEOF)
+#include <cufile.h>
+#endif
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+
+#include <cassert>
+
+static void checkCudaError(cudaError_t result, const char *message) {
+    if (result != cudaSuccess) {
+        LOG(ERROR) << message << " (Error code: " << result << " - "
+                   << cudaGetErrorString(result) << ")" << std::endl;
+        exit(EXIT_FAILURE);
+    }
+}
+#endif
+
+DEFINE_string(local_server_name, mooncake::getHostname(),
+              "Local server name for segment discovery");
+DEFINE_string(metadata_server, "192.168.3.77:2379", "etcd server host address");
+DEFINE_string(mode, "initiator",
+              "Running mode: initiator or target. Initiator node read/write "
+              "data blocks from target node");
+
+DEFINE_string(protocol, "rdma", "Transfer protocol: rdma|tcp");
+
+DEFINE_string(device_name, "mlx5_2",
+              "Device name to use, valid if protocol=rdma");
+DEFINE_string(nic_priority_matrix, "",
+              "Path to RDMA NIC priority matrix file (Advanced)");
+
+DEFINE_string(segment_id, "192.168.3.76", "Segment ID to access data");
+DEFINE_uint64(total_buffer_size, 1ull << 30,
+              "Total local memory size to register on each node");
+DEFINE_uint64(data_length, 4096000,
+              "Bytes transferred by each worker per iteration");
+DEFINE_uint64(iterations, 1, "WRITE/READ/compare iterations per worker");
+DEFINE_uint64(num_threads, 1, "Number of concurrent initiator workers");
+
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+DEFINE_bool(use_vram, true, "Allocate memory from GPU VRAM");
+DEFINE_int32(gpu_id, 0, "GPU ID to use");
+#endif
+
+using namespace mooncake;
+
+static void *allocateMemoryPool(size_t size, int socket_id,
+                                bool from_vram = false) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+    if (from_vram) {
+        int gpu_id = FLAGS_gpu_id;
+        void *d_buf;
+        checkCudaError(cudaSetDevice(gpu_id), "Failed to set device");
+        checkCudaError(cudaMalloc(&d_buf, size),
+                       "Failed to allocate device memory");
+        return d_buf;
+    }
+#endif
+    return numa_alloc_onnode(size, socket_id);
+}
+
+static void freeMemoryPool(void *addr, size_t size) {
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+    // check pointer on GPU
+    cudaPointerAttributes attributes;
+    checkCudaError(cudaPointerGetAttributes(&attributes, addr),
+                   "Failed to get pointer attributes");
+
+    if (attributes.type == cudaMemoryTypeDevice) {
+        cudaFree(addr);
+    } else if (attributes.type == cudaMemoryTypeHost) {
+        numa_free(addr, size);
+    } else {
+        LOG(ERROR) << "Unknown memory type";
+    }
+#else
+    numa_free(addr, size);
+#endif
+}
+
+int initiatorWorker(TransferEngine *engine, SegmentID segment_id, int thread_id,
+                    void *addr) {
+    bindToSocket(0);
+    auto segment_desc = engine->getMetadata()->getSegmentDescByID(segment_id);
+    uint64_t remote_base = (uint64_t)segment_desc->buffers[0].addr;
+    const size_t data_length = FLAGS_data_length;
+    const size_t local_stride = data_length * 2;
+    const size_t local_base = static_cast<size_t>(thread_id) * local_stride;
+    const size_t remote_offset =
+        static_cast<size_t>(thread_id) * data_length;
+    uint8_t *write_addr = static_cast<uint8_t *>(addr) + local_base;
+    uint8_t *read_addr = write_addr + data_length;
+
+    for (uint64_t iteration = 0; iteration < FLAGS_iterations; ++iteration) {
+        LOG(INFO) << "Stage 1: Write Data, thread=" << thread_id
+                  << ", iteration=" << iteration
+                  << ", bytes=" << data_length;
+        for (size_t offset = 0; offset < data_length; ++offset) {
+            write_addr[offset] =
+                static_cast<uint8_t>((offset + thread_id * 131 + iteration * 17) %
+                                     251);
+        }
+        std::memset(read_addr, 0, data_length);
+
+        LOG(INFO) << "Write Data: "
+                  << std::string(reinterpret_cast<char *>(write_addr),
+                                 std::min<size_t>(16, data_length))
+                  << "...";
+
+        Status s;
+
+        {
+            auto batch_id = engine->allocateBatchID(1);
+            TransferRequest entry;
+            entry.opcode = TransferRequest::WRITE;
+            entry.length = data_length;
+            entry.source = write_addr;
+            entry.target_id = segment_id;
+            entry.target_offset = remote_base + remote_offset;
+            s = engine->submitTransfer(batch_id, {entry});
+            if (!s.ok()) {
+                LOG(ERROR) << "submit WRITE failed, thread=" << thread_id
+                           << ", iteration=" << iteration;
+                engine->freeBatchID(batch_id);
+                return 1;
+            }
+            bool completed = false;
+            TransferStatus status;
+            while (!completed) {
+                Status s = engine->getTransferStatus(batch_id, 0, status);
+                if (!s.ok()) {
+                    LOG(ERROR) << "get WRITE status failed, thread="
+                               << thread_id << ", iteration=" << iteration;
+                    engine->freeBatchID(batch_id);
+                    return 1;
+                }
+                if (status.s == TransferStatusEnum::COMPLETED) {
+                    completed = true;
+                } else if (status.s == TransferStatusEnum::FAILED) {
+                    LOG(ERROR) << "WRITE FAILED, thread=" << thread_id
+                               << ", iteration=" << iteration;
+                    engine->freeBatchID(batch_id);
+                    return 1;
+                }
+            }
+            s = engine->freeBatchID(batch_id);
+            if (!s.ok()) return 1;
+        }
+
+        LOG(INFO) << "Stage 2: Read Data, thread=" << thread_id
+                  << ", iteration=" << iteration
+                  << ", bytes=" << data_length;
+        {
+            auto batch_id = engine->allocateBatchID(1);
+            TransferRequest entry;
+            entry.opcode = TransferRequest::READ;
+            entry.length = data_length;
+            entry.source = read_addr;
+            entry.target_id = segment_id;
+            entry.target_offset = remote_base + remote_offset;
+            s = engine->submitTransfer(batch_id, {entry});
+            if (!s.ok()) {
+                LOG(ERROR) << "submit READ failed, thread=" << thread_id
+                           << ", iteration=" << iteration;
+                engine->freeBatchID(batch_id);
+                return 1;
+            }
+            bool completed = false;
+            TransferStatus status;
+            while (!completed) {
+                Status s = engine->getTransferStatus(batch_id, 0, status);
+                if (!s.ok()) {
+                    LOG(ERROR) << "get READ status failed, thread="
+                               << thread_id << ", iteration=" << iteration;
+                    engine->freeBatchID(batch_id);
+                    return 1;
+                }
+                if (status.s == TransferStatusEnum::COMPLETED) {
+                    completed = true;
+                } else if (status.s == TransferStatusEnum::FAILED) {
+                    LOG(ERROR) << "READ FAILED, thread=" << thread_id
+                               << ", iteration=" << iteration;
+                    engine->freeBatchID(batch_id);
+                    return 1;
+                }
+            }
+            s = engine->freeBatchID(batch_id);
+            if (!s.ok()) return 1;
+        }
+
+        int ret = std::memcmp(write_addr, read_addr, data_length);
+        LOG(INFO) << "Read Data: "
+                  << std::string(reinterpret_cast<char *>(read_addr),
+                                 std::min<size_t>(16, data_length))
+                  << "...";
+        LOG(INFO) << "Compare: " << (ret == 0 ? "OK" : "FAILED")
+                  << ", thread=" << thread_id
+                  << ", iteration=" << iteration;
+        if (ret != 0) return 1;
+    }
+
+    return 0;
+}
+
+std::string formatDeviceNames(const std::string &device_names) {
+    std::stringstream ss(device_names);
+    std::string item;
+    std::vector<std::string> tokens;
+    while (getline(ss, item, ',')) {
+        tokens.push_back(item);
+    }
+
+    std::string formatted;
+    for (size_t i = 0; i < tokens.size(); ++i) {
+        formatted += "\"" + tokens[i] + "\"";
+        if (i < tokens.size() - 1) {
+            formatted += ",";
+        }
+    }
+    return formatted;
+}
+
+std::string loadNicPriorityMatrix() {
+    if (!FLAGS_nic_priority_matrix.empty()) {
+        std::ifstream file(FLAGS_nic_priority_matrix);
+        if (file.is_open()) {
+            std::string content((std::istreambuf_iterator<char>(file)),
+                                std::istreambuf_iterator<char>());
+            file.close();
+            return content;
+        }
+    }
+    // Build JSON Data
+    auto device_names = formatDeviceNames(FLAGS_device_name);
+    return "{\"cpu:0\": [[" + device_names +
+           "], []], "
+           " \"cpu:1\": [[" +
+           device_names +
+           "], []], "
+           " \"cuda:0\": [[" +
+           device_names +
+           "], []], "
+           " \"musa:0\": [[" +
+           device_names + "], []]}";
+}
+
+int initiator() {
+    const size_t ram_buffer_size = FLAGS_total_buffer_size;
+    const size_t required_size =
+        FLAGS_num_threads * FLAGS_data_length * 2;
+    if (required_size > ram_buffer_size) {
+        LOG(ERROR) << "total_buffer_size too small: required=" << required_size
+                   << ", configured=" << ram_buffer_size;
+        return 1;
+    }
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    Transport *xport = nullptr;
+    if (FLAGS_protocol == "rdma") {
+        auto nic_priority_matrix = loadNicPriorityMatrix();
+        void **args = (void **)malloc(2 * sizeof(void *));
+        args[0] = (void *)nic_priority_matrix.c_str();
+        args[1] = nullptr;
+        xport = engine->installTransport("rdma", args);
+    } else if (FLAGS_protocol == "tcp") {
+        xport = engine->installTransport("tcp", nullptr);
+    } else if (FLAGS_protocol == "nvmeof") {
+        xport = engine->installTransport("nvmeof", nullptr);
+    } else {
+        LOG(ERROR) << "Unsupported protocol";
+    }
+
+    LOG_ASSERT(xport);
+
+    void *addr = nullptr;
+#if defined(USE_CUDA) || defined(USE_MUSA) || defined(USE_HIP)
+    addr = allocateMemoryPool(ram_buffer_size, 0, FLAGS_use_vram);
+    std::string name_prefix = FLAGS_use_vram ? GPU_PREFIX : "cpu:";
+    int name_suffix = FLAGS_use_vram ? FLAGS_gpu_id : 0;
+    int rc = engine->registerLocalMemory(
+        addr, ram_buffer_size, name_prefix + std::to_string(name_suffix));
+    LOG_ASSERT(!rc);
+#else
+    addr = allocateMemoryPool(ram_buffer_size, 0, false);
+    int rc =
+        engine->registerLocalMemory(addr, ram_buffer_size, kWildcardLocation);
+    LOG_ASSERT(!rc);
+#endif
+
+    auto segment_id = engine->openSegment(FLAGS_segment_id.c_str());
+    std::vector<std::thread> workers;
+    std::vector<int> worker_rc(FLAGS_num_threads, 1);
+    for (uint64_t i = 0; i < FLAGS_num_threads; ++i) {
+        workers.emplace_back([&, i]() {
+            worker_rc[i] =
+                initiatorWorker(engine.get(), segment_id, static_cast<int>(i),
+                                addr);
+        });
+    }
+    for (auto &worker : workers) worker.join();
+    engine->unregisterLocalMemory(addr);
+    freeMemoryPool(addr, ram_buffer_size);
+    for (auto rc : worker_rc) {
+        if (rc != 0) return rc;
+    }
+    return 0;
+}
+
+int target() {
+    const size_t ram_buffer_size = FLAGS_total_buffer_size;
+    const size_t required_size = FLAGS_num_threads * FLAGS_data_length;
+    if (required_size > ram_buffer_size) {
+        LOG(ERROR) << "total_buffer_size too small: required=" << required_size
+                   << ", configured=" << ram_buffer_size;
+        return 1;
+    }
+    // disable topology auto discovery for testing.
+    auto engine = std::make_unique<TransferEngine>(false);
+
+    auto hostname_port = parseHostNameWithPort(FLAGS_local_server_name);
+    engine->init(FLAGS_metadata_server, FLAGS_local_server_name.c_str(),
+                 hostname_port.first.c_str(), hostname_port.second);
+
+    if (FLAGS_protocol == "rdma") {
+        auto nic_priority_matrix = loadNicPriorityMatrix();
+        void **args = (void **)malloc(2 * sizeof(void *));
+        args[0] = (void *)nic_priority_matrix.c_str();
+        args[1] = nullptr;
+        engine->installTransport("rdma", args);
+    } else if (FLAGS_protocol == "tcp") {
+        engine->installTransport("tcp", nullptr);
+    } else if (FLAGS_protocol == "nvmeof") {
+        engine->installTransport("nvmeof", nullptr);
+    } else {
+        LOG(ERROR) << "Unsupported protocol";
+    }
+
+    void *addr = nullptr;
+    addr = allocateMemoryPool(ram_buffer_size, 0);
+    int rc = engine->registerLocalMemory(addr, ram_buffer_size, "cpu:0");
+    LOG_ASSERT(!rc);
+
+    while (true) sleep(1);
+
+    engine->unregisterLocalMemory(addr);
+    freeMemoryPool(addr, ram_buffer_size);
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, false);
+
+    if (FLAGS_mode == "initiator")
+        return initiator();
+    else if (FLAGS_mode == "target")
+        return target();
+
+    LOG(ERROR) << "Unsupported mode: must be 'initiator' or 'target'";
+    exit(EXIT_FAILURE);
+}

--- a/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
+++ b/mooncake-transfer-engine/tests/worker_pool_rail_state_test.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <vector>
 
 #include <glog/logging.h>
 
@@ -108,6 +109,11 @@ class WorkerPoolTestPeer {
         pool.workers_running_.store(false);
         pool.cond_var_.notify_all();
         for (auto &entry : pool.worker_thread_) entry.join();
+    }
+
+    static size_t delayedSliceCount(WorkerPool &pool) {
+        std::lock_guard<std::mutex> lock(pool.delayed_slices_lock_);
+        return pool.delayed_slices_.size();
     }
 
     static int errorThreshold() { return WorkerPool::kRailErrorThreshold; }
@@ -277,9 +283,11 @@ TEST_F(WorkerPoolRailStateTest, RailsArePausedIndependently) {
 }
 
 // Exercise the submit path that used to mistake one peer's unavailable rails
-// for a local RNIC failure, not just the rail-pausing helper.
+// for a local RNIC failure, not just the rail-pausing helper. Unavailable peer
+// rails should now delay redispatch until recovery instead of failing
+// immediately.
 TEST_F(WorkerPoolRailStateTest,
-       AllRailsUnavailableSubmitsDoNotDeactivateContext) {
+       AllRailsUnavailableSubmitsAreDelayedWithoutDeactivatingContext) {
     constexpr SegmentID target_id = 3559;
     constexpr uint64_t buffer_addr = 0x10000;
     auto desc = std::make_shared<TransferMetadata::SegmentDesc>();
@@ -300,23 +308,26 @@ TEST_F(WorkerPoolRailStateTest,
     WorkerPoolTestPeer::setContextActive(*worker_pool_, true);
     Transport::TransferTask task;
     task.batch_id = transport_->allocateBatchID(1);
-    for (int i = 0; i < WorkerPoolTestPeer::contextFailureThreshold(); ++i) {
+    const int threshold = WorkerPoolTestPeer::contextFailureThreshold();
+    std::vector<Transport::Slice> slices(threshold);
+    for (int i = 0; i < threshold; ++i) {
         failRail(kPeerA, /*immediate_pause=*/true);
         failRail(kPeerB, /*immediate_pause=*/true);
-        Transport::Slice slice{};
+        auto &slice = slices[i];
         slice.task = &task;
         slice.target_id = target_id;
         slice.rdma.dest_addr = buffer_addr;
         slice.length = 64;
         ASSERT_EQ(worker_pool_->submitPostSend({&slice}), 0);
-        EXPECT_EQ(slice.status, Transport::Slice::FAILED);
+        EXPECT_EQ(slice.status, Transport::Slice::PENDING);
         // Device selection succeeded, so the failure was unavailable rails.
         EXPECT_TRUE(slice.rdma.dest_rkey == 11 || slice.rdma.dest_rkey == 22);
+        EXPECT_EQ(WorkerPoolTestPeer::delayedSliceCount(*worker_pool_),
+                  static_cast<size_t>(i + 1));
         EXPECT_EQ(WorkerPoolTestPeer::contextFailureCount(*worker_pool_), 0);
         EXPECT_TRUE(WorkerPoolTestPeer::contextActive(*worker_pool_));
     }
-    EXPECT_EQ(task.failed_slice_count,
-              WorkerPoolTestPeer::contextFailureThreshold());
+    EXPECT_EQ(task.failed_slice_count, 0);
     EXPECT_TRUE(transport_->freeBatchID(task.batch_id).ok());
 
     EXPECT_TRUE(WorkerPoolTestPeer::contextActive(*worker_pool_));


### PR DESCRIPTION
## Description

Add a dedicated classic Transfer Engine RDMA chaos runner and harden RDMA worker-pool retry behavior for temporary RNIC/rail unavailability.

This PR treats the chaos runner and WorkerPool reliability changes as one validation package:

- add `rdma_transport_chaos_test` plus `tests/chaos/te_chaos.py` for two-host RDMA chaos runs
- defer slices instead of failing immediately when all peer rails, target RNICs, or local RNIC handoff paths are temporarily unavailable
- handle posted-slice software timeouts in `WorkerPool` by retiring affected endpoints and fencing peer rails when an alternate exists
- keep `preTouchMemory()` from selecting an inactive placeholder context when one RNIC failed during initialization
- add `worker_pool_timeout_test` coverage for posted-slice timeout cleanup

Related: #2960

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
git diff --check
python3 -m py_compile mooncake-transfer-engine/tests/chaos/te_chaos.py
cmake -S . -B build
cmake --build build --target rdma_transport_chaos_test worker_pool_timeout_test rdma_transport_submit_task_test worker_pool_rail_state_test -j2
ctest --test-dir build -R 'worker_pool_timeout_test|rdma_transport_submit_task_test|worker_pool_rail_state_test' --output-on-failure
./scripts/code_format.sh --staged
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`rdma_transport_chaos_test` builds successfully. The actual chaos runner requires a two-host RDMA/SSH environment and was not executed in this local PR preparation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`pre-commit` is not installed in this environment, so it was not run. PR-scoped formatting was run with `./scripts/code_format.sh --staged`.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to port the chaos runner/WorkerPool changes, trim unrelated edits, run build/test validation, and prepare this PR description. The human submitter should review and own the final changes.