### PR TITLE
[Store] Allocate client host memory via SPDK hugepages under USE_NOF

### DIFF
--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -14,6 +14,9 @@
 #if defined(USE_ASCEND_DIRECT)
 #include "ascend_allocator.h"
 #endif
+#ifdef USE_NOF
+#include "spdk/spdk_wrapper.h"
+#endif
 
 #ifndef MOONCAKE_SHM_NAME
 #define MOONCAKE_SHM_NAME "mooncake_shm"
@@ -59,6 +62,12 @@ bool ShmHelper::cleanup() {
                 continue;
             }
 #endif
+#ifdef USE_NOF
+            // SPDK DMA buffers are released through the SPDK allocator.
+            SpdkWrapper::GetInstance().Free(shm->base_addr);
+            shm->base_addr = nullptr;
+            continue;
+#endif
             if (munmap(shm->base_addr, shm->size) == -1) {
                 LOG(ERROR) << "Failed to unmap shared memory: "
                            << strerror(errno);
@@ -96,6 +105,24 @@ void* ShmHelper::allocate(size_t size) {
         }
         // ascend_agent_mode && !ascend_use_fabric_mem: fall through to memfd
     }
+#endif
+
+#ifdef USE_NOF
+    // NoF (SPDK DMA) memory: allocate via SPDK hugepage/DMA buffer, which is
+    // required for NVMe-oF transfers to/from this host memory segment.
+    void* spdk_addr =
+        SpdkWrapper::GetInstance().Alloc(size, 0x1000, /*socket_id=*/-1);
+    if (spdk_addr == nullptr) {
+        throw std::runtime_error("Failed to allocate SPDK DMA memory");
+    }
+    auto spdk_shm = std::make_shared<ShmSegment>();
+    spdk_shm->fd = -1;
+    spdk_shm->base_addr = spdk_addr;
+    spdk_shm->size = size;
+    spdk_shm->name = MOONCAKE_SHM_NAME;
+    spdk_shm->registered = false;
+    shms_.push_back(spdk_shm);
+    return spdk_addr;
 #endif
 
     unsigned int flags = MFD_CLOEXEC;
@@ -153,11 +180,18 @@ int ShmHelper::free(void* addr) {
                     free_memory("ascend", (*it)->base_addr);
                 } else
 #endif
-                    if (munmap((*it)->base_addr, (*it)->size) == -1) {
+#ifdef USE_NOF
+                {
+                    // SPDK DMA buffers are released through the SPDK allocator.
+                    SpdkWrapper::GetInstance().Free((*it)->base_addr);
+                }
+#else
+                if (munmap((*it)->base_addr, (*it)->size) == -1) {
                     LOG(ERROR) << "Failed to unmap shared memory during free: "
                                << strerror(errno);
                     return -1;
                 }
+#endif
             }
             LOG(INFO) << "Freed shared memory at " << addr
                       << ", size: " << (*it)->size;
@@ -182,3 +216,4 @@ std::shared_ptr<ShmHelper::ShmSegment> ShmHelper::get_shm(void* addr) {
 }
 
 }  // namespace mooncake
+

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -216,4 +216,3 @@ std::shared_ptr<ShmHelper::ShmSegment> ShmHelper::get_shm(void* addr) {
 }
 
 }  // namespace mooncake
-


### PR DESCRIPTION
## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## Why

In a USE_NOF build, client host memory segments allocated by
`MooncakeHostMemAllocator` (ShmHelper) must be DMA-safe for NVMe-oF
transfers. The previous memfd+mmap path produced plain kernel pages that
SPDK cannot use as NVMe-oF data buffers. NOF now falls back to SPDK
hugepage allocation for these segments.

## What changed

- `ShmHelper::allocate()`: under `USE_NOF`, allocate via
  `SpdkWrapper::GetInstance().Alloc(size, 0x1000, -1)` and record the
  segment with `fd = -1`.
- `ShmHelper::cleanup()` / `free()`: release such segments via
  `SpdkWrapper::GetInstance().Free()`, with correct interaction with the
  existing `USE_ASCEND_DIRECT` fabric (VMM) path.

## Boundaries

- Only active under `USE_NOF`; the memfd+mmap path is untouched
  otherwise.
- Ascend fabric (VMM) allocation keeps precedence.
- SPDK environment init is still performed by the caller, matching
  `memory_alloc.cpp`.