### PR TITLE
[TransferEngine] Add per-target metrics to multi-target tebench

### DIFF
--- a/docs/source/performance/mooncake/tebench.md
+++ b/docs/source/performance/mooncake/tebench.md
@@ -197,6 +197,20 @@ computed from each class's actual transfer size.
 `--qos_classes_json`, and the global `--tent_intent_type`. Non-default
 per-class intents and deadlines require the TENT backend.
 
+### 4.3 Per-Target Metrics
+
+Multi-target runs print one `[target-summary]` line per target. Use
+`--result_output_jsonl=<path>` to also append a schema-versioned JSON record for
+each benchmark configuration. The record keeps the aggregate operation, byte,
+and throughput totals plus each target's segment name, assigned thread count,
+completed operations, transferred bytes, throughput, and latency distribution.
+The aggregate throughput uses the pooled average worker duration, matching the
+existing `BW (GB/s)` table calculation.
+
+Targets with no assigned worker are retained with zero-valued metrics. This
+makes an under-provisioned run (`threads < targets`) visible instead of silently
+dropping targets from the result.
+
 ## 5. Runtime Configuration
 
 This section summarizes the key runtime options that control workload behavior,
@@ -371,6 +385,8 @@ gpu_id + thread_id
 * `--qos_link_capacity_gbps` : measured usable link capacity in decimal GB/s
 * `--qos_output_jsonl` : append one schema-versioned JSON object per benchmark
   configuration
+* `--result_output_jsonl` : append aggregate and per-target metrics for each
+  benchmark configuration
 
 QoS mode intentionally requires a fixed thread count. Sweep offered load by
 running explicit cases with different class thread allocations so every output

--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -29,7 +29,8 @@ file(GLOB TEBENCH_SOURCES "*.cpp")
 # The TENT backend is only available when USE_TENT is enabled; drop its
 # translation unit (which pulls in tent/ headers) from non-TENT builds.
 if(NOT USE_TENT)
