### PR TITLE
[Bugfix][TENT] Guard deferred batch liveness checks with the batch shard

### DIFF
--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -957,7 +957,21 @@ Status TransferEngineImpl::freeBatch(BatchID batch_id) {
 
     if (deferred) {
         std::lock_guard<std::recursive_mutex> lk(progress_mutex_);
-        if (!isBatchAlive(batch_id)) {
+        // The shard lock was released before taking progress_mutex_ to keep
+        // the lock order one-way. In the default queue-off mode,
+        // progress_mutex_ does not protect the per-shard registry, so
+        // reacquire that shard before reading alive_batches_. Queue mode
+        // already makes progress_mutex_ the caller's lock and isBatchAlive()
+        // takes the shard for this check.
+        bool batch_alive = false;
+        if (runtime_queue_config_.enabled) {
+            batch_alive = isBatchAlive(batch_id);
+        } else {
+            std::lock_guard<std::recursive_mutex> shard_lk(
+                batchShardMutex(batch_id));
+            batch_alive = isBatchAlive(batch_id);
+        }
+        if (!batch_alive) {
             // We marked free_requested; another thread already reaped it.
             return Status::OK();
         }

--- a/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
@@ -1650,6 +1650,90 @@ TEST(ProgressLockShard, PollRacesWithFreeSameBatch) {
     EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), kBufLen).ok());
 }
 
