### PR TITLE
[TE] Shard TCP transport I/O across a pool of io_context threads

### DIFF
--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -35,9 +35,14 @@
 #include <utility>
 #include <vector>
 
+#include <asio/dispatch.hpp>
+#include <asio/executor_work_guard.hpp>
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
+#include <asio/post.hpp>
 #include <asio/steady_timer.hpp>
+#include <glog/logging.h>
+#include <pthread.h>
 
 #include "transfer_metadata.h"
 #include "transport/transport.h"
@@ -48,6 +53,101 @@ class TransferMetadata;
 struct ClientSession;
 class TcpContext;
 class TcpTransport;
+
+// A bounded pool of asio::io_context instances, each driven by its own thread.
+// TCP lanes and accepted server sockets are round-robin distributed across the
+// shards so a single hot peer can use more than one CPU core. With size 1 the
+// behavior is identical to the historical single-io_context transport.
+class TcpIoPool {
+   public:
+    explicit TcpIoPool(size_t num_threads) {
+        if (num_threads < 1) num_threads = 1;
+        contexts_.reserve(num_threads);
+        guards_.reserve(num_threads);
+        for (size_t i = 0; i < num_threads; ++i) {
+            contexts_.push_back(std::make_unique<asio::io_context>());
+            guards_.push_back(
+                std::make_unique<work_guard_t>(contexts_[i]->get_executor()));
+        }
+    }
+
+    ~TcpIoPool() { stop(); }
+
+    size_t size() const { return contexts_.size(); }
+
+    asio::io_context &context(size_t i) {
+        return *contexts_[i % contexts_.size()];
+    }
+
+    asio::io_context::executor_type executor(size_t i) {
+        return contexts_[i % contexts_.size()]->get_executor();
+    }
+
+    // Group coordination (pump/admission/retry/retirement timers) is pinned to
+    // one shard chosen by hash, so a group's serialized state stays on a single
+    // executor while its lanes spread across shards.
+    asio::io_context::executor_type coordinatorExecutor(size_t hash) {
+        return executor(hash % contexts_.size());
+    }
+
+    // Round-robin executor for a new lane / accepted socket.
+    asio::io_context::executor_type nextLaneExecutor() {
+        return executor(rr_.fetch_add(1, std::memory_order_relaxed));
+    }
+
+    size_t nextShardIndex() {
+        return rr_.fetch_add(1, std::memory_order_relaxed) % contexts_.size();
+    }
+
+    // Spawns one thread per shard. before_run(i) runs on shard i's thread
+    // before each io_context.run() (used to arm the acceptor on shard 0 and to
+    // re-arm it after an exception-driven restart).
+    void start(std::function<void(size_t)> before_run) {
+        for (size_t i = 0; i < contexts_.size(); ++i) {
+            threads_.emplace_back([this, i, before_run] {
+#ifdef __linux__
+                std::string name = "mc-tcp-io-" + std::to_string(i);
+                pthread_setname_np(pthread_self(), name.c_str());
+#endif
+                while (!stopping_.load(std::memory_order_acquire)) {
+                    try {
+                        if (before_run) before_run(i);
+                        contexts_[i]->run();
+                        break;
+                    } catch (const std::exception &e) {
+                        LOG(ERROR) << "TcpIoPool shard " << i
+                                   << " encountered an exception during run: "
+                                   << e.what();
+                        // Do not restart once stop() has published its intent:
+                        // re-arming (e.g. shard 0's async_accept) after stop()
+                        // stopped the context would keep run() alive and hang
+                        // join().
+                        if (stopping_.load(std::memory_order_acquire)) break;
+                        contexts_[i]->restart();
+                    }
+                }
+            });
+        }
+    }
+
+    void stop() {
+        stopping_.store(true, std::memory_order_release);
+        guards_.clear();
+        for (auto &c : contexts_) c->stop();
+        for (auto &t : threads_)
+            if (t.joinable()) t.join();
+        threads_.clear();
+    }
+
+   private:
+    using work_guard_t =
+        asio::executor_work_guard<asio::io_context::executor_type>;
+    std::vector<std::unique_ptr<asio::io_context>> contexts_;
+    std::vector<std::unique_ptr<work_guard_t>> guards_;
+    std::vector<std::thread> threads_;
+    std::atomic<size_t> rr_{0};
+    std::atomic<bool> stopping_{false};
+};
 
 class TcpTransport : public Transport {
    public:
@@ -94,8 +194,6 @@ class TcpTransport : public Transport {
     int unregisterLocalMemoryBatch(
         const std::vector<void *> &addr_list) override;
 
-    void worker();
-
     Slice *prepareTransfer(TransferTask *task, const TransferRequest &request);
 
     void startTransfer(Slice *slice,
@@ -111,7 +209,8 @@ class TcpTransport : public Transport {
    private:
     TcpContext *context_;
     std::atomic_bool running_;
-    std::thread thread_;
+    std::unique_ptr<TcpIoPool> io_pool_;
+    size_t num_io_threads_ = 1;
     bool enable_connection_pool_ = true;
 
     // Client-side bounded work queues and fixed connection lanes.
@@ -211,10 +310,16 @@ class TcpTransport : public Transport {
     enum class LaneConnectStage { NONE, RESOLVING, CONNECTING };
 
     struct ConnectionLaneRuntime {
-        explicit ConnectionLaneRuntime(asio::io_context &io_context)
-            : executor(io_context.get_executor()) {}
+        explicit ConnectionLaneRuntime(TcpIoPool &pool_arg) : pool(&pool_arg) {}
 
-        asio::io_context::executor_type executor;
+        asio::io_context::executor_type coordinatorExecutor(size_t hash) {
+            return pool->coordinatorExecutor(hash);
+        }
+        asio::io_context::executor_type nextLaneExecutor() {
+            return pool->nextLaneExecutor();
+        }
+
+        TcpIoPool *pool;
     };
 
     struct ConnectionLaneState;
@@ -222,11 +327,15 @@ class TcpTransport : public Transport {
 
     struct ConnectionLane {
         ConnectionLane(size_t lane_id_arg,
-                       const std::shared_ptr<PeerConnectionGroup> &group_arg)
-            : lane_id(lane_id_arg), group(group_arg) {}
+                       const std::shared_ptr<PeerConnectionGroup> &group_arg,
+                       const asio::io_context::executor_type &executor_arg)
+            : lane_id(lane_id_arg), group(group_arg), executor(executor_arg) {}
 
         size_t lane_id;
         std::weak_ptr<PeerConnectionGroup> group;
+        // Shard executor this lane's socket/resolver/session/timers are bound
+        // to. Round-robin assigned so a group's lanes spread across io threads.
+        asio::io_context::executor_type executor;
         LaneState state = LaneState::DISCONNECTED;
         LaneConnectStage connect_stage = LaneConnectStage::NONE;
         uint64_t operation_epoch = 0;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -365,6 +365,12 @@ TcpTransport::TcpTransport()
             "MC_TCP_ADMISSION_TIMEOUT_MS",
             getenv("MC_TCP_ADMISSION_TIMEOUT_MS"), kDefaultAdmissionTimeoutMs,
             1, kMaxAdmissionTimeoutMs));
+
+    constexpr size_t kDefaultNumIoThreads = 1;
+    constexpr size_t kMaxNumIoThreads = 32;
+    num_io_threads_ = parseBoundedTcpSetting(
+        "MC_NUM_TCP_IO_THREADS", getenv("MC_NUM_TCP_IO_THREADS"),
+        kDefaultNumIoThreads, 1, kMaxNumIoThreads);
 }
 
 TcpTransport::~TcpTransport() {
@@ -419,15 +425,22 @@ int TcpTransport::install(std::string& local_server_name,
     close(sockfd);  // the above function has opened a socket
     LOG(INFO) << "TcpTransport: listen on port " << tcp_port;
     auto metadata = metadata_;
-    context_ = new TcpContext(tcp_port, [metadata = std::move(metadata)](
-                                            uint64_t addr, uint64_t size) {
-        return validateTcpAddress(metadata, addr, size);
-    });
-    lane_runtime_ =
-        std::make_shared<ConnectionLaneRuntime>(context_->io_context);
+    io_pool_ = std::make_unique<TcpIoPool>(num_io_threads_);
+    context_ = new TcpContext(
+        *io_pool_, tcp_port,
+        [metadata = std::move(metadata)](uint64_t addr, uint64_t size) {
+            return validateTcpAddress(metadata, addr, size);
+        });
+    lane_runtime_ = std::make_shared<ConnectionLaneRuntime>(*io_pool_);
     lane_state_->runtime = lane_runtime_;
     running_ = true;
-    thread_ = std::thread(&TcpTransport::worker, this);
+    // Shard 0 owns the acceptor; arm (and re-arm after a restart) doAccept on
+    // its own thread. Other shards just drain their io_context.
+    io_pool_->start([this](size_t shard) {
+        if (shard == 0) context_->doAccept();
+    });
+    LOG(INFO) << "TcpTransport: I/O pool started with " << num_io_threads_
+              << " thread(s)";
     return 0;
 }
 
@@ -502,9 +515,16 @@ Status TcpTransport::getTransferStatus(BatchID batch_id, size_t task_id,
             std::to_string(batch_id));
     }
     auto& task = batch_desc.task_list[task_id];
-    status.transferred_bytes = task.transferred_bytes;
-    uint64_t success_slice_count = task.success_slice_count;
-    uint64_t failed_slice_count = task.failed_slice_count;
+    // These counters are updated with __atomic_fetch_add from the I/O
+    // thread(s) in Slice::markSuccess/markFailed; read them atomically here to
+    // match MultiTransport::getTransferStatus and avoid a data race with the
+    // completion path (the read runs on the polling submission thread).
+    status.transferred_bytes =
+        __atomic_load_n(&task.transferred_bytes, __ATOMIC_ACQUIRE);
+    uint64_t success_slice_count =
+        __atomic_load_n(&task.success_slice_count, __ATOMIC_ACQUIRE);
+    uint64_t failed_slice_count =
+        __atomic_load_n(&task.failed_slice_count, __ATOMIC_ACQUIRE);
     if (success_slice_count + failed_slice_count == task.slice_count) {
         if (failed_slice_count) {
             status.s = TransferStatusEnum::FAILED;
@@ -663,20 +683,6 @@ void TcpTransport::startTransferSequence(std::vector<Slice*> slices) {
     };
 
     (*advance)();
-}
-
-void TcpTransport::worker() {
-    while (running_) {
-        try {
-            context_->doAccept();
-            context_->io_context.run();
-        } catch (std::exception& e) {
-            LOG(ERROR) << "TcpTransport::worker encountered an exception "
-                          "during doAccept/run: "
-                       << e.what();
-            context_->io_context.restart();
-        }
-    }
 }
 
 std::shared_ptr<asio::ip::tcp::socket> TcpTransport::getConnection(

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_lane_impl.h
@@ -398,14 +398,15 @@ void TcpTransport::runGroupRetirement(
     const std::shared_ptr<PeerConnectionGroup>& group) {
     std::shared_ptr<asio::steady_timer> retry_timer;
     std::shared_ptr<asio::steady_timer> admission_timer;
-    std::array<std::shared_ptr<ClientSession>, kMaxTcpLanesPerPeer> sessions;
-    std::array<std::shared_ptr<asio::ip::tcp::resolver>, kMaxTcpLanesPerPeer>
-        resolvers;
-    std::array<std::shared_ptr<asio::ip::tcp::socket>, kMaxTcpLanesPerPeer>
-        sockets;
-    size_t session_count = 0;
-    size_t resolver_count = 0;
-    size_t socket_count = 0;
+    // Each lane's asio objects live on that lane's shard executor; collect them
+    // together with the executor so teardown can run on the owning shard.
+    struct LaneTeardown {
+        asio::io_context::executor_type executor;
+        std::shared_ptr<ClientSession> session;
+        std::shared_ptr<asio::ip::tcp::resolver> resolver;
+        std::shared_ptr<asio::ip::tcp::socket> socket;
+    };
+    std::vector<LaneTeardown> teardowns;
     uint64_t pump_epoch = 0;
     bool retired = false;
     {
@@ -436,12 +437,10 @@ void TcpTransport::runGroupRetirement(
             for (const auto& lane : group->lanes) {
                 ++lane->operation_epoch;
                 if (lane->operation_epoch == 0) ++lane->operation_epoch;
-                if (lane->session)
-                    sessions[session_count++] = std::move(lane->session);
-                if (lane->resolver)
-                    resolvers[resolver_count++] = std::move(lane->resolver);
-                if (lane->socket)
-                    sockets[socket_count++] = std::move(lane->socket);
+                if (lane->session || lane->resolver || lane->socket)
+                    teardowns.push_back(
+                        {lane->executor, std::move(lane->session),
+                         std::move(lane->resolver), std::move(lane->socket)});
                 lane->connect_stage = LaneConnectStage::NONE;
                 lane->state = LaneState::CLOSED;
             }
@@ -457,17 +456,28 @@ void TcpTransport::runGroupRetirement(
     }
     if (!retired) return;
 
-    for (size_t i = 0; i < session_count; ++i)
-        if (sessions[i]) sessions[i]->cancel();
-    for (size_t i = 0; i < resolver_count; ++i) {
-        const auto& resolver = resolvers[i];
-        if (!resolver) continue;
-        try {
-            resolver->cancel();
-        } catch (...) {
-        }
+    // Cancel/close each lane's socket, session and resolver ON ITS OWN SHARD
+    // so these asio objects are only touched by their owning io thread. With
+    // MC_NUM_TCP_IO_THREADS == 1 asio::dispatch runs inline (unchanged
+    // behavior); with more shards it hops to the lane's io thread, avoiding
+    // concurrent close()/cancel() against an outstanding async op.
+    for (auto& teardown : teardowns) {
+        auto session = std::move(teardown.session);
+        auto resolver = std::move(teardown.resolver);
+        auto socket = std::move(teardown.socket);
+        asio::dispatch(teardown.executor, [session, resolver, socket] {
+            if (session) session->cancel();
+            if (resolver) {
+                try {
+                    resolver->cancel();
+                } catch (...) {
+                }
+            }
+            closeSocketNoThrow(socket);
+        });
     }
-    for (size_t i = 0; i < socket_count; ++i) closeSocketNoThrow(sockets[i]);
+    // Retry/admission timers are group->executor objects and we are running on
+    // that executor, so cancel them here.
     cancelTimerNoThrow(retry_timer);
     cancelTimerNoThrow(admission_timer);
 
@@ -546,14 +556,15 @@ void TcpTransport::enqueuePooledTransfer(const std::string& logical_peer,
                 auto group_it = state->groups.find(key);
                 if (group_it == state->groups.end()) {
                     group = std::make_shared<PeerConnectionGroup>(
-                        key, runtime->executor,
+                        key,
+                        runtime->coordinatorExecutor(ConnectionKeyHash{}(key)),
                         state->max_queued_transfers_per_peer,
                         state->max_pending_admissions_per_peer,
                         state->admission_timeout, state->failure_counters);
                     group->lanes.reserve(state->lanes_per_peer);
                     for (size_t i = 0; i < state->lanes_per_peer; ++i) {
-                        group->lanes.push_back(
-                            std::make_shared<ConnectionLane>(i, group));
+                        group->lanes.push_back(std::make_shared<ConnectionLane>(
+                            i, group, runtime->nextLaneExecutor()));
                     }
                     auto [inserted_it, inserted] =
                         state->groups.emplace(key, group);
@@ -858,10 +869,26 @@ void TcpTransport::runGroupPump(
         invokeLaneObserverHook(kLaneAdmissionTimerArmed, pending_depth, 0, 0,
                                false);
 #endif
-    for (size_t i = 0; i < connect_count; ++i)
-        startLaneConnect(group, connects[i].lane, connects[i].epoch);
-    for (size_t i = 0; i < session_count; ++i)
-        startLaneSession(group, sessions[i].lane, sessions[i].epoch);
+    // Dispatch each lane's connect/session onto that lane's shard executor so
+    // its socket I/O runs on the owning io thread. asio::dispatch runs inline
+    // when already on the target executor (the single-shard/N=1 case stays
+    // identical to the historical inline calls) and hops otherwise.
+    for (size_t i = 0; i < connect_count; ++i) {
+        auto connect_lane = connects[i].lane;
+        uint64_t connect_epoch = connects[i].epoch;
+        asio::dispatch(connect_lane->executor,
+                       [group, connect_lane, connect_epoch] {
+                           startLaneConnect(group, connect_lane, connect_epoch);
+                       });
+    }
+    for (size_t i = 0; i < session_count; ++i) {
+        auto session_lane = sessions[i].lane;
+        uint64_t session_epoch = sessions[i].epoch;
+        asio::dispatch(session_lane->executor,
+                       [group, session_lane, session_epoch] {
+                           startLaneSession(group, session_lane, session_epoch);
+                       });
+    }
     failWorkItems(std::move(failed), failure_reason, group->failure_counters);
     failWorkItems(std::move(expired), WorkFailureReason::QUEUE_TIMEOUT,
                   group->failure_counters);
@@ -895,9 +922,9 @@ void TcpTransport::startLaneConnect(
 #endif
             try {
                 lane->resolver =
-                    std::make_shared<asio::ip::tcp::resolver>(group->executor);
+                    std::make_shared<asio::ip::tcp::resolver>(lane->executor);
                 lane->socket =
-                    std::make_shared<asio::ip::tcp::socket>(group->executor);
+                    std::make_shared<asio::ip::tcp::socket>(lane->executor);
                 lane->connect_stage = LaneConnectStage::RESOLVING;
                 lane->resolver->async_resolve(
                     group->key.host, std::to_string(group->key.port),
@@ -1403,49 +1430,70 @@ void TcpTransport::shutdownConnectionLanes() {
     }
 
     auto cancellation_posts = std::make_shared<LaneCancellationPostTracker>();
-    if (context_ && running_) {
+    if (io_pool_ && running_) {
+        struct LaneTeardown {
+            asio::io_context::executor_type executor;
+            std::shared_ptr<ClientSession> session;
+            std::shared_ptr<asio::ip::tcp::resolver> resolver;
+            std::shared_ptr<asio::ip::tcp::socket> socket;
+        };
         for (const auto& group : groups) {
-            cancellation_posts->add();
-            try {
-                asio::post(group->executor, [group, cancellation_posts] {
-                    std::vector<std::shared_ptr<ClientSession>> sessions;
-                    std::vector<std::shared_ptr<asio::ip::tcp::resolver>>
-                        resolvers;
-                    std::vector<std::shared_ptr<asio::ip::tcp::socket>> sockets;
-                    std::shared_ptr<asio::steady_timer> retry_timer;
-                    std::shared_ptr<asio::steady_timer> admission_timer;
-                    {
-                        std::lock_guard<std::mutex> lock(group->mutex);
-                        retry_timer = group->retry_timer;
-                        admission_timer = group->admission_timer;
-                        for (const auto& lane : group->lanes) {
-                            if (lane->session)
-                                sessions.push_back(lane->session);
-                            if (lane->resolver)
-                                resolvers.push_back(lane->resolver);
-                            if (lane->socket) sockets.push_back(lane->socket);
-                        }
-                    }
-                    for (const auto& session : sessions)
-                        if (session) session->cancel();
-                    for (const auto& resolver : resolvers) {
-                        if (!resolver) continue;
-                        try {
-                            resolver->cancel();
-                        } catch (...) {
-                        }
-                    }
-                    for (const auto& socket : sockets)
-                        closeSocketNoThrow(socket);
-                    if (retry_timer) {
-                        asio::error_code timer_ec;
-                        retry_timer->cancel(timer_ec);
-                    }
-                    cancelTimerNoThrow(admission_timer);
+            std::vector<LaneTeardown> teardowns;
+            std::shared_ptr<asio::steady_timer> retry_timer;
+            std::shared_ptr<asio::steady_timer> admission_timer;
+            {
+                std::lock_guard<std::mutex> lock(group->mutex);
+                retry_timer = group->retry_timer;
+                admission_timer = group->admission_timer;
+                for (const auto& lane : group->lanes) {
+                    if (lane->session || lane->resolver || lane->socket)
+                        teardowns.push_back({lane->executor, lane->session,
+                                             lane->resolver, lane->socket});
+                }
+            }
+            // Cancel/close each lane's asio objects on the lane's own shard;
+            // the group timers stay on the coordinator (group) executor. Each
+            // post is tracked so waitUntil() waits for all of them. At N=1
+            // asio::dispatch runs inline on the single io thread.
+            for (auto& teardown : teardowns) {
+                cancellation_posts->add();
+                auto session = teardown.session;
+                auto resolver = teardown.resolver;
+                auto socket = teardown.socket;
+                try {
+                    asio::dispatch(
+                        teardown.executor,
+                        [session, resolver, socket, cancellation_posts] {
+                            if (session) session->cancel();
+                            if (resolver) {
+                                try {
+                                    resolver->cancel();
+                                } catch (...) {
+                                }
+                            }
+                            closeSocketNoThrow(socket);
+                            cancellation_posts->done();
+                        });
+                } catch (...) {
                     cancellation_posts->done();
-                });
-            } catch (...) {
-                cancellation_posts->done();
+                }
+            }
+            if (retry_timer || admission_timer) {
+                cancellation_posts->add();
+                try {
+                    asio::dispatch(
+                        group->executor,
+                        [retry_timer, admission_timer, cancellation_posts] {
+                            if (retry_timer) {
+                                asio::error_code timer_ec;
+                                retry_timer->cancel(timer_ec);
+                            }
+                            cancelTimerNoThrow(admission_timer);
+                            cancellation_posts->done();
+                        });
+                } catch (...) {
+                    cancellation_posts->done();
+                }
             }
         }
         cancellation_posts->waitUntil(std::chrono::steady_clock::now() +
@@ -1453,8 +1501,10 @@ void TcpTransport::shutdownConnectionLanes() {
     }
 
     running_ = false;
-    if (context_) context_->io_context.stop();
-    if (thread_.joinable()) thread_.join();
+    // Stopping the pool stops every shard io_context and joins every io
+    // thread; after this returns no handler can run, which is the quiescence
+    // barrier for the synchronous teardown below.
+    if (io_pool_) io_pool_->stop();
 
     std::deque<TcpWorkItem> deferred;
     std::vector<std::shared_ptr<ClientSession>> sessions;

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport_session_impl.h
@@ -921,8 +921,11 @@ struct ClientSession : public std::enable_shared_from_this<ClientSession> {
 };
 
 struct TcpContext {
-    TcpContext(short port, ValidateAddrFn validate_addr)
-        : acceptor(io_context), validate_addr_(std::move(validate_addr)) {
+    TcpContext(TcpIoPool& pool, short port, ValidateAddrFn validate_addr)
+        : pool_(pool),
+          io_context(pool.context(0)),
+          acceptor(io_context),
+          validate_addr_(std::move(validate_addr)) {
         std::error_code ec;
         asio::ip::tcp::endpoint endpoint(asio::ip::tcp::v6(), port);
 
@@ -950,21 +953,30 @@ struct TcpContext {
     }
 
     void doAccept() {
-        acceptor.async_accept([this](asio::error_code ec, tcpsocket socket) {
-            if (!ec) {
-                asio::error_code nodelay_ec;
-                socket.set_option(asio::ip::tcp::no_delay(true), nodelay_ec);
-                auto socket_ptr =
-                    std::make_shared<tcpsocket>(std::move(socket));
-                auto session =
-                    std::make_shared<ServerSession>(socket_ptr, validate_addr_);
-                session->start();
-            }
-            doAccept();
-        });
+        // Round-robin each accepted connection onto a shard so ServerSession
+        // I/O spreads across io threads. The accept handler runs on shard 0
+        // (the acceptor's context); the accepted socket lives on the target
+        // shard, so start its session there.
+        acceptor.async_accept(
+            pool_.context(pool_.nextShardIndex()),
+            [this](asio::error_code ec, tcpsocket socket) {
+                if (!ec) {
+                    asio::error_code nodelay_ec;
+                    socket.set_option(asio::ip::tcp::no_delay(true),
+                                      nodelay_ec);
+                    auto socket_ptr =
+                        std::make_shared<tcpsocket>(std::move(socket));
+                    auto session = std::make_shared<ServerSession>(
+                        socket_ptr, validate_addr_);
+                    asio::post(socket_ptr->get_executor(),
+                               [session] { session->start(); });
+                }
+                doAccept();
+            });
     }
 
-    asio::io_context io_context;
+    TcpIoPool& pool_;
+    asio::io_context& io_context;
     asio::ip::tcp::acceptor acceptor;
     ValidateAddrFn validate_addr_;
 };


### PR DESCRIPTION
## Description

The TCP transfer path currently runs a **single `asio::io_context` on one worker thread** (`TcpTransport::worker` → `io_context.run()`). Every per-peer lane, socket completion, admission timer, and reconnect handler executes on that one thread. On a fast cross-node TCP path (~100 GbE) that single thread saturates at 100% CPU and caps throughput well below line rate — adding more lanes stops helping once they all funnel through the one thread.

This PR introduces **`TcpIoPool`**, a bounded pool of `io_context` threads, and spreads I/O across them while preserving the #2974 bounded-lane model, admission control, reconnect, and exactly-once completion.

Design:
- New `TcpIoPool` owns `N` `io_context` instances, each with its own thread and a work-guard; threads are named `mc-tcp-io-<i>`. `N = MC_NUM_TCP_IO_THREADS` (**default 1 = unchanged behavior**, bounded [1, 32]).
- Each `PeerConnectionGroup`'s coordination state (queue/admission/retry/retirement timers, pump) is pinned to a single shard chosen by hash of the connection key, so its `mutex`-guarded state stays serialized on one executor.
- Each `ConnectionLane`'s socket, and each accepted server socket, are round-robin bound to a shard (not hashed per-peer), so a single hot peer uses multiple cores. `runGroupPump` dispatches a lane's connect/session onto that lane's shard via `asio::dispatch` (runs inline when N=1, so the single-thread path is byte-for-byte the previous behavior).
- Shutdown stops every shard and joins every thread; that join-all is the quiescence barrier.

Correctness rests on the machinery that already existed for the single-thread path — `PeerConnectionGroup::mutex`, the `operation_epoch`/`pump_epoch`/`retry_epoch`/`admission_epoch` stale-handler guards, and the move-only `TerminalAction` + `ClientSession::finalize` exactly-once path. These are mutex/atomic based; they are now genuinely exercised concurrently. Because each socket is pinned to exactly one shard's single-threaded `io_context`, asio's per-socket handler serialization holds without adding strands.

This PR also fixes a **pre-existing data race** (found while adding TSan coverage): `TcpTransport::getTransferStatus` read `task.transferred_bytes` / `success_slice_count` / `failed_slice_count` with plain loads while the I/O thread updates them via `__atomic_fetch_add`. It now uses `__atomic_load_n(..., __ATOMIC_ACQUIRE)`, matching `MultiTransport::getTransferStatus`. This race predates this change (it exists between the single io thread and the polling submission thread).

Relates to RFC #1749; builds on the bounded-lane model from #2974.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix 
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two cross-node hosts over a ~100 GbE TCP path (data-transfer bytes confirmed to cross the NIC via `/proc/net/dev`). Built with `-DUSE_CUDA=ON -DBUILD_EXAMPLES=ON`. `MC_TCP_ENABLE_CONNECTION_POOL=1` (default).

**Regression — `MC_NUM_TCP_IO_THREADS=1` is unchanged:** cross-node 1 MiB read = 2.49 GB/s, identical to the pre-change baseline; loopback matches too (see below).

**Cross-node scaling (1 MiB, DRAM read):**

| MC_NUM_TCP_IO_THREADS | lanes | submit threads | GB/s |
|---|---|---|---|
| 1 | 8 | 1 | 2.49 |
| 2 | 8 | 1 | 4.61 |
| 4 | 8 | 1 | 7.51 |
| 8 | 16 | 4 | **12.28** (~5×, ≈98 Gbit/s) |

WRITE, `N=8` lanes=16 threads=4: 12.40 GB/s. Per-thread CPU spreads across `mc-tcp-io-*` instead of one thread at 100%.

**Loopback, reproducing the #2974 reviewer config** (`transfer_engine_bench`, threads=4/batch=32/64 KiB/10s):

| config | READ GB/s | WRITE GB/s |
|---|---|---|
| 4-lane pool (baseline, this repo) | 1.70 / 1.72 | 2.11 / 1.12 |
| io-pool N=1, 4-lane | 1.45 / 1.53 | 1.78 / 1.07 |
| io-pool N=4, 4-lane | 2.96 / 2.99 | 2.80 / 2.96 |
| io-pool N=8, 8-lane | 3.11 / 3.28 | 3.25 / 3.25 |

(The baseline 4-lane numbers line up with the #2974 "main 4-lane" measurements, confirming the setup is comparable.)

**Correctness — `transfer_engine_validator`, cross-node, 12 workers:** all 12 workers report `Data validation passed` at both `MC_NUM_TCP_IO_THREADS=4` and `=8`.

**ThreadSanitizer:** built `-fsanitize=thread` and ran the validator (loopback, N=4 and N=8). No data races on the new shared structures (`TcpIoPool` / `PeerConnectionGroup` / `ConnectionLane`) — the existing mutex+epoch model holds under real concurrency. The only transport race TSan reported is the pre-existing `getTransferStatus` counter read (reproducible at N=1), which this PR fixes; after the fix no transport hot-path races remain. (Remaining reports are in the benchmark harness — a `running` stop-flag and buffer reuse — and a `condition_variable` shutdown-tracker report where both sides hold the same mutex.)

**Test commands:**
```bash
cmake -S mooncake-transfer-engine -B build -G Ninja \
  -DUSE_ETCD=OFF -DUSE_CUDA=ON -DBUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build -j

# target host
MC_NUM_TCP_IO_THREADS=8 MC_TCP_LANES_PER_PEER=16 \
  ./build/example/transfer_engine_bench --mode=target \
  --metadata_server=P2PHANDSHAKE --protocol=tcp --local_server_name=<ip>:17001
# initiator host (segment_id = the target's "listening on <ip:port>")
MC_NUM_TCP_IO_THREADS=8 MC_TCP_LANES_PER_PEER=16 \
  ./build/example/transfer_engine_bench --mode=initiator \
  --metadata_server=P2PHANDSHAKE --protocol=tcp --segment_id=<ip>:<port> \
  --operation=read --block_size=1048576 --batch_size=32 --threads=4 --duration=10
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (cross-node bench + validator + TSan, described above)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue 

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

AI (Claude Code) assisted with codebase exploration, drafting the `TcpIoPool` implementation, and running the benchmark/validator/TSan sweeps. The submitter has reviewed every changed line and can defend the change end-to-end.