### PR TITLE
[TENT] Prefer the LAG-effective port speed from ibv_query_port_speed

### DIFF
--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -275,7 +275,10 @@ All slice spraying parameters are configurable via the configuration file:
   reports is preferred: for a VF over LAG that is the bandwidth left after
   a PF drops out of the bond, which the encoded link rate cannot express.
   The verb is resolved as an optional symbol, so older libraries keep
-  working on the encoded rate
+  working on the encoded rate. A query *error* keeps the last known
+  effective speed (falling back would briefly restore the higher encoded
+  rate on a degraded LAG); failures are counted per device and logged once
+  per episode
 - The theoretical rate seeds the EWMA and bounds it to
   `[ewma_min_multiplier, ewma_max_multiplier]` times that rate
 - If a device's port speed cannot be read or is outside [min, max],

--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -270,7 +270,12 @@ All slice spraying parameters are configurable via the configuration file:
 **Notes**:
 - Each device's bandwidth is read from the speed and width its port
   negotiated (`ibv_query_port`), so a 100G and a 400G NIC in the same host
-  start from different theoretical rates
+  start from different theoretical rates. Where libibverbs provides
+  `ibv_query_port_speed()` (rdma-core >= 62) the *effective* speed it
+  reports is preferred: for a VF over LAG that is the bandwidth left after
+  a PF drops out of the bond, which the encoded link rate cannot express.
+  The verb is resolved as an optional symbol, so older libraries keep
+  working on the encoded rate
 - The theoretical rate seeds the EWMA and bounds it to
   `[ewma_min_multiplier, ewma_max_multiplier]` times that rate
 - If a device's port speed cannot be read or is outside [min, max],

--- a/mooncake-common/include/ib_link_speed.h
+++ b/mooncake-common/include/ib_link_speed.h
@@ -70,6 +70,18 @@ inline double ibLinkSpeedGbps(int active_speed, int active_width) {
     return ibLaneSpeedGbps(active_speed) * ibLinkWidthLanes(active_width);
 }
 
+// Port speed in Gbps, preferring the effective speed ibv_query_port_speed()
+// reports (rdma-core >= 62, here in Mb/s) over the encoded link rate.
+// The two differ for a VF over LAG: a PF dropping out of the bond halves
+// the VF's bandwidth while its port stays ACTIVE at the same encoding, and
+// only the effective speed reflects that. 0 for effective_mbps means the
+// verb is unavailable or reported nothing, and the encodings decide.
+inline double ibPortSpeedGbps(unsigned long long effective_mbps,
+                              int active_speed, int active_width) {
+    if (effective_mbps > 0) return effective_mbps / 1000.0;
+    return ibLinkSpeedGbps(active_speed, active_width);
+}
+
 }  // namespace mooncake
 
 #endif  // MOONCAKE_IB_LINK_SPEED_H_

