### PR TITLE
[Doc] Add ROCm package to Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 
   [![PyPI CUDA <=12.9](https://img.shields.io/static/v1?label=pypi&message=CUDA%20%3C%3D12.9&color=76B900)](https://pypi.org/project/mooncake-transfer-engine)
   [![PyPI CUDA 13.0/13.1](https://img.shields.io/static/v1?label=pypi&message=CUDA%2013.0%2F13.1&color=76B900)](https://pypi.org/project/mooncake-transfer-engine-cuda13)
+  [![PyPI ROCm](https://img.shields.io/static/v1?label=pypi&message=ROCm&color=ED1C24)](https://pypi.org/project/mooncake-transfer-engine-rocm/)
   [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
   [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
   [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=F97316)](https://pypi.org/project/mooncake-transfer-engine-musa/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
   [![PyPI CUDA <=12.9](https://img.shields.io/static/v1?label=pypi&message=CUDA%20%3C%3D12.9&color=76B900)](https://pypi.org/project/mooncake-transfer-engine)
   [![PyPI CUDA 13.0/13.1](https://img.shields.io/static/v1?label=pypi&message=CUDA%2013.0%2F13.1&color=76B900)](https://pypi.org/project/mooncake-transfer-engine-cuda13)
-  [![PyPI ROCm](https://img.shields.io/static/v1?label=pypi&message=ROCm&color=ED1C24)](https://pypi.org/project/mooncake-transfer-engine-rocm/)
   [![PyPI Non-CUDA](https://img.shields.io/static/v1?label=pypi&message=non-CUDA&color=00BFFF)](https://pypi.org/project/mooncake-transfer-engine-non-cuda/)
   [![PyPI NPU](https://img.shields.io/static/v1?label=pypi&message=NPU&color=F87171)](https://pypi.org/project/mooncake-transfer-engine-npu/)
   [![PyPI MUSA](https://img.shields.io/static/v1?label=pypi&message=MUSA&color=F97316)](https://pypi.org/project/mooncake-transfer-engine-musa/)

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -27,9 +27,9 @@ variant in an environment.
 |---------------------|--------------|----------------------|
 | NVIDIA CUDA 12.1–12.9 | [`mooncake-transfer-engine`](https://pypi.org/project/mooncake-transfer-engine/) | `pip install mooncake-transfer-engine` |
 | NVIDIA CUDA 13.0/13.1 | [`mooncake-transfer-engine-cuda13`](https://pypi.org/project/mooncake-transfer-engine-cuda13/) | `pip install mooncake-transfer-engine-cuda13` |
-| AMD ROCm | [`mooncake-transfer-engine-rocm`](https://pypi.org/project/mooncake-transfer-engine-rocm/) | `pip install mooncake-transfer-engine-rocm` |
 | Non-CUDA | [`mooncake-transfer-engine-non-cuda`](https://pypi.org/project/mooncake-transfer-engine-non-cuda/) | `pip install mooncake-transfer-engine-non-cuda` |
 | Ascend NPU | [`mooncake-transfer-engine-npu`](https://pypi.org/project/mooncake-transfer-engine-npu/) | `pip install mooncake-transfer-engine-npu` |
+| AMD ROCm | [`mooncake-transfer-engine-rocm`](https://pypi.org/project/mooncake-transfer-engine-rocm/) | `pip install mooncake-transfer-engine-rocm` |
 | Moore Threads MUSA | [`mooncake-transfer-engine-musa`](https://pypi.org/project/mooncake-transfer-engine-musa/) | `pip install mooncake-transfer-engine-musa` |
 | AWS EFA with CUDA 12 | [`mooncake-transfer-engine-efa`](https://pypi.org/project/mooncake-transfer-engine-efa/) | `pip install mooncake-transfer-engine-efa` |
 | AWS EFA without CUDA | [`mooncake-transfer-engine-efa-non-cuda`](https://pypi.org/project/mooncake-transfer-engine-efa-non-cuda/) | `pip install mooncake-transfer-engine-efa-non-cuda` |

--- a/docs/source/getting_started/quick-start.md
+++ b/docs/source/getting_started/quick-start.md
@@ -27,6 +27,7 @@ variant in an environment.
 |---------------------|--------------|----------------------|
 | NVIDIA CUDA 12.1–12.9 | [`mooncake-transfer-engine`](https://pypi.org/project/mooncake-transfer-engine/) | `pip install mooncake-transfer-engine` |
 | NVIDIA CUDA 13.0/13.1 | [`mooncake-transfer-engine-cuda13`](https://pypi.org/project/mooncake-transfer-engine-cuda13/) | `pip install mooncake-transfer-engine-cuda13` |
+| AMD ROCm | [`mooncake-transfer-engine-rocm`](https://pypi.org/project/mooncake-transfer-engine-rocm/) | `pip install mooncake-transfer-engine-rocm` |
 | Non-CUDA | [`mooncake-transfer-engine-non-cuda`](https://pypi.org/project/mooncake-transfer-engine-non-cuda/) | `pip install mooncake-transfer-engine-non-cuda` |
 | Ascend NPU | [`mooncake-transfer-engine-npu`](https://pypi.org/project/mooncake-transfer-engine-npu/) | `pip install mooncake-transfer-engine-npu` |
 | Moore Threads MUSA | [`mooncake-transfer-engine-musa`](https://pypi.org/project/mooncake-transfer-engine-musa/) | `pip install mooncake-transfer-engine-musa` |


### PR DESCRIPTION
## Description

Add the published ROCm wheel to the Quick Start installation matrix and add a matching README badge so AMD users can discover the correct PyPI package and install command.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
make SPHINXBUILD=.venv/bin/sphinx-build html
pre-commit run --files README.md docs/source/getting_started/quick-start.md
curl --fail --head https://pypi.org/project/mooncake-transfer-engine-rocm/
curl --fail --head "https://img.shields.io/static/v1?label=pypi&message=ROCm&color=ED1C24"
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (verified the generated Quick Start HTML, PyPI endpoint, and rendered badge endpoint)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable to a docs-only change)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective (not applicable to a documentation-only change)
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; 2 lines changed)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (Codex updated the installation table and badge, ran documentation validation, and prepared this PR)

The human submitter is responsible for understanding and defending the change.