### PR TITLE
[Bugfix] Fail SSD eviction tests on read errors

### DIFF
--- a/mooncake-wheel/tests/test_ssd_offload_in_evict.py
+++ b/mooncake-wheel/tests/test_ssd_offload_in_evict.py
@@ -207,6 +207,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         """ 
         VALUE_SIZE = 1024 * 1024 
         MAX_REQUESTS = 1000
+        KEY_PREFIX = "put_get_k_"
         reference = {}
         
         # Initialize statistics
@@ -219,7 +220,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         put_stats.start_timer()
         index = 0
         while index < MAX_REQUESTS:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             value = os.urandom(VALUE_SIZE)
             
             # Record operation start time
@@ -254,7 +255,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         failed_keys = []
         index = 0
         while index < MAX_REQUESTS:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             
             op_start = time.perf_counter()
             retrieved = self.store.get(key)
@@ -288,7 +289,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         time.sleep(default_kv_lease_ttl / 1000)
         index = 0
         while index < MAX_REQUESTS:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             self.store.remove(key)
             index = index + 1
         print("Cleanup completed")  
@@ -308,6 +309,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         NUM_THREADS = 4
         VALUE_SIZE = 1024 * 1024
         OPERATIONS_PER_THREAD = 1000
+        KEY_PREFIX = "concurrent_k_"
 
         thread_exceptions = []
         references = {}
@@ -322,7 +324,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         
         index = 0
         while index < OPERATIONS_PER_THREAD:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             value = os.urandom(VALUE_SIZE)
             references[key] = value
             index = index + 1
@@ -335,7 +337,7 @@ class TestDistributedObjectStore(unittest.TestCase):
                 put_start = time.perf_counter()
                 index = 0
                 while index < OPERATIONS_PER_THREAD:
-                    key = "k_" + str(index)
+                    key = KEY_PREFIX + str(index)
                     test_data = references[key]
                     
                     op_start = time.perf_counter()
@@ -352,7 +354,7 @@ class TestDistributedObjectStore(unittest.TestCase):
                 get_start = time.perf_counter()
                 index = 0
                 while index < OPERATIONS_PER_THREAD:
-                    key = "k_" + str(index)
+                    key = KEY_PREFIX + str(index)
                     
                     op_start = time.perf_counter()
                     retrieved_data = self.store.get(key)
@@ -422,7 +424,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         time.sleep(default_kv_lease_ttl / 1000)
         index = 0
         while index < OPERATIONS_PER_THREAD:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             self.store.remove(key)
             index += 1
         print("Cleanup completed")  
@@ -437,6 +439,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         VALUE_SIZE = 1024 * 1024 
         MAX_REQUESTS = 1000
         BATCH_SIZE = 4
+        KEY_PREFIX = "batch_get_k_"
         reference = {}
         
         # Initialize statistics
@@ -449,7 +452,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         put_stats.start_timer()
         index = 0
         while index < MAX_REQUESTS:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             value = os.urandom(VALUE_SIZE)
             
             op_start = time.perf_counter()
@@ -502,7 +505,7 @@ class TestDistributedObjectStore(unittest.TestCase):
             for _ in range(BATCH_SIZE):
                 if index >= MAX_REQUESTS:
                     break
-                key = "k_" + str(index)
+                key = KEY_PREFIX + str(index)
                 batch_keys.append(key)
                 index += 1
                 
@@ -571,7 +574,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertEqual(self.store.unregister_buffer(large_buffer_ptr), 0, "Buffer unregistration should succeed")
         index = 0
         while index < MAX_REQUESTS:
-            key = "k_" + str(index)
+            key = KEY_PREFIX + str(index)
             self.store.remove(key)
             index += 1
         print("Cleanup completed")

--- a/mooncake-wheel/tests/test_ssd_offload_in_evict.py
+++ b/mooncake-wheel/tests/test_ssd_offload_in_evict.py
@@ -428,6 +428,11 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.store.remove(key)
             index += 1
         print("Cleanup completed")  
+        self.assertEqual(
+            get_stats.failure_count,
+            0,
+            f"{get_stats.failure_count} concurrent read(s) failed",
+        )
 
     def test_batch_get_in_evict_operations(self):
         """Test batch Put/Get operations with eviction scenario

