### PR TITLE
[P2P-Store] Release batch IDs on all performTransfer exit paths

### DIFF
--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -366,48 +366,12 @@ func (store *P2PStore) performTransfer(ctx context.Context, source uintptr, shar
 	retryCount := 0
 	maxRetryCount := max(3, shard.Count())
 	for retryCount < maxRetryCount {
-		batchID, err := store.transfer.allocateBatchID(1)
-		if err != nil {
-			return err
-		}
-
 		location := shard.GetLocation(retryCount)
 		if location == nil {
 			break
 		}
 
-		targetID, err := store.transfer.openSegment(location.SegmentName, retryCount == 0)
-		if err != nil {
-			return err
-		}
-
-		request := TransferRequest{
-			Opcode:       OPCODE_READ,
-			Source:       uint64(source),
-			TargetID:     targetID,
-			TargetOffset: location.Offset,
-			Length:       shard.Length,
-		}
-
-		err = store.transfer.submitTransfer(batchID, []TransferRequest{request})
-		if err != nil {
-			return err
-		}
-
-		var status int
-		for status == STATUS_WAITING || status == STATUS_PENDING {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				status, _, err = store.transfer.getTransferStatus(batchID, 0)
-				if err != nil {
-					return err
-				}
-			}
-		}
-
-		err = store.transfer.freeBatchID(batchID)
+		status, err := store.performTransferOnce(ctx, source, shard.Length, location, retryCount == 0)
 		if err != nil {
 			return err
 		}
@@ -420,6 +384,57 @@ func (store *P2PStore) performTransfer(ctx context.Context, source uintptr, shar
 	}
 
 	return ErrTooManyRetries
+}
+
+// performTransferOnce runs a single transfer attempt against the given
+// location. The allocated batch ID is released on every return path,
+// including context cancellation and intermediate errors.
+func (store *P2PStore) performTransferOnce(ctx context.Context, source uintptr, length uint64, location *Location, useCache bool) (status int, err error) {
+	batchID, err := store.transfer.allocateBatchID(1)
+	if err != nil {
+		return STATUS_FAILED, err
+	}
+	defer func() {
+		freeErr := store.transfer.freeBatchID(batchID)
+		if freeErr != nil {
+			log.Println("cascading error: failed to free batch ID:", freeErr)
+			if err == nil {
+				err = freeErr
+			}
+		}
+	}()
+
+	targetID, err := store.transfer.openSegment(location.SegmentName, useCache)
+	if err != nil {
+		return STATUS_FAILED, err
+	}
+
+	request := TransferRequest{
+		Opcode:       OPCODE_READ,
+		Source:       uint64(source),
+		TargetID:     targetID,
+		TargetOffset: location.Offset,
+		Length:       length,
+	}
+
+	err = store.transfer.submitTransfer(batchID, []TransferRequest{request})
+	if err != nil {
+		return STATUS_FAILED, err
+	}
+
+	for status == STATUS_WAITING || status == STATUS_PENDING {
+		select {
+		case <-ctx.Done():
+			return STATUS_FAILED, ctx.Err()
+		default:
+			status, _, err = store.transfer.getTransferStatus(batchID, 0)
+			if err != nil {
+				return STATUS_FAILED, err
+			}
+		}
+	}
+
+	return status, nil
 }
 
 func (store *P2PStore) updatePayloadMetadata(ctx context.Context, name string, addrList []uintptr, sizeList []uint64, payload *Payload, revision int64) error {

--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -371,7 +371,7 @@ func (store *P2PStore) performTransfer(ctx context.Context, source uintptr, shar
 			break
 		}
 
-		status, err := store.performTransferOnce(ctx, source, shard.Length, location, retryCount == 0)
+		status, err := performTransferOnce(ctx, store.transfer, source, shard.Length, location, retryCount == 0)
 		if err != nil {
 			return err
 		}
@@ -386,16 +386,34 @@ func (store *P2PStore) performTransfer(ctx context.Context, source uintptr, shar
 	return ErrTooManyRetries
 }
 
+// batchTransport is the subset of TransferEngine a single transfer attempt
+// needs. It lets the batch lifecycle be exercised without the native engine.
+type batchTransport interface {
+	allocateBatchID(batchSize int) (BatchID, error)
+	openSegment(segmentName string, useCache bool) (int64, error)
+	submitTransfer(batchID BatchID, requests []TransferRequest) error
+	getTransferStatus(batchID BatchID, taskID int) (int, uint64, error)
+	freeBatchID(batchID BatchID) error
+}
+
+func isTransferInFlight(status int) bool {
+	return status == STATUS_WAITING || status == STATUS_PENDING
+}
+
 // performTransferOnce runs a single transfer attempt against the given
-// location. The allocated batch ID is released on every return path,
-// including context cancellation and intermediate errors.
-func (store *P2PStore) performTransferOnce(ctx context.Context, source uintptr, length uint64, location *Location, useCache bool) (status int, err error) {
-	batchID, err := store.transfer.allocateBatchID(1)
+// location. The allocated batch ID is released on every return path.
+//
+// The engine refuses to free a batch while any of its tasks is still in
+// flight (BatchBusy), so on context cancellation the task is drained to a
+// terminal state before the deferred free runs. Cancellation latency is
+// therefore bounded by the engine's own transfer timeout.
+func performTransferOnce(ctx context.Context, transport batchTransport, source uintptr, length uint64, location *Location, useCache bool) (status int, err error) {
+	batchID, err := transport.allocateBatchID(1)
 	if err != nil {
 		return STATUS_FAILED, err
 	}
 	defer func() {
-		freeErr := store.transfer.freeBatchID(batchID)
+		freeErr := transport.freeBatchID(batchID)
 		if freeErr != nil {
 			log.Println("cascading error: failed to free batch ID:", freeErr)
 			if err == nil {
@@ -404,7 +422,7 @@ func (store *P2PStore) performTransferOnce(ctx context.Context, source uintptr, 
 		}
 	}()
 
-	targetID, err := store.transfer.openSegment(location.SegmentName, useCache)
+	targetID, err := transport.openSegment(location.SegmentName, useCache)
 	if err != nil {
 		return STATUS_FAILED, err
 	}
@@ -417,23 +435,40 @@ func (store *P2PStore) performTransferOnce(ctx context.Context, source uintptr, 
 		Length:       length,
 	}
 
-	err = store.transfer.submitTransfer(batchID, []TransferRequest{request})
+	err = transport.submitTransfer(batchID, []TransferRequest{request})
 	if err != nil {
 		return STATUS_FAILED, err
 	}
 
-	for status == STATUS_WAITING || status == STATUS_PENDING {
+	for isTransferInFlight(status) {
 		select {
 		case <-ctx.Done():
+			if _, drainErr := drainTransfer(transport, batchID); drainErr != nil {
+				return STATUS_FAILED, drainErr
+			}
 			return STATUS_FAILED, ctx.Err()
 		default:
-			status, _, err = store.transfer.getTransferStatus(batchID, 0)
+			status, _, err = transport.getTransferStatus(batchID, 0)
 			if err != nil {
 				return STATUS_FAILED, err
 			}
 		}
 	}
 
+	return status, nil
+}
+
+// drainTransfer polls the batch until its task reaches a terminal state so
+// the batch can be freed.
+func drainTransfer(transport batchTransport, batchID BatchID) (int, error) {
+	status := STATUS_WAITING
+	for isTransferInFlight(status) {
+		var err error
+		status, _, err = transport.getTransferStatus(batchID, 0)
+		if err != nil {
+			return STATUS_FAILED, err
+		}
+	}
 	return status, nil
 }
 

--- a/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
+++ b/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
@@ -1,0 +1,120 @@
+// Copyright 2024 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p2pstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+var errBatchBusy = errors.New("BatchID cannot be freed until all tasks are done")
+
+// fakeBatchTransport mirrors the engine's batch lifecycle: a submitted task
+// stays in flight for pollsUntilDone status polls, and freeBatchID refuses
+// with BatchBusy while the task is in flight, as MultiTransport::freeBatchID does.
+type fakeBatchTransport struct {
+	pollsUntilDone int
+	finalStatus    int
+	submitErr      error
+
+	polls          int
+	submitted      bool
+	freed          bool
+	busyRejections int
+}
+
+func (f *fakeBatchTransport) allocateBatchID(int) (BatchID, error) { return BatchID(42), nil }
+
+func (f *fakeBatchTransport) openSegment(string, bool) (int64, error) { return 1, nil }
+
+func (f *fakeBatchTransport) submitTransfer(BatchID, []TransferRequest) error {
+	if f.submitErr != nil {
+		return f.submitErr
+	}
+	f.submitted = true
+	return nil
+}
+
+func (f *fakeBatchTransport) inFlight() bool {
+	return f.submitted && f.polls < f.pollsUntilDone
+}
+
+func (f *fakeBatchTransport) getTransferStatus(BatchID, int) (int, uint64, error) {
+	f.polls++
+	if f.inFlight() {
+		return STATUS_PENDING, 0, nil
+	}
+	return f.finalStatus, 0, nil
+}
+
+func (f *fakeBatchTransport) freeBatchID(BatchID) error {
+	if f.inFlight() {
+		f.busyRejections++
+		return errBatchBusy
+	}
+	f.freed = true
+	return nil
+}
+
+func testLocation() *Location {
+	return &Location{SegmentName: "peer:12345", Offset: 0}
+}
+
+// TestPerformTransferOnceCancellationFreesBatch is the regression for the
+// cancellation leak: with the task still pending, returning on ctx.Done()
+// without draining makes the deferred free hit BatchBusy and leak the batch.
+func TestPerformTransferOnceCancellationFreesBatch(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fake := &fakeBatchTransport{pollsUntilDone: 3, finalStatus: STATUS_COMPLETED}
+	_, err := performTransferOnce(ctx, fake, 0, 4096, testLocation(), true)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if !fake.freed {
+		t.Fatal("batch ID leaked on cancellation")
+	}
+	if fake.busyRejections != 0 {
+		t.Fatalf("free attempted %d time(s) while the task was in flight", fake.busyRejections)
+	}
+}
+
+func TestPerformTransferOnceCompletedFreesBatch(t *testing.T) {
+	fake := &fakeBatchTransport{pollsUntilDone: 2, finalStatus: STATUS_COMPLETED}
+	status, err := performTransferOnce(context.Background(), fake, 0, 4096, testLocation(), true)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if status != STATUS_COMPLETED {
+		t.Fatalf("status = %d, want STATUS_COMPLETED", status)
+	}
+	if !fake.freed {
+		t.Fatal("batch ID leaked on completion")
+	}
+}
+
+func TestPerformTransferOnceSubmitErrorFreesBatch(t *testing.T) {
+	submitErr := errors.New("submit failed")
+	fake := &fakeBatchTransport{submitErr: submitErr}
+	_, err := performTransferOnce(context.Background(), fake, 0, 4096, testLocation(), true)
+	if !errors.Is(err, submitErr) {
+		t.Fatalf("err = %v, want submit error", err)
+	}
+	if !fake.freed {
+		t.Fatal("batch ID leaked on submit failure")
+	}
+}


### PR DESCRIPTION
## Description

`performTransfer` allocated a batch ID at the top of each retry iteration but only released it on the successful completion path. Five paths leaked the ID:

- the `location == nil` break (allocated before the location check)
- `openSegment` failure
- `submitTransfer` failure
- `getTransferStatus` failure
- context cancellation

Batch descriptors live on the C++ side of the transfer engine, so a long-running process accumulates them over time.

This PR extracts the single attempt into `performTransferOnce` and releases the batch ID with `defer` on every path. On context cancellation the in-flight task is first drained to a terminal state, because `freeBatchID` returns BatchBusy (and keeps the descriptor) while any task is unfinished; the C API exposes no cancel/abort primitive, so draining is the only route to a freeable state. Original semantics are preserved: a successful transfer followed by a failed free still surfaces the error (named return), and the location is now checked before allocation, so exhausted locations no longer allocate at all.

## Related Components

- [x] P2P Store (`mooncake-p2p-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-p2p-store/src/p2pstore
go build ./...
gofmt -l .
go vet ./...
```

**Test results:**
- [x] Manual testing done (describe below)

`go build` and `gofmt` clean. `go vet` reports three pre-existing `unsafe.Pointer` warnings in `transfer_engine.go`, unchanged by this PR (verified identical on main).

Added `perform_transfer_test.go` with a fake `batchTransport` that mirrors the engine's BatchBusy semantics (free refused while a task is in flight):
- cancellation regression: task pending + ctx cancelled, asserts the batch is freed and the free is never attempted while busy
- completion path frees the batch
- submit-error path frees the batch

```bash
go test ./...   # locally with CGO_LDFLAGS="-Wl,-undefined,dynamic_lookup" since no native engine is linked
```
Removing the drain makes the cancellation test fail with "batch ID leaked on cancellation".

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI assisted with the code audit and drafting. The submitter has reviewed, understands, and takes responsibility for all changes.
