### PR TITLE
[Bugfix][TENT] Don't throw when aggregating transfer status during teardown

### DIFF
--- a/mooncake-transfer-engine/benchmark/bench_runner.h
+++ b/mooncake-transfer-engine/benchmark/bench_runner.h
@@ -63,6 +63,9 @@ class BenchRunner {
     virtual uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,
                                          uint64_t batch_size) const = 0;
 
+    // Returns elapsed microseconds on success, or a negative value if the
+    // transfer failed. Implementations must not call exit() from worker
+    // threads.
     virtual double runSingleTransfer(uint64_t local_addr, uint64_t target_id,
                                      uint64_t target_addr, uint64_t block_size,
                                      uint64_t batch_size, OpCode opcode,

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -143,11 +143,18 @@ int processBatchSizes(
                    deadline_us * 1000ull;
         };
 
+        auto failTask = [&]() {
+            measurement_started.store(true, std::memory_order_release);
+            return -1;
+        };
+
         XferBenchTimer timer;
         while (timer.lap_us(false) < 1000000ull) {
-            runner.runSingleTransfer(local_addr, target_id, target_addr,
-                                     thread_block_size, thread_batch_size,
-                                     opcode, deadlineNs(), intent_type);
+            if (runner.runSingleTransfer(
+                    local_addr, target_id, target_addr, thread_block_size,
+                    thread_batch_size, opcode, deadlineNs(), intent_type) < 0) {
+                return failTask();
+            }
         }
         if (measurement_ready.fetch_add(1, std::memory_order_acq_rel) + 1 ==
             num_threads) {
@@ -174,6 +181,7 @@ int processBatchSizes(
                 auto val = runner.runSingleTransfer(
                     local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, WRITE, deadlineNs(), intent_type);
+                if (val < 0) return failTask();
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
                 transfer_duration.push_back(val);
@@ -182,6 +190,7 @@ int processBatchSizes(
                 val = runner.runSingleTransfer(
                     local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, READ, deadlineNs(), intent_type);
+                if (val < 0) return failTask();
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
                 if (XferBenchConfig::check_consistency)
@@ -206,6 +215,7 @@ int processBatchSizes(
                 auto val = runner.runSingleTransfer(
                     local_addr, target_id, target_addr, thread_block_size,
                     thread_batch_size, opcode, deadlineNs(), intent_type);
+                if (val < 0) return failTask();
                 thread_instant_bandwidth.push_back(
                     gbPerSecond(batch_bytes, val));
                 if (read_verify) {
@@ -459,5 +469,5 @@ int main(int argc, char* argv[]) {
         }
         runner->stopInitiator();
     }
-    return 0;
+    return interrupted ? EXIT_FAILURE : EXIT_SUCCESS;
 }

--- a/mooncake-transfer-engine/benchmark/tent_backend.cpp
+++ b/mooncake-transfer-engine/benchmark/tent_backend.cpp
@@ -15,6 +15,8 @@
 #include "tent_backend.h"
 #include "utils.h"
 #include "char_util.h"
+
+#include <atomic>
 #include "tent/common/types.h"
 #include "tent/runtime/platform.h"
 #include "tent/runtime/topology.h"
@@ -31,18 +33,18 @@
 namespace mooncake {
 namespace tent {
 
-volatile bool g_tent_running = true;
-volatile bool g_tent_triggered_sig = false;
+std::atomic<bool> g_tent_running{true};
+std::atomic<bool> g_tent_triggered_sig{false};
 
 void signalHandlerV1(int signum) {
-    if (g_tent_triggered_sig) {
+    if (g_tent_triggered_sig.load()) {
         LOG(ERROR) << "Received signal " << signum
                    << " again, forcefully terminating...";
         std::exit(EXIT_FAILURE);
     }
     LOG(INFO) << "Received signal " << signum << ", stopping target server...";
-    g_tent_running = false;
-    g_tent_triggered_sig = true;
+    g_tent_running.store(false);
+    g_tent_triggered_sig.store(true);
 }
 
 std::shared_ptr<Config> loadConfig() {
@@ -302,7 +304,7 @@ TENTBenchRunner::TENTBenchRunner() {
 TENTBenchRunner::~TENTBenchRunner() { freeBuffers(); }
 
 int TENTBenchRunner::runTarget() {
-    while (g_tent_running) sleep(1);
+    while (g_tent_running.load()) sleep(1);
     return 0;
 }
 
@@ -350,7 +352,7 @@ int TENTBenchRunner::startInitiator(int num_threads) {
     LOG(INFO) << "Opened " << target_handles_.size() << " target segments";
     threads_.resize(num_threads);
     current_task_.resize(threads_.size());
-    g_tent_running = true;
+    g_tent_running.store(true);
     for (size_t i = 0; i < threads_.size(); ++i)
         threads_[i] = std::thread(&TENTBenchRunner::runner, this, i);
     return 0;
@@ -359,7 +361,7 @@ int TENTBenchRunner::startInitiator(int num_threads) {
 int TENTBenchRunner::stopInitiator() {
     {
         std::unique_lock<std::mutex> lk(mtx_);
-        g_tent_running = false;
+        g_tent_running.store(false);
         cv_task_.notify_all();
         cv_done_.notify_all();
     }
@@ -434,14 +436,14 @@ void TENTBenchRunner::pinThread(int thread_id) {
 }
 
 int TENTBenchRunner::runner(int thread_id) {
-    while (g_tent_running) {
+    while (g_tent_running.load()) {
         std::function<int(int)> task;
         {
             std::unique_lock<std::mutex> lk(mtx_);
             cv_task_.wait(lk, [&] {
-                return !g_tent_running || current_task_[thread_id];
+                return !g_tent_running.load() || current_task_[thread_id];
             });
-            if (!g_tent_running) break;
+            if (!g_tent_running.load()) break;
             std::swap(task, current_task_[thread_id]);
         }
         if (task) task(thread_id);
@@ -460,15 +462,37 @@ int TENTBenchRunner::runInitiatorTasks(
         current_task_[id] = func;
     pending_ = (int)threads_.size();
     cv_task_.notify_all();
-    cv_done_.wait(lk, [&] { return !g_tent_running || pending_ == 0; });
-    return g_tent_running ? 0 : -1;
+    cv_done_.wait(lk, [&] { return !g_tent_running.load() || pending_ == 0; });
+    return g_tent_running.load() ? 0 : -1;
+}
+
+void TENTBenchRunner::noteTransferFailed() {
+    std::lock_guard<std::mutex> lk(mtx_);
+    g_tent_running.store(false);
+    cv_task_.notify_all();
+    cv_done_.notify_all();
 }
 
 double TENTBenchRunner::runSingleTransfer(
     uint64_t local_addr, uint64_t target_id, uint64_t target_addr,
     uint64_t block_size, uint64_t batch_size, OpCode opcode,
     uint64_t deadline_ns, IntentType intent_type) {
+    if (!g_tent_running.load()) return -1.0;
+
+    auto abortTransfer = [&](const char* why) {
+        LOG(ERROR) << why;
+        noteTransferFailed();
+        return -1.0;
+    };
+
     auto batch_id = engine_->allocateBatch(batch_size);
+    if (!batch_id) return abortTransfer("Failed to allocate transfer batch");
+
+    auto finish = [&](double duration) {
+        (void)engine_->freeBatch(batch_id);
+        return duration;
+    };
+
     std::vector<Request> requests;
     for (uint64_t i = 0; i < batch_size; ++i) {
         Request entry;
@@ -485,26 +509,39 @@ double TENTBenchRunner::runSingleTransfer(
         requests.emplace_back(entry);
     }
     XferBenchTimer timer;
+    Status submitted;
     if (XferBenchConfig::notifi) {
-        // Use target_addr as msg for verification by peer
         Notification notifi{"benchmark", std::to_string(target_addr)};
-        CHECK_FAIL(engine_->submitTransfer(batch_id, requests, notifi));
+        submitted = engine_->submitTransfer(batch_id, requests, notifi);
     } else {
-        CHECK_FAIL(engine_->submitTransfer(batch_id, requests));
+        submitted = engine_->submitTransfer(batch_id, requests);
     }
-    while (true) {
+    if (!submitted.ok()) {
+        LOG(ERROR) << "Failed to submit transfer: " << submitted.ToString();
+        noteTransferFailed();
+        return finish(-1.0);
+    }
+    while (g_tent_running.load()) {
         TransferStatus overall_status;
-        CHECK_FAIL(engine_->getTransferStatus(batch_id, overall_status));
+        auto polled = engine_->getTransferStatus(batch_id, overall_status);
+        if (!polled.ok()) {
+            LOG(ERROR) << "Failed to poll transfer: " << polled.ToString();
+            noteTransferFailed();
+            return finish(-1.0);
+        }
         if (overall_status.s == TransferStatusEnum::COMPLETED) {
-            break;
-        } else if (overall_status.s == TransferStatusEnum::FAILED) {
+            return finish(timer.lap_us());
+        }
+        if (overall_status.s == TransferStatusEnum::FAILED ||
+            overall_status.s == TransferStatusEnum::TIMEOUT ||
+            overall_status.s == TransferStatusEnum::CANCELED ||
+            overall_status.s == TransferStatusEnum::INVALID) {
             LOG(ERROR) << "Failed transfer detected";
-            exit(EXIT_FAILURE);
+            noteTransferFailed();
+            return finish(-1.0);
         }
     }
-    auto duration = timer.lap_us();
-    CHECK_FAIL(engine_->freeBatch(batch_id));
-    return duration;
+    return finish(-1.0);
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -170,6 +170,9 @@ class TENTBenchRunner : public BenchRunner {
                           "target address");
     }
 
+    // Returns elapsed microseconds on success, or a negative value if the
+    // transfer failed. Never calls exit() — workers set g_tent_running so
+    // main can join threads and stop the engine first.
     double runSingleTransfer(uint64_t local_addr, uint64_t target_id,
                              uint64_t target_addr, uint64_t block_size,
                              uint64_t batch_size, OpCode opcode,
@@ -181,6 +184,8 @@ class TENTBenchRunner : public BenchRunner {
     int freeBuffers();
 
     int runner(int thread_id);
+
+    void noteTransferFailed();
 
     size_t targetIndex(int thread_id) const;
 

--- a/mooncake-transfer-engine/tent/include/tent/common/types.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/types.h
@@ -162,6 +162,27 @@ enum TransferStatusEnum {
     FAILED
 };
 
+// Rank for aggregating batch status. Unknown values rank with FAILED so
+// getBatchStatus never throws from unordered_map::at during teardown.
+inline int transferStatusSeverity(TransferStatusEnum s) {
+    switch (s) {
+        case INITIAL:
+        case PENDING:
+        case COMPLETED:
+            return 0;
+        case INVALID:
+            return 1;
+        case CANCELED:
+            return 2;
+        case TIMEOUT:
+            return 3;
+        case FAILED:
+            return 4;
+        default:
+            return 4;
+    }
+}
+
 struct TransferStatus {
     TransferStatusEnum s;
     size_t transferred_bytes;

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -2659,11 +2659,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
     size_t total_tasks = 0;
     TransferStatusEnum worst_failure = PENDING;
     auto isWorse = [](TransferStatusEnum cur, TransferStatusEnum best) {
-        static const std::unordered_map<TransferStatusEnum, int> severity = {
-            {INITIAL, 0},  {PENDING, 0}, {COMPLETED, 0}, {INVALID, 1},
-            {CANCELED, 2}, {TIMEOUT, 3}, {FAILED, 4},
-        };
-        return severity.at(cur) > severity.at(best);
+        return transferStatusSeverity(cur) > transferStatusSeverity(best);
     };
     for (size_t task_id = 0; task_id < batch->task_list.size(); ++task_id) {
         auto& task = batch->task_list[task_id];

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -622,6 +622,22 @@ TEST(EngineFailoverE2E, OverallStatusUsesWorstFailureNotGenericFailed) {
         engine.unregisterLocalMemory(completed_buf.data(), kBufLen).ok());
 }
 
+TEST(TransferStatusSeverityTest, KnownRanksMatchFormerMap) {
+    EXPECT_EQ(transferStatusSeverity(INITIAL), 0);
+    EXPECT_EQ(transferStatusSeverity(PENDING), 0);
+    EXPECT_EQ(transferStatusSeverity(COMPLETED), 0);
+    EXPECT_EQ(transferStatusSeverity(INVALID), 1);
+    EXPECT_EQ(transferStatusSeverity(CANCELED), 2);
+    EXPECT_EQ(transferStatusSeverity(TIMEOUT), 3);
+    EXPECT_EQ(transferStatusSeverity(FAILED), 4);
+}
+
+TEST(TransferStatusSeverityTest, UnknownValueRanksWithFailedAndDoesNotThrow) {
+    auto unknown = static_cast<TransferStatusEnum>(99);
+    EXPECT_EQ(transferStatusSeverity(unknown), transferStatusSeverity(FAILED));
+    EXPECT_GT(transferStatusSeverity(unknown), transferStatusSeverity(TIMEOUT));
+}
+
 TEST(EngineFailoverE2E,
      WaitTransferCompletionUsesProgressBatchWhenPollDisabled) {
     auto cfg = makeMinimalP2PConfig();


### PR DESCRIPTION
## Description

When an RDMA peer disappears (process SIGKILL, host crash), posted writes
often complete with no error CQE. Slices wait for the software timeout,
failover exhausts the only enabled transport, and `getTransferStatus`
reports `FAILED`. Clients that poll from several threads then tear down
the engine (or exit the process) overlap `getBatchStatus` with destruction
of a function-local `unordered_map`. `.at()` throws `std::out_of_range`,
which during `terminate`/`exit` becomes `terminate called recursively`.

That is an engine teardown bug, not a benchmark-only failure. tebench
with 8 initiator threads and a killed target is how we reproduced it
end-to-end; any multi-threaded Transfer Engine client that stops the
engine on `FAILED` can hit the same throw.

This change:

- ranks transfer statuses with `transferStatusSeverity()` (a switch,
  unknown values treated as `FAILED`) so `getBatchStatus` never throws
  from `unordered_map::at` during teardown
- stops tebench workers with a flag and joins them from main instead of
  calling `exit()` on each `FAILED` (also treats `TIMEOUT` / `CANCELED` /
  `INVALID` as terminal so the poll loop cannot spin)

No GitHub issue filed. Distinct from #3636 (worker self-deadlock on a
full MPSC queue); this path reached `FAILED` in ~12s.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build -j32 --target tent_failover_test tebench
./build/mooncake-transfer-engine/tent/tests/tent_failover_test
# Two-node DRAM / TENT / RDMA: target on one host, initiator
# WRITE 1MB × 8 threads --duration=60; after measurement starts,
# SIGKILL the target process (not SIGTERM).
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

- `tent_failover_test`: 16/16 passed (including
  `TransferStatusSeverityTest` known ranks and unknown enum)
- Two-node DRAM / TENT / RDMA, 8 concurrent transfers × 1MB WRITE:
  SIGKILL peer → `FAILED` surfaced, process **exit 1**; no
  `terminate called` / `unordered_map::at`. Previously abort, exit 134.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok 4.6) helped diagnose the status-aggregation throw during
peer-death teardown, implement the ranking helper and stop-without-exit
path, and retest with a killed peer. The submitter reviewed every changed
line and reproduced the failure before and after the fix.

Made with [Cursor](https://cursor.com)