### PR TITLE
[CI/Build] Backport TestPyPI pre-release gate to v0.3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,27 @@ jobs:
         bash scripts/check_reshard_types.sh
       shell: bash
 
+  release-gate-tests:
+    name: Test TestPyPI release gate
+    if: *run-ci
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Run focused release gate tests
+      run: |
+        python -m pip install --disable-pip-version-check \
+          packaging pytest==8.3.5
+        python -m pytest -q mooncake-wheel/tests/test_testpypi_wheel_gate.py
+      shell: bash
+
   clang-format:
     name: Check code format
     if: *run-ci
@@ -699,6 +720,7 @@ jobs:
       - clang-format
       - docs-check
       - reshard-type-check
+      - release-gate-tests
       - reshard-test
       - build-wheel
       - build-flags

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -11,6 +11,11 @@ on:
         description: 'PR number (passed from parent workflow for workflow_dispatch)'
         required: false
         type: string
+      testpypi_version:
+        description: 'Exact TestPyPI CUDA 13 package version to test instead of a CI artifact'
+        required: false
+        default: ''
+        type: string
 
 jobs:
   test-sglang-integration:
@@ -18,8 +23,51 @@ jobs:
     env:
       tone_user_name: ${{ secrets.TONE_USER_NAME }}
     steps:
