### PR TITLE
[Bugfix] Preserve complete objects after snapshot restore

### DIFF
--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -9629,21 +9629,23 @@ tl::expected<void, SerializationError> MasterService::ApplySnapshotState(
         segment_access.GetAllSegmentNames(segment_names);
     }
 
-    // Cleanup expired metadata (unless test environment disables it)
+    // Cleanup incomplete metadata (unless test environment disables it)
     {
         const bool skip_cleanup =
             std::getenv("MOONCAKE_MASTER_SERVICE_SNAPSHOT_TEST_SKIP_CLEANUP");
         if (!skip_cleanup) {
-            auto cleanup_now = now;
             for (auto& shard : metadata_shards_) {
                 for (auto tenant_it = shard.tenants.begin();
                      tenant_it != shard.tenants.end();) {
                     auto& tenant_state = tenant_it->second;
                     for (auto it = tenant_state.metadata.begin();
                          it != tenant_state.metadata.end();) {
-                        if (it->second.HasDiffRepStatus(
-                                ReplicaStatus::COMPLETE) ||
-                            it->second.IsLeaseExpired(cleanup_now)) {
+                        auto& metadata = it->second;
+                        const bool has_incomplete_replica =
+                            metadata.HasDiffRepStatus(ReplicaStatus::COMPLETE)
+                                .has_value();
+                        if (has_incomplete_replica ||
+                            metadata.CountReplicas() == 0) {
                             VLOG(1) << "clear metadata key=" << it->first;
                             it = EraseMetadata(tenant_state, it,
                                                tenant_it->first);

--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
@@ -75,6 +75,55 @@ std::string GenerateKeyForSegment(const UUID& client_id,
     }
 }
 
+TEST_F(MasterServiceSnapshotTest, RestoreKeepsExpiredCompleteObject) {
+    constexpr uint64_t kLeaseTtlMs = 60'000;
+    auto service_config = MasterServiceConfig::builder()
+                              .set_memory_allocator(BufferAllocatorType::OFFSET)
+                              .set_default_kv_lease_ttl(0)
+                              .build();
+    service_.reset(new MasterService(service_config));
+    const auto context = PrepareSimpleSegment(*service_);
+    const std::string complete_key = "restored_expired_lease";
+    const std::string incomplete_key = "incomplete_object";
+
+    ASSERT_TRUE(service_
+                    ->PutStart(context.client_id, complete_key,
+                               TenantId::Default(), 1024, {.replica_num = 1})
+                    .has_value());
+    ASSERT_TRUE(service_
+                    ->PutEnd(context.client_id, complete_key,
+                             TenantId::Default(), ReplicaType::MEMORY)
+                    .has_value());
+    ASSERT_TRUE(service_
+                    ->PutStart(context.client_id, incomplete_key,
+                               TenantId::Default(), 1024, {.replica_num = 1})
+                    .has_value());
+
+    const std::string snapshot_id = GenerateSnapshotId();
+    ASSERT_TRUE(CallPersistState(service_.get(), snapshot_id).has_value());
+
+    ::unsetenv("MOONCAKE_MASTER_SERVICE_SNAPSHOT_TEST_SKIP_CLEANUP");
+    auto restore_config = MasterServiceConfig::builder()
+                              .set_memory_allocator(BufferAllocatorType::OFFSET)
+                              .set_default_kv_lease_ttl(kLeaseTtlMs)
+                              .set_enable_snapshot_restore(true)
+                              .set_snapshot_object_store_type("local")
+                              .build();
+    std::unique_ptr<MasterService> restored_service(
+        new MasterService(restore_config));
+
+    auto replicas =
+        restored_service->GetReplicaList(complete_key, TenantId::Default());
+    ASSERT_TRUE(replicas.has_value());
+    ASSERT_EQ(replicas->replicas.size(), 1);
+    EXPECT_EQ(replicas->replicas.front().status, ReplicaStatus::COMPLETE);
+
+    auto incomplete =
+        restored_service->GetReplicaList(incomplete_key, TenantId::Default());
+    ASSERT_FALSE(incomplete.has_value());
+    EXPECT_EQ(incomplete.error(), ErrorCode::OBJECT_NOT_FOUND);
+}
+
 TEST_F(MasterServiceSnapshotTest, MountUnmountSegmentWithOffsetAllocator) {
     auto service_config = MasterServiceConfig::builder()
                               .set_memory_allocator(BufferAllocatorType::OFFSET)


### PR DESCRIPTION
## Description

Snapshot restore decoded complete objects correctly, then deleted them when their persisted read lease had expired. This changes the post-restore cleanup to remove only metadata with no replicas or with an incomplete replica. Complete objects remain available, while lease expiry stays an eviction hint rather than becoming a durability decision.

The regression test restores a complete object with a zero-length lease alongside an incomplete object. It verifies that the complete object is still readable and the incomplete one is still cleaned up.

Fixes #3761

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build-snapshot-restore --target master_service_test_for_snapshot -j 12
build-snapshot-restore/mooncake-store/tests/master_service_test_for_snapshot --gtest_filter=MasterServiceSnapshotTest.RestoreKeepsExpiredCompleteObject
build-snapshot-restore/mooncake-store/tests/master_service_test_for_snapshot --gtest_filter='MasterServiceSnapshotTest.PutStartEndFlow:MasterServiceSnapshotTest.RemoveLeasedObject:MasterServiceSnapshotTest.MountUnmountSegmentWithOffsetAllocator'
pre-commit run --files mooncake-store/src/master_service.cpp mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot.cpp
```

The new regression failed against the original cleanup predicate because the complete key was missing after restore, then passed with this change. The three nearby snapshot/lease tests also pass.

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (fail-before/pass-after regression check described above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

An AI coding assistant helped trace the restore path, prepare the focused change, and run the checks. I reviewed the final diff and the test results.