### PR TITLE
[TE] Increase TCP queued transfer admission thresholds

### DIFF
--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -300,10 +300,10 @@ TcpTransport::TcpTransport()
     }
 
     constexpr size_t kDefaultLanesPerPeer = 4;
-    constexpr size_t kDefaultQueuedTransfersPerPeer = 1024;
-    constexpr size_t kMaxQueuedTransfersPerPeer = 65535;
-    constexpr size_t kDefaultPendingAdmissionsPerPeer = 1024;
-    constexpr size_t kMaxPendingAdmissionsPerPeer = 65535;
+    constexpr size_t kDefaultQueuedTransfersPerPeer = 65535;
+    constexpr size_t kMaxQueuedTransfersPerPeer = 1048576;
+    constexpr size_t kDefaultPendingAdmissionsPerPeer = 65535;
+    constexpr size_t kMaxPendingAdmissionsPerPeer = 1048576;
     constexpr size_t kDefaultAdmissionTimeoutMs = 1000;
     constexpr size_t kMaxAdmissionTimeoutMs = 600000;
 


### PR DESCRIPTION
## Description

This PR raises the classic TCP transport's default per-peer queued transfer and pending admission limits.

Previously, TCP used:
- `kDefaultQueuedTransfersPerPeer = 1024`
- `kMaxQueuedTransfersPerPeer = 65535`
- `kDefaultPendingAdmissionsPerPeer = 1024`
- `kMaxPendingAdmissionsPerPeer = 65535`

This change increases them to:
- default queued transfers per peer: `65535`
- max queued transfers per peer: `1048576`
- default pending admissions per peer: `65535`
- max pending admissions per peer: `1048576`

The intent is to reduce premature `QUEUE_FULL` hard rejections under high TCP transfer fanout while preserving bounded admission behavior.

Note: this branch currently also adds `extern/yalantinglibs` as a new gitlink without a `.gitmodules` update. Please confirm whether that submodule pointer is intentional before merging.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Not run yet.

**Test commands:**
```bash
# Not run
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI assistance was used to inspect the TCP admission behavior and draft this PR description. The human submitter should review and validate all changed lines before merge.