### PR TITLE
[Bugfix][Store] Register ShmHelper memory with SPDK for NoF zero-copy transfers

### DIFF
--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -1162,6 +1162,7 @@ Do not run binaries from before and after checksum support was introduced in the
 | `MC_STORE_HUGEPAGE_SIZE` | `2MB` | Supported: `2MB`, `1GB` |
 | `MC_MMAP_ARENA_POOL_SIZE` | unset | Pre-allocated arena pool size (e.g., `8gb`). Explicitly set to enable the arena |
 | `MC_DISABLE_MMAP_ARENA` | unset | Disable arena, fall back to per-call `mmap()`. Accepts `1`/`true`/`yes`/`on` (or `0`/`false`/`no`/`off`) |
+| `MC_STORE_REGISTER_SPDK` | unset | Set `1` to register `ShmHelper`-allocated shared memory (host pool, dummy local buffer) with SPDK for NoF zero-copy transfers. Forces HugeTLB backing for those allocations, defaulting to 2MB hugepages when `MC_STORE_USE_HUGEPAGE` is unset. Must be set on BOTH the dummy and the real process (SPDK registration is per-process) |
 
 RDMA Store segments backed by HugeTLB are populated in parallel immediately
 before transfer-engine registration. No additional population-mode setting is
@@ -1177,6 +1178,25 @@ NUMA-segmented mappings, each worker is scheduled on the NUMA node associated
 with its `mbind()` region before touching pages. The mmap arena retains its
 eager `MAP_POPULATE` behavior for DMA safety; set `MC_DISABLE_MMAP_ARENA=1` if
 the deferred direct-mmap path is desired while the arena is otherwise enabled.
