### PR TITLE
[Bugfix][PG] Balance CUDA graph capture-depth accounting

### DIFF
--- a/mooncake-pg/torch/src/mooncake_backend.cpp
+++ b/mooncake-pg/torch/src/mooncake_backend.cpp
@@ -446,8 +446,9 @@ c10::intrusive_ptr<c10d::Work> MooncakeBackend::launchCollective(
     const bool is_captured = captureStatus != cudaStreamCaptureStatusNone ||
                              at::cuda::currentStreamCaptureStatus() !=
                                  c10::cuda::CaptureStatus::None;
-    work_tracker_->notifyCapture(is_captured);
-    if (!is_captured) {
+    if (is_captured) {
+        work_tracker_->notifyCapture(true);
+    } else {
         work_tracker_->evictCompleted();
     }
     return c10::make_intrusive<MooncakeWorkCuda>(


### PR DESCRIPTION
## Description

This is a small but useful correctness fix: a minimal control-flow change
prevents eager collectives from corrupting CUDA Graph capture-depth accounting.
It is a focused follow-up to
[#3609](https://github.com/kvcache-ai/Mooncake/pull/3609).

`MooncakeWorkTracker::notifyCapture(bool)` updates a reference count: `true`
increments `capture_depth_`, while `false` decrements it. However,
`MooncakeBackend::launchCollective()` currently calls
`notifyCapture(is_captured)` for every GPU collective. As a result, each eager
collective decrements the counter even though it did not acquire a capture
reference.

The resulting sequence is:

1. An eager GPU collective changes `capture_depth_` from `0` to `-1`.
2. A later captured collective increments it from `-1` to `0`.
3. While that captured `Work` is still live, another path may call
   `evictCompleted()`.
4. Because the guard only returns when `capture_depth_ > 0`, it may query a
   retired CUDA event during capture.

This can occur in the multi-stream CUDA Graph/TBO scenario addressed by #3609,
where eager initialization or warmup may precede graph capture and PG activity
may occur on another stream. Every eager GPU collective deterministically
causes the accounting underflow; a user-visible CUDA failure additionally
requires a later captured collective and concurrent/opportunistic eviction.

This change calls `notifyCapture(true)` only when a captured collective has
actually acquired a reference. The existing `MooncakeWorkCuda` destructor
already calls `notifyCapture(false)` only for captured work, restoring a
one-to-one increment/decrement pairing. Eager collectives continue to call
`evictCompleted()` as before.

The patch is intentionally limited to this accounting imbalance. It does not
change the existing captured-resource retention policy or address the separate
#3609 follow-up concerning a captured `Work` being destroyed before CUDA Graph
capture itself ends.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build <build-dir> --target mooncake_pg_ext
python -m unittest discover -s mooncake-pg/tests \
  -p 'test_pg_collectives.py' -k CUDA -v
pre-commit run --files mooncake-pg/torch/src/mooncake_backend.cpp
git diff --check origin/main...HEAD
```

**Test results:**

- [x] Mooncake PG Python extension builds successfully.
- [x] Existing CUDA collective tests pass (14/14).
- [x] Applicable pre-commit hooks and `git diff --check` pass.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is unchanged because this is an internal accounting fix
- [ ] I have added tests to prove my changes are effective
- [x] An RFC is not required because this is a three-line bug fix

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with the validation, and PR description.