### PR TITLE
[TENT] Remove legacy transport resolve path

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -415,9 +415,6 @@ class TransferEngineImpl {
     Status getBatchStatus(BatchID batch_id, TransferStatus& overall_status,
                           bool allow_failover);
 
-    SelectionResult resolveTransport(const Request& req, int transport_index,
-                                     bool invalidate_on_fail = true);
-
     ResolvedRoute resolveExecutionRoute(const Request& req, int transport_index,
                                         bool invalidate_on_fail = true);
 

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -1556,17 +1556,6 @@ std::vector<RequestBoundaryInfo> resolveRequestBoundaries(
     return boundaries;
 }
 
-SelectionResult TransferEngineImpl::resolveTransport(const Request& req,
-                                                     int transport_index,
-                                                     bool invalidate_on_fail) {
-    auto result = getTransportType(req, transport_index);
-    if (result.transport == UNSPEC && invalidate_on_fail) {
-        metadata_->segmentManager().invalidateRemote(req.target_id);
-        result = getTransportType(req, transport_index);
-    }
-    return result;
-}
-
 TransferEngineImpl::ResolvedRoute TransferEngineImpl::resolveExecutionRoute(
     const Request& req, int transport_index, bool invalidate_on_fail) {
     ResolvedRoute resolved;
@@ -2348,13 +2337,11 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
             "Failover limit exceeded, all transports exhausted");
     }
 
-    if (task.staging)
-        task.staging = false;
-    else
-        task.xport_priority = task.failover_count;
+    task.staging = false;
+    task.xport_priority = task.failover_count;
 
-    auto result = resolveTransport(task.request, task.xport_priority);
-    auto type = result.transport;
+    auto resolved = resolveExecutionRoute(task.request, task.xport_priority);
+    auto type = resolved.route.transport;
     if (type == UNSPEC) {
         LOG(WARNING) << "No more transports available after "
                      << transportTypeName(prev_type) << " failed";
@@ -2366,6 +2353,24 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
               << task.failover_count << "/" << max_failover_attempts_ << ")";
     TENT_RECORD_TRANSPORT_FAILOVER(prev_type, type);
 
+    task.type = type;
+    task.device_mask = resolved.route.device_mask;
+    task.qp_pool = resolved.route.qp_pool.value_or("");
+    task.sub_task_id = -1;
+
+    if (resolved.staging) {
+        task.staging = true;
+        auto status = staging_proxy_->submit(&task, (BatchID)batch,
+                                             resolved.staging_params);
+        if (!status.ok()) {
+            task.staging = false;
+            task.type = UNSPEC;
+        } else {
+            task.post_time = std::chrono::steady_clock::now();
+        }
+        return status;
+    }
+
     auto& transport = transport_list_[type];
     if (!batch->sub_batch[type]) {
         CHECK_STATUS(transport->allocateSubBatch(batch->sub_batch[type],
@@ -2373,14 +2378,11 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
         attachProgressNotifier(batch, batch->sub_batch[type]);
     }
     auto& sub_batch = batch->sub_batch[type];
-    task.device_mask = result.device_mask;
-    task.qp_pool = result.qp_pool.value_or("");
     if (type == RDMA) {
         sub_batch->device_mask = task.device_mask;
         sub_batch->qp_pool = task.qp_pool;
     }
     task.sub_task_id = sub_batch->size();
-    task.type = type;
     startTransportAttempt(task, type, std::chrono::steady_clock::now());
     auto status = transport->submitTransferTasks(sub_batch, {task.request});
     if (!status.ok()) {


### PR DESCRIPTION
## Description

Remove the legacy `resolveTransport` dispatch path now that execution routing is handled through the capability graph route resolver. This keeps submit/redispatch behavior on one route-resolution path before adding intent-aware scoring in the next stacked PR.

Stacked on #3728.

## Related Issue

Related issue: #3733

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build
cmake --build build --target tent_capability_graph_test tent_transport_selector_test -j16
ctest --test-dir build -R '^(tent_capability_graph_test|tent_transport_selector_test)$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note: `pre-commit` is not installed in the local environment, so the PR-scoped pre-commit command could not be run locally.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex was used to split the original branch into focused PRs, resolve rebase conflicts, review diffs, and run local validation. The human submitter should review and be able to defend every changed line.