### PR TITLE
[Store] Self-heal dangling LOCAL_DISK replicas in Client::Put

### DIFF
--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -786,12 +786,23 @@ class Client {
      */
     ErrorCode ConnectToMaster(const std::string& master_server_entry);
     // When PutStart reports OBJECT_ALREADY_EXISTS, check whether every
-    // completed replica is a LOCAL_DISK replica owned by this client, and
-    // probe its last byte through the normal read path to prove the backing
-    // file is gone (issue #3709). Only then evict the dangling replica so the
-    // Put can be retried; any other outcome keeps the old idempotent path.
-    // Returns true only when a replica was actually evicted.
+    // completed replica is a LOCAL_DISK replica owned by this client, and ask
+    // the installed probe (FileStorage::Exists over the offload files) whether
+    // the backing file is gone (issue #3709). Only then evict the dangling
+    // replica so the Put can be retried; any other outcome keeps the old
+    // idempotent path. Returns true only when a replica was actually evicted.
     bool healDanglingLocalDiskReplica(const ObjectKey& key);
+    // The BatchPutStart counterpart: heals the OBJECT_ALREADY_EXISTS subset
+    // with one batched replica-list query and one batched evict, then retries
+    // PutStart for just the evicted keys and splices the responses back, so a
+    // healthy idempotent batch pays one extra RPC and no evictions.
+    void healDanglingLocalDiskBatchStarts(
+        std::vector<PutOperation>& ops,
+        const std::vector<size_t>& active_indices,
+        const std::vector<size_t>& already_exists,
+        const std::vector<std::string>& keys,
+        const std::vector<std::vector<uint64_t>>& slice_lengths,
+        const ReplicateConfig& config);
     ErrorCode InitTransferEngine(
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -482,6 +482,16 @@ class Client {
     tl::expected<void, ErrorCode> UnmountLocalDiskSegment();
 
     /**
+     * @brief Installs the existence probe used by the dangling-replica heal.
+     * The probe lives outside this class because the offload file storage is
+     * owned by the caller (RealClient), not by Client.
+     */
+    void SetLocalDiskProbe(
+        std::function<std::optional<bool>(const std::string& key)> probe) {
+        local_disk_probe_fn_ = std::move(probe);
+    }
+
+    /**
      * @brief Heartbeat call to collect object-level statistics and retrieve the
      * set of non-offloaded objects.
      * @param enable_offloading Indicates whether offloading is enabled for this
@@ -964,6 +974,14 @@ class Client {
     ThreadPool write_thread_pool_;
     std::shared_ptr<StorageBackend> storage_backend_;
     std::shared_ptr<DistributedStorageBackend> dfs_storage_backend_;
+
+    // Probe used by healDanglingLocalDiskReplica to prove a completed
+    // LOCAL_DISK replica's backing file is gone. Installed by the owner of
+    // the offload file storage (RealClient); unset means no local-disk
+    // offload is active and the heal stays inert. true: file is gone,
+    // false: file present, nullopt: unknown (keep the old path).
+    std::function<std::optional<bool>(const std::string& key)>
+        local_disk_probe_fn_;
 
     // For high availability
     std::unique_ptr<ha::LeaderCoordinator> leader_coordinator_;

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -776,10 +776,11 @@ class Client {
      */
     ErrorCode ConnectToMaster(const std::string& master_server_entry);
     // When PutStart reports OBJECT_ALREADY_EXISTS, check whether every
-    // completed replica is a LOCAL_DISK replica owned by this client and its
-    // backing file is gone (issue #3709). If so, evict the dangling replica
-    // so the Put can be retried. Returns true only when a replica was
-    // actually evicted.
+    // completed replica is a LOCAL_DISK replica owned by this client, and
+    // probe its last byte through the normal read path to prove the backing
+    // file is gone (issue #3709). Only then evict the dangling replica so the
+    // Put can be retried; any other outcome keeps the old idempotent path.
+    // Returns true only when a replica was actually evicted.
     bool healDanglingLocalDiskReplica(const ObjectKey& key);
     ErrorCode InitTransferEngine(
         const std::string& local_hostname,

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -775,6 +775,12 @@ class Client {
      * @brief Internal helper functions for initialization and data transfer
      */
     ErrorCode ConnectToMaster(const std::string& master_server_entry);
+    // When PutStart reports OBJECT_ALREADY_EXISTS, check whether every
+    // completed replica is a LOCAL_DISK replica owned by this client and its
+    // backing file is gone (issue #3709). If so, evict the dangling replica
+    // so the Put can be retried. Returns true only when a replica was
+    // actually evicted.
+    bool healDanglingLocalDiskReplica(const ObjectKey& key);
     ErrorCode InitTransferEngine(
         const std::string& local_hostname,
         const std::string& metadata_connstring, const std::string& protocol,

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -108,8 +108,10 @@ class FileStorage {
     // friendship, so the dangling-replica tests are friended by their
     // generated class names (plain friend, no gtest include in a production
     // header).
-    friend class FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplica_Test;
-    friend class FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket_Test;
+    friend class
+        FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplica_Test;
+    friend class
+        FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket_Test;
     struct AllocatedBatch {
         uint64_t batch_id;
         std::vector<BufferHandle> handles;

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <gtest/gtest_prod.h>
+
 #include "client_service.h"
 #include "client_buffer.h"
 #include "storage_backend.h"
@@ -81,6 +83,16 @@ class FileStorage {
         return pinned_restore_arena_allocator_ != nullptr;
     }
 
+    /**
+     * @brief Reports whether the backend still holds an entry for the key.
+     *
+     * Answers existence only, without allocating read buffers. After a
+     * physical wipe the per-key backend's filesystem lookup and the bucket
+     * backend's in-memory index both report false, which is exactly the
+     * divergence a dangling-replica probe needs to detect.
+     */
+    tl::expected<bool, ErrorCode> Exists(const std::string& key);
+
     FileStorageConfig config_;
 
     /**
@@ -94,6 +106,12 @@ class FileStorage {
    private:
     friend class FileStorageTest;
     friend class FileStoragePromotionTest;
+    // TEST_F bodies are generated subclasses and do not inherit the fixture's
+    // friendship, so the dangling-replica tests are friended by name.
+    FRIEND_TEST(FileStorageTest,
+                PutAfterPhysicalWipeHealsDanglingLocalDiskReplica);
+    FRIEND_TEST(FileStorageTest,
+                PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket);
     struct AllocatedBatch {
         uint64_t batch_id;
         std::vector<BufferHandle> handles;

--- a/mooncake-store/include/file_storage.h
+++ b/mooncake-store/include/file_storage.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <gtest/gtest_prod.h>
-
 #include "client_service.h"
 #include "client_buffer.h"
 #include "storage_backend.h"
@@ -107,11 +105,11 @@ class FileStorage {
     friend class FileStorageTest;
     friend class FileStoragePromotionTest;
     // TEST_F bodies are generated subclasses and do not inherit the fixture's
-    // friendship, so the dangling-replica tests are friended by name.
-    FRIEND_TEST(FileStorageTest,
-                PutAfterPhysicalWipeHealsDanglingLocalDiskReplica);
-    FRIEND_TEST(FileStorageTest,
-                PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket);
+    // friendship, so the dangling-replica tests are friended by their
+    // generated class names (plain friend, no gtest include in a production
+    // header).
+    friend class FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplica_Test;
+    friend class FileStorageTest_PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket_Test;
     struct AllocatedBatch {
         uint64_t batch_id;
         std::vector<BufferHandle> handles;

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2017,32 +2017,18 @@ bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
         // still serve reads, so there is nothing for this client to heal.
         return false;
     }
-    if (!local_disk || !transfer_submitter_) {
+    if (!local_disk || !local_disk_probe_fn_) {
         return false;
     }
     // RemoveAll wipes client SSD files while master keeps the metadata
     // (issue #3709), leaving a completed entry whose backing file is gone.
-    // Reporting success for a Put on top of it would store nothing. Probe the
-    // last byte through the normal read path: a file-gone error proves the
-    // replica is dangling. Anything else (readable, or a transport error)
-    // keeps the old idempotent path so we never evict a healthy replica.
-    const uint64_t object_size =
-        local_disk->get_local_disk_descriptor().object_size;
-    if (object_size == 0) {
-        return false;
-    }
-    char probe = 0;
-    std::vector<Slice> probe_slice{Slice{&probe, 1}};
-    const ErrorCode probe_err =
-        TransferReadRange(*local_disk, probe_slice, object_size - 1);
-    // The offload read path reports a wiped SSD file as INVALID_KEY (the
-    // storage key is gone from the backend), while other backends surface
-    // OBJECT_NOT_FOUND / FILE_OPEN_FAIL. All three prove the file is gone;
-    // transport/config failures come back as different codes, so a healthy
-    // replica still can never be evicted by mistake.
-    if (probe_err != ErrorCode::OBJECT_NOT_FOUND &&
-        probe_err != ErrorCode::FILE_OPEN_FAIL &&
-        probe_err != ErrorCode::INVALID_KEY) {
+    // Reporting success for a Put on top of it would store nothing. Ask the
+    // installed probe (the offload file storage owned by RealClient) whether
+    // the file is still there. Only a proven-gone answer evicts; present or
+    // unknown (transport/config trouble) keeps the old idempotent path, so a
+    // healthy replica can never be evicted by mistake.
+    const std::optional<bool> file_gone = local_disk_probe_fn_(key);
+    if (file_gone != true) {
         return false;
     }
     auto evicted =

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1880,6 +1880,11 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
 
     // Start put operation
     auto start_result = master_client_.PutStart(key, slice_lengths, client_cfg);
+    if (!start_result &&
+        start_result.error() == ErrorCode::OBJECT_ALREADY_EXISTS &&
+        healDanglingLocalDiskReplica(key)) {
+        start_result = master_client_.PutStart(key, slice_lengths, client_cfg);
+    }
     if (!start_result) {
         ErrorCode err = start_result.error();
         if (err == ErrorCode::OBJECT_ALREADY_EXISTS) {
@@ -1991,6 +1996,47 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
     }
 
     return {};
+}
+
+bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
+    auto replicas = master_client_.GetReplicaList(key);
+    if (!replicas) {
+        return false;
+    }
+    bool has_completed_local_disk = false;
+    for (const auto& replica : replicas->replicas) {
+        if (replica.status != ReplicaStatus::COMPLETE) {
+            continue;
+        }
+        if (replica.is_local_disk_replica() &&
+            replica.get_local_disk_descriptor().client_id == client_id_) {
+            has_completed_local_disk = true;
+            continue;
+        }
+        // A completed replica owned elsewhere (memory, remote disk, DFS) can
+        // still serve reads, so there is nothing for this client to heal.
+        return false;
+    }
+    if (!has_completed_local_disk || !storage_backend_) {
+        return false;
+    }
+    // RemoveAll wipes client SSD files while master keeps the metadata
+    // (issue #3709), leaving a completed entry whose backing file is gone.
+    // Reporting success for a Put on top of it would store nothing.
+    auto exists = storage_backend_->IsExist(key);
+    if (!exists || *exists) {
+        return false;
+    }
+    auto evicted =
+        master_client_.EvictDiskReplica(key, ReplicaType::LOCAL_DISK);
+    if (!evicted) {
+        LOG(WARNING) << "Failed to evict dangling LOCAL_DISK replica for key="
+                     << key << ": " << toString(evicted.error());
+        return false;
+    }
+    LOG(WARNING) << "Evicted dangling LOCAL_DISK replica for key=" << key
+                 << " (backing file already gone)";
+    return true;
 }
 
 tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2035,8 +2035,14 @@ bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
     std::vector<Slice> probe_slice{Slice{&probe, 1}};
     const ErrorCode probe_err =
         TransferReadRange(*local_disk, probe_slice, object_size - 1);
+    // The offload read path reports a wiped SSD file as INVALID_KEY (the
+    // storage key is gone from the backend), while other backends surface
+    // OBJECT_NOT_FOUND / FILE_OPEN_FAIL. All three prove the file is gone;
+    // transport/config failures come back as different codes, so a healthy
+    // replica still can never be evicted by mistake.
     if (probe_err != ErrorCode::OBJECT_NOT_FOUND &&
-        probe_err != ErrorCode::FILE_OPEN_FAIL) {
+        probe_err != ErrorCode::FILE_OPEN_FAIL &&
+        probe_err != ErrorCode::INVALID_KEY) {
         return false;
     }
     auto evicted =

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2003,28 +2003,40 @@ bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
     if (!replicas) {
         return false;
     }
-    bool has_completed_local_disk = false;
+    const Replica::Descriptor* local_disk = nullptr;
     for (const auto& replica : replicas->replicas) {
         if (replica.status != ReplicaStatus::COMPLETE) {
             continue;
         }
         if (replica.is_local_disk_replica() &&
             replica.get_local_disk_descriptor().client_id == client_id_) {
-            has_completed_local_disk = true;
+            local_disk = &replica;
             continue;
         }
         // A completed replica owned elsewhere (memory, remote disk, DFS) can
         // still serve reads, so there is nothing for this client to heal.
         return false;
     }
-    if (!has_completed_local_disk || !storage_backend_) {
+    if (!local_disk || !transfer_submitter_) {
         return false;
     }
     // RemoveAll wipes client SSD files while master keeps the metadata
     // (issue #3709), leaving a completed entry whose backing file is gone.
-    // Reporting success for a Put on top of it would store nothing.
-    auto exists = storage_backend_->IsExist(key);
-    if (!exists || *exists) {
+    // Reporting success for a Put on top of it would store nothing. Probe the
+    // last byte through the normal read path: a file-gone error proves the
+    // replica is dangling. Anything else (readable, or a transport error)
+    // keeps the old idempotent path so we never evict a healthy replica.
+    const uint64_t object_size =
+        local_disk->get_local_disk_descriptor().object_size;
+    if (object_size == 0) {
+        return false;
+    }
+    char probe = 0;
+    std::vector<Slice> probe_slice{Slice{&probe, 1}};
+    const ErrorCode probe_err =
+        TransferReadRange(*local_disk, probe_slice, object_size - 1);
+    if (probe_err != ErrorCode::OBJECT_NOT_FOUND &&
+        probe_err != ErrorCode::FILE_OPEN_FAIL) {
         return false;
     }
     auto evicted =

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1998,26 +1998,36 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
     return {};
 }
 
-bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
-    auto replicas = master_client_.GetReplicaList(key);
-    if (!replicas) {
-        return false;
-    }
-    const Replica::Descriptor* local_disk = nullptr;
-    for (const auto& replica : replicas->replicas) {
+namespace {
+
+// Every COMPLETE replica in the list is a LOCAL_DISK replica owned by this
+// client, so nothing else can serve reads for the key.
+bool HasOnlyClientLocalDiskReplicas(
+    const std::vector<Replica::Descriptor>& replicas, const UUID& client_id) {
+    bool has_local_disk = false;
+    for (const auto& replica : replicas) {
         if (replica.status != ReplicaStatus::COMPLETE) {
             continue;
         }
         if (replica.is_local_disk_replica() &&
-            replica.get_local_disk_descriptor().client_id == client_id_) {
-            local_disk = &replica;
+            replica.get_local_disk_descriptor().client_id == client_id) {
+            has_local_disk = true;
             continue;
         }
         // A completed replica owned elsewhere (memory, remote disk, DFS) can
         // still serve reads, so there is nothing for this client to heal.
         return false;
     }
-    if (!local_disk || !local_disk_probe_fn_) {
+    return has_local_disk;
+}
+
+}  // namespace
+
+bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
+    auto replicas = master_client_.GetReplicaList(key);
+    if (!replicas ||
+        !HasOnlyClientLocalDiskReplicas(replicas->replicas, client_id_) ||
+        !local_disk_probe_fn_) {
         return false;
     }
     // RemoveAll wipes client SSD files while master keeps the metadata
@@ -2041,6 +2051,99 @@ bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
     LOG(WARNING) << "Evicted dangling LOCAL_DISK replica for key=" << key
                  << " (backing file already gone)";
     return true;
+}
+
+void Client::healDanglingLocalDiskBatchStarts(
+    std::vector<PutOperation>& ops, const std::vector<size_t>& active_indices,
+    const std::vector<size_t>& already_exists,
+    const std::vector<std::string>& keys,
+    const std::vector<std::vector<uint64_t>>& slice_lengths,
+    const ReplicateConfig& config) {
+    if (already_exists.empty() || !local_disk_probe_fn_) {
+        return;
+    }
+    std::vector<std::string> candidate_keys;
+    candidate_keys.reserve(already_exists.size());
+    for (size_t i : already_exists) {
+        candidate_keys.emplace_back(keys[i]);
+    }
+    // One round trip for the whole subset: a healthy idempotent batch pays a
+    // single batched query and no evictions, and the per-key work left over
+    // is a local filesystem probe.
+    auto replica_lists = master_client_.BatchGetReplicaList(candidate_keys);
+    if (replica_lists.size() != candidate_keys.size()) {
+        return;
+    }
+    std::vector<std::string> evict_keys;
+    std::vector<size_t> evict_positions;
+    for (size_t j = 0; j < candidate_keys.size(); ++j) {
+        if (!replica_lists[j] || !HasOnlyClientLocalDiskReplicas(
+                                     replica_lists[j]->replicas, client_id_)) {
+            continue;
+        }
+        const std::optional<bool> file_gone =
+            local_disk_probe_fn_(candidate_keys[j]);
+        if (file_gone != true) {
+            continue;
+        }
+        evict_keys.emplace_back(candidate_keys[j]);
+        evict_positions.emplace_back(j);
+    }
+    if (evict_keys.empty()) {
+        return;
+    }
+    auto evicted = master_client_.BatchEvictDiskReplica(
+        evict_keys, ReplicaType::LOCAL_DISK);
+    if (evicted.size() != evict_keys.size()) {
+        return;
+    }
+    std::vector<std::string> retry_keys;
+    std::vector<std::vector<uint64_t>> retry_slices;
+    std::vector<size_t> retry_positions;
+    for (size_t j = 0; j < evict_keys.size(); ++j) {
+        if (!evicted[j]) {
+            LOG(WARNING) << "Failed to evict dangling LOCAL_DISK replica for "
+                         << "key=" << evict_keys[j] << ": "
+                         << toString(evicted[j].error());
+            continue;
+        }
+        LOG(WARNING) << "Evicted dangling LOCAL_DISK replica for key="
+                     << evict_keys[j] << " (backing file already gone)";
+        retry_positions.emplace_back(evict_positions[j]);
+        retry_keys.emplace_back(keys[already_exists[evict_positions[j]]]);
+        retry_slices.emplace_back(
+            slice_lengths[already_exists[evict_positions[j]]]);
+    }
+    if (retry_keys.empty()) {
+        return;
+    }
+    auto retry_responses =
+        master_client_.BatchPutStart(retry_keys, retry_slices, config);
+    if (retry_responses.size() != retry_keys.size()) {
+        return;
+    }
+    for (size_t r = 0; r < retry_keys.size(); ++r) {
+        auto& op = ops[active_indices[already_exists[retry_positions[r]]]];
+        if (!retry_responses[r]) {
+            // OBJECT_ALREADY_EXISTS again means another writer won the race;
+            // the idempotent skip applies. Any other error is reported as is.
+            if (retry_responses[r].error() !=
+                ErrorCode::OBJECT_ALREADY_EXISTS) {
+                op.SetTerminalError(retry_responses[r].error(),
+                                    PutOperationState::MASTER_FAILED,
+                                    "Master failed to start put operation");
+            }
+            continue;
+        }
+        op.replicas = retry_responses[r].value();
+        op.RecordAllocatedReplicas();
+        if (!HasExpectedReplicaAllocation(config, op.transfer_summary)) {
+            op.SetTerminalError(ErrorCode::NO_AVAILABLE_HANDLE,
+                                PutOperationState::MASTER_FAILED,
+                                "Allocated replicas do not satisfy "
+                                "requested replica policy");
+        }
+    }
 }
 
 tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
@@ -2429,10 +2532,19 @@ void Client::StartBatchPut(std::vector<PutOperation>& ops,
     }
 
     // Process individual responses with robust error handling
+    std::vector<size_t> already_exists;
     for (size_t i = 0; i < active_indices.size(); ++i) {
         auto& op = ops[active_indices[i]];
         op.InitializeRequestedReplicas(config);
         if (!start_responses[i]) {
+            if (start_responses[i].error() ==
+                ErrorCode::OBJECT_ALREADY_EXISTS) {
+                // Decided after the heal pass below: retried when the
+                // replica proves dangling, or the idempotent skip that
+                // CollectResults already grants.
+                already_exists.emplace_back(i);
+                continue;
+            }
             op.SetTerminalError(start_responses[i].error(),
                                 PutOperationState::MASTER_FAILED,
                                 "Master failed to start put operation");
@@ -2450,6 +2562,17 @@ void Client::StartBatchPut(std::vector<PutOperation>& ops,
             // until fully successful
             VLOG(1) << "Successfully started put for key " << op.key << " with "
                     << op.replicas.size() << " replicas";
+        }
+    }
+
+    healDanglingLocalDiskBatchStarts(ops, active_indices, already_exists, keys,
+                                     slice_lengths, config);
+    for (size_t i : already_exists) {
+        auto& op = ops[active_indices[i]];
+        if (!op.IsResolved() && op.replicas.empty()) {
+            op.SetTerminalError(ErrorCode::OBJECT_ALREADY_EXISTS,
+                                PutOperationState::MASTER_FAILED,
+                                "Master failed to start put operation");
         }
     }
 }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -2053,99 +2053,6 @@ bool Client::healDanglingLocalDiskReplica(const ObjectKey& key) {
     return true;
 }
 
-void Client::healDanglingLocalDiskBatchStarts(
-    std::vector<PutOperation>& ops, const std::vector<size_t>& active_indices,
-    const std::vector<size_t>& already_exists,
-    const std::vector<std::string>& keys,
-    const std::vector<std::vector<uint64_t>>& slice_lengths,
-    const ReplicateConfig& config) {
-    if (already_exists.empty() || !local_disk_probe_fn_) {
-        return;
-    }
-    std::vector<std::string> candidate_keys;
-    candidate_keys.reserve(already_exists.size());
-    for (size_t i : already_exists) {
-        candidate_keys.emplace_back(keys[i]);
-    }
-    // One round trip for the whole subset: a healthy idempotent batch pays a
-    // single batched query and no evictions, and the per-key work left over
-    // is a local filesystem probe.
-    auto replica_lists = master_client_.BatchGetReplicaList(candidate_keys);
-    if (replica_lists.size() != candidate_keys.size()) {
-        return;
-    }
-    std::vector<std::string> evict_keys;
-    std::vector<size_t> evict_positions;
-    for (size_t j = 0; j < candidate_keys.size(); ++j) {
-        if (!replica_lists[j] || !HasOnlyClientLocalDiskReplicas(
-                                     replica_lists[j]->replicas, client_id_)) {
-            continue;
-        }
-        const std::optional<bool> file_gone =
-            local_disk_probe_fn_(candidate_keys[j]);
-        if (file_gone != true) {
-            continue;
-        }
-        evict_keys.emplace_back(candidate_keys[j]);
-        evict_positions.emplace_back(j);
-    }
-    if (evict_keys.empty()) {
-        return;
-    }
-    auto evicted = master_client_.BatchEvictDiskReplica(
-        evict_keys, ReplicaType::LOCAL_DISK);
-    if (evicted.size() != evict_keys.size()) {
-        return;
-    }
-    std::vector<std::string> retry_keys;
-    std::vector<std::vector<uint64_t>> retry_slices;
-    std::vector<size_t> retry_positions;
-    for (size_t j = 0; j < evict_keys.size(); ++j) {
-        if (!evicted[j]) {
-            LOG(WARNING) << "Failed to evict dangling LOCAL_DISK replica for "
-                         << "key=" << evict_keys[j] << ": "
-                         << toString(evicted[j].error());
-            continue;
-        }
-        LOG(WARNING) << "Evicted dangling LOCAL_DISK replica for key="
-                     << evict_keys[j] << " (backing file already gone)";
-        retry_positions.emplace_back(evict_positions[j]);
-        retry_keys.emplace_back(keys[already_exists[evict_positions[j]]]);
-        retry_slices.emplace_back(
-            slice_lengths[already_exists[evict_positions[j]]]);
-    }
-    if (retry_keys.empty()) {
-        return;
-    }
-    auto retry_responses =
-        master_client_.BatchPutStart(retry_keys, retry_slices, config);
-    if (retry_responses.size() != retry_keys.size()) {
-        return;
-    }
-    for (size_t r = 0; r < retry_keys.size(); ++r) {
-        auto& op = ops[active_indices[already_exists[retry_positions[r]]]];
-        if (!retry_responses[r]) {
-            // OBJECT_ALREADY_EXISTS again means another writer won the race;
-            // the idempotent skip applies. Any other error is reported as is.
-            if (retry_responses[r].error() !=
-                ErrorCode::OBJECT_ALREADY_EXISTS) {
-                op.SetTerminalError(retry_responses[r].error(),
-                                    PutOperationState::MASTER_FAILED,
-                                    "Master failed to start put operation");
-            }
-            continue;
-        }
-        op.replicas = retry_responses[r].value();
-        op.RecordAllocatedReplicas();
-        if (!HasExpectedReplicaAllocation(config, op.transfer_summary)) {
-            op.SetTerminalError(ErrorCode::NO_AVAILABLE_HANDLE,
-                                PutOperationState::MASTER_FAILED,
-                                "Allocated replicas do not satisfy "
-                                "requested replica policy");
-        }
-    }
-}
-
 tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
                                              std::vector<Slice>& slices,
                                              const ReplicateConfig& config) {
@@ -2475,6 +2382,99 @@ void Client::ComputeBatchObjectChecksums(std::vector<PutOperation>& ops) {
             continue;
         }
         op.object_checksum = *checksum_result;
+    }
+}
+
+void Client::healDanglingLocalDiskBatchStarts(
+    std::vector<PutOperation>& ops, const std::vector<size_t>& active_indices,
+    const std::vector<size_t>& already_exists,
+    const std::vector<std::string>& keys,
+    const std::vector<std::vector<uint64_t>>& slice_lengths,
+    const ReplicateConfig& config) {
+    if (already_exists.empty() || !local_disk_probe_fn_) {
+        return;
+    }
+    std::vector<std::string> candidate_keys;
+    candidate_keys.reserve(already_exists.size());
+    for (size_t i : already_exists) {
+        candidate_keys.emplace_back(keys[i]);
+    }
+    // One round trip for the whole subset: a healthy idempotent batch pays a
+    // single batched query and no evictions, and the per-key work left over
+    // is a local filesystem probe.
+    auto replica_lists = master_client_.BatchGetReplicaList(candidate_keys);
+    if (replica_lists.size() != candidate_keys.size()) {
+        return;
+    }
+    std::vector<std::string> evict_keys;
+    std::vector<size_t> evict_positions;
+    for (size_t j = 0; j < candidate_keys.size(); ++j) {
+        if (!replica_lists[j] || !HasOnlyClientLocalDiskReplicas(
+                                     replica_lists[j]->replicas, client_id_)) {
+            continue;
+        }
+        const std::optional<bool> file_gone =
+            local_disk_probe_fn_(candidate_keys[j]);
+        if (file_gone != true) {
+            continue;
+        }
+        evict_keys.emplace_back(candidate_keys[j]);
+        evict_positions.emplace_back(j);
+    }
+    if (evict_keys.empty()) {
+        return;
+    }
+    auto evicted = master_client_.BatchEvictDiskReplica(
+        evict_keys, ReplicaType::LOCAL_DISK);
+    if (evicted.size() != evict_keys.size()) {
+        return;
+    }
+    std::vector<std::string> retry_keys;
+    std::vector<std::vector<uint64_t>> retry_slices;
+    std::vector<size_t> retry_positions;
+    for (size_t j = 0; j < evict_keys.size(); ++j) {
+        if (!evicted[j]) {
+            LOG(WARNING) << "Failed to evict dangling LOCAL_DISK replica for "
+                         << "key=" << evict_keys[j] << ": "
+                         << toString(evicted[j].error());
+            continue;
+        }
+        LOG(WARNING) << "Evicted dangling LOCAL_DISK replica for key="
+                     << evict_keys[j] << " (backing file already gone)";
+        retry_positions.emplace_back(evict_positions[j]);
+        retry_keys.emplace_back(keys[already_exists[evict_positions[j]]]);
+        retry_slices.emplace_back(
+            slice_lengths[already_exists[evict_positions[j]]]);
+    }
+    if (retry_keys.empty()) {
+        return;
+    }
+    auto retry_responses =
+        master_client_.BatchPutStart(retry_keys, retry_slices, config);
+    if (retry_responses.size() != retry_keys.size()) {
+        return;
+    }
+    for (size_t r = 0; r < retry_keys.size(); ++r) {
+        auto& op = ops[active_indices[already_exists[retry_positions[r]]]];
+        if (!retry_responses[r]) {
+            // OBJECT_ALREADY_EXISTS again means another writer won the race;
+            // the idempotent skip applies. Any other error is reported as is.
+            if (retry_responses[r].error() !=
+                ErrorCode::OBJECT_ALREADY_EXISTS) {
+                op.SetTerminalError(retry_responses[r].error(),
+                                    PutOperationState::MASTER_FAILED,
+                                    "Master failed to start put operation");
+            }
+            continue;
+        }
+        op.replicas = retry_responses[r].value();
+        op.RecordAllocatedReplicas();
+        if (!HasExpectedReplicaAllocation(config, op.transfer_summary)) {
+            op.SetTerminalError(ErrorCode::NO_AVAILABLE_HANDLE,
+                                PutOperationState::MASTER_FAILED,
+                                "Allocated replicas do not satisfy "
+                                "requested replica policy");
+        }
     }
 }
 

--- a/mooncake-store/src/file_storage.cpp
+++ b/mooncake-store/src/file_storage.cpp
@@ -1178,6 +1178,14 @@ void FileStorage::ClientBufferGCThreadFunc() {
     LOG(INFO) << "action=client_buffer_gc_thread_stopped";
 }
 
+tl::expected<bool, ErrorCode> FileStorage::Exists(const std::string& key) {
+    if (!storage_backend_) {
+        LOG(ERROR) << "Storage backend is not initialized. Call Init() first.";
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
+    return storage_backend_->IsExist(key);
+}
+
 bool FileStorage::ReleaseBuffer(uint64_t batch_id) {
     MutexLocker locker(&client_buffer_mutex_);
     auto it = client_buffer_allocated_batches_.find(batch_id);

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1146,7 +1146,7 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
         // owns. true: backing file is gone, false: present, nullopt: unknown.
         std::weak_ptr<FileStorage> weak_storage = file_storage_;
         client_->SetLocalDiskProbe(
-            [weak_storage](const std::string& key) -> std::optional<bool> {
+            [weak_storage](const std::string &key) -> std::optional<bool> {
                 auto storage = weak_storage.lock();
                 if (!storage) {
                     return std::nullopt;

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1141,6 +1141,22 @@ tl::expected<void, ErrorCode> RealClient::setup_internal(
                        << init_result.error();
             return init_result;
         }
+        // The dangling-replica heal in Client::Put needs an existence check
+        // against this process's offload files, which only the FileStorage
+        // owns. true: backing file is gone, false: present, nullopt: unknown.
+        std::weak_ptr<FileStorage> weak_storage = file_storage_;
+        client_->SetLocalDiskProbe(
+            [weak_storage](const std::string& key) -> std::optional<bool> {
+                auto storage = weak_storage.lock();
+                if (!storage) {
+                    return std::nullopt;
+                }
+                auto exists = storage->Exists(key);
+                if (!exists) {
+                    return std::nullopt;
+                }
+                return !*exists;
+            });
     }
     client_requester_ = std::make_shared<ClientRequester>();
     const bool should_start_http_server =

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -364,6 +364,130 @@ class FileStorageTest : public ::testing::Test {
         EXPECT_TRUE(unmount.has_value());
         std::free(seg_ptr);
     }
+    void RunBatchPutHealWipeScenario(const std::string& data_path) {
+        std::filesystem::path master_root =
+            std::filesystem::path(data_path) / "heal_master_batch";
+        std::filesystem::create_directories(master_root);
+
+        testing::InProcMaster master;
+        auto master_config = InProcMasterConfigBuilder()
+                                 .set_enable_offload(true)
+                                 .set_root_fs_dir(master_root.string())
+                                 .build();
+        ASSERT_TRUE(master.Start(master_config));
+
+        std::string local_rpc_addr =
+            "127.0.0.1:" + std::to_string(getFreeTcpPort());
+        auto client =
+            Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                           std::nullopt, master.master_address());
+        ASSERT_TRUE(client.has_value());
+        ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+        constexpr size_t kSegSize = 64 * 1024 * 1024;
+        void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
+        ASSERT_NE(seg_ptr, nullptr);
+        ASSERT_TRUE(
+            client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
+        SimpleAllocator allocator(16 * 1024 * 1024);
+        ASSERT_TRUE(client.value()
+                        ->RegisterLocalMemory(allocator.getBase(),
+                                              16 * 1024 * 1024, "cpu:0", false,
+                                              false)
+                        .has_value());
+
+        FileStorageConfig config = FileStorageConfig::FromEnvironment();
+        config.storage_backend_type = StorageBackendType::kFilePerKey;
+        config.storage_filepath = data_path + "/heal_ssd_batch";
+        config.local_buffer_size = 4 * 1024 * 1024;
+        fs::create_directories(config.storage_filepath);
+        FileStorage file_storage(config, client.value(), local_rpc_addr);
+        ASSERT_TRUE(file_storage.storage_backend_->Init());
+        {
+            MutexLocker locker(&file_storage.offloading_mutex_);
+            file_storage.enable_offloading_ = true;
+        }
+
+        // Offload two keys, then wipe the backing files to recreate the #3709
+        // divergence on both.
+        const std::vector<std::string> wiped_keys = {"heal_batch_a",
+                                                     "heal_batch_b"};
+        std::string original(512, 'x');
+        std::unordered_map<std::string, std::vector<Slice>> batch_object;
+        for (const auto& key : wiped_keys) {
+            batch_object.emplace(
+                key, std::vector<Slice>{Slice{original.data(), 512}});
+        }
+        auto offload_result = file_storage.storage_backend_->BatchOffload(
+            batch_object,
+            [&file_storage](const std::vector<std::string>& keys,
+                            std::vector<StorageObjectMetadata>& metadatas) {
+                for (auto& metadata : metadatas) {
+                    metadata.transport_endpoint = file_storage.local_rpc_addr_;
+                }
+                auto result =
+                    file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
+                return result ? ErrorCode::OK : result.error();
+            });
+        ASSERT_TRUE(offload_result.has_value());
+
+        client.value()->SetLocalDiskProbe(
+            [&file_storage](const std::string& k) -> std::optional<bool> {
+                auto exists = file_storage.Exists(k);
+                if (!exists) {
+                    return std::nullopt;
+                }
+                return !*exists;
+            });
+
+        file_storage.storage_backend_->RemoveAll();
+        auto exists = file_storage.Exists(wiped_keys[0]);
+        ASSERT_TRUE(exists.has_value());
+        ASSERT_FALSE(exists.value());
+
+        // One batch with both wiped keys and a fresh key.
+        const std::string fresh_key = "heal_batch_fresh";
+        const std::string updated(512, 'y');
+        std::vector<ObjectKey> keys = {wiped_keys[0], wiped_keys[1], fresh_key};
+        std::vector<std::vector<Slice>> batched_slices;
+        std::vector<void*> buffers;
+        for (size_t i = 0; i < keys.size(); ++i) {
+            void* buf = allocator.allocate(512);
+            ASSERT_NE(buf, nullptr);
+            std::memcpy(buf, updated.data(), 512);
+            buffers.push_back(buf);
+            batched_slices.push_back({Slice{buf, 512}});
+        }
+        ReplicateConfig cfg;
+        cfg.replica_num = 1;
+        auto results = client.value()->BatchPut(keys, batched_slices, cfg);
+        ASSERT_EQ(results.size(), keys.size());
+        for (size_t i = 0; i < results.size(); ++i) {
+            ASSERT_TRUE(results[i].has_value())
+                << "BatchPut over a dangling replica failed for " << keys[i]
+                << ": " << toString(results[i].error());
+        }
+
+        // Every key, healed or fresh, reads the new data back.
+        for (const auto& key : keys) {
+            void* read_buf = allocator.allocate(512);
+            ASSERT_NE(read_buf, nullptr);
+            std::vector<Slice> read_slices{Slice{read_buf, 512}};
+            auto get = client.value()->Get(key, read_slices);
+            ASSERT_TRUE(get.has_value())
+                << "Get after batch self-heal failed for " << key << ": "
+                << toString(get.error());
+            EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
+            allocator.deallocate(read_buf, 512);
+        }
+        for (void* buf : buffers) {
+            allocator.deallocate(buf, 512);
+        }
+
+        auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
+        EXPECT_TRUE(unmount.has_value());
+        std::free(seg_ptr);
+    }
 };
 
 TEST_F(FileStorageTest, IsEnableOffloading) {
@@ -894,132 +1018,14 @@ TEST_F(FileStorageTest, BatchLoadRecordsSsdMetrics) {
     // Create FileStorage WITH SsdMetric
     SsdMetric ssd_metric;
     FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003",
-                            &ssd_metric);
-
-    // Write test data to disk
-    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
-    ASSERT_FALSE(keys.empty());
-
-    // Allocate buffers and call BatchLoad (read path)
-    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
-    ASSERT_TRUE(allocate_res);
-
-    auto load_result =
-        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices);
-    ASSERT_TRUE(load_result);
-
-    // Verify SSD read metrics were recorded
-    EXPECT_EQ(ssd_metric.ssd_read_ops.value(),
-              static_cast<int64_t>(allocate_res.value()->slices.size()));
-
-    // Verify bytes: sum of all slice sizes
-    int64_t expected_bytes = 0;
-    for (const auto& [key, slice] : allocate_res.value()->slices) {
-        expected_bytes += slice.size;
-    }
-    EXPECT_EQ(ssd_metric.ssd_read_bytes.value(), expected_bytes);
-    EXPECT_GT(expected_bytes, 0);
-
-    // Verify latency histogram has exactly 1 observation (one BatchLoad call)
-    auto buckets = ssd_metric.ssd_read_latency_us.get_bucket_counts();
-    int64_t total_observations = 0;
-    for (auto& b : buckets) {
-        total_observations += b->value();
-    }
-    EXPECT_EQ(total_observations, 1);
-
-    // Write metrics should remain 0 (BatchOffloadUtil bypasses FileStorage)
-    EXPECT_EQ(ssd_metric.ssd_write_ops.value(), 0);
-    EXPECT_EQ(ssd_metric.ssd_write_bytes.value(), 0);
-
-    LOG(INFO) << "SSD read metrics after BatchLoad: ops="
-              << ssd_metric.ssd_read_ops.value()
-              << ", bytes=" << ssd_metric.ssd_read_bytes.value();
-}
-
-TEST_F(FileStorageTest, BatchLoadFailureDoesNotRecordSsdMetrics) {
-    auto file_storage_config = FileStorageConfig::FromEnvironment();
-    file_storage_config.storage_filepath = data_path;
-
-    SsdMetric ssd_metric;
-    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003",
-                            &ssd_metric);
-
-    // Init storage backend so we can call BatchLoad
-    // But load with keys that don't exist on disk -> should fail
-    std::unordered_map<std::string, Slice> batch_object;
-    char dummy_buf[4096] = {};
-    batch_object["nonexistent_key_1"] = Slice{dummy_buf, 4096};
-    batch_object["nonexistent_key_2"] = Slice{dummy_buf, 8192};
-
-    auto result = FileStorageBatchLoad(fileStorage, batch_object);
-    // Expect failure (keys don't exist on disk)
-    EXPECT_FALSE(result);
-
-    // Metrics should remain 0 - failed operations are not counted
-    EXPECT_EQ(ssd_metric.ssd_read_ops.value(), 0);
-    EXPECT_EQ(ssd_metric.ssd_read_bytes.value(), 0);
-
-    auto buckets = ssd_metric.ssd_read_latency_us.get_bucket_counts();
-    int64_t total_observations = 0;
-    for (auto& b : buckets) {
-        total_observations += b->value();
-    }
-    EXPECT_EQ(total_observations, 0);
-
-    LOG(INFO) << "SSD metrics after failed BatchLoad: ops="
-              << ssd_metric.ssd_read_ops.value()
-              << ", bytes=" << ssd_metric.ssd_read_bytes.value();
-}
-
-TEST_F(FileStorageTest, NullSsdMetricDoesNotCrash) {
-    // FileStorage with nullptr SsdMetric should work fine (no metrics recorded)
-    std::vector<std::string> keys;
-    std::vector<int64_t> sizes;
-    std::unordered_map<std::string, std::string> batch_data;
-
-    auto file_storage_config = FileStorageConfig::FromEnvironment();
-    file_storage_config.storage_filepath = data_path;
-
-    // nullptr SsdMetric (default)
-    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
-
-    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
-    ASSERT_FALSE(keys.empty());
-
-    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
-    ASSERT_TRUE(allocate_res);
-
-    auto load_result =
-        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices);
-    ASSERT_TRUE(load_result);
-    // No crash = success. No metrics pointer, so nothing to verify.
-}
-
-// Issue #3709: a RemoveAll-style physical wipe of the SSD files while master
-// still tracks the key's LOCAL_DISK replica leaves a dangling entry. A Put
-// for the same key must not report success while storing nothing: the client
-// evicts the dangling replica and retries PutStart, so the new data is
-// actually written.
-
-TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
-    // The per-key file backend reports the wiped file as OBJECT_NOT_FOUND /
-    // FILE_OPEN_FAIL, the original proof set.
-    RunPutHealWipeScenario(data_path, StorageBackendType::kFilePerKey,
-                           "_per_key");
-}
-
-TEST_F(FileStorageTest,
-       PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket) {
-    // The bucket backend's BatchLoad reports a missing key as INVALID_KEY
-    // (fanganpai's production trace in #3709); the heal must still fire.
-    RunPutHealWipeScenario(data_path, StorageBackendType::kBucket, "_bucket");
-}
-
 TEST_F(FileStorageTest,
        BatchPutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
-    // The BatchPut twin of the scenario above: OBJECT_ALREADY_EXISTS results
-    // on the batch path must not be converted to success for keys whose
+        // The BatchPut twin of the scenario above: OBJECT_ALREADY_EXISTS
+        // results on the batch path must not be converted to success for keys
+        // whose backing file is gone. Two wiped keys and one fresh key go
+        // through one batch; every key must really store.
+        RunBatchPutHealWipeScenario(data_path);
+}
     // backing file is gone. Two wiped keys and one fresh key go through one
     // batch; every key must really store.
     std::filesystem::path master_root =
@@ -1077,22 +1083,22 @@ TEST_F(FileStorageTest,
         batch_object,
         [&file_storage](const std::vector<std::string>& keys,
                         std::vector<StorageObjectMetadata>& metadatas) {
-            for (auto& metadata : metadatas) {
-                metadata.transport_endpoint = file_storage.local_rpc_addr_;
-            }
-            auto result =
-                file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
-            return result ? ErrorCode::OK : result.error();
+        for (auto& metadata : metadatas) {
+            metadata.transport_endpoint = file_storage.local_rpc_addr_;
+        }
+        auto result =
+            file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
+        return result ? ErrorCode::OK : result.error();
         });
     ASSERT_TRUE(offload_result.has_value());
 
     client.value()->SetLocalDiskProbe(
         [&file_storage](const std::string& k) -> std::optional<bool> {
-            auto exists = file_storage.Exists(k);
-            if (!exists) {
-                return std::nullopt;
-            }
-            return !*exists;
+        auto exists = file_storage.Exists(k);
+        if (!exists) {
+            return std::nullopt;
+        }
+        return !*exists;
         });
 
     file_storage.storage_backend_->RemoveAll();

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -943,6 +943,17 @@ void RunPutHealWipeScenario(const std::string& data_path,
         });
     ASSERT_TRUE(offload_result.has_value());
 
+    // Wire the probe the way RealClient does in production: existence against
+    // this process's offload files.
+    client.value()->SetLocalDiskProbe(
+        [&file_storage](const std::string& k) -> std::optional<bool> {
+            auto exists = file_storage.Exists(k);
+            if (!exists) {
+                return std::nullopt;
+            }
+            return !*exists;
+        });
+
     auto query = client.value()->Query(key);
     ASSERT_TRUE(query.has_value());
     bool has_local_disk = false;
@@ -954,11 +965,12 @@ void RunPutHealWipeScenario(const std::string& data_path,
     // Simulate the #3709 divergence: the SSD file is wiped physically while
     // master keeps the metadata.
     file_storage.storage_backend_->RemoveAll();
-    auto exists = file_storage.storage_backend_->IsExist(key);
+    auto exists = file_storage.Exists(key);
     ASSERT_TRUE(exists.has_value());
     ASSERT_FALSE(exists.value());
-    query = client.value()->Query(key);
-    ASSERT_TRUE(query.has_value());
+    // QueryResult is not assignable, so re-query into a fresh variable.
+    auto query_after_wipe = client.value()->Query(key);
+    ASSERT_TRUE(query_after_wipe.has_value());
 
     // Put the same key again: the dangling replica must be evicted and the
     // Put must really store new data.

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -14,6 +14,7 @@
 #include "storage_backend.h"
 #include "tenant_id.h"
 #include "test_server_helpers.h"
+#include "utils.h"
 #include "utils/common.h"
 
 namespace mooncake {
@@ -868,6 +869,120 @@ TEST_F(FileStorageTest, NullSsdMetricDoesNotCrash) {
         FileStorageBatchLoad(fileStorage, allocate_res.value()->slices);
     ASSERT_TRUE(load_result);
     // No crash = success. No metrics pointer, so nothing to verify.
+}
+
+// Issue #3709: a RemoveAll-style physical wipe of the SSD files while master
+// still tracks the key's LOCAL_DISK replica leaves a dangling entry. A Put
+// for the same key must not report success while storing nothing: the client
+// evicts the dangling replica and retries PutStart, so the new data is
+// actually written.
+TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
+    std::filesystem::path master_root =
+        std::filesystem::path(data_path) / "heal_master";
+    std::filesystem::create_directories(master_root);
+
+    testing::InProcMaster master;
+    auto master_config = InProcMasterConfigBuilder()
+                             .set_enable_offload(true)
+                             .set_root_fs_dir(master_root.string())
+                             .build();
+    ASSERT_TRUE(master.Start(master_config));
+
+    std::string local_rpc_addr =
+        "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                                 std::nullopt, master.master_address());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+    // Memory segment and registered buffers, so the retried PutStart can
+    // allocate a memory replica and Get can read it back.
+    constexpr size_t kSegSize = 64 * 1024 * 1024;
+    void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
+    ASSERT_NE(seg_ptr, nullptr);
+    ASSERT_TRUE(
+        client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
+    SimpleAllocator allocator(16 * 1024 * 1024);
+    ASSERT_TRUE(client.value()
+                    ->RegisterLocalMemory(allocator.getBase(), 16 * 1024 * 1024,
+                                          "cpu:0", false, false)
+                    .has_value());
+
+    FileStorageConfig config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kFilePerKey;
+    config.storage_filepath = data_path + "/heal_ssd";
+    config.local_buffer_size = 4 * 1024 * 1024;
+    fs::create_directories(config.storage_filepath);
+    FileStorage file_storage(config, client.value(), local_rpc_addr);
+    ASSERT_TRUE(file_storage.storage_backend_->Init());
+    {
+        MutexLocker locker(&file_storage.offloading_mutex_);
+        file_storage.enable_offloading_ = true;
+    }
+
+    // Offload one key so master tracks a LOCAL_DISK replica backed by a real
+    // file on the client SSD.
+    const std::string key = "heal_key";
+    std::string original(512, 'x');
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    batch_object.emplace(key, std::vector<Slice>{Slice{original.data(), 512}});
+    auto offload_result = file_storage.storage_backend_->BatchOffload(
+        batch_object,
+        [&file_storage](const std::vector<std::string>& keys,
+                        std::vector<StorageObjectMetadata>& metadatas) {
+            for (auto& metadata : metadatas) {
+                metadata.transport_endpoint = file_storage.local_rpc_addr_;
+            }
+            auto result =
+                file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
+            return result ? ErrorCode::OK : result.error();
+        });
+    ASSERT_TRUE(offload_result.has_value());
+
+    auto query = client.value()->Query(key);
+    ASSERT_TRUE(query.has_value());
+    bool has_local_disk = false;
+    for (const auto& replica : query->replicas) {
+        has_local_disk |= replica.is_local_disk_replica();
+    }
+    ASSERT_TRUE(has_local_disk);
+
+    // Simulate the #3709 divergence: the SSD file is wiped physically while
+    // master keeps the metadata.
+    file_storage.storage_backend_->RemoveAll();
+    auto exists = file_storage.storage_backend_->IsExist(key);
+    ASSERT_TRUE(exists.has_value());
+    ASSERT_FALSE(exists.value());
+    query = client.value()->Query(key);
+    ASSERT_TRUE(query.has_value());
+
+    // Put the same key again: the dangling replica must be evicted and the
+    // Put must really store new data.
+    void* buf = allocator.allocate(512);
+    ASSERT_NE(buf, nullptr);
+    std::string updated(512, 'y');
+    std::memcpy(buf, updated.data(), 512);
+    std::vector<Slice> slices{Slice{buf, 512}};
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    auto put = client.value()->Put(key, slices, cfg);
+    ASSERT_TRUE(put.has_value())
+        << "Put over a dangling replica failed: " << toString(put.error());
+    allocator.deallocate(buf, 512);
+
+    // The new data is readable through the normal Get path.
+    void* read_buf = allocator.allocate(512);
+    ASSERT_NE(read_buf, nullptr);
+    std::vector<Slice> read_slices{Slice{read_buf, 512}};
+    auto get = client.value()->Get(key, read_slices);
+    ASSERT_TRUE(get.has_value())
+        << "Get after self-heal failed: " << toString(get.error());
+    EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
+    allocator.deallocate(read_buf, 512);
+
+    auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
+    EXPECT_TRUE(unmount.has_value());
+    std::free(seg_ptr);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -876,9 +876,13 @@ TEST_F(FileStorageTest, NullSsdMetricDoesNotCrash) {
 // for the same key must not report success while storing nothing: the client
 // evicts the dangling replica and retries PutStart, so the new data is
 // actually written.
-TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
+namespace {
+
+void RunPutHealWipeScenario(const std::string& data_path,
+                            StorageBackendType backend_type,
+                            const std::string& suffix) {
     std::filesystem::path master_root =
-        std::filesystem::path(data_path) / "heal_master";
+        std::filesystem::path(data_path) / ("heal_master" + suffix);
     std::filesystem::create_directories(master_root);
 
     testing::InProcMaster master;
@@ -909,8 +913,8 @@ TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
                     .has_value());
 
     FileStorageConfig config = FileStorageConfig::FromEnvironment();
-    config.storage_backend_type = StorageBackendType::kFilePerKey;
-    config.storage_filepath = data_path + "/heal_ssd";
+    config.storage_backend_type = backend_type;
+    config.storage_filepath = data_path + "/heal_ssd" + suffix;
     config.local_buffer_size = 4 * 1024 * 1024;
     fs::create_directories(config.storage_filepath);
     FileStorage file_storage(config, client.value(), local_rpc_addr);
@@ -922,7 +926,7 @@ TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
 
     // Offload one key so master tracks a LOCAL_DISK replica backed by a real
     // file on the client SSD.
-    const std::string key = "heal_key";
+    const std::string key = "heal_key" + suffix;
     std::string original(512, 'x');
     std::unordered_map<std::string, std::vector<Slice>> batch_object;
     batch_object.emplace(key, std::vector<Slice>{Slice{original.data(), 512}});
@@ -983,6 +987,22 @@ TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
     auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
     EXPECT_TRUE(unmount.has_value());
     std::free(seg_ptr);
+}
+
+}  // namespace
+
+TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
+    // The per-key file backend reports the wiped file as OBJECT_NOT_FOUND /
+    // FILE_OPEN_FAIL, the original proof set.
+    RunPutHealWipeScenario(data_path, StorageBackendType::kFilePerKey,
+                           "_per_key");
+}
+
+TEST_F(FileStorageTest,
+       PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket) {
+    // The bucket backend's BatchLoad reports a missing key as INVALID_KEY
+    // (fanganpai's production trace in #3709); the heal must still fire.
+    RunPutHealWipeScenario(data_path, StorageBackendType::kBucket, "_bucket");
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -1018,135 +1018,135 @@ TEST_F(FileStorageTest, BatchLoadRecordsSsdMetrics) {
     // Create FileStorage WITH SsdMetric
     SsdMetric ssd_metric;
     FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003",
+                            &ssd_metric);
+
+    // Write test data to disk
+    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
+    ASSERT_FALSE(keys.empty());
+
+    // Allocate buffers and call BatchLoad (read path)
+    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
+    ASSERT_TRUE(allocate_res);
+
+    auto load_result =
+        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices);
+    ASSERT_TRUE(load_result);
+
+    // Verify SSD read metrics were recorded
+    EXPECT_EQ(ssd_metric.ssd_read_ops.value(),
+              static_cast<int64_t>(allocate_res.value()->slices.size()));
+
+    // Verify bytes: sum of all slice sizes
+    int64_t expected_bytes = 0;
+    for (const auto& [key, slice] : allocate_res.value()->slices) {
+        expected_bytes += slice.size;
+    }
+    EXPECT_EQ(ssd_metric.ssd_read_bytes.value(), expected_bytes);
+    EXPECT_GT(expected_bytes, 0);
+
+    // Verify latency histogram has exactly 1 observation (one BatchLoad call)
+    auto buckets = ssd_metric.ssd_read_latency_us.get_bucket_counts();
+    int64_t total_observations = 0;
+    for (auto& b : buckets) {
+        total_observations += b->value();
+    }
+    EXPECT_EQ(total_observations, 1);
+
+    // Write metrics should remain 0 (BatchOffloadUtil bypasses FileStorage)
+    EXPECT_EQ(ssd_metric.ssd_write_ops.value(), 0);
+    EXPECT_EQ(ssd_metric.ssd_write_bytes.value(), 0);
+
+    LOG(INFO) << "SSD read metrics after BatchLoad: ops="
+              << ssd_metric.ssd_read_ops.value()
+              << ", bytes=" << ssd_metric.ssd_read_bytes.value();
+}
+
+TEST_F(FileStorageTest, BatchLoadFailureDoesNotRecordSsdMetrics) {
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    SsdMetric ssd_metric;
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003",
+                            &ssd_metric);
+
+    // Init storage backend so we can call BatchLoad
+    // But load with keys that don't exist on disk -> should fail
+    std::unordered_map<std::string, Slice> batch_object;
+    char dummy_buf[4096] = {};
+    batch_object["nonexistent_key_1"] = Slice{dummy_buf, 4096};
+    batch_object["nonexistent_key_2"] = Slice{dummy_buf, 8192};
+
+    auto result = FileStorageBatchLoad(fileStorage, batch_object);
+    // Expect failure (keys don't exist on disk)
+    EXPECT_FALSE(result);
+
+    // Metrics should remain 0 - failed operations are not counted
+    EXPECT_EQ(ssd_metric.ssd_read_ops.value(), 0);
+    EXPECT_EQ(ssd_metric.ssd_read_bytes.value(), 0);
+
+    auto buckets = ssd_metric.ssd_read_latency_us.get_bucket_counts();
+    int64_t total_observations = 0;
+    for (auto& b : buckets) {
+        total_observations += b->value();
+    }
+    EXPECT_EQ(total_observations, 0);
+
+    LOG(INFO) << "SSD metrics after failed BatchLoad: ops="
+              << ssd_metric.ssd_read_ops.value()
+              << ", bytes=" << ssd_metric.ssd_read_bytes.value();
+}
+
+TEST_F(FileStorageTest, NullSsdMetricDoesNotCrash) {
+    // FileStorage with nullptr SsdMetric should work fine (no metrics recorded)
+    std::vector<std::string> keys;
+    std::vector<int64_t> sizes;
+    std::unordered_map<std::string, std::string> batch_data;
+
+    auto file_storage_config = FileStorageConfig::FromEnvironment();
+    file_storage_config.storage_filepath = data_path;
+
+    // nullptr SsdMetric (default)
+    FileStorage fileStorage(file_storage_config, nullptr, "localhost:9003");
+
+    ASSERT_TRUE(FileStorageBatchOffload(fileStorage, keys, sizes, batch_data));
+    ASSERT_FALSE(keys.empty());
+
+    auto allocate_res = FileStorageAllocateBatch(fileStorage, keys, sizes);
+    ASSERT_TRUE(allocate_res);
+
+    auto load_result =
+        FileStorageBatchLoad(fileStorage, allocate_res.value()->slices);
+    ASSERT_TRUE(load_result);
+    // No crash = success. No metrics pointer, so nothing to verify.
+}
+
+// Issue #3709: a RemoveAll-style physical wipe of the SSD files while master
+// still tracks the key's LOCAL_DISK replica leaves a dangling entry. A Put
+// for the same key must not report success while storing nothing: the client
+// evicts the dangling replica and retries PutStart, so the new data is
+// actually written.
+
+TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
+    // The per-key file backend reports the wiped file as OBJECT_NOT_FOUND /
+    // FILE_OPEN_FAIL, the original proof set.
+    RunPutHealWipeScenario(data_path, StorageBackendType::kFilePerKey,
+                           "_per_key");
+}
+
+TEST_F(FileStorageTest,
+       PutAfterPhysicalWipeHealsDanglingLocalDiskReplicaOnBucket) {
+    // The bucket backend's BatchLoad reports a missing key as INVALID_KEY
+    // (fanganpai's production trace in #3709); the heal must still fire.
+    RunPutHealWipeScenario(data_path, StorageBackendType::kBucket, "_bucket");
+}
+
 TEST_F(FileStorageTest,
        BatchPutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
-        // The BatchPut twin of the scenario above: OBJECT_ALREADY_EXISTS
-        // results on the batch path must not be converted to success for keys
-        // whose backing file is gone. Two wiped keys and one fresh key go
-        // through one batch; every key must really store.
-        RunBatchPutHealWipeScenario(data_path);
-}
+    // The BatchPut twin of the scenario above: OBJECT_ALREADY_EXISTS results
+    // on the batch path must not be converted to success for keys whose
     // backing file is gone. Two wiped keys and one fresh key go through one
     // batch; every key must really store.
-    std::filesystem::path master_root =
-        std::filesystem::path(data_path) / "heal_master_batch";
-    std::filesystem::create_directories(master_root);
-
-    testing::InProcMaster master;
-    auto master_config = InProcMasterConfigBuilder()
-                             .set_enable_offload(true)
-                             .set_root_fs_dir(master_root.string())
-                             .build();
-    ASSERT_TRUE(master.Start(master_config));
-
-    std::string local_rpc_addr =
-        "127.0.0.1:" + std::to_string(getFreeTcpPort());
-    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
-                                 std::nullopt, master.master_address());
-    ASSERT_TRUE(client.has_value());
-    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
-
-    constexpr size_t kSegSize = 64 * 1024 * 1024;
-    void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
-    ASSERT_NE(seg_ptr, nullptr);
-    ASSERT_TRUE(
-        client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
-    SimpleAllocator allocator(16 * 1024 * 1024);
-    ASSERT_TRUE(client.value()
-                    ->RegisterLocalMemory(allocator.getBase(), 16 * 1024 * 1024,
-                                          "cpu:0", false, false)
-                    .has_value());
-
-    FileStorageConfig config = FileStorageConfig::FromEnvironment();
-    config.storage_backend_type = StorageBackendType::kFilePerKey;
-    config.storage_filepath = data_path + "/heal_ssd_batch";
-    config.local_buffer_size = 4 * 1024 * 1024;
-    fs::create_directories(config.storage_filepath);
-    FileStorage file_storage(config, client.value(), local_rpc_addr);
-    ASSERT_TRUE(file_storage.storage_backend_->Init());
-    {
-        MutexLocker locker(&file_storage.offloading_mutex_);
-        file_storage.enable_offloading_ = true;
-    }
-
-    // Offload two keys, then wipe the backing files to recreate the #3709
-    // divergence on both.
-    const std::vector<std::string> wiped_keys = {"heal_batch_a",
-                                                 "heal_batch_b"};
-    std::string original(512, 'x');
-    std::unordered_map<std::string, std::vector<Slice>> batch_object;
-    for (const auto& key : wiped_keys) {
-        batch_object.emplace(key,
-                             std::vector<Slice>{Slice{original.data(), 512}});
-    }
-    auto offload_result = file_storage.storage_backend_->BatchOffload(
-        batch_object,
-        [&file_storage](const std::vector<std::string>& keys,
-                        std::vector<StorageObjectMetadata>& metadatas) {
-        for (auto& metadata : metadatas) {
-            metadata.transport_endpoint = file_storage.local_rpc_addr_;
-        }
-        auto result =
-            file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
-        return result ? ErrorCode::OK : result.error();
-        });
-    ASSERT_TRUE(offload_result.has_value());
-
-    client.value()->SetLocalDiskProbe(
-        [&file_storage](const std::string& k) -> std::optional<bool> {
-        auto exists = file_storage.Exists(k);
-        if (!exists) {
-            return std::nullopt;
-        }
-        return !*exists;
-        });
-
-    file_storage.storage_backend_->RemoveAll();
-    auto exists = file_storage.Exists(wiped_keys[0]);
-    ASSERT_TRUE(exists.has_value());
-    ASSERT_FALSE(exists.value());
-
-    // One batch with both wiped keys and a fresh key.
-    const std::string fresh_key = "heal_batch_fresh";
-    const std::string updated(512, 'y');
-    std::vector<ObjectKey> keys = {wiped_keys[0], wiped_keys[1], fresh_key};
-    std::vector<std::vector<Slice>> batched_slices;
-    std::vector<void*> buffers;
-    for (size_t i = 0; i < keys.size(); ++i) {
-        void* buf = allocator.allocate(512);
-        ASSERT_NE(buf, nullptr);
-        std::memcpy(buf, updated.data(), 512);
-        buffers.push_back(buf);
-        batched_slices.push_back({Slice{buf, 512}});
-    }
-    ReplicateConfig cfg;
-    cfg.replica_num = 1;
-    auto results = client.value()->BatchPut(keys, batched_slices, cfg);
-    ASSERT_EQ(results.size(), keys.size());
-    for (size_t i = 0; i < results.size(); ++i) {
-        ASSERT_TRUE(results[i].has_value())
-            << "BatchPut over a dangling replica failed for " << keys[i] << ": "
-            << toString(results[i].error());
-    }
-
-    // Every key, healed or fresh, reads the new data back.
-    for (const auto& key : keys) {
-        void* read_buf = allocator.allocate(512);
-        ASSERT_NE(read_buf, nullptr);
-        std::vector<Slice> read_slices{Slice{read_buf, 512}};
-        auto get = client.value()->Get(key, read_slices);
-        ASSERT_TRUE(get.has_value()) << "Get after batch self-heal failed for "
-                                     << key << ": " << toString(get.error());
-        EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
-        allocator.deallocate(read_buf, 512);
-    }
-    for (void* buf : buffers) {
-        allocator.deallocate(buf, 512);
-    }
-
-    auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
-    EXPECT_TRUE(unmount.has_value());
-    std::free(seg_ptr);
+    RunBatchPutHealWipeScenario(data_path);
 }
 
 }  // namespace mooncake

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -239,6 +239,131 @@ class FileStorageTest : public ::testing::Test {
             }
         }
     }
+    void RunPutHealWipeScenario(const std::string& data_path,
+                                StorageBackendType backend_type,
+                                const std::string& suffix) {
+        std::filesystem::path master_root =
+            std::filesystem::path(data_path) / ("heal_master" + suffix);
+        std::filesystem::create_directories(master_root);
+
+        testing::InProcMaster master;
+        auto master_config = InProcMasterConfigBuilder()
+                                 .set_enable_offload(true)
+                                 .set_root_fs_dir(master_root.string())
+                                 .build();
+        ASSERT_TRUE(master.Start(master_config));
+
+        std::string local_rpc_addr =
+            "127.0.0.1:" + std::to_string(getFreeTcpPort());
+        auto client =
+            Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                           std::nullopt, master.master_address());
+        ASSERT_TRUE(client.has_value());
+        ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+        // Memory segment and registered buffers, so the retried PutStart can
+        // allocate a memory replica and Get can read it back.
+        constexpr size_t kSegSize = 64 * 1024 * 1024;
+        void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
+        ASSERT_NE(seg_ptr, nullptr);
+        ASSERT_TRUE(
+            client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
+        SimpleAllocator allocator(16 * 1024 * 1024);
+        ASSERT_TRUE(client.value()
+                        ->RegisterLocalMemory(allocator.getBase(),
+                                              16 * 1024 * 1024, "cpu:0", false,
+                                              false)
+                        .has_value());
+
+        FileStorageConfig config = FileStorageConfig::FromEnvironment();
+        config.storage_backend_type = backend_type;
+        config.storage_filepath = data_path + "/heal_ssd" + suffix;
+        config.local_buffer_size = 4 * 1024 * 1024;
+        fs::create_directories(config.storage_filepath);
+        FileStorage file_storage(config, client.value(), local_rpc_addr);
+        ASSERT_TRUE(file_storage.storage_backend_->Init());
+        {
+            MutexLocker locker(&file_storage.offloading_mutex_);
+            file_storage.enable_offloading_ = true;
+        }
+
+        // Offload one key so master tracks a LOCAL_DISK replica backed by a
+        // real file on the client SSD.
+        const std::string key = "heal_key" + suffix;
+        std::string original(512, 'x');
+        std::unordered_map<std::string, std::vector<Slice>> batch_object;
+        batch_object.emplace(key,
+                             std::vector<Slice>{Slice{original.data(), 512}});
+        auto offload_result = file_storage.storage_backend_->BatchOffload(
+            batch_object,
+            [&file_storage](const std::vector<std::string>& keys,
+                            std::vector<StorageObjectMetadata>& metadatas) {
+                for (auto& metadata : metadatas) {
+                    metadata.transport_endpoint = file_storage.local_rpc_addr_;
+                }
+                auto result =
+                    file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
+                return result ? ErrorCode::OK : result.error();
+            });
+        ASSERT_TRUE(offload_result.has_value());
+
+        // Wire the probe the way RealClient does in production: existence
+        // against this process's offload files.
+        client.value()->SetLocalDiskProbe(
+            [&file_storage](const std::string& k) -> std::optional<bool> {
+                auto exists = file_storage.Exists(k);
+                if (!exists) {
+                    return std::nullopt;
+                }
+                return !*exists;
+            });
+
+        auto query = client.value()->Query(key);
+        ASSERT_TRUE(query.has_value());
+        bool has_local_disk = false;
+        for (const auto& replica : query->replicas) {
+            has_local_disk |= replica.is_local_disk_replica();
+        }
+        ASSERT_TRUE(has_local_disk);
+
+        // Simulate the #3709 divergence: the SSD file is wiped physically while
+        // master keeps the metadata.
+        file_storage.storage_backend_->RemoveAll();
+        auto exists = file_storage.Exists(key);
+        ASSERT_TRUE(exists.has_value());
+        ASSERT_FALSE(exists.value());
+        // QueryResult is not assignable, so re-query into a fresh variable.
+        auto query_after_wipe = client.value()->Query(key);
+        ASSERT_TRUE(query_after_wipe.has_value());
+
+        // Put the same key again: the dangling replica must be evicted and the
+        // Put must really store new data.
+        void* buf = allocator.allocate(512);
+        ASSERT_NE(buf, nullptr);
+        std::string updated(512, 'y');
+        std::memcpy(buf, updated.data(), 512);
+        std::vector<Slice> slices{Slice{buf, 512}};
+        ReplicateConfig cfg;
+        cfg.replica_num = 1;
+        auto put = client.value()->Put(key, slices, cfg);
+        ASSERT_TRUE(put.has_value())
+            << "Put over a dangling replica failed: " << toString(put.error());
+        allocator.deallocate(buf, 512);
+
+        // The new data is readable through the normal Get path.
+        void* read_buf = allocator.allocate(512);
+        ASSERT_NE(read_buf, nullptr);
+        std::vector<Slice> read_slices{Slice{read_buf, 512}};
+        auto get = client.value()->Get(key, read_slices);
+        ASSERT_TRUE(get.has_value())
+            << "Get after self-heal failed: " << toString(get.error());
+        EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
+        allocator.deallocate(read_buf, 512);
+
+        auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
+        EXPECT_TRUE(unmount.has_value());
+        std::free(seg_ptr);
+    }
 };
 
 TEST_F(FileStorageTest, IsEnableOffloading) {
@@ -876,132 +1001,6 @@ TEST_F(FileStorageTest, NullSsdMetricDoesNotCrash) {
 // for the same key must not report success while storing nothing: the client
 // evicts the dangling replica and retries PutStart, so the new data is
 // actually written.
-namespace {
-
-void RunPutHealWipeScenario(const std::string& data_path,
-                            StorageBackendType backend_type,
-                            const std::string& suffix) {
-    std::filesystem::path master_root =
-        std::filesystem::path(data_path) / ("heal_master" + suffix);
-    std::filesystem::create_directories(master_root);
-
-    testing::InProcMaster master;
-    auto master_config = InProcMasterConfigBuilder()
-                             .set_enable_offload(true)
-                             .set_root_fs_dir(master_root.string())
-                             .build();
-    ASSERT_TRUE(master.Start(master_config));
-
-    std::string local_rpc_addr =
-        "127.0.0.1:" + std::to_string(getFreeTcpPort());
-    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
-                                 std::nullopt, master.master_address());
-    ASSERT_TRUE(client.has_value());
-    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
-
-    // Memory segment and registered buffers, so the retried PutStart can
-    // allocate a memory replica and Get can read it back.
-    constexpr size_t kSegSize = 64 * 1024 * 1024;
-    void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
-    ASSERT_NE(seg_ptr, nullptr);
-    ASSERT_TRUE(
-        client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
-    SimpleAllocator allocator(16 * 1024 * 1024);
-    ASSERT_TRUE(client.value()
-                    ->RegisterLocalMemory(allocator.getBase(), 16 * 1024 * 1024,
-                                          "cpu:0", false, false)
-                    .has_value());
-
-    FileStorageConfig config = FileStorageConfig::FromEnvironment();
-    config.storage_backend_type = backend_type;
-    config.storage_filepath = data_path + "/heal_ssd" + suffix;
-    config.local_buffer_size = 4 * 1024 * 1024;
-    fs::create_directories(config.storage_filepath);
-    FileStorage file_storage(config, client.value(), local_rpc_addr);
-    ASSERT_TRUE(file_storage.storage_backend_->Init());
-    {
-        MutexLocker locker(&file_storage.offloading_mutex_);
-        file_storage.enable_offloading_ = true;
-    }
-
-    // Offload one key so master tracks a LOCAL_DISK replica backed by a real
-    // file on the client SSD.
-    const std::string key = "heal_key" + suffix;
-    std::string original(512, 'x');
-    std::unordered_map<std::string, std::vector<Slice>> batch_object;
-    batch_object.emplace(key, std::vector<Slice>{Slice{original.data(), 512}});
-    auto offload_result = file_storage.storage_backend_->BatchOffload(
-        batch_object,
-        [&file_storage](const std::vector<std::string>& keys,
-                        std::vector<StorageObjectMetadata>& metadatas) {
-            for (auto& metadata : metadatas) {
-                metadata.transport_endpoint = file_storage.local_rpc_addr_;
-            }
-            auto result =
-                file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
-            return result ? ErrorCode::OK : result.error();
-        });
-    ASSERT_TRUE(offload_result.has_value());
-
-    // Wire the probe the way RealClient does in production: existence against
-    // this process's offload files.
-    client.value()->SetLocalDiskProbe(
-        [&file_storage](const std::string& k) -> std::optional<bool> {
-            auto exists = file_storage.Exists(k);
-            if (!exists) {
-                return std::nullopt;
-            }
-            return !*exists;
-        });
-
-    auto query = client.value()->Query(key);
-    ASSERT_TRUE(query.has_value());
-    bool has_local_disk = false;
-    for (const auto& replica : query->replicas) {
-        has_local_disk |= replica.is_local_disk_replica();
-    }
-    ASSERT_TRUE(has_local_disk);
-
-    // Simulate the #3709 divergence: the SSD file is wiped physically while
-    // master keeps the metadata.
-    file_storage.storage_backend_->RemoveAll();
-    auto exists = file_storage.Exists(key);
-    ASSERT_TRUE(exists.has_value());
-    ASSERT_FALSE(exists.value());
-    // QueryResult is not assignable, so re-query into a fresh variable.
-    auto query_after_wipe = client.value()->Query(key);
-    ASSERT_TRUE(query_after_wipe.has_value());
-
-    // Put the same key again: the dangling replica must be evicted and the
-    // Put must really store new data.
-    void* buf = allocator.allocate(512);
-    ASSERT_NE(buf, nullptr);
-    std::string updated(512, 'y');
-    std::memcpy(buf, updated.data(), 512);
-    std::vector<Slice> slices{Slice{buf, 512}};
-    ReplicateConfig cfg;
-    cfg.replica_num = 1;
-    auto put = client.value()->Put(key, slices, cfg);
-    ASSERT_TRUE(put.has_value())
-        << "Put over a dangling replica failed: " << toString(put.error());
-    allocator.deallocate(buf, 512);
-
-    // The new data is readable through the normal Get path.
-    void* read_buf = allocator.allocate(512);
-    ASSERT_NE(read_buf, nullptr);
-    std::vector<Slice> read_slices{Slice{read_buf, 512}};
-    auto get = client.value()->Get(key, read_slices);
-    ASSERT_TRUE(get.has_value())
-        << "Get after self-heal failed: " << toString(get.error());
-    EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
-    allocator.deallocate(read_buf, 512);
-
-    auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
-    EXPECT_TRUE(unmount.has_value());
-    std::free(seg_ptr);
-}
-
-}  // namespace
 
 TEST_F(FileStorageTest, PutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
     // The per-key file backend reports the wiped file as OBJECT_NOT_FOUND /

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -946,7 +946,7 @@ void RunPutHealWipeScenario(const std::string& data_path,
     // Wire the probe the way RealClient does in production: existence against
     // this process's offload files.
     client.value()->SetLocalDiskProbe(
-        [&file_storage](const std::string &k) -> std::optional<bool> {
+        [&file_storage](const std::string& k) -> std::optional<bool> {
             auto exists = file_storage.Exists(k);
             if (!exists) {
                 return std::nullopt;

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -946,7 +946,7 @@ void RunPutHealWipeScenario(const std::string& data_path,
     // Wire the probe the way RealClient does in production: existence against
     // this process's offload files.
     client.value()->SetLocalDiskProbe(
-        [&file_storage](const std::string& k) -> std::optional<bool> {
+        [&file_storage](const std::string &k) -> std::optional<bool> {
             auto exists = file_storage.Exists(k);
             if (!exists) {
                 return std::nullopt;

--- a/mooncake-store/tests/file_storage_test.cpp
+++ b/mooncake-store/tests/file_storage_test.cpp
@@ -1016,4 +1016,131 @@ TEST_F(FileStorageTest,
     RunPutHealWipeScenario(data_path, StorageBackendType::kBucket, "_bucket");
 }
 
+TEST_F(FileStorageTest,
+       BatchPutAfterPhysicalWipeHealsDanglingLocalDiskReplica) {
+    // The BatchPut twin of the scenario above: OBJECT_ALREADY_EXISTS results
+    // on the batch path must not be converted to success for keys whose
+    // backing file is gone. Two wiped keys and one fresh key go through one
+    // batch; every key must really store.
+    std::filesystem::path master_root =
+        std::filesystem::path(data_path) / "heal_master_batch";
+    std::filesystem::create_directories(master_root);
+
+    testing::InProcMaster master;
+    auto master_config = InProcMasterConfigBuilder()
+                             .set_enable_offload(true)
+                             .set_root_fs_dir(master_root.string())
+                             .build();
+    ASSERT_TRUE(master.Start(master_config));
+
+    std::string local_rpc_addr =
+        "127.0.0.1:" + std::to_string(getFreeTcpPort());
+    auto client = Client::Create(local_rpc_addr, master.metadata_url(), "tcp",
+                                 std::nullopt, master.master_address());
+    ASSERT_TRUE(client.has_value());
+    ASSERT_TRUE(client.value()->MountLocalDiskSegment(true).has_value());
+
+    constexpr size_t kSegSize = 64 * 1024 * 1024;
+    void* seg_ptr = allocate_buffer_allocator_memory(kSegSize);
+    ASSERT_NE(seg_ptr, nullptr);
+    ASSERT_TRUE(
+        client.value()->MountSegment(seg_ptr, kSegSize, "tcp").has_value());
+    SimpleAllocator allocator(16 * 1024 * 1024);
+    ASSERT_TRUE(client.value()
+                    ->RegisterLocalMemory(allocator.getBase(), 16 * 1024 * 1024,
+                                          "cpu:0", false, false)
+                    .has_value());
+
+    FileStorageConfig config = FileStorageConfig::FromEnvironment();
+    config.storage_backend_type = StorageBackendType::kFilePerKey;
+    config.storage_filepath = data_path + "/heal_ssd_batch";
+    config.local_buffer_size = 4 * 1024 * 1024;
+    fs::create_directories(config.storage_filepath);
+    FileStorage file_storage(config, client.value(), local_rpc_addr);
+    ASSERT_TRUE(file_storage.storage_backend_->Init());
+    {
+        MutexLocker locker(&file_storage.offloading_mutex_);
+        file_storage.enable_offloading_ = true;
+    }
+
+    // Offload two keys, then wipe the backing files to recreate the #3709
+    // divergence on both.
+    const std::vector<std::string> wiped_keys = {"heal_batch_a",
+                                                 "heal_batch_b"};
+    std::string original(512, 'x');
+    std::unordered_map<std::string, std::vector<Slice>> batch_object;
+    for (const auto& key : wiped_keys) {
+        batch_object.emplace(key,
+                             std::vector<Slice>{Slice{original.data(), 512}});
+    }
+    auto offload_result = file_storage.storage_backend_->BatchOffload(
+        batch_object,
+        [&file_storage](const std::vector<std::string>& keys,
+                        std::vector<StorageObjectMetadata>& metadatas) {
+            for (auto& metadata : metadatas) {
+                metadata.transport_endpoint = file_storage.local_rpc_addr_;
+            }
+            auto result =
+                file_storage.client_->NotifyOffloadSuccess(keys, metadatas);
+            return result ? ErrorCode::OK : result.error();
+        });
+    ASSERT_TRUE(offload_result.has_value());
+
+    client.value()->SetLocalDiskProbe(
+        [&file_storage](const std::string& k) -> std::optional<bool> {
+            auto exists = file_storage.Exists(k);
+            if (!exists) {
+                return std::nullopt;
+            }
+            return !*exists;
+        });
+
+    file_storage.storage_backend_->RemoveAll();
+    auto exists = file_storage.Exists(wiped_keys[0]);
+    ASSERT_TRUE(exists.has_value());
+    ASSERT_FALSE(exists.value());
+
+    // One batch with both wiped keys and a fresh key.
+    const std::string fresh_key = "heal_batch_fresh";
+    const std::string updated(512, 'y');
+    std::vector<ObjectKey> keys = {wiped_keys[0], wiped_keys[1], fresh_key};
+    std::vector<std::vector<Slice>> batched_slices;
+    std::vector<void*> buffers;
+    for (size_t i = 0; i < keys.size(); ++i) {
+        void* buf = allocator.allocate(512);
+        ASSERT_NE(buf, nullptr);
+        std::memcpy(buf, updated.data(), 512);
+        buffers.push_back(buf);
+        batched_slices.push_back({Slice{buf, 512}});
+    }
+    ReplicateConfig cfg;
+    cfg.replica_num = 1;
+    auto results = client.value()->BatchPut(keys, batched_slices, cfg);
+    ASSERT_EQ(results.size(), keys.size());
+    for (size_t i = 0; i < results.size(); ++i) {
+        ASSERT_TRUE(results[i].has_value())
+            << "BatchPut over a dangling replica failed for " << keys[i] << ": "
+            << toString(results[i].error());
+    }
+
+    // Every key, healed or fresh, reads the new data back.
+    for (const auto& key : keys) {
+        void* read_buf = allocator.allocate(512);
+        ASSERT_NE(read_buf, nullptr);
+        std::vector<Slice> read_slices{Slice{read_buf, 512}};
+        auto get = client.value()->Get(key, read_slices);
+        ASSERT_TRUE(get.has_value()) << "Get after batch self-heal failed for "
+                                     << key << ": " << toString(get.error());
+        EXPECT_EQ(std::memcmp(read_slices[0].ptr, updated.data(), 512), 0);
+        allocator.deallocate(read_buf, 512);
+    }
+    for (void* buf : buffers) {
+        allocator.deallocate(buf, 512);
+    }
+
+    auto unmount = client.value()->UnmountSegment(seg_ptr, kSegSize);
+    EXPECT_TRUE(unmount.has_value());
+    std::free(seg_ptr);
+}
+
 }  // namespace mooncake


### PR DESCRIPTION
## Description

## Status

Mitigation, not the root fix. This PR heals the divergence on the Put and BatchPut paths so a wedged key becomes writable again; the RemoveAll/broadcast boundary redesign is tracked in #3715. Read-only keys are not covered by the heal and stay inconsistent until rewritten, by design (a read that evicts would change read semantics).

Fixes #3709.

A non-forced RemoveAll (or the master mailbox broadcast) physically wipes client SSD files without consulting lease state, while master keeps lease-protected metadata. The result is a completed LOCAL_DISK entry whose backing file is gone: reads fail, and every later Put for the key hits `OBJECT_ALREADY_EXISTS`, which `Client::Put` converted into a silent success. The engine then believed data was stored when nothing was ever written, and the key could never be re-written.

When `PutStart` reports `OBJECT_ALREADY_EXISTS` and every completed replica is a LOCAL_DISK replica owned by this client, the client asks the offload file storage whether the backing file still exists (`FileStorage::Exists`): a proven-gone answer evicts the dangling replica through the existing `EvictDiskReplica` RPC and retries `PutStart` once. Any other outcome (file present, or an unknown answer from transport or config trouble) keeps the old idempotent already-exists path, so a healthy replica can never be evicted by mistake. `StartBatchPut` covers the same gap on the batch path: the `OBJECT_ALREADY_EXISTS` subset goes through one batched replica-list query and one batched evict, and only the evicted keys are retried, so a healthy idempotent batch pays one extra RPC and no evictions.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
ctest -R file_storage_test --output-on-failure
```

**Test results:**
- [ ] Unit tests pass — new regression test `PutAfterPhysicalWipeHealsDanglingLocalDiskReplica` builds the exact divergence: offload a key so master tracks a LOCAL_DISK replica, wipe the SSD file physically, then Put the same key and assert the write really lands and the new data reads back. The batch twin `BatchPutAfterPhysicalWipeHealsDanglingLocalDiskReplica` wipes two offloaded keys and batches them with a fresh key, then asserts every key really stores and reads back the new data. It needs the store test build, which does not compile on this machine (no rdma-core / Linux headers on macOS), so it runs on CI. I verified the touched code paths by close read against the in-tree type definitions; no local build was possible.
- [ ] Integration tests pass (if applicable) — runs on CI, see above.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Prepared with Kimi K3 assistance. The divergence mechanism (both physical-wipe paths ignore lease state, the silent already-exists success, and the heal-via-EvictDiskReplica route using only existing RPCs) was re-verified against the source before submission.