-  list(REMOVE_ITEM TEBENCH_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/tent_backend.cpp")
+  list(REMOVE_ITEM TEBENCH_SOURCES
+       "${CMAKE_CURRENT_SOURCE_DIR}/tent_backend.cpp")
   list(APPEND TEBENCH_SOURCES
        "${CMAKE_CURRENT_SOURCE_DIR}/../tent/src/common/qos_metrics.cpp")
 endif()
@@ -41,10 +42,11 @@ if(USE_TENT)
   target_link_libraries(tebench PUBLIC tent_link_group)
 else()
   # The classic backend still uses a couple of header-only helpers that live
-  # under tent/include (SimpleRandom in utils.h, bindToSocket in te_backend.cpp).
-  # Expose just the header path so tebench builds without the TENT library.
-  target_include_directories(tebench PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
+  # under tent/include (SimpleRandom in utils.h, bindToSocket in
+  # te_backend.cpp). Expose just the header path so tebench builds without the
+  # TENT library.
+  target_include_directories(
+    tebench PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
 endif()
 if(USE_CUDA)
   target_link_libraries(tebench PUBLIC CUDA::cudart)
@@ -63,19 +65,21 @@ else()
   set(TANGRT_RPATH "")
 endif()
 set_target_properties(
-  tebench PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
-                     INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../../mooncake-common${TANGRT_RPATH}")
+  tebench
+  PROPERTIES BUILD_WITH_INSTALL_RPATH TRUE
+             INSTALL_RPATH
+             "$ORIGIN/../lib:$ORIGIN/../../mooncake-common${TANGRT_RPATH}")
 
 if(BUILD_UNIT_TESTS)
-  add_executable(tebench_qos_metrics_test tests/qos_metrics_test.cpp
-                                          qos_metrics_adapter.cpp
-                                          workload_config.cpp utils.cpp)
+  add_executable(
+    tebench_qos_metrics_test tests/qos_metrics_test.cpp qos_metrics_adapter.cpp
+                             workload_config.cpp utils.cpp)
   if(NOT USE_TENT)
-    target_sources(tebench_qos_metrics_test PRIVATE
-                   ../tent/src/common/qos_metrics.cpp)
+    target_sources(tebench_qos_metrics_test
+                   PRIVATE ../tent/src/common/qos_metrics.cpp)
   endif()
-  target_link_libraries(tebench_qos_metrics_test
-                        PRIVATE transfer_engine gtest gtest_main)
+  target_link_libraries(tebench_qos_metrics_test PRIVATE transfer_engine gtest
+                                                         gtest_main)
   if(USE_TENT)
     target_link_libraries(tebench_qos_metrics_test PRIVATE tent_common)
   endif()
@@ -84,4 +88,17 @@ if(BUILD_UNIT_TESTS)
     PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
             "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
   add_test(NAME tebench_qos_metrics_test COMMAND tebench_qos_metrics_test)
+
+  add_executable(tebench_target_metrics_test tests/target_metrics_test.cpp
+                                             target_metrics.cpp utils.cpp)
+  target_link_libraries(tebench_target_metrics_test PRIVATE transfer_engine
+                                                            gtest gtest_main)
+  if(USE_TENT)
+    target_link_libraries(tebench_target_metrics_test PRIVATE tent_common)
+  endif()
+  target_include_directories(
+    tebench_target_metrics_test
+    PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+            "${CMAKE_CURRENT_SOURCE_DIR}/../tent/include")
+  add_test(NAME tebench_target_metrics_test COMMAND tebench_target_metrics_test)
 endif()

--- a/mooncake-transfer-engine/benchmark/bench_runner.h
+++ b/mooncake-transfer-engine/benchmark/bench_runner.h
@@ -56,6 +56,8 @@ class BenchRunner {
 
     virtual size_t getTargetCount() const = 0;
 
+    virtual size_t getTargetIndex(int thread_id) const = 0;
+
     virtual uint64_t getTargetSegmentId(int thread_id) const = 0;
 
     virtual uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,

--- a/mooncake-transfer-engine/benchmark/main.cpp
+++ b/mooncake-transfer-engine/benchmark/main.cpp
@@ -16,6 +16,7 @@
 
 #include "bench_runner.h"
 #include "qos_metrics_adapter.h"
+#include "target_metrics.h"
 #include "te_backend.h"
 #include "workload_config.h"
 #ifdef USE_TENT
@@ -73,6 +74,12 @@ int processBatchSizes(
 
     XferBenchStats stats;
     std::vector<XferBenchStats> qos_stats(qos_classes.size());
+    std::vector<TargetBenchStats> target_stats(runner.getTargetCount());
+    const auto target_names =
+        splitCommaSeparated(XferBenchConfig::target_seg_name);
+    LOG_ASSERT(target_names.size() == target_stats.size());
+    for (size_t i = 0; i < target_stats.size(); ++i)
+        target_stats[i].segment_name = target_names[i];
     XferBenchStats tight_stats;
     XferBenchStats loose_stats;
     std::mutex mutex;
@@ -110,6 +117,7 @@ int processBatchSizes(
         uint64_t target_addr = runner.getTargetBufferBase(
             target_thread_id, address_stride_bytes, 1);
         uint64_t target_id = runner.getTargetSegmentId(target_thread_id);
+        const size_t target_index = runner.getTargetIndex(target_thread_id);
         const bool qos_enabled = !qos_classes.empty();
         const size_t qos_class =
             qos_enabled ? qosClassForThread(qos_classes, thread_id) : 0;
@@ -208,10 +216,23 @@ int processBatchSizes(
             }
         }
         auto total_duration = timer.lap_us();
+        const uint64_t bytes_per_operation = checkedMul(
+            thread_block_size, thread_batch_size, "operation payload size");
+        const uint64_t transferred_bytes =
+            checkedMul(bytes_per_operation, transfer_duration.size(),
+                       "thread transferred bytes");
         std::lock_guard<std::mutex> lock(mutex);
         stats.total_duration.add(total_duration);
         stats.transfer_duration.add(transfer_duration);
         stats.instant_bandwidth.add(thread_instant_bandwidth);
+        auto& target = target_stats[target_index];
+        ++target.threads;
+        target.transferred_bytes =
+            checkedAdd(target.transferred_bytes, transferred_bytes,
+                       "target transferred bytes");
+        target.stats.total_duration.add(total_duration);
+        target.stats.transfer_duration.add(transfer_duration);
+        target.stats.instant_bandwidth.add(thread_instant_bandwidth);
         if (qos_enabled) {
             qos_stats[qos_class].total_duration.add(total_duration);
             qos_stats[qos_class].transfer_duration.add(transfer_duration);
@@ -227,6 +248,18 @@ int processBatchSizes(
     if (rc != 0) return -1;
     if (workload_classes.empty())
         printStats(block_size, batch_size, stats, num_threads);
+    auto target_report = calculateTargetMetrics(
+        block_size, batch_size, num_threads, XferBenchConfig::backend,
+        XferBenchConfig::op_type, &target_stats);
+    if (runner.getTargetCount() > 1) printTargetMetrics(target_report);
+    if (!XferBenchConfig::result_output_jsonl.empty()) {
+        std::string error;
+        if (!appendTargetMetricsJsonl(XferBenchConfig::result_output_jsonl,
+                                      target_report, &error)) {
+            LOG(ERROR) << error;
+            return -1;
+        }
+    }
     if (!qos_classes.empty()) {
         std::vector<uint64_t> bytes_per_operation;
         for (const auto& config : workload_classes) {

--- a/mooncake-transfer-engine/benchmark/target_metrics.cpp
+++ b/mooncake-transfer-engine/benchmark/target_metrics.cpp
@@ -1,0 +1,144 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "target_metrics.h"
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake {
+namespace tent {
+
+TargetMetricsReport calculateTargetMetrics(
+    size_t block_size, size_t batch_size, int num_threads,
+    const std::string& backend, const std::string& op_type,
+    std::vector<TargetBenchStats>* stats) {
+    TargetMetricsReport report;
+    report.block_size = block_size;
+    report.batch_size = batch_size;
+    report.num_threads = num_threads;
+    report.backend = backend;
+    report.op_type = op_type;
+    report.targets.reserve(stats->size());
+    double aggregate_duration_sum_us = 0.0;
+    int assigned_threads = 0;
+
+    for (size_t i = 0; i < stats->size(); ++i) {
+        auto& input = (*stats)[i];
+        TargetMetrics metrics;
+        metrics.index = i;
+        metrics.segment_name = input.segment_name;
+        metrics.threads = input.threads;
+        metrics.operations = input.stats.transfer_duration.count();
+        metrics.transferred_bytes = input.transferred_bytes;
+        metrics.total_duration_us = input.stats.total_duration.avg();
+        metrics.avg_transfer_us = input.stats.transfer_duration.avg();
+        metrics.p99_us = input.stats.transfer_duration.p99();
+        metrics.p999_us = input.stats.transfer_duration.p999();
+        metrics.avg_instant_gbps = input.stats.instant_bandwidth.avg();
+        if (metrics.operations != 0) {
+            metrics.avg_latency_us = metrics.total_duration_us *
+                                     metrics.threads / metrics.operations;
+        }
+        if (metrics.total_duration_us > 0.0) {
+            metrics.throughput_gbps =
+                static_cast<double>(metrics.transferred_bytes) / 1000.0 /
+                metrics.total_duration_us;
+        }
+        report.aggregate_operations =
+            checkedAdd(report.aggregate_operations, metrics.operations,
+                       "aggregate operations");
+        report.aggregate_transferred_bytes = checkedAdd(
+            report.aggregate_transferred_bytes, metrics.transferred_bytes,
+            "aggregate transferred bytes");
+        aggregate_duration_sum_us +=
+            metrics.total_duration_us * metrics.threads;
+        assigned_threads += metrics.threads;
+        report.targets.push_back(std::move(metrics));
+    }
+    if (assigned_threads > 0 && aggregate_duration_sum_us > 0.0) {
+        const double aggregate_duration_us =
+            aggregate_duration_sum_us / assigned_threads;
+        report.aggregate_throughput_gbps =
+            static_cast<double>(report.aggregate_transferred_bytes) / 1000.0 /
+            aggregate_duration_us;
+    }
+    return report;
+}
+
+void printTargetMetrics(const TargetMetricsReport& report) {
+    for (const auto& metrics : report.targets) {
+        std::cout << "  [target-summary] index=" << metrics.index
+                  << " name=" << metrics.segment_name
+                  << " threads=" << metrics.threads
+                  << " operations=" << metrics.operations
+                  << " transferred_bytes=" << metrics.transferred_bytes
+                  << " throughput=" << std::fixed << std::setprecision(6)
+                  << metrics.throughput_gbps
+                  << " GB/s p99_us=" << std::setprecision(1) << metrics.p99_us
+                  << std::endl;
+    }
+}
+
+bool appendTargetMetricsJsonl(const std::string& path,
+                              const TargetMetricsReport& report,
+                              std::string* error) {
+    nlohmann::json root = {
+        {"schema_version", 1},
+        {"record_type", "target_metrics"},
+        {"backend", report.backend},
+        {"op_type", report.op_type},
+        {"block_size", report.block_size},
+        {"batch_size", report.batch_size},
+        {"num_threads", report.num_threads},
+        {"aggregate_operations", report.aggregate_operations},
+        {"aggregate_transferred_bytes", report.aggregate_transferred_bytes},
+        {"aggregate_throughput_gbps", report.aggregate_throughput_gbps},
+        {"targets", nlohmann::json::array()},
+    };
+    for (const auto& metrics : report.targets) {
+        root["targets"].push_back({
+            {"index", metrics.index},
+            {"segment_name", metrics.segment_name},
+            {"threads", metrics.threads},
+            {"operations", metrics.operations},
+            {"transferred_bytes", metrics.transferred_bytes},
+            {"total_duration_us", metrics.total_duration_us},
+            {"throughput_gbps", metrics.throughput_gbps},
+            {"avg_latency_us", metrics.avg_latency_us},
+            {"avg_transfer_us", metrics.avg_transfer_us},
+            {"p99_us", metrics.p99_us},
+            {"p999_us", metrics.p999_us},
+            {"avg_instant_gbps", metrics.avg_instant_gbps},
+        });
+    }
+
+    std::ofstream output(path, std::ios::app);
+    if (!output) {
+        *error = "failed to open target JSONL output: " + path;
+        return false;
+    }
+    output << root.dump() << '\n';
+    if (!output) {
+        *error = "failed to write target JSONL output: " + path;
+        return false;
+    }
+    return true;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/benchmark/target_metrics.h
+++ b/mooncake-transfer-engine/benchmark/target_metrics.h
@@ -1,0 +1,75 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TEBENCH_TARGET_METRICS_H
+#define TEBENCH_TARGET_METRICS_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "utils.h"
+
+namespace mooncake {
+namespace tent {
+
+struct TargetBenchStats {
+    std::string segment_name;
+    int threads = 0;
+    uint64_t transferred_bytes = 0;
+    XferBenchStats stats;
+};
+
+struct TargetMetrics {
+    size_t index = 0;
+    std::string segment_name;
+    int threads = 0;
+    uint64_t operations = 0;
+    uint64_t transferred_bytes = 0;
+    double total_duration_us = 0.0;
+    double throughput_gbps = 0.0;
+    double avg_latency_us = 0.0;
+    double avg_transfer_us = 0.0;
+    double p99_us = 0.0;
+    double p999_us = 0.0;
+    double avg_instant_gbps = 0.0;
+};
+
+struct TargetMetricsReport {
+    size_t block_size = 0;
+    size_t batch_size = 0;
+    int num_threads = 0;
+    std::string backend;
+    std::string op_type;
+    uint64_t aggregate_operations = 0;
+    uint64_t aggregate_transferred_bytes = 0;
+    double aggregate_throughput_gbps = 0.0;
+    std::vector<TargetMetrics> targets;
+};
+
+TargetMetricsReport calculateTargetMetrics(
+    size_t block_size, size_t batch_size, int num_threads,
+    const std::string& backend, const std::string& op_type,
+    std::vector<TargetBenchStats>* stats);
+
+void printTargetMetrics(const TargetMetricsReport& report);
+
+bool appendTargetMetricsJsonl(const std::string& path,
+                              const TargetMetricsReport& report,
+                              std::string* error);
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TEBENCH_TARGET_METRICS_H

--- a/mooncake-transfer-engine/benchmark/te_backend.h
+++ b/mooncake-transfer-engine/benchmark/te_backend.h
@@ -63,6 +63,10 @@ class TEBenchRunner : public BenchRunner {
 
     size_t getTargetCount() const;
 
+    size_t getTargetIndex(int thread_id) const {
+        return targetIndex(thread_id);
+    }
+
     uint64_t getTargetSegmentId(int thread_id) const;
 
     uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,

--- a/mooncake-transfer-engine/benchmark/tent_backend.h
+++ b/mooncake-transfer-engine/benchmark/tent_backend.h
@@ -89,6 +89,10 @@ class TENTBenchRunner : public BenchRunner {
 
     size_t getTargetCount() const;
 
+    size_t getTargetIndex(int thread_id) const {
+        return targetIndex(thread_id);
+    }
+
     uint64_t getTargetSegmentId(int thread_id) const;
 
     uint64_t getTargetBufferBase(int thread_id, uint64_t block_size,

--- a/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
+++ b/mooncake-transfer-engine/benchmark/tests/target_metrics_test.cpp
@@ -1,0 +1,66 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "target_metrics.h"
+
+#include <cstdio>
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "tent/thirdparty/nlohmann/json.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+TEST(TargetMetricsTest, ReportsEachTargetAndWritesJsonl) {
+    std::vector<TargetBenchStats> stats(2);
+    stats[0].segment_name = "target-a";
+    stats[0].threads = 2;
+    stats[0].transferred_bytes = 6000;
+    stats[0].stats.total_duration.add(1000.0);
+    stats[0].stats.total_duration.add(1000.0);
+    stats[0].stats.transfer_duration.add({10.0, 20.0, 30.0});
+    stats[0].stats.instant_bandwidth.add({0.1, 0.2, 0.3});
+    stats[1].segment_name = "target-b";
+
+    const auto report =
+        calculateTargetMetrics(1000, 2, 2, "tent", "read", &stats);
+    ASSERT_EQ(report.targets.size(), 2u);
+    EXPECT_EQ(report.aggregate_operations, 3u);
+    EXPECT_EQ(report.aggregate_transferred_bytes, 6000u);
+    EXPECT_NEAR(report.aggregate_throughput_gbps, 0.006, 1e-12);
+    EXPECT_EQ(report.targets[0].threads, 2);
+    EXPECT_NEAR(report.targets[0].avg_latency_us, 2000.0 / 3.0, 1e-12);
+    EXPECT_DOUBLE_EQ(report.targets[1].throughput_gbps, 0.0);
+
+    const std::string path = "tebench_target_metrics_test.jsonl";
+    std::remove(path.c_str());
+    std::string error;
+    ASSERT_TRUE(appendTargetMetricsJsonl(path, report, &error)) << error;
+    std::ifstream input(path);
+    nlohmann::json record;
+    ASSERT_NO_THROW(input >> record);
+    EXPECT_EQ(record["schema_version"], 1);
+    EXPECT_EQ(record["record_type"], "target_metrics");
+    ASSERT_EQ(record["targets"].size(), 2u);
+    EXPECT_EQ(record["targets"][0]["segment_name"], "target-a");
+    EXPECT_EQ(record["targets"][1]["operations"], 0);
+    std::remove(path.c_str());
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/benchmark/utils.cpp
+++ b/mooncake-transfer-engine/benchmark/utils.cpp
@@ -71,6 +71,9 @@ DEFINE_double(qos_link_capacity_gbps, 0.0,
               "Link capacity in GB/s for total utilization (0 reports N/A).");
 DEFINE_string(qos_output_jsonl, "",
               "Append versioned QoS metric records to this JSONL file.");
+DEFINE_string(result_output_jsonl, "",
+              "Append versioned benchmark result records, including "
+              "per-target metrics, to this JSONL file.");
 DEFINE_uint64(request_interval_us, 0,
               "Per-thread delay before issuing each transfer batch, in "
               "microseconds. 0 disables pacing.");
@@ -132,6 +135,7 @@ std::string XferBenchConfig::qos_classes_json;
 std::string XferBenchConfig::workload_classes_json;
 double XferBenchConfig::qos_link_capacity_gbps = 0.0;
 std::string XferBenchConfig::qos_output_jsonl;
+std::string XferBenchConfig::result_output_jsonl;
 uint64_t XferBenchConfig::request_interval_us = 0;
 uint64_t XferBenchConfig::deadline_us = 0;
 int XferBenchConfig::deadline_tight_threads = 0;
@@ -171,6 +175,7 @@ void XferBenchConfig::loadFromFlags() {
     workload_classes_json = FLAGS_workload_classes_json;
     qos_link_capacity_gbps = FLAGS_qos_link_capacity_gbps;
     qos_output_jsonl = FLAGS_qos_output_jsonl;
+    result_output_jsonl = FLAGS_result_output_jsonl;
     request_interval_us = FLAGS_request_interval_us;
     deadline_us = FLAGS_deadline_us;
     deadline_tight_threads = FLAGS_deadline_tight_threads;

--- a/mooncake-transfer-engine/benchmark/utils.h
+++ b/mooncake-transfer-engine/benchmark/utils.h
@@ -79,6 +79,7 @@ struct XferBenchConfig {
     static std::string workload_classes_json;
     static double qos_link_capacity_gbps;
     static std::string qos_output_jsonl;
+    static std::string result_output_jsonl;
     static uint64_t request_interval_us;
     static uint64_t deadline_us;
     static int deadline_tight_threads;


### PR DESCRIPTION
## What this PR does

This PR builds on the multi-target tebench support introduced in #3391 and adds per-target observability.

- Reports throughput, latency, p99/p999, operation count, and transferred bytes for each target
- Adds optional JSONL output through `--result_output_jsonl`
- Supports both classic Transfer Engine and TENT
- Preserves the existing single-target output
- Includes targets with no assigned operations, making load imbalance visible
- Adds focused unit tests and documentation

## Motivation

Aggregate metrics can hide imbalance between targets in multi-target benchmarks. Per-target results are needed to evaluate target selection and identify slow or underutilized peers before introducing more advanced placement or weighting policies.

## Validation

- Built with TENT enabled and disabled
- Passed existing and new unit tests
- Verified with a local two-target TENT smoke test
- Verified JSONL output
- Passed formatting, documentation, and spelling checks

Part of #3371.