### PR TITLE
fix(transfer-engine): cleanupIdleConnections() only inspected deque tail

### DIFF
--- a/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
+++ b/mooncake-transfer-engine/include/transport/tcp_transport/tcp_transport.h
@@ -142,7 +142,8 @@ class TcpTransport : public Transport {
                           std::shared_ptr<asio::ip::tcp::socket> socket);
     void cleanupIdleConnections();
 
-    static constexpr std::chrono::seconds kConnectionIdleTimeout{60};
+    // Configurable via MC_TCP_CONNECTION_IDLE_TIMEOUT env var (default: 60s)
+    std::chrono::seconds connection_idle_timeout_{60};
 };
 }  // namespace mooncake
 

--- a/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
+++ b/mooncake-transfer-engine/src/transport/tcp_transport/tcp_transport.cpp
@@ -487,6 +487,15 @@ TcpTransport::TcpTransport() : context_(nullptr), running_(false) {
             enable_connection_pool_ = true;
         }
     }
+    // Allow tuning the idle timeout via env var (default: 60s).
+    // A shorter timeout reclaims idle sockets faster, reducing pool memory
+    // and fd usage under bursty workloads.
+    if (getenv("MC_TCP_CONNECTION_IDLE_TIMEOUT") != nullptr) {
+        int timeout_val = atoi(getenv("MC_TCP_CONNECTION_IDLE_TIMEOUT"));
+        if (timeout_val > 0) {
+            connection_idle_timeout_ = std::chrono::seconds(timeout_val);
+        }
+    }
 }
 
 TcpTransport::~TcpTransport() {
@@ -841,25 +850,30 @@ void TcpTransport::cleanupIdleConnections() {
     for (auto it = connection_pool_.begin(); it != connection_pool_.end();) {
         auto& queue = it->second;
 
-        // Remove idle connections that exceed timeout
-        while (!queue.empty()) {
-            auto& entry = queue.back();
+        // Remove ALL idle connections that exceed timeout (not just the tail).
+        // The previous implementation only inspected queue.back(), which meant
+        // that a single in_use or non-expired entry at the tail prevented
+        // cleanup of every older idle entry earlier in the deque.  In
+        // long-running services this caused unbounded socket/fd accumulation
+        // because connections were created faster than they could be reused.
+        for (auto qit = queue.begin(); qit != queue.end();) {
+            auto& entry = *qit;
             if (!entry->in_use) {
                 auto idle_duration =
                     std::chrono::duration_cast<std::chrono::seconds>(
                         now - entry->last_used)
                         .count();
-                if (idle_duration > kConnectionIdleTimeout.count()) {
+                if (idle_duration > connection_idle_timeout_.count()) {
                     if (entry->socket && entry->socket->is_open()) {
                         asio::error_code ec;
                         entry->socket->close(ec);
                     }
-                    queue.pop_back();
+                    qit = queue.erase(qit);
                 } else {
-                    break;
+                    ++qit;
                 }
             } else {
-                break;
+                ++qit;
             }
         }
 


### PR DESCRIPTION
## Problem

`cleanupIdleConnections()` only inspected `queue.back()` — the tail of each endpoint's connection deque. The while-loop popped expired idle connections from the back, but **broke immediately** when it hit either:
1. An `in_use` connection at the tail (common — newer connections are pushed to the back and may still be in use)
2. A non-expired idle connection at the tail

This meant any idle-expired connections **earlier in the deque** were never cleaned up. Over time, the pool grew unboundedly.

## Impact

Observed in production (sglang PD disaggregated inference, mooncake_tcp transport, 1P2D cluster):

| Metric | Value |
|--------|-------|
| ESTABLISHED connections (single prefill node) | **27,232** |
| Effective bandwidth | **~1.1 Gbps** (vs 36 Gbps iperf3) |
| KV transfer latency | **14.6s avg** (vs ~2s expected) |
| TTFT (first token) | **~24s** (vs ~3s expected) |

The 27K connections overwhelmed the kernel TCP stack, throttling bandwidth to 3% of available. This caused cascading latency: KV transfer 14.6s → bootstrap queue backup (164 requests) → TTFT 24s.

## Root Cause

```cpp
// BEFORE (buggy): only checks queue.back()
while (!queue.empty()) {
    auto& entry = queue.back();
    if (!entry->in_use && idle > timeout) { queue.pop_back(); }
    else break;  // ← BUG: stops at first non-expired or in_use
}
```

Connections are returned to the back of the deque via `returnConnection()`. When a newer `in_use` connection sits at the tail, the loop terminates immediately — every older idle connection at the front is permanently orphaned.

## Fix

```cpp
// AFTER: iterate ALL entries
for (auto qit = queue.begin(); qit != queue.end();) {
    auto& entry = *qit;
    if (!entry->in_use && idle > timeout) { qit = queue.erase(qit); }
    else ++qit;
}
```

## Performance

O(n) per call where n = pool size per endpoint (~hundreds). At ~10ns per entry comparison, cleanup costs ~microseconds — negligible vs the TCP transfer itself (seconds). The lock (`pool_mutex_`) is held for the same microsecond duration, so no contention impact.

## Additional Change

Made the idle timeout configurable via `MC_TCP_CONNECTION_IDLE_TIMEOUT` env var (default 60s, unchanged). A shorter timeout (e.g. 10s) helps under bursty workloads where the pool grows during peaks and needs to shrink quickly during lulls.

## Testing

- Based on v0.3.11.post1
- Observed in sglang PD with GLM-5.3 (78 layers, 8 TP, 8 CP, 1P2D)
- With the fix + connection pool enabled: ESTAB expected to stabilize at ~6,400 (peak concurrency × connections/request) vs 27K (buggy) or ~600 (pool disabled with 259K TIME_WAIT)