### PR TITLE
[TransferEngine][EP] Support Kimi K3 & guard against duplicate glog initialization

### DIFF
--- a/mooncake-common/FindGLOG.cmake
+++ b/mooncake-common/FindGLOG.cmake
@@ -7,63 +7,64 @@ find_package(glog QUIET CONFIG)
 set(GLOG_DETECTED_VERSION "")
 
 if(TARGET glog::glog)
-    set(GLOG_FOUND TRUE)
-    set(GLOG_TARGET glog::glog)
-    if(DEFINED glog_VERSION)
-        set(GLOG_DETECTED_VERSION "${glog_VERSION}")
-    endif()
+  set(GLOG_FOUND TRUE)
+  set(GLOG_TARGET glog::glog)
+  if(DEFINED glog_VERSION)
+    set(GLOG_DETECTED_VERSION "${glog_VERSION}")
+  endif()
 else()
-    find_package(PkgConfig QUIET)
-    if(PKG_CONFIG_FOUND)
-        pkg_check_modules(PC_GLOG QUIET libglog)
-    endif()
+  find_package(PkgConfig QUIET)
+  if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_GLOG QUIET libglog)
+  endif()
 
-    find_path(GLOG_INCLUDE_DIR glog/logging.h
-        HINTS ${PC_GLOG_INCLUDEDIR} ${PC_GLOG_INCLUDE_DIRS}
-        PATHS /usr/include /usr/local/include)
-    
-    find_library(GLOG_LIBRARY glog
-        HINTS ${PC_GLOG_LIBDIR} ${PC_GLOG_LIBRARY_DIRS}
-        PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
+  find_path(
+    GLOG_INCLUDE_DIR glog/logging.h
+    HINTS ${PC_GLOG_INCLUDEDIR} ${PC_GLOG_INCLUDE_DIRS}
+    PATHS /usr/include /usr/local/include)
 
-    if(GLOG_INCLUDE_DIR AND GLOG_LIBRARY)
-        set(GLOG_FOUND TRUE)
-        add_library(glog::glog INTERFACE IMPORTED)
-        target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIR})
-        target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
-        set(GLOG_TARGET glog::glog)
-    endif()
+  find_library(
+    GLOG_LIBRARY glog
+    HINTS ${PC_GLOG_LIBDIR} ${PC_GLOG_LIBRARY_DIRS}
+    PATHS /usr/lib /usr/lib64 /usr/local/lib /usr/local/lib64)
 
-    if(PC_GLOG_VERSION)
-        set(GLOG_DETECTED_VERSION "${PC_GLOG_VERSION}")
-    endif()
+  if(GLOG_INCLUDE_DIR AND GLOG_LIBRARY)
+    set(GLOG_FOUND TRUE)
+    add_library(glog::glog INTERFACE IMPORTED)
+    target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIR})
+    target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
+    set(GLOG_TARGET glog::glog)
+  endif()
+
+  if(PC_GLOG_VERSION)
+    set(GLOG_DETECTED_VERSION "${PC_GLOG_VERSION}")
+  endif()
 endif()
 
 # The version comes from CONFIG (glog_VERSION) or pkg-config (PC_GLOG_VERSION)
 # above. A missing version is treated as "old".
 
-# Only enable the newer API when we can positively confirm glog >= 0.6.0.
-# When the version cannot be determined we conservatively assume it is too old
-# and use the internal-symbol fallback declared in config.cpp. Note: on every
-# glog version, an *unconditional* duplicate InitGoogleLogging() trips a CHECK
-# and abort()s at runtime ("You called InitGoogleLogging() twice!"). Both code
-# paths therefore guard with IsGoogleLoggingInitialized() before initializing;
-# the only difference is where that symbol lives (top-level in >= 0.6.0, the
+# Only enable the newer API when we can positively confirm glog >= 0.6.0. When
+# the version cannot be determined we conservatively assume it is too old and
+# use the internal-symbol fallback declared in config.cpp. Note: on every glog
+# version, an *unconditional* duplicate InitGoogleLogging() trips a CHECK and
+# abort()s at runtime ("You called InitGoogleLogging() twice!"). Both code paths
+# therefore guard with IsGoogleLoggingInitialized() before initializing; the
+# only difference is where that symbol lives (top-level in >= 0.6.0, the
 # internal namespace otherwise).
 if(TARGET glog::glog)
