### PR TITLE
[EP] retain tensors for deferred receive hooks

### DIFF
--- a/python/mooncake/mooncake_ep_buffer.py
+++ b/python/mooncake/mooncake_ep_buffer.py
@@ -536,7 +536,7 @@ class Buffer:
             (packed_recv_x, packed_recv_x_scales) if use_fp8 else packed_recv_x,
             packed_recv_count,
             handle,
-            EventOverlap(event, tensors_to_record if async_finish else None),
+            EventOverlap(event, tensors_to_record if async_finish or return_recv_hook else None),
             hook,
         )
 
@@ -677,7 +677,7 @@ class Buffer:
         )
         return (
             combined_x,
-            EventOverlap(event, tensors_to_record if async_finish else None),
+            EventOverlap(event, tensors_to_record if async_finish or return_recv_hook else None),
             hook,
         )
 


### PR DESCRIPTION
## Description



I forgot to keep-alive `tensors_to_record` under the `return_recv_hook` case, causing errors with the latest SGLang.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [x] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

SGLang's latest `test_mooncake_ep_small.py` passes.

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)



Codex helped me identify the cause of the bug.