--- a/mooncake-wheel/tests/test_ssd_offload_in_evict.py
+++ b/mooncake-wheel/tests/test_ssd_offload_in_evict.py
@@ -251,6 +251,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         # Phase 2: Data verification
         # --------------------------
         get_stats.start_timer()
+        failed_keys = []
         index = 0
         while index < MAX_REQUESTS:
             key = "k_" + str(index)
@@ -265,8 +266,10 @@ class TestDistributedObjectStore(unittest.TestCase):
                 success = (retrieved == expected)
                 get_stats.record_operation(success, ADD_OPERATION_COUNT_ONE, latency, VALUE_SIZE)
                 if not success:
+                    failed_keys.append(key)
                     print(f"Data mismatch for key: {key}")
             else:
+                failed_keys.append(key)
                 get_stats.record_operation(False, ADD_OPERATION_COUNT_ONE, latency, VALUE_SIZE, -1)
             
             index = index + 1
@@ -289,6 +292,11 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.store.remove(key)
             index = index + 1
         print("Cleanup completed")  
+        self.assertEqual(
+            get_stats.failure_count,
+            0,
+            f"{get_stats.failure_count} read(s) failed; first failed keys: {failed_keys[:10]}",
+        )
 
     def test_concurrent_stress(self):
         """Multi-threaded stress test for Put/Get operations
@@ -485,6 +493,7 @@ class TestDistributedObjectStore(unittest.TestCase):
         self.assertEqual(result, 0, "Buffer registration should succeed")
 
         get_stats.start_timer()
+        failed_keys = []
         index = 0
         while index < MAX_REQUESTS:
             batch_keys = []
@@ -532,10 +541,13 @@ class TestDistributedObjectStore(unittest.TestCase):
                         success = (read_data == expected)
                         get_stats.record_operation(success, ADD_OPERATION_COUNT_ONE, NO_ADD_LATENCY, VALUE_SIZE)
                         if not success:
+                            failed_keys.append(current_key)
                             print(f"Data mismatch for key {current_key}")
                     else:
+                        failed_keys.append(current_key)
                         get_stats.record_operation(False, ADD_OPERATION_COUNT_ONE, NO_ADD_LATENCY, VALUE_SIZE, result)
                 else:
+                    failed_keys.append(current_key)
                     get_stats.record_operation(False, ADD_OPERATION_COUNT_ONE, NO_ADD_LATENCY, VALUE_SIZE, -2)
 
             if success_counter == BATCH_SIZE:
@@ -563,6 +575,11 @@ class TestDistributedObjectStore(unittest.TestCase):
             self.store.remove(key)
             index += 1
         print("Cleanup completed")
+        self.assertEqual(
+            get_stats.failure_count,
+            0,
+            f"{get_stats.failure_count} batch read(s) failed; first failed keys: {failed_keys[:10]}",
+        )
     
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Fixes #3735.

The SSD eviction test now fails after cleanup when a read returns empty or corrupted data. The same assertion is applied to the batched batch_get_into path, which had the same false-green behavior. Failure messages retain the count and the first failed keys.

This is separate from #3669: that PR only changes where the test runs and explicitly leaves this assertion gap to #3735.

## Module

- [ ] Transfer Engine
- [ ] Mooncake Store
- [ ] Reshard
- [ ] Mooncake EP
- [ ] Mooncake PG
- [ ] Integration
- [ ] P2P Store
- [x] Python Wheel
- [ ] Common
- [ ] Mooncake RL
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Test commands:

    python -m py_compile mooncake-wheel/tests/test_ssd_offload_in_evict.py
    pre-commit run ruff --files mooncake-wheel/tests/test_ssd_offload_in_evict.py
    pre-commit run codespell --files mooncake-wheel/tests/test_ssd_offload_in_evict.py

Test results:

- [x] Unit-level verification passes
- [ ] Integration tests pass
- [x] Manual testing done

A focused harness ran the actual test method against valid, empty, and corrupted batch reads. Valid data passed; both bad-read cases failed after unregistering the buffer and removing all keys. A live SSD-backed Mooncake integration test was not available locally.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using ./scripts/code_format.sh
- [ ] I have run every pre-commit hook on the changed file
- [x] Documentation is not needed for this test-only change
- [x] I have added assertions that prove the change is effective
- [x] The change is below 500 LOC, so no RFC is needed

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

Claude was used to review the two readback paths and help draft the assertions. I reviewed every changed line and verified the behavior described above.