--- a/mooncake-common/tests/ib_link_speed_test.cpp
+++ b/mooncake-common/tests/ib_link_speed_test.cpp
@@ -52,6 +52,23 @@ TEST(IbLinkSpeedTest, ConvertsPortAttrEncodingsToGbps) {
 
 // An encoding the table does not know must not be guessed at: 0 tells the
 // caller the speed is unknown so it can fall back explicitly.
+// ibv_query_port_speed() (rdma-core >= 62) reports the port's *effective*
+// speed in Mb/s: for a VF over LAG that is the bandwidth left
+// after a PF drops out, which the encoded link rate cannot express. When
+// available it wins; otherwise the encodings decide as before.
+TEST(IbLinkSpeedTest, EffectiveSpeedWinsOverEncodedRate) {
+    // 400G link, but the LAG under this VF is down to one 200G PF.
+    EXPECT_DOUBLE_EQ(ibPortSpeedGbps(200'000, 128, 2), 200.0);
+    // Effective speed known, encodings unknown: still usable.
+    EXPECT_DOUBLE_EQ(ibPortSpeedGbps(100'000, 0, 0), 100.0);
+}
+
+TEST(IbLinkSpeedTest, EncodedRateWhenEffectiveSpeedIsUnavailable) {
+    // 0 = the library predates the verb or the driver reported nothing.
+    EXPECT_DOUBLE_EQ(ibPortSpeedGbps(0, 128, 2), 400.0);
+    EXPECT_DOUBLE_EQ(ibPortSpeedGbps(0, 0, 0), 0.0);
+}
+
 TEST(IbLinkSpeedTest, UnknownEncodingsReportZero) {
     EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(0, 2), 0.0);   // speed unset
     EXPECT_DOUBLE_EQ(ibLinkSpeedGbps(32, 0), 0.0);  // width unset

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -134,6 +134,18 @@ class RdmaContext {
 
     RdmaParams &params() const { return *params_.get(); }
 
+    // True while linkSpeedGbps() is derived from ibv_query_port_speed()
+    // rather than the encoded speed x width.
+    bool effectiveSpeedKnown() const {
+        return effective_speed_mbps_.load(std::memory_order_relaxed) > 0;
+    }
+
+    // ibv_query_port_speed() errors since the device was opened. The verb
+    // being absent, or reporting 0, is not an error.
+    uint64_t effectiveSpeedQueryFailures() const {
+        return effective_speed_query_failures_.load(std::memory_order_relaxed);
+    }
+
     // PCIe Relaxed Ordering support
     bool isRelaxedOrderingEnabled() const { return relaxed_ordering_enabled_; }
 
@@ -145,7 +157,10 @@ class RdmaContext {
     // Decode one ibv_query_port result into active_speed_/active_width_.
     void recordPortSpeed(const ibv_port_attr &port_attr);
     // Ask ibv_query_port_speed() for the effective speed when the library
-    // has it; records 0 otherwise so linkSpeedGbps() falls back.
+    // has it; records 0 when the verb is absent or reports nothing, so
+    // linkSpeedGbps() falls back. A verb *error* keeps the last known value
+    // instead: on a degraded LAG, falling back would briefly restore the
+    // higher encoded rate. Failures are counted and logged on transition.
     void queryEffectiveSpeed();
 
     // Release every resource currently owned by this context. This is
@@ -177,6 +192,9 @@ class RdmaContext {
     std::atomic<int> active_width_{0};
     // From ibv_query_port_speed(), converted to Mb/s; 0 = unavailable.
     std::atomic<uint64_t> effective_speed_mbps_{0};
+    std::atomic<uint64_t> effective_speed_query_failures_{0};
+    // Whether the last query errored; drives the transition logging.
+    std::atomic<bool> effective_speed_query_failing_{false};
     int gid_index_ = -1;
     ibv_gid gid_;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -46,6 +46,7 @@ class RdmaTransport;
 class RdmaContext {
     friend class RdmaCQ;
     friend class RdmaEndPoint;
+    friend class RdmaContextTestPeer;
 
    public:
     RdmaContext(RdmaTransport &transport);
@@ -191,7 +192,11 @@ class RdmaContext {
     // PCIe Relaxed Ordering support
     bool relaxed_ordering_enabled_ = false;
 
-    const IbvSymbols &verbs_;
+    // The context's own copy of the loader's verbs table (copied once at
+    // construction, read-only afterwards). A copy rather than a reference so
+    // tests can substitute individual entries and drive the port-attribute
+    // and event paths without an RNIC.
+    IbvSymbols verbs_;
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -113,7 +113,9 @@ class RdmaContext {
     // The one port this context opened; 0 for a slot that never constructed.
     uint8_t portNum() const { return params_ ? params_->device.port : 0; }
 
-    // Negotiated port speed in Gbps, 0 when it could not be determined.
+    // Port speed in Gbps: the effective speed from ibv_query_port_speed()
+    // where the library provides it (LAG-aware), otherwise the negotiated
+    // link rate. 0 when neither could be determined.
     double linkSpeedGbps() const;
 
     // Re-read the port's negotiated speed and width from the hardware, so
@@ -141,6 +143,9 @@ class RdmaContext {
     int openDevice(const std::string &device_name, uint8_t port);
     // Decode one ibv_query_port result into active_speed_/active_width_.
     void recordPortSpeed(const ibv_port_attr &port_attr);
+    // Ask ibv_query_port_speed() for the effective speed when the library
+    // has it; records 0 otherwise so linkSpeedGbps() falls back.
+    void queryEffectiveSpeed();
 
     // Release every resource currently owned by this context. This is
     // intentionally state-independent so it can clean up a partially completed
@@ -169,6 +174,8 @@ class RdmaContext {
     // atomic so a reader added elsewhere stays well-defined.
     std::atomic<int> active_speed_{0};
     std::atomic<int> active_width_{0};
+    // From ibv_query_port_speed(), converted to Mb/s; 0 = unavailable.
+    std::atomic<uint64_t> effective_speed_mbps_{0};
     int gid_index_ = -1;
     ibv_gid gid_;
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/ibv_loader.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/ibv_loader.h
@@ -31,6 +31,11 @@ struct IbvSymbols {
                          int index, union ibv_gid* gid);
     int (*ibv_query_port_default)(ibv_context* context, uint8_t port_num,
                                   ibv_port_attr* port_attr);
+    // Optional (rdma-core >= 62): effective port speed in 100 Mb/s units,
+    // LAG-aware. nullptr on older libraries; callers fall back to the
+    // ibv_port_attr encodings.
+    int (*ibv_query_port_speed)(ibv_context* context, uint32_t port_num,
+                                uint64_t* port_speed);
     const char* (*ibv_get_device_name)(struct ibv_device* device);
 
     ibv_pd* (*ibv_alloc_pd)(ibv_context* context);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -883,11 +883,34 @@ int RdmaContext::refreshPortAttributes() {
 }
 
 void RdmaContext::queryEffectiveSpeed() {
+    if (!native_context_ || !verbs_.ibv_query_port_speed) {
+        effective_speed_mbps_.store(0, std::memory_order_relaxed);
+        return;
+    }
     uint64_t speed = 0;
-    if (native_context_ && verbs_.ibv_query_port_speed &&
-        verbs_.ibv_query_port_speed(native_context_, params_->device.port,
-                                    &speed) != 0) {
-        speed = 0;  // verb present but failed: encodings decide
+    int rc = verbs_.ibv_query_port_speed(native_context_, params_->device.port,
+                                         &speed);
+    if (rc != 0) {
+        // Keep the last known value: on a degraded LAG, dropping to the
+        // encoded rate would overstate the port until the next successful
+        // query. Log once per failure episode, not per query.
+        effective_speed_query_failures_.fetch_add(1, std::memory_order_relaxed);
+        if (!effective_speed_query_failing_.exchange(
+                true, std::memory_order_relaxed)) {
+            LOG(WARNING) << "ibv_query_port_speed failed on " << device_name_
+                         << " (rc " << rc << "), keeping "
+                         << effective_speed_mbps_.load(
+                                std::memory_order_relaxed)
+                         << " Mb/s ("
+                         << effective_speed_query_failures_.load(
+                                std::memory_order_relaxed)
+                         << " failures so far)";
+        }
+        return;
+    }
+    if (effective_speed_query_failing_.exchange(false,
+                                                std::memory_order_relaxed)) {
+        LOG(INFO) << "ibv_query_port_speed recovered on " << device_name_;
     }
     // The verb reports 100 Mb/s units; store plain Mb/s.
     effective_speed_mbps_.store(speed * 100, std::memory_order_relaxed);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -851,6 +851,7 @@ int RdmaContext::openDevice(const std::string& device_name, uint8_t port) {
     native_context_ = context.release();
     lid_ = port_attr.lid;
     recordPortSpeed(port_attr);
+    queryEffectiveSpeed();
     return 0;
 }
 
@@ -877,12 +878,26 @@ int RdmaContext::refreshPortAttributes() {
         return -1;
     }
     recordPortSpeed(port_attr);
+    queryEffectiveSpeed();
     return 0;
 }
 
+void RdmaContext::queryEffectiveSpeed() {
+    uint64_t speed = 0;
+    if (native_context_ && verbs_.ibv_query_port_speed &&
+        verbs_.ibv_query_port_speed(native_context_, params_->device.port,
+                                    &speed) != 0) {
+        speed = 0;  // verb present but failed: encodings decide
+    }
+    // The verb reports 100 Mb/s units; store plain Mb/s.
+    effective_speed_mbps_.store(speed * 100, std::memory_order_relaxed);
+}
+
 double RdmaContext::linkSpeedGbps() const {
-    return ibLinkSpeedGbps(active_speed_.load(std::memory_order_relaxed),
-                           active_width_.load(std::memory_order_relaxed));
+    return ibPortSpeedGbps(
+        effective_speed_mbps_.load(std::memory_order_relaxed),
+        active_speed_.load(std::memory_order_relaxed),
+        active_width_.load(std::memory_order_relaxed));
 }
 }  // namespace tent
 }  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/transport/rdma/ibv_loader.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/ibv_loader.cpp
@@ -32,6 +32,19 @@ bool LoadSymbol(void* handle, const char* name, Fn& out) {
     return true;
 }
 
+// A symbol newer libibverbs add; its absence must not disable RDMA.
+template <typename Fn>
+void LoadOptionalSymbol(void* handle, const char* name, Fn& out) {
+    void* sym = dlsym(handle, name);
+    if (!sym) {
+        LOG(INFO) << "libibverbs lacks optional symbol " << name
+                  << "; the fallback path will be used";
+        out = nullptr;
+        return;
+    }
+    out = reinterpret_cast<Fn>(sym);
+}
+
 IbvLoader& IbvLoader::Instance() {
     static IbvLoader instance;
     return instance;
@@ -55,6 +68,8 @@ IbvLoader::IbvLoader() {
     ok &= LoadSymbol(handle_, "ibv_query_gid", symbols_.ibv_query_gid);
     ok &=
         LoadSymbol(handle_, "ibv_query_port", symbols_.ibv_query_port_default);
+    LoadOptionalSymbol(handle_, "ibv_query_port_speed",
+                       symbols_.ibv_query_port_speed);
     ok &= LoadSymbol(handle_, "ibv_get_device_name",
                      symbols_.ibv_get_device_name);
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -914,7 +914,10 @@ void Workers::refreshLinkSpeed(int dev_id, RdmaContext& context) {
     // configured default and warns, the same as at startup.
     if (after == before) return;
     LOG(WARNING) << context.name() << " link speed " << before << " -> "
-                 << after << " Gbps, re-seeding its bandwidth estimate";
+                 << after << " Gbps ("
+                 << (context.effectiveSpeedKnown() ? "effective speed"
+                                                   : "encoded rate")
+                 << "), re-seeding its bandwidth estimate";
     device_selector_->setDeviceBandwidth(dev_id, after);
 }
 

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cerrno>
 #include <dlfcn.h>
 #include <gtest/gtest.h>
 #include <infiniband/verbs.h>
@@ -79,6 +80,27 @@ class RdmaTransportTestPeer {
 
     static const RdmaContextSet& contextSet(const RdmaTransport& transport) {
         return transport.context_set_;
+    }
+};
+
+// Friend accessor for RdmaContext: TENT reaches libibverbs through a table of
+// function pointers the context copies from IbvLoader, so a test can replace
+// individual entries and hand the context a placeholder device instead of
+// needing an RNIC.
+class RdmaContextTestPeer {
+   public:
+    static IbvSymbols& verbs(RdmaContext& context) { return context.verbs_; }
+
+    // Make the context look opened on `native` (never dereferenced by the
+    // port-attribute paths, only passed back to the verbs) with `params`.
+    static void bindDevice(RdmaContext& context, ibv_context* native,
+                           std::shared_ptr<RdmaParams> params) {
+        context.native_context_ = native;
+        context.params_ = std::move(params);
+    }
+
+    static void unbindDevice(RdmaContext& context) {
+        context.native_context_ = nullptr;
     }
 };
 
@@ -435,6 +457,161 @@ TEST(RdmaContextPortSpeedTest, EffectiveSpeedVerbIsOptional) {
     // Mandatory symbols resolve regardless of the optional one.
     EXPECT_NE(sym.ibv_query_port_default, nullptr);
     EXPECT_NE(sym.ibv_open_device, nullptr);
+}
+
+// Verbs stand-ins wired through RdmaContextTestPeer::verbs(). Plain function
+// pointers, so state lives in one static block.
+struct FakePortVerbs {
+    ibv_context native{};      // placeholder handle, never dereferenced
+    uint8_t active_speed = 0;  // what ibv_query_port reports
+    uint8_t active_width = 0;
+    int query_port_rc = 0;
+    uint64_t speed_100mbps = 0;  // what ibv_query_port_speed reports
+    int query_speed_rc = 0;
+    int query_speed_calls = 0;
+};
+FakePortVerbs fake_port;
+
+int fakeQueryPort(ibv_context* context, uint8_t, ibv_port_attr* attr) {
+    if (context != &fake_port.native) return EINVAL;
+    if (fake_port.query_port_rc) return fake_port.query_port_rc;
+    *attr = {};
+    attr->state = IBV_PORT_ACTIVE;
+    attr->active_speed = fake_port.active_speed;
+    attr->active_width = fake_port.active_width;
+    return 0;
+}
+
+int fakeQueryPortSpeed(ibv_context* context, uint32_t, uint64_t* speed) {
+    ++fake_port.query_speed_calls;
+    if (context != &fake_port.native) return EINVAL;
+    if (fake_port.query_speed_rc) return fake_port.query_speed_rc;
+    *speed = fake_port.speed_100mbps;
+    return 0;
+}
+
+// A context whose port-attribute verbs are the fakes above, "opened" on the
+// placeholder device. Exercises refreshPortAttributes()/linkSpeedGbps()
+// exactly as the monitor thread does, without an RNIC.
+class RdmaContextFakeVerbsTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        fake_port = FakePortVerbs{};
+        fake_port.active_speed = 128;  // NDR
+        fake_port.active_width = 2;    // 4x -> 400 Gbps encoded
+        context_ = std::make_unique<RdmaContext>(transport_);
+        auto& verbs = RdmaContextTestPeer::verbs(*context_);
+        verbs.ibv_query_port_default = fakeQueryPort;
+        verbs.ibv_query_port_speed = fakeQueryPortSpeed;
+        RdmaContextTestPeer::bindDevice(*context_, &fake_port.native,
+                                        std::make_shared<RdmaParams>());
+    }
+
+    void TearDown() override {
+        // The context never owned the placeholder; keep its destructor away
+        // from it.
+        RdmaContextTestPeer::unbindDevice(*context_);
+    }
+
+    RdmaTransport transport_;
+    std::unique_ptr<RdmaContext> context_;
+};
+
+TEST_F(RdmaContextFakeVerbsTest, EffectiveSpeedPreferredWhenVerbReportsIt) {
+    fake_port.speed_100mbps = 2000;  // LAG down to one 200G PF
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
+    EXPECT_EQ(fake_port.query_speed_calls, 1);
+}
+
+TEST_F(RdmaContextFakeVerbsTest, EncodedRateWhenVerbFails) {
+    fake_port.speed_100mbps = 2000;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    ASSERT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
+    // The verb starts failing: the stale effective value must not linger.
+    fake_port.query_speed_rc = -1;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);
+}
+
+TEST_F(RdmaContextFakeVerbsTest, EncodedRateWhenVerbAbsent) {
+    fake_port.speed_100mbps = 2000;
+    RdmaContextTestPeer::verbs(*context_).ibv_query_port_speed = nullptr;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);
+    EXPECT_EQ(fake_port.query_speed_calls, 0);
+}
+
+TEST_F(RdmaContextFakeVerbsTest, RefreshSeesRenegotiatedLink) {
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    ASSERT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);
+    fake_port.active_speed = 32;  // came back as EDR 4x
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 100.0);
+}
+
+TEST_F(RdmaContextFakeVerbsTest, RefreshFailsCleanlyWhenQueryPortFails) {
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    fake_port.query_port_rc = EIO;
+    fake_port.active_speed = 32;
+    EXPECT_EQ(context_->refreshPortAttributes(), -1);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);  // cached values kept
+}
+
+// The whole runtime chain: a port event reaches Workers::applyContextEvent,
+// the context re-reads its (fake) port, and the selector is re-seeded only
+// when the speed actually changed -- with the device marked available again
+// on the new rate, not the old one.
+TEST(RdmaContextEventChainTest, PortActiveReseedsOnlyWhenTheSpeedChanged) {
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                    .ok());
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport), 0u);
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    auto* selector = workers->getDeviceSelector();
+    constexpr int kDev = 1;
+    auto& context = *RdmaTransportTestPeer::contextSet(transport)[kDev];
+
+    fake_port = FakePortVerbs{};
+    fake_port.active_speed = 128;
+    fake_port.active_width = 2;  // 400G
+    auto& verbs = RdmaContextTestPeer::verbs(context);
+    verbs.ibv_query_port_default = fakeQueryPort;
+    verbs.ibv_query_port_speed = fakeQueryPortSpeed;
+    RdmaContextTestPeer::bindDevice(context, &fake_port.native,
+                                    std::make_shared<RdmaParams>());
+
+    // Pretend init seeded it at 400G and it learned ~45 GB/s since.
+    ASSERT_EQ(context.refreshPortAttributes(), 0);
+    ASSERT_TRUE(
+        selector->setDeviceBandwidth(kDev, context.linkSpeedGbps()).ok());
+    ASSERT_TRUE(selector->setDeviceAvailable(kDev, true).ok());
+    for (int i = 0; i < 64; ++i)
+        ASSERT_TRUE(selector->release(kDev, 1 << 20, (1 << 20) / 45e9).ok());
+    ASSERT_NEAR(selector->getAggregateEwmaBandwidth(), 45e9, 45e9 * 0.02);
+
+    ibv_async_event event{};
+    event.event_type = IBV_EVENT_PORT_ACTIVE;
+    event.element.port_num = context.portNum();
+
+    // Same speed after the flap: keep what was learned.
+    RdmaTransportTestPeer::applyContextEvent(*workers, kDev, context, event);
+    EXPECT_NEAR(selector->getAggregateEwmaBandwidth(), 45e9, 45e9 * 0.02);
+    EXPECT_TRUE(selector->isDeviceAvailable(kDev));
+
+    // LAG lost a PF: the effective speed halves, the seed and clamp follow.
+    fake_port.speed_100mbps = 2000;
+    RdmaTransportTestPeer::applyContextEvent(*workers, kDev, context, event);
+    EXPECT_DOUBLE_EQ(context.linkSpeedGbps(), 200.0);
+    EXPECT_DOUBLE_EQ(selector->getAggregateEwmaBandwidth(), 25e9);
+    EXPECT_TRUE(selector->isDeviceAvailable(kDev));
+
+    RdmaContextTestPeer::unbindDevice(context);
 }
 
 TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <dlfcn.h>
 #include <gtest/gtest.h>
 #include <infiniband/verbs.h>
 #include <sys/wait.h>
@@ -34,6 +35,7 @@
 #include "tent/transport/rdma/params.h"
 #include "tent/transport/rdma/quota.h"
 #include "tent/transport/rdma/rdma_transport.h"
+#include "tent/transport/rdma/ibv_loader.h"
 #include "tent/transport/rdma/workers.h"
 
 namespace mooncake {
@@ -415,6 +417,24 @@ TEST_F(RdmaContextEventTest, DeviceFatalMarksUnavailableRegardlessOfPort) {
 TEST_F(RdmaContextEventTest, CqErrLeavesAvailabilityAlone) {
     fire(IBV_EVENT_CQ_ERR, ourPort());
     EXPECT_TRUE(selector_->isDeviceAvailable(kDev));
+}
+
+// ibv_query_port_speed() exists only in rdma-core >= 62. It must be resolved
+// as an optional symbol: present -> non-null, absent -> null, and either way
+// the mandatory verbs are still there (an older libibverbs must not lose
+// RDMA over it). Compared against a direct dlsym so the expectation is
+// whatever this host's library actually has.
+TEST(RdmaContextPortSpeedTest, EffectiveSpeedVerbIsOptional) {
+    void* lib = dlopen("libibverbs.so.1", RTLD_NOW | RTLD_LOCAL);
+    if (!lib) GTEST_SKIP() << "libibverbs.so.1 not loadable";
+    const bool host_has_verb = dlsym(lib, "ibv_query_port_speed") != nullptr;
+    dlclose(lib);
+
+    const auto& sym = IbvLoader::Instance().sym();
+    EXPECT_EQ(sym.ibv_query_port_speed != nullptr, host_has_verb);
+    // Mandatory symbols resolve regardless of the optional one.
+    EXPECT_NE(sym.ibv_query_port_default, nullptr);
+    EXPECT_NE(sym.ibv_open_device, nullptr);
 }
 
 TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -524,14 +524,37 @@ TEST_F(RdmaContextFakeVerbsTest, EffectiveSpeedPreferredWhenVerbReportsIt) {
     EXPECT_EQ(fake_port.query_speed_calls, 1);
 }
 
-TEST_F(RdmaContextFakeVerbsTest, EncodedRateWhenVerbFails) {
+// A transient verb failure must not revert a degraded LAG to the higher
+// encoded rate: the last known effective speed is held until a query
+// succeeds again (a real recovery re-fires PORT_ACTIVE / SPEED_CHANGE).
+TEST_F(RdmaContextFakeVerbsTest, EffectiveSpeedHeldWhenVerbFails) {
     fake_port.speed_100mbps = 2000;
     ASSERT_EQ(context_->refreshPortAttributes(), 0);
     ASSERT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
-    // The verb starts failing: the stale effective value must not linger.
-    fake_port.query_speed_rc = -1;
+    fake_port.query_speed_rc = EIO;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
+    EXPECT_EQ(context_->effectiveSpeedQueryFailures(), 2u);
+    // Recovery at a new speed is picked up again.
+    fake_port.query_speed_rc = 0;
+    fake_port.speed_100mbps = 4000;
     ASSERT_EQ(context_->refreshPortAttributes(), 0);
     EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);
+    EXPECT_EQ(context_->effectiveSpeedQueryFailures(), 2u);
+}
+
+// A verb that succeeds but reports 0 means "nothing to say", not a failure:
+// the encodings decide, as when the verb is absent.
+TEST_F(RdmaContextFakeVerbsTest, EncodedRateWhenVerbReportsZero) {
+    fake_port.speed_100mbps = 2000;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    ASSERT_DOUBLE_EQ(context_->linkSpeedGbps(), 200.0);
+    fake_port.speed_100mbps = 0;
+    ASSERT_EQ(context_->refreshPortAttributes(), 0);
+    EXPECT_DOUBLE_EQ(context_->linkSpeedGbps(), 400.0);
+    EXPECT_EQ(context_->effectiveSpeedQueryFailures(), 0u);
 }
 
 TEST_F(RdmaContextFakeVerbsTest, EncodedRateWhenVerbAbsent) {


### PR DESCRIPTION
## Description

  `RdmaContext::linkSpeedGbps()` decodes `active_speed × active_width`, the physical link's encoded rate. For a VF over VF LAG / multiport LAG, a PF dropping out of the bond halves the VF's bandwidth while its port stays `ACTIVE` at the same encoding, so the re-read on `IBV_EVENT_DEVICE_SPEED_CHANGE` (#3644) saw no change and never re-seeded the selector. rdma-core v62 added `ibv_query_port_speed()` alongside that event to report the *effective* speed (100 Mb/s units, LAG-aware).

  - `ibPortSpeedGbps()` in `ib_link_speed.h`: effective speed wins when > 0, the encodings decide otherwise.
  - `IbvLoader` resolves `ibv_query_port_speed` as an **optional** symbol (`nullptr` on older libraries; never disables RDMA).
  - `RdmaContext` queries it after every `ibv_query_port` (open and refresh), caches it, and `linkSpeedGbps()` prefers it. A present-but-failing verb records 0 so the fallback applies.
  - `RdmaContext::verbs_` becomes a per-context copy of the loader's table so tests can substitute entries (`RdmaContextTestPeer`), covering the effective-speed and refresh paths without an RNIC.

  No public API or config changes. Refs #3750 (follow-up section).

  ## Module

  - [x] Transfer Engine (`mooncake-transfer-engine`)
  - [x] Common (`mooncake-common`)
  - [x] Docs

  ## Type of Change

  - [x] Bug fix

  ## How Has This Been Tested?

  **Test commands:**
  ```bash
  cd build
  cmake --build . --target ib_link_speed_test tent_rdma_transport_test tent_device_selector_test tent_qos_contract_test bw_arbitration_test
  ctest -R 'ib_link_speed_test|tent_rdma_transport_test|tent_device_selector_test|tent_qos_contract_test|bw_arbitration_test' --output-on-failure

  Test results:
  - [x] Unit tests pass — 100% tests passed, 0 tests failed out of 5 (Ubuntu 22.04, rdma-core 39, no RNIC)
  - [ ] Integration tests pass (if applicable)
  - [x] Manual testing done (describe below)

  New tests, each observed failing before the change:
  - ib_link_speed_test: effective speed beats the encoded rate (2000 → 200 Gbps over an NDR 4x link); falls back to the encodings when 0.
  - tent_rdma_transport_test: the optional symbol resolves iff this host's libibverbs exports it, with the mandatory verbs still resolved; with fake verbs injected through RdmaContextTestPeer: effective speed preferred, cleared when the verb fails, skipped when absent, refresh sees a renegotiated link, failed ibv_query_port keeps cached values; end-to-end through Workers::applyContextEvent: PORT_ACTIVE at the same speed keeps the learned EWMA, a LAG-halved effective speed re-seeds it to the new rate and the device stays available.

  Not covered without hardware: a real driver reporting a LAG-reduced speed (rdma-core ≥ 62 + Linux ≥ 7.0 + mlx5 + LAG).

  Checklist
  
  - [x] I have performed a self-review of my own code
  - [x] I have formatted my code using ./scripts/code_format.sh
  - [x] I have run pre-commit on the files changed in this PR and all hooks pass
  - [x] I have updated the documentation (if applicable)
  - [x] I have added tests to prove my changes are effective
  - [ ] For changes >500 LOC: I have filed an RFC issue (N/A, ~290 LOC incl. tests)

  AI Assistance Disclosure

  - [ ] No AI tools were used
  - [x] AI tools were used (specify below)