-    if(GLOG_DETECTED_VERSION AND
-       NOT GLOG_DETECTED_VERSION VERSION_LESS "0.6.0")
-        target_compile_definitions(glog::glog
-            INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=1)
-        message(STATUS "glog ${GLOG_DETECTED_VERSION}: "
-            "IsGoogleLoggingInitialized() available")
-    else()
-        target_compile_definitions(glog::glog
-            INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=0)
-        message(STATUS "glog version "
-            "'${GLOG_DETECTED_VERSION}' (< 0.6.0 or unknown): "
-            "IsGoogleLoggingInitialized() unavailable")
-    endif()
+  if(GLOG_DETECTED_VERSION AND NOT GLOG_DETECTED_VERSION VERSION_LESS "0.6.0")
+    target_compile_definitions(glog::glog
+                               INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=1)
+    message(STATUS "glog ${GLOG_DETECTED_VERSION}: "
+                   "IsGoogleLoggingInitialized() available")
+  else()
+    target_compile_definitions(glog::glog
+                               INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=0)
+    message(STATUS "glog version "
+                   "'${GLOG_DETECTED_VERSION}' (< 0.6.0 or unknown): "
+                   "IsGoogleLoggingInitialized() unavailable")
+  endif()
 endif()
 
 include(FindPackageHandleStandardArgs)

--- a/mooncake-common/FindGLOG.cmake
+++ b/mooncake-common/FindGLOG.cmake
@@ -1,8 +1,17 @@
 find_package(glog QUIET CONFIG)
 
+# Track the detected glog version so we can decide whether newer public APIs
+# (e.g. google::IsGoogleLoggingInitialized(), added in glog 0.6.0) are
+# available. Different distros ship different glog versions, so relying on that
+# symbol unconditionally breaks builds against glog < 0.6.0.
+set(GLOG_DETECTED_VERSION "")
+
 if(TARGET glog::glog)
     set(GLOG_FOUND TRUE)
     set(GLOG_TARGET glog::glog)
+    if(DEFINED glog_VERSION)
+        set(GLOG_DETECTED_VERSION "${glog_VERSION}")
+    endif()
 else()
     find_package(PkgConfig QUIET)
     if(PKG_CONFIG_FOUND)
@@ -23,6 +32,37 @@ else()
         target_include_directories(glog::glog INTERFACE ${GLOG_INCLUDE_DIR})
         target_link_libraries(glog::glog INTERFACE ${GLOG_LIBRARY})
         set(GLOG_TARGET glog::glog)
+    endif()
+
+    if(PC_GLOG_VERSION)
+        set(GLOG_DETECTED_VERSION "${PC_GLOG_VERSION}")
+    endif()
+endif()
+
+# The version comes from CONFIG (glog_VERSION) or pkg-config (PC_GLOG_VERSION)
+# above. A missing version is treated as "old".
+
+# Only enable the newer API when we can positively confirm glog >= 0.6.0.
+# When the version cannot be determined we conservatively assume it is too old
+# and use the internal-symbol fallback declared in config.cpp. Note: on every
+# glog version, an *unconditional* duplicate InitGoogleLogging() trips a CHECK
+# and abort()s at runtime ("You called InitGoogleLogging() twice!"). Both code
+# paths therefore guard with IsGoogleLoggingInitialized() before initializing;
+# the only difference is where that symbol lives (top-level in >= 0.6.0, the
+# internal namespace otherwise).
+if(TARGET glog::glog)
+    if(GLOG_DETECTED_VERSION AND
+       NOT GLOG_DETECTED_VERSION VERSION_LESS "0.6.0")
+        target_compile_definitions(glog::glog
+            INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=1)
+        message(STATUS "glog ${GLOG_DETECTED_VERSION}: "
+            "IsGoogleLoggingInitialized() available")
+    else()
+        target_compile_definitions(glog::glog
+            INTERFACE MOONCAKE_GLOG_HAS_IS_INITIALIZED=0)
+        message(STATUS "glog version "
+            "'${GLOG_DETECTED_VERSION}' (< 0.6.0 or unknown): "
+            "IsGoogleLoggingInitialized() unavailable")
     endif()
 endif()
 

--- a/mooncake-ep/include/mooncake_ep_launch.cuh
+++ b/mooncake-ep/include/mooncake_ep_launch.cuh
@@ -71,6 +71,8 @@
             case_macro(2560);                              \
         case 3072:                                         \
             case_macro(3072); /* for gpt-oss */            \
