### PR TITLE
[Bugfix][Store] Remove partial files after short pwritev

### DIFF
--- a/mooncake-store/src/posix_file.cpp
+++ b/mooncake-store/src/posix_file.cpp
@@ -117,8 +117,14 @@ tl::expected<size_t, ErrorCode> PosixFile::vector_write(const iovec *iov,
         return make_error<size_t>(ErrorCode::FILE_NOT_FOUND);
     }
 
+    size_t expected_bytes = 0;
+    for (int i = 0; i < iovcnt; ++i) expected_bytes += iov[i].iov_len;
+
     ssize_t ret = ::pwritev(fd_, iov, iovcnt, offset);
     if (ret < 0) {
+        return make_error<size_t>(ErrorCode::FILE_WRITE_FAIL);
+    }
+    if (static_cast<size_t>(ret) != expected_bytes) {
         return make_error<size_t>(ErrorCode::FILE_WRITE_FAIL);
     }
 

--- a/mooncake-store/tests/posix_file_test.cpp
+++ b/mooncake-store/tests/posix_file_test.cpp
@@ -1,9 +1,13 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <array>
+#include <cerrno>
+#include <csignal>
 #include <cstdlib>
 #include <memory>
 #include <fcntl.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <sys/uio.h>
 #include <string_view>
@@ -164,6 +168,50 @@ TEST_F(PosixFileTest, VectorizedWrite) {
                         << toString(result.error());
     EXPECT_EQ(*result, data1.size() + data2.size());
     EXPECT_EQ(posix_file.get_error_code(), ErrorCode::OK);
+}
+
+// A short pwritev must be treated as a failed write. Otherwise the PosixFile
+// destructor has no failure state and leaves a truncated object on disk.
+TEST_F(PosixFileTest, ShortVectorizedWriteRemovesPartialFile) {
+#if defined(RLIMIT_FSIZE) && defined(SIGXFSZ)
+    const std::string partial_filename =
+        "short_vector_write_" + std::to_string(getpid()) + ".tmp";
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << "Failed to fork short-write test";
+
+    if (child == 0) {
+        if (signal(SIGXFSZ, SIG_IGN) == SIG_ERR) _exit(10);
+
+        const struct rlimit limit = {4096, 4096};
+        if (setrlimit(RLIMIT_FSIZE, &limit) != 0) _exit(11);
+
+        int fd =
+            open(partial_filename.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+        if (fd < 0) _exit(12);
+
+        std::string data(8192, 'x');
+        {
+            PosixFile posix_file(partial_filename, fd);
+            iovec iov{data.data(), data.size()};
+            auto result = posix_file.vector_write(&iov, 1, 0);
+            if (result || result.error() != ErrorCode::FILE_WRITE_FAIL)
+                _exit(13);
+        }
+
+        if (access(partial_filename.c_str(), F_OK) == 0) _exit(14);
+        if (errno != ENOENT) _exit(15);
+        _exit(0);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    unlink(partial_filename.c_str());
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+#else
+    GTEST_SKIP() << "RLIMIT_FSIZE/SIGXFSZ is unavailable on this platform";
+#endif
 }
 
 // Test vectorized read operation


### PR DESCRIPTION
## Description

### Problem

`pwritev` can return a positive byte count smaller than the requested iovec
length. `PosixFile::vector_write` previously returned this as success, so its
error state remained `OK` even though the caller rejected the size mismatch.
The destructor therefore did not remove the partially written file, leaving
untracked disk usage or an incomplete file for recovery scanning.

### When it can happen

A positive short write can occur when the filesystem or quota becomes full,
when a file-size limit is reached, or when available space changes between
Mooncake's space check and the actual write.

### Solution

The write now succeeds only when `pwritev` returns the full requested length.
A short result sets `FILE_WRITE_FAIL`, allowing the existing RAII cleanup to
remove the incomplete file. A regression test uses `RLIMIT_FSIZE` to force a
short write and verifies both the error and file removal.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

### Code paths covered

- `PosixFile::vector_write` rejects positive short `pwritev` results.
- Existing RAII cleanup is verified for the POSIX path.

### Test commands

```bash
cmake --build <build-dir> --target posix_file_test -j2
<build-dir>/mooncake-store/tests/posix_file_test --gtest_color=no
<build-dir>/mooncake-store/tests/storage_backend_test --gtest_color=no
git diff --check
pre-commit run --files \
  mooncake-store/src/posix_file.cpp \
  mooncake-store/tests/posix_file_test.cpp
```

### Test results

- [x] Unit tests pass: `posix_file_test`, 15/15 tests.
- [x] Storage backend tests pass: `storage_backend_test`, 100/100 tests.
- [x] Deterministic POSIX regression test passes:
  `PosixFileTest.ShortVectorizedWriteRemovesPartialFile`.
- [x] `git diff --check` passes.
- [x] Pre-commit passes, including the repository C/C++ formatting hook,
  whitespace, spelling, and metadata checks.
- [ ] Integration tests pass (not run; the focused unit and storage backend
  suites cover this local file-handling change).
- [x] Manual system-call validation done: under `RLIMIT_FSIZE`, `pwritev`
  returned a positive short result (`8192` requested, `4096` written), and the
  partial file was removed.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have formatted my code using `./scripts/code_format.sh` (through the
  pre-commit C/C++ hook).
- [x] I have run pre-commit on the files changed in this PR and all hooks pass.
- [x] I have added tests to prove my changes are effective.
- [x] Documentation update is not applicable; this is internal failure
  handling with no new user-facing configuration.
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable; this
  change is below 500 LOC).

## AI Assistance Disclosure

- [ ] No AI tools were used.
- [x] AI tools were used.
  OpenAI Codex assisted with code review, implementation, and PR-draft organization.