### PR TITLE
Revert "[CI/Build] Add RISC-V build support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
   [![GitHub commit activity](https://img.shields.io/github/commit-activity/w/kvcache-ai/Mooncake)](https://github.com/kvcache-ai/Mooncake/graphs/commit-activity)
   [![license](https://img.shields.io/github/license/kvcache-ai/mooncake.svg)](https://github.com/kvcache-ai/Mooncake/blob/main/LICENSE-APACHE)
   [![Docker](https://img.shields.io/docker/v/kvcacheai/mooncake?label=docker&logo=docker&logoColor=white&color=2496ED)](https://hub.docker.com/r/kvcacheai/mooncake)
-  [![RISC-V](https://img.shields.io/badge/RISC--V-supported-283272?logo=riscv&logoColor=white)](https://kvcache-ai.github.io/Mooncake/getting_started/build.html#risc-v-build)
   <br />
 
   [![PyPI CUDA <=12.9](https://img.shields.io/static/v1?label=pypi&message=CUDA%20%3C%3D12.9&color=76B900)](https://pypi.org/project/mooncake-transfer-engine)

--- a/docs/source/getting_started/build.md
+++ b/docs/source/getting_started/build.md
@@ -75,38 +75,6 @@ sudo make install
 `-DUSE_NOF=ON` builds the NoF registration APIs and deployment tools. Use
 `-DUSE_NOF=OFF` or omit the option when the NVMe-oF SSD pool is not needed.
 
-### RISC-V Build
-
-Mooncake supports native 64-bit RISC-V Linux builds with `USE_RISCV` enabled.
-The option keeps regular Release optimizations but disables interprocedural
-optimization for the Python extensions, avoiding the excessive memory use of
-full GNU LTO on RISC-V build hosts. The build also detects whether 16-byte
-atomic operations require `libatomic` and links it automatically.
-
-The following configuration builds the C++, Python, and Rust components while
-disabling every component that requires Go:
-
-```bash
-mkdir build-riscv
-cd build-riscv
-cmake -G Ninja .. \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DUSE_RISCV=ON \
-  -DWITH_STORE_GO=OFF \
-  -DWITH_P2P_STORE=OFF \
-  -DUSE_ETCD=OFF \
-  -DSTORE_USE_ETCD=OFF \
-  -DSTORE_USE_K8S_LEASE=OFF \
-  -DBUILD_UNIT_TESTS=OFF \
-  -DBUILD_EXAMPLES=OFF \
-  -DBUILD_BENCHMARK=OFF
-cmake --build . --parallel 4
-```
-
-Adjust the parallel job count for the available memory. The example uses four
-jobs because optimized C++ and Python binding translation units can each need
-several gigabytes of memory on RISC-V.
-
 ### Hardware Backend Setup
 
 Run `sudo bash dependencies.sh` before using any of these backend-specific build
@@ -238,7 +206,6 @@ The following options can be passed to `cmake ..`.
 | `-DUSE_HYGON=ON/OFF` | `OFF` | Enable Hygon DCU support via DTK SDK. Uses a CUDA-compatible runtime. |
 | `-DUSE_COREX=ON/OFF` | `OFF` | Enable Iluvatar CoreX GPU support. Uses a CUDA-compatible runtime. |
 | `-DUSE_MLU=ON/OFF` | `OFF` | Enable Cambricon MLU memory support via Neuware, including memory detection, topology discovery, and RDMA registration. |
-| `-DUSE_RISCV=ON/OFF` | `OFF` | Enable RISC-V build compatibility settings, including disabling full IPO/LTO for Python extensions. |
 | `-DUSE_ASCEND_DIRECT=ON/OFF` | `OFF` | Enable Ascend Direct transport and HCCS support via the ADXL engine. Recommended for Ascend builds. |
 | `-DUSE_UBSHMEM=ON/OFF` | `OFF` | Enable Huawei Ascend NPU shared memory transport via CANN VMM APIs. |
 | `-DUSE_INTRA_NVLINK=ON/OFF` | `OFF` | Enable intranode NVLink transport. |

--- a/mooncake-common/common.cmake
+++ b/mooncake-common/common.cmake
@@ -87,20 +87,6 @@ option(USE_HIP "option for enabling gpu features for AMD GPU" OFF)
 option(USE_HYGON "option for enabling gpu features for Hygon DCU with DTK" OFF)
 option(USE_COREX "option for enabling gpu features for Iluvatar CoreX" OFF)
 option(USE_SUPA "option for enabling gpu features for Biren GPU with SUPA" OFF)
-option(USE_RISCV "Enable RISC-V build compatibility settings" OFF)
-if(USE_RISCV)
-  if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^riscv")
-    message(
-      WARNING
-        "USE_RISCV is enabled, but CMAKE_SYSTEM_PROCESSOR is '${CMAKE_SYSTEM_PROCESSOR}'"
-    )
-  endif()
-  # Define this before any pybind11 module is created. Otherwise pybind11 adds
-  # its default full-LTO target, which is prohibitively resource-intensive on
-  # RISC-V build hosts.
-  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
-  message(STATUS "RISC-V: IPO disabled for Mooncake Python extensions")
-endif()
 option(USE_NVMEOF "option for using NVMe over Fabric" OFF)
 option(USE_TCP "option for using TCP transport" ON)
 option(USE_BAREX "option for using accl-barex transport" OFF)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -108,44 +108,6 @@ endif()
 set(EXTRA_LIBS "")
 set(SPDK_STATIC_LIBS "")
 
-# RISC-V toolchains may implement 16-byte atomic operations in libatomic rather
-# than emitting native instructions. Boost.Lockfree uses these operations in the
-# Store master, so detect and propagate the runtime library in RISC-V mode.
-if(USE_RISCV)
-  include(CheckCXXSourceCompiles)
-  check_cxx_source_compiles(
-    "
-alignas(16) volatile unsigned __int128 value = 0;
-int main(int argc, char**) {
-  __atomic_store_n(&value, static_cast<unsigned __int128>(argc),
-                   __ATOMIC_SEQ_CST);
-  return static_cast<int>(__atomic_load_n(&value, __ATOMIC_SEQ_CST));
-}
-"
-    MOONCAKE_HAS_NATIVE_16BYTE_ATOMICS)
-  if(NOT MOONCAKE_HAS_NATIVE_16BYTE_ATOMICS)
-    set(CMAKE_REQUIRED_LIBRARIES_SAVE ${CMAKE_REQUIRED_LIBRARIES})
-    set(CMAKE_REQUIRED_LIBRARIES atomic)
-    check_cxx_source_compiles(
-      "
-alignas(16) volatile unsigned __int128 value = 0;
-int main(int argc, char**) {
-  __atomic_store_n(&value, static_cast<unsigned __int128>(argc),
-                   __ATOMIC_SEQ_CST);
-  return static_cast<int>(__atomic_load_n(&value, __ATOMIC_SEQ_CST));
-}
-"
-      MOONCAKE_HAS_LIBATOMIC_16BYTE_ATOMICS)
-    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_SAVE})
-    if(MOONCAKE_HAS_LIBATOMIC_16BYTE_ATOMICS)
-      list(APPEND EXTRA_LIBS atomic)
-      message(STATUS "16-byte atomics: using libatomic")
-    else()
-      message(FATAL_ERROR "16-byte atomic operations are not supported")
-    endif()
-  endif()
-endif()
-
 # Find AWS SDK
 find_package(AWSSDK QUIET COMPONENTS s3)
 if(AWSSDK_FOUND)


### PR DESCRIPTION
This reverts kvcache-ai/Mooncake#3590, as it was merged while we were still having an offline discussion about whether we should add this badge here. Since we support a wide range of architectures, not just RISC-V, highlighting only RISC-V here may seem a bit out of place. I would suggest instead listing the architectures we support, such as x86_64 and RISC-V, in the Supported Hardware section, perhaps alongside the sentence: “Mooncake supports hardware backends across accelerator vendors, cloud fabrics, and standard datacenter interconnects.”