+        case 3584:                                         \
+            case_macro(3584); /* for kimi k3 */            \
         case 4096:                                         \
             case_macro(4096);                              \
         case 5120:                                         \

--- a/mooncake-ep/src/mooncake_ep_kernel.cu
+++ b/mooncake-ep/src/mooncake_ep_kernel.cu
@@ -484,7 +484,7 @@ void dispatch(void* packed_recv_x, float* packed_recv_x_scales,
               int num_topk, int num_experts, int rank, int num_ranks, bool use_fp8,
               void* workspace, cudaStream_t stream,
               int64_t timeout_ticks, int phases, int active_qps_per_rank) {
-    constexpr int kNumMaxTopK = 11;
+    constexpr int kNumMaxTopK = 17;
     constexpr int kNumWarpsPerGroup = 4;
     int num_warp_groups = 8;
 #ifdef MOONCAKE_EP_USE_MUSA
@@ -770,7 +770,7 @@ void combine(void* combined_x, int32_t* active_ranks,
              int active_qps_per_rank) {
     constexpr int kNumWarpsPerGroup = 4;
     constexpr int kNumWarpGroups = 8;
-    constexpr int kNumMaxTopk = 11;
+    constexpr int kNumMaxTopk = 17;
 
     const auto num_warps = kNumWarpGroups * kNumWarpsPerGroup;
     const auto num_sms = cell_div(num_experts, kNumWarpGroups);

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -443,7 +443,9 @@ void loadGlobalConfig(GlobalConfig& config) {
 
     const char* log_dir_path = std::getenv("MC_LOG_DIR");
     if (log_dir_path) {
-        google::InitGoogleLogging("mooncake-transfer-engine");
+        if (!google::IsGoogleLoggingInitialized()) {
+            google::InitGoogleLogging("mooncake-transfer-engine");
+        }
         std::error_code ec;
         if (!std::filesystem::is_directory(log_dir_path, ec)) {
             LOG(WARNING)

--- a/mooncake-transfer-engine/src/config.cpp
+++ b/mooncake-transfer-engine/src/config.cpp
@@ -14,6 +14,35 @@
 
 #include "config.h"
 
+// MOONCAKE_GLOG_HAS_IS_INITIALIZED is defined by FindGLOG.cmake via the
+// glog::glog INTERFACE compile definitions. It is set to 1 only when the
+// detected glog version is >= 0.6.0, where google::IsGoogleLoggingInitialized()
+// is publicly exported as a top-level symbol. This defensive fallback keeps the
+// file buildable even if the macro was not propagated for some reason.
+#ifndef MOONCAKE_GLOG_HAS_IS_INITIALIZED
+#define MOONCAKE_GLOG_HAS_IS_INITIALIZED 0
+#endif
+
+#if !MOONCAKE_GLOG_HAS_IS_INITIALIZED
+// glog < 0.6.0 does NOT export google::IsGoogleLoggingInitialized() at the
+// top level; the public declaration was only added in 0.6.0. However, the same
+// function has always existed in these older versions inside the internal
+// namespace google::glog_internal_namespace_ (declared in glog's private
+// header src/utilities.h, which is not installed). The symbol is exported by
+// libglog, so we forward-declare it here to reuse it without depending on any
+// private header. This lets old glog perform a real "already initialized"
+// check instead of blindly re-initializing.
+//
+// NOTE: In glog >= 0.6.0 this internal symbol no longer exists (it was moved
+// to the top-level google:: namespace), which is exactly why this branch is
+// only compiled when MOONCAKE_GLOG_HAS_IS_INITIALIZED == 0.
+namespace google {
+namespace glog_internal_namespace_ {
+bool IsGoogleLoggingInitialized();
+}  // namespace glog_internal_namespace_
+}  // namespace google
+#endif
+
 #include <charconv>
 #include <cstring>
 #include <cstdio>
@@ -443,7 +472,21 @@ void loadGlobalConfig(GlobalConfig& config) {
 
     const char* log_dir_path = std::getenv("MC_LOG_DIR");
     if (log_dir_path) {
-        if (!google::IsGoogleLoggingInitialized()) {
+        // Only initialize when the caller (upstream program) has not already
+        // initialized glog, to avoid double initialization. On both new and old
+        // glog versions this performs a real "already initialized" check:
+        //   - glog >= 0.6.0: public google::IsGoogleLoggingInitialized()
+        //   - glog <  0.6.0: the equivalent function that lives in the internal
+        //     namespace google::glog_internal_namespace_ (forward-declared at
+        //     the top of this file).
+        // The using-declaration below selects the right overload for the
+        // detected version, so the call site stays identical.
+#if MOONCAKE_GLOG_HAS_IS_INITIALIZED
+        using google::IsGoogleLoggingInitialized;
+#else
+        using google::glog_internal_namespace_::IsGoogleLoggingInitialized;
+#endif
+        if (!IsGoogleLoggingInitialized()) {
             google::InitGoogleLogging("mooncake-transfer-engine");
         }
         std::error_code ec;

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -353,6 +353,12 @@ add_executable(config_test ${WORKSPACE}/config_test.cpp)
 target_link_libraries(config_test PUBLIC transfer_engine gtest gtest_main)
 add_test(NAME config_test COMMAND config_test)
 
+add_executable(glog_preinitialized_test
+               ${WORKSPACE}/glog_preinitialized_test.cpp)
+target_link_libraries(glog_preinitialized_test PUBLIC transfer_engine gtest
+                                                      gtest_main glog::glog)
+add_test(NAME glog_preinitialized_test COMMAND glog_preinitialized_test)
+
 add_executable(rdma_gid_probe_test ${WORKSPACE}/rdma_gid_probe_test.cpp)
 target_link_libraries(rdma_gid_probe_test PUBLIC transfer_engine gtest
                                                  gtest_main)

--- a/mooncake-transfer-engine/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tests/CMakeLists.txt
@@ -50,8 +50,8 @@ add_test(NAME rdma_endpoint_state_test COMMAND rdma_endpoint_state_test)
 
 # Regression test for the reconnect storm of issue #3299: repeated local
 # completion faults toward one peer RNIC must pause that path instead of
-# re-handshaking it forever. The rail monitor is plain per-worker-pool state,
-# so this runs on every CI runner without an RDMA device.
+# re-handshaking it forever. The rail monitor is plain per-worker-pool state, so
+# this runs on every CI runner without an RDMA device.
 add_executable(worker_pool_rail_state_test
                ${WORKSPACE}/worker_pool_rail_state_test.cpp)
 target_link_libraries(worker_pool_rail_state_test PUBLIC transfer_engine gtest

--- a/mooncake-transfer-engine/tests/glog_preinitialized_test.cpp
+++ b/mooncake-transfer-engine/tests/glog_preinitialized_test.cpp
@@ -1,0 +1,48 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "config.h"
+
+namespace mooncake {
+namespace {
+
+class GlogPreinitializedTest : public ::testing::Test {
+   protected:
+    void TearDown() override {
+        ::unsetenv("MC_LOG_DIR");
+        if (google::IsGoogleLoggingInitialized()) {
+            google::ShutdownGoogleLogging();
+        }
+    }
+};
+
+TEST_F(GlogPreinitializedTest, LoadGlobalConfigReusesHostLogging) {
+    google::InitGoogleLogging("glog-preinitialized-test");
+    ASSERT_TRUE(google::IsGoogleLoggingInitialized());
+    ASSERT_EQ(::setenv("MC_LOG_DIR", ".", 1), 0);
+
+    GlobalConfig config;
+    loadGlobalConfig(config);
+
+    EXPECT_TRUE(google::IsGoogleLoggingInitialized());
+    EXPECT_EQ(FLAGS_log_dir, ".");
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tests/glog_preinitialized_test.cpp
+++ b/mooncake-transfer-engine/tests/glog_preinitialized_test.cpp
@@ -19,28 +19,61 @@
 
 #include "config.h"
 
+// MOONCAKE_GLOG_HAS_IS_INITIALIZED is provided by FindGLOG.cmake through the
+// glog::glog INTERFACE compile definitions. It is 1 only when glog >= 0.6.0,
+// where google::IsGoogleLoggingInitialized() is publicly exported at the top
+// level. On older glog versions the same function is available in the internal
+// namespace google::glog_internal_namespace_, so we forward-declare it below to
+// exercise the exact same behavior this test verifies in config.cpp.
+#ifndef MOONCAKE_GLOG_HAS_IS_INITIALIZED
+#define MOONCAKE_GLOG_HAS_IS_INITIALIZED 0
+#endif
+
+#if !MOONCAKE_GLOG_HAS_IS_INITIALIZED
+// See config.cpp for the rationale: glog < 0.6.0 keeps this function in the
+// internal namespace; the symbol is exported by libglog, so we forward-declare
+// it here instead of depending on glog's private, non-installed utilities.h.
+namespace google {
+namespace glog_internal_namespace_ {
+bool IsGoogleLoggingInitialized();
+}  // namespace glog_internal_namespace_
+}  // namespace google
+#endif
+
 namespace mooncake {
 namespace {
+
+// Version-agnostic wrapper resolving to the correct glog symbol.
+inline bool testGlogInitialized() {
+#if MOONCAKE_GLOG_HAS_IS_INITIALIZED
+    return google::IsGoogleLoggingInitialized();
+#else
+    return google::glog_internal_namespace_::IsGoogleLoggingInitialized();
+#endif
+}
 
 class GlogPreinitializedTest : public ::testing::Test {
    protected:
     void TearDown() override {
         ::unsetenv("MC_LOG_DIR");
-        if (google::IsGoogleLoggingInitialized()) {
+        if (testGlogInitialized()) {
             google::ShutdownGoogleLogging();
         }
     }
 };
 
 TEST_F(GlogPreinitializedTest, LoadGlobalConfigReusesHostLogging) {
+    // Simulate the caller (host program) having already initialized glog.
     google::InitGoogleLogging("glog-preinitialized-test");
-    ASSERT_TRUE(google::IsGoogleLoggingInitialized());
+    ASSERT_TRUE(testGlogInitialized());
     ASSERT_EQ(::setenv("MC_LOG_DIR", ".", 1), 0);
 
     GlobalConfig config;
     loadGlobalConfig(config);
 
-    EXPECT_TRUE(google::IsGoogleLoggingInitialized());
+    // loadGlobalConfig must detect the pre-initialized state and reuse it
+    // rather than re-initializing glog.
+    EXPECT_TRUE(testGlogInitialized());
     EXPECT_EQ(FLAGS_log_dir, ".");
 }
 


### PR DESCRIPTION
## Description

This PR bundles six related commits from the `kyx1999/add-kimi-k3-support` branch, covering Kimi K3 EP support and a duplicate-glog-initialization fix (plus its cross-version glog compatibility):

1. **Kimi K3 support (EP)** — Add hidden size `3584` to the `SWITCH_HIDDEN` dispatch macro (`case 3584 /* for kimi k3 */`) and raise `kNumMaxTopK` / `kNumMaxTopk` from `11` to `17` in the EP kernel (both the dispatch and combine launch paths) so the expert-parallel path can accommodate Kimi K3's model configuration and routing.
2. **Reproduce duplicate glog initialization** — Add a regression test (`glog_preinitialized_test`) that reproduces the abort caused by re-initializing glog when the host process has already initialized Google logging.
3. **Fix duplicate glog initialization** — Guard `google::InitGoogleLogging` in `loadGlobalConfig` (triggered by the `MC_LOG_DIR` env var) with an "already initialized" check so the transfer engine reuses the host's existing logging setup instead of triggering a duplicate-initialization abort (`"You called InitGoogleLogging() twice!"`).
4. **Support glog < 0.6.0** — `IsGoogleLoggingInitialized()` was only exported at the top level in glog 0.6.0. To keep building against older distros, `FindGLOG.cmake` now detects the glog version (via CONFIG or pkg-config) and defines `MOONCAKE_GLOG_HAS_IS_INITIALIZED=1` only when glog >= 0.6.0. `config.cpp` (and the test) select the right symbol accordingly: the public `google::IsGoogleLoggingInitialized()` on >= 0.6.0, and the forward-declared `google::glog_internal_namespace_::IsGoogleLoggingInitialized()` on older versions, keeping the call site identical.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

A new unit test (`glog_preinitialized_test`) reproduces the duplicate glog initialization scenario: it pre-initializes glog as the host would, then calls `loadGlobalConfig` and verifies logging is reused (no re-init) while `FLAGS_log_dir` is still applied from `MC_LOG_DIR`. The test is version-agnostic and resolves to the correct glog symbol via `MOONCAKE_GLOG_HAS_IS_INITIALIZED`. The Kimi K3 changes were validated by exercising the EP dispatch path with hidden size `3584`.

**Test commands:**
```bash
# Build and run the transfer engine tests (includes glog_preinitialized_test)
ctest --test-dir build -R glog_preinitialized_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (EP dispatch verified for hidden size 3584)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (N/A: total ~+202/-27 lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex is used to locate some bugs.
