### PR TITLE
[Bugfix][Store] Return failure from PushOffloadingQueue on no-op enqueue

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -157,6 +157,8 @@ class MasterService {
     // double-erase processing_keys UAF repro (2026-08-03 prod segfault)
     friend class test::MasterServiceProcessingKeyDoubleEraseTest;
     friend class test::LocalDiskUnmountInterleavingTest;
+    // #2997 regression: exercises PushOffloadingQueue's no-op paths directly.
+    friend class test::MasterServiceSSDTest;
     friend class MasterSnapshotManager;    // Allow access to internal state for
                                            // snapshot
     friend class ha::MasterSnapshotCodec;  // Allow codec to access private

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -100,6 +100,10 @@ class MasterServiceProcessingKeyDoubleEraseTest;
 // with a competing mount + register serialized between them, pinning the
 // interleaving instead of hoping a thread scheduler produces it.
 class LocalDiskUnmountInterleavingTest;
+// Friended so the #2997 regression test can call the private
+// PushOffloadingQueue directly with degenerate replica states that the
+// public PutStart/PutEnd path never produces.
+class MasterServiceSSDTest;
 }  // namespace test
 namespace benchmarks {
 class BatchEvictBench;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7542,10 +7542,10 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
     const ObjectIdentity& object_id, Replica& replica,
     std::vector<UUID>* mirror_clients) {
     const auto& segment_names = replica.get_segment_names();
-    // A replica with no segment names is RAM-only (e.g. was never mounted to a
-    // local-disk segment). Returning a silent {} here caused the caller to
-    // record an OffloadingTask + inc_refcnt for work that was never enqueued,
-    // leaking the refcount until TTL expiry (issue #2997). Return an explicit
+    // No source segment names means there is no usable source segment to
+    // offload from. Returning a silent {} here caused the caller to record an
+    // OffloadingTask + inc_refcnt for work that was never enqueued, leaking the
+    // refcount until TTL expiry (issue #2997). Return an explicit
     // UNABLE_OFFLOADING so callers treat this as a no-op rather than a success.
     if (segment_names.empty()) {
         return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
@@ -7581,9 +7581,9 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
         }
         any_enqueued = true;
     }
