### PR TITLE
[Bugfix][Store] Keep scanning for a local MEMORY replica past a local NoF one

### DIFF
--- a/mooncake-store/include/replica_selection.h
+++ b/mooncake-store/include/replica_selection.h
@@ -125,6 +125,7 @@ inline const Replica::Descriptor *SelectBestReplica(
     const std::unordered_set<std::string> &local_endpoints) {
     const Replica::Descriptor *first_memory = nullptr;
     const Replica::Descriptor *first_nof = nullptr;
+    const Replica::Descriptor *local_nof = nullptr;
     for (const auto &r : replicas) {
         if (r.status != ReplicaStatus::COMPLETE) continue;
         if (r.is_memory_replica()) {
@@ -138,11 +139,16 @@ inline const Replica::Descriptor *SelectBestReplica(
             if (local_endpoints.count(
                     r.get_nof_descriptor()
                         .buffer_descriptor.transport_endpoint_)) {
-                return &r;  // local NOF_SSD — also good
+                // local NOF_SSD — good, but local MEMORY outranks it and may
+                // still appear later, so remember it and keep scanning.
+                if (!local_nof) local_nof = &r;
+                continue;
             }
             if (!first_nof) first_nof = &r;
         }
     }
+    // No local MEMORY replica: a local NOF_SSD still beats every remote one.
+    if (local_nof) return local_nof;
     // No local replica. Among remote MEMORY replicas, optionally pick the
     // best-scoring one instead of the first encountered (issue #2516).
     if (first_memory && RemoteReplicaScoringEnabled()) {

--- a/mooncake-store/tests/replica_selection_test.cpp
+++ b/mooncake-store/tests/replica_selection_test.cpp
@@ -97,6 +97,44 @@ TEST_F(ReplicaSelectionTest, LocalMemoryAlwaysWins) {
         "nodeB");  // locality beats protocol
 }
 
+TEST_F(ReplicaSelectionTest, LocalMemoryWinsOverEarlierLocalNoF) {
+    // Master may return replicas in any order, so a local NOF_SSD listed
+    // before a local MEMORY replica must not win: local MEMORY outranks it.
+    std::unordered_set<std::string> local = {"nodeA"};
+    std::vector<Replica::Descriptor> reps = {
+        MakeNoF("nodeA"),             // local, but slower tier
+        MakeMemory("nodeA", "rdma"),  // local MEMORY -> must win
+    };
+    const auto* sel = SelectBestReplica(reps, local);
+    ASSERT_NE(sel, nullptr);
+    EXPECT_TRUE(sel->is_memory_replica());
+}
+
+TEST_F(ReplicaSelectionTest, IncompleteLocalMemoryFallsBackToLocalNoF) {
+    // The local MEMORY replica is not readable yet, so the local NOF_SSD one
+    // remains the best choice.
+    std::unordered_set<std::string> local = {"nodeA"};
+    std::vector<Replica::Descriptor> reps = {
+        MakeNoF("nodeA"),
+        MakeMemory("nodeA", "rdma", ReplicaStatus::PROCESSING),
+    };
+    const auto* sel = SelectBestReplica(reps, local);
+    ASSERT_NE(sel, nullptr);
+    EXPECT_TRUE(sel->is_nof_replica());
+}
+
+TEST_F(ReplicaSelectionTest, LocalNoFPrecedesRemoteMemory) {
+    // Locality still outranks tier for remote MEMORY replicas.
+    std::unordered_set<std::string> local = {"nodeA"};
+    std::vector<Replica::Descriptor> reps = {
+        MakeNoF("nodeA"),
+        MakeMemory("nodeB", "rdma"),
+    };
+    const auto* sel = SelectBestReplica(reps, local);
+    ASSERT_NE(sel, nullptr);
+    EXPECT_TRUE(sel->is_nof_replica());
+}
+
 TEST_F(ReplicaSelectionTest, ScoringOffKeepsFirstRemoteMemory) {
     // No scorer injected and env not set -> must return the FIRST remote
     // MEMORY.


### PR DESCRIPTION
## Description

`SelectBestReplica` documents the priority local MEMORY > local NOF_SSD > remote MEMORY > remote NOF_SSD, and its comments note twice that the master may return replicas in any order so the scan must not stop early. The scan did stop early. The first COMPLETE local NOF_SSD replica was returned as soon as it was seen, so a local MEMORY replica sitting later in the list was never examined and the read went over NVMe-over-Fabrics instead of local host memory.

The result depends only on the order the master happened to return, which makes it easy to miss. With the memory replica listed first the selection is correct, with the NoF replica first it is not.

The fix remembers the first local NOF_SSD replica and keeps scanning. It is returned after the loop, so it still outranks every remote replica and the rest of the policy is unchanged.

## Module
- [x] Mooncake Store (`mooncake-store`)

## Type of Change
- [x] Bug fix

## How Has This Been Tested?

Three cases added to `replica_selection_test.cpp`. `LocalMemoryWinsOverEarlierLocalNoF` fails on main and passes with this change. The other two pin behavior the fix must not break, so they pass either way. A local MEMORY replica that is not COMPLETE still falls back to the local NoF one, and a local NoF replica still beats a remote MEMORY one.

**Test commands:**
```bash
ctest -R replica_selection_test --output-on-failure
```

**Test results:**
- [x] Unit tests pass

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Claude Code helped review the selection logic against the documented priority, wrote the failing test case, and drafted the fix. I have reviewed every changed line and can defend the change end to end.