+      - name: Require T-one credentials for the pre-release gate
+        if: ${{ inputs.testpypi_version != '' }}
+        env:
+          TONE_USER_NAME: ${{ secrets.TONE_USER_NAME }}
+          TONE_USER_TOKEN: ${{ secrets.TONE_USER_TOKEN }}
+        run: |
+          if [ -z "$TONE_USER_NAME" ] || [ -z "$TONE_USER_TOKEN" ]; then
+            echo "TONE_USER_NAME and TONE_USER_TOKEN are required for pre-release validation"
+            exit 1
+          fi
+
+      - name: Set up Python for TestPyPI download
+        if: ${{ inputs.testpypi_version != '' }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download the exact indexed CUDA 13 wheel
+        if: ${{ inputs.testpypi_version != '' }}
+        env:
+          TESTPYPI_VERSION: ${{ inputs.testpypi_version }}
+        run: |
+          python -m pip download \
+            --index-url https://test.pypi.org/simple \
+            --no-cache-dir \
+            --no-deps \
+            --only-binary=:all: \
+            --pre \
+            --dest integration-wheel \
+            "mooncake-transfer-engine-cuda13==${TESTPYPI_VERSION}"
+
+      - name: Stage the indexed wheel for T-one
+        if: ${{ inputs.testpypi_version != '' }}
+        id: testpypi-wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: mooncake-testpypi-tone-${{ inputs.testpypi_version }}
+          path: integration-wheel/*.whl
+          if-no-files-found: error
+          retention-days: 14
+
       - name: trigger T-one test
         if: ${{ env.tone_user_name != '' }}
+        env:
+          TESTPYPI_ARTIFACT_ID: ${{ steps.testpypi-wheel.outputs.artifact-id }}
         run: |
           # Priority: explicit inputs > PR event context > push SHA
           SHA="${{ inputs.pr_sha || github.event.pull_request.head.sha || github.sha }}"
@@ -30,9 +78,10 @@ jobs:
             PR_ID=""
           fi
           echo "PR_ID=${PR_ID}"
+          artifact_id="$TESTPYPI_ARTIFACT_ID"
           max_attempts=120
           attempt=1
-          while [ $attempt -le $max_attempts ]; do
+          while [ -z "$artifact_id" ] && [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt: Fetching artifact..."
             echo "Target SHA=${SHA}"
             artifact_id=""
@@ -86,6 +135,9 @@ jobs:
           fi
 
           ENV_INFO="ARTIFACT_ID=${artifact_id} GIT_REPO=${{ github.repository }}"
+          if [ -n "${{ inputs.testpypi_version }}" ]; then
+            ENV_INFO="${ENV_INFO} BRANCH=${{ github.ref_name }}"
+          fi
           if [ -n "$PR_ID" ]; then
             ENV_INFO="${ENV_INFO} PR_ID=${PR_ID}"
           fi

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,11 +1,8 @@
 name: Pre-Release
 
-# Dry run of the release pipelines: build wheels through the same _build-wheel.yaml
-# the Release / Release Non-CUDA / Release CUDA 13 workflows use, validate the
-# artifacts, but do not create a GitHub Release or publish to PyPI.
-#
-# Trigger by pushing a pre-release tag, for example:
-#   git tag v1.0.0-rc1 && git push origin v1.0.0-rc1
+# Build the same core wheel matrix as the stable release workflows, publish the
+# exact artifacts to TestPyPI, then consume them in smoke and T-one tests.
+# No production PyPI or GitHub Release publication happens here.
 on:
   push:
     tags:
@@ -15,7 +12,40 @@ on:
       - 'v*-pre*'
 
 jobs:
+  version-stamp:
+    name: Normalize pre-release version
+    if: github.repository == 'kvcache-ai/Mooncake'
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+    steps:
+      - name: Checkout release gate
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install version parser
+        run: python -m pip install packaging
+
+      - name: Normalize tag as a PEP 440 pre-release
+        id: version
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          normalized=$(python scripts/ci/testpypi_wheel_gate.py \
+            normalize-version --tag "$RELEASE_TAG")
+          echo "package_version=${normalized}" >> "$GITHUB_OUTPUT"
+          echo "Normalized ${RELEASE_TAG} to ${normalized}"
+
   build:
+    needs: version-stamp
     strategy:
       fail-fast: false
       matrix:
@@ -43,13 +73,20 @@ jobs:
       variant: ${{ matrix.variant }}
       architecture: ${{ matrix.architecture }}
       artifact-prefix: ${{ matrix.artifact-prefix }}
+      version-override: ${{ needs.version-stamp.outputs.package_version }}
 
-  validate-release:
-    name: Validate release artifacts
-    needs: build
+  publish-testpypi:
+    name: Validate and publish wheels to TestPyPI
+    needs: [version-stamp, build]
     runs-on: ubuntu-22.04
+    environment: nightly
+    concurrency:
+      group: pre-release-testpypi-${{ needs.version-stamp.outputs.package_version }}
+      cancel-in-progress: false
     permissions:
       contents: read
+    env:
+      PACKAGE_VERSION: ${{ needs.version-stamp.outputs.package_version }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -60,42 +97,173 @@ jobs:
           path: mooncake-wheel/dist-all
           pattern: mooncake-wheel*pre-release*
 
-      - name: Prepare wheels for validation
+      - name: Collect wheels for publication
         run: |
           mkdir -p mooncake-wheel/dist-release
-          find mooncake-wheel/dist-all -name "*.whl" -exec cp {} mooncake-wheel/dist-release/ \;
+          find mooncake-wheel/dist-all -name "*.whl" \
+            -exec cp {} mooncake-wheel/dist-release/ \;
           echo "Pre-release tag: ${GITHUB_REF_NAME}"
+          echo "Package version: ${PACKAGE_VERSION}"
           echo "Collected wheels:"
           ls -la mooncake-wheel/dist-release/
-          wheel_count=$(find mooncake-wheel/dist-release -name "*.whl" | wc -l)
-          echo "wheel_count=${wheel_count}" >> "$GITHUB_ENV"
-          if [ "${wheel_count}" -lt 24 ]; then
-            echo "Expected at least 24 wheels (4 Python versions x 3 variants x 2 architectures), found ${wheel_count}"
-            exit 1
-          fi
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
+      - name: Install publication tools
+        run: python -m pip install packaging twine
+
+      - name: Require TestPyPI credentials
+        env:
+          TESTPYPI_API_TOKEN: ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: |
+          if [ -z "$TESTPYPI_API_TOKEN" ]; then
+            echo "TESTPYPI_API_TOKEN is required"
+            exit 1
+          fi
+
       - name: Validate wheels with twine
-        run: |
-          pip install twine
-          twine check mooncake-wheel/dist-release/*.whl
+        run: twine check mooncake-wheel/dist-release/*.whl
 
-      - name: Upload validated wheels as workflow artifacts
-        uses: actions/upload-artifact@v4
+      - name: Validate empty or resumable TestPyPI upload state
+        run: |
+          python scripts/ci/testpypi_wheel_gate.py validate-upload-state \
+            --directory mooncake-wheel/dist-release \
+            --version "$PACKAGE_VERSION"
+
+      - name: Publish exact wheels to TestPyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TESTPYPI_API_TOKEN }}
+        run: >-
+          twine upload --repository testpypi --skip-existing
+          mooncake-wheel/dist-release/*.whl
+
+      - name: Verify every published wheel hash
+        run: |
+          python scripts/ci/testpypi_wheel_gate.py wait-upload-state \
+            --directory mooncake-wheel/dist-release \
+            --version "$PACKAGE_VERSION"
+
+  consume-testpypi:
+    name: Consume ${{ matrix.package }} on ${{ matrix.architecture }}
+    needs: [version-stamp, publish-testpypi]
+    runs-on: ${{ matrix.architecture == 'aarch64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - mooncake-transfer-engine
+          - mooncake-transfer-engine-cuda13
+          - mooncake-transfer-engine-non-cuda
+        architecture:
+          - x86_64
+          - aarch64
+    env:
+      PACKAGE_VERSION: ${{ needs.version-stamp.outputs.package_version }}
+      TARGET_PACKAGE: ${{ matrix.package }}
+    steps:
+      - name: Install CUDA runtime and driver stub
+        if: ${{ matrix.package != 'mooncake-transfer-engine-non-cuda' }}
+        env:
+          CUDA_PACKAGE_VERSION: ${{ matrix.package == 'mooncake-transfer-engine-cuda13' && '13-0' || '12-8' }}
+        run: |
+          set -euo pipefail
+          if [ "$(uname -m)" = x86_64 ]; then
+            repository_architecture=x86_64
+          else
+            repository_architecture=sbsa
+          fi
+          keyring=$(mktemp --suffix=.deb)
+          curl --fail --location --retry 3 \
+            "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/${repository_architecture}/cuda-keyring_1.1-1_all.deb" \
+            --output "$keyring"
+          sudo dpkg -i "$keyring"
+          sudo apt-get update
+          sudo apt-get install -y \
+            "cuda-cudart-${CUDA_PACKAGE_VERSION}" \
+            "cuda-driver-dev-${CUDA_PACKAGE_VERSION}"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          name: mooncake-wheels-pre-release-${{ github.ref_name }}
-          path: mooncake-wheel/dist-release/*.whl
-          retention-days: 14
+          python-version: '3.12'
 
-      - name: Pre-release validation summary
+      - name: Download, install, and smoke the indexed wheel
         run: |
-          echo "## Pre-Release validation passed" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Tag: \`${GITHUB_REF_NAME}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Wheels built: ${wheel_count}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- PyPI publish: skipped (pre-release dry run)" >> "$GITHUB_STEP_SUMMARY"
-          echo "- GitHub Release upload: skipped (pre-release dry run)" >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            libcurl4 libibverbs1 rdma-core librdmacm1 libnuma1 liburing2
+
+          download_dir=$(mktemp -d)
+
+          python -m pip download \
+            --index-url https://test.pypi.org/simple \
+            --no-cache-dir \
+            --no-deps \
+            --only-binary=:all: \
+            --pre \
+            --dest "$download_dir" \
+            "${TARGET_PACKAGE}==${PACKAGE_VERSION}"
+
+          # Install the wheel downloaded above. Its ordinary dependencies are
+          # resolved from production PyPI, never TestPyPI.
+          python -m pip install \
+            --index-url https://pypi.org/simple \
+            "$download_dir"/*.whl
+
+          if [ "$TARGET_PACKAGE" != mooncake-transfer-engine-non-cuda ]; then
+            cuda_stub=
+            for candidate in /usr/local/cuda*/lib64/stubs/libcuda.so \
+                             /usr/local/cuda*/targets/*/lib/stubs/libcuda.so; do
+              if [ -f "$candidate" ]; then
+                cuda_stub="$candidate"
+                break
+              fi
+            done
+            if [ -z "$cuda_stub" ]; then
+              echo "CUDA driver stub libcuda.so was not found"
+              exit 1
+            fi
+            stub_dir=$(mktemp -d)
+            ln -s "$cuda_stub" "$stub_dir/libcuda.so.1"
+            export LD_LIBRARY_PATH="$stub_dir:${LD_LIBRARY_PATH:-}"
+            for directory in /usr/local/cuda*/lib64 \
+                             /usr/local/cuda*/targets/*/lib; do
+              if [ -d "$directory" ]; then
+                export LD_LIBRARY_PATH="$directory:$LD_LIBRARY_PATH"
+              fi
+            done
+          fi
+
+          python - "$TARGET_PACKAGE" "$PACKAGE_VERSION" <<'PY'
+          import importlib.metadata
+          import sys
+
+          package, expected = sys.argv[1:]
+          installed = importlib.metadata.version(package)
+          if installed != expected:
+              raise SystemExit(
+                  f"installed {package} version {installed}, expected {expected}"
+              )
+
+          import mooncake
+          import mooncake.engine
+          import mooncake.http_metadata_server
+          import mooncake.store
+          PY
+          mooncake_http_metadata_server --help >/dev/null
+          mooncake_master --version
+
+  tone-integration:
+    name: Validate T-one integration with TestPyPI wheel
+    needs: [version-stamp, consume-testpypi]
+    uses: ./.github/workflows/integration-test.yml
+    with:
+      testpypi_version: ${{ needs.version-stamp.outputs.package_version }}
+    secrets: inherit

--- a/mooncake-wheel/tests/test_testpypi_wheel_gate.py
+++ b/mooncake-wheel/tests/test_testpypi_wheel_gate.py
@@ -1,0 +1,196 @@
+"""Focused tests for the TestPyPI pre-release wheel gate."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+from packaging.version import Version
+
+
+def _load_gate_module():
+    repository = Path(__file__).resolve().parents[2]
+    script = repository / "scripts" / "ci" / "testpypi_wheel_gate.py"
+    spec = importlib.util.spec_from_file_location("testpypi_wheel_gate", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load_gate_module()
+
+
+def _wheel(package: str, version: str, python_tag: str, architecture: str) -> str:
+    distribution = package.replace("-", "_")
+    return (
+        f"{distribution}-{version}-{python_tag}-{python_tag}-"
+        f"manylinux_2_28_{architecture}.whl"
+    )
+
+
+def _complete_matrix(version: str) -> list[str]:
+    return [
+        _wheel(package, version, python_tag, architecture)
+        for package in gate.CORE_PACKAGES
+        for python_tag in gate.PYTHON_TAGS
+        for architecture in gate.ARCHITECTURES
+    ]
+
+
+def _write_wheel(
+    directory: Path,
+    package: str,
+    filename_version: str,
+    python_tag: str,
+    architecture: str,
+    *,
+    metadata_version: str | None = None,
+) -> Path:
+    path = directory / _wheel(package, filename_version, python_tag, architecture)
+    dist_info = f"{package.replace('-', '_')}-{filename_version}.dist-info"
+    with ZipFile(path, "w") as wheel:
+        wheel.writestr(
+            f"{dist_info}/METADATA",
+            "\n".join(
+                (
+                    "Metadata-Version: 2.1",
+                    f"Name: {package}",
+                    f"Version: {metadata_version or filename_version}",
+                    "",
+                )
+            ),
+        )
+    return path
+
+
+def _write_complete_matrix(directory: Path, version: str) -> list[Path]:
+    return [
+        _write_wheel(directory, package, version, python_tag, architecture)
+        for package in gate.CORE_PACKAGES
+        for python_tag in gate.PYTHON_TAGS
+        for architecture in gate.ARCHITECTURES
+    ]
+
+
+def _artifacts(
+    wheels: list[Path],
+    hashes: dict[str, str | None] | None = None,
+) -> list[gate.IndexedArtifact]:
+    hashes = hashes or {}
+    return [
+        gate.IndexedArtifact(
+            wheel.name,
+            hashes[wheel.name] if wheel.name in hashes else gate._sha256(wheel),
+        )
+        for wheel in wheels
+    ]
+
+
+def test_prerelease_tag_normalization_rejects_non_public_versions() -> None:
+    assert str(gate.normalize_prerelease_tag("v1.2.0-rc1")) == "1.2.0rc1"
+
+    for tag in ("1.2.0-rc1", "v1.2.0", "v1.2.0rc1+local", "vnot-a-version"):
+        with pytest.raises(gate.GateError):
+            gate.normalize_prerelease_tag(tag)
+
+
+def test_complete_matrix_requires_exact_version_and_all_24_targets() -> None:
+    filenames = _complete_matrix("1.2.0rc1")
+
+    gate.validate_wheel_set(filenames, Version("1.2.0-rc1"))
+
+    with pytest.raises(gate.GateError, match="missing targets"):
+        gate.validate_wheel_set(filenames[:-1], Version("1.2.0rc1"))
+
+    wrong_version = [*filenames[:-1], filenames[-1].replace("1.2.0rc1", "1.2.0rc2")]
+    with pytest.raises(gate.GateError, match="has version 1.2.0rc2"):
+        gate.validate_wheel_set(wrong_version, Version("1.2.0rc1"))
+
+    equivalent_version = _complete_matrix("1.2rc1")
+    with pytest.raises(gate.GateError, match="has version 1.2rc1"):
+        gate.validate_wheel_set(equivalent_version, Version("1.2.0rc1"))
+
+
+def test_local_validation_reads_each_wheel_metadata(tmp_path: Path) -> None:
+    _write_complete_matrix(tmp_path, "1.2.0rc1")
+    gate.validate_local(tmp_path, Version("1.2.0rc1"))
+
+    package = gate.CORE_PACKAGES[-1]
+    for bad_version in ("1.2.0rc2", "1.2rc1"):
+        _write_wheel(
+            tmp_path,
+            package,
+            "1.2.0rc1",
+            gate.PYTHON_TAGS[-1],
+            gate.ARCHITECTURES[-1],
+            metadata_version=bad_version,
+        )
+        with pytest.raises(gate.GateError, match=f"metadata version {bad_version}"):
+            gate.validate_local(tmp_path, Version("1.2.0rc1"))
+
+
+def test_upload_state_accepts_only_hash_matching_partial_uploads(
+    tmp_path: Path,
+) -> None:
+    wheels = _write_complete_matrix(tmp_path, "1.2.0rc1")
+    existing = wheels[:7]
+
+    gate.validate_upload_state(
+        tmp_path,
+        Version("1.2.0rc1"),
+        fetcher=lambda _index_url: _artifacts(existing),
+    )
+
+    changed = existing[0]
+    with pytest.raises(gate.GateError, match="refusing to mix builds"):
+        gate.validate_upload_state(
+            tmp_path,
+            Version("1.2.0rc1"),
+            fetcher=lambda _index_url: _artifacts([changed], {changed.name: "0" * 64}),
+        )
+
+
+def test_upload_state_rejects_unverifiable_or_unexpected_artifacts(
+    tmp_path: Path,
+) -> None:
+    wheels = _write_complete_matrix(tmp_path, "1.2.0rc1")
+    existing = wheels[0]
+
+    with pytest.raises(gate.GateError, match="did not advertise a SHA-256"):
+        gate.validate_upload_state(
+            tmp_path,
+            Version("1.2.0rc1"),
+            fetcher=lambda _index_url: _artifacts([existing], {existing.name: None}),
+        )
+
+    unexpected = existing.name.replace("x86_64", "ppc64le")
+    with pytest.raises(gate.GateError, match="unexpected artifact"):
+        gate.validate_upload_state(
+            tmp_path,
+            Version("1.2.0rc1"),
+            fetcher=lambda _index_url: [gate.IndexedArtifact(unexpected, "0" * 64)],
+        )
+
+
+def test_upload_state_waits_for_the_complete_hash_matching_matrix(
+    tmp_path: Path,
+) -> None:
+    wheels = _write_complete_matrix(tmp_path, "1.2.0rc1")
+    responses = iter((_artifacts(wheels[:-1]), _artifacts(wheels)))
+    sleeps = []
+
+    gate.wait_for_upload_state(
+        tmp_path,
+        gate.DEFAULT_INDEX_URL,
+        Version("1.2.0rc1"),
+        attempts=3,
+        initial_delay=1,
+        max_delay=4,
+        fetcher=lambda _index_url: next(responses),
+        sleeper=sleeps.append,
+    )
+
+    assert sleeps == [1]

--- a/scripts/ci/testpypi_wheel_gate.py
+++ b/scripts/ci/testpypi_wheel_gate.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Validate the core Mooncake pre-release wheel set on disk or TestPyPI."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+from collections.abc import Callable, Iterable
+from pathlib import Path
+from typing import NamedTuple
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+from zipfile import BadZipFile, ZipFile
+
+from packaging.metadata import InvalidMetadata, Metadata
+from packaging.utils import (
+    InvalidSdistFilename,
+    InvalidWheelFilename,
+    canonicalize_name,
+    parse_sdist_filename,
+    parse_wheel_filename,
+)
+from packaging.version import InvalidVersion, Version
+
+CORE_PACKAGES = (
+    "mooncake-transfer-engine",
+    "mooncake-transfer-engine-cuda13",
+    "mooncake-transfer-engine-non-cuda",
+)
+PYTHON_TAGS = ("cp310", "cp311", "cp312", "cp313")
+ARCHITECTURES = ("x86_64", "aarch64")
+DEFAULT_INDEX_URL = "https://test.pypi.org/simple"
+
+WheelTarget = tuple[str, str, str]
+
+
+class IndexedArtifact(NamedTuple):
+    """One artifact advertised by a package's Simple API page."""
+
+    filename: str
+    sha256: str | None
+
+
+ArtifactFetcher = Callable[[str], list[IndexedArtifact]]
+
+
+class GateError(RuntimeError):
+    """A release gate invariant was not satisfied."""
+
+
+def expected_targets() -> set[WheelTarget]:
+    """Return every package/Python/architecture target in the core matrix."""
+    return {
+        (canonicalize_name(package), python_tag, architecture)
+        for package in CORE_PACKAGES
+        for python_tag in PYTHON_TAGS
+        for architecture in ARCHITECTURES
+    }
+
+
+def normalize_prerelease_tag(tag: str) -> Version:
+    """Normalize a public PEP 440 pre-release tag starting with ``v``."""
+    if not tag.startswith("v"):
+        raise GateError(f"pre-release tag must start with v: {tag!r}")
+    try:
+        version = Version(tag[1:])
+    except InvalidVersion as error:
+        raise GateError(f"invalid PEP 440 version in tag {tag!r}: {error}") from error
+    if not version.is_prerelease or version.local is not None:
+        raise GateError(f"tag {tag!r} must identify a public PEP 440 pre-release")
+    return version
+
+
+def _target_from_wheel(filename: str, expected_version: Version) -> WheelTarget:
+    try:
+        package, version, _build, tags = parse_wheel_filename(filename)
+    except InvalidWheelFilename as error:
+        raise GateError(f"invalid wheel filename {filename!r}: {error}") from error
+
+    if str(version) != str(expected_version):
+        raise GateError(
+            f"wheel {filename!r} has version {version}, expected {expected_version}"
+        )
+
+    package = canonicalize_name(package)
+    candidates = {
+        (package, tag.interpreter, architecture)
+        for tag in tags
+        if tag.interpreter in PYTHON_TAGS
+        for architecture in ARCHITECTURES
+        if tag.platform.endswith(f"_{architecture}")
+    }
+    if len(candidates) != 1:
+        raise GateError(
+            f"wheel {filename!r} does not identify exactly one expected "
+            f"Python/architecture target: {sorted(candidates)}"
+        )
+    return candidates.pop()
+
+
+def validate_wheel_set(filenames: Iterable[str], version: Version) -> None:
+    """Require exactly one wheel for each target at ``version``."""
+    files_by_target: dict[WheelTarget, str] = {}
+    for filename in filenames:
+        target = _target_from_wheel(filename, version)
+        if target in files_by_target:
+            raise GateError(
+                f"duplicate wheels for {target}: "
+                f"{files_by_target[target]!r} and {filename!r}"
+            )
+        files_by_target[target] = filename
+
+    actual = set(files_by_target)
+    expected = expected_targets()
+    missing = sorted(expected - actual)
+    unexpected = sorted(actual - expected)
+    if missing or unexpected:
+        details = []
+        if missing:
+            details.append(f"missing targets: {missing}")
+        if unexpected:
+            details.append(f"unexpected targets: {unexpected}")
+        raise GateError("; ".join(details))
+
+
+def _validate_wheel_metadata(path: Path, expected_version: Version) -> None:
+    expected_package = _target_from_wheel(path.name, expected_version)[0]
+    try:
+        with ZipFile(path) as wheel:
+            metadata_files = [
+                name
+                for name in wheel.namelist()
+                if name.endswith(".dist-info/METADATA")
+            ]
+            if len(metadata_files) != 1:
+                raise GateError(
+                    f"wheel {path.name!r} contains {len(metadata_files)} "
+                    ".dist-info/METADATA files, expected exactly one"
+                )
+            metadata = Metadata.from_email(
+                wheel.read(metadata_files[0]), validate=False
+            )
+            metadata_package = canonicalize_name(metadata.name)
+            metadata_version = metadata.version
+    except (BadZipFile, InvalidMetadata, OSError) as error:
+        raise GateError(f"cannot read wheel {path.name!r}: {error}") from error
+
+    if metadata_package != expected_package:
+        raise GateError(
+            f"wheel {path.name!r} has metadata name {metadata.name!r}, "
+            f"expected {expected_package!r}"
+        )
+    if str(metadata_version) != str(expected_version):
+        raise GateError(
+            f"wheel {path.name!r} has metadata version {metadata_version}, "
+            f"expected {expected_version}"
+        )
+
+
+def validate_local(directory: Path, version: Version) -> None:
+    """Validate all wheels collected for publication."""
+    wheels = sorted(directory.glob("*.whl"))
+    if not wheels:
+        raise GateError(f"no wheels found in {directory}")
+    validate_wheel_set((path.name for path in wheels), version)
+    for path in wheels:
+        _validate_wheel_metadata(path, version)
+    print(f"Validated {len(wheels)} local wheels for {version}")
+
+
+def _fetch_package_artifacts(index_url: str, package: str) -> list[IndexedArtifact]:
+    """Read artifact filenames and hashes from a Simple API project page."""
+    project_url = f"{index_url.rstrip('/')}/{canonicalize_name(package)}/"
+    request = Request(
+        project_url,
+        headers={
+            "Accept": "application/vnd.pypi.simple.v1+json",
+            "User-Agent": "Mooncake-TestPyPI-release-gate/1",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.load(response)
+    except HTTPError as error:
+        if error.code == 404:
+            return []
+        raise
+    return [
+        IndexedArtifact(item["filename"], item.get("hashes", {}).get("sha256"))
+        for item in payload.get("files", [])
+    ]
+
+
+def fetch_index_artifacts(index_url: str) -> list[IndexedArtifact]:
+    return [
+        artifact
+        for package in CORE_PACKAGES
+        for artifact in _fetch_package_artifacts(index_url, package)
+    ]
+
+
+def _artifact_version(filename: str) -> Version | None:
+    try:
+        if filename.endswith(".whl"):
+            return parse_wheel_filename(filename)[1]
+        return parse_sdist_filename(filename)[1]
+    except (InvalidSdistFilename, InvalidWheelFilename, InvalidVersion):
+        return None
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as wheel:
+        for chunk in iter(lambda: wheel.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _local_wheel_hashes(directory: Path, version: Version) -> dict[str, str]:
+    validate_local(directory, version)
+    return {path.name: _sha256(path) for path in sorted(directory.glob("*.whl"))}
+
+
+def _indexed_version_artifacts(
+    index_url: str,
+    version: Version,
+    fetcher: ArtifactFetcher,
+) -> dict[str, str | None]:
+    indexed: dict[str, str | None] = {}
+    for artifact in fetcher(index_url):
+        if _artifact_version(artifact.filename) != version:
+            continue
+        if artifact.filename in indexed:
+            raise GateError(f"TestPyPI lists {artifact.filename!r} more than once")
+        indexed[artifact.filename] = artifact.sha256
+    return indexed
+
+
+def _validate_indexed_hashes(
+    local_hashes: dict[str, str],
+    indexed: dict[str, str | None],
+    version: Version,
+    *,
+    require_complete: bool,
+) -> None:
+    """Require every visible artifact to match and optionally require all files."""
+    if require_complete:
+        missing = sorted(set(local_hashes) - set(indexed))
+        if missing:
+            raise GateError(
+                f"TestPyPI is missing {len(missing)} artifacts for {version}: {missing}"
+            )
+
+    for filename, indexed_hash in sorted(indexed.items()):
+        local_hash = local_hashes.get(filename)
+        if local_hash is None:
+            raise GateError(
+                f"TestPyPI contains unexpected artifact {filename!r} for {version}"
+            )
+        if not indexed_hash:
+            raise GateError(
+                f"TestPyPI did not advertise a SHA-256 hash for {filename!r}"
+            )
+        if indexed_hash.lower() != local_hash:
+            raise GateError(
+                f"TestPyPI artifact {filename!r} has SHA-256 {indexed_hash}, "
+                f"but the local wheel has {local_hash}; refusing to mix builds"
+            )
+
+
+def validate_upload_state(
+    directory: Path,
+    version: Version,
+    fetcher: ArtifactFetcher = fetch_index_artifacts,
+    *,
+    index_url: str = DEFAULT_INDEX_URL,
+) -> None:
+    """Allow an empty index or an exact, hash-matching partial upload.
+
+    TestPyPI filenames do not identify build contents. Comparing the hashes
+    advertised by the Simple API prevents a retry from combining wheels from
+    two different builds under one immutable version.
+    """
+    local_hashes = _local_wheel_hashes(directory, version)
+    indexed = _indexed_version_artifacts(index_url, version, fetcher)
+    _validate_indexed_hashes(
+        local_hashes,
+        indexed,
+        version,
+        require_complete=False,
+    )
+
+    if indexed:
+        print(
+            f"Validated {len(indexed)} matching existing TestPyPI artifacts; "
+            "the upload can safely resume"
+        )
+    else:
+        print(f"TestPyPI has no existing core artifacts for {version}")
+
+
+def wait_for_upload_state(
+    directory: Path,
+    index_url: str,
+    version: Version,
+    attempts: int,
+    initial_delay: float,
+    max_delay: float,
+    fetcher: ArtifactFetcher = fetch_index_artifacts,
+    sleeper: Callable[[float], None] = time.sleep,
+) -> None:
+    """Wait until every published wheel is visible with its local SHA-256."""
+    if attempts < 1:
+        raise GateError("attempts must be at least 1")
+
+    local_hashes = _local_wheel_hashes(directory, version)
+    delay = initial_delay
+    last_error: Exception | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            indexed = _indexed_version_artifacts(index_url, version, fetcher)
+            _validate_indexed_hashes(
+                local_hashes,
+                indexed,
+                version,
+                require_complete=True,
+            )
+        except (GateError, OSError) as error:
+            last_error = error
+            if attempt == attempts:
+                break
+            print(
+                "TestPyPI hashes are not ready "
+                f"(attempt {attempt}/{attempts}): {error}; "
+                f"retrying in {delay:g}s",
+                flush=True,
+            )
+            sleeper(delay)
+            delay = min(delay * 2, max_delay)
+        else:
+            print(
+                f"Validated all {len(indexed)} published TestPyPI hashes for {version}"
+            )
+            return
+
+    raise GateError(
+        f"TestPyPI did not expose the complete, hash-matching wheel set for "
+        f"{version} after {attempts} attempts: {last_error}"
+    )
+
+
+def _version(value: str) -> Version:
+    try:
+        return Version(value)
+    except InvalidVersion as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    normalize = subparsers.add_parser("normalize-version")
+    normalize.add_argument("--tag", required=True)
+
+    upload = subparsers.add_parser("validate-upload-state")
+    upload.add_argument("--directory", type=Path, required=True)
+    upload.add_argument("--index-url", default=DEFAULT_INDEX_URL)
+    upload.add_argument("--version", type=_version, required=True)
+
+    wait_upload = subparsers.add_parser("wait-upload-state")
+    wait_upload.add_argument("--directory", type=Path, required=True)
+    wait_upload.add_argument("--index-url", default=DEFAULT_INDEX_URL)
+    wait_upload.add_argument("--version", type=_version, required=True)
+    wait_upload.add_argument("--attempts", type=int, default=8)
+    wait_upload.add_argument("--initial-delay", type=float, default=5)
+    wait_upload.add_argument("--max-delay", type=float, default=30)
+
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "normalize-version":
+            print(normalize_prerelease_tag(args.tag))
+        elif args.command == "validate-upload-state":
+            validate_upload_state(
+                args.directory,
+                args.version,
+                index_url=args.index_url,
+            )
+        elif args.command == "wait-upload-state":
+            wait_for_upload_state(
+                args.directory,
+                args.index_url,
+                args.version,
+                args.attempts,
+                args.initial_delay,
+                args.max_delay,
+            )
+    except GateError as error:
+        print(f"release gate failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Description

Backport #3672 to `release/v0.3.13` so the next pre-release tag publishes the exact wheel matrix to TestPyPI and validates installation and T-one integration before a stable release.

This is a clean cherry-pick of squash commit `d850a2f47ec3ae0121827f12c066016a2ff4b6d7` from the merged source PR.

## Module

- [x] Python Wheel (`mooncake-wheel`)
- [x] CI/CD

## Type of Change

- [x] Other: release-branch backport

## How Has This Been Tested?

**Test commands:**
```bash
uv run --no-project --with pytest --with packaging python -m pytest -q mooncake-wheel/tests/test_testpypi_wheel_gate.py
pre-commit run --files .github/workflows/ci.yml .github/workflows/integration-test.yml .github/workflows/pre-release.yaml mooncake-wheel/tests/test_testpypi_wheel_gate.py scripts/ci/testpypi_wheel_gate.py
actionlint .github/workflows/integration-test.yml .github/workflows/pre-release.yaml
git diff --check origin/release/v0.3.13...HEAD
```

**Test results:**
- [x] Unit tests pass (6 passed)
- [ ] Integration tests pass (requires release infrastructure)
- [ ] Manual testing done

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; exact backport of merged #3672)

## AI Assistance Disclosure

- [x] AI tools were used

Codex assisted with the cherry-pick, validation, and PR preparation. The change itself is an exact backport of the already reviewed and merged #3672.