### PR TITLE
[Bugfix][Store] Support Dummy external buffer registration

### DIFF
--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -210,6 +210,9 @@ class DummyClient : public PyClient {
     bool is_device_buffer(void *buffer) const;
     bool is_dummy_shm_buffer(void *buffer, size_t size) const;
     std::optional<size_t> external_buffer_remaining(void *buffer) const;
+    bool is_registered_buffer(void *buffer, size_t size) const;
+    int register_external_buffer(void *buffer, size_t size);
+    int unregister_external_buffer(void *buffer);
     std::optional<PreparedBuffer> prepare_buffer(void *buffer, size_t size,
                                                  bool copy_to_staging,
                                                  bool copy_back = false);
@@ -311,6 +314,7 @@ class DummyClient : public PyClient {
     std::atomic<bool> connected_{false};
 
 #if defined(USE_ASCEND_DIRECT)
+    mutable std::mutex external_fabric_registration_mutex_;
     mutable std::mutex registered_device_buffers_mutex_;
     std::unordered_map<uint64_t, size_t> registered_device_buffers_;
 #endif

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -207,6 +207,7 @@ class DummyClient : public PyClient {
         bool copy_back = false;
     };
 
+    bool is_device_buffer(void *buffer) const;
     bool is_dummy_shm_buffer(void *buffer, size_t size) const;
     std::optional<size_t> external_buffer_remaining(void *buffer) const;
     std::optional<PreparedBuffer> prepare_buffer(void *buffer, size_t size,

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -222,9 +222,16 @@ class DummyClient : public PyClient {
         size_t size = 0;
         size_t references = 0;
     };
+    using BufferRegistrationMap =
+        std::unordered_map<uintptr_t, ExternalBufferRegistration>;
+    enum class BufferRegistrationAction { kReject, kFirst, kRetained };
+    enum class BufferReleaseAction { kReject, kFinal, kRetained };
+    static BufferRegistrationAction retain_buffer_registration(
+        BufferRegistrationMap &registrations, uintptr_t base, size_t size);
+    static BufferReleaseAction release_buffer_registration(
+        BufferRegistrationMap &registrations, uintptr_t base);
     mutable std::mutex registered_external_buffers_mutex_;
-    std::unordered_map<uintptr_t, ExternalBufferRegistration>
-        registered_external_buffers_;
+    BufferRegistrationMap registered_external_buffers_;
 
     ErrorCode connect(const std::string &server_address);
 
@@ -239,8 +246,9 @@ class DummyClient : public PyClient {
 
     int unregister_device_buffer_for_reconnect(void *buffer);
 
-    [[nodiscard]] std::vector<ShmHelper::ShmSegment>
-    get_registered_device_buffers() const;
+    int reregister_fabric_buffers();
+
+    int reregister_device_buffers();
 #endif
 
     /**
@@ -316,7 +324,7 @@ class DummyClient : public PyClient {
 #if defined(USE_ASCEND_DIRECT)
     mutable std::mutex external_fabric_registration_mutex_;
     mutable std::mutex registered_device_buffers_mutex_;
-    std::unordered_map<uint64_t, size_t> registered_device_buffers_;
+    BufferRegistrationMap registered_device_buffers_;
 #endif
 
     // Ascend physical device id for dummy-real RPC to real, set in setup_dummy

--- a/mooncake-store/include/dummy_client.h
+++ b/mooncake-store/include/dummy_client.h
@@ -199,6 +199,29 @@ class DummyClient : public PyClient {
     std::optional<BufferHandle> allocate_client_buffer(size_t size) override;
 
    private:
+    struct PreparedBuffer {
+        void *original = nullptr;
+        void *dummy = nullptr;
+        size_t size = 0;
+        std::unique_ptr<BufferHandle> staging;
+        bool copy_back = false;
+    };
+
+    bool is_dummy_shm_buffer(void *buffer, size_t size) const;
+    std::optional<size_t> external_buffer_remaining(void *buffer) const;
+    std::optional<PreparedBuffer> prepare_buffer(void *buffer, size_t size,
+                                                 bool copy_to_staging,
+                                                 bool copy_back = false);
+    bool copy_from_staging(const PreparedBuffer &buffer, size_t size) const;
+
+    struct ExternalBufferRegistration {
+        size_t size = 0;
+        size_t references = 0;
+    };
+    mutable std::mutex registered_external_buffers_mutex_;
+    std::unordered_map<uintptr_t, ExternalBufferRegistration>
+        registered_external_buffers_;
+
     ErrorCode connect(const std::string &server_address);
 
     int register_ascend_shm(const ShmHelper::ShmSegment *shm,

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -605,7 +605,7 @@ std::optional<BufferHandle> DummyClient::allocate_client_buffer(size_t size) {
                                             std::move(release));
 }
 
-bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
+bool DummyClient::is_dummy_shm_buffer(void* buffer, size_t size) const {
     if (buffer == nullptr || shm_helper_ == nullptr) return false;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) return false;
@@ -615,16 +615,17 @@ bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
     return size <= shm->size - (address - base);
 }
 
-bool DummyClient::is_device_buffer(void *buffer) const {
+bool DummyClient::is_device_buffer(void* buffer) const {
     return device::GetAcceleratorRegistry()
                .RuntimeAccelerators()
                .FindDeviceForPointer(buffer) != nullptr;
 }
 
-std::optional<size_t> DummyClient::external_buffer_remaining(void *buffer) const {
+std::optional<size_t> DummyClient::external_buffer_remaining(
+    void* buffer) const {
     const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
     std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-    for (const auto &[base, registration] : registered_external_buffers_) {
+    for (const auto& [base, registration] : registered_external_buffers_) {
         if (address >= base && address - base <= registration.size) {
             return registration.size - (address - base);
         }
@@ -633,7 +634,7 @@ std::optional<size_t> DummyClient::external_buffer_remaining(void *buffer) const
 }
 
 std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
-    void *buffer, size_t size, bool copy_to_staging, bool copy_back) {
+    void* buffer, size_t size, bool copy_to_staging, bool copy_back) {
     if (buffer == nullptr && size != 0) return std::nullopt;
     if (size == 0) return PreparedBuffer{buffer, buffer, 0, nullptr, false};
     if (shm_helper_ != nullptr) {
@@ -653,17 +654,22 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
     if (!allocation) return std::nullopt;
     auto staging = std::make_unique<BufferHandle>(std::move(*allocation));
     if (copy_to_staging) {
-        const auto &runtime = device::GetAcceleratorRegistry().RuntimeAccelerators();
-        if (!runtime.CopyToHost(staging->ptr(), buffer, size)) return std::nullopt;
+        const auto& runtime =
+            device::GetAcceleratorRegistry().RuntimeAccelerators();
+        if (!runtime.CopyToHost(staging->ptr(), buffer, size))
+            return std::nullopt;
     }
     return PreparedBuffer{buffer, staging->ptr(), size, std::move(staging),
                           copy_back || !copy_to_staging};
 }
 
-bool DummyClient::copy_from_staging(const PreparedBuffer &buffer, size_t size) const {
-    if (!buffer.copy_back || buffer.staging == nullptr || size == 0) return true;
+bool DummyClient::copy_from_staging(const PreparedBuffer& buffer,
+                                    size_t size) const {
+    if (!buffer.copy_back || buffer.staging == nullptr || size == 0)
+        return true;
     if (size > buffer.size) return false;
-    const auto &runtime = device::GetAcceleratorRegistry().RuntimeAccelerators();
+    const auto& runtime =
+        device::GetAcceleratorRegistry().RuntimeAccelerators();
     return runtime.CopyFromHost(buffer.original, buffer.staging->ptr(), size);
 }
 
@@ -784,7 +790,8 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
         if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
         std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-        for (const auto &[other_base, registration] : registered_external_buffers_) {
+        for (const auto& [other_base, registration] :
+             registered_external_buffers_) {
             if (base < other_base + registration.size &&
                 other_base < base + size &&
                 (base != other_base || size != registration.size)) {
@@ -940,7 +947,8 @@ std::vector<int> DummyClient::batch_upsert_from(
     for (size_t i = 0; i < keys.size(); ++i) {
         auto item = prepare_buffer(buffer_ptrs[i], sizes[i], true);
         if (!item) {
-            return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+            return std::vector<int>(keys.size(),
+                                    toInt(ErrorCode::INVALID_PARAMS));
         }
         buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
         prepared.push_back(std::move(*item));
@@ -1260,7 +1268,8 @@ std::vector<int> DummyClient::batch_put_from(
     for (size_t i = 0; i < keys.size(); ++i) {
         auto item = prepare_buffer(buffer_ptrs[i], sizes[i], true);
         if (!item) {
-            return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+            return std::vector<int>(keys.size(),
+                                    toInt(ErrorCode::INVALID_PARAMS));
         }
         buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
         prepared.push_back(std::move(*item));
@@ -1296,7 +1305,8 @@ std::vector<int64_t> DummyClient::batch_get_into(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes) {
     if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
-        return std::vector<int64_t>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+        return std::vector<int64_t>(keys.size(),
+                                    toInt(ErrorCode::INVALID_PARAMS));
     }
     if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
         dst_buffers && keys.size() == dst_buffers->size()) {
@@ -1320,7 +1330,8 @@ std::vector<int64_t> DummyClient::batch_get_into(
     for (size_t i = 0; i < keys.size(); ++i) {
         auto item = prepare_buffer(buffer_ptrs[i], sizes[i], false, true);
         if (!item) {
-            return std::vector<int64_t>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+            return std::vector<int64_t>(keys.size(),
+                                        toInt(ErrorCode::INVALID_PARAMS));
         }
         buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
         prepared.push_back(std::move(*item));

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -609,10 +609,6 @@ bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
     if (buffer == nullptr || shm_helper_ == nullptr) return false;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) return false;
-    // Only query accelerator pointer attributes after the numeric SHM lookup
-    // hits.  This keeps ordinary external host pointers on the cheap path
-    // while preventing CUDA UVA addresses from being mistaken for SHM.
-    if (is_device_buffer(buffer)) return false;
     const uintptr_t base = reinterpret_cast<uintptr_t>(shm->base_addr);
     const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
     if (address < base || address - base > shm->size) return false;
@@ -640,14 +636,15 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
     void *buffer, size_t size, bool copy_to_staging, bool copy_back) {
     if (buffer == nullptr && size != 0) return std::nullopt;
     if (size == 0) return PreparedBuffer{buffer, buffer, 0, nullptr, false};
-    const bool device_buffer = is_device_buffer(buffer);
-    if (!device_buffer && shm_helper_ != nullptr &&
-        shm_helper_->get_shm(buffer) != nullptr &&
-        !is_dummy_shm_buffer(buffer, size)) {
-        return std::nullopt;
-    }
-    if (!device_buffer && is_dummy_shm_buffer(buffer, size)) {
-        return PreparedBuffer{buffer, buffer, size, nullptr, false};
+    if (shm_helper_ != nullptr) {
+        auto shm = shm_helper_->get_shm(buffer);
+        if (shm != nullptr && !is_device_buffer(buffer)) {
+            if (!is_dummy_shm_buffer(buffer, size)) {
+                return std::nullopt;
+            } else {
+                return PreparedBuffer{buffer, buffer, size, nullptr, false};
+            }
+        }
     }
     auto remaining = external_buffer_remaining(buffer);
     if (!remaining.has_value() || size > *remaining) return std::nullopt;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -624,13 +624,78 @@ bool DummyClient::is_device_buffer(void* buffer) const {
 std::optional<size_t> DummyClient::external_buffer_remaining(
     void* buffer) const {
     const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
-    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-    for (const auto& [base, registration] : registered_external_buffers_) {
-        if (address >= base && address - base <= registration.size) {
-            return registration.size - (address - base);
+    {
+        std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+        for (const auto& [base, registration] : registered_external_buffers_) {
+            if (address >= base && address - base <= registration.size) {
+                return registration.size - (address - base);
+            }
         }
     }
+
+#if defined(USE_ASCEND_DIRECT)
+    // Ascend device allocations are registered through register_ascend_shm()
+    // and tracked separately so they can be restored after reconnect.  Treat
+    // those mappings as registered external buffers for all transfer paths.
+    {
+        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+        for (const auto& [base, size] : registered_device_buffers_) {
+            if (address >= base && address - base <= size) {
+                return size - (address - base);
+            }
+        }
+    }
+#endif
+
     return std::nullopt;
+}
+
+bool DummyClient::is_registered_buffer(void* buffer, size_t size) const {
+    if (buffer == nullptr) return size == 0;
+    auto remaining = external_buffer_remaining(buffer);
+    return remaining.has_value() && size <= *remaining;
+}
+
+int DummyClient::register_external_buffer(void* buffer, size_t size) {
+    if (buffer == nullptr || size == 0) return -1;
+
+    const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
+    if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
+
+    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+    for (const auto& [other_base, registration] :
+         registered_external_buffers_) {
+        const uintptr_t other_end = other_base + registration.size;
+        const uintptr_t end = base + size;
+        if (base < other_end && other_base < end &&
+            (base != other_base || size != registration.size)) {
+            LOG(ERROR) << "Overlapping external buffer registration";
+            return -1;
+        }
+    }
+
+    auto [it, inserted] = registered_external_buffers_.emplace(
+        base, ExternalBufferRegistration{size, 1});
+    if (!inserted) {
+        if (it->second.size != size) return -1;
+        ++it->second.references;
+    }
+    return 0;
+}
+
+int DummyClient::unregister_external_buffer(void* buffer) {
+    if (buffer == nullptr) return -1;
+
+    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+    auto it =
+        registered_external_buffers_.find(reinterpret_cast<uintptr_t>(buffer));
+    if (it == registered_external_buffers_.end()) return -1;
+    if (it->second.references > 1) {
+        --it->second.references;
+    } else {
+        registered_external_buffers_.erase(it);
+    }
+    return 0;
 }
 
 std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
@@ -690,6 +755,11 @@ int64_t DummyClient::unregister_shm() {
 int DummyClient::register_device_buffer_for_reconnect(void* buffer,
                                                       size_t size) {
     const auto buffer_addr = reinterpret_cast<uint64_t>(buffer);
+    if (size == 0 || size > std::numeric_limits<uintptr_t>::max() -
+                                static_cast<uintptr_t>(buffer_addr)) {
+        LOG(ERROR) << "Device buffer registration overflows address range";
+        return -1;
+    }
     {
         std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
         auto it = registered_device_buffers_.find(buffer_addr);
@@ -770,10 +840,23 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
             return register_device_buffer_for_reconnect(buffer, size);
         }
         if (globalConfig().ascend_use_fabric_mem) {
+            std::lock_guard<std::mutex> registration_lock(
+                external_fabric_registration_mutex_);
             auto shm = std::make_shared<ShmHelper::ShmSegment>();
             shm->base_addr = buffer;
             shm->size = size;
+
+            // Fabric host buffers are mapped by register_ascend_shm(), but
+            // unlike Dummy SHM they are not discoverable through ShmHelper.
+            // Track the range locally so put/get/ranged-read validation can
+            // accept the same subranges after registration.
+            if (register_external_buffer(buffer, size) != 0) {
+                LOG(ERROR) << "Invalid or overlapping Fabric buffer"
+                           << ", buffer=" << buffer << ", size=" << size;
+                return -1;
+            }
             if (register_ascend_shm(shm.get(), false) != 0) {
+                (void)unregister_external_buffer(buffer);
                 LOG(ERROR) << "Failed to register buffer, buffer=" << buffer
                            << ", size=" << size;
                 return -1;
@@ -787,25 +870,7 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
     auto shm = shm_helper_->get_shm(buffer);
     if (shm && is_device_buffer(buffer)) shm = nullptr;
     if (!shm) {
-        const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
-        if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
-        std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-        for (const auto& [other_base, registration] :
-             registered_external_buffers_) {
-            if (base < other_base + registration.size &&
-                other_base < base + size &&
-                (base != other_base || size != registration.size)) {
-                LOG(ERROR) << "Overlapping external buffer registration";
-                return -1;
-            }
-        }
-        auto [it, inserted] = registered_external_buffers_.emplace(
-            base, ExternalBufferRegistration{size, 1});
-        if (!inserted) {
-            if (it->second.size != size) return -1;
-            ++it->second.references;
-        }
-        return 0;
+        return register_external_buffer(buffer, size);
     }
     if (shm_helper_->is_hugepage()) {
         const size_t alignment = get_hugepage_size_from_env();
@@ -847,6 +912,30 @@ int DummyClient::unregister_buffer(void* buffer) {
 
 #if defined(USE_ASCEND_DIRECT)
     if (globalConfig().ascend_agent_mode) {
+        if (globalConfig().ascend_use_fabric_mem) {
+            std::lock_guard<std::mutex> registration_lock(
+                external_fabric_registration_mutex_);
+            const auto address = reinterpret_cast<uintptr_t>(buffer);
+            std::lock_guard<std::mutex> lock(
+                registered_external_buffers_mutex_);
+            auto it = registered_external_buffers_.find(address);
+            if (it != registered_external_buffers_.end()) {
+                if (it->second.references > 1) {
+                    --it->second.references;
+                    return 0;
+                }
+
+                // Keep the local registration until the real-side mapping is
+                // removed successfully.  This makes a failed unregister
+                // retryable instead of silently losing the range.
+                auto ret =
+                    invoke_rpc<&RealClient::unregister_shm_buffer_internal,
+                               void>(static_cast<uint64_t>(address),
+                                     client_id_);
+                if (ret.has_value()) registered_external_buffers_.erase(it);
+                return to_py_ret(ret);
+            }
+        }
         aclrtPtrAttributes attributes{};
         auto acl_ret = aclrtPointerGetAttributes(buffer, &attributes);
         if (acl_ret == ACL_ERROR_NONE &&
@@ -860,16 +949,7 @@ int DummyClient::unregister_buffer(void* buffer) {
     auto shm = shm_helper_->get_shm(buffer);
     if (shm && is_device_buffer(buffer)) shm = nullptr;
     if (!shm) {
-        std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-        auto it = registered_external_buffers_.find(
-            reinterpret_cast<uintptr_t>(buffer));
-        if (it == registered_external_buffers_.end()) return -1;
-        if (it->second.references > 1) {
-            --it->second.references;
-        } else {
-            registered_external_buffers_.erase(it);
-        }
-        return 0;
+        return unregister_external_buffer(buffer);
     }
     if (!shm->registered) {
         LOG(ERROR) << "Buffer is not registered with RealClient";
@@ -1184,7 +1264,64 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
     const std::vector<std::vector<std::vector<size_t>>>& all_src_offsets,
     const std::vector<std::vector<std::vector<size_t>>>& all_sizes,
     const QueryResultCache* query_result_cache) {
-    std::vector<uint64_t> dummy_buffers = void_ptrs_to_u64(buffers);
+    if (buffers.size() != all_keys.size() ||
+        buffers.size() != all_dst_offsets.size() ||
+        buffers.size() != all_src_offsets.size() ||
+        buffers.size() != all_sizes.size()) {
+        return build_ranged_read_error_results(buffers.size(), all_keys,
+                                               all_dst_offsets,
+                                               ErrorCode::INVALID_PARAMS);
+    }
+
+    // RealClient only understands addresses in the Dummy SHM mappings.  For
+    // registered host/device pointers, use a per-call SHM staging allocation,
+    // preserve untouched destination holes, and copy the result back after
+    // the remote scatter completes.
+    std::vector<PreparedBuffer> prepared;
+    std::vector<uint64_t> dummy_buffers;
+    prepared.reserve(buffers.size());
+    dummy_buffers.reserve(buffers.size());
+    for (size_t i = 0; i < buffers.size(); ++i) {
+        if (all_keys[i].size() != all_dst_offsets[i].size() ||
+            all_keys[i].size() != all_src_offsets[i].size() ||
+            all_keys[i].size() != all_sizes[i].size()) {
+            return build_ranged_read_error_results(buffers.size(), all_keys,
+                                                   all_dst_offsets,
+                                                   ErrorCode::INVALID_PARAMS);
+        }
+
+        size_t required_size = 0;
+        for (size_t j = 0; j < all_dst_offsets[i].size(); ++j) {
+            if (all_dst_offsets[i][j].size() != all_src_offsets[i][j].size() ||
+                all_dst_offsets[i][j].size() != all_sizes[i][j].size()) {
+                return build_ranged_read_error_results(
+                    buffers.size(), all_keys, all_dst_offsets,
+                    ErrorCode::INVALID_PARAMS);
+            }
+            for (size_t k = 0; k < all_dst_offsets[i][j].size(); ++k) {
+                const size_t dst_offset = all_dst_offsets[i][j][k];
+                const size_t size = all_sizes[i][j][k];
+                if (size > std::numeric_limits<size_t>::max() - dst_offset) {
+                    return build_ranged_read_error_results(
+                        buffers.size(), all_keys, all_dst_offsets,
+                        ErrorCode::INVALID_PARAMS);
+                }
+                required_size = std::max(required_size, dst_offset + size);
+            }
+        }
+
+        // Seed staging with the caller's destination.  This preserves bytes
+        // in holes between ranges when the remote operation copies back.
+        auto item = prepare_buffer(buffers[i], required_size, true, true);
+        if (!item) {
+            return build_ranged_read_error_results(buffers.size(), all_keys,
+                                                   all_dst_offsets,
+                                                   ErrorCode::INVALID_PARAMS);
+        }
+        dummy_buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
+        prepared.push_back(std::move(*item));
+    }
+
     auto cached_query_results =
         build_cached_query_results_from_query_result_cache(query_result_cache);
     const auto start_time = std::chrono::steady_clock::now();
@@ -1202,6 +1339,56 @@ std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
                                                internal_results.error());
     }
     auto results = convert_ranged_read_results(internal_results.value());
+
+    if (results.size() != prepared.size()) {
+        LOG(ERROR) << "get_into_ranges response size mismatch: expected "
+                   << prepared.size() << ", got " << results.size();
+        return build_ranged_read_error_results(buffers.size(), all_keys,
+                                               all_dst_offsets,
+                                               ErrorCode::INTERNAL_ERROR);
+    }
+    for (size_t i = 0; i < results.size(); ++i) {
+        if (results[i].size() != all_keys[i].size()) {
+            LOG(ERROR) << "get_into_ranges response key count mismatch at " << i
+                       << ": expected " << all_keys[i].size() << ", got "
+                       << results[i].size();
+            return build_ranged_read_error_results(buffers.size(), all_keys,
+                                                   all_dst_offsets,
+                                                   ErrorCode::INTERNAL_ERROR);
+        }
+        for (size_t j = 0; j < results[i].size(); ++j) {
+            if (results[i][j].size() != all_sizes[i][j].size()) {
+                LOG(ERROR)
+                    << "get_into_ranges response fragment count mismatch "
+                    << "at [" << i << "][" << j << "]: expected "
+                    << all_sizes[i][j].size() << ", got "
+                    << results[i][j].size();
+                return build_ranged_read_error_results(
+                    buffers.size(), all_keys, all_dst_offsets,
+                    ErrorCode::INTERNAL_ERROR);
+            }
+        }
+    }
+
+    for (size_t i = 0; i < prepared.size(); ++i) {
+        size_t required_size = 0;
+        for (size_t j = 0; j < all_dst_offsets[i].size(); ++j) {
+            for (size_t k = 0; k < all_dst_offsets[i][j].size(); ++k) {
+                required_size =
+                    std::max(required_size,
+                             all_dst_offsets[i][j][k] + all_sizes[i][j][k]);
+            }
+        }
+        if (!copy_from_staging(prepared[i], required_size)) {
+            LOG(ERROR) << "Failed to copy ranged read staging buffer back";
+            for (auto& key_results : results[i]) {
+                for (auto& result : key_results) {
+                    if (result >= 0) result = toInt(ErrorCode::INTERNAL_ERROR);
+                }
+            }
+        }
+    }
+
     const size_t total_bytes = sum_positive_ranges(results);
     if (total_bytes > 0) {
         ObserveTransferMetric(TransferOperationKind::kRead, "get_into_ranges",
@@ -1247,18 +1434,31 @@ std::vector<int> DummyClient::batch_put_from(
     if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
         return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
     }
-    if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
-        payloads && keys.size() == payloads->size()) {
-        std::vector<CudaIpcWriteRequest> requests;
-        requests.reserve(keys.size());
-        for (size_t i = 0; i < keys.size(); ++i) {
-            requests.push_back(CudaIpcWriteRequest{
-                .key = keys[i],
-                .metadata = CudaIpcShmBufferRef{},
-                .payload = (*payloads)[i],
-            });
+    // CUDA IPC requests carry a process-local allocation handle.  Only export
+    // buffers that are currently registered with the Dummy client; otherwise
+    // an unregistered allocation (or a stale pointer after unregister) would
+    // bypass prepare_buffer()'s bounds and lifetime checks.
+    bool all_buffers_registered = true;
+    for (size_t i = 0; i < buffer_ptrs.size(); ++i) {
+        if (!is_registered_buffer(buffer_ptrs[i], sizes[i])) {
+            all_buffers_registered = false;
+            break;
         }
-        return batch_put_from_cuda_ipc(requests, config);
+    }
+    if (all_buffers_registered) {
+        if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
+            payloads && keys.size() == payloads->size()) {
+            std::vector<CudaIpcWriteRequest> requests;
+            requests.reserve(keys.size());
+            for (size_t i = 0; i < keys.size(); ++i) {
+                requests.push_back(CudaIpcWriteRequest{
+                    .key = keys[i],
+                    .metadata = CudaIpcShmBufferRef{},
+                    .payload = (*payloads)[i],
+                });
+            }
+            return batch_put_from_cuda_ipc(requests, config);
+        }
     }
 
     std::vector<PreparedBuffer> prepared;
@@ -1308,19 +1508,30 @@ std::vector<int64_t> DummyClient::batch_get_into(
         return std::vector<int64_t>(keys.size(),
                                     toInt(ErrorCode::INVALID_PARAMS));
     }
-    if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
-        dst_buffers && keys.size() == dst_buffers->size()) {
-        std::vector<CudaIpcReadRequest> requests;
-        requests.reserve(keys.size());
-        for (size_t i = 0; i < keys.size(); ++i) {
-            requests.push_back(CudaIpcReadRequest{
-                .key = keys[i],
-                .destination = (*dst_buffers)[i],
-                .source_offset = 0,
-                .size = static_cast<uint64_t>(sizes[i]),
-            });
+    // Keep the CUDA IPC fast path subject to the same registration and range
+    // checks as the staging path below.
+    bool all_buffers_registered = true;
+    for (size_t i = 0; i < buffer_ptrs.size(); ++i) {
+        if (!is_registered_buffer(buffer_ptrs[i], sizes[i])) {
+            all_buffers_registered = false;
+            break;
         }
-        return batch_get_into_cuda_ipc(requests);
+    }
+    if (all_buffers_registered) {
+        if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
+            dst_buffers && keys.size() == dst_buffers->size()) {
+            std::vector<CudaIpcReadRequest> requests;
+            requests.reserve(keys.size());
+            for (size_t i = 0; i < keys.size(); ++i) {
+                requests.push_back(CudaIpcReadRequest{
+                    .key = keys[i],
+                    .destination = (*dst_buffers)[i],
+                    .source_offset = 0,
+                    .size = static_cast<uint64_t>(sizes[i]),
+                });
+            }
+            return batch_get_into_cuda_ipc(requests);
+        }
     }
 
     std::vector<PreparedBuffer> prepared;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -638,7 +638,7 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
         return PreparedBuffer{buffer, buffer, size, nullptr, false};
     }
     auto remaining = external_buffer_remaining(buffer);
-    if (remaining.has_value() && size > *remaining) return std::nullopt;
+    if (!remaining.has_value() || size > *remaining) return std::nullopt;
 
     auto allocation = allocate_client_buffer(size);
     if (!allocation) return std::nullopt;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -607,12 +607,19 @@ std::optional<BufferHandle> DummyClient::allocate_client_buffer(size_t size) {
 
 bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
     if (buffer == nullptr || shm_helper_ == nullptr) return false;
+    if (is_device_buffer(buffer)) return false;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) return false;
     const uintptr_t base = reinterpret_cast<uintptr_t>(shm->base_addr);
     const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
     if (address < base || address - base > shm->size) return false;
     return size <= shm->size - (address - base);
+}
+
+bool DummyClient::is_device_buffer(void *buffer) const {
+    return device::GetAcceleratorRegistry()
+               .RuntimeAccelerators()
+               .FindDeviceForPointer(buffer) != nullptr;
 }
 
 std::optional<size_t> DummyClient::external_buffer_remaining(void *buffer) const {
@@ -630,7 +637,8 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
     void *buffer, size_t size, bool copy_to_staging, bool copy_back) {
     if (buffer == nullptr && size != 0) return std::nullopt;
     if (size == 0) return PreparedBuffer{buffer, buffer, 0, nullptr, false};
-    if (shm_helper_ != nullptr && shm_helper_->get_shm(buffer) != nullptr &&
+    if (!is_device_buffer(buffer) && shm_helper_ != nullptr &&
+        shm_helper_->get_shm(buffer) != nullptr &&
         !is_dummy_shm_buffer(buffer, size)) {
         return std::nullopt;
     }
@@ -769,7 +777,7 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
     }
 #endif
     if (shm_helper_ == nullptr) return -1;
-    auto shm = shm_helper_->get_shm(buffer);
+    auto shm = is_device_buffer(buffer) ? nullptr : shm_helper_->get_shm(buffer);
     if (!shm) {
         const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
         if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
@@ -840,7 +848,7 @@ int DummyClient::unregister_buffer(void* buffer) {
 #endif
 
     if (shm_helper_ == nullptr) return -1;
-    auto shm = shm_helper_->get_shm(buffer);
+    auto shm = is_device_buffer(buffer) ? nullptr : shm_helper_->get_shm(buffer);
     if (!shm) {
         std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
         auto it = registered_external_buffers_.find(

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -9,6 +9,8 @@
 #include <unistd.h>    // For ftruncate, close, shm_unlink
 #include <chrono>
 #include <cstdlib>
+#include <algorithm>
+#include <limits>
 
 #include "real_client.h"
 #include "dummy_client.h"
@@ -20,6 +22,7 @@
 #include "default_config.h"
 #include "config.h"
 #include "device/cuda_ipc_buffer.h"
+#include "device/accelerator_registry.h"
 #ifdef USE_ASCEND_DIRECT
 #include "acl/acl_rt.h"
 #include "ascend_allocator.h"
@@ -574,6 +577,8 @@ int DummyClient::tearDownAll() {
     }
     connected_.store(false);
     last_ping_healthy_.store(false);
+    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+    registered_external_buffers_.clear();
 #if defined(USE_ASCEND_DIRECT)
     {
         std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
@@ -598,6 +603,59 @@ std::optional<BufferHandle> DummyClient::allocate_client_buffer(size_t size) {
     };
     return std::make_optional<BufferHandle>(local_ptr, allocated_size,
                                             std::move(release));
+}
+
+bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
+    if (buffer == nullptr || shm_helper_ == nullptr) return false;
+    auto shm = shm_helper_->get_shm(buffer);
+    if (!shm) return false;
+    const uintptr_t base = reinterpret_cast<uintptr_t>(shm->base_addr);
+    const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
+    if (address < base || address - base > shm->size) return false;
+    return size <= shm->size - (address - base);
+}
+
+std::optional<size_t> DummyClient::external_buffer_remaining(void *buffer) const {
+    const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
+    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+    for (const auto &[base, registration] : registered_external_buffers_) {
+        if (address >= base && address - base <= registration.size) {
+            return registration.size - (address - base);
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
+    void *buffer, size_t size, bool copy_to_staging, bool copy_back) {
+    if (buffer == nullptr && size != 0) return std::nullopt;
+    if (size == 0) return PreparedBuffer{buffer, buffer, 0, nullptr, false};
+    if (shm_helper_ != nullptr && shm_helper_->get_shm(buffer) != nullptr &&
+        !is_dummy_shm_buffer(buffer, size)) {
+        return std::nullopt;
+    }
+    if (is_dummy_shm_buffer(buffer, size)) {
+        return PreparedBuffer{buffer, buffer, size, nullptr, false};
+    }
+    auto remaining = external_buffer_remaining(buffer);
+    if (!remaining.has_value() || size > *remaining) return std::nullopt;
+
+    auto allocation = allocate_client_buffer(size);
+    if (!allocation) return std::nullopt;
+    auto staging = std::make_unique<BufferHandle>(std::move(*allocation));
+    if (copy_to_staging) {
+        const auto &runtime = device::GetAcceleratorRegistry().RuntimeAccelerators();
+        if (!runtime.CopyToHost(staging->ptr(), buffer, size)) return std::nullopt;
+    }
+    return PreparedBuffer{buffer, staging->ptr(), size, std::move(staging),
+                          copy_back || !copy_to_staging};
+}
+
+bool DummyClient::copy_from_staging(const PreparedBuffer &buffer, size_t size) const {
+    if (!buffer.copy_back || buffer.staging == nullptr || size == 0) return true;
+    if (size > buffer.size) return false;
+    const auto &runtime = device::GetAcceleratorRegistry().RuntimeAccelerators();
+    return runtime.CopyFromHost(buffer.original, buffer.staging->ptr(), size);
 }
 
 int64_t DummyClient::unregister_shm() {
@@ -681,7 +739,7 @@ std::vector<ShmHelper::ShmSegment> DummyClient::get_registered_device_buffers()
 
 // Dummy only register buffer within the shared memory region
 int DummyClient::register_buffer(void* buffer, size_t size) {
-    if (buffer == nullptr) {
+    if (buffer == nullptr || size == 0) {
         LOG(ERROR) << "Invalid buffer pointer";
         return -1;
     }
@@ -710,11 +768,27 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         // non-Fabric Host: same rules as shm
     }
 #endif
-    // Find which shm this buffer belongs to
+    if (shm_helper_ == nullptr) return -1;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) {
-        LOG(ERROR) << "Buffer is not in any registered shared memory";
-        return -1;
+        const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
+        if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
+        std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+        for (const auto &[other_base, registration] : registered_external_buffers_) {
+            if (base < other_base + registration.size &&
+                other_base < base + size &&
+                (base != other_base || size != registration.size)) {
+                LOG(ERROR) << "Overlapping external buffer registration";
+                return -1;
+            }
+        }
+        auto [it, inserted] = registered_external_buffers_.emplace(
+            base, ExternalBufferRegistration{size, 1});
+        if (!inserted) {
+            if (it->second.size != size) return -1;
+            ++it->second.references;
+        }
+        return 0;
     }
     if (shm_helper_->is_hugepage()) {
         size = align_up(size, get_hugepage_size_from_env());
@@ -759,10 +833,19 @@ int DummyClient::unregister_buffer(void* buffer) {
     }
 #endif
 
+    if (shm_helper_ == nullptr) return -1;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) {
-        LOG(ERROR) << "Buffer is not in any registered shared memory";
-        return -1;
+        std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+        auto it = registered_external_buffers_.find(
+            reinterpret_cast<uintptr_t>(buffer));
+        if (it == registered_external_buffers_.end()) return -1;
+        if (it->second.references > 1) {
+            --it->second.references;
+        } else {
+            registered_external_buffers_.erase(it);
+        }
+        return 0;
     }
     if (!shm->registered) {
         LOG(ERROR) << "Buffer is not registered with RealClient";
@@ -823,18 +906,27 @@ int DummyClient::upsert(const std::string& key, std::span<const char> value,
 
 int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
                              const ReplicateConfig& config) {
-    uint64_t dummy_addr = reinterpret_cast<uint64_t>(buffer);
-    return invoke_observed_void_rpc<&RealClient::upsert_from_dummy_helper>(
-        TransferOperationKind::kWrite, "upsert_from", size, false, key,
-        dummy_addr, size, config, client_id_);
+    auto results = batch_upsert_from({key}, {buffer}, {size}, config);
+    return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
 }
 
 std::vector<int> DummyClient::batch_upsert_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
+    if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
+        return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+    }
+    std::vector<PreparedBuffer> prepared;
     std::vector<uint64_t> buffers;
-    for (auto ptr : buffer_ptrs) {
-        buffers.push_back(reinterpret_cast<uint64_t>(ptr));
+    prepared.reserve(keys.size());
+    buffers.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto item = prepare_buffer(buffer_ptrs[i], sizes[i], true);
+        if (!item) {
+            return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+        }
+        buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
+        prepared.push_back(std::move(*item));
     }
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
@@ -1056,34 +1148,8 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
 
 int64_t DummyClient::get_into(const std::string& key, void* buffer,
                               size_t size) {
-    if (auto dst_buffer = try_export_cuda_ipc_buffers({buffer}, {size})) {
-        std::vector<CudaIpcReadRequest> requests{
-            CudaIpcReadRequest{
-                .key = key,
-                .destination = (*dst_buffer)[0],
-                .source_offset = 0,
-                .size = static_cast<uint64_t>(size),
-            },
-        };
-        auto results = batch_get_into_cuda_ipc(requests);
-        return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
-    }
-
-    uint64_t buf_addr = reinterpret_cast<uint64_t>(buffer);
-    const auto start_time = std::chrono::steady_clock::now();
-    auto result = invoke_rpc<&RealClient::get_into_range_shm_helper,
-                             tl::expected<int64_t, ErrorCode>>(
-        key, buf_addr, 0, 0, size, true, true, client_id_);
-    if (!result) {
-        return static_cast<int64_t>(toInt(result.error()));
-    }
-    const int64_t bytes_read = to_py_ret(*result);
-    if (bytes_read >= 0) {
-        ObserveTransferMetric(TransferOperationKind::kRead, "get_into",
-                              static_cast<size_t>(bytes_read),
-                              elapsed_us_since(start_time), false);
-    }
-    return bytes_read;
+    auto results = batch_get_into({key}, {buffer}, {size});
+    return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
 }
 
 std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
@@ -1153,6 +1219,9 @@ std::string DummyClient::get_hostname() const {
 std::vector<int> DummyClient::batch_put_from(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes, const ReplicateConfig& config) {
+    if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
+        return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+    }
     if (auto payloads = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
         payloads && keys.size() == payloads->size()) {
         std::vector<CudaIpcWriteRequest> requests;
@@ -1167,7 +1236,18 @@ std::vector<int> DummyClient::batch_put_from(
         return batch_put_from_cuda_ipc(requests, config);
     }
 
-    std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
+    std::vector<PreparedBuffer> prepared;
+    std::vector<uint64_t> buffers;
+    prepared.reserve(keys.size());
+    buffers.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto item = prepare_buffer(buffer_ptrs[i], sizes[i], true);
+        if (!item) {
+            return std::vector<int>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+        }
+        buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
+        prepared.push_back(std::move(*item));
+    }
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_batch_rpc<&RealClient::batch_put_from_dummy_helper, void>(
@@ -1198,6 +1278,9 @@ int DummyClient::put_from(const std::string& key, void* buffer, size_t size,
 std::vector<int64_t> DummyClient::batch_get_into(
     const std::vector<std::string>& keys, const std::vector<void*>& buffer_ptrs,
     const std::vector<size_t>& sizes) {
+    if (keys.size() != buffer_ptrs.size() || keys.size() != sizes.size()) {
+        return std::vector<int64_t>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+    }
     if (auto dst_buffers = try_export_cuda_ipc_buffers(buffer_ptrs, sizes);
         dst_buffers && keys.size() == dst_buffers->size()) {
         std::vector<CudaIpcReadRequest> requests;
@@ -1213,12 +1296,30 @@ std::vector<int64_t> DummyClient::batch_get_into(
         return batch_get_into_cuda_ipc(requests);
     }
 
-    std::vector<uint64_t> buffers = void_ptrs_to_u64(buffer_ptrs);
+    std::vector<PreparedBuffer> prepared;
+    std::vector<uint64_t> buffers;
+    prepared.reserve(keys.size());
+    buffers.reserve(keys.size());
+    for (size_t i = 0; i < keys.size(); ++i) {
+        auto item = prepare_buffer(buffer_ptrs[i], sizes[i], false, true);
+        if (!item) {
+            return std::vector<int64_t>(keys.size(), toInt(ErrorCode::INVALID_PARAMS));
+        }
+        buffers.push_back(reinterpret_cast<uint64_t>(item->dummy));
+        prepared.push_back(std::move(*item));
+    }
     const auto start_time = std::chrono::steady_clock::now();
     auto internal_results =
         invoke_batch_rpc<&RealClient::batch_get_into_dummy_helper, int64_t>(
             keys.size(), keys, buffers, sizes, device_id_, client_id_);
     auto results = expected_results_to_py(internal_results);
+
+    for (size_t i = 0; i < results.size() && i < prepared.size(); ++i) {
+        if (results[i] >= 0 &&
+            !copy_from_staging(prepared[i], static_cast<size_t>(results[i]))) {
+            results[i] = toInt(ErrorCode::INTERNAL_ERROR);
+        }
+    }
 
     const size_t total_bytes = sum_positive_results(results);
     if (total_bytes > 0) {

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -607,9 +607,12 @@ std::optional<BufferHandle> DummyClient::allocate_client_buffer(size_t size) {
 
 bool DummyClient::is_dummy_shm_buffer(void *buffer, size_t size) const {
     if (buffer == nullptr || shm_helper_ == nullptr) return false;
-    if (is_device_buffer(buffer)) return false;
     auto shm = shm_helper_->get_shm(buffer);
     if (!shm) return false;
+    // Only query accelerator pointer attributes after the numeric SHM lookup
+    // hits.  This keeps ordinary external host pointers on the cheap path
+    // while preventing CUDA UVA addresses from being mistaken for SHM.
+    if (is_device_buffer(buffer)) return false;
     const uintptr_t base = reinterpret_cast<uintptr_t>(shm->base_addr);
     const uintptr_t address = reinterpret_cast<uintptr_t>(buffer);
     if (address < base || address - base > shm->size) return false;
@@ -637,12 +640,13 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
     void *buffer, size_t size, bool copy_to_staging, bool copy_back) {
     if (buffer == nullptr && size != 0) return std::nullopt;
     if (size == 0) return PreparedBuffer{buffer, buffer, 0, nullptr, false};
-    if (!is_device_buffer(buffer) && shm_helper_ != nullptr &&
+    const bool device_buffer = is_device_buffer(buffer);
+    if (!device_buffer && shm_helper_ != nullptr &&
         shm_helper_->get_shm(buffer) != nullptr &&
         !is_dummy_shm_buffer(buffer, size)) {
         return std::nullopt;
     }
-    if (is_dummy_shm_buffer(buffer, size)) {
+    if (!device_buffer && is_dummy_shm_buffer(buffer, size)) {
         return PreparedBuffer{buffer, buffer, size, nullptr, false};
     }
     auto remaining = external_buffer_remaining(buffer);
@@ -777,7 +781,8 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
     }
 #endif
     if (shm_helper_ == nullptr) return -1;
-    auto shm = is_device_buffer(buffer) ? nullptr : shm_helper_->get_shm(buffer);
+    auto shm = shm_helper_->get_shm(buffer);
+    if (shm && is_device_buffer(buffer)) shm = nullptr;
     if (!shm) {
         const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
         if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
@@ -848,7 +853,8 @@ int DummyClient::unregister_buffer(void* buffer) {
 #endif
 
     if (shm_helper_ == nullptr) return -1;
-    auto shm = is_device_buffer(buffer) ? nullptr : shm_helper_->get_shm(buffer);
+    auto shm = shm_helper_->get_shm(buffer);
+    if (shm && is_device_buffer(buffer)) shm = nullptr;
     if (!shm) {
         std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
         auto it = registered_external_buffers_.find(

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -791,7 +791,13 @@ int DummyClient::register_buffer(void* buffer, size_t size) {
         return 0;
     }
     if (shm_helper_->is_hugepage()) {
-        size = align_up(size, get_hugepage_size_from_env());
+        const size_t alignment = get_hugepage_size_from_env();
+        if (alignment != 0 &&
+            size > std::numeric_limits<size_t>::max() - (alignment - 1)) {
+            LOG(ERROR) << "Buffer size overflows hugepage alignment";
+            return -1;
+        }
+        size = align_up(size, alignment);
     }
     // Check bounds
     if (reinterpret_cast<uint8_t*>(buffer) !=

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -638,7 +638,7 @@ std::optional<DummyClient::PreparedBuffer> DummyClient::prepare_buffer(
         return PreparedBuffer{buffer, buffer, size, nullptr, false};
     }
     auto remaining = external_buffer_remaining(buffer);
-    if (!remaining.has_value() || size > *remaining) return std::nullopt;
+    if (remaining.has_value() && size > *remaining) return std::nullopt;
 
     auto allocation = allocate_client_buffer(size);
     if (!allocation) return std::nullopt;

--- a/mooncake-store/src/dummy_client.cpp
+++ b/mooncake-store/src/dummy_client.cpp
@@ -639,9 +639,9 @@ std::optional<size_t> DummyClient::external_buffer_remaining(
     // those mappings as registered external buffers for all transfer paths.
     {
         std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-        for (const auto& [base, size] : registered_device_buffers_) {
-            if (address >= base && address - base <= size) {
-                return size - (address - base);
+        for (const auto& [base, registration] : registered_device_buffers_) {
+            if (address >= base && address - base <= registration.size) {
+                return registration.size - (address - base);
             }
         }
     }
@@ -656,6 +656,36 @@ bool DummyClient::is_registered_buffer(void* buffer, size_t size) const {
     return remaining.has_value() && size <= *remaining;
 }
 
+DummyClient::BufferRegistrationAction DummyClient::retain_buffer_registration(
+    BufferRegistrationMap& registrations, uintptr_t base, size_t size) {
+    const uintptr_t end = base + size;
+    for (const auto& [other_base, registration] : registrations) {
+        const uintptr_t other_end = other_base + registration.size;
+        if (base < other_end && other_base < end &&
+            (base != other_base || size != registration.size)) {
+            return BufferRegistrationAction::kReject;
+        }
+    }
+
+    auto [it, inserted] =
+        registrations.emplace(base, ExternalBufferRegistration{size, 1});
+    if (inserted) return BufferRegistrationAction::kFirst;
+    if (it->second.references == std::numeric_limits<size_t>::max()) {
+        return BufferRegistrationAction::kReject;
+    }
+    ++it->second.references;
+    return BufferRegistrationAction::kRetained;
+}
+
+DummyClient::BufferReleaseAction DummyClient::release_buffer_registration(
+    BufferRegistrationMap& registrations, uintptr_t base) {
+    auto it = registrations.find(base);
+    if (it == registrations.end()) return BufferReleaseAction::kReject;
+    if (it->second.references == 1) return BufferReleaseAction::kFinal;
+    --it->second.references;
+    return BufferReleaseAction::kRetained;
+}
+
 int DummyClient::register_external_buffer(void* buffer, size_t size) {
     if (buffer == nullptr || size == 0) return -1;
 
@@ -663,22 +693,10 @@ int DummyClient::register_external_buffer(void* buffer, size_t size) {
     if (size > std::numeric_limits<uintptr_t>::max() - base) return -1;
 
     std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-    for (const auto& [other_base, registration] :
-         registered_external_buffers_) {
-        const uintptr_t other_end = other_base + registration.size;
-        const uintptr_t end = base + size;
-        if (base < other_end && other_base < end &&
-            (base != other_base || size != registration.size)) {
-            LOG(ERROR) << "Overlapping external buffer registration";
-            return -1;
-        }
-    }
-
-    auto [it, inserted] = registered_external_buffers_.emplace(
-        base, ExternalBufferRegistration{size, 1});
-    if (!inserted) {
-        if (it->second.size != size) return -1;
-        ++it->second.references;
+    if (retain_buffer_registration(registered_external_buffers_, base, size) ==
+        BufferRegistrationAction::kReject) {
+        LOG(ERROR) << "Invalid or overlapping external buffer registration";
+        return -1;
     }
     return 0;
 }
@@ -687,14 +705,12 @@ int DummyClient::unregister_external_buffer(void* buffer) {
     if (buffer == nullptr) return -1;
 
     std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
-    auto it =
-        registered_external_buffers_.find(reinterpret_cast<uintptr_t>(buffer));
-    if (it == registered_external_buffers_.end()) return -1;
-    if (it->second.references > 1) {
-        --it->second.references;
-    } else {
-        registered_external_buffers_.erase(it);
-    }
+    const uintptr_t base = reinterpret_cast<uintptr_t>(buffer);
+    const auto action =
+        release_buffer_registration(registered_external_buffers_, base);
+    if (action == BufferReleaseAction::kReject) return -1;
+    if (action == BufferReleaseAction::kFinal)
+        registered_external_buffers_.erase(base);
     return 0;
 }
 
@@ -754,71 +770,76 @@ int64_t DummyClient::unregister_shm() {
 #if defined(USE_ASCEND_DIRECT)
 int DummyClient::register_device_buffer_for_reconnect(void* buffer,
                                                       size_t size) {
-    const auto buffer_addr = reinterpret_cast<uint64_t>(buffer);
-    if (size == 0 || size > std::numeric_limits<uintptr_t>::max() -
-                                static_cast<uintptr_t>(buffer_addr)) {
+    const auto buffer_addr = reinterpret_cast<uintptr_t>(buffer);
+    if (size == 0 ||
+        size > std::numeric_limits<uintptr_t>::max() - buffer_addr) {
         LOG(ERROR) << "Device buffer registration overflows address range";
         return -1;
     }
-    {
-        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-        auto it = registered_device_buffers_.find(buffer_addr);
-        if (it != registered_device_buffers_.end() && it->second != size) {
-            LOG(ERROR) << "Device buffer size mismatch for tracked buffer, "
-                       << "buffer=" << buffer << ", size=" << size
-                       << ", tracked_size=" << it->second;
-            return -1;
-        }
+
+    std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+    const auto action = retain_buffer_registration(registered_device_buffers_,
+                                                   buffer_addr, size);
+    if (action == BufferRegistrationAction::kReject) {
+        LOG(ERROR) << "Invalid or overlapping device buffer registration, "
+                   << "buffer=" << buffer << ", size=" << size;
+        return -1;
     }
+    if (action == BufferRegistrationAction::kRetained) return 0;
 
     ShmHelper::ShmSegment shm{};
     shm.base_addr = buffer;
     shm.size = size;
     if (register_ascend_shm(&shm, false) != 0) {
+        registered_device_buffers_.erase(buffer_addr);
         LOG(ERROR) << "Failed to register device buffer, buffer=" << buffer
                    << ", size=" << size;
         return -1;
     }
 
-    {
-        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-        registered_device_buffers_[buffer_addr] = size;
-    }
     return 0;
 }
 
 int DummyClient::unregister_device_buffer_for_reconnect(void* buffer) {
-    const auto buffer_addr = reinterpret_cast<uint64_t>(buffer);
-    {
-        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-        if (registered_device_buffers_.find(buffer_addr) ==
-            registered_device_buffers_.end()) {
-            LOG(ERROR) << "Device buffer is not registered with RealClient";
-            return -1;
-        }
+    const auto buffer_addr = reinterpret_cast<uintptr_t>(buffer);
+    std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+    const auto action =
+        release_buffer_registration(registered_device_buffers_, buffer_addr);
+    if (action == BufferReleaseAction::kReject) {
+        LOG(ERROR) << "Device buffer is not registered with RealClient";
+        return -1;
     }
+    if (action == BufferReleaseAction::kRetained) return 0;
 
     auto ret = invoke_rpc<&RealClient::unregister_shm_buffer_internal, void>(
-        buffer_addr, client_id_);
-    if (ret.has_value()) {
-        std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-        registered_device_buffers_.erase(buffer_addr);
-    }
+        static_cast<uint64_t>(buffer_addr), client_id_);
+    if (ret.has_value()) registered_device_buffers_.erase(buffer_addr);
     return to_py_ret(ret);
 }
 
-std::vector<ShmHelper::ShmSegment> DummyClient::get_registered_device_buffers()
-    const {
-    std::vector<ShmHelper::ShmSegment> device_buffers;
-    std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
-    device_buffers.reserve(registered_device_buffers_.size());
-    for (const auto& [buffer_addr, size] : registered_device_buffers_) {
+int DummyClient::reregister_fabric_buffers() {
+    std::lock_guard<std::mutex> registration_lock(
+        external_fabric_registration_mutex_);
+    std::lock_guard<std::mutex> lock(registered_external_buffers_mutex_);
+    for (const auto& [buffer_addr, registration] :
+         registered_external_buffers_) {
         ShmHelper::ShmSegment shm{};
         shm.base_addr = reinterpret_cast<void*>(buffer_addr);
-        shm.size = size;
-        device_buffers.push_back(std::move(shm));
+        shm.size = registration.size;
+        if (register_ascend_shm(&shm, false) != 0) return -1;
     }
-    return device_buffers;
+    return 0;
+}
+
+int DummyClient::reregister_device_buffers() {
+    std::lock_guard<std::mutex> lock(registered_device_buffers_mutex_);
+    for (const auto& [buffer_addr, registration] : registered_device_buffers_) {
+        ShmHelper::ShmSegment shm{};
+        shm.base_addr = reinterpret_cast<void*>(buffer_addr);
+        shm.size = registration.size;
+        if (register_ascend_shm(&shm, false) != 0) return -1;
+    }
+    return 0;
 }
 #endif
 
@@ -918,12 +939,10 @@ int DummyClient::unregister_buffer(void* buffer) {
             const auto address = reinterpret_cast<uintptr_t>(buffer);
             std::lock_guard<std::mutex> lock(
                 registered_external_buffers_mutex_);
-            auto it = registered_external_buffers_.find(address);
-            if (it != registered_external_buffers_.end()) {
-                if (it->second.references > 1) {
-                    --it->second.references;
-                    return 0;
-                }
+            const auto action = release_buffer_registration(
+                registered_external_buffers_, address);
+            if (action != BufferReleaseAction::kReject) {
+                if (action == BufferReleaseAction::kRetained) return 0;
 
                 // Keep the local registration until the real-side mapping is
                 // removed successfully.  This makes a failed unregister
@@ -932,7 +951,8 @@ int DummyClient::unregister_buffer(void* buffer) {
                     invoke_rpc<&RealClient::unregister_shm_buffer_internal,
                                void>(static_cast<uint64_t>(address),
                                      client_id_);
-                if (ret.has_value()) registered_external_buffers_.erase(it);
+                if (ret.has_value())
+                    registered_external_buffers_.erase(address);
                 return to_py_ret(ret);
             }
         }
@@ -1010,8 +1030,12 @@ int DummyClient::upsert(const std::string& key, std::span<const char> value,
 
 int DummyClient::upsert_from(const std::string& key, void* buffer, size_t size,
                              const ReplicateConfig& config) {
-    auto results = batch_upsert_from({key}, {buffer}, {size}, config);
-    return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
+    auto prepared = prepare_buffer(buffer, size, true);
+    if (!prepared) return toInt(ErrorCode::INVALID_PARAMS);
+    const uint64_t dummy_addr = reinterpret_cast<uint64_t>(prepared->dummy);
+    return invoke_observed_void_rpc<&RealClient::upsert_from_dummy_helper>(
+        TransferOperationKind::kWrite, "upsert_from", size, false, key,
+        dummy_addr, size, config, client_id_);
 }
 
 std::vector<int> DummyClient::batch_upsert_from(
@@ -1253,8 +1277,41 @@ std::vector<std::shared_ptr<BufferHandle>> DummyClient::batch_get_buffer(
 
 int64_t DummyClient::get_into(const std::string& key, void* buffer,
                               size_t size) {
-    auto results = batch_get_into({key}, {buffer}, {size});
-    return results.empty() ? toInt(ErrorCode::INVALID_PARAMS) : results[0];
+    if (is_registered_buffer(buffer, size)) {
+        if (auto dst_buffer = try_export_cuda_ipc_buffers({buffer}, {size})) {
+            std::vector<CudaIpcReadRequest> requests{
+                CudaIpcReadRequest{
+                    .key = key,
+                    .destination = (*dst_buffer)[0],
+                    .source_offset = 0,
+                    .size = static_cast<uint64_t>(size),
+                },
+            };
+            auto results = batch_get_into_cuda_ipc(requests);
+            return results.empty() ? toInt(ErrorCode::INVALID_PARAMS)
+                                   : results[0];
+        }
+    }
+
+    auto prepared = prepare_buffer(buffer, size, false, true);
+    if (!prepared) return toInt(ErrorCode::INVALID_PARAMS);
+    const uint64_t dummy_addr = reinterpret_cast<uint64_t>(prepared->dummy);
+    const auto start_time = std::chrono::steady_clock::now();
+    auto result = invoke_rpc<&RealClient::get_into_range_shm_helper,
+                             tl::expected<int64_t, ErrorCode>>(
+        key, dummy_addr, 0, 0, size, true, true, client_id_);
+    if (!result) return static_cast<int64_t>(toInt(result.error()));
+
+    const int64_t bytes_read = to_py_ret(*result);
+    if (bytes_read >= 0) {
+        if (!copy_from_staging(*prepared, static_cast<size_t>(bytes_read))) {
+            return toInt(ErrorCode::INTERNAL_ERROR);
+        }
+        ObserveTransferMetric(TransferOperationKind::kRead, "get_into",
+                              static_cast<size_t>(bytes_read),
+                              elapsed_us_since(start_time), false);
+    }
+    return bytes_read;
 }
 
 std::vector<std::vector<std::vector<int64_t>>> DummyClient::get_into_ranges(
@@ -1816,17 +1873,16 @@ void DummyClient::ping_thread_main() {
 
 #if defined(USE_ASCEND_DIRECT)
                 if (all_registered && globalConfig().ascend_agent_mode) {
-                    auto device_buffers = get_registered_device_buffers();
-                    for (const auto& device_buffer : device_buffers) {
-                        if (register_ascend_shm(&device_buffer, false) != 0) {
-                            LOG(WARNING)
-                                << "Failed to re-register device buffer "
-                                   "during reconnection, buffer="
-                                << device_buffer.base_addr
-                                << ", size=" << device_buffer.size;
-                            all_registered = false;
-                            break;
-                        }
+                    if (globalConfig().ascend_use_fabric_mem &&
+                        reregister_fabric_buffers() != 0) {
+                        LOG(WARNING) << "Failed to re-register Fabric buffers "
+                                        "during reconnection";
+                        all_registered = false;
+                    }
+                    if (all_registered && reregister_device_buffers() != 0) {
+                        LOG(WARNING) << "Failed to re-register device buffers "
+                                        "during reconnection";
+                        all_registered = false;
                     }
                 }
 #endif

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -2757,8 +2757,10 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     std::unique_lock<std::shared_mutex> lock(dummy_client_mutex_);
     auto it = shm_contexts_.find(client_id);
     if (it == shm_contexts_.end()) {
-        LOG(ERROR) << "client_id=" << client_id << ", error=shm_not_mapped";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        // Per-buffer unregistration is idempotent so a DummyClient can safely
+        // retry after the RealClient completed an earlier request but its
+        // response was lost.
+        return {};
     }
     auto &context = it->second;
 
@@ -2773,11 +2775,7 @@ tl::expected<void, ErrorCode> RealClient::unregister_shm_buffer_internal(
     }
 
     if (shm_it == context.mapped_shms.end()) {
-        std::stringstream addr_stream;
-        addr_stream << "0x" << std::hex << dummy_base_addr;
-        LOG(ERROR) << "Share memory not found for dummy address: "
-                   << addr_stream.str() << " (client_id: " << client_id << ")";
-        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        return {};
     }
 
     // Unmap and clean up the shm

--- a/mooncake-store/src/shm_helper.cpp
+++ b/mooncake-store/src/shm_helper.cpp
@@ -171,10 +171,10 @@ int ShmHelper::free(void* addr) {
 
 std::shared_ptr<ShmHelper::ShmSegment> ShmHelper::get_shm(void* addr) {
     std::lock_guard<std::mutex> lock(shm_mutex_);
+    const uintptr_t address = reinterpret_cast<uintptr_t>(addr);
     for (auto& shm : shms_) {
-        if (addr >= shm->base_addr &&
-            reinterpret_cast<uint8_t*>(addr) <
-                reinterpret_cast<uint8_t*>(shm->base_addr) + shm->size) {
+        const uintptr_t base = reinterpret_cast<uintptr_t>(shm->base_addr);
+        if (address >= base && address - base < shm->size) {
             return shm;
         }
     }

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -496,6 +496,13 @@ TEST_F(DummyClientGetBufferTest, ExternalHostRangedRead) {
     EXPECT_EQ(destination[15], '_');
 
     ASSERT_EQ(dummy_client_->unregister_buffer(destination.data()), 0);
+    const auto rejected = dummy_client_->get_into_ranges(
+        {destination.data()}, {{key}}, {{{4, 20}}}, {{{2, 10}}}, {{{6, 8}}});
+    ASSERT_EQ(rejected.size(), 1);
+    ASSERT_EQ(rejected[0].size(), 1);
+    EXPECT_EQ(rejected[0][0],
+              (std::vector<int64_t>{toInt(ErrorCode::INVALID_PARAMS),
+                                    toInt(ErrorCode::INVALID_PARAMS)}));
 }
 
 // ---- Test: get_buffer via hot cache shm zero-copy path ----

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -471,6 +471,16 @@ TEST_F(DummyClientGetBufferTest, ExternalHostRegistrationLifecycle) {
     ASSERT_EQ(dummy_client_->unregister_buffer(destination.data()), 0);
 }
 
+TEST_F(DummyClientGetBufferTest,
+       UnregisterMissingRealBufferMappingIsIdempotent) {
+    auto client = RealClient::create();
+    ASSERT_NE(client, nullptr);
+
+    const auto result =
+        client->unregister_shm_buffer_internal(0x1234, UUID{1, 2});
+    EXPECT_TRUE(result.has_value());
+}
+
 TEST_F(DummyClientGetBufferTest, ExternalHostRangedRead) {
     ASSERT_TRUE(SetupStack()) << "Failed to bring up real+dummy stack";
 

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -46,6 +46,7 @@ static void RegisterRpcHandlers(coro_rpc::coro_rpc_server &server,
     server.register_handler<&RealClient::isExist_internal>(&rc);
     server.register_handler<&RealClient::getSize_internal>(&rc);
     server.register_handler<&RealClient::get_into_range_shm_helper>(&rc);
+    server.register_handler<&RealClient::get_into_ranges_shm_helper>(&rc);
     server.register_handler<&RealClient::batch_get_into_dummy_helper>(&rc);
     server.register_handler<&RealClient::batch_put_from_dummy_helper>(&rc);
     server.register_handler<&RealClient::allocate_buffer_dummy>(&rc);
@@ -465,6 +466,35 @@ TEST_F(DummyClientGetBufferTest, ExternalHostRegistrationLifecycle) {
         << "one duplicate unregister must keep registration alive";
     ASSERT_EQ(dummy_client_->unregister_buffer(source.data()), 0);
     EXPECT_NE(dummy_client_->unregister_buffer(source.data()), 0);
+    EXPECT_NE(dummy_client_->put_from(key, source.data(), 1), 0)
+        << "transfers after the final unregister must be rejected";
+    ASSERT_EQ(dummy_client_->unregister_buffer(destination.data()), 0);
+}
+
+TEST_F(DummyClientGetBufferTest, ExternalHostRangedRead) {
+    ASSERT_TRUE(SetupStack()) << "Failed to bring up real+dummy stack";
+
+    const std::string key = "dummy_external_host_ranged_read";
+    const std::string data = "0123456789abcdefghijklmnopqrstuvwxyz";
+    PutData(key, data);
+
+    std::vector<char> destination(32, '_');
+    ASSERT_EQ(
+        dummy_client_->register_buffer(destination.data(), destination.size()),
+        0);
+
+    const auto results = dummy_client_->get_into_ranges(
+        {destination.data()}, {{key}}, {{{4, 20}}}, {{{2, 10}}}, {{{6, 8}}});
+    ASSERT_EQ(results.size(), 1);
+    ASSERT_EQ(results[0].size(), 1);
+    ASSERT_EQ(results[0][0], (std::vector<int64_t>{6, 8}));
+    EXPECT_EQ(std::string(destination.begin() + 4, destination.begin() + 10),
+              data.substr(2, 6));
+    EXPECT_EQ(std::string(destination.begin() + 20, destination.begin() + 28),
+              data.substr(10, 8));
+    EXPECT_EQ(destination[0], '_');
+    EXPECT_EQ(destination[15], '_');
+
     ASSERT_EQ(dummy_client_->unregister_buffer(destination.data()), 0);
 }
 

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -14,6 +14,9 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include <algorithm>
+#include <limits>
+#include <numeric>
 
 #include "dummy_client.h"
 #include "environ.h"
@@ -45,6 +48,7 @@ static void RegisterRpcHandlers(coro_rpc::coro_rpc_server &server,
     server.register_handler<&RealClient::get_into_range_shm_helper>(&rc);
     server.register_handler<&RealClient::batch_get_into_dummy_helper>(&rc);
     server.register_handler<&RealClient::batch_put_from_dummy_helper>(&rc);
+    server.register_handler<&RealClient::allocate_buffer_dummy>(&rc);
     server.register_handler<&RealClient::acquire_hot_cache>(&rc);
     server.register_handler<&RealClient::release_hot_cache>(&rc);
     server.register_handler<&RealClient::batch_acquire_hot_cache>(&rc);
@@ -428,6 +432,40 @@ TEST_F(DummyClientGetBufferTest, BatchQueryPreservesObjectChecksum) {
     ASSERT_TRUE(dummy_results[0].has_value());
     EXPECT_EQ(dummy_results[0]->object_checksum,
               real_results[0]->object_checksum);
+}
+
+TEST_F(DummyClientGetBufferTest, ExternalHostRegistrationLifecycle) {
+    ASSERT_TRUE(SetupStack()) << "Failed to bring up real+dummy stack";
+
+    constexpr size_t kSize = 4096;
+    std::vector<char> source(kSize);
+    std::vector<char> destination(kSize, 0);
+    std::iota(source.begin(), source.end(), 0);
+
+    ASSERT_EQ(dummy_client_->register_buffer(source.data(), kSize), 0);
+    ASSERT_EQ(dummy_client_->register_buffer(destination.data(), kSize), 0);
+    EXPECT_EQ(dummy_client_->register_buffer(source.data(), kSize), 0)
+        << "same range registration should be reference counted";
+    EXPECT_NE(dummy_client_->register_buffer(source.data(), kSize - 1), 0);
+    EXPECT_NE(dummy_client_->register_buffer(source.data() + 1, kSize - 1), 0);
+    EXPECT_NE(dummy_client_->register_buffer(
+                  reinterpret_cast<void *>(std::numeric_limits<uintptr_t>::max() - 3),
+                  8),
+              0);
+
+    const std::string key = "dummy_external_host_lifecycle";
+    ASSERT_EQ(dummy_client_->put_from(key, source.data() + 128, 512), 0);
+    ASSERT_EQ(dummy_client_->get_into(key, destination.data() + 256, 512),
+              512);
+    EXPECT_TRUE(std::equal(source.begin() + 128, source.begin() + 640,
+                           destination.begin() + 256));
+
+    ASSERT_EQ(dummy_client_->unregister_buffer(source.data()), 0);
+    ASSERT_EQ(dummy_client_->put_from(key, source.data() + 128, 512), 0)
+        << "one duplicate unregister must keep registration alive";
+    ASSERT_EQ(dummy_client_->unregister_buffer(source.data()), 0);
+    EXPECT_NE(dummy_client_->unregister_buffer(source.data()), 0);
+    ASSERT_EQ(dummy_client_->unregister_buffer(destination.data()), 0);
 }
 
 // ---- Test: get_buffer via hot cache shm zero-copy path ----

--- a/mooncake-store/tests/dummy_client_get_buffer_test.cpp
+++ b/mooncake-store/tests/dummy_client_get_buffer_test.cpp
@@ -448,15 +448,15 @@ TEST_F(DummyClientGetBufferTest, ExternalHostRegistrationLifecycle) {
         << "same range registration should be reference counted";
     EXPECT_NE(dummy_client_->register_buffer(source.data(), kSize - 1), 0);
     EXPECT_NE(dummy_client_->register_buffer(source.data() + 1, kSize - 1), 0);
-    EXPECT_NE(dummy_client_->register_buffer(
-                  reinterpret_cast<void *>(std::numeric_limits<uintptr_t>::max() - 3),
-                  8),
-              0);
+    EXPECT_NE(
+        dummy_client_->register_buffer(
+            reinterpret_cast<void *>(std::numeric_limits<uintptr_t>::max() - 3),
+            8),
+        0);
 
     const std::string key = "dummy_external_host_lifecycle";
     ASSERT_EQ(dummy_client_->put_from(key, source.data() + 128, 512), 0);
-    ASSERT_EQ(dummy_client_->get_into(key, destination.data() + 256, 512),
-              512);
+    ASSERT_EQ(dummy_client_->get_into(key, destination.data() + 256, 512), 512);
     EXPECT_TRUE(std::equal(source.begin() + 128, source.begin() + 640,
                            destination.begin() + 256));
 


### PR DESCRIPTION
## Description

DummyClient previously accepted only pointers inside its own shared-memory
segments. As a result, `register_buffer(ptr, size)` rejected ordinary host,
pinned-host, and CUDA allocations, and external addresses could not be used
safely by the Dummy read/write APIs.

This PR adds explicit external-buffer registration semantics:

- register host, pinned-host, and CUDA addresses outside Dummy SHM;
- reference-count repeated registration of the exact `(base, size)`;
- reject same-base size changes and partially overlapping ranges;
- validate address/size and hugepage-alignment overflow;
- require exact base addresses for unregister and erase on the final release;
- clear external registrations during teardown;
- validate every external transfer range before staging;
- retain CUDA IPC fast paths and use owned SHM staging only where the Dummy
  RPC boundary requires it.
- include Ascend device and Fabric-host registrations in the same range
  validation path;
- validate CUDA IPC fast paths before export, including post-unregister and
  subrange-capacity checks;
- support `get_into_ranges` for registered external destinations by staging
  the requested prefix and copying it back after the scatter completes.

The change is limited to DummyClient registration and generic external
pointer transfers. Tensor-specific `*_from` multi-buffer routing is covered
by PR-2.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Integration (`mooncake-integration`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build-review-nocuda --target dummy_client_get_buffer_test -j16
ctest --test-dir build-review-nocuda -R dummy_client_get_buffer_test --output-on-failure
```

**Test results:**

- [x] No-CUDA build passed on machine 70.
- [x] `dummy_client_get_buffer_test` passed: 12 test cases (10 passed, 2 skipped), latest run after rebase 81.19 s.
- [x] External host registration lifecycle covered: duplicate registration,
  size mismatch, overlap rejection, overflow rejection, partial transfer, and
  exact unregister, plus transfer rejection after the final unregister.
- [x] External-host ranged read covered, including non-contiguous destination
  ranges, preservation of untouched bytes, and rejection after unregister.
- [ ] CUDA-enabled build: blocked by latest `main` baseline incompatibility
  with the CUDA headers installed on machine 70 (`CUmemFabricHandle`,
  `CU_MEM_HANDLE_TYPE_FABRIC`, and
  `CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_FABRIC_SUPPORTED` are unavailable).
- [ ] Full Python suite — not required for this focused C++ registration PR.

**Review notes:**

- The review follow-up commits (rebased onto latest `main` at `b8f294d4`) add
  309 lines and delete 57 lines across three
  source/test files. The cumulative PR branch diff from the merge-base with
  `main` is 513 additions and 70 deletions across four files (including the
  earlier registration work and its tests).
- `register_buffer` itself performs registration bookkeeping only; it does not
  allocate a staging buffer or copy user data.
- External Dummy transfers may use one operation-scoped SHM staging allocation
  because the RPC handler runs against the Dummy-mapped address space.