+TEST(ProgressLockShard, DeferredFreeRegistryReadRacesWithAllocation) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("enable_runtime_queue", false);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    std::atomic<bool> complete{false};
+    auto pending_poll = [&complete](const Request& request, int) {
+        if (complete.load(std::memory_order_acquire)) {
+            return TransferStatus{TransferStatusEnum::COMPLETED,
+                                  request.length};
+        }
+        return TransferStatus{TransferStatusEnum::PENDING, 0};
+    };
+    auto fake_rdma = std::make_shared<FakeTransport>(
+        RDMA, FakeTransport::StatusFactory{}, pending_poll);
+    auto fake_tcp = std::make_shared<FakeTransport>(
+        TCP, FakeTransport::StatusFactory{}, pending_poll);
+    installFakeRdmaAndTcp(engine, fake_rdma, fake_tcp);
+
+    constexpr size_t kBufLen = 4096;
+    constexpr int kPendingBatches = 8;
+    constexpr int kRounds = 512;
+    constexpr int kAllocatorThreads = 4;
+    std::vector<uint8_t> buf(kBufLen, 0x33);
+    ASSERT_TRUE(engine.registerLocalMemory(buf.data(), buf.size()).ok());
+
+    std::vector<BatchID> pending_batches;
+    pending_batches.reserve(kPendingBatches);
+    for (int i = 0; i < kPendingBatches; ++i) {
+        BatchID batch_id = engine.allocateBatch(1);
+        ASSERT_NE(batch_id, (BatchID)0);
+        ASSERT_TRUE(engine
+                        .submitTransfer(
+                            batch_id, {makeLocalWriteReq(buf.data(), kBufLen)})
+                        .ok());
+        pending_batches.push_back(batch_id);
+    }
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> stop{false};
+    std::atomic<int> allocator_failures{0};
+    std::vector<std::thread> allocators;
+    allocators.reserve(kAllocatorThreads);
+    for (int i = 0; i < kAllocatorThreads; ++i) {
+        allocators.emplace_back([&] {
+            while (!start.load(std::memory_order_acquire))
+                std::this_thread::yield();
+            while (!stop.load(std::memory_order_acquire)) {
+                // Empty batches complete immediately, so this thread mutates
+                // the shard registry without growing the deferred freelist.
+                BatchID batch_id = engine.allocateBatch(0);
+                if (!batch_id) {
+                    ++allocator_failures;
+                    return;
+                }
+                if (!engine.freeBatch(batch_id).ok()) ++allocator_failures;
+            }
+        });
+    }
+    start.store(true, std::memory_order_release);
+
+    int free_failures = 0;
+    for (int round = 0; round < kRounds; ++round) {
+        for (BatchID batch_id : pending_batches) {
+            if (!engine.freeBatch(batch_id).ok()) ++free_failures;
+        }
+    }
+
+    stop.store(true, std::memory_order_release);
+    for (auto& allocator : allocators) allocator.join();
+
+    EXPECT_EQ(free_failures, 0);
+    EXPECT_EQ(allocator_failures.load(std::memory_order_acquire), 0);
+    EXPECT_EQ(engine.aliveBatchCountForTest(), kPendingBatches);
+
+    // Let the deferred batches drain before the engine and registered memory
+    // are torn down.
+    complete.store(true, std::memory_order_release);
+    EXPECT_TRUE(engine.freeBatch(pending_batches.front()).ok());
+    EXPECT_EQ(engine.aliveBatchCountForTest(), 0);
+    EXPECT_TRUE(engine.unregisterLocalMemory(buf.data(), buf.size()).ok());
+}
+
 TEST(ProgressLockShard, RuntimeQueuePollAndFreeDoesNotDeadlock) {
     auto cfg = makeMinimalP2PConfig();
     cfg->set("enable_runtime_queue", true);


### PR DESCRIPTION
## Description

This is a small, focused fix for a real TENT concurrency bug. The bug affects
the queue-off deferred-free path introduced when the global batch lock was
replaced with per-batch shards in
[#3648](https://github.com/kvcache-ai/Mooncake/pull/3648).

When the runtime queue is disabled (the default), `isBatchAlive()` intentionally
reads a shard's `alive_batches` set without locking it because its callers are
expected to already hold that shard. The deferred `freeBatch()` path violated
that contract:

```text
freeBatch(batch_id)
  -> lock batch shard
  -> mark batch->free_requested
  -> unlock batch shard
  -> lock progress_mutex_
  -> isBatchAlive(batch_id)       // queue off: unlocked set read

concurrent allocateBatch()/reclaim
  -> lock the same batch shard
  -> mutate shard.alive_batches
```

Reading an `unordered_set` concurrently with a mutation is undefined behavior.
It was reproduced as a segmentation fault while deferred frees raced with
empty-batch allocation and reclamation.

The fix reacquires the batch shard around the queue-off liveness check after
`progress_mutex_` has been acquired. Queue-enabled behavior is unchanged:
`isBatchAlive()` already locks the shard in that mode. The established lock
order remains one-way:

```text
progress_mutex_ -> batch shard
```

The additional lock is limited to the deferred-free path. The normal terminal
fast path and per-batch polling path are unchanged. There are no public API,
configuration, or user-facing behavior changes.

### Regression test

`ProgressLockShard.DeferredFreeRegistryReadRacesWithAllocation` keeps eight
batches pending while four threads repeatedly allocate and immediately free
empty batches. Both fake transports report pending status so transport
selection cannot make the pending batches complete accidentally.

During development, the unpatched implementation reproduced `SIGSEGV` (exit
139) during a 10-run repeat. With this fix, the test passed 20 consecutive
runs and also passed under ThreadSanitizer.

### Relationship to other work

This is a focused follow-up to #3648. It does not overlap the bounded queue
work in [#3661](https://github.com/kvcache-ai/Mooncake/pull/3661) or the timeout
cleanup work in [#3508](https://github.com/kvcache-ai/Mooncake/pull/3508).

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build <cpu-build-dir> --target tent_progress_worker_test --parallel 8
<cpu-build-dir>/mooncake-transfer-engine/tent/tests/tent_progress_worker_test \
  --gtest_filter='ProgressLockShard.DeferredFreeRegistryReadRacesWithAllocation' \
  --gtest_repeat=20 --gtest_break_on_failure
ctest --test-dir <cpu-build-dir> --output-on-failure -R '^tent_' -j8

cmake --build <cuda-build-dir> --target tent_progress_worker_test --parallel 8
CUDA_VISIBLE_DEVICES=0,1 \
  <cuda-build-dir>/mooncake-transfer-engine/tent/tests/tent_progress_worker_test

setarch x86_64 -R env TSAN_OPTIONS='halt_on_error=1' \
  <tsan-build-dir>/mooncake-transfer-engine/tent/tests/tent_progress_worker_test \
  --gtest_filter='ProgressLockShard.DeferredFreeRegistryReadRacesWithAllocation'

pre-commit run --files \
  mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp \
  mooncake-transfer-engine/tent/tests/progress_worker_test.cpp
git diff --check
```

**Test results:**

- [x] Regression test passed 20 consecutive runs.
- [x] Targeted ThreadSanitizer regression test passed.
- [x] CPU TENT CTest suite passed (31/31).
- [x] CUDA `tent_progress_worker_test` suite passed (23/23).
- [x] Applicable pre-commit hooks and `git diff --check` passed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] Documentation is unchanged because this is an internal concurrency fix
- [x] I have added tests to prove my changes are effective
- [x] An RFC is not required because this is a focused bug fix under 500 LOC

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specified below)

OpenAI Codex assisted with implementation, testing, and PR description.