### PR TITLE
[Bugfix][TENT] Offload TCP SendData/RecvData and raise default RPC threads

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
+++ b/mooncake-transfer-engine/tent/include/tent/rpc/rpc.h
@@ -78,9 +78,10 @@ class CoroRpcAgent {
                             bool offload = false);
 
     // threads: number of io_context worker threads (default 1, the
-    // historical behavior). The TCP data-path handlers do full-payload
-    // blocking copies inline, so a single thread caps TCP throughput;
-    // sourced from the rpc_server_threads config key.
+    // historical RDMA-only behavior). TCP SendData/RecvData copies are
+    // offloaded off this pool, but attachments are still read here; when
+    // TCP is enabled the engine defaults rpc_server_threads higher so
+    // concurrent bulk transfers are not serialized on one io_context.
     Status start(uint16_t &port, bool ipv6 = false, size_t threads = 1);
 
     Status stop();

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -179,9 +179,11 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     // MC_CUSTOM_TOPO_JSON works under MC_USE_TENT. Inline
     // topology/priority_matrix in MC_TENT_CONF still takes precedence.
     setConfig(config, "MC_CUSTOM_TOPO_JSON", "topology/custom_json_path");
-    // TENT RPC server io_context threads. The TCP data-path handlers do
-    // full-payload blocking copies inline, so deployments pushing bulk data
-    // over the TENT TCP transport raise this above the default of 1.
+    // TENT RPC server io_context threads. TCP SendData/RecvData copies are
+    // offloaded onto the blocking executor; this pool still reads the RPC
+    // attachments. When TCP is enabled and this key is unset, the engine
+    // defaults to several threads so concurrent bulk transfers are not
+    // serialized on one io_context.
     setConfig(config, "MC_TENT_RPC_THREADS", "rpc_server_threads");
     return status;
 }

--- a/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/control_plane.cpp
@@ -249,16 +249,22 @@ ControlService::ControlService(const std::string& type,
         [this](const std::string_view& request, std::string& response) {
             onBootstrapRdma(request, response);
         });