-    // All segment_name entries were nullopt — same as empty: nothing was
-    // enqueued, so treat as UNABLE_OFFLOADING to prevent the caller from
-    // recording a task for non-existent work.
+    // Every segment name was nullopt (or EnqueueOffload found no usable
+    // segment), so nothing was enqueued. Same invariant as the empty case:
+    // never report success when no task was actually submitted.
     if (!any_enqueued) {
         return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
     }

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -7542,9 +7542,15 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
     const ObjectIdentity& object_id, Replica& replica,
     std::vector<UUID>* mirror_clients) {
     const auto& segment_names = replica.get_segment_names();
+    // A replica with no segment names is RAM-only (e.g. was never mounted to a
+    // local-disk segment). Returning a silent {} here caused the caller to
+    // record an OffloadingTask + inc_refcnt for work that was never enqueued,
+    // leaking the refcount until TTL expiry (issue #2997). Return an explicit
+    // UNABLE_OFFLOADING so callers treat this as a no-op rather than a success.
     if (segment_names.empty()) {
-        return {};
+        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
     }
+    bool any_enqueued = false;
     for (const auto& segment_name_it : segment_names) {
         if (!segment_name_it.has_value()) {
             continue;
@@ -7573,6 +7579,13 @@ tl::expected<void, ErrorCode> MasterService::PushOffloadingQueue(
         if (mirror_clients != nullptr) {
             mirror_clients->push_back(*client_id);
         }
+        any_enqueued = true;
+    }
+    // All segment_name entries were nullopt — same as empty: nothing was
+    // enqueued, so treat as UNABLE_OFFLOADING to prevent the caller from
+    // recording a task for non-existent work.
+    if (!any_enqueued) {
+        return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING);
     }
     return {};
 }

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -29,12 +29,16 @@ class MasterServiceSSDTest : public ::testing::Test {
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
 
-    // PushOffloadingQueue is private; this fixture is a friend of MasterService
-    // (friendship is not inherited by the per-test subclass TEST_F generates,
-    // so the call must live in a member of this class). See issue #2997.
+    // PushOffloadingQueue AND its ObjectIdentity parameter type are both private
+    // to MasterService; this fixture is a friend, but friendship is not inherited
+    // by the per-test subclass TEST_F generates. So both naming ObjectIdentity
+    // and calling PushOffloadingQueue must happen inside a member of this class,
+    // not in the TEST_F body. Take plain tenant/key args and build the private
+    // identity here. See issue #2997.
     static tl::expected<void, ErrorCode> CallPushOffloadingQueue(
-        MasterService& service, const MasterService::ObjectIdentity& id,
+        MasterService& service, const TenantId& tenant, const std::string& key,
         Replica& replica) {
+        const MasterService::ObjectIdentity id{tenant, key};
         return service.PushOffloadingQueue(id, replica);
     }
 };
@@ -1218,14 +1222,16 @@ TEST_F(LocalDiskUnmountInterleavingTest,
 // reported as a failure rather than a silent success.
 TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     auto service = CreateSsdAwareOffloadService();
-    const MasterService::ObjectIdentity id{TenantId::Default(),
-                                           "noop_offload_key"};
+    // ObjectIdentity is private to MasterService, so it is constructed inside the
+    // friend helper from these plain args rather than named here (see helper).
+    const TenantId tenant = TenantId::Default();
+    const std::string key = "noop_offload_key";
 
     // Path 2: MEMORY replica with a null buffer -> get_segment_names() is
     // [nullopt] -> the loop enqueues nothing -> the !any_enqueued guard fires.
     Replica all_nullopt_replica(/*buffer=*/nullptr, ReplicaStatus::COMPLETE);
     ASSERT_FALSE(all_nullopt_replica.get_segment_names().empty());
-    auto r2 = CallPushOffloadingQueue(*service, id, all_nullopt_replica);
+    auto r2 = CallPushOffloadingQueue(*service, tenant, key, all_nullopt_replica);
     ASSERT_FALSE(r2.has_value())
         << "all-nullopt segment names must not report a silent success "
            "(issue #2997)";
@@ -1236,7 +1242,7 @@ TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     Replica empty_names_replica(/*file_path=*/"/tmp/nonexistent_offload_src",
                                 /*object_size=*/1024, ReplicaStatus::COMPLETE);
     ASSERT_TRUE(empty_names_replica.get_segment_names().empty());
-    auto r1 = CallPushOffloadingQueue(*service, id, empty_names_replica);
+    auto r1 = CallPushOffloadingQueue(*service, tenant, key, empty_names_replica);
     ASSERT_FALSE(r1.has_value())
         << "empty segment names must not report a silent success (issue #2997)";
     EXPECT_EQ(ErrorCode::UNABLE_OFFLOADING, r1.error());

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -1222,15 +1222,16 @@ TEST_F(MasterServiceSSDTest, PutEndNoopOffloadDoesNotLeakRefcount) {
     ReplicateConfig config;
     config.replica_num = 1;
 
-    ASSERT_TRUE(
-        service->PutStart(client_id, key, TenantId::Default(), slice_length,
-                          config)
-            .has_value());
+    ASSERT_TRUE(service
+                    ->PutStart(client_id, key, TenantId::Default(),
+                               slice_length, config)
+                    .has_value());
 
     // PutEnd triggers the offload enqueue, which is a no-op here. With the fix
     // it stays best-effort and still succeeds.
     ASSERT_TRUE(
-        service->PutEnd(client_id, key, TenantId::Default(), ReplicaType::MEMORY)
+        service
+            ->PutEnd(client_id, key, TenantId::Default(), ReplicaType::MEMORY)
             .has_value());
 
     // The object is readable...

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -29,12 +29,12 @@ class MasterServiceSSDTest : public ::testing::Test {
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
 
-    // PushOffloadingQueue AND its ObjectIdentity parameter type are both private
-    // to MasterService; this fixture is a friend, but friendship is not inherited
-    // by the per-test subclass TEST_F generates. So both naming ObjectIdentity
-    // and calling PushOffloadingQueue must happen inside a member of this class,
-    // not in the TEST_F body. Take plain tenant/key args and build the private
-    // identity here. See issue #2997.
+    // PushOffloadingQueue AND its ObjectIdentity parameter type are both
+    // private to MasterService; this fixture is a friend, but friendship is not
+    // inherited by the per-test subclass TEST_F generates. So both naming
+    // ObjectIdentity and calling PushOffloadingQueue must happen inside a
+    // member of this class, not in the TEST_F body. Take plain tenant/key args
+    // and build the private identity here. See issue #2997.
     static tl::expected<void, ErrorCode> CallPushOffloadingQueue(
         MasterService& service, const TenantId& tenant, const std::string& key,
         Replica& replica) {
@@ -1222,8 +1222,9 @@ TEST_F(LocalDiskUnmountInterleavingTest,
 // reported as a failure rather than a silent success.
 TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     auto service = CreateSsdAwareOffloadService();
-    // ObjectIdentity is private to MasterService, so it is constructed inside the
-    // friend helper from these plain args rather than named here (see helper).
+    // ObjectIdentity is private to MasterService, so it is constructed inside
+    // the friend helper from these plain args rather than named here (see
+    // helper).
     const TenantId tenant = TenantId::Default();
     const std::string key = "noop_offload_key";
 
@@ -1231,7 +1232,8 @@ TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     // [nullopt] -> the loop enqueues nothing -> the !any_enqueued guard fires.
     Replica all_nullopt_replica(/*buffer=*/nullptr, ReplicaStatus::COMPLETE);
     ASSERT_FALSE(all_nullopt_replica.get_segment_names().empty());
-    auto r2 = CallPushOffloadingQueue(*service, tenant, key, all_nullopt_replica);
+    auto r2 =
+        CallPushOffloadingQueue(*service, tenant, key, all_nullopt_replica);
     ASSERT_FALSE(r2.has_value())
         << "all-nullopt segment names must not report a silent success "
            "(issue #2997)";
@@ -1242,7 +1244,8 @@ TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     Replica empty_names_replica(/*file_path=*/"/tmp/nonexistent_offload_src",
                                 /*object_size=*/1024, ReplicaStatus::COMPLETE);
     ASSERT_TRUE(empty_names_replica.get_segment_names().empty());
-    auto r1 = CallPushOffloadingQueue(*service, tenant, key, empty_names_replica);
+    auto r1 =
+        CallPushOffloadingQueue(*service, tenant, key, empty_names_replica);
     ASSERT_FALSE(r1.has_value())
         << "empty segment names must not report a silent success (issue #2997)";
     EXPECT_EQ(ErrorCode::UNABLE_OFFLOADING, r1.error());

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -28,6 +28,15 @@ class MasterServiceSSDTest : public ::testing::Test {
     }
 
     void TearDown() override { google::ShutdownGoogleLogging(); }
+
+    // PushOffloadingQueue is private; this fixture is a friend of MasterService
+    // (friendship is not inherited by the per-test subclass TEST_F generates,
+    // so the call must live in a member of this class). See issue #2997.
+    static tl::expected<void, ErrorCode> CallPushOffloadingQueue(
+        MasterService& service, const MasterService::ObjectIdentity& id,
+        Replica& replica) {
+        return service.PushOffloadingQueue(id, replica);
+    }
 };
 
 std::unique_ptr<MasterService> CreateSsdAwareOffloadService() {
@@ -1185,72 +1194,52 @@ TEST_F(LocalDiskUnmountInterleavingTest,
 
 // Regression test for issue #2997.
 //
-// When PutEnd completes a memory replica and offload is enabled, it asks
-// PushOffloadingQueue to enqueue an offload task. If the client has no
-// local-disk (offloading) segment, no task can be enqueued and
-// PushOffloadingQueue must report the no-op with an explicit failure.
+// PushOffloadingQueue has two no-op paths that used to return a silent success
+// ({}) without enqueuing anything:
 //
-// The bug was that PushOffloadingQueue returned a silent success ({}) in that
-// case. PutEnd then recorded a phantom OffloadingTask and called inc_refcnt()
-// on the source replica for work that was never submitted, leaking the
-// refcount until the 600s TTL reaper ran. A pinned (refcnt > 0) replica is
-// treated as busy, so an immediate overwrite of the same key is rejected with
-// OBJECT_REPLICA_BUSY even though no reader actually holds it.
+//   1. get_segment_names() is empty   — the replica carries no source segment
+//      metadata (e.g. a DISK/LOCAL_DISK/DFS replica).
+//   2. every segment name is nullopt  — a MEMORY/NOF replica whose backing
+//      buffer is absent or has an invalid allocator, so get_segment_names()
+//      yields a single nullopt entry and the loop body is skipped for it.
 //
-// This test exercises the public PutEnd path: it mounts a memory-only segment
-// (no MountLocalDiskSegment), so the offload enqueue is guaranteed to be a
-// no-op, and verifies that (1) PutEnd still succeeds (offload is best-effort)
-// and (2) no phantom refcount is left behind, observable through a same-size
-// UpsertStart that must not fail with OBJECT_REPLICA_BUSY.
-TEST_F(MasterServiceSSDTest, PutEndNoopOffloadDoesNotLeakRefcount) {
+// In both cases the caller's `if (result)` branch fired and executed
+// inc_refcnt() + offloading_tasks.emplace() for work that was never submitted,
+// leaking the source replica's refcount until the 600s TTL reaper cleared the
+// phantom task. The fix returns UNABLE_OFFLOADING from both paths.
+//
+// These two states cannot arise from the public PutStart/PutEnd path — that
+// path always produces a MEMORY replica with a valid buffer, whose
+// segment_names is a single real name, so PushOffloadingQueue reaches
+// EnqueueOffload and (pre-fix as well as post-fix) already returned
+// UNABLE_OFFLOADING via SEGMENT_NOT_FOUND. To actually guard the two lines this
+// PR changed, the test constructs the degenerate replicas directly and calls
+// PushOffloadingQueue through the test-friend seam, asserting the no-op is
+// reported as a failure rather than a silent success.
+TEST_F(MasterServiceSSDTest, PushOffloadingQueueReportsNoopAsFailure) {
     auto service = CreateSsdAwareOffloadService();
-    UUID client_id = generate_uuid();
+    const MasterService::ObjectIdentity id{TenantId::Default(),
+                                           "noop_offload_key"};
 
-    // Memory segment only -- deliberately no MountLocalDiskSegment, so the
-    // client has no offloading-capable segment and the offload enqueue is a
-    // no-op.
-    Segment segment;
-    segment.id = generate_uuid();
-    segment.name = "mem_only_segment";
-    segment.base = 0x400000000;
-    segment.size = 64 * 1024 * 1024;
-    segment.te_endpoint = segment.name;
-    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+    // Path 2: MEMORY replica with a null buffer -> get_segment_names() is
+    // [nullopt] -> the loop enqueues nothing -> the !any_enqueued guard fires.
+    Replica all_nullopt_replica(/*buffer=*/nullptr, ReplicaStatus::COMPLETE);
+    ASSERT_FALSE(all_nullopt_replica.get_segment_names().empty());
+    auto r2 = CallPushOffloadingQueue(*service, id, all_nullopt_replica);
+    ASSERT_FALSE(r2.has_value())
+        << "all-nullopt segment names must not report a silent success "
+           "(issue #2997)";
+    EXPECT_EQ(ErrorCode::UNABLE_OFFLOADING, r2.error());
 
-    const std::string key = "noop_offload_key";
-    constexpr uint64_t slice_length = 1024;
-    ReplicateConfig config;
-    config.replica_num = 1;
-
-    ASSERT_TRUE(service
-                    ->PutStart(client_id, key, TenantId::Default(),
-                               slice_length, config)
-                    .has_value());
-
-    // PutEnd triggers the offload enqueue, which is a no-op here. With the fix
-    // it stays best-effort and still succeeds.
-    ASSERT_TRUE(
-        service
-            ->PutEnd(client_id, key, TenantId::Default(), ReplicaType::MEMORY)
-            .has_value());
-
-    // The object is readable...
-    auto replicas = service->GetReplicaList(key, TenantId::Default());
-    ASSERT_TRUE(replicas.has_value());
-    ASSERT_EQ(1u, replicas.value().replicas.size());
-
-    // ...and, crucially, no phantom offload task pinned it. A same-size
-    // UpsertStart rejects a genuinely busy (refcnt > 0) object with
-    // OBJECT_REPLICA_BUSY; the leaked inc_refcnt() from the buggy silent
-    // success would trip exactly that path. With the fix the refcount is 0 and
-    // the overwrite proceeds instead.
-    auto upsert = service->UpsertStart(client_id, key, TenantId::Default(),
-                                       slice_length, config);
-    if (!upsert.has_value()) {
-        EXPECT_NE(ErrorCode::OBJECT_REPLICA_BUSY, upsert.error())
-            << "PutEnd leaked a refcount from a no-op offload enqueue "
-               "(issue #2997)";
-    }
+    // Path 1: a non-MEMORY/non-NOF replica -> get_segment_names() is empty ->
+    // the empty-source guard fires before the loop.
+    Replica empty_names_replica(/*file_path=*/"/tmp/nonexistent_offload_src",
+                                /*object_size=*/1024, ReplicaStatus::COMPLETE);
+    ASSERT_TRUE(empty_names_replica.get_segment_names().empty());
+    auto r1 = CallPushOffloadingQueue(*service, id, empty_names_replica);
+    ASSERT_FALSE(r1.has_value())
+        << "empty segment names must not report a silent success (issue #2997)";
+    EXPECT_EQ(ErrorCode::UNABLE_OFFLOADING, r1.error());
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/master_service_ssd_test.cpp
+++ b/mooncake-store/tests/master_service_ssd_test.cpp
@@ -1183,6 +1183,75 @@ TEST_F(LocalDiskUnmountInterleavingTest,
     EXPECT_TRUE(late_replicas.value().replicas[0].is_local_disk_replica());
 }
 
+// Regression test for issue #2997.
+//
+// When PutEnd completes a memory replica and offload is enabled, it asks
+// PushOffloadingQueue to enqueue an offload task. If the client has no
+// local-disk (offloading) segment, no task can be enqueued and
+// PushOffloadingQueue must report the no-op with an explicit failure.
+//
+// The bug was that PushOffloadingQueue returned a silent success ({}) in that
+// case. PutEnd then recorded a phantom OffloadingTask and called inc_refcnt()
+// on the source replica for work that was never submitted, leaking the
+// refcount until the 600s TTL reaper ran. A pinned (refcnt > 0) replica is
+// treated as busy, so an immediate overwrite of the same key is rejected with
+// OBJECT_REPLICA_BUSY even though no reader actually holds it.
+//
+// This test exercises the public PutEnd path: it mounts a memory-only segment
+// (no MountLocalDiskSegment), so the offload enqueue is guaranteed to be a
+// no-op, and verifies that (1) PutEnd still succeeds (offload is best-effort)
+// and (2) no phantom refcount is left behind, observable through a same-size
+// UpsertStart that must not fail with OBJECT_REPLICA_BUSY.
+TEST_F(MasterServiceSSDTest, PutEndNoopOffloadDoesNotLeakRefcount) {
+    auto service = CreateSsdAwareOffloadService();
+    UUID client_id = generate_uuid();
+
+    // Memory segment only -- deliberately no MountLocalDiskSegment, so the
+    // client has no offloading-capable segment and the offload enqueue is a
+    // no-op.
+    Segment segment;
+    segment.id = generate_uuid();
+    segment.name = "mem_only_segment";
+    segment.base = 0x400000000;
+    segment.size = 64 * 1024 * 1024;
+    segment.te_endpoint = segment.name;
+    ASSERT_TRUE(service->MountSegment(segment, client_id).has_value());
+
+    const std::string key = "noop_offload_key";
+    constexpr uint64_t slice_length = 1024;
+    ReplicateConfig config;
+    config.replica_num = 1;
+
+    ASSERT_TRUE(
+        service->PutStart(client_id, key, TenantId::Default(), slice_length,
+                          config)
+            .has_value());
+
+    // PutEnd triggers the offload enqueue, which is a no-op here. With the fix
+    // it stays best-effort and still succeeds.
+    ASSERT_TRUE(
+        service->PutEnd(client_id, key, TenantId::Default(), ReplicaType::MEMORY)
+            .has_value());
+
+    // The object is readable...
+    auto replicas = service->GetReplicaList(key, TenantId::Default());
+    ASSERT_TRUE(replicas.has_value());
+    ASSERT_EQ(1u, replicas.value().replicas.size());
+
+    // ...and, crucially, no phantom offload task pinned it. A same-size
+    // UpsertStart rejects a genuinely busy (refcnt > 0) object with
+    // OBJECT_REPLICA_BUSY; the leaked inc_refcnt() from the buggy silent
+    // success would trip exactly that path. With the fix the refcount is 0 and
+    // the overwrite proceeds instead.
+    auto upsert = service->UpsertStart(client_id, key, TenantId::Default(),
+                                       slice_length, config);
+    if (!upsert.has_value()) {
+        EXPECT_NE(ErrorCode::OBJECT_REPLICA_BUSY, upsert.error())
+            << "PutEnd leaked a refcount from a no-op offload enqueue "
+               "(issue #2997)";
+    }
+}
+
 }  // namespace mooncake::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Affected code paths
- mooncake-store/src/master_service.cpp
  - MasterService::PushOffloadingQueue(): two early-return paths that
    returned `{}` (success) without enqueuing anything now return
    `ErrorCode::UNABLE_OFFLOADING`

## Root cause
PushOffloadingQueue had two paths that reported success while enqueuing
nothing:

1. segment_names.empty() — early return before the loop, for RAM-only
   replicas that carry no SSD segment name.
2. All segment_name entries are nullopt — the loop body was skipped for
   every entry via continue, so nothing was enqueued yet `{}` was returned.

In both cases the caller's `if (result)` branch fired and executed
inc_refcnt() plus offloading_tasks.emplace() for work that was never
submitted. The source replica's refcount leaked until the 600s TTL reaper
cleared the phantom task — with no log or metric — producing a persistent
gap between pool exits and disk evictions (~9% in the reporter's
production deployment).

## The fix
Return tl::make_unexpected(ErrorCode::UNABLE_OFFLOADING) from both no-op
paths. All three call sites (PutEnd, batch eviction, tenant eviction)
already guard on `if (result)`, so they skip inc_refcnt() /
offloading_tasks.emplace() and treat UNABLE_OFFLOADING as a clean no-op
with no further change needed.

PR #3014 adds an offload_enqueue_failed counter and sampled log for
observable failures such as SEGMENT_NOT_FOUND and KEYS_ULTRA_LIMIT; it
does not cover these silent-success paths. This PR closes them.

## How it has been tested
- git diff reviewed: 1 file, 14 insertions, 1 deletion.
- All three PushOffloadingQueue call sites verified to guard on
  `if (result)` and skip refcount/task bookkeeping on any non-success
  return, so UNABLE_OFFLOADING is already handled as a no-op.

Partially addresses kvcache-ai/Mooncake#2997 — this PR fixes the silent-success / phantom-task subsection; the ordinary enqueue-failure observability is handled separately by #3014.

## Description



## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)