### PR TITLE
[Store] Bound eventual PutStart retries in scenario tests

### DIFF
--- a/mooncake-store/tests/master_service/dsl/scenario.cpp
+++ b/mooncake-store/tests/master_service/dsl/scenario.cpp
@@ -404,9 +404,20 @@ MasterScenario& MasterScenario::WhenPutStart(PutStartActionData action) {
     if (action.group_ids.has_value()) {
         config.group_ids = std::move(action.group_ids);
     }
-    const auto result =
-        service_->PutStart(ActorId(action.actor), action.key,
-                           TenantId(action.tenant), action.size, config);
+    const auto actor_id = ActorId(action.actor);
+    const TenantId tenant_id(action.tenant);
+    const auto deadline =
+        std::chrono::steady_clock::now() + action.eventual_timeout;
+    auto result = service_->PutStart(actor_id, action.key, tenant_id,
+                                     action.size, config);
+    while (!result && action.eventual_timeout.count() > 0 &&
+           (result.error() == ErrorCode::TENANT_QUOTA_EXCEEDED ||
+            result.error() == ErrorCode::NO_AVAILABLE_HANDLE) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        result = service_->PutStart(actor_id, action.key, tenant_id,
+                                    action.size, config);
+    }
     ValidateStartResult("PutStart(" + action.key + ")", action.expected_error,
                         action.expected_replica_count,
                         action.expected_replica_status, result,

--- a/mooncake-store/tests/master_service/dsl/scenario.h
+++ b/mooncake-store/tests/master_service/dsl/scenario.h
@@ -124,6 +124,7 @@ struct PutStartActionData {
     std::optional<size_t> expected_replica_count{};
     std::optional<ReplicaStatus> expected_replica_status{};
     std::optional<std::vector<std::string>> expected_memory_nodes{};
+    std::chrono::milliseconds eventual_timeout{};
 
     template <PutStartExpectation>
     friend struct PutStartAction;
@@ -240,6 +241,15 @@ struct PutStartAction : PutStartActionData {
     {
         PutStartAction<PutStartExpectation::SUCCESS> action(*this);
         action.expected_memory_nodes.emplace(values.begin(), values.end());
+        return action;
+    }
+
+    auto Eventually(
+        std::chrono::milliseconds timeout = std::chrono::seconds(2)) const
+        requires(expectation != PutStartExpectation::ERROR)
+    {
+        PutStartAction<PutStartExpectation::SUCCESS> action(*this);
+        action.eventual_timeout = timeout;
         return action;
     }
 

--- a/mooncake-store/tests/master_service/dsl/scenario_contract_test.cpp
+++ b/mooncake-store/tests/master_service/dsl/scenario_contract_test.cpp
@@ -18,6 +18,9 @@ concept SupportsExpectStatus =
     requires(T value) { value.ExpectStatus(ReplicaStatus::COMPLETE); };
 
 template <typename T>
+concept SupportsEventually = requires(T value) { value.Eventually(); };
+
+template <typename T>
 concept SupportsIsReadable = requires(T value) { value.IsReadable(); };
 
 template <typename T>
@@ -83,7 +86,11 @@ using ReadableObjects = decltype(Objects(0, 1).AreReadable());
 
 static_assert(!SupportsExpectReplicas<ErrorExpectedPutStart>);
 static_assert(!SupportsExpectStatus<ErrorExpectedPutStart>);
+static_assert(!SupportsEventually<ErrorExpectedPutStart>);
 static_assert(!SupportsExpectError<SuccessExpectedPutStart>);
+static_assert(SupportsEventually<SuccessExpectedPutStart>);
+static_assert(!SupportsExpectError<
+              decltype(PutStart("compile-time", 1_KB).Eventually())>);
 static_assert(!SupportsExpectedReplicaCountMutation<ErrorExpectedPutStart>);
 static_assert(!SupportsExpectedErrorMutation<SuccessExpectedPutStart>);
 static_assert(!SupportsExpectReplicas<ErrorExpectedUpsertStart>);
@@ -168,6 +175,31 @@ TEST(MasterScenarioContractTest, ReportsPutStartReplicaStatusMismatch) {
             .Given(MemoryNode("memory"))
             .When(PutStart("key", 1_KB).ExpectStatus(ReplicaStatus::COMPLETE)),
         "PutStart(key) replica status mismatch");
+}
+
+TEST(MasterScenarioContractTest, PutStartEventuallyHasBoundedTimeout) {
+    MasterScenario scenario("bounded put start eventual timeout");
+    scenario.Given(MemoryNode("memory").Capacity(1_KB));
+
+    const auto started = std::chrono::steady_clock::now();
+    EXPECT_NONFATAL_FAILURE(
+        scenario.When(PutStart("key", 2_KB)
+                          .ExpectReplicas(1)
+                          .Eventually(std::chrono::milliseconds(10))),
+        "PutStart(key) failed: NO_AVAILABLE_HANDLE");
+    EXPECT_LT(std::chrono::steady_clock::now() - started,
+              std::chrono::seconds(1));
+}
+
+TEST(MasterScenarioContractTest, PutStartEventuallyStopsOnPermanentError) {
+    MasterScenario scenario("put start eventual permanent error");
+    scenario.Given(MemoryNode("memory")).When(PutStart("key", 1_KB));
+
+    const auto started = std::chrono::steady_clock::now();
+    EXPECT_NONFATAL_FAILURE(scenario.When(PutStart("key", 1_KB).Eventually()),
+                            "PutStart(key) failed: OBJECT_ALREADY_EXISTS");
+    EXPECT_LT(std::chrono::steady_clock::now() - started,
+              std::chrono::seconds(1));
 }
 
 TEST(MasterScenarioContractTest, ReportsUpsertStartReplicaCountMismatch) {

--- a/mooncake-store/tests/master_service_evict_scenario_test.cpp
+++ b/mooncake-store/tests/master_service_evict_scenario_test.cpp
@@ -505,7 +505,8 @@ TEST_F(MasterServiceEvictScenarioTest,
     ReadBatchEventually(storage, 3, batch);
     scenario.When(PutStart("after-durable", kObjectSize)
                       .ForTenant(tenant)
-                      .ExpectReplicas(1));
+                      .ExpectReplicas(1)
+                      .Eventually());
 }
 
 TEST_F(MasterServiceEvictScenarioTest,


### PR DESCRIPTION
## Description

Fix a flaky nightly coverage test caused by a race between batch OpLog durability and asynchronous eviction cleanup.

`master_service_evict_scenario_test` could observe the eviction OpLog batch as durable before the durable callback had finished releasing the evicted memory replica. As a result, the following `PutStart` could intermittently fail with `NO_AVAILABLE_HANDLE` even though the tenant quota had already become reclaimable.

This change:

- adds a bounded `.Eventually()` mode for successful `PutStart` actions in the typed `MasterScenario` DSL;
- retries only transient `TENANT_QUOTA_EXCEEDED` and `NO_AVAILABLE_HANDLE` errors;
- uses a hard deadline to guarantee bounded execution;
- stops immediately for permanent errors such as `OBJECT_ALREADY_EXISTS`;
- updates the durability eviction scenario to wait for the next `PutStart` to succeed;
- adds contract tests covering timeout behavior, permanent errors, and compile-time restrictions.

The production eviction and OpLog implementations are unchanged.

## Module

- [x] Mooncake Store (`mooncake-store`)
- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build build --target master_scenario_test master_service_evict_scenario_test -j32

ctest --test-dir build \
  -R '^(master_scenario_test|master_service_evict_scenario_test)$' \
  --output-on-failure

./build/mooncake-store/tests/master_service_evict_scenario_test \
  --gtest_filter=MasterServiceEvictScenarioTest.OpLogDurabilityGatesTenantQuotaReclamation \
  --gtest_repeat=200 \
  --gtest_break_on_failure

cmake --build build-coverage \
  --target master_scenario_test master_service_evict_scenario_test -j32

env LSAN_OPTIONS=detect_leaks=0 \
  ctest --test-dir build-coverage \
  -R '^(master_scenario_test|master_service_evict_scenario_test)$' \
  --output-on-failure

env LSAN_OPTIONS=detect_leaks=0 \
  ./build-coverage/mooncake-store/tests/master_service_evict_scenario_test \
  --gtest_filter=MasterServiceEvictScenarioTest.OpLogDurabilityGatesTenantQuotaReclamation \
  --gtest_repeat=20 \
  --gtest_break_on_failure

pre-commit run --files \
  mooncake-store/tests/master_service/dsl/scenario.h \
  mooncake-store/tests/master_service/dsl/scenario.cpp \
  mooncake-store/tests/master_service/dsl/scenario_contract_test.cpp \
  mooncake-store/tests/master_service_evict_scenario_test.cpp
```

Test results:

- [x] Unit tests pass
- [x] ASAN/coverage validation passes
- [x] Original failing eviction scenario passes
- [x] Original failing scenario passes 200 repeated runs in the regular build
- [x] Original failing scenario passes 20 repeated runs in the ASAN/coverage build
- [x] Pre-commit checks pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using ./scripts/code_format.sh
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (OpenAI Codex)

Codex assisted with nightly failure analysis, implementation, test design, and validation. The human submitter has reviewed the changed lines and is responsible for understanding and defending the change end-to-end.