+    // SendData/RecvData copy the full TCP payload. Running them inline on the
+    // io_context serializes every bulk transfer and stalls Probe/Bootstrap
+    // on the same thread. Offload matches Delegate: the connection coroutine
+    // suspends, copies run on the blocking executor, and other RPCs proceed.
     rpc_server_->registerFunction(
         SendData,
         [this](const std::string_view& request, std::string& response) {
             onSendData(request, response);
-        });
+        },
+        /*offload=*/true);
     rpc_server_->registerFunction(
         RecvData,
         [this](const std::string_view& request, std::string& response) {
             onRecvData(request, response);
-        });
+        },
+        /*offload=*/true);
     rpc_server_->registerFunction(
         Notify, [this](const std::string_view& request, std::string& response) {
             onNotify(request, response);

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -343,8 +343,18 @@ Status TransferEngineImpl::construct() {
     hostname_ = conf_->get("rpc_server_hostname", "");
     local_segment_name_ = conf_->get("local_segment_name", "");
     CHECK_STATUS(getRpcServerPortFromConfig(*conf_, 0, port_));
+    // TCP SendData/RecvData copies are offloaded, but the RPC io_context still
+    // reads the full attachment. One thread serializes concurrent bulk TCP.
+    // Leave RDMA-only at 1; when TCP is on and the user did not set
+    // rpc_server_threads, use several so attachments can be read in parallel.
     size_t rpc_server_threads = 1;
-    CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, 1, rpc_server_threads));
+    const size_t rpc_threads_default =
+        conf_->get("transports/tcp/enable", false)
+            ? std::min<size_t>(
+                  8, std::max<size_t>(4, std::thread::hardware_concurrency()))
+            : 1;
+    CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, rpc_threads_default,
+                                               rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
     max_failover_attempts_ = conf_->get("max_failover_attempts", 3);
     enable_auto_failover_on_poll_ =

--- a/mooncake-transfer-engine/tent/tests/tcp_datapath_roundtrip_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/tcp_datapath_roundtrip_test.cpp
@@ -236,8 +236,9 @@ TEST(TcpDataPathRoundtripTest, WriteThenReadAcrossProcesses) {
     runWriteThenReadAcrossProcesses(1);
 }
 
-// Same round trip with a multi-threaded RPC server, as used by bulk-TCP
-// deployments (MC_TENT_RPC_THREADS / rpc_server_threads).
+// Same round trip with a multi-threaded RPC server. SendData/RecvData are
+// offloaded, so this also covers concurrent bulk copies overlapping other
+// RPCs (MC_TENT_RPC_THREADS / rpc_server_threads).
 TEST(TcpDataPathRoundtripTest, WriteThenReadAcrossProcessesMultiThreadedRpc) {
     runWriteThenReadAcrossProcesses(4);
 }


### PR DESCRIPTION
## Description

Follow-up to #3535 and #3536 (and the offload mechanism from #3404).

#3535 made `rpc_server_threads` / `MC_TENT_RPC_THREADS` configurable but
kept the default at 1 (opt-in). #3536 cut extra copies on that path and
added `tent_tcp_datapath_roundtrip_test`. #3535 also measured
`SendData`/`RecvData` `offload=true` and did not land it: copies move off
the `io_context`, but attachment socket reads still serialize on one
thread, so bandwidth barely moves.

Unset configs (including tebench without that key) still hit the 1-thread
cap. This change:

- registers `SendData`/`RecvData` with `offload=true` (same as `Delegate`
  in #3404), so copies do not stall `Probe`/`Bootstrap` on the same thread
- when TCP is enabled and `rpc_server_threads` is unset, defaults to up
  to 8 RPC io threads so attachments can be read in parallel; RDMA-only
  stays at 1. Explicit `rpc_server_threads` / `MC_TENT_RPC_THREADS` still
  wins

The default-thread change is intentional and overrides #3535's opt-in
choice, so TCP gets the #3535 gain without requiring the knob. No GitHub
issue filed.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build -j32 \
  --target tent_rpc_handler_isolation_test tent_tcp_datapath_roundtrip_test
./build/mooncake-transfer-engine/tent/tests/tent_rpc_handler_isolation_test
./build/mooncake-transfer-engine/tent/tests/tent_tcp_datapath_roundtrip_test \
  --gtest_filter=TcpDataPathRoundtripTest.WriteThenReadAcrossProcesses
./build/mooncake-transfer-engine/tent/tests/tent_tcp_datapath_roundtrip_test \
  --gtest_filter=TcpDataPathRoundtripTest.WriteThenReadAcrossProcessesMultiThreadedRpc
# Two-node DRAM / TENT / TCP tebench, 3s: target on one host, initiator on
# another; WRITE 16MB t1/t4/t8, WRITE 4KB t1/t8,
# mix --check_consistency 16MB t4/t8 and 4KB t8
./scripts/code_format.sh --check --changed-lines --base origin/main
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- `tent_rpc_handler_isolation_test`: 4/4 passed
- `TcpDataPathRoundtripTest.WriteThenReadAcrossProcesses`: passed (`memcmp` of 8×4MB slices)
- `TcpDataPathRoundtripTest.WriteThenReadAcrossProcessesMultiThreadedRpc`: passed (4 RPC threads)
- tebench DRAM / TENT / TCP, two machines, `mix --check_consistency`: 16MB t4, 16MB t8, 4KB t8 all exit 0; no `Failed transfer` / `Inconsistent data`
- WRITE bandwidth (GB/s), same two-node setup, 3s:

  | case | before | after |
  |---|---|---|
  | 16MB × 1 | 0.391 | 0.485 |
  | 16MB × 4 | 0.812 | 1.865 |
  | 16MB × 8 | 0.599 | 3.227 |
  | 4KB × 1 | 0.018 | 0.018 |
  | 4KB × 8 | 0.176 | 0.173 |

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Correctness is covered by the existing TCP datapath roundtrip tests (byte
`memcmp`); this PR only updates the multi-thread comment. No new test file.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok 4.6) helped offload `SendData`/`RecvData`, default TCP RPC
threads, and run unit + tebench checks. The submitter reviewed every changed
line and compared before/after tebench bandwidth and `check_consistency`.

Made with [Cursor](https://cursor.com)