### PR TITLE
[feat]Add observe-only segment admission controller

### DIFF
--- a/mooncake-store/include/master_config.h
+++ b/mooncake-store/include/master_config.h
@@ -3,10 +3,12 @@
 #include <optional>
 #include <stdexcept>
 #include <string_view>
+#include <utility>
 
 #include <glog/logging.h>
 
 #include "config_helper.h"
+#include "segment_admission_config.h"
 #include "types.h"
 
 namespace mooncake {
@@ -68,6 +70,19 @@ struct MasterConfig {
     int64_t global_file_segment_size;
     std::string memory_allocator;
     std::string allocation_strategy;
+
+    // Volatile admission state for mounted memory segments. PR1 evaluates
+    // decisions in observe mode without changing allocation results.
+    std::string segment_write_admission_mode = "observe";
+    uint64_t segment_ramp_up_duration_sec = 60;
+    double segment_ramp_initial_ratio = 0.05;
+    uint64_t segment_ramp_min_successful_remote_writes = 16;
+    uint64_t segment_max_inflight_remote_write_ops = 64;
+    uint64_t segment_max_inflight_remote_write_bytes = 0;
+    uint64_t segment_failure_window_sec = 5;
+    uint64_t segment_failure_threshold = 3;
+    uint64_t segment_quarantine_duration_sec = 10;
+    uint64_t segment_result_retention_sec = 30;
 
     // HTTP metadata server configuration
     bool enable_http_metadata_server;
@@ -211,6 +226,7 @@ class MasterServiceSupervisorConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     AllocationStrategyType allocation_strategy_type =
         AllocationStrategyType::RANDOM;
+    SegmentAdmissionConfig segment_admission_config;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
@@ -378,6 +394,17 @@ class MasterServiceSupervisorConfig {
             allocation_strategy_type = AllocationStrategyType::RANDOM;
         }
 
+        segment_admission_config = BuildSegmentAdmissionConfig(
+            config.segment_write_admission_mode,
+            config.segment_ramp_up_duration_sec,
+            config.segment_ramp_initial_ratio,
+            config.segment_ramp_min_successful_remote_writes,
+            config.segment_max_inflight_remote_write_ops,
+            config.segment_max_inflight_remote_write_bytes,
+            config.segment_failure_window_sec, config.segment_failure_threshold,
+            config.segment_quarantine_duration_sec,
+            config.segment_result_retention_sec);
+
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
         enable_disk_eviction = config.enable_disk_eviction;
@@ -533,6 +560,7 @@ class WrappedMasterServiceConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     AllocationStrategyType allocation_strategy_type =
         AllocationStrategyType::RANDOM;
+    SegmentAdmissionConfig segment_admission_config;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
@@ -663,6 +691,17 @@ class WrappedMasterServiceConfig {
             allocation_strategy_type = AllocationStrategyType::RANDOM;
         }
 
+        segment_admission_config = BuildSegmentAdmissionConfig(
+            config.segment_write_admission_mode,
+            config.segment_ramp_up_duration_sec,
+            config.segment_ramp_initial_ratio,
+            config.segment_ramp_min_successful_remote_writes,
+            config.segment_max_inflight_remote_write_ops,
+            config.segment_max_inflight_remote_write_bytes,
+            config.segment_failure_window_sec, config.segment_failure_threshold,
+            config.segment_quarantine_duration_sec,
+            config.segment_result_retention_sec);
+
         put_start_discard_timeout_sec = config.put_start_discard_timeout_sec;
         put_start_release_timeout_sec = config.put_start_release_timeout_sec;
 
@@ -754,6 +793,7 @@ class WrappedMasterServiceConfig {
         global_file_segment_size = config.global_file_segment_size;
         memory_allocator = config.memory_allocator;
         allocation_strategy_type = config.allocation_strategy_type;
+        segment_admission_config = config.segment_admission_config;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
         enable_multi_tenants = config.enable_multi_tenants;
@@ -823,6 +863,7 @@ class MasterServiceConfigBuilder {
     BufferAllocatorType memory_allocator_ = BufferAllocatorType::OFFSET;
     AllocationStrategyType allocation_strategy_type_ =
         AllocationStrategyType::RANDOM;
+    SegmentAdmissionConfig segment_admission_config_;
     bool enable_disk_eviction_ = true;
     uint64_t quota_bytes_ = 0;
     bool enable_multi_tenants_ = false;
@@ -986,6 +1027,13 @@ class MasterServiceConfigBuilder {
     MasterServiceConfigBuilder& set_allocation_strategy_type(
         AllocationStrategyType type) {
         allocation_strategy_type_ = type;
+        return *this;
+    }
+
+    MasterServiceConfigBuilder& set_segment_admission_config(
+        SegmentAdmissionConfig config) {
+        config.Validate();
+        segment_admission_config_ = std::move(config);
         return *this;
     }
 
@@ -1210,6 +1258,7 @@ class MasterServiceConfig {
     BufferAllocatorType memory_allocator = BufferAllocatorType::OFFSET;
     AllocationStrategyType allocation_strategy_type =
         AllocationStrategyType::RANDOM;
+    SegmentAdmissionConfig segment_admission_config;
     uint64_t put_start_discard_timeout_sec = DEFAULT_PUT_START_DISCARD_TIMEOUT;
     uint64_t put_start_release_timeout_sec = DEFAULT_PUT_START_RELEASE_TIMEOUT;
     bool enable_disk_eviction = true;
@@ -1302,6 +1351,7 @@ class MasterServiceConfig {
         memory_allocator =
             config.enable_cxl ? cxl_allocator_type : config.memory_allocator;
         allocation_strategy_type = config.allocation_strategy_type;
+        segment_admission_config = config.segment_admission_config;
         enable_disk_eviction = config.enable_disk_eviction;
         quota_bytes = config.quota_bytes;
         enable_multi_tenants = config.enable_multi_tenants;
@@ -1370,6 +1420,7 @@ inline MasterServiceConfig MasterServiceConfigBuilder::build() const {
     config.global_file_segment_size = global_file_segment_size_;
     config.memory_allocator = memory_allocator_;
     config.allocation_strategy_type = allocation_strategy_type_;
+    config.segment_admission_config = segment_admission_config_;
     config.put_start_discard_timeout_sec = put_start_discard_timeout_sec_;
     config.put_start_release_timeout_sec = put_start_release_timeout_sec_;
     config.enable_disk_eviction = enable_disk_eviction_;

--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -32,6 +32,14 @@ class MasterMetricManager {
     void inc_total_mem_capacity(const std::string& segment, int64_t val = 1);
     void dec_total_mem_capacity(const std::string& segment, int64_t val = 1);
     void reset_total_mem_capacity();
+    void update_segment_admission_metrics(const std::string& segment,
+                                          int64_t state, double ratio,
+                                          int64_t inflight_ops,
+                                          int64_t inflight_bytes);
+    void remove_segment_admission_metrics(const std::string& segment);
+    void inc_segment_admission_observe_reject(const std::string& segment,
+                                              const std::string& reason,
+                                              int64_t val = 1);
 
     void inc_mem_cache_hit_nums(int64_t val = 1);
     void inc_file_cache_hit_nums(int64_t val = 1);
@@ -553,6 +561,11 @@ class MasterMetricManager {
     ylt::metric::dynamic_gauge_1t
         mem_total_capacity_per_segment_;  // Segment memory capacity update for
                                           // gauge
+    ylt::metric::dynamic_gauge_1t segment_admission_state_;
+    ylt::metric::basic_dynamic_gauge<double, 1> segment_admission_ratio_;
+    ylt::metric::dynamic_gauge_1t segment_inflight_remote_write_ops_;
+    ylt::metric::dynamic_gauge_1t segment_inflight_remote_write_bytes_;
+    ylt::metric::dynamic_counter_2t put_start_admission_observe_rejected_total_;
 
     // NoF Segment Metrics
     ylt::metric::gauge_t

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -34,6 +34,7 @@
 #include "master_metric_manager.h"
 #include "mutex.h"
 #include "segment.h"
+#include "segment_admission_controller.h"
 #include "local_ssd/manager.h"
 #include "tenant_quota_ledger.h"
 #include "tenant_quota_sharded.h"
@@ -342,6 +343,16 @@ class MasterService {
         SegmentStatus status{SegmentStatus::UNDEFINED};
         uint64_t allocator_used_bytes{0};
         uint64_t allocator_capacity_bytes{0};
+        bool admission_tracked{false};
+        std::string admission_mode;
+        std::string admission_state;
+        double admission_ratio{0.0};
+        uint64_t inflight_remote_write_ops{0};
+        uint64_t inflight_remote_write_bytes{0};
+        uint64_t admission_observed_remote_writes{0};
+        uint64_t admission_observed_would_reject{0};
+        int64_t admission_quarantine_remaining_ms{0};
+        int64_t admission_owner_heartbeat_age_ms{0};
     };
 
     /**
@@ -1995,6 +2006,11 @@ class MasterService {
         std::optional<std::chrono::system_clock::time_point>
             committed_soft_pin_timeout = std::nullopt)
         -> tl::expected<std::vector<Replica::Descriptor>, ErrorCode>;
+    void ObserveAllocatedMemoryReplicas(const std::vector<Replica>& replicas,
+                                        const std::string& writer_host_id,
+                                        uint64_t value_length);
+    void PublishSegmentAdmissionSnapshot(
+        const SegmentAdmissionSnapshot& snapshot);
 
     /**
      * @brief Helper to discard expired processing keys.
@@ -2678,6 +2694,7 @@ class MasterService {
     std::unique_ptr<DfsGlobalAllocator> dfs_allocator_;
 
     // Segment management
+    SegmentAdmissionController segment_admission_controller_;
     SegmentManager segment_manager_;
     LocalSsdManager local_ssd_manager_;
     NoFSegmentManager nof_segment_manager_;

--- a/mooncake-store/include/segment_admission_config.h
+++ b/mooncake-store/include/segment_admission_config.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+namespace mooncake {
+
+enum class SegmentWriteAdmissionMode : uint8_t {
+    DISABLED = 0,
+    OBSERVE = 1,
+    ENFORCE = 2,
+};
+
+inline std::string_view ToString(SegmentWriteAdmissionMode mode) noexcept {
+    switch (mode) {
+        case SegmentWriteAdmissionMode::DISABLED:
+            return "disabled";
+        case SegmentWriteAdmissionMode::OBSERVE:
+            return "observe";
+        case SegmentWriteAdmissionMode::ENFORCE:
+            return "enforce";
+    }
+    return "unknown";
+}
+
+inline std::optional<SegmentWriteAdmissionMode> ParseSegmentWriteAdmissionMode(
+    std::string_view value) noexcept {
+    if (value == "disabled") {
+        return SegmentWriteAdmissionMode::DISABLED;
+    }
+    if (value == "observe") {
+        return SegmentWriteAdmissionMode::OBSERVE;
+    }
+    if (value == "enforce") {
+        return SegmentWriteAdmissionMode::ENFORCE;
+    }
+    return std::nullopt;
+}
+
+struct SegmentAdmissionConfig {
+    SegmentWriteAdmissionMode mode{SegmentWriteAdmissionMode::OBSERVE};
+    uint64_t ramp_up_duration_sec{60};
+    double ramp_initial_ratio{0.05};
+    uint64_t ramp_min_successful_remote_writes{16};
+    uint64_t max_inflight_remote_write_ops{64};
+    uint64_t max_inflight_remote_write_bytes{0};
+    uint64_t failure_window_sec{5};
+    uint64_t failure_threshold{3};
+    uint64_t quarantine_duration_sec{10};
+    uint64_t result_retention_sec{30};
+
+    void Validate() const {
+        if (mode != SegmentWriteAdmissionMode::DISABLED &&
+            mode != SegmentWriteAdmissionMode::OBSERVE &&
+            mode != SegmentWriteAdmissionMode::ENFORCE) {
+            throw std::invalid_argument(
+                "segment_write_admission_mode is invalid");
+        }
+        if (ramp_up_duration_sec == 0) {
+            throw std::invalid_argument(
+                "segment_ramp_up_duration_sec must be greater than 0");
+        }
+        if (!std::isfinite(ramp_initial_ratio) || ramp_initial_ratio <= 0.0 ||
+            ramp_initial_ratio > 1.0) {
+            throw std::invalid_argument(
+                "segment_ramp_initial_ratio must be in (0, 1]");
+        }
+        if (failure_window_sec == 0) {
+            throw std::invalid_argument(
+                "segment_failure_window_sec must be greater than 0");
+        }
+        if (failure_threshold == 0) {
+            throw std::invalid_argument(
+                "segment_failure_threshold must be greater than 0");
+        }
+        if (quarantine_duration_sec == 0) {
+            throw std::invalid_argument(
+                "segment_quarantine_duration_sec must be greater than 0");
+        }
+        if (result_retention_sec == 0) {
+            throw std::invalid_argument(
+                "segment_result_retention_sec must be greater than 0");
+        }
+    }
+};
+
+inline SegmentAdmissionConfig BuildSegmentAdmissionConfig(
+    std::string_view mode, uint64_t ramp_up_duration_sec,
+    double ramp_initial_ratio, uint64_t ramp_min_successful_remote_writes,
+    uint64_t max_inflight_remote_write_ops,
+    uint64_t max_inflight_remote_write_bytes, uint64_t failure_window_sec,
+    uint64_t failure_threshold, uint64_t quarantine_duration_sec,
+    uint64_t result_retention_sec) {
+    const auto parsed_mode = ParseSegmentWriteAdmissionMode(mode);
+    if (!parsed_mode) {
+        throw std::invalid_argument(
+            "segment_write_admission_mode must be disabled, observe, or "
+            "enforce");
+    }
+    SegmentAdmissionConfig config{
+        .mode = *parsed_mode,
+        .ramp_up_duration_sec = ramp_up_duration_sec,
+        .ramp_initial_ratio = ramp_initial_ratio,
+        .ramp_min_successful_remote_writes = ramp_min_successful_remote_writes,
+        .max_inflight_remote_write_ops = max_inflight_remote_write_ops,
+        .max_inflight_remote_write_bytes = max_inflight_remote_write_bytes,
+        .failure_window_sec = failure_window_sec,
+        .failure_threshold = failure_threshold,
+        .quarantine_duration_sec = quarantine_duration_sec,
+        .result_retention_sec = result_retention_sec,
+    };
+    config.Validate();
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/include/segment_admission_controller.h
+++ b/mooncake-store/include/segment_admission_controller.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <boost/functional/hash.hpp>
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "segment_admission_config.h"
+#include "types.h"
+
+namespace mooncake {
+
+enum class SegmentAdmissionState : uint8_t {
+    RAMPING = 0,
+    ACTIVE = 1,
+    QUARANTINED = 2,
+};
+
+std::string_view ToString(SegmentAdmissionState state) noexcept;
+int64_t SegmentAdmissionStateMetricValue(SegmentAdmissionState state) noexcept;
+
+enum class SegmentAdmissionRejectReason : uint8_t {
+    NONE = 0,
+    QUARANTINED,
+    INFLIGHT_OP_LIMIT,
+    INFLIGHT_BYTE_LIMIT,
+};
+
+std::string_view ToString(SegmentAdmissionRejectReason reason) noexcept;
+
+class SegmentAdmissionClock {
+   public:
+    using TimePoint = std::chrono::steady_clock::time_point;
+
+    virtual ~SegmentAdmissionClock() = default;
+    virtual TimePoint Now() const = 0;
+};
+
+class SteadySegmentAdmissionClock final : public SegmentAdmissionClock {
+   public:
+    TimePoint Now() const override { return std::chrono::steady_clock::now(); }
+};
+
+struct SegmentAdmissionSnapshot {
+    UUID segment_id{0, 0};
+    UUID owner_client_id{0, 0};
+    std::string segment_name;
+    std::string segment_host_id;
+    SegmentAdmissionState state{SegmentAdmissionState::RAMPING};
+    double effective_ratio{0.0};
+    uint64_t inflight_remote_write_ops{0};
+    uint64_t inflight_remote_write_bytes{0};
+    uint64_t successful_remote_writes_in_ramp{0};
+    uint64_t recent_failures{0};
+    uint64_t observed_remote_writes{0};
+    uint64_t observed_would_reject{0};
+    int64_t quarantine_remaining_ms{0};
+    int64_t owner_heartbeat_age_ms{0};
+};
+
+struct SegmentAdmissionObservation {
+    bool would_admit{true};
+    SegmentAdmissionRejectReason reason{SegmentAdmissionRejectReason::NONE};
+    SegmentAdmissionSnapshot snapshot;
+};
+
+// Owns the volatile admission state of mounted memory segments. PR1 only
+// observes decisions: callers may inspect would_admit, but must not use it to
+// alter placement until the reservation/result-reporting path is introduced.
+class SegmentAdmissionController {
+   public:
+    explicit SegmentAdmissionController(
+        SegmentAdmissionConfig config = {},
+        std::shared_ptr<SegmentAdmissionClock> clock =
+            std::make_shared<SteadySegmentAdmissionClock>());
+
+    SegmentWriteAdmissionMode mode() const noexcept { return config_.mode; }
+    const SegmentAdmissionConfig& config() const noexcept { return config_; }
+
+    std::optional<SegmentAdmissionSnapshot> OnMount(
+        const Segment& segment, const UUID& owner_client_id,
+        bool restored_active = false);
+    std::vector<SegmentAdmissionSnapshot> OnOwnerHeartbeat(
+        const UUID& owner_client_id);
+    std::optional<SegmentAdmissionSnapshot> OnUnmount(const UUID& segment_id);
+
+    // These result hooks are intentionally controller-local in PR1. They make
+    // the state machine testable and are wired to client reports in a later PR.
+    std::optional<SegmentAdmissionSnapshot> RecordRemoteWriteSuccess(
+        const UUID& segment_id);
+    std::optional<SegmentAdmissionSnapshot> RecordRemoteWriteFailure(
+        const UUID& segment_id);
+
+    SegmentAdmissionObservation ObserveRemoteWrite(
+        const std::string& segment_name, const std::string& writer_host_id,
+        uint64_t bytes);
+
+    std::optional<SegmentAdmissionSnapshot> GetSnapshot(const UUID& segment_id);
+    std::vector<SegmentAdmissionSnapshot> GetSnapshots();
+    size_t size() const;
+
+   private:
+    struct Runtime {
+        UUID segment_id{0, 0};
+        UUID owner_client_id{0, 0};
+        std::string segment_name;
+        std::string segment_host_id;
+        uint64_t segment_capacity_bytes{0};
+        SegmentAdmissionState state{SegmentAdmissionState::RAMPING};
+        SegmentAdmissionClock::TimePoint state_since{};
+        SegmentAdmissionClock::TimePoint quarantine_until{};
+        SegmentAdmissionClock::TimePoint last_owner_heartbeat{};
+        uint64_t inflight_remote_write_ops{0};
+        uint64_t inflight_remote_write_bytes{0};
+        uint64_t successful_remote_writes_in_ramp{0};
+        std::deque<SegmentAdmissionClock::TimePoint> recent_failures;
+        uint64_t observed_remote_writes{0};
+        uint64_t observed_would_reject{0};
+    };
+
+    double EffectiveRatioLocked(
+        const Runtime& runtime,
+        SegmentAdmissionClock::TimePoint now) const noexcept;
+    uint64_t FullByteLimitLocked(const Runtime& runtime) const noexcept;
+    uint64_t EffectiveByteLimitLocked(const Runtime& runtime,
+                                      double ratio) const noexcept;
+    uint64_t EffectiveOpLimitLocked(double ratio) const noexcept;
+    void AdvanceStateLocked(Runtime& runtime,
+                            SegmentAdmissionClock::TimePoint now);
+    void PruneFailuresLocked(Runtime& runtime,
+                             SegmentAdmissionClock::TimePoint now) const;
+    SegmentAdmissionSnapshot SnapshotLocked(
+        const Runtime& runtime, SegmentAdmissionClock::TimePoint now) const;
+    void LogTransitionLocked(const Runtime& runtime,
+                             SegmentAdmissionState old_state,
+                             std::string_view reason,
+                             SegmentAdmissionClock::TimePoint now) const;
+
+    SegmentAdmissionConfig config_;
+    std::shared_ptr<SegmentAdmissionClock> clock_;
+    mutable std::mutex mutex_;
+    std::unordered_map<UUID, Runtime, boost::hash<UUID>> runtimes_;
+    std::unordered_map<std::string, UUID> segment_name_index_;
+    std::unordered_map<UUID, std::unordered_set<UUID, boost::hash<UUID>>,
+                       boost::hash<UUID>>
+        owner_segments_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     master_snapshot_repository.cpp
     master_metric_manager.cpp
     segment.cpp
+    segment_admission_controller.cpp
     tenant_quota.cpp
     tenant_quota_ledger.cpp
     tenant_quota_policy_store.cpp

--- a/mooncake-store/src/master.cpp
+++ b/mooncake-store/src/master.cpp
@@ -323,6 +323,32 @@ DEFINE_string(
     allocation_strategy, "random",
     "Allocation strategy for segments, random | free_ratio_first | cxl | "
     "ssd_free_ratio_first | local_first");
+DEFINE_string(segment_write_admission_mode, "observe",
+              "Memory segment write admission mode: disabled, observe, or "
+              "enforce. PR1 records decisions only and never changes "
+              "placement");
+DEFINE_uint64(segment_ramp_up_duration_sec, 60,
+              "Minimum seconds for a new memory segment to ramp to full "
+              "remote-write budget");
+DEFINE_double(segment_ramp_initial_ratio, 0.05,
+              "Initial remote-write budget ratio for a ramping segment");
+DEFINE_uint64(segment_ramp_min_successful_remote_writes, 16,
+              "Successful remote writes required to finish segment ramp-up");
+DEFINE_uint64(segment_max_inflight_remote_write_ops, 64,
+              "Full-state per-segment remote-write operation budget; 0 "
+              "disables the operation limit");
+DEFINE_uint64(segment_max_inflight_remote_write_bytes, 0,
+              "Full-state per-segment remote-write byte budget; 0 derives "
+              "the budget from segment capacity");
+DEFINE_uint64(segment_failure_window_sec, 5,
+              "Sliding window in seconds for remote-write failures");
+DEFINE_uint64(segment_failure_threshold, 3,
+              "Failures in the sliding window required to quarantine a "
+              "segment");
+DEFINE_uint64(segment_quarantine_duration_sec, 10,
+              "Minimum segment quarantine duration in seconds");
+DEFINE_uint64(segment_result_retention_sec, 30,
+              "Retention in seconds for completed admission reservations");
 DEFINE_bool(enable_http_metadata_server, false,
             "Enable HTTP metadata server instead of etcd");
 DEFINE_int32(http_metadata_server_port, 8080,
@@ -631,6 +657,39 @@ void InitMasterConf(const mooncake::DefaultConfig& default_config,
     default_config.GetString("allocation_strategy",
                              &master_config.allocation_strategy,
                              FLAGS_allocation_strategy);
+    default_config.GetString("segment_write_admission_mode",
+                             &master_config.segment_write_admission_mode,
+                             FLAGS_segment_write_admission_mode);
+    default_config.GetUInt64("segment_ramp_up_duration_sec",
+                             &master_config.segment_ramp_up_duration_sec,
+                             FLAGS_segment_ramp_up_duration_sec);
+    default_config.GetDouble("segment_ramp_initial_ratio",
+                             &master_config.segment_ramp_initial_ratio,
+                             FLAGS_segment_ramp_initial_ratio);
+    default_config.GetUInt64(
+        "segment_ramp_min_successful_remote_writes",
+        &master_config.segment_ramp_min_successful_remote_writes,
+        FLAGS_segment_ramp_min_successful_remote_writes);
+    default_config.GetUInt64(
+        "segment_max_inflight_remote_write_ops",
+        &master_config.segment_max_inflight_remote_write_ops,
+        FLAGS_segment_max_inflight_remote_write_ops);
+    default_config.GetUInt64(
+        "segment_max_inflight_remote_write_bytes",
+        &master_config.segment_max_inflight_remote_write_bytes,
+        FLAGS_segment_max_inflight_remote_write_bytes);
+    default_config.GetUInt64("segment_failure_window_sec",
+                             &master_config.segment_failure_window_sec,
+                             FLAGS_segment_failure_window_sec);
+    default_config.GetUInt64("segment_failure_threshold",
+                             &master_config.segment_failure_threshold,
+                             FLAGS_segment_failure_threshold);
+    default_config.GetUInt64("segment_quarantine_duration_sec",
+                             &master_config.segment_quarantine_duration_sec,
+                             FLAGS_segment_quarantine_duration_sec);
+    default_config.GetUInt64("segment_result_retention_sec",
+                             &master_config.segment_result_retention_sec,
+                             FLAGS_segment_result_retention_sec);
     default_config.GetBool("enable_http_metadata_server",
                            &master_config.enable_http_metadata_server,
                            FLAGS_enable_http_metadata_server);
@@ -1143,6 +1202,73 @@ void LoadConfigFromCmdline(mooncake::MasterConfig& master_config,
          !info.is_default) ||
         !conf_set) {
         master_config.allocation_strategy = FLAGS_allocation_strategy;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_write_admission_mode",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_write_admission_mode =
+            FLAGS_segment_write_admission_mode;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_ramp_up_duration_sec",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_ramp_up_duration_sec =
+            FLAGS_segment_ramp_up_duration_sec;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_ramp_initial_ratio", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_ramp_initial_ratio =
+            FLAGS_segment_ramp_initial_ratio;
+    }
+    if ((google::GetCommandLineFlagInfo(
+             "segment_ramp_min_successful_remote_writes", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_ramp_min_successful_remote_writes =
+            FLAGS_segment_ramp_min_successful_remote_writes;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_max_inflight_remote_write_ops",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_max_inflight_remote_write_ops =
+            FLAGS_segment_max_inflight_remote_write_ops;
+    }
+    if ((google::GetCommandLineFlagInfo(
+             "segment_max_inflight_remote_write_bytes", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_max_inflight_remote_write_bytes =
+            FLAGS_segment_max_inflight_remote_write_bytes;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_failure_window_sec", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_failure_window_sec =
+            FLAGS_segment_failure_window_sec;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_failure_threshold", &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_failure_threshold =
+            FLAGS_segment_failure_threshold;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_quarantine_duration_sec",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_quarantine_duration_sec =
+            FLAGS_segment_quarantine_duration_sec;
+    }
+    if ((google::GetCommandLineFlagInfo("segment_result_retention_sec",
+                                        &info) &&
+         !info.is_default) ||
+        !conf_set) {
+        master_config.segment_result_retention_sec =
+            FLAGS_segment_result_retention_sec;
     }
     if ((google::GetCommandLineFlagInfo("enable_http_metadata_server", &info) &&
          !info.is_default) ||

--- a/mooncake-store/src/master_admin_service.cpp
+++ b/mooncake-store/src/master_admin_service.cpp
@@ -698,11 +698,25 @@ struct HttpSegmentDetailItem {
     uint64_t allocator_used_bytes{0};
     uint64_t allocator_capacity_bytes{0};
     double allocator_usage_percent{0.0};
+    bool admission_tracked{false};
+    std::string admission_mode;
+    std::string admission_state;
+    double admission_ratio{0.0};
+    uint64_t inflight_remote_write_ops{0};
+    uint64_t inflight_remote_write_bytes{0};
+    uint64_t admission_observed_remote_writes{0};
+    uint64_t admission_observed_would_reject{0};
+    int64_t admission_quarantine_remaining_ms{0};
+    int64_t admission_owner_heartbeat_age_ms{0};
 };
 YLT_REFL(HttpSegmentDetailItem, segment_name, segment_id, client_id,
          base_address, size_bytes, size_human, te_endpoint, protocol, status,
          allocator_used_bytes, allocator_capacity_bytes,
-         allocator_usage_percent);
+         allocator_usage_percent, admission_tracked, admission_mode,
+         admission_state, admission_ratio, inflight_remote_write_ops,
+         inflight_remote_write_bytes, admission_observed_remote_writes,
+         admission_observed_would_reject, admission_quarantine_remaining_ms,
+         admission_owner_heartbeat_age_ms);
 
 struct HttpSegmentsDetailResponse {
     uint64_t total_segments{0};
@@ -748,6 +762,20 @@ void MasterAdminServer::HandleGetSegmentsDetail(
                     ? (static_cast<double>(info.allocator_used_bytes) /
                        info.allocator_capacity_bytes * 100.0)
                     : 0.0;
+            item.admission_tracked = info.admission_tracked;
+            item.admission_mode = info.admission_mode;
+            item.admission_state = info.admission_state;
+            item.admission_ratio = info.admission_ratio;
+            item.inflight_remote_write_ops = info.inflight_remote_write_ops;
+            item.inflight_remote_write_bytes = info.inflight_remote_write_bytes;
+            item.admission_observed_remote_writes =
+                info.admission_observed_remote_writes;
+            item.admission_observed_would_reject =
+                info.admission_observed_would_reject;
+            item.admission_quarantine_remaining_ms =
+                info.admission_quarantine_remaining_ms;
+            item.admission_owner_heartbeat_age_ms =
+                info.admission_owner_heartbeat_age_ms;
             payload.segments.push_back(std::move(item));
         }
         WriteJsonResponse(resp, coro_http::status_type::ok, payload);

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -2396,7 +2396,7 @@ std::string MasterMetricManager::get_summary_string(
         }
     }
 
-    auto delta = [&](int64_t SummaryCounters::*field) {
+    auto delta = [&](int64_t SummaryCounters::* field) {
         if (!has_previous_summary) {
             return int64_t{0};
         }

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -33,6 +33,26 @@ MasterMetricManager::MasterMetricManager()
       mem_total_capacity_per_segment_(
           "segment_total_capacity_bytes",
           "Total memory capacity of the mounted segment", {"segment"}),
+      segment_admission_state_(
+          "mooncake_segment_admission_state",
+          "Memory segment admission state: 0=RAMPING, 1=ACTIVE, "
+          "2=QUARANTINED",
+          {"segment"}),
+      segment_admission_ratio_(
+          "mooncake_segment_admission_ratio",
+          "Effective memory segment remote-write admission ratio", {"segment"}),
+      segment_inflight_remote_write_ops_(
+          "mooncake_segment_inflight_remote_write_ops",
+          "Current in-flight remote-write operations for the memory segment",
+          {"segment"}),
+      segment_inflight_remote_write_bytes_(
+          "mooncake_segment_inflight_remote_write_bytes",
+          "Current in-flight remote-write bytes for the memory segment",
+          {"segment"}),
+      put_start_admission_observe_rejected_total_(
+          "mooncake_put_start_admission_observe_rejected_total",
+          "PutStart targets that admission would reject in observe mode",
+          {"segment", "reason"}),
       nof_allocated_size_(
           "master_nof_allocated_bytes",
           "Total nof ssd bytes currently allocated across all segments"),
@@ -706,6 +726,33 @@ int64_t MasterMetricManager::get_segment_total_mem_capacity(
 void MasterMetricManager::remove_segment_metrics(const std::string& segment) {
     mem_allocated_size_per_segment_.remove_label_value({{"segment", segment}});
     mem_total_capacity_per_segment_.remove_label_value({{"segment", segment}});
+}
+
+void MasterMetricManager::update_segment_admission_metrics(
+    const std::string& segment, int64_t state, double ratio,
+    int64_t inflight_ops, int64_t inflight_bytes) {
+    if (segment.empty()) {
+        return;
+    }
+    segment_admission_state_.update({segment}, state);
+    segment_admission_ratio_.update({segment}, ratio);
+    segment_inflight_remote_write_ops_.update({segment}, inflight_ops);
+    segment_inflight_remote_write_bytes_.update({segment}, inflight_bytes);
+}
+
+void MasterMetricManager::remove_segment_admission_metrics(
+    const std::string& segment) {
+    segment_admission_state_.remove_label_value({{"segment", segment}});
+    segment_admission_ratio_.remove_label_value({{"segment", segment}});
+    segment_inflight_remote_write_ops_.remove_label_value(
+        {{"segment", segment}});
+    segment_inflight_remote_write_bytes_.remove_label_value(
+        {{"segment", segment}});
+}
+
+void MasterMetricManager::inc_segment_admission_observe_reject(
+    const std::string& segment, const std::string& reason, int64_t val) {
+    put_start_admission_observe_rejected_total_.inc({segment, reason}, val);
 }
 
 // NoF segment Metrics
@@ -1818,6 +1865,11 @@ std::string MasterMetricManager::serialize_metrics() {
     serialize_metric(mem_total_capacity_);
     serialize_metric(mem_allocated_size_per_segment_);
     serialize_metric(mem_total_capacity_per_segment_);
+    serialize_metric(segment_admission_state_);
+    serialize_metric(segment_admission_ratio_);
+    serialize_metric(segment_inflight_remote_write_ops_);
+    serialize_metric(segment_inflight_remote_write_bytes_);
+    serialize_metric(put_start_admission_observe_rejected_total_);
     serialize_metric(nof_allocated_size_);
     serialize_metric(nof_total_capacity_);
     serialize_metric(nof_allocated_size_per_segment_);
@@ -2344,7 +2396,7 @@ std::string MasterMetricManager::get_summary_string(
         }
     }
 
-    auto delta = [&](int64_t SummaryCounters::* field) {
+    auto delta = [&](int64_t SummaryCounters::*field) {
         if (!has_previous_summary) {
             return int64_t{0};
         }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -211,6 +211,7 @@ MasterService::MasterService(const MasterServiceConfig& config)
       enable_disk_eviction_(config.enable_disk_eviction),
       quota_bytes_(config.quota_bytes),
       enable_multi_tenants_(config.enable_multi_tenants),
+      segment_admission_controller_(config.segment_admission_config),
       segment_manager_(config.memory_allocator, config.enable_cxl),
       nof_segment_manager_(config.memory_allocator),
       memory_allocator_type_(config.memory_allocator),
@@ -230,6 +231,15 @@ MasterService::MasterService(const MasterServiceConfig& config)
               return std::make_unique<OrderedOpLogWriter>(
                   std::move(writer_config), std::move(write_batch));
           }) {
+    LOG(INFO) << "segment_write_admission_mode="
+              << ToString(segment_admission_controller_.mode())
+              << ", action=initialize_segment_admission_controller";
+    if (segment_admission_controller_.mode() ==
+        SegmentWriteAdmissionMode::ENFORCE) {
+        LOG(WARNING) << "segment_write_admission_mode=enforce was configured, "
+                        "but PR1 is observe-only; allocation results will not "
+                        "be changed";
+    }
     if (default_kv_soft_pin_ttl_ > max_kv_soft_pin_ttl_) {
         LOG(ERROR) << "Invalid soft-pin TTL configuration: default="
                    << default_kv_soft_pin_ttl_
@@ -283,6 +293,22 @@ MasterService::MasterService(const MasterServiceConfig& config)
 
     if (config.enable_snapshot_restore) {
         RestoreState();
+        std::vector<std::pair<Segment, UUID>> restored_segments;
+        {
+            auto segment_access = segment_manager_.getSegmentAccess();
+            if (segment_access.GetAllSegments(restored_segments) !=
+                ErrorCode::OK) {
+                throw std::runtime_error(
+                    "Failed to initialize admission state for restored "
+                    "segments");
+            }
+        }
+        for (const auto& [segment, owner_client_id] : restored_segments) {
+            if (auto snapshot = segment_admission_controller_.OnMount(
+                    segment, owner_client_id, true)) {
+                PublishSegmentAdmissionSnapshot(*snapshot);
+            }
+        }
     }
     if (enable_multi_tenants_) {
         LoadTenantQuotaPoliciesFromStoreOrThrow();
@@ -692,6 +718,10 @@ MasterService::~MasterService() {
             segment, static_cast<int64_t>(bytes));
         MasterMetricManager::instance().remove_segment_metrics(segment);
     }
+    for (const auto& admission : segment_admission_controller_.GetSnapshots()) {
+        MasterMetricManager::instance().remove_segment_admission_metrics(
+            admission.segment_name);
+    }
 
     // Segments still mounted here never went through CommitUnmountSegment;
     // release their capacity contribution so the process-lifetime
@@ -927,6 +957,12 @@ auto MasterService::MountSegment(const Segment& segment, const UUID& client_id)
                                        std::string(bytes.begin(), bytes.end()));
     }
     UpdateClientHostId(client_id, segment.host_id);
+    if (mount_result == ErrorCode::OK) {
+        if (auto snapshot =
+                segment_admission_controller_.OnMount(segment, client_id)) {
+            PublishSegmentAdmissionSnapshot(*snapshot);
+        }
+    }
     if (mount_result == ErrorCode::OK) {
         RecomputeTenantEffectiveQuotas();
     }
@@ -1264,6 +1300,12 @@ auto MasterService::ReMountSegment(const std::vector<Segment>& segments,
         // Change the client status to OK
         ok_client_.insert(client_id);
         MasterMetricManager::instance().inc_active_clients();
+        for (size_t i = 0; i < segments.size(); ++i) {
+            if (auto snapshot = segment_admission_controller_.OnMount(
+                    segments[i], client_id, segment_existed[i])) {
+                PublishSegmentAdmissionSnapshot(*snapshot);
+            }
+        }
     }
 
     if (enable_oplog_ && ordered_oplog_writer_) {
@@ -1328,6 +1370,48 @@ std::string MasterService::GetClientHostId(const UUID& client_id) const {
     std::shared_lock<std::shared_mutex> lock(client_mutex_);
     auto it = client_host_id_.find(client_id);
     return it == client_host_id_.end() ? std::string() : it->second;
+}
+
+void MasterService::PublishSegmentAdmissionSnapshot(
+    const SegmentAdmissionSnapshot& snapshot) {
+    MasterMetricManager::instance().update_segment_admission_metrics(
+        snapshot.segment_name, SegmentAdmissionStateMetricValue(snapshot.state),
+        snapshot.effective_ratio,
+        static_cast<int64_t>(snapshot.inflight_remote_write_ops),
+        static_cast<int64_t>(snapshot.inflight_remote_write_bytes));
+}
+
+void MasterService::ObserveAllocatedMemoryReplicas(
+    const std::vector<Replica>& replicas, const std::string& writer_host_id,
+    uint64_t value_length) {
+    if (segment_admission_controller_.mode() ==
+        SegmentWriteAdmissionMode::DISABLED) {
+        return;
+    }
+    for (const auto& replica : replicas) {
+        if (!replica.is_memory_replica()) {
+            continue;
+        }
+        for (const auto& segment_name : replica.get_segment_names()) {
+            if (!segment_name) {
+                continue;
+            }
+            auto observation = segment_admission_controller_.ObserveRemoteWrite(
+                *segment_name, writer_host_id, value_length);
+            PublishSegmentAdmissionSnapshot(observation.snapshot);
+            if (!observation.would_admit) {
+                MasterMetricManager::instance()
+                    .inc_segment_admission_observe_reject(
+                        *segment_name,
+                        std::string(ToString(observation.reason)));
+                VLOG(1) << "segment_name=" << *segment_name
+                        << ", writer_host_id=" << writer_host_id
+                        << ", value_length=" << value_length
+                        << ", admission_reason=" << ToString(observation.reason)
+                        << ", action=observe_segment_admission_reject";
+            }
+        }
+    }
 }
 
 size_t MasterService::getMetadataShardIndex(const TenantId& tenant_id,
@@ -2636,6 +2720,11 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
             segment_id, metrics_dec_capacity);
         if (err == ErrorCode::SEGMENT_NOT_FOUND) {
             // Return OK because this is an idempotent operation
+            if (auto removed =
+                    segment_admission_controller_.OnUnmount(segment_id)) {
+                MasterMetricManager::instance()
+                    .remove_segment_admission_metrics(removed->segment_name);
+            }
             return {};
         }
         if (err != ErrorCode::OK) {
@@ -2677,6 +2766,10 @@ auto MasterService::UnmountSegment(const UUID& segment_id,
         PersistSegmentOpForHAOrEnqueue("UnmountSegment",
                                        OpType::SEGMENT_UNMOUNT, te_endpoint,
                                        std::string(bytes.begin(), bytes.end()));
+    }
+    if (auto removed = segment_admission_controller_.OnUnmount(segment_id)) {
+        MasterMetricManager::instance().remove_segment_admission_metrics(
+            removed->segment_name);
     }
     RecomputeTenantEffectiveQuotas();
     return {};
@@ -2947,6 +3040,30 @@ auto MasterService::GetSegmentsDetail()
         segment_access.QuerySegments(segment.name, used, capacity);
         info.allocator_used_bytes = used;
         info.allocator_capacity_bytes = capacity;
+
+        info.admission_mode =
+            std::string(ToString(segment_admission_controller_.mode()));
+        if (auto admission =
+                segment_admission_controller_.GetSnapshot(segment.id)) {
+            info.admission_tracked = true;
+            info.admission_state = std::string(ToString(admission->state));
+            info.admission_ratio = admission->effective_ratio;
+            info.inflight_remote_write_ops =
+                admission->inflight_remote_write_ops;
+            info.inflight_remote_write_bytes =
+                admission->inflight_remote_write_bytes;
+            info.admission_observed_remote_writes =
+                admission->observed_remote_writes;
+            info.admission_observed_would_reject =
+                admission->observed_would_reject;
+            info.admission_quarantine_remaining_ms =
+                admission->quarantine_remaining_ms;
+            info.admission_owner_heartbeat_age_ms =
+                admission->owner_heartbeat_age_ms;
+            PublishSegmentAdmissionSnapshot(*admission);
+        } else {
+            info.admission_state = "UNTRACKED";
+        }
 
         result.push_back(std::move(info));
     }
@@ -4196,6 +4313,10 @@ auto MasterService::AllocateAndInsertMetadata(
                      << ", requested_nof_replicas=" << config.nof_replica_num
                      << ", allocated_nof_replicas=" << allocated_nof_replicas;
     }
+
+    // Evaluate the targets selected by the existing allocation strategy. PR1
+    // only emits state/metrics and never feeds this result back into placement.
+    ObserveAllocatedMemoryReplicas(replicas, writer_host_id, value_length);
 
     if (use_disk_replica_) {
         std::string file_path =
@@ -11027,6 +11148,10 @@ void MasterService::ClientMonitorFunc() {
             UUID client_id = {pod_client_id.first, pod_client_id.second};
             client_ttl[client_id] =
                 now + std::chrono::seconds(client_live_ttl_sec_);
+            for (const auto& snapshot :
+                 segment_admission_controller_.OnOwnerHeartbeat(client_id)) {
+                PublishSegmentAdmissionSnapshot(snapshot);
+            }
         }
 
         // Find out expired clients
@@ -11114,8 +11239,19 @@ void MasterService::ClientMonitorFunc() {
                 ScopedSegmentAccess segment_access =
                     segment_manager_.getSegmentAccess();
                 for (size_t i = 0; i < unmount_segments.size(); i++) {
-                    segment_access.CommitUnmountSegment(
-                        unmount_segments[i], client_ids[i], dec_capacities[i]);
+                    const auto commit_result =
+                        segment_access.CommitUnmountSegment(unmount_segments[i],
+                                                            client_ids[i],
+                                                            dec_capacities[i]);
+                    if (commit_result == ErrorCode::OK) {
+                        if (auto removed =
+                                segment_admission_controller_.OnUnmount(
+                                    unmount_segments[i])) {
+                            MasterMetricManager::instance()
+                                .remove_segment_admission_metrics(
+                                    removed->segment_name);
+                        }
+                    }
                     LOG(INFO) << "client_id=" << client_ids[i]
                               << ", segment_name=" << segment_names[i]
                               << ", action=unmount_expired_mem_segment";

--- a/mooncake-store/src/segment_admission_controller.cpp
+++ b/mooncake-store/src/segment_admission_controller.cpp
@@ -1,0 +1,462 @@
+#include "segment_admission_controller.h"
+
+#include <glog/logging.h>
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace mooncake {
+namespace {
+
+constexpr uint64_t kMiB = 1024ULL * 1024ULL;
+constexpr uint64_t kMinAutoByteLimit = 64ULL * kMiB;
+constexpr uint64_t kMaxAutoByteLimit = 1024ULL * kMiB;
+
+uint64_t ScaleLimit(uint64_t limit, double ratio) noexcept {
+    if (limit == 0) {
+        return 0;
+    }
+    return std::max<uint64_t>(1, static_cast<uint64_t>(std::floor(
+                                     static_cast<long double>(limit) * ratio)));
+}
+
+}  // namespace
+
+std::string_view ToString(SegmentAdmissionState state) noexcept {
+    switch (state) {
+        case SegmentAdmissionState::RAMPING:
+            return "RAMPING";
+        case SegmentAdmissionState::ACTIVE:
+            return "ACTIVE";
+        case SegmentAdmissionState::QUARANTINED:
+            return "QUARANTINED";
+    }
+    return "UNKNOWN";
+}
+
+int64_t SegmentAdmissionStateMetricValue(SegmentAdmissionState state) noexcept {
+    return static_cast<int64_t>(state);
+}
+
+std::string_view ToString(SegmentAdmissionRejectReason reason) noexcept {
+    switch (reason) {
+        case SegmentAdmissionRejectReason::NONE:
+            return "none";
+        case SegmentAdmissionRejectReason::QUARANTINED:
+            return "quarantined";
+        case SegmentAdmissionRejectReason::INFLIGHT_OP_LIMIT:
+            return "inflight_op_limit";
+        case SegmentAdmissionRejectReason::INFLIGHT_BYTE_LIMIT:
+            return "inflight_byte_limit";
+    }
+    return "unknown";
+}
+
+SegmentAdmissionController::SegmentAdmissionController(
+    SegmentAdmissionConfig config, std::shared_ptr<SegmentAdmissionClock> clock)
+    : config_(std::move(config)), clock_(std::move(clock)) {
+    config_.Validate();
+    if (!clock_) {
+        throw std::invalid_argument("segment admission clock must not be null");
+    }
+}
+
+std::optional<SegmentAdmissionSnapshot> SegmentAdmissionController::OnMount(
+    const Segment& segment, const UUID& owner_client_id, bool restored_active) {
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return std::nullopt;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto now = clock_->Now();
+    auto existing = runtimes_.find(segment.id);
+    if (existing != runtimes_.end()) {
+        auto& runtime = existing->second;
+        if (runtime.owner_client_id != owner_client_id) {
+            auto old_owner = owner_segments_.find(runtime.owner_client_id);
+            if (old_owner != owner_segments_.end()) {
+                old_owner->second.erase(segment.id);
+                if (old_owner->second.empty()) {
+                    owner_segments_.erase(old_owner);
+                }
+            }
+            runtime.owner_client_id = owner_client_id;
+            owner_segments_[owner_client_id].insert(segment.id);
+        }
+        runtime.segment_host_id = segment.host_id;
+        runtime.segment_capacity_bytes = segment.size;
+        runtime.last_owner_heartbeat = now;
+        AdvanceStateLocked(runtime, now);
+        return SnapshotLocked(runtime, now);
+    }
+
+    const bool first_segment = runtimes_.empty();
+    Runtime runtime;
+    runtime.segment_id = segment.id;
+    runtime.owner_client_id = owner_client_id;
+    runtime.segment_name = segment.name;
+    runtime.segment_host_id = segment.host_id;
+    runtime.segment_capacity_bytes = segment.size;
+    runtime.state = (first_segment || restored_active)
+                        ? SegmentAdmissionState::ACTIVE
+                        : SegmentAdmissionState::RAMPING;
+    runtime.state_since = now;
+    runtime.last_owner_heartbeat = now;
+
+    auto stale_name = segment_name_index_.find(segment.name);
+    if (stale_name != segment_name_index_.end() &&
+        stale_name->second != segment.id) {
+        LOG(WARNING) << "segment_name=" << segment.name
+                     << ", old_segment_id=" << stale_name->second
+                     << ", new_segment_id=" << segment.id
+                     << ", action=replace_stale_admission_name_index";
+    }
+    segment_name_index_[segment.name] = segment.id;
+    owner_segments_[owner_client_id].insert(segment.id);
+    auto [it, inserted] = runtimes_.emplace(segment.id, std::move(runtime));
+    (void)inserted;
+    LOG(INFO) << "segment_name=" << it->second.segment_name
+              << ", segment_id=" << it->second.segment_id
+              << ", owner_client_id=" << owner_client_id
+              << ", admission_state=" << ToString(it->second.state)
+              << ", action=segment_admission_mount";
+    return SnapshotLocked(it->second, now);
+}
+
+std::vector<SegmentAdmissionSnapshot>
+SegmentAdmissionController::OnOwnerHeartbeat(const UUID& owner_client_id) {
+    std::vector<SegmentAdmissionSnapshot> snapshots;
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return snapshots;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto now = clock_->Now();
+    auto owner = owner_segments_.find(owner_client_id);
+    if (owner == owner_segments_.end()) {
+        return snapshots;
+    }
+    snapshots.reserve(owner->second.size());
+    for (const auto& segment_id : owner->second) {
+        auto runtime = runtimes_.find(segment_id);
+        if (runtime == runtimes_.end()) {
+            continue;
+        }
+        runtime->second.last_owner_heartbeat = now;
+        AdvanceStateLocked(runtime->second, now);
+        snapshots.push_back(SnapshotLocked(runtime->second, now));
+    }
+    return snapshots;
+}
+
+std::optional<SegmentAdmissionSnapshot> SegmentAdmissionController::OnUnmount(
+    const UUID& segment_id) {
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return std::nullopt;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto runtime = runtimes_.find(segment_id);
+    if (runtime == runtimes_.end()) {
+        return std::nullopt;
+    }
+    const auto now = clock_->Now();
+    auto snapshot = SnapshotLocked(runtime->second, now);
+    auto name_index = segment_name_index_.find(runtime->second.segment_name);
+    if (name_index != segment_name_index_.end() &&
+        name_index->second == segment_id) {
+        segment_name_index_.erase(name_index);
+    }
+    auto owner = owner_segments_.find(runtime->second.owner_client_id);
+    if (owner != owner_segments_.end()) {
+        owner->second.erase(segment_id);
+        if (owner->second.empty()) {
+            owner_segments_.erase(owner);
+        }
+    }
+    LOG(INFO) << "segment_name=" << runtime->second.segment_name
+              << ", segment_id=" << segment_id
+              << ", admission_state=" << ToString(runtime->second.state)
+              << ", action=segment_admission_unmount";
+    runtimes_.erase(runtime);
+    return snapshot;
+}
+
+std::optional<SegmentAdmissionSnapshot>
+SegmentAdmissionController::RecordRemoteWriteSuccess(const UUID& segment_id) {
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return std::nullopt;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto runtime = runtimes_.find(segment_id);
+    if (runtime == runtimes_.end()) {
+        return std::nullopt;
+    }
+    const auto now = clock_->Now();
+    if (runtime->second.state == SegmentAdmissionState::RAMPING) {
+        ++runtime->second.successful_remote_writes_in_ramp;
+    }
+    AdvanceStateLocked(runtime->second, now);
+    return SnapshotLocked(runtime->second, now);
+}
+
+std::optional<SegmentAdmissionSnapshot>
+SegmentAdmissionController::RecordRemoteWriteFailure(const UUID& segment_id) {
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return std::nullopt;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto runtime = runtimes_.find(segment_id);
+    if (runtime == runtimes_.end()) {
+        return std::nullopt;
+    }
+    const auto now = clock_->Now();
+    auto& value = runtime->second;
+    value.recent_failures.push_back(now);
+    PruneFailuresLocked(value, now);
+    if (value.state != SegmentAdmissionState::QUARANTINED &&
+        value.recent_failures.size() >= config_.failure_threshold) {
+        const auto old_state = value.state;
+        value.state = SegmentAdmissionState::QUARANTINED;
+        value.state_since = now;
+        value.quarantine_until =
+            now + std::chrono::seconds(config_.quarantine_duration_sec);
+        LogTransitionLocked(value, old_state, "failure_threshold", now);
+    }
+    return SnapshotLocked(value, now);
+}
+
+SegmentAdmissionObservation SegmentAdmissionController::ObserveRemoteWrite(
+    const std::string& segment_name, const std::string& writer_host_id,
+    uint64_t bytes) {
+    SegmentAdmissionObservation observation;
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return observation;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto index = segment_name_index_.find(segment_name);
+    if (index == segment_name_index_.end()) {
+        return observation;
+    }
+    auto runtime = runtimes_.find(index->second);
+    if (runtime == runtimes_.end()) {
+        return observation;
+    }
+
+    const auto now = clock_->Now();
+    auto& value = runtime->second;
+    AdvanceStateLocked(value, now);
+    const bool local_write = !writer_host_id.empty() &&
+                             !value.segment_host_id.empty() &&
+                             writer_host_id == value.segment_host_id;
+    if (!local_write) {
+        ++value.observed_remote_writes;
+        if (value.state == SegmentAdmissionState::QUARANTINED) {
+            observation.would_admit = false;
+            observation.reason = SegmentAdmissionRejectReason::QUARANTINED;
+        } else {
+            const double ratio = EffectiveRatioLocked(value, now);
+            const uint64_t op_limit = EffectiveOpLimitLocked(ratio);
+            const uint64_t full_byte_limit = FullByteLimitLocked(value);
+            const uint64_t byte_limit = EffectiveByteLimitLocked(value, ratio);
+            if (op_limit != 0 && value.inflight_remote_write_ops >= op_limit) {
+                observation.would_admit = false;
+                observation.reason =
+                    SegmentAdmissionRejectReason::INFLIGHT_OP_LIMIT;
+            } else if (full_byte_limit != 0 && bytes > full_byte_limit) {
+                observation.would_admit = false;
+                observation.reason =
+                    SegmentAdmissionRejectReason::INFLIGHT_BYTE_LIMIT;
+            } else if (byte_limit != 0 && bytes > byte_limit &&
+                       (value.inflight_remote_write_ops != 0 ||
+                        value.inflight_remote_write_bytes != 0)) {
+                observation.would_admit = false;
+                observation.reason =
+                    SegmentAdmissionRejectReason::INFLIGHT_BYTE_LIMIT;
+            } else if (byte_limit != 0 &&
+                       value.inflight_remote_write_bytes >
+                           byte_limit - std::min(bytes, byte_limit)) {
+                observation.would_admit = false;
+                observation.reason =
+                    SegmentAdmissionRejectReason::INFLIGHT_BYTE_LIMIT;
+            }
+        }
+        if (!observation.would_admit) {
+            ++value.observed_would_reject;
+        }
+    }
+    observation.snapshot = SnapshotLocked(value, now);
+    return observation;
+}
+
+std::optional<SegmentAdmissionSnapshot> SegmentAdmissionController::GetSnapshot(
+    const UUID& segment_id) {
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return std::nullopt;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto runtime = runtimes_.find(segment_id);
+    if (runtime == runtimes_.end()) {
+        return std::nullopt;
+    }
+    const auto now = clock_->Now();
+    AdvanceStateLocked(runtime->second, now);
+    return SnapshotLocked(runtime->second, now);
+}
+
+std::vector<SegmentAdmissionSnapshot>
+SegmentAdmissionController::GetSnapshots() {
+    std::vector<SegmentAdmissionSnapshot> snapshots;
+    if (config_.mode == SegmentWriteAdmissionMode::DISABLED) {
+        return snapshots;
+    }
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto now = clock_->Now();
+    snapshots.reserve(runtimes_.size());
+    for (auto& [_, runtime] : runtimes_) {
+        AdvanceStateLocked(runtime, now);
+        snapshots.push_back(SnapshotLocked(runtime, now));
+    }
+    return snapshots;
+}
+
+size_t SegmentAdmissionController::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return runtimes_.size();
+}
+
+double SegmentAdmissionController::EffectiveRatioLocked(
+    const Runtime& runtime,
+    SegmentAdmissionClock::TimePoint now) const noexcept {
+    if (runtime.state == SegmentAdmissionState::ACTIVE) {
+        return 1.0;
+    }
+    if (runtime.state == SegmentAdmissionState::QUARANTINED) {
+        return 0.0;
+    }
+    const double elapsed_seconds =
+        std::chrono::duration<double>(now - runtime.state_since).count();
+    const double time_progress = std::clamp(
+        elapsed_seconds / static_cast<double>(config_.ramp_up_duration_sec),
+        0.0, 1.0);
+    const double time_factor =
+        config_.ramp_initial_ratio +
+        (1.0 - config_.ramp_initial_ratio) * time_progress;
+    const double success_progress =
+        config_.ramp_min_successful_remote_writes == 0
+            ? 1.0
+            : std::clamp(static_cast<double>(
+                             runtime.successful_remote_writes_in_ramp) /
+                             static_cast<double>(
+                                 config_.ramp_min_successful_remote_writes),
+                         0.0, 1.0);
+    const double success_factor =
+        config_.ramp_initial_ratio +
+        (1.0 - config_.ramp_initial_ratio) * success_progress;
+    return std::min(time_factor, success_factor);
+}
+
+uint64_t SegmentAdmissionController::EffectiveByteLimitLocked(
+    const Runtime& runtime, double ratio) const noexcept {
+    return ScaleLimit(FullByteLimitLocked(runtime), ratio);
+}
+
+uint64_t SegmentAdmissionController::FullByteLimitLocked(
+    const Runtime& runtime) const noexcept {
+    if (config_.max_inflight_remote_write_bytes != 0) {
+        return config_.max_inflight_remote_write_bytes;
+    }
+    return std::clamp(runtime.segment_capacity_bytes / 1024, kMinAutoByteLimit,
+                      kMaxAutoByteLimit);
+}
+
+uint64_t SegmentAdmissionController::EffectiveOpLimitLocked(
+    double ratio) const noexcept {
+    return ScaleLimit(config_.max_inflight_remote_write_ops, ratio);
+}
+
+void SegmentAdmissionController::AdvanceStateLocked(
+    Runtime& runtime, SegmentAdmissionClock::TimePoint now) {
+    PruneFailuresLocked(runtime, now);
+    if (runtime.state == SegmentAdmissionState::QUARANTINED) {
+        if (now >= runtime.quarantine_until &&
+            runtime.last_owner_heartbeat > runtime.state_since) {
+            const auto old_state = runtime.state;
+            runtime.state = SegmentAdmissionState::RAMPING;
+            runtime.state_since = now;
+            runtime.successful_remote_writes_in_ramp = 0;
+            runtime.recent_failures.clear();
+            LogTransitionLocked(runtime, old_state, "cooldown_and_heartbeat",
+                                now);
+        }
+        return;
+    }
+    if (runtime.state == SegmentAdmissionState::RAMPING &&
+        EffectiveRatioLocked(runtime, now) >= 1.0) {
+        const auto old_state = runtime.state;
+        runtime.state = SegmentAdmissionState::ACTIVE;
+        runtime.state_since = now;
+        LogTransitionLocked(runtime, old_state, "ramp_complete", now);
+    }
+}
+
+void SegmentAdmissionController::PruneFailuresLocked(
+    Runtime& runtime, SegmentAdmissionClock::TimePoint now) const {
+    const auto earliest =
+        now - std::chrono::seconds(config_.failure_window_sec);
+    while (!runtime.recent_failures.empty() &&
+           runtime.recent_failures.front() < earliest) {
+        runtime.recent_failures.pop_front();
+    }
+}
+
+SegmentAdmissionSnapshot SegmentAdmissionController::SnapshotLocked(
+    const Runtime& runtime, SegmentAdmissionClock::TimePoint now) const {
+    SegmentAdmissionSnapshot snapshot;
+    snapshot.segment_id = runtime.segment_id;
+    snapshot.owner_client_id = runtime.owner_client_id;
+    snapshot.segment_name = runtime.segment_name;
+    snapshot.segment_host_id = runtime.segment_host_id;
+    snapshot.state = runtime.state;
+    snapshot.effective_ratio = EffectiveRatioLocked(runtime, now);
+    snapshot.inflight_remote_write_ops = runtime.inflight_remote_write_ops;
+    snapshot.inflight_remote_write_bytes = runtime.inflight_remote_write_bytes;
+    snapshot.successful_remote_writes_in_ramp =
+        runtime.successful_remote_writes_in_ramp;
+    snapshot.recent_failures = runtime.recent_failures.size();
+    snapshot.observed_remote_writes = runtime.observed_remote_writes;
+    snapshot.observed_would_reject = runtime.observed_would_reject;
+    if (runtime.state == SegmentAdmissionState::QUARANTINED &&
+        runtime.quarantine_until > now) {
+        snapshot.quarantine_remaining_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                runtime.quarantine_until - now)
+                .count();
+    }
+    snapshot.owner_heartbeat_age_ms = std::max<int64_t>(
+        0, std::chrono::duration_cast<std::chrono::milliseconds>(
+               now - runtime.last_owner_heartbeat)
+               .count());
+    return snapshot;
+}
+
+void SegmentAdmissionController::LogTransitionLocked(
+    const Runtime& runtime, SegmentAdmissionState old_state,
+    std::string_view reason, SegmentAdmissionClock::TimePoint now) const {
+    const auto snapshot = SnapshotLocked(runtime, now);
+    LOG(INFO) << "segment_name=" << runtime.segment_name
+              << ", segment_id=" << runtime.segment_id
+              << ", admission_state_from=" << ToString(old_state)
+              << ", admission_state_to=" << ToString(runtime.state)
+              << ", reason=" << reason
+              << ", effective_ratio=" << snapshot.effective_ratio
+              << ", inflight_ops=" << snapshot.inflight_remote_write_ops
+              << ", inflight_bytes=" << snapshot.inflight_remote_write_bytes
+              << ", recent_failures=" << snapshot.recent_failures
+              << ", owner_heartbeat_age_ms=" << snapshot.owner_heartbeat_age_ms
+              << ", action=segment_admission_transition";
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -125,6 +125,8 @@ add_store_test(tenant_quota_test tenant_quota_test.cpp)
 add_store_test(tenant_quota_ledger_test tenant_quota_ledger_test.cpp)
 add_store_test(tenant_id_test tenant_id_test.cpp)
 add_store_test(segment_test segment_test.cpp)
+add_store_test(segment_admission_controller_test
+               segment_admission_controller_test.cpp)
 add_executable(local_ssd_test local_ssd/local_ssd_test.cpp)
 target_include_directories(local_ssd_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(local_ssd_test PRIVATE mooncake_local_ssd gtest

--- a/mooncake-store/tests/master_admin_server_test.cpp
+++ b/mooncake-store/tests/master_admin_server_test.cpp
@@ -830,6 +830,16 @@ TEST_F(MasterAdminServerWithServiceTest, GetSegmentsDetailReturnsDetailedInfo) {
     EXPECT_NE(resp.body.find("\"allocator_used_bytes\""), std::string::npos);
     EXPECT_NE(resp.body.find("\"allocator_capacity_bytes\""),
               std::string::npos);
+    EXPECT_NE(resp.body.find("\"admission_tracked\":true"), std::string::npos);
+    EXPECT_NE(resp.body.find("\"admission_mode\":\"observe\""),
+              std::string::npos);
+    EXPECT_NE(resp.body.find("\"admission_state\":\"ACTIVE\""),
+              std::string::npos);
+    EXPECT_NE(resp.body.find("\"admission_ratio\":"), std::string::npos);
+    EXPECT_NE(resp.body.find("\"inflight_remote_write_ops\":"),
+              std::string::npos);
+    EXPECT_NE(resp.body.find("\"inflight_remote_write_bytes\":"),
+              std::string::npos);
 }
 
 // -----------------------------------------------------------------------

--- a/mooncake-store/tests/master_metrics_test.cpp
+++ b/mooncake-store/tests/master_metrics_test.cpp
@@ -135,6 +135,33 @@ TEST_F(MasterMetricsTest, InitialStatusTest) {
     ASSERT_EQ(metrics.get_put_start_discarded_staging_size(), 0);
 }
 
+TEST_F(MasterMetricsTest, SegmentAdmissionMetricsArePublishedAndRemoved) {
+    auto& metrics = MasterMetricManager::instance();
+    const std::string segment =
+        "admission_metric_segment_" + UuidToString(generate_uuid());
+
+    metrics.update_segment_admission_metrics(segment, 0, 0.25, 3, 4096);
+    const auto published = metrics.serialize_metrics();
+    EXPECT_NE(published.find("mooncake_segment_admission_state{segment=\"" +
+                             segment + "\"}"),
+              std::string::npos);
+    EXPECT_NE(published.find("mooncake_segment_admission_ratio{segment=\"" +
+                             segment + "\"}"),
+              std::string::npos);
+    EXPECT_NE(
+        published.find("mooncake_segment_inflight_remote_write_ops{segment=\"" +
+                       segment + "\"}"),
+        std::string::npos);
+    EXPECT_NE(published.find(
+                  "mooncake_segment_inflight_remote_write_bytes{segment=\"" +
+                  segment + "\"}"),
+              std::string::npos);
+
+    metrics.remove_segment_admission_metrics(segment);
+    EXPECT_EQ(metrics.serialize_metrics().find("segment=\"" + segment + "\""),
+              std::string::npos);
+}
+
 TEST_F(MasterMetricsTest, BasicRequestTest) {
     const uint64_t default_kv_lease_ttl = 100;
     auto& metrics = MasterMetricManager::instance();

--- a/mooncake-store/tests/master_service_config_test.cpp
+++ b/mooncake-store/tests/master_service_config_test.cpp
@@ -46,4 +46,57 @@ TEST(MasterServiceConfigTest, OplogBatchMaxEntriesBuilderOverrideRespected) {
     EXPECT_EQ(17u, config.oplog_batch_max_entries);
 }
 
+TEST(MasterServiceConfigTest, SegmentAdmissionDefaultsToObserve) {
+    MasterConfig master_config;
+    EXPECT_EQ("observe", master_config.segment_write_admission_mode);
+
+    MasterServiceConfig service_config;
+    EXPECT_EQ(SegmentWriteAdmissionMode::OBSERVE,
+              service_config.segment_admission_config.mode);
+    EXPECT_EQ(60u,
+              service_config.segment_admission_config.ramp_up_duration_sec);
+    EXPECT_DOUBLE_EQ(
+        0.05, service_config.segment_admission_config.ramp_initial_ratio);
+}
+
+TEST(MasterServiceConfigTest, SegmentAdmissionPropagatesThroughHaConfig) {
+    MasterConfig master_config{};
+    master_config.segment_write_admission_mode = "enforce";
+    master_config.segment_ramp_up_duration_sec = 23;
+    master_config.segment_ramp_initial_ratio = 0.2;
+    master_config.segment_failure_threshold = 7;
+
+    MasterServiceSupervisorConfig supervisor_config(master_config);
+    WrappedMasterServiceConfig wrapped_config(supervisor_config, 1);
+    MasterServiceConfig service_config(wrapped_config);
+
+    EXPECT_EQ(SegmentWriteAdmissionMode::ENFORCE,
+              service_config.segment_admission_config.mode);
+    EXPECT_EQ(23u,
+              service_config.segment_admission_config.ramp_up_duration_sec);
+    EXPECT_DOUBLE_EQ(
+        0.2, service_config.segment_admission_config.ramp_initial_ratio);
+    EXPECT_EQ(7u, service_config.segment_admission_config.failure_threshold);
+}
+
+TEST(MasterServiceConfigTest, SegmentAdmissionRejectsInvalidMode) {
+    MasterConfig master_config{};
+    master_config.segment_write_admission_mode = "Observe";
+    EXPECT_THROW(MasterServiceSupervisorConfig(master_config),
+                 std::invalid_argument);
+}
+
+TEST(MasterServiceConfigTest, SegmentAdmissionBuilderOverrideIsRespected) {
+    SegmentAdmissionConfig admission;
+    admission.mode = SegmentWriteAdmissionMode::DISABLED;
+    admission.ramp_initial_ratio = 0.25;
+    auto config = MasterServiceConfig::builder()
+                      .set_segment_admission_config(admission)
+                      .build();
+
+    EXPECT_EQ(SegmentWriteAdmissionMode::DISABLED,
+              config.segment_admission_config.mode);
+    EXPECT_DOUBLE_EQ(0.25, config.segment_admission_config.ramp_initial_ratio);
+}
+
 }  // namespace mooncake::test

--- a/mooncake-store/tests/segment_admission_controller_test.cpp
+++ b/mooncake-store/tests/segment_admission_controller_test.cpp
@@ -1,0 +1,264 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "segment_admission_controller.h"
+#include "master_service.h"
+
+namespace mooncake::test {
+namespace {
+
+class FakeSegmentAdmissionClock final : public SegmentAdmissionClock {
+   public:
+    TimePoint Now() const override { return now_; }
+
+    template <typename Rep, typename Period>
+    void Advance(std::chrono::duration<Rep, Period> duration) {
+        now_ += std::chrono::duration_cast<TimePoint::duration>(duration);
+    }
+
+   private:
+    TimePoint now_{};
+};
+
+Segment MakeSegment(UUID id, std::string name, std::string host_id) {
+    Segment segment;
+    segment.id = id;
+    segment.name = std::move(name);
+    segment.host_id = std::move(host_id);
+    segment.size = 128ULL * 1024ULL * 1024ULL * 1024ULL;
+    return segment;
+}
+
+SegmentAdmissionConfig TestConfig() {
+    SegmentAdmissionConfig config;
+    config.ramp_up_duration_sec = 10;
+    config.ramp_initial_ratio = 0.1;
+    config.ramp_min_successful_remote_writes = 4;
+    config.failure_window_sec = 5;
+    config.failure_threshold = 3;
+    config.quarantine_duration_sec = 10;
+    return config;
+}
+
+TEST(SegmentAdmissionConfigTest, RejectsInvalidValues) {
+    auto config = TestConfig();
+    config.ramp_initial_ratio = 0.0;
+    EXPECT_THROW(config.Validate(), std::invalid_argument);
+
+    config = TestConfig();
+    config.failure_threshold = 0;
+    EXPECT_THROW(config.Validate(), std::invalid_argument);
+
+    EXPECT_FALSE(ParseSegmentWriteAdmissionMode("OBSERVE"));
+    auto enforce = ParseSegmentWriteAdmissionMode("enforce");
+    ASSERT_TRUE(enforce);
+    EXPECT_EQ(*enforce, SegmentWriteAdmissionMode::ENFORCE);
+}
+
+TEST(SegmentAdmissionControllerTest, FirstSegmentIsActiveAndNextRamps) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID owner_a{1, 1};
+    const UUID owner_b{2, 2};
+    auto first = controller.OnMount(MakeSegment({11, 1}, "segment-a", "host-a"),
+                                    owner_a);
+    ASSERT_TRUE(first);
+    EXPECT_EQ(first->state, SegmentAdmissionState::ACTIVE);
+    EXPECT_DOUBLE_EQ(first->effective_ratio, 1.0);
+
+    auto second = controller.OnMount(
+        MakeSegment({22, 2}, "segment-b", "host-b"), owner_b);
+    ASSERT_TRUE(second);
+    EXPECT_EQ(second->state, SegmentAdmissionState::RAMPING);
+    EXPECT_DOUBLE_EQ(second->effective_ratio, 0.1);
+}
+
+TEST(SegmentAdmissionControllerTest,
+     TimeAndSuccessFactorsIndependentlyLimitRampUp) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    controller.OnMount(MakeSegment({1, 1}, "first", "host-a"), {10, 10});
+    const UUID ramping_id{2, 2};
+    controller.OnMount(MakeSegment(ramping_id, "ramping", "host-b"), {20, 20});
+
+    clock->Advance(std::chrono::seconds(10));
+    auto time_only = controller.GetSnapshot(ramping_id);
+    ASSERT_TRUE(time_only);
+    EXPECT_EQ(time_only->state, SegmentAdmissionState::RAMPING);
+    EXPECT_DOUBLE_EQ(time_only->effective_ratio, 0.1);
+
+    for (int i = 0; i < 3; ++i) {
+        controller.RecordRemoteWriteSuccess(ramping_id);
+    }
+    auto success_limited = controller.GetSnapshot(ramping_id);
+    ASSERT_TRUE(success_limited);
+    EXPECT_EQ(success_limited->state, SegmentAdmissionState::RAMPING);
+    EXPECT_NEAR(success_limited->effective_ratio, 0.775, 1e-9);
+
+    auto active = controller.RecordRemoteWriteSuccess(ramping_id);
+    ASSERT_TRUE(active);
+    EXPECT_EQ(active->state, SegmentAdmissionState::ACTIVE);
+    EXPECT_DOUBLE_EQ(active->effective_ratio, 1.0);
+}
+
+TEST(SegmentAdmissionControllerTest,
+     QuarantineRecoveryRequiresCooldownAndNewHeartbeat) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID segment_id{1, 1};
+    const UUID owner_id{10, 10};
+    controller.OnMount(MakeSegment(segment_id, "segment", "host"), owner_id);
+
+    controller.RecordRemoteWriteFailure(segment_id);
+    controller.RecordRemoteWriteFailure(segment_id);
+    auto quarantined = controller.RecordRemoteWriteFailure(segment_id);
+    ASSERT_TRUE(quarantined);
+    EXPECT_EQ(quarantined->state, SegmentAdmissionState::QUARANTINED);
+
+    clock->Advance(std::chrono::seconds(11));
+    auto without_heartbeat = controller.GetSnapshot(segment_id);
+    ASSERT_TRUE(without_heartbeat);
+    EXPECT_EQ(without_heartbeat->state, SegmentAdmissionState::QUARANTINED);
+
+    auto recovered = controller.OnOwnerHeartbeat(owner_id);
+    ASSERT_EQ(recovered.size(), 1);
+    EXPECT_EQ(recovered[0].state, SegmentAdmissionState::RAMPING);
+    EXPECT_DOUBLE_EQ(recovered[0].effective_ratio, 0.1);
+}
+
+TEST(SegmentAdmissionControllerTest, FailureWindowExpiresOldFailures) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID segment_id{1, 1};
+    controller.OnMount(MakeSegment(segment_id, "segment", "host"), {10, 10});
+
+    controller.RecordRemoteWriteFailure(segment_id);
+    controller.RecordRemoteWriteFailure(segment_id);
+    clock->Advance(std::chrono::seconds(6));
+    auto snapshot = controller.RecordRemoteWriteFailure(segment_id);
+    ASSERT_TRUE(snapshot);
+    EXPECT_EQ(snapshot->state, SegmentAdmissionState::ACTIVE);
+    EXPECT_EQ(snapshot->recent_failures, 1);
+}
+
+TEST(SegmentAdmissionControllerTest,
+     ObserveCountsWouldRejectWithoutChangingRuntimeBudget) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID segment_id{1, 1};
+    controller.OnMount(MakeSegment(segment_id, "segment", "host-a"), {10, 10});
+    controller.RecordRemoteWriteFailure(segment_id);
+    controller.RecordRemoteWriteFailure(segment_id);
+    controller.RecordRemoteWriteFailure(segment_id);
+
+    auto local = controller.ObserveRemoteWrite("segment", "host-a", 4096);
+    EXPECT_TRUE(local.would_admit);
+    EXPECT_EQ(local.snapshot.observed_remote_writes, 0);
+
+    auto remote = controller.ObserveRemoteWrite("segment", "host-b", 4096);
+    EXPECT_FALSE(remote.would_admit);
+    EXPECT_EQ(remote.reason, SegmentAdmissionRejectReason::QUARANTINED);
+    EXPECT_EQ(remote.snapshot.observed_remote_writes, 1);
+    EXPECT_EQ(remote.snapshot.observed_would_reject, 1);
+    EXPECT_EQ(remote.snapshot.inflight_remote_write_ops, 0);
+    EXPECT_EQ(remote.snapshot.inflight_remote_write_bytes, 0);
+}
+
+TEST(SegmentAdmissionControllerTest, UnmountDropsRuntimeBySegmentId) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID old_id{1, 1};
+    controller.OnMount(MakeSegment(old_id, "segment", "host"), {10, 10});
+    EXPECT_TRUE(controller.OnUnmount(old_id));
+    EXPECT_EQ(controller.size(), 0);
+
+    const UUID new_id{2, 2};
+    auto replacement =
+        controller.OnMount(MakeSegment(new_id, "segment", "host"), {20, 20});
+    ASSERT_TRUE(replacement);
+    EXPECT_EQ(replacement->segment_id, new_id);
+    EXPECT_FALSE(controller.GetSnapshot(old_id));
+}
+
+TEST(SegmentAdmissionControllerTest, RemountRefreshesOwnerHeartbeatIndex) {
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(TestConfig(), clock);
+    const UUID segment_id{1, 1};
+    auto segment = MakeSegment(segment_id, "segment", "host");
+    controller.OnMount(segment, {10, 10});
+    controller.OnMount(segment, {20, 20}, true);
+
+    EXPECT_TRUE(controller.OnOwnerHeartbeat({10, 10}).empty());
+    auto new_owner = controller.OnOwnerHeartbeat({20, 20});
+    ASSERT_EQ(new_owner.size(), 1);
+    EXPECT_EQ(new_owner.front().owner_client_id, UUID(20, 20));
+}
+
+TEST(SegmentAdmissionControllerTest, DisabledModeCreatesNoRuntime) {
+    auto config = TestConfig();
+    config.mode = SegmentWriteAdmissionMode::DISABLED;
+    auto clock = std::make_shared<FakeSegmentAdmissionClock>();
+    SegmentAdmissionController controller(config, clock);
+    EXPECT_FALSE(
+        controller.OnMount(MakeSegment({1, 1}, "segment", "host"), {10, 10}));
+    EXPECT_EQ(controller.size(), 0);
+    EXPECT_TRUE(
+        controller.ObserveRemoteWrite("segment", "remote", 4096).would_admit);
+}
+
+TEST(SegmentAdmissionObserveIntegrationTest,
+     WouldRejectMetricDoesNotChangePreferredPlacement) {
+    auto admission = TestConfig();
+    admission.max_inflight_remote_write_bytes = 1024;
+    auto service_config = MasterServiceConfig::builder()
+                              .set_segment_admission_config(admission)
+                              .build();
+    MasterService service(service_config);
+
+    auto active = MakeSegment({1, 1}, "active", "host-a");
+    active.base = 0x300000000;
+    active.size = 16ULL * 1024ULL * 1024ULL;
+    active.te_endpoint = active.name;
+    auto ramping = MakeSegment({2, 2}, "ramping", "host-b");
+    ramping.base = 0x400000000;
+    ramping.size = 16ULL * 1024ULL * 1024ULL;
+    ramping.te_endpoint = ramping.name;
+    ASSERT_TRUE(service.MountSegment(active, {10, 10}));
+    ASSERT_TRUE(service.MountSegment(ramping, {20, 20}));
+
+    ReplicateConfig replicate_config;
+    replicate_config.replica_num = 1;
+    replicate_config.preferred_segment = ramping.name;
+    auto put = service.PutStart({30, 30}, "observe-only-key",
+                                TenantId::Default(), 2048, replicate_config);
+    ASSERT_TRUE(put);
+    ASSERT_EQ(put->size(), 1);
+    EXPECT_EQ(put->front()
+                  .get_memory_descriptor()
+                  .buffer_descriptor.transport_endpoint_,
+              ramping.name);
+
+    auto details = service.GetSegmentsDetail();
+    ASSERT_TRUE(details);
+    auto detail = std::find_if(
+        details->begin(), details->end(),
+        [&](const auto& item) { return item.segment_id == ramping.id; });
+    ASSERT_NE(detail, details->end());
+    EXPECT_EQ(detail->admission_state, "RAMPING");
+    EXPECT_EQ(detail->admission_observed_remote_writes, 1);
+    EXPECT_EQ(detail->admission_observed_would_reject, 1);
+    EXPECT_EQ(detail->inflight_remote_write_ops, 0);
+    EXPECT_EQ(detail->inflight_remote_write_bytes, 0);
+
+    EXPECT_TRUE(service.PutRevoke({30, 30}, "observe-only-key",
+                                  TenantId::Default(), ReplicaType::MEMORY));
+}
+
+}  // namespace
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description
Related issue: https://github.com/kvcache-ai/Mooncake/issues/3688

When one instance managed by Mooncake stops, it may remain eligible for allocation until heartbeat TTL expiration and unmount. Remote writes assigned to that instance can therefore wait for transport timeout and retry.

After the instance restarts, its empty DRAM segment is immediately treated as fully available, while surviving segments may already be nearly full. This can concentrate new writes on the restarted instance, overload the transfer path, trigger HIXL timeout/retransmission, and increase TTFT for other healthy instances.

The planned solution is to add a `SegmentAdmissionController` before the existing allocation strategies. It will:

- maintain `RAMPING`, `ACTIVE`, and `QUARANTINED` states;
- gradually ramp up newly mounted or recovered segments;
- limit per-segment remote-write operations and in-flight bytes;
- quarantine segments after repeated transfer failures;
- use client transfer results and owner heartbeats for recovery;
- exclude unhealthy or overloaded segments during `PutStart`.

This PR implements the first, observe-only stage:

- add the admission controller, configuration, and validation;
- track runtime state across mount, remount, heartbeat, restore, and unmount;
- observe targets selected by the existing allocation path;
- add admission metrics and Admin segment-detail fields;
- add fake-clock, configuration, metrics, Admin, and integration tests.

This PR does not change allocation results, create reservations, reject `PutStart`, or add client result-reporting RPCs. If `enforce` is configured at this stage, the master logs a warning and continues in observe-only mode.

Therefore, this PR provides the foundation and production observability for the complete fix, but does not close #3688 by itself.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?
Tests were added for:
- ramp-up and quarantine state transitions using a fake clock;
- mount/remount/heartbeat/unmount runtime handling;
- configuration propagation through normal and HA paths;
- metrics and Admin fields;
- observe-only decisions not changing preferred placement.


**Test commands:**
```bash
cmake -S . -B build-pr1 -G Ninja \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DWITH_TE=ON \
  -DWITH_STORE=ON \
  -DWITH_STORE_RUST=OFF \
  -DWITH_STORE_GO=OFF \
  -DWITH_P2P_STORE=OFF \
  -DWITH_EP=OFF \
  -DUSE_CUDA=OFF \
  -DUSE_HTTP=ON \
  -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF \
  -DWITH_METRICS=ON

cmake --build build-pr1 --parallel "$(nproc)" \
  --target segment_admission_controller_test \
           master_service_config_test \
           master_metrics_test \
           master_admin_server_test

ctest --test-dir build-pr1 \
  --parallel "$(nproc)" \
  --output-on-failure \
  -R '^(segment_admission_controller_test|master_service_config_test|master_metrics_test|master_admin_server_test)$'

```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specified below)
Cursor was used to assist with implementation and test drafting.