### PR TITLE
[CI/Build] Run etcd wrapper Go tests with CTest

### DIFF
--- a/mooncake-common/etcd/CMakeLists.txt
+++ b/mooncake-common/etcd/CMakeLists.txt
@@ -14,6 +14,13 @@ add_custom_target(
     DEPENDS ${ETCD_WRAPPER_LIB}
 )
 
+if(BUILD_UNIT_TESTS)
+  add_test(
+    NAME etcd_wrapper_go_test
+    COMMAND go test ./...
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
 install(
     FILES ${ETCD_WRAPPER_LIB}
     DESTINATION lib


### PR DESCRIPTION
## Description

Register `go test ./...` for `mooncake-common/etcd` as a CTest test when `BUILD_UNIT_TESTS` is enabled. The existing etcd-enabled nightly job already uses that option and runs the top-level CTest suite, so a wrapper test failure now fails the job. Local builds can run the same test with `ctest -R '^etcd_wrapper_go_test$'`.

Closes #3752.

PR #2643 proposes moving this wrapper into `mooncake-common/ha-wrapper`. If it lands, the test registration will need to move with it.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**

```bash
cd mooncake-common/etcd
go test ./...
cd ../..

cmake_root=$(cmake --system-information | sed -n 's/^CMAKE_ROOT "\(.*\)"$/\1/p')
cmake -Wno-dev -S mooncake-common/etcd \
  -B /tmp/mooncake-etcd-ctest-pr-3752-on \
  -DBUILD_UNIT_TESTS=ON \
  -DCMAKE_PROJECT_INCLUDE="$cmake_root/Modules/CTest.cmake"
ctest --test-dir /tmp/mooncake-etcd-ctest-pr-3752-on \
  -N -R '^etcd_wrapper_go_test$'
ctest --test-dir /tmp/mooncake-etcd-ctest-pr-3752-on \
  -R '^etcd_wrapper_go_test$' --output-on-failure

cmake -Wno-dev -S mooncake-common/etcd \
  -B /tmp/mooncake-etcd-ctest-pr-3752-off \
  -DBUILD_UNIT_TESTS=OFF \
  -DCMAKE_PROJECT_INCLUDE="$cmake_root/Modules/CTest.cmake"
ctest --test-dir /tmp/mooncake-etcd-ctest-pr-3752-off \
  -N -R '^etcd_wrapper_go_test$'

git diff --check
SKIP=cmake-format pre-commit run --files mooncake-common/etcd/CMakeLists.txt
```

**Test results:**

- [x] Unit tests pass: the current wrapper module reports no test files.
- [ ] Integration tests pass (not applicable; this only registers the existing Go test command).
- [x] Manual testing done: CTest discovered the test with `BUILD_UNIT_TESTS=ON`, omitted it with `BUILD_UNIT_TESTS=OFF`, and passed the current module. A temporary failing `*_test.go` made CTest fail as expected and was removed after the check.

The non-CMake pre-commit hooks pass. `cmake-format` also formats 14 pre-existing lines in this 20-line file. Those unrelated changes are not included; the new block uses the formatter's output.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh` (not applicable; no C or C++ source changed)
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass (see the `cmake-format` note above)
- [ ] I have updated the documentation (not applicable; the test is exposed through CTest)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable; this change adds seven lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used: AI assistance helped trace the CMake and CI paths, prepare the focused change, and run the checks above. The submitter reviewed every changed line and can explain the change end to end.