+
+For NoF (NVMe-oF) zero-copy, `MC_STORE_REGISTER_SPDK=1` registers the shared
+memory allocated by `ShmHelper` (SGLang host pool, dummy local buffer) with
+SPDK (`spdk_mem_register`) so the NoF RDMA transport can DMA to/from it
+directly — without it those buffers fail with `No translation for ptr`.
+`spdk_mem_register` is per-process, so set this switch on BOTH the dummy
+(sender) and the real client (receiver): the dummy registers its own mapping
+in `ShmHelper::allocate`, and the real client registers its separate mapping
+of the same shared fd in `RealClient::map_shm_internal_with_device`. Setting
+it on only one process leaves the other without an SPDK translation and NoF
+transfers still fail with `No translation for ptr`. SPDK
+registration in iova=pa mode requires PHYSICALLY 2MB-aligned memory, which only
+HugeTLB pages satisfy, so this switch forces HugeTLB for the affected
+allocations even when `MC_STORE_USE_HUGEPAGE` is unset; it then defaults to 2MB
+hugepages (set `MC_STORE_USE_HUGEPAGE=1` and `MC_STORE_HUGEPAGE_SIZE=1GB` for
+1GB). Reserve enough HugeTLB pages (`/proc/sys/vm/nr_hugepages`) for the host
+pool plus any hugepage-backed segments; when the pool is exhausted the first
+allocation aborts with a clear error naming the hugepage size and count needed
+rather than silently degrading.
 
 #### yalantinglibs Log Level
 

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -952,6 +952,10 @@ class RealClient : public PyClient {
         void *shm_buffer = nullptr;
         size_t shm_size = 0;
         uintptr_t dummy_base_addr = 0;
+        // Whether this receiver-side mapping was registered with SPDK for NoF
+        // zero-copy (see RealClient::map_shm_internal_with_device). Must be
+        // unregistered before munmap on every teardown path.
+        bool spdk_registered = false;
         bool is_ascend = false;
         bool is_ipc = false;
         // Ascend physical device id from dummy (dummy-real RPC).

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -1080,6 +1080,16 @@ class RealClient : public PyClient {
     void ReleaseAllMountedSegmentRecords();
     void ReleaseAllocatedSegmentRecord(const std::string &segment_id);
     void ReleaseAllAllocatedSegmentRecords();
+
+    // MappedShm whose spdk_mem_unregister failed during teardown. The mapping
+    // is deliberately retained (never munmapped) so SPDK does not hold a
+    // translation to a freed/reused VA; retried on later teardown entry points.
+    // Guarded by dummy_client_mutex_.
+    std::vector<MappedShm> quarantine_shms_;
+
+    // Re-attempt unregister+munmap of quarantine_shms_. Caller must hold
+    // dummy_client_mutex_. Failures stay quarantined.
+    void RetryQuarantinedShmsLocked();
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -956,6 +956,13 @@ class RealClient : public PyClient {
         // zero-copy (see RealClient::map_shm_internal_with_device). Must be
         // unregistered before munmap on every teardown path.
         bool spdk_registered = false;
+        // Set when the transfer engine's unregisterLocalMemory() failed during
+        // teardown: TE still holds this region (RdmaTransport does not
+        // deregister the MR when the metadata update fails, and
+        // TransferEngineImpl keeps its region record), so the mapping must not
+        // be munmapped until a later retry releases it (see
+        // RetryQuarantinedShmsLocked).
+        bool te_unregister_pending = false;
         bool is_ascend = false;
         bool is_ipc = false;
         // Ascend physical device id from dummy (dummy-real RPC).
@@ -1081,14 +1088,16 @@ class RealClient : public PyClient {
     void ReleaseAllocatedSegmentRecord(const std::string &segment_id);
     void ReleaseAllAllocatedSegmentRecords();
 
-    // MappedShm whose spdk_mem_unregister failed during teardown. The mapping
-    // is deliberately retained (never munmapped) so SPDK does not hold a
-    // translation to a freed/reused VA; retried on later teardown entry points.
-    // Guarded by dummy_client_mutex_.
+    // MappedShm whose spdk_mem_unregister() (spdk_registered) or transfer
+    // engine unregisterLocalMemory() (te_unregister_pending) failed during
+    // teardown. The mapping is deliberately retained (never munmapped) so
+    // neither SPDK nor the transfer engine keeps a registration to a
+    // freed/reused VA; retried on later teardown entry points. Guarded by
+    // dummy_client_mutex_.
     std::vector<MappedShm> quarantine_shms_;
 
-    // Re-attempt unregister+munmap of quarantine_shms_. Caller must hold
-    // dummy_client_mutex_. Failures stay quarantined.
+    // Re-attempt TE + SPDK unregister and munmap of quarantine_shms_. Caller
+    // must hold dummy_client_mutex_. Failures stay quarantined.
     void RetryQuarantinedShmsLocked();
 };
 

--- a/mooncake-store/include/shm_helper.h
+++ b/mooncake-store/include/shm_helper.h
@@ -26,6 +26,7 @@ class ShmHelper {
         size_t size = 0;
         std::string name;
         bool registered = false;
+        bool spdk_registered = false;
         bool is_local = false;
     };
 
@@ -55,6 +56,7 @@ class ShmHelper {
     std::vector<std::shared_ptr<ShmSegment>> shms_;
     static std::mutex shm_mutex_;
     bool use_hugepage_ = false;
+    bool register_spdk_ = false;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/include/shm_helper.h
+++ b/mooncake-store/include/shm_helper.h
@@ -23,7 +23,13 @@ class ShmHelper {
     struct ShmSegment {
         int fd = -1;
         void *base_addr = nullptr;
+        // Size of the actual mapping; may be padded up to the hugepage/2MB
+        // boundary when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1).
         size_t size = 0;
+        // Size the caller requested in allocate(); == size unless padded. Callers
+        // that must match the original request (e.g. DummyClient::register_buffer)
+        // compare against this, not size, so they don't re-derive the alignment.
+        size_t requested_size = 0;
         std::string name;
         bool registered = false;
         bool spdk_registered = false;

--- a/mooncake-store/include/shm_helper.h
+++ b/mooncake-store/include/shm_helper.h
@@ -52,6 +52,12 @@ class ShmHelper {
 
     bool is_hugepage() const { return use_hugepage_; }
 
+    // Whether the MC_STORE_REGISTER_SPDK feature is enabled (env == "1").
+    // Single source of truth for the env semantics, shared by ShmHelper's
+    // constructor and the RealClient-side (receiver) registration so both sides
+    // of the dummy/real split gate identically.
+    static bool is_register_spdk_enabled();
+
     ShmHelper(const ShmHelper &) = delete;
     ShmHelper &operator=(const ShmHelper &) = delete;
 

--- a/mooncake-store/include/shm_helper.h
+++ b/mooncake-store/include/shm_helper.h
@@ -24,11 +24,13 @@ class ShmHelper {
         int fd = -1;
         void *base_addr = nullptr;
         // Size of the actual mapping; may be padded up to the hugepage/2MB
-        // boundary when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1).
+        // boundary when SPDK registration is enabled
+        // (MC_STORE_REGISTER_SPDK=1).
         size_t size = 0;
-        // Size the caller requested in allocate(); == size unless padded. Callers
-        // that must match the original request (e.g. DummyClient::register_buffer)
-        // compare against this, not size, so they don't re-derive the alignment.
+        // Size the caller requested in allocate(); == size unless padded.
+        // Callers that must match the original request (e.g.
+        // DummyClient::register_buffer) compare against this, not size, so they
+        // don't re-derive the alignment.
         size_t requested_size = 0;
         std::string name;
         bool registered = false;

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -53,6 +53,25 @@ class SpdkWrapper {
     bool ProbeNofSegment(const std::string &tr_str, uint32_t timeout_ms,
                          std::string *error_reason = nullptr);
 
+    /** @brief Register external memory with SPDK for NoF zero-copy transfers.
+     *
+     * Memory returned by Alloc() is already registered with SPDK; use this to
+     * register memory allocated outside of SPDK (e.g. mmap'd shared memory) so
+     * that NoF RDMA transfers can DMA to/from it directly
+     * (spdk_rdma_get_translation).
+     *
+     * @param addr Start of the region; must be page-aligned.
+     * @param size Region length; must be a multiple of the page size.
+     * @return 0 on success, non-zero on failure.
+     */
+    int RegisterMemory(void *addr, size_t size);
+
+    /** @brief Unregister memory previously registered via RegisterMemory().
+     *
+     * @return 0 on success, non-zero on failure.
+     */
+    int UnregisterMemory(void *addr, size_t size);
+
    private:
     struct ProbeBuffer {
         void *ptr{nullptr};

--- a/mooncake-store/include/spdk/spdk_wrapper.h
+++ b/mooncake-store/include/spdk/spdk_wrapper.h
@@ -60,8 +60,16 @@ class SpdkWrapper {
      * that NoF RDMA transfers can DMA to/from it directly
      * (spdk_rdma_get_translation).
      *
-     * @param addr Start of the region; must be page-aligned.
-     * @param size Region length; must be a multiple of the page size.
+     * The pinned SPDK (v23.01.1) requires BOTH addr and size to be 2MB-aligned
+     * (MASK_2MB), and in iova=pa mode (the typical libibverbs NoF setup) the
+     * PHYSICAL pages must be 2MB-aligned too, which only HugeTLB pages satisfy.
+     * 4KB page-aligned memory always fails with -EINVAL. Callers must pass
+     * 2MB-aligned, hugepage-backed memory (ShmHelper forces this under
+     * MC_STORE_REGISTER_SPDK=1); a failed registration leaves SPDK's
+     * g_mem_reg_map half-marked, so callers should UnregisterMemory() on error.
+     *
+     * @param addr Start of the region; must be 2MB-aligned (hugepage-backed).
+     * @param size Region length; must be a multiple of 2MB.
      * @return 0 on success, non-zero on failure.
      */
     int RegisterMemory(void *addr, size_t size);

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -7,6 +7,8 @@
 #include <optional>
 #include <linux/memfd.h>
 #include <linux/mman.h>
+#include <sys/mman.h>
+#include <cstdint>
 #include <string>
 #include <limits>
 #include <type_traits>
@@ -280,6 +282,56 @@ inline size_t align_up(size_t size, size_t alignment) {
         return size;
     }
     return ((size + alignment - 1) / alignment) * alignment;
+}
+
+/**
+ * @brief Place a memfd mapping at a 2MB-aligned address while keeping the file
+ * offset at 0, so the returned base matches what a peer process mapping the fd
+ * at offset 0 sees (cross-process fd sharing is unchanged).
+ *
+ * SPDK before 26.09 (e.g. the v23.01.1 pinned by dependencies.sh) rejects
+ * spdk_mem_register() unless both the start and the length are 2MB-aligned;
+ * plain mmap only guarantees 4KB alignment. Reserve a PROT_NONE region large
+ * enough to contain a 2MB-aligned window, then MAP_FIXED the memfd into it
+ * (which only replaces the reservation, never live mappings), and release the
+ * unaligned head/tail. `size` should be a multiple of 2MB (callers align it).
+ *
+ * NOTE: SPDK >= 26.09 (commit d6dc356ff) supports 4KB-aligned registrations, so
+ * once the pinned version is upgraded this helper and the 2MB size padding in
+ * ShmHelper::allocate can be removed and a plain mmap used instead.
+ *
+ * @param size Mapping length; must be a multiple of 2MB for a clean head/tail.
+ * @param fd memfd to map at offset 0.
+ * @return The 2MB-aligned base, or MAP_FAILED on error.
+ */
+inline void* mmap_shm_2mb_aligned(size_t size, int fd) {
+    const size_t reserve_size = size + SZ_2MB;
+    void* hint = mmap(nullptr, reserve_size, PROT_NONE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (hint == MAP_FAILED) {
+        return MAP_FAILED;
+    }
+    const uintptr_t hint_addr = reinterpret_cast<uintptr_t>(hint);
+    const uintptr_t target = static_cast<uintptr_t>(
+        align_up(static_cast<size_t>(hint_addr), SZ_2MB));
+    void* base =
+        mmap(reinterpret_cast<void*>(target), size, PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_FIXED | MAP_POPULATE, fd, 0);
+    if (base == MAP_FAILED) {
+        munmap(hint, reserve_size);
+        return MAP_FAILED;
+    }
+    // Release the unaligned head and tail of the reservation.
+    const uintptr_t base_addr = reinterpret_cast<uintptr_t>(base);
+    if (base_addr > hint_addr) {
+        munmap(hint, base_addr - hint_addr);
+    }
+    const uintptr_t reserve_end = hint_addr + reserve_size;
+    const uintptr_t tail = base_addr + size;
+    if (tail < reserve_end) {
+        munmap(reinterpret_cast<void*>(tail), reserve_end - tail);
+    }
+    return base;
 }
 
 /**

--- a/mooncake-store/include/utils.h
+++ b/mooncake-store/include/utils.h
@@ -296,9 +296,19 @@ inline size_t align_up(size_t size, size_t alignment) {
  * (which only replaces the reservation, never live mappings), and release the
  * unaligned head/tail. `size` should be a multiple of 2MB (callers align it).
  *
- * NOTE: SPDK >= 26.09 (commit d6dc356ff) supports 4KB-aligned registrations, so
- * once the pinned version is upgraded this helper and the 2MB size padding in
- * ShmHelper::allocate can be removed and a plain mmap used instead.
+ * NOTE: virtual 2MB alignment is NECESSARY but NOT sufficient on the pinned
+ * SPDK: in iova=pa mode spdk_mem_register additionally checks each segment's
+ * PHYSICAL address (vtophys pagemap path, `paddr & MASK_2MB`), so the memory
+ * must also be hugepage-backed or registration fails with -EINVAL. HugeTLB
+ * mappings are automatically 2MB/1GB-aligned, so this helper is only needed
+ * where the source cannot be hugepage-backed; today it is used solely by the
+ * receiver (RealClient::map_shm_internal_with_device) for the shared fd
+ * (1GB-hugepage fds whose MAP_FIXED here fails fall back to a plain mmap). The
+ * sender (ShmHelper::allocate) always maps hugepages under
+ * MC_STORE_REGISTER_SPDK=1 and needs no aligned base. SPDK >= 26.09 (commit
+ * d6dc356ff) relaxes the API check to 4KB, but iova=pa still needs hugepages,
+ * so a plain mmap remains insufficient for SPDK registration regardless of
+ * version.
  *
  * @param size Mapping length; must be a multiple of 2MB for a clean head/tail.
  * @param fd memfd to map at offset 0.

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -657,7 +657,13 @@ int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
 
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         buffer_addr, client_id_);
-    if (ret.has_value()) {
+    // Same contract as unregister_buffer: the receiver tears the mapping down
+    // even on INTERNAL_ERROR, and INVALID_PARAMS means the server has no such
+    // mapping, so drop the local bookkeeping then; keep it on RPC_FAIL /
+    // RPC_TIMEOUT where the server may not have run.
+    if (ret.has_value() ||
+        (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
+                              ret.error() == ErrorCode::INVALID_PARAMS))) {
         std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
         registered_device_buffers_.erase(buffer_addr);
     }
@@ -717,17 +723,19 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         return -1;
     }
     // Check bounds. The buffer must be the segment base and the size must match
-    // the caller's original request (ShmSegment::requested_size). shm->size may
-    // be padded up to the hugepage/2MB boundary for SPDK registration, so it is
-    // NOT the size the caller should pass here.
+    // either the caller's original request (ShmSegment::requested_size) or the
+    // padded mapping size (shm->size, aligned up to the hugepage/2MB boundary
+    // for SPDK registration). Both are valid: IPC always sends shm->size, and
+    // legacy callers may pass the padded size directly.
     if (reinterpret_cast<uint8_t*>(buffer) !=
             reinterpret_cast<uint8_t*>(shm->base_addr) ||
-        size != shm->requested_size) {
+        (size != shm->requested_size && size != shm->size)) {
         LOG(ERROR) << "Invalid buffer address or size for registration: "
                       "Buffer addr: "
                    << buffer << ", need addr: " << shm->base_addr
                    << ", buffer size: " << size
-                   << ", need size: " << shm->requested_size;
+                   << ", need size: " << shm->requested_size
+                   << " (padded: " << shm->size << ")";
         return -1;
     }
 
@@ -776,7 +784,15 @@ int DummyClient::unregister_buffer(void* buffer) {
     }
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         reinterpret_cast<uint64_t>(buffer), client_id_);
-    if (ret.has_value()) {
+    // The receiver unregisters and unmaps the shm even when its internal
+    // unregisterLocalMemory fails (it reports INTERNAL_ERROR only after
+    // munmap/erase), so the mapping is gone on that side: clear the local flag
+    // for INTERNAL_ERROR (server executed the teardown) and INVALID_PARAMS
+    // (server has no such mapping). Keep it on RPC_FAIL/RPC_TIMEOUT, where the
+    // RPC may never have reached the server and the mapping may still be alive.
+    if (ret.has_value() ||
+        (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
+                              ret.error() == ErrorCode::INVALID_PARAMS))) {
         shm->registered = false;
     }
     return to_py_ret(ret);

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -657,10 +657,11 @@ int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
 
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         buffer_addr, client_id_);
-    // Same contract as unregister_buffer: the receiver tears the mapping down
-    // even on INTERNAL_ERROR, and INVALID_PARAMS means the server has no such
-    // mapping, so drop the local bookkeeping then; keep it on RPC_FAIL /
-    // RPC_TIMEOUT where the server may not have run.
+    // Same contract as unregister_buffer: the receiver removes the mapping on
+    // INTERNAL_ERROR too (unmapped, or quarantined when the SPDK unregister
+    // fails), and INVALID_PARAMS means the server has no such mapping, so drop
+    // the local bookkeeping then; keep it on RPC_FAIL / RPC_TIMEOUT where the
+    // server may not have run.
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {
@@ -784,12 +785,14 @@ int DummyClient::unregister_buffer(void* buffer) {
     }
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         reinterpret_cast<uint64_t>(buffer), client_id_);
-    // The receiver unregisters and unmaps the shm even when its internal
-    // unregisterLocalMemory fails (it reports INTERNAL_ERROR only after
-    // munmap/erase), so the mapping is gone on that side: clear the local flag
-    // for INTERNAL_ERROR (server executed the teardown) and INVALID_PARAMS
-    // (server has no such mapping). Keep it on RPC_FAIL/RPC_TIMEOUT, where the
-    // RPC may never have reached the server and the mapping may still be alive.
+    // INTERNAL_ERROR means the receiver still executed the teardown and removed
+    // the segment from its active mappings: it unmaps normally, or -- when the
+    // SPDK unregister fails -- quarantines the mapping (retained, never reused
+    // for new registrations). Either way the old mapping is no longer usable on
+    // the receiver, so drop the local flag for INTERNAL_ERROR; also drop it for
+    // INVALID_PARAMS (server has no such mapping). Keep it on RPC_FAIL /
+    // RPC_TIMEOUT, where the RPC may never have reached the server and the
+    // mapping may still be alive.
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -716,17 +716,18 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         LOG(ERROR) << "Buffer is not in any registered shared memory";
         return -1;
     }
-    if (shm_helper_->is_hugepage()) {
-        size = align_up(size, get_hugepage_size_from_env());
-    }
-    // Check bounds
+    // Check bounds. The buffer must be the segment base and the size must match
+    // the caller's original request (ShmSegment::requested_size). shm->size may
+    // be padded up to the hugepage/2MB boundary for SPDK registration, so it is
+    // NOT the size the caller should pass here.
     if (reinterpret_cast<uint8_t*>(buffer) !=
             reinterpret_cast<uint8_t*>(shm->base_addr) ||
-        size != shm->size) {
+        size != shm->requested_size) {
         LOG(ERROR) << "Invalid buffer address or size for registration: "
                       "Buffer addr: "
                    << buffer << ", need addr: " << shm->base_addr
-                   << ", buffer size: " << size << ", need size: " << shm->size;
+                   << ", buffer size: " << size
+                   << ", need size: " << shm->requested_size;
         return -1;
     }
 

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -661,7 +661,7 @@ int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
     // INTERNAL_ERROR too (unmapped, or quarantined when the SPDK or transfer
     // engine unregister fails), and INVALID_PARAMS means the server has no such
     // mapping, so drop the local bookkeeping then; keep it on RPC_FAIL /
-    // RPC_TIMEOUT where the server may not have run.
+    // RPC_TIMEOUT where the server may not have run (see unregister_buffer).
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {
@@ -791,8 +791,11 @@ int DummyClient::unregister_buffer(void* buffer) {
     // (retained, never reused for new registrations). Either way the old
     // mapping is no longer usable on the receiver, so drop the local flag for
     // INTERNAL_ERROR and for INVALID_PARAMS (server has no such mapping). Keep
-    // it on RPC_FAIL / RPC_TIMEOUT, where the RPC may never have reached the
-    // server and the mapping may still be alive.
+    // it on RPC_FAIL / RPC_TIMEOUT: the RPC may never have reached the server,
+    // or the receiver may have refused before touching anything (Ascend context
+    // setup failure in unregister_shm_buffer_internal returns RPC_FAIL for
+    // exactly that reason), so the mapping can still be alive and a retry must
+    // reach the receiver.
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -658,10 +658,10 @@ int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
         buffer_addr, client_id_);
     // Same contract as unregister_buffer: the receiver removes the mapping on
-    // INTERNAL_ERROR too (unmapped, or quarantined when the SPDK unregister
-    // fails), and INVALID_PARAMS means the server has no such mapping, so drop
-    // the local bookkeeping then; keep it on RPC_FAIL / RPC_TIMEOUT where the
-    // server may not have run.
+    // INTERNAL_ERROR too (unmapped, or quarantined when the SPDK or transfer
+    // engine unregister fails), and INVALID_PARAMS means the server has no such
+    // mapping, so drop the local bookkeeping then; keep it on RPC_FAIL /
+    // RPC_TIMEOUT where the server may not have run.
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {
@@ -787,12 +787,12 @@ int DummyClient::unregister_buffer(void* buffer) {
         reinterpret_cast<uint64_t>(buffer), client_id_);
     // INTERNAL_ERROR means the receiver still executed the teardown and removed
     // the segment from its active mappings: it unmaps normally, or -- when the
-    // SPDK unregister fails -- quarantines the mapping (retained, never reused
-    // for new registrations). Either way the old mapping is no longer usable on
-    // the receiver, so drop the local flag for INTERNAL_ERROR; also drop it for
-    // INVALID_PARAMS (server has no such mapping). Keep it on RPC_FAIL /
-    // RPC_TIMEOUT, where the RPC may never have reached the server and the
-    // mapping may still be alive.
+    // SPDK or transfer engine unregister fails -- quarantines the mapping
+    // (retained, never reused for new registrations). Either way the old
+    // mapping is no longer usable on the receiver, so drop the local flag for
+    // INTERNAL_ERROR and for INVALID_PARAMS (server has no such mapping). Keep
+    // it on RPC_FAIL / RPC_TIMEOUT, where the RPC may never have reached the
+    // server and the mapping may still be alive.
     if (ret.has_value() ||
         (!ret.has_value() && (ret.error() == ErrorCode::INTERNAL_ERROR ||
                               ret.error() == ErrorCode::INVALID_PARAMS))) {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1458,8 +1458,8 @@ void RealClient::RetryQuarantinedShmsLocked() {
         // A quarantined segment still has a live SPDK registration: only
         // munmap once the translation is actually released.
         if (it->spdk_registered) {
-            if (SpdkWrapper::GetInstance().UnregisterMemory(it->shm_buffer,
-                                                            it->shm_size) != 0) {
+            if (SpdkWrapper::GetInstance().UnregisterMemory(
+                    it->shm_buffer, it->shm_size) != 0) {
                 ++it;
                 continue;
             }
@@ -2591,9 +2591,10 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
             if (shm.spdk_registered) {
                 if (SpdkWrapper::GetInstance().UnregisterMemory(
                         shm.shm_buffer, shm.shm_size) != 0) {
-                    LOG(ERROR) << "Failed to unregister received shm from SPDK: "
-                               << shm.shm_buffer
-                               << "; quarantining mapping (never munmap)";
+                    LOG(ERROR)
+                        << "Failed to unregister received shm from SPDK: "
+                        << shm.shm_buffer
+                        << "; quarantining mapping (never munmap)";
                     quarantine_shms_.push_back(std::move(shm));
                     shm.shm_buffer = nullptr;
                     failed = true;
@@ -2986,8 +2987,8 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                     shm_it->spdk_registered = false;
                 }
                 if (!rc) {
-                    LOG(ERROR) << "Failed to unregister memory: "
-                               << shm_it->shm_name;
+                    LOG(ERROR)
+                        << "Failed to unregister memory: " << shm_it->shm_name;
                     unregister_failed = true;
                 }
                 // munmap and erase even after an unregisterLocalMemory failure
@@ -2996,13 +2997,13 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                 // issuing NoF against a buffer whose SPDK translation is gone.
                 // Mirrors unmap_shm_internal.
                 if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
-                    LOG(ERROR) << "Failed to munmap shared memory: "
-                               << shm_it->shm_name
-                               << ", error: " << strerror(errno);
+                    LOG(ERROR)
+                        << "Failed to munmap shared memory: "
+                        << shm_it->shm_name << ", error: " << strerror(errno);
                 } else {
-                    LOG(INFO) << "Unmapped and cleaned up shared memory: "
-                              << shm_it->shm_name
-                              << ", size: " << shm_it->shm_size;
+                    LOG(INFO)
+                        << "Unmapped and cleaned up shared memory: "
+                        << shm_it->shm_name << ", size: " << shm_it->shm_size;
                 }
             }
 #else
@@ -3017,8 +3018,7 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                            << ", error: " << strerror(errno);
             } else {
                 LOG(INFO) << "Unmapped and cleaned up shared memory: "
-                          << shm_it->shm_name
-                          << ", size: " << shm_it->shm_size;
+                          << shm_it->shm_name << ", size: " << shm_it->shm_size;
             }
 #endif
         }

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1413,14 +1413,20 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
             }
 #ifdef USE_NOF
             // Unregister the SPDK registration before munmap (see
-            // unmap_shm_internal). Non-fatal on failure.
+            // unmap_shm_internal). munmap is only safe once the SPDK
+            // translation is gone; if unregister fails, retain the mapping
+            // (quarantine) so the VA cannot be reused while SPDK still holds a
+            // translation to it.
             if (seg.spdk_registered) {
                 if (SpdkWrapper::GetInstance().UnregisterMemory(
                         seg.shm_buffer, seg.shm_size) != 0) {
-                    LOG(WARNING)
-                        << "Failed to unregister received shm from SPDK during "
-                           "teardown: "
-                        << seg.shm_buffer;
+                    LOG(ERROR) << "Failed to unregister received shm from SPDK "
+                                  "during teardown: "
+                               << seg.shm_buffer
+                               << "; quarantining mapping (never munmap)";
+                    quarantine_shms_.push_back(std::move(seg));
+                    seg.shm_buffer = nullptr;
+                    continue;
                 }
                 seg.spdk_registered = false;
             }
@@ -1437,7 +1443,39 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
 
         shm_it = shm_contexts_.erase(shm_it);
     }
+    // Re-attempt quarantined segments (unregister failed during this teardown
+    // or an earlier one). Any that still fail are retained until process exit,
+    // which is safe: they are never munmapped, so SPDK's translations never
+    // point at freed/reused VAs.
+    RetryQuarantinedShmsLocked();
     return {};
+}
+
+void RealClient::RetryQuarantinedShmsLocked() {
+#ifdef USE_NOF
+    auto it = quarantine_shms_.begin();
+    while (it != quarantine_shms_.end()) {
+        // A quarantined segment still has a live SPDK registration: only
+        // munmap once the translation is actually released.
+        if (it->spdk_registered) {
+            if (SpdkWrapper::GetInstance().UnregisterMemory(it->shm_buffer,
+                                                            it->shm_size) != 0) {
+                ++it;
+                continue;
+            }
+            it->spdk_registered = false;
+        }
+        if (munmap(it->shm_buffer, it->shm_size) != 0) {
+            LOG(ERROR) << "Failed to munmap quarantined shm: " << it->shm_name
+                       << ", error: " << strerror(errno);
+            ++it;
+            continue;
+        }
+        LOG(INFO) << "Released quarantined shared memory: " << it->shm_name
+                  << ", size: " << it->shm_size;
+        it = quarantine_shms_.erase(it);
+    }
+#endif
 }
 
 int RealClient::tearDownAll() { return to_py_ret(tearDownAll_internal()); }
@@ -2536,20 +2574,30 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     auto &context = it->second;
     context.client_buffer_allocator.reset();
 
+    // Retry previously quarantined segments (unregister failed earlier) before
+    // tearing down this context.
+    RetryQuarantinedShmsLocked();
+
     bool failed = false;
     for (auto &shm : context.mapped_shms) {
         if (shm.shm_buffer) {
             auto rc = client_->unregisterLocalMemory(shm.shm_buffer, true);
 #ifdef USE_NOF
             // Unregister the SPDK registration BEFORE munmap, mirroring
-            // ShmHelper::free()/cleanup(). Failure is non-fatal (logged); the
-            // flag is cleared so a later teardown pass does not re-unregister.
+            // ShmHelper::free()/cleanup(). munmap is only safe once the SPDK
+            // translation is gone; if unregister fails, retain the mapping
+            // (quarantine) so the VA cannot be reused while SPDK still holds a
+            // translation to it.
             if (shm.spdk_registered) {
                 if (SpdkWrapper::GetInstance().UnregisterMemory(
                         shm.shm_buffer, shm.shm_size) != 0) {
-                    LOG(WARNING)
-                        << "Failed to unregister received shm from SPDK: "
-                        << shm.shm_buffer;
+                    LOG(ERROR) << "Failed to unregister received shm from SPDK: "
+                               << shm.shm_buffer
+                               << "; quarantining mapping (never munmap)";
+                    quarantine_shms_.push_back(std::move(shm));
+                    shm.shm_buffer = nullptr;
+                    failed = true;
+                    continue;
                 }
                 shm.spdk_registered = false;
             }
@@ -2558,10 +2606,11 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
                 LOG(ERROR) << "Failed to unregister memory: " << shm.shm_name;
                 failed = true;
             }
-            // munmap every segment (including siblings after a failure) so a
-            // partial unregisterLocalMemory failure does not leak mappings or
-            // their SPDK registrations.
+            // munmap every remaining segment (including siblings after a
+            // failure) so a partial unregisterLocalMemory failure does not leak
+            // mappings or their SPDK registrations.
             munmap(shm.shm_buffer, shm.shm_size);
+            shm.shm_buffer = nullptr;
         }
     }
     context.mapped_shms.clear();
@@ -2779,11 +2828,16 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
     auto &context = it->second;
     context.client_buffer_allocator.reset();
 
+    // Retry previously quarantined segments (unregister failed earlier) before
+    // tearing down this context.
+    RetryQuarantinedShmsLocked();
+
     // Move regions out before cleanup so failure paths cannot erase the map
     // entry while iterating (undefined behavior) or double-erase at the end.
     std::vector<MappedShm> shms = std::move(context.mapped_shms);
     context.mapped_shms.clear();
 
+    bool failed = false;
     for (auto &shm : shms) {
         if (!shm.shm_buffer) {
             continue;
@@ -2814,14 +2868,21 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
                 }
 #ifdef USE_NOF
             // Unregister the SPDK registration before munmap (see
-            // unmap_shm_internal). Non-fatal on failure.
+            // unmap_shm_internal). munmap is only safe once the SPDK
+            // translation is gone; if unregister fails, retain the mapping
+            // (quarantine) so the VA cannot be reused while SPDK still holds a
+            // translation to it.
             if (shm.spdk_registered) {
                 if (SpdkWrapper::GetInstance().UnregisterMemory(
                         shm.shm_buffer, shm.shm_size) != 0) {
-                    LOG(WARNING)
-                        << "Failed to unregister received shm from SPDK during "
-                           "unmap: "
-                        << shm.shm_buffer;
+                    LOG(ERROR) << "Failed to unregister received shm from SPDK "
+                                  "during unmap: "
+                               << shm.shm_buffer
+                               << "; quarantining mapping (never munmap)";
+                    quarantine_shms_.push_back(std::move(shm));
+                    shm.shm_buffer = nullptr;
+                    failed = true;
+                    continue;
                 }
                 shm.spdk_registered = false;
             }
@@ -2836,6 +2897,9 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
         }
     }
     shm_contexts_.erase(it);
+    if (failed) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     return {};
 }
 
@@ -2865,6 +2929,10 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     }
     auto &context = it->second;
     bool unregister_failed = false;
+
+    // Retry previously quarantined segments (unregister failed earlier) before
+    // handling this buffer.
+    RetryQuarantinedShmsLocked();
 
     // Find the shm corresponding to this dummy address
     auto shm_it = context.mapped_shms.end();
@@ -2899,36 +2967,60 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
             auto rc = client_->unregisterLocalMemory(shm_it->shm_buffer, true);
 #ifdef USE_NOF
             // Unregister the SPDK registration before munmap (see
-            // unmap_shm_internal). Non-fatal on failure.
-            if (shm_it->spdk_registered) {
-                if (SpdkWrapper::GetInstance().UnregisterMemory(
-                        shm_it->shm_buffer, shm_it->shm_size) != 0) {
-                    LOG(WARNING)
-                        << "Failed to unregister received shm from SPDK during "
-                           "unregister: "
-                        << shm_it->shm_buffer;
+            // unmap_shm_internal). munmap is only safe once the SPDK
+            // translation is gone; if unregister fails, retain the mapping
+            // (quarantine) so the VA cannot be reused while SPDK still holds a
+            // translation to it.
+            if (shm_it->spdk_registered &&
+                SpdkWrapper::GetInstance().UnregisterMemory(
+                    shm_it->shm_buffer, shm_it->shm_size) != 0) {
+                LOG(ERROR) << "Failed to unregister received shm from SPDK "
+                              "during unregister: "
+                           << shm_it->shm_buffer
+                           << "; quarantining mapping (never munmap)";
+                quarantine_shms_.push_back(std::move(*shm_it));
+                shm_it->shm_buffer = nullptr;
+                unregister_failed = true;
+            } else {
+                if (shm_it->spdk_registered) {
+                    shm_it->spdk_registered = false;
                 }
-                shm_it->spdk_registered = false;
+                if (!rc) {
+                    LOG(ERROR) << "Failed to unregister memory: "
+                               << shm_it->shm_name;
+                    unregister_failed = true;
+                }
+                // munmap and erase even after an unregisterLocalMemory failure
+                // (the SPDK registration above was already torn down), so a
+                // partial failure does not leak the mapping or leave the dummy
+                // issuing NoF against a buffer whose SPDK translation is gone.
+                // Mirrors unmap_shm_internal.
+                if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
+                    LOG(ERROR) << "Failed to munmap shared memory: "
+                               << shm_it->shm_name
+                               << ", error: " << strerror(errno);
+                } else {
+                    LOG(INFO) << "Unmapped and cleaned up shared memory: "
+                              << shm_it->shm_name
+                              << ", size: " << shm_it->shm_size;
+                }
             }
-#endif
+#else
             if (!rc) {
                 LOG(ERROR) << "Failed to unregister memory: "
                            << shm_it->shm_name;
                 unregister_failed = true;
             }
-            // munmap and erase even after an unregisterLocalMemory failure (the
-            // SPDK registration above was already torn down), so a partial
-            // failure does not leak the mapping or leave the dummy issuing NoF
-            // against a buffer whose SPDK translation is gone. Mirrors
-            // unmap_shm_internal.
             if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap shared memory: "
                            << shm_it->shm_name
                            << ", error: " << strerror(errno);
             } else {
                 LOG(INFO) << "Unmapped and cleaned up shared memory: "
-                          << shm_it->shm_name << ", size: " << shm_it->shm_size;
+                          << shm_it->shm_name
+                          << ", size: " << shm_it->shm_size;
             }
+#endif
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1411,6 +1411,20 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
             if (seg.shm_buffer == nullptr) {
                 continue;
             }
+#ifdef USE_NOF
+            // Unregister the SPDK registration before munmap (see
+            // unmap_shm_internal). Non-fatal on failure.
+            if (seg.spdk_registered) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(
+                        seg.shm_buffer, seg.shm_size) != 0) {
+                    LOG(WARNING)
+                        << "Failed to unregister received shm from SPDK during "
+                           "teardown: "
+                        << seg.shm_buffer;
+                }
+                seg.spdk_registered = false;
+            }
+#endif
             if (seg.is_ascend) {
                 teardown_ascend_shm_buffer(seg);
             } else if (munmap(seg.shm_buffer, seg.shm_size) != 0) {
@@ -2396,9 +2410,36 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
     }
 #endif
 
-    // Map shared memory from FD
-    void *shm_buffer =
-        mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    // Map shared memory from FD.
+    void *shm_buffer = nullptr;
+#ifdef USE_NOF
+    // Register this receiver-side mapping with SPDK for NoF zero-copy.
+    // spdk_mem_register is per-process: the sender (ShmHelper::allocate) registers
+    // ITS mapping, and in the dummy/real split the NoF submit runs HERE on our
+    // mapping of the shared fd, so it must be registered too. Gated on the same
+    // env as the sender (MC_STORE_REGISTER_SPDK=1). On SPDK < 26.09 the base must
+    // be 2MB-aligned, so when we will register and the sender padded shm_size to a
+    // 2MB multiple, map the fd at a 2MB-aligned address (mmap_shm_2mb_aligned).
+    // If shm_size is not a 2MB multiple (env mismatch: sender didn't pad), fall
+    // back to a plain mmap and let the registration attempt fail non-fatally.
+    const bool register_spdk = ShmHelper::is_register_spdk_enabled();
+    if (register_spdk && (shm_size % SZ_2MB == 0)) {
+        shm_buffer = mmap_shm_2mb_aligned(shm_size, fd);
+        if (shm_buffer == MAP_FAILED) {
+            // 2MB-aligned MAP_FIXED fails for HugeTLB fds whose base must be
+            // hugepage-aligned (e.g. 1GB hugepages): fall back to a plain mmap,
+            // which lets the kernel pick a hugepage-aligned base (2MB or 1GB,
+            // both multiples of 2MB). Registration below then succeeds for those
+            // fds; for non-hugetlb fds that fail alignment it degrades non-fatally.
+            shm_buffer =
+                mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+        }
+    } else
+#endif
+    {
+        shm_buffer =
+            mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    }
     if (shm_buffer == MAP_FAILED) {
         LOG(ERROR) << "Failed to map shared memory from fd: " << fd
                    << ", name: " << shm_name << ", error: " << strerror(errno);
@@ -2442,6 +2483,24 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
             ClientBufferAllocator::create(shm_buffer, shm_size, this->protocol);
     }
 
+#ifdef USE_NOF
+    // Register this mapping with SPDK for NoF zero-copy. Non-fatal on failure:
+    // the buffer stays usable for all non-NoF paths. Placed after the
+    // error-returning paths above so no failure path leaves a dangling SPDK
+    // registration (the unregister below is symmetric on every teardown path).
+    if (register_spdk) {
+        if (SpdkWrapper::GetInstance().RegisterMemory(shm.shm_buffer,
+                                                      shm.shm_size) != 0) {
+            LOG(WARNING) << "Failed to register received shm with SPDK: "
+                         << shm.shm_buffer << ", size=" << shm.shm_size
+                         << "; NoF zero-copy transfers to this buffer will be "
+                            "unavailable";
+        } else {
+            shm.spdk_registered = true;
+        }
+    }
+#endif
+
     context.mapped_shms.push_back(std::move(shm));
 
     LOG(INFO) << "Mapped new shared memory: " << shm_name
@@ -2464,6 +2523,20 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     for (auto &shm : context.mapped_shms) {
         if (shm.shm_buffer) {
             auto rc = client_->unregisterLocalMemory(shm.shm_buffer, true);
+#ifdef USE_NOF
+            // Unregister the SPDK registration BEFORE munmap, mirroring
+            // ShmHelper::free()/cleanup(). Failure is non-fatal (logged); the
+            // flag is cleared so a later teardown pass does not re-unregister.
+            if (shm.spdk_registered) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(
+                        shm.shm_buffer, shm.shm_size) != 0) {
+                    LOG(WARNING)
+                        << "Failed to unregister received shm from SPDK: "
+                        << shm.shm_buffer;
+                }
+                shm.spdk_registered = false;
+            }
+#endif
             if (!rc) {
                 LOG(ERROR) << "Failed to unregister memory";
                 munmap(shm.shm_buffer, shm.shm_size);
@@ -2719,6 +2792,20 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
                                      << ", error: " << toString(res.error());
                     }
                 }
+#ifdef USE_NOF
+            // Unregister the SPDK registration before munmap (see
+            // unmap_shm_internal). Non-fatal on failure.
+            if (shm.spdk_registered) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(
+                        shm.shm_buffer, shm.shm_size) != 0) {
+                    LOG(WARNING)
+                        << "Failed to unregister received shm from SPDK during "
+                           "unmap: "
+                        << shm.shm_buffer;
+                }
+                shm.spdk_registered = false;
+            }
+#endif
             if (munmap(shm.shm_buffer, shm.shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap POSIX shared memory: "
                            << shm.shm_name << ", error: " << strerror(errno);
@@ -2794,6 +2881,20 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                            << shm_it->shm_name;
                 return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
             }
+#ifdef USE_NOF
+            // Unregister the SPDK registration before munmap (see
+            // unmap_shm_internal). Non-fatal on failure.
+            if (shm_it->spdk_registered) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(
+                        shm_it->shm_buffer, shm_it->shm_size) != 0) {
+                    LOG(WARNING)
+                        << "Failed to unregister received shm from SPDK during "
+                           "unregister: "
+                        << shm_it->shm_buffer;
+                }
+                shm_it->spdk_registered = false;
+            }
+#endif
             if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap shared memory: "
                            << shm_it->shm_name

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2502,6 +2502,15 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
                          << shm.shm_buffer << ", size=" << shm.shm_size
                          << "; NoF zero-copy transfers to this buffer will be "
                             "unavailable";
+            // spdk_mem_register() marks g_mem_reg_map REGISTERED before running
+            // its notify callbacks and does NOT roll back on failure (SPDK
+            // v23.01.1, lib/env_dpdk/memory.c). Unregister the range so a later
+            // registration of the same virtual address (e.g. mmap reuse after
+            // munmap) does not return -EBUSY. Mirrors ShmHelper::allocate. The
+            // unregister path tolerates ranges that were never fully
+            // registered.
+            SpdkWrapper::GetInstance().UnregisterMemory(shm.shm_buffer,
+                                                        shm.shm_size);
         } else {
             shm.spdk_registered = true;
         }
@@ -2855,6 +2864,7 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     auto &context = it->second;
+    bool unregister_failed = false;
 
     // Find the shm corresponding to this dummy address
     auto shm_it = context.mapped_shms.end();
@@ -2904,8 +2914,13 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
             if (!rc) {
                 LOG(ERROR) << "Failed to unregister memory: "
                            << shm_it->shm_name;
-                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                unregister_failed = true;
             }
+            // munmap and erase even after an unregisterLocalMemory failure (the
+            // SPDK registration above was already torn down), so a partial
+            // failure does not leak the mapping or leave the dummy issuing NoF
+            // against a buffer whose SPDK translation is gone. Mirrors
+            // unmap_shm_internal.
             if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap shared memory: "
                            << shm_it->shm_name
@@ -2920,6 +2935,9 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     // Remove shm from list
     context.mapped_shms.erase(shm_it);
 
+    if (unregister_failed) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     return {};
 }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2414,14 +2414,15 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
     void *shm_buffer = nullptr;
 #ifdef USE_NOF
     // Register this receiver-side mapping with SPDK for NoF zero-copy.
-    // spdk_mem_register is per-process: the sender (ShmHelper::allocate) registers
-    // ITS mapping, and in the dummy/real split the NoF submit runs HERE on our
-    // mapping of the shared fd, so it must be registered too. Gated on the same
-    // env as the sender (MC_STORE_REGISTER_SPDK=1). On SPDK < 26.09 the base must
-    // be 2MB-aligned, so when we will register and the sender padded shm_size to a
-    // 2MB multiple, map the fd at a 2MB-aligned address (mmap_shm_2mb_aligned).
-    // If shm_size is not a 2MB multiple (env mismatch: sender didn't pad), fall
-    // back to a plain mmap and let the registration attempt fail non-fatally.
+    // spdk_mem_register is per-process: the sender (ShmHelper::allocate)
+    // registers ITS mapping, and in the dummy/real split the NoF submit runs
+    // HERE on our mapping of the shared fd, so it must be registered too. Gated
+    // on the same env as the sender (MC_STORE_REGISTER_SPDK=1). On SPDK < 26.09
+    // the base must be 2MB-aligned, so when we will register and the sender
+    // padded shm_size to a 2MB multiple, map the fd at a 2MB-aligned address
+    // (mmap_shm_2mb_aligned). If shm_size is not a 2MB multiple (env mismatch:
+    // sender didn't pad), fall back to a plain mmap and let the registration
+    // attempt fail non-fatally.
     const bool register_spdk = ShmHelper::is_register_spdk_enabled();
     if (register_spdk && (shm_size % SZ_2MB == 0)) {
         shm_buffer = mmap_shm_2mb_aligned(shm_size, fd);
@@ -2429,10 +2430,11 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
             // 2MB-aligned MAP_FIXED fails for HugeTLB fds whose base must be
             // hugepage-aligned (e.g. 1GB hugepages): fall back to a plain mmap,
             // which lets the kernel pick a hugepage-aligned base (2MB or 1GB,
-            // both multiples of 2MB). Registration below then succeeds for those
-            // fds; for non-hugetlb fds that fail alignment it degrades non-fatally.
-            shm_buffer =
-                mmap(nullptr, shm_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            // both multiples of 2MB). Registration below then succeeds for
+            // those fds; for non-hugetlb fds that fail alignment it degrades
+            // non-fatally.
+            shm_buffer = mmap(nullptr, shm_size, PROT_READ | PROT_WRITE,
+                              MAP_SHARED, fd, 0);
         }
     } else
 #endif
@@ -2483,6 +2485,11 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
             ClientBufferAllocator::create(shm_buffer, shm_size, this->protocol);
     }
 
+    // Ensure push_back below cannot reallocate and throw bad_alloc after the
+    // SPDK registration succeeded (which would leak the registration and the
+    // mapping). If reserve itself throws it happens before registration.
+    context.mapped_shms.reserve(context.mapped_shms.size() + 1);
+
 #ifdef USE_NOF
     // Register this mapping with SPDK for NoF zero-copy. Non-fatal on failure:
     // the buffer stays usable for all non-NoF paths. Placed after the
@@ -2520,6 +2527,7 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     auto &context = it->second;
     context.client_buffer_allocator.reset();
 
+    bool failed = false;
     for (auto &shm : context.mapped_shms) {
         if (shm.shm_buffer) {
             auto rc = client_->unregisterLocalMemory(shm.shm_buffer, true);
@@ -2538,17 +2546,20 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
             }
 #endif
             if (!rc) {
-                LOG(ERROR) << "Failed to unregister memory";
-                munmap(shm.shm_buffer, shm.shm_size);
-                context.mapped_shms.clear();
-                shm_contexts_.erase(it);
-                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+                LOG(ERROR) << "Failed to unregister memory: " << shm.shm_name;
+                failed = true;
             }
+            // munmap every segment (including siblings after a failure) so a
+            // partial unregisterLocalMemory failure does not leak mappings or
+            // their SPDK registrations.
             munmap(shm.shm_buffer, shm.shm_size);
         }
     }
     context.mapped_shms.clear();
     shm_contexts_.erase(it);
+    if (failed) {
+        return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+    }
     return {};
 }
 
@@ -2876,11 +2887,6 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
             }
 #endif
             auto rc = client_->unregisterLocalMemory(shm_it->shm_buffer, true);
-            if (!rc) {
-                LOG(ERROR) << "Failed to unregister memory: "
-                           << shm_it->shm_name;
-                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-            }
 #ifdef USE_NOF
             // Unregister the SPDK registration before munmap (see
             // unmap_shm_internal). Non-fatal on failure.
@@ -2895,6 +2901,11 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                 shm_it->spdk_registered = false;
             }
 #endif
+            if (!rc) {
+                LOG(ERROR) << "Failed to unregister memory: "
+                           << shm_it->shm_name;
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
             if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap shared memory: "
                            << shm_it->shm_name

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -1446,16 +1446,34 @@ tl::expected<void, ErrorCode> RealClient::tearDownAll_internal() {
     // Re-attempt quarantined segments (unregister failed during this teardown
     // or an earlier one). Any that still fail are retained until process exit,
     // which is safe: they are never munmapped, so SPDK's translations never
-    // point at freed/reused VAs.
+    // point at freed/reused virtual addresses.
     RetryQuarantinedShmsLocked();
     return {};
 }
 
 void RealClient::RetryQuarantinedShmsLocked() {
-#ifdef USE_NOF
     auto it = quarantine_shms_.begin();
     while (it != quarantine_shms_.end()) {
-        // A quarantined segment still has a live SPDK registration: only
+        // The transfer engine may still hold this region (unregisterLocalMemory
+        // failed earlier): retry it first, and never munmap while TE still has
+        // the MR registered, or a later mmap reusing this VA would collide
+        // (ERR_ADDRESS_OVERLAPPED) or DMA to unmapped memory.
+        if (it->te_unregister_pending) {
+            if (!client_) {
+                // No client left to retry against (torn down). Conservatively
+                // retain the mapping rather than risk a stale TE registration;
+                // it is released by the OS at process exit.
+                ++it;
+                continue;
+            }
+            if (!client_->unregisterLocalMemory(it->shm_buffer, true)) {
+                ++it;
+                continue;
+            }
+            it->te_unregister_pending = false;
+        }
+#ifdef USE_NOF
+        // A quarantined segment may still have a live SPDK registration: only
         // munmap once the translation is actually released.
         if (it->spdk_registered) {
             if (SpdkWrapper::GetInstance().UnregisterMemory(
@@ -1465,6 +1483,7 @@ void RealClient::RetryQuarantinedShmsLocked() {
             }
             it->spdk_registered = false;
         }
+#endif
         if (munmap(it->shm_buffer, it->shm_size) != 0) {
             LOG(ERROR) << "Failed to munmap quarantined shm: " << it->shm_name
                        << ", error: " << strerror(errno);
@@ -1475,7 +1494,6 @@ void RealClient::RetryQuarantinedShmsLocked() {
                   << ", size: " << it->shm_size;
         it = quarantine_shms_.erase(it);
     }
-#endif
 }
 
 int RealClient::tearDownAll() { return to_py_ret(tearDownAll_internal()); }
@@ -2547,8 +2565,23 @@ tl::expected<void, ErrorCode> RealClient::map_shm_internal_with_device(
             // munmap) does not return -EBUSY. Mirrors ShmHelper::allocate. The
             // unregister path tolerates ranges that were never fully
             // registered.
-            SpdkWrapper::GetInstance().UnregisterMemory(shm.shm_buffer,
-                                                        shm.shm_size);
+            const int rollback_rc = SpdkWrapper::GetInstance().UnregisterMemory(
+                shm.shm_buffer, shm.shm_size);
+            // -EINVAL is the documented benign no-op for a range that never
+            // reached g_mem_reg_map (see SpdkWrapper::UnregisterMemory). Any
+            // other failure means SPDK may still retain (partial) registration
+            // state for this range, so mark it registered: the teardown paths
+            // will then attempt the unregister again and quarantine the mapping
+            // instead of munmapping while SPDK still holds a translation to it.
+            if (rollback_rc != 0 && rollback_rc != -EINVAL) {
+                LOG(ERROR)
+                    << "Failed to roll back incomplete SPDK registration: "
+                    << shm.shm_buffer << ", size: " << shm.shm_size
+                    << ", rc: " << rollback_rc
+                    << "; treating the range as registered so teardown "
+                       "unregisters or quarantines it";
+                shm.spdk_registered = true;
+            }
         } else {
             shm.spdk_registered = true;
         }
@@ -2579,40 +2612,65 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
     RetryQuarantinedShmsLocked();
 
     bool failed = false;
+    // Keep the quarantine push_back below from reallocating (and throwing
+    // bad_alloc) in the middle of tearing a context down.
+    quarantine_shms_.reserve(quarantine_shms_.size() +
+                             context.mapped_shms.size());
     for (auto &shm : context.mapped_shms) {
-        if (shm.shm_buffer) {
-            auto rc = client_->unregisterLocalMemory(shm.shm_buffer, true);
+        if (!shm.shm_buffer) {
+            continue;
+        }
+        // Unregister with the transfer engine first: TE retains its region
+        // record when unregisterLocalMemory() fails and
+        // RdmaTransport::unregisterLocalMemoryInternal returns before
+        // deregistering the MR, so munmapping here would leave TE registered
+        // for an address a later mmap can reuse (ERR_ADDRESS_OVERLAPPED, or DMA
+        // to unmapped memory).
+        const bool te_ok = static_cast<bool>(
+            client_->unregisterLocalMemory(shm.shm_buffer, true));
 #ifdef USE_NOF
-            // Unregister the SPDK registration BEFORE munmap, mirroring
-            // ShmHelper::free()/cleanup(). munmap is only safe once the SPDK
-            // translation is gone; if unregister fails, retain the mapping
-            // (quarantine) so the VA cannot be reused while SPDK still holds a
-            // translation to it.
-            if (shm.spdk_registered) {
-                if (SpdkWrapper::GetInstance().UnregisterMemory(
-                        shm.shm_buffer, shm.shm_size) != 0) {
-                    LOG(ERROR)
-                        << "Failed to unregister received shm from SPDK: "
-                        << shm.shm_buffer
-                        << "; quarantining mapping (never munmap)";
-                    quarantine_shms_.push_back(std::move(shm));
-                    shm.shm_buffer = nullptr;
-                    failed = true;
-                    continue;
-                }
-                shm.spdk_registered = false;
-            }
+        // Unregister the SPDK registration BEFORE munmap, mirroring
+        // ShmHelper::free()/cleanup(). munmap is only safe once the SPDK
+        // translation is gone.
+        bool spdk_ok = true;
+        if (shm.spdk_registered) {
+            spdk_ok = SpdkWrapper::GetInstance().UnregisterMemory(
+                          shm.shm_buffer, shm.shm_size) == 0;
+        }
+#else
+        const bool spdk_ok = true;
 #endif
-            if (!rc) {
-                LOG(ERROR) << "Failed to unregister memory: " << shm.shm_name;
-                failed = true;
-            }
-            // munmap every remaining segment (including siblings after a
-            // failure) so a partial unregisterLocalMemory failure does not leak
-            // mappings or their SPDK registrations.
+        if (te_ok && spdk_ok) {
+#ifdef USE_NOF
+            shm.spdk_registered = false;
+#endif
+            // Both unregisters succeeded, so the VA is no longer referenced by
+            // TE or SPDK and can be released. Siblings that fail are handled by
+            // their own iterations, so a single failure does not leak the rest.
             munmap(shm.shm_buffer, shm.shm_size);
             shm.shm_buffer = nullptr;
+            continue;
         }
+        // Unregister failed: retain the mapping (never munmap) so neither TE
+        // nor SPDK keeps a registration to a freed/reused VA, and quarantine it
+        // for a retry on a later teardown entry point.
+        if (!te_ok) {
+            LOG(ERROR) << "Failed to unregister memory: " << shm.shm_name
+                       << "; quarantining mapping (never munmap)";
+        }
+#ifdef USE_NOF
+        if (!spdk_ok) {
+            LOG(ERROR) << "Failed to unregister received shm from SPDK: "
+                       << shm.shm_buffer
+                       << "; quarantining mapping (never munmap)";
+        }
+#endif
+        shm.te_unregister_pending = !te_ok;
+        quarantine_shms_.push_back(std::move(shm));
+        // std::move leaves raw pointer members unchanged; clear it so the
+        // moved-from entry cannot be munmapped a second time.
+        shm.shm_buffer = nullptr;
+        failed = true;
     }
     context.mapped_shms.clear();
     shm_contexts_.erase(it);
@@ -2846,6 +2904,11 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
         if (shm.is_ascend) {
             teardown_ascend_shm_buffer(shm);
         } else {
+            // Unregister with the transfer engine first: TE retains its region
+            // record when unregisterLocalMemory() fails (see
+            // unmap_shm_internal), so munmapping here would leave TE registered
+            // for an address a later mmap can reuse.
+            bool te_ok = true;
 #ifdef USE_ASCEND_DIRECT
             auto context_result = set_context_if_needed(protocol, shm.device_id,
                                                         "POSIX shm cleanup");
@@ -2858,35 +2921,48 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
                 // Host POSIX shm mapped via map_shm_internal (memfd); not
                 // Ascend VMM/IPC.
                 if (shm.shm_size > 0 && client_) {
-                    auto res =
+                    const auto res =
                         client_->unregisterLocalMemory(shm.shm_buffer, true);
                     if (!res) {
-                        LOG(WARNING) << "Failed to unregister local memory for "
-                                        "POSIX shm: "
-                                     << shm.shm_name
-                                     << ", error: " << toString(res.error());
+                        te_ok = false;
+                        LOG(ERROR) << "Failed to unregister local memory for "
+                                      "POSIX shm: "
+                                   << shm.shm_name
+                                   << ", error: " << toString(res.error())
+                                   << "; quarantining mapping (never munmap)";
                     }
                 }
-#ifdef USE_NOF
             // Unregister the SPDK registration before munmap (see
             // unmap_shm_internal). munmap is only safe once the SPDK
-            // translation is gone; if unregister fails, retain the mapping
-            // (quarantine) so the VA cannot be reused while SPDK still holds a
-            // translation to it.
+            // translation is gone.
+            bool spdk_ok = true;
+#ifdef USE_NOF
             if (shm.spdk_registered) {
-                if (SpdkWrapper::GetInstance().UnregisterMemory(
-                        shm.shm_buffer, shm.shm_size) != 0) {
+                spdk_ok = SpdkWrapper::GetInstance().UnregisterMemory(
+                              shm.shm_buffer, shm.shm_size) == 0;
+            }
+#endif
+            if (!te_ok || !spdk_ok) {
+                // Unregister failed: retain the mapping (never munmap) so
+                // neither TE nor SPDK keeps a registration to a freed/reused
+                // VA, and quarantine it for a retry on a later teardown entry
+                // point.
+                if (!spdk_ok) {
                     LOG(ERROR) << "Failed to unregister received shm from SPDK "
                                   "during unmap: "
                                << shm.shm_buffer
                                << "; quarantining mapping (never munmap)";
-                    quarantine_shms_.push_back(std::move(shm));
-                    shm.shm_buffer = nullptr;
-                    failed = true;
-                    continue;
                 }
-                shm.spdk_registered = false;
+                shm.te_unregister_pending = !te_ok;
+                quarantine_shms_.push_back(std::move(shm));
+                // std::move leaves raw pointer members unchanged; clear it so
+                // the moved-from entry cannot be munmapped a second time.
+                shm.shm_buffer = nullptr;
+                failed = true;
+                continue;
             }
+#ifdef USE_NOF
+            shm.spdk_registered = false;
 #endif
             if (munmap(shm.shm_buffer, shm.shm_size) != 0) {
                 LOG(ERROR) << "Failed to munmap POSIX shared memory: "
@@ -2965,37 +3041,49 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                 return context_result;
             }
 #endif
-            auto rc = client_->unregisterLocalMemory(shm_it->shm_buffer, true);
-#ifdef USE_NOF
+            // Unregister with the transfer engine first: TE retains its region
+            // record when unregisterLocalMemory() fails (see
+            // unmap_shm_internal), so munmapping here would leave TE registered
+            // for an address a later mmap can reuse.
+            const bool te_ok = static_cast<bool>(
+                client_->unregisterLocalMemory(shm_it->shm_buffer, true));
+            if (!te_ok) {
+                LOG(ERROR) << "Failed to unregister memory: "
+                           << shm_it->shm_name
+                           << "; quarantining mapping (never munmap)";
+            }
             // Unregister the SPDK registration before munmap (see
             // unmap_shm_internal). munmap is only safe once the SPDK
-            // translation is gone; if unregister fails, retain the mapping
-            // (quarantine) so the VA cannot be reused while SPDK still holds a
-            // translation to it.
-            if (shm_it->spdk_registered &&
-                SpdkWrapper::GetInstance().UnregisterMemory(
-                    shm_it->shm_buffer, shm_it->shm_size) != 0) {
-                LOG(ERROR) << "Failed to unregister received shm from SPDK "
-                              "during unregister: "
-                           << shm_it->shm_buffer
-                           << "; quarantining mapping (never munmap)";
+            // translation is gone.
+            bool spdk_ok = true;
+#ifdef USE_NOF
+            if (shm_it->spdk_registered) {
+                spdk_ok = SpdkWrapper::GetInstance().UnregisterMemory(
+                              shm_it->shm_buffer, shm_it->shm_size) == 0;
+            }
+#endif
+            if (!te_ok || !spdk_ok) {
+                // Unregister failed: retain the mapping (never munmap) so
+                // neither TE nor SPDK keeps a registration to a freed/reused
+                // VA, and quarantine it for a retry on a later teardown entry
+                // point.
+                if (!spdk_ok) {
+                    LOG(ERROR) << "Failed to unregister received shm from SPDK "
+                                  "during unregister: "
+                               << shm_it->shm_buffer
+                               << "; quarantining mapping (never munmap)";
+                }
+                shm_it->te_unregister_pending = !te_ok;
                 quarantine_shms_.push_back(std::move(*shm_it));
+                // std::move leaves raw pointer members unchanged; clear it so
+                // the moved-from entry cannot be munmapped again (the entry is
+                // erased just below).
                 shm_it->shm_buffer = nullptr;
                 unregister_failed = true;
             } else {
-                if (shm_it->spdk_registered) {
-                    shm_it->spdk_registered = false;
-                }
-                if (!rc) {
-                    LOG(ERROR)
-                        << "Failed to unregister memory: " << shm_it->shm_name;
-                    unregister_failed = true;
-                }
-                // munmap and erase even after an unregisterLocalMemory failure
-                // (the SPDK registration above was already torn down), so a
-                // partial failure does not leak the mapping or leave the dummy
-                // issuing NoF against a buffer whose SPDK translation is gone.
-                // Mirrors unmap_shm_internal.
+#ifdef USE_NOF
+                shm_it->spdk_registered = false;
+#endif
                 if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
                     LOG(ERROR)
                         << "Failed to munmap shared memory: "
@@ -3006,21 +3094,6 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                         << shm_it->shm_name << ", size: " << shm_it->shm_size;
                 }
             }
-#else
-            if (!rc) {
-                LOG(ERROR) << "Failed to unregister memory: "
-                           << shm_it->shm_name;
-                unregister_failed = true;
-            }
-            if (munmap(shm_it->shm_buffer, shm_it->shm_size) != 0) {
-                LOG(ERROR) << "Failed to munmap shared memory: "
-                           << shm_it->shm_name
-                           << ", error: " << strerror(errno);
-            } else {
-                LOG(INFO) << "Unmapped and cleaned up shared memory: "
-                          << shm_it->shm_name << ", size: " << shm_it->shm_size;
-            }
-#endif
         }
     }
 

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2666,6 +2666,16 @@ tl::expected<void, ErrorCode> RealClient::unmap_shm_internal(
         }
 #endif
         shm.te_unregister_pending = !te_ok;
+#ifdef USE_NOF
+        // Record only the side that is still registered. Clear spdk_registered
+        // when the SPDK unregister above succeeded even though the mapping
+        // stays quarantined: a later RetryQuarantinedShmsLocked() would
+        // otherwise call spdk_mem_unregister() a second time, get the benign
+        // -EINVAL no-op for an already released range (SPDK memory.c: no
+        // segment is marked REGISTERED), treat it as a failure, and keep the
+        // mapping quarantined (never munmapped) forever.
+        shm.spdk_registered = !spdk_ok;
+#endif
         quarantine_shms_.push_back(std::move(shm));
         // std::move leaves raw pointer members unchanged; clear it so the
         // moved-from entry cannot be munmapped a second time.
@@ -2954,6 +2964,13 @@ tl::expected<void, ErrorCode> RealClient::ascend_unmap_shm_internal(
                                << "; quarantining mapping (never munmap)";
                 }
                 shm.te_unregister_pending = !te_ok;
+#ifdef USE_NOF
+                // Clear spdk_registered when the SPDK unregister above
+                // succeeded: see unmap_shm_internal (a stale flag makes the
+                // retry re-unregister an already released range, get -EINVAL,
+                // and keep the mapping quarantined forever).
+                shm.spdk_registered = !spdk_ok;
+#endif
                 quarantine_shms_.push_back(std::move(shm));
                 // std::move leaves raw pointer members unchanged; clear it so
                 // the moved-from entry cannot be munmapped a second time.
@@ -3074,6 +3091,13 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
                                << "; quarantining mapping (never munmap)";
                 }
                 shm_it->te_unregister_pending = !te_ok;
+#ifdef USE_NOF
+                // Clear spdk_registered when the SPDK unregister above
+                // succeeded: see unmap_shm_internal (a stale flag makes the
+                // retry re-unregister an already released range, get -EINVAL,
+                // and keep the mapping quarantined forever).
+                shm_it->spdk_registered = !spdk_ok;
+#endif
                 quarantine_shms_.push_back(std::move(*shm_it));
                 // std::move leaves raw pointer members unchanged; clear it so
                 // the moved-from entry cannot be munmapped again (the entry is

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -3055,7 +3055,24 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
             auto context_result = set_context_if_needed(
                 protocol, shm_it->device_id, "POSIX shm unregister");
             if (!context_result) {
-                return context_result;
+                // Nothing was torn down: the mapping, its TE region and its
+                // SPDK registration are all still live here, and shm_it stays
+                // in context.mapped_shms. Report RPC_FAIL instead of
+                // propagating INVALID_PARAMS, which the two early returns above
+                // use for "the receiver holds no such mapping": the caller must
+                // be able to tell "nothing was registered here" apart from "the
+                // teardown did not run", so that it keeps its local bookkeeping
+                // and retries instead of leaking this mapping until process
+                // exit. DummyClient::unregister_buffer() only drops its
+                // shm->registered flag for OK / INTERNAL_ERROR /
+                // INVALID_PARAMS.
+                LOG(ERROR) << "Cannot unregister shm buffer for client_id="
+                           << client_id
+                           << ": could not set the Ascend context for device "
+                           << shm_it->device_id
+                           << ", error: " << toString(context_result.error())
+                           << "; no teardown performed, mapping retained";
+                return tl::make_unexpected(ErrorCode::RPC_FAIL);
             }
 #endif
             // Unregister with the transfer engine first: TE retains its region

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -80,6 +80,18 @@ ShmHelper* ShmHelper::getInstance() {
 }
 
 ShmHelper::ShmHelper() {
+#ifdef USE_NOF
+    // Force SpdkWrapper to complete construction before ShmHelper does, so that
+    // at process exit ShmHelper is destroyed FIRST: its cleanup() (which calls
+    // SpdkWrapper::UnregisterMemory) runs while the SPDK env is still alive,
+    // before ~SpdkWrapper -> Cleanup() -> spdk_env_fini(). Without this, the
+    // first host-pool allocation constructs SpdkWrapper AFTER ShmHelper, so at
+    // exit SpdkWrapper is destroyed first and cleanup() would call
+    // spdk_mem_unregister after spdk_env_fini() (UB / NULL-deref on SPDK >= 26.09).
+    // Constructing SpdkWrapper here is side-effect free: its ctor is `= default`
+    // and the env is only initialized lazily via InitializeEnv().
+    SpdkWrapper::GetInstance();
+#endif
     const char* hp = std::getenv("MC_STORE_USE_HUGEPAGE");
     use_hugepage_ = (hp != nullptr);
     // Read once at construction (ShmHelper is a singleton). Opt-in only: with

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -11,6 +11,9 @@
 
 #include "utils.h"
 #include "config.h"
+#ifdef USE_NOF
+#include "spdk/spdk_wrapper.h"
+#endif
 #if defined(USE_ASCEND_DIRECT)
 #include "ascend_allocator.h"
 #endif
@@ -31,6 +34,46 @@ static int memfd_create_wrapper(const char* name, unsigned int flags) {
 #endif
 }
 
+#ifdef USE_NOF
+// Place a memfd mapping at a 2MB-aligned address while keeping the file offset
+// at 0, so the returned base matches what a peer process mapping the fd at
+// offset 0 sees (cross-process fd sharing is unchanged). SPDK before 26.09
+// (e.g. the v23.01.1 pinned by dependencies.sh) rejects spdk_mem_register()
+// unless both the start and the length are 2MB-aligned; plain mmap only
+// guarantees 4KB alignment. Reserve a PROT_NONE region large enough to contain
+// a 2MB-aligned window, then MAP_FIXED the memfd into it (which only replaces
+// the reservation, never live mappings), and release the unaligned head/tail.
+static void* mmap_shm_2mb_aligned(size_t size, int fd) {
+    const size_t reserve_size = size + SZ_2MB;
+    void* hint = mmap(nullptr, reserve_size, PROT_NONE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (hint == MAP_FAILED) {
+        return MAP_FAILED;
+    }
+    const uintptr_t hint_addr = reinterpret_cast<uintptr_t>(hint);
+    const uintptr_t target = static_cast<uintptr_t>(
+        align_up(static_cast<size_t>(hint_addr), SZ_2MB));
+    void* base =
+        mmap(reinterpret_cast<void*>(target), size, PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_FIXED | MAP_POPULATE, fd, 0);
+    if (base == MAP_FAILED) {
+        munmap(hint, reserve_size);
+        return MAP_FAILED;
+    }
+    // Release the unaligned head and tail of the reservation.
+    const uintptr_t base_addr = reinterpret_cast<uintptr_t>(base);
+    if (base_addr > hint_addr) {
+        munmap(hint, base_addr - hint_addr);
+    }
+    const uintptr_t reserve_end = hint_addr + reserve_size;
+    const uintptr_t tail = base_addr + size;
+    if (tail < reserve_end) {
+        munmap(reinterpret_cast<void*>(tail), reserve_end - tail);
+    }
+    return base;
+}
+#endif
+
 ShmHelper* ShmHelper::getInstance() {
     static ShmHelper instance;
     return &instance;
@@ -39,6 +82,16 @@ ShmHelper* ShmHelper::getInstance() {
 ShmHelper::ShmHelper() {
     const char* hp = std::getenv("MC_STORE_USE_HUGEPAGE");
     use_hugepage_ = (hp != nullptr);
+    // Read once at construction (ShmHelper is a singleton). Opt-in only: with
+    // MC_STORE_REGISTER_SPDK=1, ShmHelper mappings are registered with SPDK so
+    // NoF zero-copy transfers can DMA to/from them; otherwise the previous
+    // allocation behavior is preserved exactly.
+    const char* rs = std::getenv("MC_STORE_REGISTER_SPDK");
+    register_spdk_ = (rs != nullptr && std::strcmp(rs, "1") == 0);
+    if (register_spdk_) {
+        LOG(INFO) << "MC_STORE_REGISTER_SPDK=1: shared memory will be "
+                     "registered with SPDK for NoF zero-copy transfers";
+    }
 }
 
 ShmHelper::~ShmHelper() { cleanup(); }
@@ -52,6 +105,18 @@ bool ShmHelper::cleanup() {
             shm->fd = -1;
         }
         if (shm->base_addr) {
+#ifdef USE_NOF
+            if (shm->spdk_registered) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(shm->base_addr,
+                                                                shm->size) != 0) {
+                    LOG(WARNING)
+                        << "Failed to unregister shared memory from SPDK "
+                           "during cleanup: "
+                        << shm->base_addr;
+                }
+                shm->spdk_registered = false;
+            }
+#endif
 #if defined(USE_ASCEND_DIRECT)
             if (globalConfig().ascend_agent_mode &&
                 globalConfig().ascend_use_fabric_mem) {
@@ -104,6 +169,23 @@ void* ShmHelper::allocate(size_t size) {
         size = align_up(size, get_hugepage_size_from_env(&flags, use_memfd));
         LOG(INFO) << "Using huge pages for shared memory, size: " << size;
     }
+#ifdef USE_NOF
+    // spdk_mem_register() requires an aligned start and an aligned length.
+    // SPDK before 26.09 (e.g. the v23.01.1 pinned by dependencies.sh) only
+    // accepts 2MB-aligned registrations (MASK_2MB); 4KB support arrived in
+    // 26.09 (commit d6dc356ff). 2MB alignment satisfies both. When hugepages
+    // are configured the size is already a hugepage multiple (and MAP_HUGETLB
+    // guarantees a 2MB-aligned base); otherwise align to 2MB so the tail is
+    // compatible with older SPDK. mmap() already maps whole pages, so this only
+    // pads the tail and does not change the bytes visible to callers. Only
+    // applied when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1) so
+    // the default flow keeps the exact previous allocation sizes.
+    if (register_spdk_) {
+        const size_t hp_size = get_hugepage_size_from_env();
+        const size_t align = hp_size > 0 ? hp_size : static_cast<size_t>(SZ_2MB);
+        size = align_up(size, align);
+    }
+#endif
 
     int fd = memfd_create_wrapper(MOONCAKE_SHM_NAME, flags);
     if (fd == -1) {
@@ -120,8 +202,19 @@ void* ShmHelper::allocate(size_t size) {
                                  std::string(strerror(errno)));
     }
 
-    void* base_addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-                           MAP_SHARED | MAP_POPULATE, fd, 0);
+    void* base_addr = nullptr;
+#ifdef USE_NOF
+    // SPDK < 26.09 (v23.01.1) needs a 2MB-aligned base; the hugepage path
+    // already provides one, so only the non-hugepage path needs the aligned
+    // mapping (keeps MC_STORE_USE_HUGEPAGE optional).
+    if (register_spdk_ && !use_hugepage_) {
+        base_addr = mmap_shm_2mb_aligned(size, fd);
+    } else
+#endif
+    {
+        base_addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_POPULATE, fd, 0);
+    }
     if (base_addr == MAP_FAILED) {
         close(fd);
         throw std::runtime_error("Failed to map shared memory: " +
@@ -134,6 +227,22 @@ void* ShmHelper::allocate(size_t size) {
     shm->size = size;
     shm->name = MOONCAKE_SHM_NAME;
     shm->registered = false;
+#ifdef USE_NOF
+    // Register the mapping with SPDK so NoF (NVMe-oF) RDMA transfers can DMA
+    // to/from this buffer directly (spdk_rdma_get_translation). Registration
+    // failure is non-fatal: the buffer stays usable for all non-NoF paths.
+    // Enabled only with MC_STORE_REGISTER_SPDK=1 (read once at construction).
+    if (register_spdk_) {
+        if (SpdkWrapper::GetInstance().RegisterMemory(base_addr, size) != 0) {
+            LOG(WARNING) << "Failed to register shared memory with SPDK: addr="
+                         << base_addr << ", size=" << size
+                         << "; NoF zero-copy transfers to this buffer will be "
+                            "unavailable";
+        } else {
+            shm->spdk_registered = true;
+        }
+    }
+#endif
     shms_.push_back(shm);
 
     return base_addr;
@@ -147,6 +256,18 @@ int ShmHelper::free(void* addr) {
                 close((*it)->fd);
             }
             if ((*it)->base_addr) {
+#ifdef USE_NOF
+                if ((*it)->spdk_registered) {
+                    if (SpdkWrapper::GetInstance().UnregisterMemory(
+                            (*it)->base_addr, (*it)->size) != 0) {
+                        LOG(WARNING)
+                            << "Failed to unregister shared memory from SPDK "
+                               "during free: "
+                            << (*it)->base_addr;
+                    }
+                    (*it)->spdk_registered = false;
+                }
+#endif
 #if defined(USE_ASCEND_DIRECT)
                 if (globalConfig().ascend_agent_mode &&
                     globalConfig().ascend_use_fabric_mem) {

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -154,6 +154,7 @@ void* ShmHelper::allocate(size_t size) {
             shm->fd = -1;
             shm->base_addr = base_addr;
             shm->size = alloc_size;
+            shm->requested_size = alloc_size;
             shm->name = MOONCAKE_SHM_NAME;
             shm->registered = false;
             shms_.push_back(shm);
@@ -162,6 +163,12 @@ void* ShmHelper::allocate(size_t size) {
         // ascend_agent_mode && !ascend_use_fabric_mem: fall through to memfd
     }
 #endif
+
+    // Remember the caller-requested size before any alignment padding (hugepage
+    // or 2MB for SPDK registration). shm->size is the padded size; consumers that
+    // must match the original request (e.g. DummyClient::register_buffer) use
+    // requested_size instead of re-deriving the alignment policy.
+    const size_t requested = size;
 
     unsigned int flags = MFD_CLOEXEC;
     if (use_hugepage_) {
@@ -225,6 +232,7 @@ void* ShmHelper::allocate(size_t size) {
     shm->fd = fd;
     shm->base_addr = base_addr;
     shm->size = size;
+    shm->requested_size = requested;
     shm->name = MOONCAKE_SHM_NAME;
     shm->registered = false;
 #ifdef USE_NOF

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -121,10 +121,17 @@ bool ShmHelper::cleanup() {
             if (shm->spdk_registered) {
                 if (SpdkWrapper::GetInstance().UnregisterMemory(
                         shm->base_addr, shm->size) != 0) {
-                    LOG(WARNING)
-                        << "Failed to unregister shared memory from SPDK "
-                           "during cleanup: "
-                        << shm->base_addr;
+                    // SPDK still holds a translation for this range: do NOT
+                    // munmap or clear spdk_registered, or a later mmap could
+                    // reuse the VA and NoF would silently DMA to the wrong
+                    // memory. Retain the mapping (released by the OS at process
+                    // exit; cleanup() only runs from ~ShmHelper).
+                    LOG(ERROR) << "Failed to unregister shared memory from "
+                                  "SPDK during cleanup; retaining mapping "
+                                  "(never munmap): "
+                               << shm->base_addr;
+                    ret = false;
+                    continue;
                 }
                 shm->spdk_registered = false;
             }
@@ -273,16 +280,22 @@ int ShmHelper::free(void* addr) {
         if ((*it)->base_addr == addr) {
             if ((*it)->fd != -1) {
                 close((*it)->fd);
+                (*it)->fd = -1;
             }
             if ((*it)->base_addr) {
 #ifdef USE_NOF
                 if ((*it)->spdk_registered) {
                     if (SpdkWrapper::GetInstance().UnregisterMemory(
                             (*it)->base_addr, (*it)->size) != 0) {
-                        LOG(WARNING)
-                            << "Failed to unregister shared memory from SPDK "
-                               "during free: "
-                            << (*it)->base_addr;
+                        // SPDK still holds a translation for this range: do NOT
+                        // munmap, clear spdk_registered, or erase the segment.
+                        // Retain the mapping so the VA cannot be reused while
+                        // SPDK's translation is live (a later free() retries).
+                        LOG(ERROR) << "Failed to unregister shared memory from "
+                                      "SPDK during free; retaining mapping "
+                                      "(never munmap): "
+                                   << (*it)->base_addr;
+                        return -1;
                     }
                     (*it)->spdk_registered = false;
                 }

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -34,46 +34,6 @@ static int memfd_create_wrapper(const char* name, unsigned int flags) {
 #endif
 }
 
-#ifdef USE_NOF
-// Place a memfd mapping at a 2MB-aligned address while keeping the file offset
-// at 0, so the returned base matches what a peer process mapping the fd at
-// offset 0 sees (cross-process fd sharing is unchanged). SPDK before 26.09
-// (e.g. the v23.01.1 pinned by dependencies.sh) rejects spdk_mem_register()
-// unless both the start and the length are 2MB-aligned; plain mmap only
-// guarantees 4KB alignment. Reserve a PROT_NONE region large enough to contain
-// a 2MB-aligned window, then MAP_FIXED the memfd into it (which only replaces
-// the reservation, never live mappings), and release the unaligned head/tail.
-static void* mmap_shm_2mb_aligned(size_t size, int fd) {
-    const size_t reserve_size = size + SZ_2MB;
-    void* hint = mmap(nullptr, reserve_size, PROT_NONE,
-                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (hint == MAP_FAILED) {
-        return MAP_FAILED;
-    }
-    const uintptr_t hint_addr = reinterpret_cast<uintptr_t>(hint);
-    const uintptr_t target = static_cast<uintptr_t>(
-        align_up(static_cast<size_t>(hint_addr), SZ_2MB));
-    void* base =
-        mmap(reinterpret_cast<void*>(target), size, PROT_READ | PROT_WRITE,
-             MAP_SHARED | MAP_FIXED | MAP_POPULATE, fd, 0);
-    if (base == MAP_FAILED) {
-        munmap(hint, reserve_size);
-        return MAP_FAILED;
-    }
-    // Release the unaligned head and tail of the reservation.
-    const uintptr_t base_addr = reinterpret_cast<uintptr_t>(base);
-    if (base_addr > hint_addr) {
-        munmap(hint, base_addr - hint_addr);
-    }
-    const uintptr_t reserve_end = hint_addr + reserve_size;
-    const uintptr_t tail = base_addr + size;
-    if (tail < reserve_end) {
-        munmap(reinterpret_cast<void*>(tail), reserve_end - tail);
-    }
-    return base;
-}
-#endif
-
 ShmHelper* ShmHelper::getInstance() {
     static ShmHelper instance;
     return &instance;
@@ -98,12 +58,16 @@ ShmHelper::ShmHelper() {
     // MC_STORE_REGISTER_SPDK=1, ShmHelper mappings are registered with SPDK so
     // NoF zero-copy transfers can DMA to/from them; otherwise the previous
     // allocation behavior is preserved exactly.
-    const char* rs = std::getenv("MC_STORE_REGISTER_SPDK");
-    register_spdk_ = (rs != nullptr && std::strcmp(rs, "1") == 0);
+    register_spdk_ = is_register_spdk_enabled();
     if (register_spdk_) {
         LOG(INFO) << "MC_STORE_REGISTER_SPDK=1: shared memory will be "
                      "registered with SPDK for NoF zero-copy transfers";
     }
+}
+
+bool ShmHelper::is_register_spdk_enabled() {
+    const char* rs = std::getenv("MC_STORE_REGISTER_SPDK");
+    return rs != nullptr && std::strcmp(rs, "1") == 0;
 }
 
 ShmHelper::~ShmHelper() { cleanup(); }
@@ -199,6 +163,9 @@ void* ShmHelper::allocate(size_t size) {
     // pads the tail and does not change the bytes visible to callers. Only
     // applied when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1) so
     // the default flow keeps the exact previous allocation sizes.
+    // NOTE: SPDK >= 26.09 supports 4KB-aligned registrations, so once the pinned
+    // version is upgraded this 2MB size padding AND the aligned base mapping
+    // (mmap_shm_2mb_aligned, utils.h) can be removed and plain mmap used.
     if (register_spdk_) {
         const size_t hp_size = get_hugepage_size_from_env();
         const size_t align = hp_size > 0 ? hp_size : static_cast<size_t>(SZ_2MB);

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -34,6 +34,31 @@ static int memfd_create_wrapper(const char* name, unsigned int flags) {
 #endif
 }
 
+// Build a clear error message for a failed shared-memory allocation step.
+// When the allocation uses hugepages (forced by MC_STORE_REGISTER_SPDK=1), the
+// usual failure is an insufficient hugepage pool (ENOMEM at ftruncate/mmap);
+// spell out exactly how many hugepages of what size are needed so the operator
+// can configure them. Non-hugepage messages keep the pre-existing text exactly.
+static std::string shm_alloc_error(const char* step, size_t size,
+                                   bool use_hugepage, size_t hp_size, int err) {
+    if (!use_hugepage) {
+        return std::string("Failed to ") + step + ": " + strerror(err);
+    }
+    std::string msg = std::string("Failed to ") + step + " using ";
+    if (hp_size >= SZ_1GB) {
+        msg += std::to_string(hp_size / SZ_1GB) + "GB hugepages";
+    } else {
+        msg += std::to_string(hp_size / (1024 * 1024)) + "MB hugepages";
+    }
+    msg += " (size " + std::to_string(size) + " bytes, need " +
+           std::to_string(size / hp_size) + " hugepages): " + strerror(err);
+    msg +=
+        ". Configure enough hugepages via /proc/sys/vm/nr_hugepages (or "
+        "hugepages-2048kB/hugepages-1048576kB nr_hugepages), or unset "
+        "MC_STORE_REGISTER_SPDK to skip SPDK registration";
+    return msg;
+}
+
 ShmHelper* ShmHelper::getInstance() {
     static ShmHelper instance;
     return &instance;
@@ -60,6 +85,17 @@ ShmHelper::ShmHelper() {
     // allocation behavior is preserved exactly.
     register_spdk_ = is_register_spdk_enabled();
     if (register_spdk_) {
+#ifdef USE_NOF
+        // spdk_mem_register() requires hugepage-backed memory: SPDK's vtophys
+        // notify checks each 2MB segment's PHYSICAL address for 2MB alignment,
+        // which only hugepage pages satisfy (4KB-backed memory always fails
+        // with -EINVAL, on v23.01.1 and every later version in iova=pa mode).
+        // Virtual-address alignment alone (mmap_shm_2mb_aligned) is not
+        // sufficient, so force hugepages here; if not enough are configured the
+        // allocation below fails with a clear error instead of silently losing
+        // NoF zero-copy.
+        use_hugepage_ = true;
+#endif
         LOG(INFO) << "MC_STORE_REGISTER_SPDK=1: shared memory will be "
                      "registered with SPDK for NoF zero-copy transfers";
     }
@@ -147,66 +183,53 @@ void* ShmHelper::allocate(size_t size) {
     const size_t requested = size;
 
     unsigned int flags = MFD_CLOEXEC;
+    size_t hp_size = 0;  // hugepage size when use_hugepage_ (0 otherwise)
     if (use_hugepage_) {
         bool use_memfd = true;
-        size = align_up(size, get_hugepage_size_from_env(&flags, use_memfd));
+        hp_size = get_hugepage_size_from_env(&flags, use_memfd);
+        if (!(flags & MFD_HUGETLB)) {
+            // get_hugepage_size_from_env() returns 0 and sets no MFD_HUGETLB
+            // flag when MC_STORE_USE_HUGEPAGE is unset -- exactly the case when
+            // MC_STORE_REGISTER_SPDK=1 forces hugepages (see constructor).
+            // Default to 2MB hugepages.
+            flags |= MFD_HUGETLB | MFD_HUGE_2MB;
+            if (hp_size == 0) {
+                hp_size = SZ_2MB;
+            }
+            LOG(INFO) << "Using 2MB hugepages (set MC_STORE_USE_HUGEPAGE and "
+                         "MC_STORE_HUGEPAGE_SIZE=1GB to use 1GB)";
+        }
+        size = align_up(size, hp_size);
         LOG(INFO) << "Using huge pages for shared memory, size: " << size;
     }
-#ifdef USE_NOF
-    // spdk_mem_register() requires an aligned start and an aligned length.
-    // SPDK before 26.09 (e.g. the v23.01.1 pinned by dependencies.sh) only
-    // accepts 2MB-aligned registrations (MASK_2MB); 4KB support arrived in
-    // 26.09 (commit d6dc356ff). 2MB alignment satisfies both. When hugepages
-    // are configured the size is already a hugepage multiple (and MAP_HUGETLB
-    // guarantees a 2MB-aligned base); otherwise align to 2MB so the tail is
-    // compatible with older SPDK. mmap() already maps whole pages, so this only
-    // pads the tail and does not change the bytes visible to callers. Only
-    // applied when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1) so
-    // the default flow keeps the exact previous allocation sizes.
-    // NOTE: SPDK >= 26.09 supports 4KB-aligned registrations, so once the
-    // pinned version is upgraded this 2MB size padding AND the aligned base
-    // mapping (mmap_shm_2mb_aligned, utils.h) can be removed and plain mmap
-    // used.
-    if (register_spdk_) {
-        const size_t hp_size = get_hugepage_size_from_env();
-        const size_t align =
-            hp_size > 0 ? hp_size : static_cast<size_t>(SZ_2MB);
-        size = align_up(size, align);
-    }
-#endif
+    // When MC_STORE_REGISTER_SPDK=1 forces hugepages, the branch above already
+    // aligned size to the hugepage size, and hugetlb mmap returns a
+    // hugepage-aligned base, so no separate 2MB size padding or aligned base
+    // mapping (mmap_shm_2mb_aligned, utils.h) is needed on the sender side.
+    // (The receiver maps the shared fd and aligns its own base in
+    // RealClient::map_shm_internal_with_device.)
 
     int fd = memfd_create_wrapper(MOONCAKE_SHM_NAME, flags);
     if (fd == -1) {
-        std::string extra_msg =
-            use_hugepage_ ? " (Check /proc/sys/vm/nr_hugepages?)" : "";
-        throw std::runtime_error("Failed to create anonymous shared memory" +
-                                 extra_msg + ": " +
-                                 std::string(strerror(errno)));
+        throw std::runtime_error(
+            shm_alloc_error("create anonymous shared memory", size,
+                            use_hugepage_, hp_size, errno));
     }
 
     if (ftruncate(fd, size) == -1) {
+        int err = errno;
         close(fd);
-        throw std::runtime_error("Failed to set shared memory size: " +
-                                 std::string(strerror(errno)));
+        throw std::runtime_error(shm_alloc_error("set shared memory size", size,
+                                                 use_hugepage_, hp_size, err));
     }
 
-    void* base_addr = nullptr;
-#ifdef USE_NOF
-    // SPDK < 26.09 (v23.01.1) needs a 2MB-aligned base; the hugepage path
-    // already provides one, so only the non-hugepage path needs the aligned
-    // mapping (keeps MC_STORE_USE_HUGEPAGE optional).
-    if (register_spdk_ && !use_hugepage_) {
-        base_addr = mmap_shm_2mb_aligned(size, fd);
-    } else
-#endif
-    {
-        base_addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
-                         MAP_SHARED | MAP_POPULATE, fd, 0);
-    }
+    void* base_addr = mmap(nullptr, size, PROT_READ | PROT_WRITE,
+                           MAP_SHARED | MAP_POPULATE, fd, 0);
     if (base_addr == MAP_FAILED) {
+        int err = errno;
         close(fd);
-        throw std::runtime_error("Failed to map shared memory: " +
-                                 std::string(strerror(errno)));
+        throw std::runtime_error(shm_alloc_error("map shared memory", size,
+                                                 use_hugepage_, hp_size, err));
     }
 
     auto shm = std::make_shared<ShmSegment>();
@@ -227,6 +250,13 @@ void* ShmHelper::allocate(size_t size) {
                          << base_addr << ", size=" << size
                          << "; NoF zero-copy transfers to this buffer will be "
                             "unavailable";
+            // spdk_mem_register() marks g_mem_reg_map REGISTERED before running
+            // its notify callbacks and does NOT roll back on failure (SPDK
+            // v23.01.1, lib/env_dpdk/memory.c). Unregister the range so a later
+            // registration of the same virtual address (e.g. mmap reuse after
+            // free) does not return -EBUSY. The unregister path tolerates
+            // ranges that were never fully registered.
+            SpdkWrapper::GetInstance().UnregisterMemory(base_addr, size);
         } else {
             shm->spdk_registered = true;
         }

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -47,9 +47,9 @@ ShmHelper::ShmHelper() {
     // before ~SpdkWrapper -> Cleanup() -> spdk_env_fini(). Without this, the
     // first host-pool allocation constructs SpdkWrapper AFTER ShmHelper, so at
     // exit SpdkWrapper is destroyed first and cleanup() would call
-    // spdk_mem_unregister after spdk_env_fini() (UB / NULL-deref on SPDK >= 26.09).
-    // Constructing SpdkWrapper here is side-effect free: its ctor is `= default`
-    // and the env is only initialized lazily via InitializeEnv().
+    // spdk_mem_unregister after spdk_env_fini() (UB / NULL-deref on SPDK
+    // >= 26.09). Constructing SpdkWrapper here is side-effect free: its ctor is
+    // `= default` and the env is only initialized lazily via InitializeEnv().
     SpdkWrapper::GetInstance();
 #endif
     const char* hp = std::getenv("MC_STORE_USE_HUGEPAGE");
@@ -83,8 +83,8 @@ bool ShmHelper::cleanup() {
         if (shm->base_addr) {
 #ifdef USE_NOF
             if (shm->spdk_registered) {
-                if (SpdkWrapper::GetInstance().UnregisterMemory(shm->base_addr,
-                                                                shm->size) != 0) {
+                if (SpdkWrapper::GetInstance().UnregisterMemory(
+                        shm->base_addr, shm->size) != 0) {
                     LOG(WARNING)
                         << "Failed to unregister shared memory from SPDK "
                            "during cleanup: "
@@ -141,9 +141,9 @@ void* ShmHelper::allocate(size_t size) {
 #endif
 
     // Remember the caller-requested size before any alignment padding (hugepage
-    // or 2MB for SPDK registration). shm->size is the padded size; consumers that
-    // must match the original request (e.g. DummyClient::register_buffer) use
-    // requested_size instead of re-deriving the alignment policy.
+    // or 2MB for SPDK registration). shm->size is the padded size; consumers
+    // that must match the original request (e.g. DummyClient::register_buffer)
+    // use requested_size instead of re-deriving the alignment policy.
     const size_t requested = size;
 
     unsigned int flags = MFD_CLOEXEC;
@@ -163,12 +163,14 @@ void* ShmHelper::allocate(size_t size) {
     // pads the tail and does not change the bytes visible to callers. Only
     // applied when SPDK registration is enabled (MC_STORE_REGISTER_SPDK=1) so
     // the default flow keeps the exact previous allocation sizes.
-    // NOTE: SPDK >= 26.09 supports 4KB-aligned registrations, so once the pinned
-    // version is upgraded this 2MB size padding AND the aligned base mapping
-    // (mmap_shm_2mb_aligned, utils.h) can be removed and plain mmap used.
+    // NOTE: SPDK >= 26.09 supports 4KB-aligned registrations, so once the
+    // pinned version is upgraded this 2MB size padding AND the aligned base
+    // mapping (mmap_shm_2mb_aligned, utils.h) can be removed and plain mmap
+    // used.
     if (register_spdk_) {
         const size_t hp_size = get_hugepage_size_from_env();
-        const size_t align = hp_size > 0 ? hp_size : static_cast<size_t>(SZ_2MB);
+        const size_t align =
+            hp_size > 0 ? hp_size : static_cast<size_t>(SZ_2MB);
         size = align_up(size, align);
     }
 #endif

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -1,5 +1,6 @@
 #include "shm_helper.h"
 
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
 #include <sys/mman.h>
@@ -263,7 +264,23 @@ void* ShmHelper::allocate(size_t size) {
             // registration of the same virtual address (e.g. mmap reuse after
             // free) does not return -EBUSY. The unregister path tolerates
             // ranges that were never fully registered.
-            SpdkWrapper::GetInstance().UnregisterMemory(base_addr, size);
+            const int rollback_rc =
+                SpdkWrapper::GetInstance().UnregisterMemory(base_addr, size);
+            // -EINVAL is the documented benign no-op for a range that never
+            // reached g_mem_reg_map (see SpdkWrapper::UnregisterMemory). Any
+            // other failure means SPDK may still retain (partial) registration
+            // state for this range, so mark it registered: free()/cleanup()
+            // will then attempt the unregister again and quarantine the mapping
+            // instead of munmapping while SPDK still holds a translation to it.
+            if (rollback_rc != 0 && rollback_rc != -EINVAL) {
+                LOG(ERROR)
+                    << "Failed to roll back incomplete SPDK registration: "
+                    << base_addr << ", size: " << size
+                    << ", rc: " << rollback_rc
+                    << "; treating the range as registered so teardown "
+                       "unregisters or quarantines it";
+                shm->spdk_registered = true;
+            }
         } else {
             shm->spdk_registered = true;
         }

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -214,7 +214,15 @@ int SpdkWrapper::UnregisterMemory(void *addr, size_t size) {
         return 0;
     }
     int rc = spdk_mem_unregister(addr, size);
-    if (rc != 0) {
+    if (rc != 0 && rc != -EINVAL) {
+        // -EINVAL is the expected no-op on the register-failure cleanup path:
+        // spdk_mem_unregister returns it (memory.c:404/426) both when the range
+        // fails the 2MB alignment check -- a failed spdk_mem_register never
+        // reached g_mem_reg_map -- and when no segment is marked REGISTERED, so
+        // there is nothing to clean up. Logging it as an error would mislead
+        // operators on a path that already degrades gracefully with a WARNING.
+        // Other codes (-ERANGE etc.) indicate a real teardown problem on a
+        // range that was registered and keep the ERROR level.
         LOG(ERROR) << "spdk_mem_unregister failed (addr=" << addr
                    << ", size=" << size << "): " << strerror(-rc);
     }

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -204,6 +204,14 @@ int SpdkWrapper::UnregisterMemory(void *addr, size_t size) {
     if (!addr || size == 0) {
         return -1;
     }
+    // SPDK env may not be initialized (registration is opt-in) or may already
+    // have been finalized by Cleanup() -> spdk_env_fini(). In both cases there
+    // is no registered memory to release; calling spdk_mem_unregister would walk
+    // a torn-down or never-created global mem_map. (With ShmHelper destroyed
+    // before SpdkWrapper, the `initialized` atomic is still alive here.)
+    if (!initialized.load(std::memory_order_acquire)) {
+        return 0;
+    }
     int rc = spdk_mem_unregister(addr, size);
     if (rc != 0) {
         LOG(ERROR) << "spdk_mem_unregister failed (addr=" << addr

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -184,6 +184,34 @@ void SpdkWrapper::Free(void *ptr) {
     }
 }
 
+int SpdkWrapper::RegisterMemory(void *addr, size_t size) {
+    if (!addr || size == 0) {
+        return -1;
+    }
+    if (!InitializeEnv()) {
+        LOG(ERROR) << "SPDK env init failed, cannot register memory";
+        return -1;
+    }
+    int rc = spdk_mem_register(addr, size);
+    if (rc != 0) {
+        LOG(ERROR) << "spdk_mem_register failed (addr=" << addr
+                   << ", size=" << size << "): " << strerror(-rc);
+    }
+    return rc;
+}
+
+int SpdkWrapper::UnregisterMemory(void *addr, size_t size) {
+    if (!addr || size == 0) {
+        return -1;
+    }
+    int rc = spdk_mem_unregister(addr, size);
+    if (rc != 0) {
+        LOG(ERROR) << "spdk_mem_unregister failed (addr=" << addr
+                   << ", size=" << size << "): " << strerror(-rc);
+    }
+    return rc;
+}
+
 void SpdkWrapper::ProbeReadComplete(void *ctx,
                                     const struct spdk_nvme_cpl *cpl) {
     auto *probe_ctx = reinterpret_cast<ProbeRequestContext *>(ctx);

--- a/mooncake-store/src/spdk/spdk_wrapper.cpp
+++ b/mooncake-store/src/spdk/spdk_wrapper.cpp
@@ -206,9 +206,10 @@ int SpdkWrapper::UnregisterMemory(void *addr, size_t size) {
     }
     // SPDK env may not be initialized (registration is opt-in) or may already
     // have been finalized by Cleanup() -> spdk_env_fini(). In both cases there
-    // is no registered memory to release; calling spdk_mem_unregister would walk
-    // a torn-down or never-created global mem_map. (With ShmHelper destroyed
-    // before SpdkWrapper, the `initialized` atomic is still alive here.)
+    // is no registered memory to release; calling spdk_mem_unregister would
+    // walk a torn-down or never-created global mem_map. (With ShmHelper
+    // destroyed before SpdkWrapper, the `initialized` atomic is still alive
+    // here.)
     if (!initialized.load(std::memory_order_acquire)) {
         return 0;
     }


### PR DESCRIPTION
## Description
fix: https://github.com/kvcache-ai/Mooncake/issues/3736
Implement NOF integration with SGLang, SPDK's RDMA transport can only DMA from SPDK-registered memory. The host pool allocated via ShmHelper (memfd+mmap) was never registered, so NoF (NVMe-oF) put/get passing user buffers directly fails with "spdk_rdma_get_translation: No translation for ptr".

Register the mapping with spdk_mem_register in allocate() (USE_NOF only) and unregister before munmap in free()/cleanup(). Registration failure is non-fatal so non-NoF paths are unaffected. A dedicated ShmSegment::spdk_registered flag tracks SPDK registration, keeping the existing `registered` flag (used by DummyClient for IPC registration) untouched.

This PR fixes an issue where SGLang's MooncakeHostTensorAllocator triggers a No translation for ptr error under Mooncake NoF mode. The allocator uses MooncakeHostMemAllocator → ShmHelper (memfd+mmap), but the allocated memory was not registered with SPDK, so RDMA transport cannot access the buffer. The patch adds spdk_mem_register()/spdk_mem_unregister() to ShmHelper's allocate/free paths to enable NoF zero-copy transfers for SGLang. 

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)