### PR TITLE
[CI/Build] Keep 0.3.13 non-CUDA wheels CUDA-free

### DIFF
--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -223,11 +223,20 @@ jobs:
           if [ "${VARIANT_FLAG:-}" = "NON_CUDA_BUILD" ]; then
             site_packages=$("$smoke_venv/bin/python" -c \
               'import sysconfig; print(sysconfig.get_paths()["purelib"])')
-            master="$site_packages/mooncake/mooncake_master"
-            if readelf -d "$master" | grep -Eq \
-              'Shared library: \[(libcuda|libcudart)\.so'; then
-              echo "Non-CUDA mooncake_master depends on CUDA"
-              readelf -d "$master" | grep 'Shared library:'
+            cuda_dependency_found=false
+            for package_path in "$site_packages"/mooncake*; do
+              [ -e "$package_path" ] || continue
+              while IFS= read -r -d '' file; do
+                cuda_dependencies=$(readelf -d "$file" 2>/dev/null | grep -E \
+                  'Shared library: \[(libcuda|libcudart|libcublas|libcufft|libcurand|libcusolver|libcusparse|libcufile|libcupti|libnvrtc|libnvJitLink|libnvToolsExt|libnvfatbin|libnvidia|libnccl)\.so' || true)
+                if [ -n "$cuda_dependencies" ]; then
+                  echo "::error file=$file::Non-CUDA wheel artifact depends on CUDA"
+                  echo "$cuda_dependencies"
+                  cuda_dependency_found=true
+                fi
+              done < <(find "$package_path" -type f -print0)
+            done
+            if [ "$cuda_dependency_found" = true ]; then
               exit 1
             fi
           fi

--- a/.github/workflows/_build-wheel.yaml
+++ b/.github/workflows/_build-wheel.yaml
@@ -214,6 +214,7 @@ jobs:
           VERSION: ${{ env.VERSION }}
 
       - name: Smoke test repaired wheel
+        shell: bash
         run: |
           smoke_venv=$(mktemp -d)
           python -m venv "$smoke_venv"

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -296,12 +296,13 @@ check_pie_supported(LANGUAGES CXX)
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE_UPPER)
 
-# Store Client sources call GPU runtime APIs directly. Detect the available
-# runtime independently from the Transfer Engine feature flags so that each
-# target below can declare its own compile and link requirements.
-find_package(CUDAToolkit QUIET)
-if(NOT CUDAToolkit_FOUND)
-  find_package(hip QUIET)
+# Store Client accelerator staging follows the explicitly selected build
+# backend. In particular, non-CUDA wheels are built in a CUDA toolchain image,
+# so SDK presence must not enable CUDA support by itself.
+if(USE_CUDA)
+  find_package(CUDAToolkit REQUIRED)
+elseif(USE_HIP)
+  find_package(hip REQUIRED)
 endif()
 
 # Sources used by both the Master and Client sides of Store.
@@ -410,13 +411,13 @@ endif()
 if(STORE_USE_ETCD)
   add_dependencies(mooncake_store_client_objects build_etcd_wrapper)
 endif()
-if(CUDAToolkit_FOUND)
-  message(STATUS "mooncake_store: CUDAToolkit detected, enabling D2H staging")
+if(USE_CUDA)
+  message(STATUS "mooncake_store: CUDA enabled, enabling D2H staging")
   target_compile_definitions(mooncake_store_client_objects PRIVATE USE_CUDA)
   target_include_directories(mooncake_store_client_objects
                              PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-elseif(hip_FOUND)
-  message(STATUS "mooncake_store: HIP detected, enabling D2H staging")
+elseif(USE_HIP)
+  message(STATUS "mooncake_store: HIP enabled, enabling D2H staging")
   target_compile_definitions(mooncake_store_client_objects PRIVATE USE_HIP)
 endif()
 if(USE_ASCEND
@@ -490,9 +491,9 @@ if(TARGET Mooncake::liburing)
   target_compile_definitions(mooncake_store PUBLIC USE_URING)
   target_link_libraries(mooncake_store PUBLIC Mooncake::liburing)
 endif()
-if(CUDAToolkit_FOUND)
+if(USE_CUDA)
   target_link_libraries(mooncake_store PRIVATE CUDA::cudart)
-elseif(hip_FOUND)
+elseif(USE_HIP)
   target_link_libraries(mooncake_store PRIVATE hip::host)
 endif()
 if(USE_ASCEND
@@ -546,12 +547,12 @@ set_target_properties(mooncake_client PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(
   mooncake_client PRIVATE mooncake_store transfer_engine asio_shared
                           gflags::gflags yalantinglibs::yalantinglibs)
-if(CUDAToolkit_FOUND)
+if(USE_CUDA)
   target_compile_definitions(mooncake_client PRIVATE USE_CUDA)
   target_include_directories(mooncake_client
                              PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
   target_link_libraries(mooncake_client PRIVATE CUDA::cudart)
-elseif(hip_FOUND)
+elseif(USE_HIP)
   target_compile_definitions(mooncake_client PRIVATE USE_HIP)
   target_link_libraries(mooncake_client PRIVATE hip::host)
 endif()


### PR DESCRIPTION
## Description

Release-branch counterpart of #3745, targeting `release/v0.3.13`.

The published 0.3.13 non-CUDA wheel still links `mooncake_client` and
`store.so` against `libcudart.so.12`. Non-CUDA wheels use a CUDA manylinux
image as their toolchain, and Store was treating the presence of that toolkit
as permission to enable CUDA staging.

This change:

- enables Store CUDA/HIP staging only when the corresponding project option is
  selected;
- requires the selected CUDA/HIP toolkit to be available;
- scans every Mooncake artifact in an installed non-CUDA wheel for CUDA runtime
  dependencies instead of checking only `mooncake_master`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [x] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake -S . -B /tmp/mooncake-noncuda-config -G Ninja \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_BENCHMARK=OFF \
  -DUSE_CUDA=OFF -DUSE_HTTP=ON -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF -DWITH_EP=OFF -DWITH_STORE_RUST=OFF
cmake --build /tmp/mooncake-noncuda-config --parallel 128 \
  --target mooncake_client store
readelf -d /tmp/mooncake-noncuda-config/mooncake-store/src/mooncake_client
readelf -d /tmp/mooncake-noncuda-config/mooncake-integration/store.cpython-310-x86_64-linux-gnu.so

cmake -S . -B /tmp/mooncake-cuda-config -G Ninja \
  -DBUILD_UNIT_TESTS=OFF -DBUILD_BENCHMARK=OFF \
  -DUSE_CUDA=ON -DUSE_HTTP=ON -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF -DWITH_EP=OFF -DWITH_STORE_RUST=OFF

pre-commit run --files \
  .github/workflows/_build-wheel.yaml \
  mooncake-store/src/CMakeLists.txt
```

**Test results:**

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done: non-CUDA targets build without CUDA `DT_NEEDED`
  entries; CUDA configuration finds and links CUDAToolkit.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable;
  no C/C++ source changed)
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: Codex helped inspect the published wheel, trace the
  CMake dependency, implement the fix, and run validation. The submitter has
  reviewed the complete diff.