### PR TITLE
[Bugfix][TENT] Retry RDMA bootstrap after stale peer endpoints

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/control_plane.h
@@ -48,7 +48,7 @@ struct BootstrapDesc {
     // RDMA address of local_nic_path.
     uint16_t local_lid = 0;
     std::string local_gid;
-    std::string reply_msg;       // on error
+    std::string reply_msg;  // non-empty means the bootstrap callback failed
     uint32_t notify_qp_num = 0;  // Notification QP number (0 = not supported)
 
    public:
@@ -80,6 +80,11 @@ class ControlClient {
     static Status bootstrap(const std::string& server_addr,
                             const BootstrapDesc& request,
                             BootstrapDesc& response);
+
+    // Parse a BootstrapRdma RPC body. A non-empty reply_msg or missing GID is
+    // a handshake failure even when the RPC transport itself succeeded.
+    static Status decodeBootstrapResponse(const std::string& response_raw,
+                                          BootstrapDesc& response);
 
     static Status sendData(const std::string& server_addr,
                            uint64_t peer_mem_addr, void* local_mem_addr,

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -16,6 +16,7 @@
 #include "tent/runtime/transfer_engine_impl.h"
 
 #include <cassert>
+#include <exception>
 #include <set>
 #include <utility>
 
@@ -57,6 +58,24 @@ Status ControlClient::getSegmentDesc(const std::string& server_addr,
     return tl_rpc_agent.call(server_addr, GetSegmentDesc, request, response);
 }
 
+Status ControlClient::decodeBootstrapResponse(const std::string& response_raw,
+                                              BootstrapDesc& response) {
+    try {
+        response = json::parse(response_raw).get<BootstrapDesc>();
+    } catch (const std::exception& e) {
+        return Status::MalformedJson(
+            std::string("Invalid bootstrap response: ") + e.what() + LOC_MARK);
+    }
+    if (!response.reply_msg.empty()) {
+        return Status::RpcServiceError(response.reply_msg);
+    }
+    if (response.local_gid.empty()) {
+        return Status::InvalidArgument(
+            "Missing peer GID in bootstrap" LOC_MARK);
+    }
+    return Status::OK();
+}
+
 Status ControlClient::bootstrap(const std::string& server_addr,
                                 const BootstrapDesc& request,
                                 BootstrapDesc& response) {
@@ -65,8 +84,7 @@ Status ControlClient::bootstrap(const std::string& server_addr,
     request_raw = j.dump();
     CHECK_STATUS(tl_rpc_agent.call(server_addr, BootstrapRdma, request_raw,
                                    response_raw));
-    response = json::parse(response_raw).get<BootstrapDesc>();
-    return Status::OK();
+    return decodeBootstrapResponse(response_raw, response);
 }
 
 Status ControlClient::sendData(const std::string& server_addr,

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -19,18 +19,20 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <sstream>
 #include <iomanip>
-#include <queue>
 #include <mutex>
+#include <queue>
+#include <sstream>
+#include <string_view>
 
 #include "tent/common/status.h"
 #include "tent/common/types.h"
-#include "tent/transport/rdma/context.h"
-#include "tent/transport/rdma/endpoint_store.h"
 #include "tent/common/utils/os.h"
 #include "tent/common/utils/string_builder.h"
+#include "tent/runtime/control_plane.h"
 #include "tent/thirdparty/nlohmann/json.h"
+#include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/endpoint_store.h"
 
 namespace mooncake {
 namespace tent {
@@ -58,6 +60,18 @@ static int setupNotifyQpConnection(ibv_qp* qp, RdmaContext* ctx,
                                    uint16_t pkey_index,
                                    uint8_t service_level = 0,
                                    uint8_t traffic_class = 0);
+
+// A peer that reused the same nic path after restarting retires the stale
+// endpoint on the first bootstrap and expects a retry. Older peers also
+// returned success with an empty GID for that case.
+static bool isStaleEndpointBootstrapError(const Status& status) {
+    if (status.ok()) return false;
+    const std::string_view msg = status.message();
+    return msg.find("retired for reconnection") != std::string_view::npos ||
+           msg.find("Missing peer GID") != std::string_view::npos ||
+           msg.find("Endpoint not in handshaking state") !=
+               std::string_view::npos;
+}
 
 RdmaEndPoint::RdmaEndPoint()
     : status_(EP_UNINIT),
@@ -470,25 +484,53 @@ Status RdmaEndPoint::connect(const std::string& peer_server_name,
         }
         auto bootstrap_status =
             ControlClient::bootstrap(rpc_server_addr, local_desc, peer_desc);
+        auto simultaneousOpenReady = [&]() {
+            RWSpinlock::WriteGuard guard(lock_);
+            const bool same_peer = peer_server_name_ == peer_server_name &&
+                                   peer_nic_name_ == peer_nic_name;
+            const bool same_local_qps = qpNum() == local_desc.qp_num;
+            return status_.load(std::memory_order_relaxed) == EP_READY &&
+                   same_peer && same_local_qps;
+        };
         if (!bootstrap_status.ok()) {
             // With simultaneous open, the peer's bootstrap request may finish
             // our passive setup while this outbound RPC is still in flight.
             // A timeout therefore does not necessarily mean that connection
             // establishment failed. Reuse only the exact endpoint generation
             // that issued this RPC; EP_READY alone is not sufficient.
-            RWSpinlock::WriteGuard guard(lock_);
-            const bool same_peer = peer_server_name_ == peer_server_name &&
-                                   peer_nic_name_ == peer_nic_name;
-            const bool same_local_qps = qpNum() == local_desc.qp_num;
-            if (status_.load(std::memory_order_relaxed) == EP_READY &&
-                same_peer && same_local_qps) {
+            if (simultaneousOpenReady()) {
                 LOG(WARNING)
                     << "Bootstrap RPC failed after simultaneous-open passive "
                        "setup completed; reusing the established endpoint "
                     << endpoint_name_ << ": " << bootstrap_status.ToString();
                 return mooncake::tent::Status::OK();
             }
-            return bootstrap_status;
+            // Target retired a leftover endpoint from a previous peer process.
+            // The first RPC drops it; a second bootstrap creates a new one.
+            // Fixed targets also retry inside the same RPC, so this is the
+            // mixed-version / race fallback.
+            if (isStaleEndpointBootstrapError(bootstrap_status)) {
+                LOG(INFO)
+                    << "Retrying RDMA bootstrap after stale peer endpoint: "
+                    << bootstrap_status.ToString();
+                peer_desc = BootstrapDesc();
+                bootstrap_status = ControlClient::bootstrap(
+                    rpc_server_addr, local_desc, peer_desc);
+                if (!bootstrap_status.ok()) {
+                    if (simultaneousOpenReady()) {
+                        LOG(WARNING)
+                            << "Bootstrap retry failed after simultaneous-open "
+                               "passive setup completed; reusing the "
+                               "established endpoint "
+                            << endpoint_name_ << ": "
+                            << bootstrap_status.ToString();
+                        return mooncake::tent::Status::OK();
+                    }
+                    return bootstrap_status;
+                }
+            } else {
+                return bootstrap_status;
+            }
         }
         qp_num = peer_desc.qp_num;
         peer_gid = peer_desc.local_gid;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -674,27 +674,46 @@ int RdmaTransport::onSetupRdmaConnections(const BootstrapDesc& peer_desc,
         local_desc.reply_msg = ss.str();
         return -1;
     }
-    auto endpoint =
-        context->endpointStore()->getOrInsert(peer_desc.local_nic_path);
-    if (!endpoint) {
-        std::stringstream ss;
-        ss << "Cannot allocate endpoint: " << peer_desc.local_nic_path;
-        LOG(ERROR) << ss.str();
-        local_desc.reply_msg = ss.str();
-        return -1;
-    }
-    auto status = endpoint->accept(peer_desc, local_desc);
-    if (!status.ok()) {
-        if (endpoint->status() == RdmaEndPoint::EP_DESTROYING ||
-            endpoint->status() == RdmaEndPoint::EP_DESTROYED) {
-            context->endpointStore()->remove(endpoint.get());
+    // Endpoints are never reset. A peer process that reused the same nic path
+    // (same IP:port after a restart) hits an EP_READY endpoint whose QPs no
+    // longer exist. accept() retires it and the next getOrInsert() creates a
+    // fresh one. Do that retry inside this RPC so the initiator receives a
+    // valid GID instead of an empty bootstrap reply.
+    auto store = context->endpointStore();
+    constexpr int kMaxAcceptAttempts = 2;
+    for (int attempt = 0; attempt < kMaxAcceptAttempts; ++attempt) {
+        auto endpoint = store->getOrInsert(peer_desc.local_nic_path);
+        if (!endpoint) {
+            std::stringstream ss;
+            ss << "Cannot allocate endpoint: " << peer_desc.local_nic_path;
+            LOG(ERROR) << ss.str();
+            local_desc.reply_msg = ss.str();
+            return -1;
+        }
+        local_desc = BootstrapDesc();
+        auto status = endpoint->accept(peer_desc, local_desc);
+        if (status.ok()) {
+            local_desc.reply_msg.clear();
+            return 0;
+        }
+        const auto ep_status = endpoint->status();
+        const bool retired = ep_status == RdmaEndPoint::EP_DESTROYING ||
+                             ep_status == RdmaEndPoint::EP_DESTROYED;
+        if (retired) {
+            store->remove(endpoint.get());
+            if (attempt + 1 < kMaxAcceptAttempts) {
+                LOG(INFO) << "Retrying RDMA bootstrap after retiring stale "
+                             "endpoint for "
+                          << peer_desc.local_nic_path;
+                continue;
+            }
         }
         LOG(ERROR) << status.ToString();
         local_desc.reply_msg = status.ToString();
         return -1;
     }
 
-    return 0;
+    return -1;
 }
 
 std::shared_ptr<RdmaEndPoint> RdmaTransport::getEndpoint(SegmentID target_id,

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -207,6 +207,13 @@ target_include_directories(tent_endpoint_lifecycle_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_endpoint_lifecycle_test COMMAND tent_endpoint_lifecycle_test)
 
+add_executable(tent_bootstrap_response_test bootstrap_response_test.cpp)
+target_link_libraries(tent_bootstrap_response_test PRIVATE gtest gtest_main
+                                                           tent_link_group)
+target_include_directories(tent_bootstrap_response_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+add_test(NAME tent_bootstrap_response_test COMMAND tent_bootstrap_response_test)
+
 add_executable(tent_endpoint_store_test endpoint_store_test.cpp)
 target_link_libraries(tent_endpoint_store_test PRIVATE gtest gtest_main
                                                        tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/bootstrap_response_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/bootstrap_response_test.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include "tent/runtime/control_plane.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+TEST(BootstrapResponseTest, ValidGidIsSuccess) {
+    BootstrapDesc desc;
+    desc.local_gid = "fe80::1";
+    desc.qp_num = {1, 2};
+    BootstrapDesc parsed;
+    auto status =
+        ControlClient::decodeBootstrapResponse(json(desc).dump(), parsed);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(parsed.local_gid, "fe80::1");
+    EXPECT_EQ(parsed.qp_num, desc.qp_num);
+}
+
+TEST(BootstrapResponseTest, ReplyMsgIsHandshakeFailure) {
+    BootstrapDesc desc;
+    desc.local_gid = "fe80::1";
+    desc.reply_msg = "Endpoint retired for reconnection from peer";
+    BootstrapDesc parsed;
+    auto status =
+        ControlClient::decodeBootstrapResponse(json(desc).dump(), parsed);
+    EXPECT_TRUE(status.IsRpcServiceError());
+    EXPECT_NE(status.message().find("retired for reconnection"),
+              std::string_view::npos);
+}
+
+TEST(BootstrapResponseTest, EmptyGidIsHandshakeFailure) {
+    BootstrapDesc desc;
+    BootstrapDesc parsed;
+    auto status =
+        ControlClient::decodeBootstrapResponse(json(desc).dump(), parsed);
+    EXPECT_TRUE(status.IsInvalidArgument());
+    EXPECT_NE(status.message().find("Missing peer GID"),
+              std::string_view::npos);
+}
+
+TEST(BootstrapResponseTest, InvalidJsonIsMalformed) {
+    BootstrapDesc parsed;
+    auto status = ControlClient::decodeBootstrapResponse("not-json", parsed);
+    EXPECT_TRUE(status.IsMalformedJson());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/endpoint_lifecycle_test.cpp
@@ -185,6 +185,10 @@ TEST(EndpointLifecycleTest, BootstrapWithNewPeerQpsRetiresEstablishedEndpoint) {
 
     EXPECT_FALSE(endpoint.accept(peer_desc, local_desc).ok());
     EXPECT_EQ(endpoint.status(), RdmaEndPoint::EP_DESTROYING);
+    // The failed accept does not populate a GID. The transport retries on a
+    // newly inserted endpoint in the same bootstrap RPC so the initiator is
+    // not left with an empty reply.
+    EXPECT_TRUE(local_desc.local_gid.empty());
 }
 
 TEST(EndpointLifecycleTest, ExternalOwnerCanReleaseAfterExplicitDeconstruct) {


### PR DESCRIPTION
## Description

When an initiator process restarts and reuses the same nic path (`IP:port`),
the target still holds an `EP_READY` endpoint whose QPs no longer exist.
#3188 correctly retires that endpoint, but `onSetupRdmaConnections()` returned
from the same RPC without inserting a replacement. `ControlClient::bootstrap()`
then treated RPC transport success as handshake success, so the initiator saw
an empty `local_gid` and failed with `Missing peer GID in bootstrap`.

This change:

- retries `accept()` once inside the same bootstrap RPC after retiring the
  stale endpoint, so the first handshake can return a valid GID
- treats a non-empty `reply_msg` or empty GID as a handshake failure in
  `ControlClient::decodeBootstrapResponse()`
- retries `connect()` once on the initiator for mixed-version peers and the
  remaining retire race

Follow-up to #3188. No GitHub issue filed for this specific failure.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build-gid-fix -j32 \
  --target tent_bootstrap_response_test tent_endpoint_lifecycle_test
./build-gid-fix/mooncake-transfer-engine/tent/tests/tent_bootstrap_response_test
./build-gid-fix/mooncake-transfer-engine/tent/tests/tent_endpoint_lifecycle_test
# Two-node tebench: keep target on 10.206.0.9:19001, restart initiator
# four times with --rpc_server_port=19002 (same nic path).
./scripts/code_format.sh --check --changed-lines --base origin/main
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- `tent_bootstrap_response_test`: 4/4 passed
- `tent_endpoint_lifecycle_test`: 15/15 passed
- tebench DRAM / TENT / RDMA, target left running: four initiator reconnects
  (4KB, 4KB, 1MB, 16MB) all succeeded; no `Missing peer GID` or
  `Failed transfer`. Previously the second 4KB run failed on reuse.
- `./scripts/code_format.sh --check --changed-lines --base origin/main` passed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

`cmake-format` would rewrite unrelated targets in
`mooncake-transfer-engine/tent/tests/CMakeLists.txt`; only the new
`tent_bootstrap_response_test` target is included.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok 4.6) helped diagnose the empty-GID bootstrap path, implement the
same-RPC retry / decode / connect retry, and add unit tests. The submitter
reviewed every changed line and reproduced the tebench reuse case before and
after the fix.

Made with [Cursor](https://cursor.com)