### PR TITLE
[Bugfix][TENT] Predict deadline MLU from a metered wire rate and the bytes ahead

### DIFF
--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -81,7 +81,7 @@ The penalty is applied as a multiplier to predicted completion time, making remo
 
 ### EWMA Bandwidth Estimation
 
-Each device maintains an EWMA (Exponentially Weighted Moving Average) of its effective bandwidth:
+Each device maintains a **selection EWMA** (Exponentially Weighted Moving Average) of its effective bandwidth, the series that device selection scores with:
 
 ```
 initial_value = theoretical_bandwidth
@@ -109,6 +109,56 @@ The EWMA provides:
 - **Memory**: Recent observations have more influence than old ones
 - **Stability**: Smooths out transient fluctuations
 - **Adaptability**: Tracks gradual changes in link quality
+
+#### Transmit Estimate
+
+Each device also keeps a second series, the **transmit estimate**, for the
+admission queue's deadline-infeasible drop (`runtime_queue/mlu_local_threshold`,
+which reads the sum over devices). It predicts the MLU from it as:
+
+```
+predicted_mlu = ((bytes_ahead + length) / transmit_bandwidth) / remaining_window
+```
+
+`bytes_ahead` is what the request must wait behind before its own bytes move:
+every drop-eligible owner (RDMA, not staged) already dispatched and not yet
+completed — owners on other transports share the queue but not the NIC.
+
+The deadline is absolute, so that wait counts against the window — as an
+additive delay over the wire rate, not as a slower bandwidth (which would
+multiply the wait by the request's slice count).
+
+It uses the same update rule and clamp as the selection EWMA, but it is fed
+from a different measurement because it answers a different question:
+
+| | Selection EWMA | Transmit estimate |
+|---|---|---|
+| Question | Which NIC should the next slice go to? | How fast does this NIC move bytes? |
+| Sample | one successful completion: bytes / (post → completion), so the NIC's own queueing behind earlier work requests is included and a backed-up NIC scores worse | one meter interval: bytes completed / time the NIC spent with work posted |
+| α | `bandwidth_learning_rate` = 0.01 (~99% latest sample) | `transmit_bandwidth_learning_rate` = 0.9 (~10 intervals, ≈100 ms, to follow a change) |
+
+Per-completion timing cannot answer the second question. Up to `max_qp_wr`
+work requests are posted in one call with timestamps that are effectively
+one, and a poll pass timestamps every completion it collects alike, so a
+slice's own "post → completion" grows with the depth of the batch it
+travelled in — deep enough and the estimate would sit on its lower clamp on
+a healthy link. Bytes over the NIC's busy time does not care how the work was
+batched.
+
+Busy time is the time the device has had at least one work request posted:
+a stretch opens when its posted bytes go from zero to non-zero and closes
+when they return to zero, so the gaps of a workload that bursts and waits are
+not charged to the link. A sample is offered only at the last completion of a
+poll pass (every completion in a pass carries the same timestamp), and one
+that spans more than `transmit_meter_max_interval_ns` of wall clock is
+dropped rather than learned from: it describes a link too far in the past. A
+posted slice that ends without moving its bytes — failed, flushed, timed
+out — makes its stretch unusable, so the meter starts its next interval
+fresh. With no usable interval the estimate keeps its last value, or the
+link-speed seed — the optimistic direction, which cannot cause a false drop.
+
+With queueing carried by `bytes_ahead`, the rate itself must exclude
+queueing or the wait would be counted twice.
 
 ### Multi-Path Allocation
 
@@ -243,6 +293,9 @@ cross-node outage.
   "transports": {
     "rdma": {
       "bandwidth_learning_rate": 0.01,
+      "transmit_bandwidth_learning_rate": 0.9,
+      "transmit_meter_interval_ns": 10000000,
+      "transmit_meter_max_interval_ns": 50000000,
       "ewma_min_bandwidth_multiplier": 0.1,
       "ewma_max_bandwidth_multiplier": 10.0
     }
@@ -252,15 +305,20 @@ cross-node outage.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `bandwidth_learning_rate` | float | `0.01` | EWMA learning rate (0.0 = full adaptation, 1.0 = no learning) |
+| `bandwidth_learning_rate` | float | `0.01` | Selection EWMA learning rate (0.0 = full adaptation, 1.0 = no learning) |
+| `transmit_bandwidth_learning_rate` | float | `0.9` | Transmit estimate learning rate, same convention; read by the deadline predictors |
+| `transmit_meter_interval_ns` | uint | `10000000` | How often a device's throughput is sampled (10 ms) |
+| `transmit_meter_max_interval_ns` | uint | `50000000` | An interval longer than this is re-baselined instead of learned from |
 | `ewma_min_bandwidth_multiplier` | float | `0.1` | Minimum bandwidth as fraction of theoretical |
 | `ewma_max_bandwidth_multiplier` | float | `10.0` | Maximum bandwidth as fraction of theoretical |
 
 **Guidelines**:
 - Lower α (e.g., 0.001) → faster adaptation, more volatile → responds quickly to changes
 - Higher α (e.g., 0.1) → slower adaptation, more stable → smooths out transient fluctuations
-- Default α = 0.01 provides balanced adaptation
-- Multipliers constrain EWMA to reasonable range [0.1×, 10.0×] of theoretical bandwidth
+- Default α = 0.01 provides balanced adaptation for device selection
+- Keep `transmit_bandwidth_learning_rate` high: it backs an irreversible
+  drop decision, so it should follow sustained change, not single samples
+- Multipliers constrain both series to [0.1×, 10.0×] of theoretical bandwidth
 
 ### Device Selection Scoring
 

--- a/docs/source/design/tent/slice-spraying.md
+++ b/docs/source/design/tent/slice-spraying.md
@@ -113,16 +113,27 @@ The EWMA provides:
 #### Transmit Estimate
 
 Each device also keeps a second series, the **transmit estimate**, for the
-admission queue's deadline-infeasible drop (`runtime_queue/mlu_local_threshold`,
-which reads the sum over devices). It predicts the MLU from it as:
+deadline predictors: the admission queue's deadline-infeasible drop
+(`runtime_queue/mlu_local_threshold`, reads the sum over devices) and the RDMA
+workers' bandwidth arbitration (`transports/rdma/deadline_bw_arbitration`,
+reads the local NIC's value). Both compute the same predicted MLU from it:
 
 ```
 predicted_mlu = ((bytes_ahead + length) / transmit_bandwidth) / remaining_window
 ```
 
 `bytes_ahead` is what the request must wait behind before its own bytes move:
-every drop-eligible owner (RDMA, not staged) already dispatched and not yet
-completed — owners on other transports share the queue but not the NIC.
+for the admission queue, every drop-eligible owner (RDMA, not staged) already
+dispatched and not yet completed — owners on other transports share the queue
+but not the NIC. For the arbitration it is the NIC's **posted bytes**: what
+has reached the hardware and not yet completed. That is deliberately not the
+selector's `inflight_bytes`, which is charged when a slice is *allocated* and
+so would include the very slices being ordered as well as work still sitting
+in a worker queue. The order is then built one slot at a time — the slice
+that takes a slot joins `bytes_ahead` for the ones still waiting, since the
+QP posts them in that order (exactly for the first 64 slots, which is more
+than one post can take; the rest are ranked once against the bytes those
+slots accumulated).
 
 The deadline is absolute, so that wait counts against the window — as an
 additive delay over the wire rate, not as a slower bandwidth (which would

--- a/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/admission_queue.h
@@ -51,12 +51,13 @@ struct QueueLimits {
     // it does not admit/reject or otherwise change what gets dispatched.
     bool deadline_aware{false};
     // Opt-in deadline-infeasible drop (RFC #2519 step 3). Local-decode MLU
-    // threshold θ_local. 0 (default) disables drop entirely — behavior is the
-    // step-2 EDF ordering (or FIFO). When > 0 (e.g. 1.5) and a bandwidth
-    // provider is set, an owner whose predicted MLU
-    // (= predicted_transfer_time / remaining_window) reaches this threshold is
-    // dropped instead of dispatched, and on_local_decode_suggested is raised so
-    // the caller can recompute locally. Requires deadline_aware = true.
+    // threshold θ_local. <= 0 (default 0) disables drop entirely — behavior is
+    // the step-2 EDF ordering (or FIFO). When > 0 (e.g. 1.5) and a bandwidth
+    // provider is set, an owner whose predicted MLU (see DeadlineMlu:
+    // (eligible bytes already dispatched + length) / bandwidth, over the
+    // remaining window) reaches this threshold is dropped instead of
+    // dispatched, and on_local_decode_suggested is raised so the caller can
+    // recompute locally. Requires deadline_aware = true.
     double mlu_local_threshold{0.0};
     // Opt-in deadline proximity promotion. When > 0, pickForDispatch promotes
     // queued owners whose remaining slack (deadline_ns - now) is below this
@@ -75,9 +76,11 @@ struct QueueOwnerInput {
     Request request{};
     QueueOwnerKind kind{QueueOwnerKind::User};
     // True only when the caller has established that this owner's transfer
-    // time is governed by the installed bandwidth provider. Default false
-    // keeps degradation explicitly opt-in so a new enqueue path cannot
-    // accidentally apply an RDMA EWMA to MNNVL/TCP/staging paths.
+    // time is governed by the installed bandwidth provider -- for the RDMA
+    // wiring, the aggregate transmit estimate over the local NICs. Default
+    // false keeps degradation explicitly opt-in so a new enqueue path cannot
+    // accidentally predict an MNNVL/TCP/staging transfer, whose completion
+    // time that estimate says nothing about, from an RDMA wire rate.
     bool degradation_eligible{false};
 };
 
@@ -96,9 +99,13 @@ struct DegradationHooks {
     std::function<void(const Request&)> on_local_decode_suggested;
 };
 
-// Returns the predicted transfer bandwidth in bytes/second, or <= 0 if unknown
-// (in which case the drop decision is skipped). Injected by the owner so the
-// admission queue does not depend on the device-selection layer directly.
+// Returns the rate at which the bytes of a degradation-eligible owner move on
+// the wire, in bytes/second, or <= 0 if unknown (in which case the drop
+// decision is skipped). This is a transmit rate, not a rate that folds in the
+// wait behind other work: queueing enters the prediction separately, as
+// DeadlineMlu's `bytes_ahead`. The RDMA wiring supplies the sum of the local
+// NICs' transmit estimates. Injected by the owner so the admission queue does
+// not depend on the device-selection layer directly.
 using BandwidthProvider = std::function<double()>;
 
 // Returns "now" as a steady-clock timestamp in nanoseconds, matching the units
@@ -182,6 +189,10 @@ class LocalTransferAdmissionQueue {
     size_t outstanding_bytes_{0};
     size_t outstanding_user_owners_{0};
     size_t outstanding_user_bytes_{0};
+    // Bytes of degradation-eligible owners dispatched and not yet completed:
+    // the queue-ahead term of the step-3 drop prediction. Owners on other
+    // transports share the queue but not the provider's bandwidth.
+    size_t dispatching_bytes_{0};
 
     // RFC #2519 step 3 degradation policy (all optional / opt-in).
     BandwidthProvider bandwidth_provider_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/deadline_mlu.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/deadline_mlu.h
@@ -1,0 +1,55 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// The one definition of a request's predicted deadline feasibility (MLU),
+// shared by the admission queue's drop predictor (RFC #2519 step 3) and the
+// RDMA workers' bandwidth arbitration (RFC #2792). Both must rank the same
+// request the same way from the same bandwidth series, or the admission
+// layer can drop a flow the NIC layer just promoted.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace mooncake {
+namespace tent {
+
+// Predicted MLU = predicted completion time / remaining deadline window,
+// where predicted completion time = (bytes_ahead + length) / bw_bps.
+//
+// The deadline is absolute, so the request must first wait for the bytes
+// already in the pipeline ahead of it (`bytes_ahead`: dispatched but not
+// completed) and then spend its own wire time. Queueing is therefore an
+// additive term over the wire rate -- not folded into a slower bandwidth,
+// which would scale the wait by the request's size.
+//
+// Higher == more urgent. No deadline (deadline_ns == 0) or no usable
+// bandwidth (bw_bps <= 0) yields 0: nothing to predict, so never urgent and
+// never dropped. A deadline already reached is infinitely urgent.
+inline double DeadlineMlu(size_t bytes_ahead, size_t length,
+                          uint64_t deadline_ns, uint64_t now_ns,
+                          double bw_bps) {
+    if (deadline_ns == 0 || bw_bps <= 0.0) return 0.0;
+    if (deadline_ns <= now_ns) return std::numeric_limits<double>::max();
+    const double window_s = (deadline_ns - now_ns) / 1e9;
+    const double predicted_time_s =
+        (static_cast<double>(bytes_ahead) + static_cast<double>(length)) /
+        bw_bps;
+    return predicted_time_s / window_s;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/bw_arbitration.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/bw_arbitration.h
@@ -32,9 +32,9 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <limits>
-#include <numeric>
 #include <vector>
+
+#include "tent/runtime/deadline_mlu.h"
 
 namespace mooncake {
 namespace tent {
@@ -46,37 +46,73 @@ struct ArbFlow {
     size_t length;         // bytes to transfer
 };
 
-// Predicted Missed-Latency-per-Unit: predicted transfer time / remaining
-// deadline window. Higher == more urgent (closer to / past its deadline).
-// A flow with no deadline (deadline_ns == 0) is least urgent (MLU 0). A flow
-// already past its deadline, or that cannot fit its window at the given
-// bandwidth, gets a very high MLU so it sorts first. bw_bps <= 0 disables
-// prediction (returns 0 for everyone == no reordering).
-inline double PredictedMlu(const ArbFlow& f, uint64_t now_ns, double bw_bps) {
-    if (f.deadline_ns == 0 || bw_bps <= 0.0) return 0.0;
-    if (f.deadline_ns <= now_ns) return std::numeric_limits<double>::max();
-    const double window_s = (f.deadline_ns - now_ns) / 1e9;
-    const double predicted_time_s = static_cast<double>(f.length) / bw_bps;
-    return predicted_time_s / window_s;
+// Predicted MLU for one contending flow; see DeadlineMlu for the semantics.
+// `bytes_ahead` is what the NIC has to move before this flow: the bytes
+// already posted to it, plus those of the flows OrderByUrgency has placed
+// ahead of this one. Higher == more urgent (closer to / past its deadline).
+// bw_bps <= 0 disables prediction (returns 0 for everyone == no reordering).
+inline double PredictedMlu(const ArbFlow& f, uint64_t now_ns, double bw_bps,
+                           size_t bytes_ahead = 0) {
+    return DeadlineMlu(bytes_ahead, f.length, f.deadline_ns, now_ns, bw_bps);
 }
 
 // Return the indices of `flows` ordered most-urgent-first (highest predicted
-// MLU first). Ties and the no-deadline case keep original (FIFO) order — a
-// stable sort — so a symmetric set degrades to today's behavior. This does not
-// drop or admit anything; it only reorders selection among already-eligible,
-// same-tier flows.
+// MLU first). Ties keep the original relative order, so with no deadlines
+// anywhere the input order is preserved exactly. This never drops or admits
+// anything; it only reorders selection among already-eligible, same-tier
+// flows.
+//
+// The order is built one slot at a time: the flow that takes a slot is then
+// part of what the remaining flows wait behind, so its bytes join
+// `bytes_ahead` before the next slot is scored. `bytes_ahead` on entry is
+// what the NIC owes that is *not* in `flows`. Scoring every flow once
+// against the same value would instead treat all of them as simultaneous.
+//
+// Cost is O(n * kGreedySlots). Callers post a prefix of this order (the QP
+// budget decides how long), so only the head is worth resolving exactly;
+// past kGreedySlots the remainder is ranked in one pass against the bytes
+// accumulated so far.
+inline constexpr size_t kGreedySlots = 64;
+
 inline std::vector<size_t> OrderByUrgency(const std::vector<ArbFlow>& flows,
-                                          uint64_t now_ns, double bw_bps) {
-    std::vector<size_t> idx(flows.size());
-    std::iota(idx.begin(), idx.end(), size_t{0});
-    std::vector<double> mlu(flows.size());
-    for (size_t i = 0; i < flows.size(); ++i) {
-        mlu[i] = PredictedMlu(flows[i], now_ns, bw_bps);
+                                          uint64_t now_ns, double bw_bps,
+                                          size_t bytes_ahead = 0) {
+    const size_t n = flows.size();
+    std::vector<size_t> order;
+    order.reserve(n);
+    std::vector<bool> taken(n, false);
+
+    const size_t greedy = std::min(n, kGreedySlots);
+    for (size_t slot = 0; slot < greedy; ++slot) {
+        size_t best = n;
+        double best_mlu = 0.0;
+        for (size_t i = 0; i < n; ++i) {
+            if (taken[i]) continue;
+            const double mlu =
+                PredictedMlu(flows[i], now_ns, bw_bps, bytes_ahead);
+            // Strictly greater keeps the lowest index on ties (FIFO).
+            if (best == n || mlu > best_mlu) {
+                best = i;
+                best_mlu = mlu;
+            }
+        }
+        taken[best] = true;
+        order.push_back(best);
+        bytes_ahead += flows[best].length;
     }
-    std::stable_sort(idx.begin(), idx.end(), [&](size_t a, size_t b) {
-        return mlu[a] > mlu[b];  // higher MLU first; stable keeps FIFO on ties
-    });
-    return idx;
+    if (order.size() == n) return order;
+
+    std::vector<size_t> rest;
+    rest.reserve(n - order.size());
+    for (size_t i = 0; i < n; ++i)
+        if (!taken[i]) rest.push_back(i);
+    std::vector<double> mlu(n, 0.0);
+    for (size_t i : rest)
+        mlu[i] = PredictedMlu(flows[i], now_ns, bw_bps, bytes_ahead);
+    std::stable_sort(rest.begin(), rest.end(),
+                     [&](size_t a, size_t b) { return mlu[a] > mlu[b]; });
+    order.insert(order.end(), rest.begin(), rest.end());
+    return order;
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -165,9 +165,10 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // return how many were taken (posted or marked `failed`). `on_post`,
     // when given, runs for each of those before ibv_post_send: on a shared
     // queue pair another lane can poll a completion before this call
-    // returns, so whatever the poller must find in place (the set entry)
-    // has to be written first. Slices the hardware rejects come back with
-    // `failed` set; the caller undoes what it did for them.
+    // returns, so whatever the poller must find in place (the posted
+    // device, the set entry) has to be written first. Slices the hardware
+    // rejects come back with `failed` set; the caller undoes what it did for
+    // them.
     int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index,
                      const std::function<void(RdmaSlice*)>& on_post = {});
 

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/endpoint.h
@@ -16,6 +16,7 @@
 #define TENT_ENDPOINT_H
 
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <queue>
 #include <unordered_set>
@@ -160,11 +161,24 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
         bool failed;
     };
 
-    int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index);
+    // Post as many of `slice_list` as the queue pair's budget allows and
+    // return how many were taken (posted or marked `failed`). `on_post`,
+    // when given, runs for each of those before ibv_post_send: on a shared
+    // queue pair another lane can poll a completion before this call
+    // returns, so whatever the poller must find in place (the set entry)
+    // has to be written first. Slices the hardware rejects come back with
+    // `failed` set; the caller undoes what it did for them.
+    int submitSlices(std::vector<RdmaSlice*>& slice_list, int qp_index,
+                     const std::function<void(RdmaSlice*)>& on_post = {});
 
     int submitRecvImmDataRequest(int qp_index, uint64_t id);
 
-    size_t acknowledge(RdmaSlice* slice, TransferStatusEnum status);
+    // Pop `slice` and every slice queued before it on the same QP, giving
+    // them `status`. `on_each` is invoked for every popped slice so the
+    // caller can return per-slice accounting (the worker's selector charge)
+    // for slices it never sees otherwise.
+    size_t acknowledge(RdmaSlice* slice, TransferStatusEnum status,
+                       const std::function<void(RdmaSlice*)>& on_each = {});
 
     std::atomic<int>* getQuotaCounter(int qp_index) const {
         return &wr_depth_list_[qp_index].value;
@@ -204,6 +218,7 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
 
    private:
     friend class EndpointTestAccess;
+    friend class RdmaEndPointTestPeer;
 
     std::atomic<EndPointStatus> status_;
     RdmaContext* context_;
@@ -215,8 +230,15 @@ class RdmaEndPoint : public std::enable_shared_from_this<RdmaEndPoint> {
     // Empty = default single pool spanning all of qp_list_. Each segment's
     // [begin, begin+num_qp) indexes into qp_list_. Read-only after construct().
     std::vector<QpPoolSegment> qp_pool_segments_;
-    // Each data QP queue is owned by exactly one worker lane; reset/deconstruct
-    // are synchronized by the endpoint lifecycle lock.
+    // One queue per data QP. With the default lane layout a queue pair is
+    // posted and polled by a single worker lane. A qp_pools layout with
+    // fewer QPs than lanes folds several lanes onto one queue pair, and
+    // then two lanes can reach the same queue at once: submitSlices and
+    // acknowledge both hold only a read guard, which does not exclude them
+    // from each other, and the queue itself is unsynchronized. That is a
+    // data race in that layout, not a property this code relies on; it
+    // needs a per-QP lock. reset/deconstruct are synchronized by the
+    // endpoint lifecycle lock.
     std::vector<BoundedSliceQueue> slice_queue_;
     WrDepthBlock* wr_depth_list_;
     std::atomic<int> inflight_slices_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -51,6 +51,19 @@ class SharedSlotManager;
  * EWMA update:
  *     ewma_bandwidth <- alpha * ewma_bandwidth + (1 - alpha) *
  * observed_bandwidth
+ *
+ * Besides the selection EWMA, each device carries a transmit estimate for
+ * the deadline predictors (admission drop, NIC arbitration): the same update
+ * rule and clamp, but fed from a meter -- bytes completed over the time the
+ * NIC spent with work posted to it, so idle gaps inside an interval are not
+ * charged -- rather than from any one completion's latency. Per-completion
+ * timing cannot answer "how fast does this NIC move bytes": work requests
+ * are posted in batches whose timestamps are effectively one, and a poll
+ * pass timestamps their completions together, so a slice's own
+ * post-to-completion grows with the depth of the batch it travelled in. The
+ * selection EWMA goes on learning from each successful completion's own
+ * post-to-completion time on purpose, so that a NIC backed up behind
+ * earlier work requests scores worse.
  */
 class DeviceSelector {
    public:
@@ -61,7 +74,10 @@ class DeviceSelector {
         bool is_cross_numa;
     };
 
-    struct DeviceInfo {
+    // 64-byte aligned so the padding below really does put each hot atomic
+    // on a cache line of its own (the map's nodes would otherwise place the
+    // struct at any 8-byte boundary).
+    struct alignas(64) DeviceInfo {
         int dev_id;
         // Negotiated link speed in Gbps. setDeviceBandwidth() may rewrite it
         // after traffic has started while workers read it in release(), so
@@ -79,8 +95,38 @@ class DeviceSelector {
         uint64_t padding1[7];
         std::atomic<double> ewma_bandwidth_bps{50e9};
         uint64_t padding2[7];
+        std::atomic<double> ewma_transmit_bps{50e9};
+        uint64_t padding4[7];
         std::atomic<uint64_t> total_bytes{0};
-        uint64_t padding3[5];
+        uint64_t padding3[7];
+        // Bytes handed to the hardware: charged when a WR is posted and
+        // returned when it leaves the queue pair. Unlike inflight_bytes
+        // (charged at allocation) this is the NIC's own backlog.
+        std::atomic<uint64_t> posted_bytes{0};
+        uint64_t padding5[7];
+        // Bytes that completed successfully, monotonic.
+        std::atomic<uint64_t> completed_bytes{0};
+        uint64_t padding6[7];
+        // Transmit meter: the counters as of the last sample, which the
+        // next one measures against. Whichever worker wins the CAS on
+        // meter_ts owns that sample and is the only one touching the other
+        // two. resetTransmitMeter only zeroes meter_ts, so the next sample
+        // rebuilds both baselines under its own CAS instead of learning; a
+        // sampler that had already won before the reset finishes on the
+        // baselines it took, which are at least consistent with each other.
+        std::atomic<uint64_t> meter_ts{0};
+        std::atomic<uint64_t> meter_completed{0};
+        std::atomic<uint64_t> meter_busy_ns{0};
+        // Time this NIC has spent with something posted to it, and when the
+        // stretch in progress began. Advanced only on the posted_bytes
+        // 0 <-> non-zero transitions, so the cost is one timestamp per burst
+        // edge rather than per slice. busy_since is never cleared: a stale
+        // value can only over-count busy time, which reads the link slow,
+        // whereas a zero would charge it the whole clock and read it as
+        // stopped.
+        std::atomic<uint64_t> busy_ns{0};
+        std::atomic<uint64_t> busy_since{0};
+        uint64_t padding7[3];
 
         uint64_t getInflightBytes() const {
             return inflight_bytes.load(std::memory_order_relaxed);
@@ -96,6 +142,14 @@ class DeviceSelector {
 
         double getEwmaBandwidth() const {
             return ewma_bandwidth_bps.load(std::memory_order_relaxed);
+        }
+
+        double getTransmitBandwidth() const {
+            return ewma_transmit_bps.load(std::memory_order_relaxed);
+        }
+
+        uint64_t getPostedBytes() const {
+            return posted_bytes.load(std::memory_order_relaxed);
         }
     };
 
@@ -150,6 +204,40 @@ class DeviceSelector {
     Status allocate(uint64_t length, const std::string &location,
                     int &chosen_dev_id, int priority, uint64_t device_mask);
 
+    // The NIC's own backlog: `notePosted` when a WR reaches the hardware,
+    // `notePostEnded` when it leaves the queue pair (completion, sweep or
+    // cancellation). This is the queue a slice posted now waits behind --
+    // work still sitting in a worker queue is not part of it. `now_ns` marks
+    // the transitions between an idle and a busy NIC, which is the time the
+    // transmit meter charges its bytes to.
+    void notePosted(int dev_id, uint64_t bytes, uint64_t now_ns);
+    void notePostEnded(int dev_id, uint64_t bytes, uint64_t now_ns);
+    uint64_t getPostedBytes(int dev_id) const;
+    // Nanoseconds this device has spent with something posted to it.
+    uint64_t getBusyNs(int dev_id) const;
+
+    // A successful completion moved `bytes` on the wire.
+    void noteCompleted(int dev_id, uint64_t bytes);
+
+    // Abandon the meter's current interval without learning from it. Busy
+    // time is only worth dividing into bytes that the NIC spent it moving,
+    // so a posted slice that ends without its bytes being counted -- failed,
+    // flushed, timed out -- makes the stretch it belonged to unusable. The
+    // next sample starts over from fresh baselines. A NIC that keeps
+    // producing such slices faster than the meter interval therefore never
+    // closes an interval and keeps its last estimate.
+    void resetTransmitMeter(int dev_id);
+
+    // Feed the transmit estimate one throughput sample -- bytes completed
+    // over the busy time accrued since the last sample -- if this device's
+    // meter interval has passed. Per-completion latency cannot serve here:
+    // work requests are posted in batches whose timestamps are effectively
+    // one, and a poll pass timestamps every completion it reaps alike, so a
+    // slice's own "post to completion" grows with the batch depth. Bytes
+    // over busy time does not care how the work was batched, and charges
+    // nothing for the gaps in which the NIC had nothing posted.
+    void maybeSampleTransmit(int dev_id, uint64_t now_ns);
+
     // Charge `length` bytes to one device without running device selection,
     // for a caller that has already settled on it: a retry re-posting a
     // slice whose charge the failure path returned, or a first attempt
@@ -159,7 +247,8 @@ class DeviceSelector {
 
     // Return a slice's inflight charge and learn from its completion.
     // `latency` is a successful attempt's post->completion time and feeds
-    // the selection EWMA; <= 0 means no sample.
+    // the selection EWMA; <= 0 means no sample. The transmit estimate is
+    // fed by the meter instead, see maybeSampleTransmit().
     Status release(int dev_id, uint64_t length, double latency);
 
     Status getNicLoadStats(std::vector<NicLoadStats> &stats) const;
@@ -186,6 +275,10 @@ class DeviceSelector {
 
     // Bytes charged to one device and not yet released, or 0 if unknown.
     uint64_t getInflightBytes(int dev_id) const;
+    // Transmit estimate (bytes/s) for one device, or -1 if unknown.
+    double getTransmitBandwidth(int dev_id) const;
+    // Sum of the transmit estimates over all devices, or -1 if none.
+    double getAggregateTransmitBandwidth() const;
 
     void fillDevicePriorities();
     int getDevicePriority(int dev_id) const;
@@ -202,6 +295,20 @@ class DeviceSelector {
         // EWMA bandwidth learning rate (0.0 = full adaptation, 1.0 = no
         // learning)
         double bandwidth_learning_rate = 0.01;
+
+        // Transmit estimate learning rate, same convention. One sample per
+        // meter interval below, so 0.9 is ~10 intervals (100 ms) to follow a
+        // change -- slow enough that one odd interval cannot flip an
+        // irreversible drop decision.
+        double transmit_bandwidth_learning_rate = 0.9;
+
+        // How often a device's throughput is sampled, and how far back a
+        // sample may reach before it is dropped instead of learned from: the
+        // meter charges bytes to busy time, so idle gaps do not spoil an
+        // interval, but a sample spanning this much wall clock describes a
+        // link too far in the past to attribute to the link as it is now.
+        uint64_t transmit_meter_interval_ns = 10'000'000;      // 10 ms
+        uint64_t transmit_meter_max_interval_ns = 50'000'000;  // 50 ms
 
         // Enable priority-based filtering
         bool enable_priority_filtering = true;
@@ -233,6 +340,17 @@ class DeviceSelector {
 
     void setSchedulingParams(const SchedulingParams &params) {
         sched_params_ = params;
+        // Both are weights on the old EWMA value; outside [0, 1] the update
+        // is meaningless (negative or runaway estimates).
+        sched_params_.bandwidth_learning_rate =
+            std::clamp(params.bandwidth_learning_rate, 0.0, 1.0);
+        sched_params_.transmit_bandwidth_learning_rate =
+            std::clamp(params.transmit_bandwidth_learning_rate, 0.0, 1.0);
+        // A staleness bound shorter than the sampling interval would reject
+        // every sample, silently freezing the estimate on its seed.
+        sched_params_.transmit_meter_max_interval_ns =
+            std::max(params.transmit_meter_max_interval_ns,
+                     params.transmit_meter_interval_ns);
     }
 
     const SchedulingParams &getSchedulingParams() const {
@@ -252,6 +370,16 @@ class DeviceSelector {
     // Bytes/s the device is rated for: bw_gbps when it is inside the
     // configured [min, max], default_bandwidth_gbps otherwise.
     double theoreticalBandwidth(const DeviceInfo &dev) const;
+
+    // Nanoseconds `dev` has spent with work posted, up to `now_ns`: the
+    // stretches that have ended plus the one still open. Both the sample
+    // and the reset measure against this, so they cannot drift apart.
+    static uint64_t busyNsAt(const DeviceInfo &dev, uint64_t now_ns);
+
+    // EWMA step with the [min, max] x theoretical clamp: new = alpha * old
+    // + (1 - alpha) * observed.
+    void learnRate(const DeviceInfo &dev, std::atomic<double> &series,
+                   double alpha, double observed_bps) const;
 
     // Known to the selector and currently able to carry traffic.
     bool usable(int dev_id) const {

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/quota.h
@@ -135,15 +135,10 @@ class DeviceSelector {
     // Allocate devices for a request (new API)
     // slice_bytes: pre-calculated slice size from rdma_transport to ensure
     // consistency
-    // slice_charged_bytes (optional): filled, in lockstep with slice_dev_ids,
-    // with the exact inflight bytes charged for each slice so the caller can
-    // release precisely what was added (0 entries in baseline mode, which does
-    // not track inflight).
     Status allocate(uint64_t total_length, uint32_t num_slices,
                     uint64_t slice_bytes, const std::string &location,
                     std::vector<int> &slice_dev_ids, int priority = PRIO_HIGH,
-                    uint64_t device_mask = ~0ULL,
-                    std::vector<uint64_t> *slice_charged_bytes = nullptr);
+                    uint64_t device_mask = ~0ULL);
 
     Status allocate(uint64_t length, const std::string &location,
                     int &chosen_dev_id);
@@ -155,14 +150,17 @@ class DeviceSelector {
     Status allocate(uint64_t length, const std::string &location,
                     int &chosen_dev_id, int priority, uint64_t device_mask);
 
-    Status release(int dev_id, uint64_t length, double latency);
-
-    // Charge inflight bytes against a specific device without running device
-    // selection. Used when the routing NIC changes after the original charge
-    // (fallback re-route) or when a retry has to re-enter the inflight view, so
-    // that the charged device stays symmetric with the device release()
-    // unwinds.
+    // Charge `length` bytes to one device without running device selection,
+    // for a caller that has already settled on it: a retry re-posting a
+    // slice whose charge the failure path returned, or a first attempt
+    // falling back from the NIC the allocator picked. release() balances
+    // it. Fails only for a device the selector does not know.
     Status chargeDevice(int dev_id, uint64_t length);
+
+    // Return a slice's inflight charge and learn from its completion.
+    // `latency` is a successful attempt's post->completion time and feeds
+    // the selection EWMA; <= 0 means no sample.
+    Status release(int dev_id, uint64_t length, double latency);
 
     Status getNicLoadStats(std::vector<NicLoadStats> &stats) const;
 
@@ -185,6 +183,9 @@ class DeviceSelector {
     void printTrafficStats();
 
     double getAggregateEwmaBandwidth() const;
+
+    // Bytes charged to one device and not yet released, or 0 if unknown.
+    uint64_t getInflightBytes(int dev_id) const;
 
     void fillDevicePriorities();
     int getDevicePriority(int dev_id) const;
@@ -279,14 +280,15 @@ class DeviceSelector {
 
     void selectSinglePath(const std::vector<Candidate> &candidates,
                           uint32_t num_slices, uint64_t total_length,
-                          std::vector<int> &slice_dev_ids,
-                          std::vector<uint64_t> *slice_charged_bytes = nullptr);
+                          std::vector<int> &slice_dev_ids);
 
+    // `slice_bytes` is the caller's block size: slice i carries
+    // min(slice_bytes, total_length - i * slice_bytes), and that is what
+    // release() will return, so it is also what gets charged.
     void selectMultiPath(const std::vector<Candidate> &candidates,
                          uint32_t num_slices, uint64_t total_length,
-                         std::vector<int> &slice_dev_ids,
-                         bool probe_mode = false,
-                         std::vector<uint64_t> *slice_charged_bytes = nullptr);
+                         uint64_t slice_bytes, std::vector<int> &slice_dev_ids,
+                         bool probe_mode = false);
 };
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -138,6 +138,10 @@ struct RdmaSlice {
     // source_dev_id cannot misdirect the release. Atomic because on a pooled
     // QP the timeout sweep and the CQ poller run on different workers.
     std::atomic<int> charged_dev{-1};
+    // Device whose posted backlog counts this slice: set when the work
+    // request reaches the hardware, -1 again once the slice leaves the queue
+    // pair. A charged slice waiting in a worker queue is not posted.
+    std::atomic<int> posted_dev{-1};
     uint64_t enqueue_ts = 0;
     uint64_t submit_ts = 0;
     // Non-owning pointer to the per-worker RailMonitor for this slice's

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/slice.h
@@ -107,28 +107,37 @@ struct RdmaSlice {
     std::weak_ptr<RdmaEndPoint> ep_weak_ptr;
     TransferStatusEnum word = TransferStatusEnum::INITIAL;
     int qp_index = 0;
+    // Worker lane that enqueued this slice: the one whose inflight_slice_set
+    // holds it. Whichever lane later sweeps the slice off a queue pair must
+    // hand the set entry back to this one -- with qp_pools several lanes can
+    // share a queue pair, so the sweeper is often somebody else. -1 until
+    // Workers::submit() picks a lane. Atomic because a retry re-points it to
+    // the lane that re-queued the slice (Workers::submitFromTick) while the
+    // lane it is leaving may still hold a set entry it has not drained, and
+    // reads that entry to route the removal home.
+    std::atomic<int> owner_worker{-1};
+    // Worker lane whose inflight_slices counts this slice, -1 while none
+    // does. Each accounting the slice carries names the counter it sits in,
+    // so whichever path takes it out -- its own completion, another lane's
+    // sweep of the queue pair they share, the timeout pass that finds it
+    // already terminal -- exchanges the field for -1 and pays back exactly
+    // what it read; a second path reads -1 and does nothing. Usually the
+    // owner lane, but a retry moves the count in one exchange
+    // (Workers::submitFromTick) while the old set entry drains later.
+    std::atomic<int> counted_lane{-1};
     int retry_count = 0;
     // Flat (source,target) combination index last tried by
     // selectFallbackDevice; the next fallback resumes just past it so retries
     // rotate through all combinations with wraparound instead of hammering one.
     int last_fallback_idx = -1;
     bool failed = false;
-    // True while DeviceSelector accounts this slice's inflight bytes against
-    // charged_dev_id. The worker clears it exactly once on completion, failure,
-    // or cancel.
-    bool quota_charged = false;
-    // Device the inflight bytes are actually charged against. This is tracked
-    // separately from source_dev_id because a fallback re-route (or a retry)
-    // can change the routing NIC after the charge was made; releasing against
-    // source_dev_id would then leak the original NIC's charge and underflow the
-    // fallback NIC. Kept in sync with the routing device by chargeSliceQuota.
-    int charged_dev_id = -1;
-    // Exact number of inflight bytes charged for this slice, recorded at charge
-    // time so release unwinds precisely what was added. The allocator charges a
-    // per-slice estimate (ceil(total/num_slices)) that can differ from the
-    // slice's real length; releasing by length would otherwise leave residue on
-    // some NICs and underflow others.
-    uint64_t charged_bytes = 0;
+    // Device DeviceSelector accounts this slice against, -1 while none.
+    // Same discipline as counted_lane: whoever releases the charge --
+    // completion, failure, timeout or cancel -- exchanges it for -1 and
+    // pays that device, so a fallback that has already rewritten
+    // source_dev_id cannot misdirect the release. Atomic because on a pooled
+    // QP the timeout sweep and the CQ poller run on different workers.
+    std::atomic<int> charged_dev{-1};
     uint64_t enqueue_ts = 0;
     uint64_t submit_ts = 0;
     // Non-owning pointer to the per-worker RailMonitor for this slice's

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -39,10 +39,6 @@ class DeviceSelector;
 
 class Workers {
     friend class RdmaTransportTestPeer;
-    // Grants the quota-accounting unit test access to the private static
-    // charge/release reconcile helpers (they only need a DeviceSelector, so the
-    // test can exercise them without constructing a Workers / RdmaTransport).
-    friend class WorkersQuotaTestAccessor;
 
    public:
     static constexpr size_t kCapacity = 1024 * 8;
@@ -75,18 +71,78 @@ class Workers {
 
     void asyncPollCq();
 
-    bool cancelUnpostedSlice(WorkerContext& worker, RdmaSlice* slice);
+    // Resolve one completion: give back what the slice's lane accounts for
+    // and either finish, retry or fail it. Split from asyncPollCq so a test
+    // can drive it with a synthesized ibv_wc.
+    void handleCompletion(WorkerContext& worker, RdmaContext& context,
+                          const ibv_wc& wc, uint64_t poll_ts);
 
-    // Release a slice's inflight charge against the device it was charged on,
-    // unwinding exactly charged_bytes. static so the accounting can be unit
-    // tested with just a DeviceSelector (no Workers/RdmaTransport instance).
-    static void releaseSliceQuota(DeviceSelector* selector, RdmaSlice* slice,
-                                  double latency = 0.0);
+    // The lane whose inflight_slice_set holds `slice`'s entry, or nullptr
+    // when it cannot be resolved (no lane recorded, or the worker array is
+    // not up yet).
+    WorkerContext* ownerContext(const RdmaSlice* slice);
 
-    // Reconcile a slice's inflight charge onto its current routing NIC
-    // (source_dev_id), migrating a stale charge or re-charging after a retry.
-    // static for the same testability reason as releaseSliceQuota.
-    static void chargeSliceQuota(DeviceSelector* selector, RdmaSlice* slice);
+    // Index of `worker` in the lane array, or -1 when that array is not up
+    // yet: the inverse of ownerContext().
+    int laneIndex(const WorkerContext& worker) const;
+
+    // Give back everything a slice swept off a queue pair with a terminal
+    // status still holds: its selector charge, its place in whichever
+    // lane's inflight count has it, and its entry in whichever lane's set.
+    // `deferred`, when given, collects the entries `self` is to erase, so
+    // the caller can do it after it stops iterating that set.
+    void retireSweptSlice(WorkerContext& self, RdmaSlice* slice,
+                          std::vector<RdmaSlice*>* deferred);
+
+    // Take `slice` out of whichever lane's inflight count holds it, exactly
+    // once (`counted_lane` comes back -1 for everyone after): for a slice
+    // popped off a queue pair that is still in flight, for one dropped
+    // before it was posted, and for one finished by any path that leaves
+    // the count to be settled here. A re-submit needs no prior discount;
+    // submitFromTick moves the count itself.
+    void discountFromOwner(WorkerContext& self, RdmaSlice* slice);
+
+    // Decide who takes `slice` out of an inflight set. Returns true when the
+    // entry is `self`'s to erase -- because `self` holds it, or because
+    // nobody else does -- and false when it has been handed to the owning
+    // lane's reclaim list instead.
+    bool routeSetRemoval(WorkerContext& self, RdmaSlice* slice);
+
+    // Take out the slices other lanes swept on this lane's behalf.
+    void drainReclaimed(WorkerContext& worker);
+
+    // This lane's pass over its inflight set: take out what other lanes
+    // handed back, retire entries that turned terminal behind its back, and
+    // fail every slice that has waited longer than slice_timeout_ns_ since
+    // it was enqueued (software timeout). Split from asyncPollCq so it can
+    // be driven with a synthetic clock in tests.
+    void expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns);
+
+    // Charge `slice` to `dev_id`, moving or establishing the selector's
+    // accounting for it. Called when a retry or a fallback settles on a
+    // device: a retry's charge was returned by the failure path that
+    // re-submitted it, a fallback's still sits on the NIC the allocator
+    // picked. A device the selector does not know cannot be charged; the
+    // slice then keeps whatever charge it has, so the release still balances.
+    void rechargeSlice(RdmaSlice* slice, int dev_id);
+
+    // True when `slice` must not be posted -- the transfer was cancelled, or
+    // another lane resolved the slice while it waited for a re-post. Retires
+    // it like a sweep would (retireSweptSlice), so the caller can simply
+    // skip it.
+    bool dropUnpostableSlice(WorkerContext& worker, RdmaSlice* slice);
+
+    // Hand back the selector's allocation charge for this slice, to the
+    // device it was charged on. `latency` is a successful attempt's
+    // post->completion time in seconds; 0 = no sample. See
+    // DeviceSelector::release.
+    void releaseSliceQuota(RdmaSlice* slice, double latency = 0.0);
+
+    // What a posting lane writes for a slice the moment it goes on the
+    // wire: the post timestamp and the lane's set entry. Runs inside
+    // submitSlices, before ibv_post_send, so a completion polled on a
+    // shared queue pair finds both in place.
+    void markPosted(WorkerContext& worker, RdmaSlice* slice, uint64_t post_ts);
 
     void monitorThread();
 
@@ -255,7 +311,13 @@ class Workers {
         std::thread thread;
         BoundedSliceQueue queues[kNumPriorityLevels];  // Priority queues
         GroupedRequests requests;
+        // Only this lane may touch its own set, so slices swept by another
+        // lane are handed over here and erased on this lane's next pass.
+        // Empty unless queue pairs are shared (qp_pools), so the mutex is
+        // cold.
         std::unordered_set<RdmaSlice*> inflight_slice_set;
+        std::mutex reclaim_mutex;
+        std::vector<RdmaSlice*> reclaimed;
         std::atomic<int64_t> inflight_slices = 0;
 
         std::mutex mutex;
@@ -286,7 +348,8 @@ class Workers {
 
     // Tick-internal re-enqueue: the worker thread must never block on its own
     // queue (issue #3637), so these park into requeue_overflow on a full queue
-    // and the asyncPostSend drain consumes them first.
+    // and the asyncPostSend drain consumes them first. Moves the slice's
+    // inflight count to `worker` from whichever lane still holds it.
     void submitFromTick(WorkerContext& worker, RdmaSlice* slice);
 
     WorkerContext* worker_context_;

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -126,6 +126,12 @@ class Workers {
     // be driven with a synthetic clock in tests.
     void expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns);
 
+    // Reorder `slices` (all contending for one NIC path) most-urgent-first
+    // by predicted MLU, RFC #2792. Split from asyncPostSend so a test can
+    // drive it with a live DeviceSelector and no endpoint.
+    void orderByDeadline(std::vector<RdmaSlice*>& slices, int dev_id,
+                         uint64_t now_ns);
+
     // Charge `slice` to `dev_id`, moving or establishing the selector's
     // accounting for it. Called when a retry or a fallback settles on a
     // device: a retry's charge was returned by the failure path that

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -71,11 +71,15 @@ class Workers {
 
     void asyncPollCq();
 
-    // Resolve one completion: give back what the slice's lane accounts for
-    // and either finish, retry or fail it. Split from asyncPollCq so a test
-    // can drive it with a synthesized ibv_wc.
+    // Resolve one completion: give back what the slice's lane accounts for,
+    // feed the transmit meter, and either finish, retry or fail it. Split
+    // from asyncPollCq so a test can drive it with a synthesized ibv_wc.
+    // `last_in_pass` is true for the final work completion of a poll pass:
+    // the meter is only offered a sample there, so an interval never ends
+    // partway through a group of completions that share one timestamp.
     void handleCompletion(WorkerContext& worker, RdmaContext& context,
-                          const ibv_wc& wc, uint64_t poll_ts);
+                          const ibv_wc& wc, uint64_t poll_ts,
+                          bool last_in_pass = true);
 
     // The lane whose inflight_slice_set holds `slice`'s entry, or nullptr
     // when it cannot be resolved (no lane recorded, or the worker array is
@@ -89,10 +93,14 @@ class Workers {
     // Give back everything a slice swept off a queue pair with a terminal
     // status still holds: its selector charge, its place in whichever
     // lane's inflight count has it, and its entry in whichever lane's set.
-    // `deferred`, when given, collects the entries `self` is to erase, so
-    // the caller can do it after it stops iterating that set.
+    // Unless `bytes_moved` (the sweep finished it with COMPLETED and its own
+    // completion will credit the bytes), a posted slice also ends a stretch
+    // of busy time with nothing to show for it, so the transmit meter
+    // starts over. `deferred`, when given, collects the entries `self` is
+    // to erase, so the caller can do it after it stops iterating that set.
     void retireSweptSlice(WorkerContext& self, RdmaSlice* slice,
-                          std::vector<RdmaSlice*>* deferred);
+                          uint64_t now_ns, std::vector<RdmaSlice*>* deferred,
+                          bool bytes_moved = false);
 
     // Take `slice` out of whichever lane's inflight count holds it, exactly
     // once (`counted_lane` comes back -1 for everyone after): for a slice
@@ -132,16 +140,25 @@ class Workers {
     // skip it.
     bool dropUnpostableSlice(WorkerContext& worker, RdmaSlice* slice);
 
-    // Hand back the selector's allocation charge for this slice, to the
-    // device it was charged on. `latency` is a successful attempt's
-    // post->completion time in seconds; 0 = no sample. See
+    // Hand back everything the selector accounts for this slice: its
+    // allocation charge and, if it reached the hardware, its share of the
+    // NIC's posted backlog. `now_ns` closes the NIC's busy stretch when
+    // that share was the last of it, so it must come from the same clock as
+    // the timestamps the slice was posted with. `latency` is a successful
+    // attempt's post->completion time in seconds; 0 = no sample. See
     // DeviceSelector::release.
-    void releaseSliceQuota(RdmaSlice* slice, double latency = 0.0);
+    void releaseSliceQuota(RdmaSlice* slice, uint64_t now_ns,
+                           double latency = 0.0);
+
+    // Record that `slice` has reached its source device's hardware. Its
+    // submit_ts opens the device's busy stretch when nothing else was
+    // posted to it.
+    void notePostedSlice(RdmaSlice* slice);
 
     // What a posting lane writes for a slice the moment it goes on the
-    // wire: the post timestamp and the lane's set entry. Runs inside
-    // submitSlices, before ibv_post_send, so a completion polled on a
-    // shared queue pair finds both in place.
+    // wire: the post timestamp, the device's posted backlog and the lane's
+    // set entry. Runs inside submitSlices, before ibv_post_send, so a
+    // completion polled on a shared queue pair finds all three in place.
     void markPosted(WorkerContext& worker, RdmaSlice* slice, uint64_t post_ts);
 
     void monitorThread();

--- a/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/admission_queue.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "tent/runtime/admission_queue.h"
+#include "tent/runtime/deadline_mlu.h"
 
 #include <algorithm>
 #include <chrono>
@@ -274,17 +275,19 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         });
     }
 
-    // Predicted MLU = predicted_transfer_time / remaining_window. Returns true
-    // if the owner is predicted to miss its deadline hard enough to drop.
-    auto shouldDrop = [&](const QueueOwner& owner) -> bool {
-        if (!drop_enabled || !owner.degradation_eligible || bw_bps <= 0.0)
-            return false;
-        const uint64_t deadline_ns = owner.request.deadline_ns;
-        if (deadline_ns == 0) return false;      // no deadline
-        if (deadline_ns <= now_ns) return true;  // already past
-        const double window_s = (deadline_ns - now_ns) / 1e9;
-        const double predicted_time_s = owner.request.length / bw_bps;
-        const double mlu = predicted_time_s / window_s;
+    // True if the owner is predicted to miss its deadline hard enough to
+    // drop, by the same DeadlineMlu the RDMA workers order QP slots with.
+    // `bytes_ahead`: eligible bytes dispatched and still in flight,
+    // including what this call already picked. No deadline or no bandwidth
+    // (<= 0) means nothing to predict from, so never a drop -- not even
+    // past the deadline; DeadlineMlu yields 0 there too, the explicit
+    // checks just keep the rule readable here.
+    auto shouldDrop = [&](const QueueOwner& owner, size_t bytes_ahead) {
+        if (!drop_enabled || !owner.degradation_eligible) return false;
+        if (owner.request.deadline_ns == 0 || bw_bps <= 0.0) return false;
+        const double mlu =
+            DeadlineMlu(bytes_ahead, owner.request.length,
+                        owner.request.deadline_ns, now_ns, bw_bps);
         return mlu >= limits_.mlu_local_threshold;
     };
 
@@ -321,7 +324,7 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
         // dispatched) and does not consume the dispatch budget. Because the
         // queue is EDF-ordered, later owners have looser deadlines, so we keep
         // scanning rather than stopping.
-        if (shouldDrop(owner_it->second)) {
+        if (shouldDrop(owner_it->second, dispatching_bytes_)) {
             fifo_.pop_front();
             dropOwner(owner_id, owner_it->second);
             continue;
@@ -333,6 +336,8 @@ std::vector<QueueOwnerId> LocalTransferAdmissionQueue::pickForDispatch(
 
         fifo_.pop_front();
         owner_it->second.state = QueueState::Dispatching;
+        if (owner.degradation_eligible)
+            dispatching_bytes_ += owner.request.length;
         picked.push_back(owner_id);
         ++used_owners;
         used_bytes += owner.request.length;
@@ -360,6 +365,7 @@ Status LocalTransferAdmissionQueue::complete(
 
     owner.state = QueueState::Terminal;
     owner.terminal_status = terminal_status;
+    if (owner.degradation_eligible) dispatching_bytes_ -= owner.request.length;
     --outstanding_owners_;
     outstanding_bytes_ -= owner.request.length;
     if (owner.kind == QueueOwnerKind::User) {

--- a/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/endpoint.cpp
@@ -752,7 +752,8 @@ static ibv_wr_opcode getOpCode(RdmaSlice* slice) {
 }
 
 int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
-                               int qp_index) {
+                               int qp_index,
+                               const std::function<void(RdmaSlice*)>& on_post) {
     const static int kSgeEntries = 1;
     RWSpinlock::ReadGuard guard(lock_);
     if (qp_list_.empty()) return 0;
@@ -798,6 +799,7 @@ int RdmaEndPoint::submitSlices(std::vector<RdmaSlice*>& slice_list,
         current->ep_weak_ptr = self;
         current->qp_index = qp_index;
         current->failed = false;
+        if (on_post) on_post(current);
         wr.wr_id = (uint64_t)current;
         wr.opcode = getOpCode(current);
         wr.num_sge = kSgeEntries;
@@ -866,7 +868,9 @@ void RdmaEndPoint::resetInflightSlices() {
     }
 }
 
-size_t RdmaEndPoint::acknowledge(RdmaSlice* slice, TransferStatusEnum status) {
+size_t RdmaEndPoint::acknowledge(
+    RdmaSlice* slice, TransferStatusEnum status,
+    const std::function<void(RdmaSlice*)>& on_each) {
     RWSpinlock::ReadGuard guard(lock_);
     auto qp_index = slice->qp_index;
     if (qp_index < 0 || qp_index >= (int)slice_queue_.size()) return 0;
@@ -878,6 +882,7 @@ size_t RdmaEndPoint::acknowledge(RdmaSlice* slice, TransferStatusEnum status) {
         current = queue.pop();
         if (!current) break;
         num_entries++;
+        if (on_each) on_each(current);
         updateSliceStatus(current, status);
     } while (current != slice);
     cancelQuota(qp_index, num_entries);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -96,14 +96,9 @@ Status DeviceSelector::allocate(uint64_t total_length, uint32_t num_slices,
                                 uint64_t slice_bytes,
                                 const std::string& location,
                                 std::vector<int>& slice_dev_ids, int priority,
-                                uint64_t device_mask,
-                                std::vector<uint64_t>* slice_charged_bytes) {
+                                uint64_t device_mask) {
     slice_dev_ids.clear();
     slice_dev_ids.reserve(num_slices);
-    if (slice_charged_bytes) {
-        slice_charged_bytes->clear();
-        slice_charged_bytes->reserve(num_slices);
-    }
     auto entry = local_topology_->getMemEntry(location);
     if (!entry) return Status::InvalidArgument("Unknown location" LOC_MARK);
 
@@ -148,10 +143,10 @@ Status DeviceSelector::allocate(uint64_t total_length, uint32_t num_slices,
                 uint64_t this_slice_bytes =
                     std::min(slice_bytes, total_length - offset);
                 offset += this_slice_bytes;
+                // Baseline mode does not track inflight (release() and
+                // chargeDevice() skip it too); only lifetime traffic counts.
                 devices_[dev_id].total_bytes.fetch_add(
                     this_slice_bytes, std::memory_order_relaxed);
-                // Baseline mode does not track inflight, so nothing is charged.
-                if (slice_charged_bytes) slice_charged_bytes->push_back(0);
             }
             return Status::OK();
         }
@@ -163,15 +158,15 @@ Status DeviceSelector::allocate(uint64_t total_length, uint32_t num_slices,
                                     tl_candidates, priority);
     if (!status.ok()) return status;
     if (num_slices == 1) {
-        selectSinglePath(tl_candidates, num_slices, total_length, slice_dev_ids,
-                         slice_charged_bytes);
+        selectSinglePath(tl_candidates, num_slices, total_length,
+                         slice_dev_ids);
     } else {
         // Probe mode: every 100th call uses round-robin distribution
         // to ensure all devices are sampled for EWMA updates
         thread_local uint64_t tl_call_count = 0;
         bool probe_mode = ((++tl_call_count % 100) == 0);
-        selectMultiPath(tl_candidates, num_slices, total_length, slice_dev_ids,
-                        probe_mode, slice_charged_bytes);
+        selectMultiPath(tl_candidates, num_slices, total_length, slice_bytes,
+                        slice_dev_ids, probe_mode);
     }
     return Status::OK();
 }
@@ -290,10 +285,10 @@ Status DeviceSelector::buildCandidates(const Topology::MemEntry* entry,
     return Status::OK();
 }
 
-void DeviceSelector::selectSinglePath(
-    const std::vector<Candidate>& candidates, uint32_t num_slices,
-    uint64_t total_length, std::vector<int>& slice_dev_ids,
-    std::vector<uint64_t>* slice_charged_bytes) {
+void DeviceSelector::selectSinglePath(const std::vector<Candidate>& candidates,
+                                      uint32_t num_slices,
+                                      uint64_t total_length,
+                                      std::vector<int>& slice_dev_ids) {
     if (candidates.empty()) return;
 
     const Candidate& best = candidates[0];
@@ -303,33 +298,24 @@ void DeviceSelector::selectSinglePath(
     dev.addInflight(total_length);
     dev.total_bytes.fetch_add(total_length, std::memory_order_relaxed);
 
-    // Single path is only used for num_slices == 1, so the whole request's
-    // inflight charge belongs to that one slice.
     for (uint32_t i = 0; i < num_slices; ++i) {
         slice_dev_ids.push_back(dev_id);
-        if (slice_charged_bytes) slice_charged_bytes->push_back(total_length);
     }
 }
 
-void DeviceSelector::selectMultiPath(
-    const std::vector<Candidate>& candidates, uint32_t num_slices,
-    uint64_t total_length, std::vector<int>& slice_dev_ids, bool probe_mode,
-    std::vector<uint64_t>* slice_charged_bytes) {
+void DeviceSelector::selectMultiPath(const std::vector<Candidate>& candidates,
+                                     uint32_t num_slices, uint64_t total_length,
+                                     uint64_t slice_bytes,
+                                     std::vector<int>& slice_dev_ids,
+                                     bool probe_mode) {
     if (candidates.empty()) return;
-    uint64_t slice_bytes = (total_length + num_slices - 1) / num_slices;
-    // Each slice is charged `slice_bytes` of inflight, so record that per slice
-    // for a precise release later.
+    const size_t first = slice_dev_ids.size();
     if (probe_mode) {
         // Probe mode: round-robin distribution to ensure all devices are
         // sampled Activates every 100th call to prevent EWMA starvation
         for (uint32_t i = 0; i < num_slices; ++i) {
             const Candidate& c = candidates[i % candidates.size()];
             slice_dev_ids.push_back(c.dev_id);
-            if (slice_charged_bytes)
-                slice_charged_bytes->push_back(slice_bytes);
-            devices_[c.dev_id].addInflight(slice_bytes);
-            devices_[c.dev_id].total_bytes.fetch_add(slice_bytes,
-                                                     std::memory_order_relaxed);
         }
     } else {
         // Normal mode: weighted distribution based on inverse score
@@ -360,29 +346,26 @@ void DeviceSelector::selectMultiPath(
                 const Candidate& c = candidates[i];
                 for (uint32_t s = 0; s < assigned; ++s) {
                     slice_dev_ids.push_back(c.dev_id);
-                    if (slice_charged_bytes)
-                        slice_charged_bytes->push_back(slice_bytes);
                 }
-                uint64_t total_assigned_bytes =
-                    static_cast<uint64_t>(slice_bytes) * assigned;
-                devices_[c.dev_id].addInflight(total_assigned_bytes);
-                devices_[c.dev_id].total_bytes.fetch_add(
-                    total_assigned_bytes, std::memory_order_relaxed);
             }
         }
         if (remaining_slices > 0) {
             const Candidate& c = candidates[best_dev_idx];
             for (uint32_t s = 0; s < remaining_slices; ++s) {
                 slice_dev_ids.push_back(c.dev_id);
-                if (slice_charged_bytes)
-                    slice_charged_bytes->push_back(slice_bytes);
             }
-            uint64_t total_assigned_bytes =
-                static_cast<uint64_t>(slice_bytes) * remaining_slices;
-            devices_[c.dev_id].addInflight(total_assigned_bytes);
-            devices_[c.dev_id].total_bytes.fetch_add(total_assigned_bytes,
-                                                     std::memory_order_relaxed);
         }
+    }
+    // Charge each device what its slices actually carry, in the caller's
+    // slice order, so release() (which returns the slice's length) balances
+    // per device; ceil(total / n) per slice would not.
+    uint64_t offset = 0;
+    for (size_t i = first; i < slice_dev_ids.size(); ++i) {
+        const uint64_t bytes = std::min(slice_bytes, total_length - offset);
+        offset += bytes;
+        auto& dev = devices_[slice_dev_ids[i]];
+        dev.addInflight(bytes);
+        dev.total_bytes.fetch_add(bytes, std::memory_order_relaxed);
     }
 }
 
@@ -406,16 +389,15 @@ Status DeviceSelector::allocate(uint64_t length, const std::string& location,
 }
 
 Status DeviceSelector::chargeDevice(int dev_id, uint64_t length) {
-    // Baseline mode does not track inflight, so a charge here would never be
-    // matched by a release -- skip it to keep the inflight counter consistent.
-    if (!smart_selection_enabled_) return Status::OK();
     auto it = devices_.find(dev_id);
     if (it == devices_.end())
         return Status::InvalidArgument("device not found");
-    // Only inflight is (re)charged here. total_bytes is cumulative traffic and
-    // is already counted once at allocation time; re-adding it on a fallback
-    // re-route or retry would double-count.
-    it->second.addInflight(length);
+    // Inflight is only tracked in smart mode; see allocate() and release().
+    if (smart_selection_enabled_) it->second.addInflight(length);
+    // Each attempt is bytes this NIC is asked to move, so a retry -- or a
+    // first attempt that fell back to another NIC -- counts again here:
+    // total_bytes is a lifetime traffic figure, not a request count.
+    it->second.total_bytes.fetch_add(length, std::memory_order_relaxed);
     return Status::OK();
 }
 
@@ -427,13 +409,12 @@ Status DeviceSelector::release(int dev_id, uint64_t length, double latency) {
     auto& dev = it->second;
     // Inflight is only ever charged in smart mode; releasing in baseline mode
     // would drive the unsigned counter below zero.
-    if (smart_selection_enabled_) dev.releaseInflight(length);
+    if (!smart_selection_enabled_) return Status::OK();
+    dev.releaseInflight(length);
 
-    // Cancellation of an unposted slice must release its inflight charge but
-    // has no latency sample from which to learn bandwidth.
-    if (!smart_selection_enabled_ || latency <= 0.0) {
-        return Status::OK();
-    }
+    // A release with no latency sample -- cancelled, timed out, failed,
+    // swept off a queue pair, or moved to another device -- learns nothing.
+    if (latency <= 0.0) return Status::OK();
 
     // Update EWMA bandwidth: new = α × old + (1-α) × observed
     // α = 0: always use observed (full adaptation)
@@ -451,7 +432,6 @@ Status DeviceSelector::release(int dev_id, uint64_t length, double latency) {
         std::min(sched_params_.ewma_max_multiplier * theoretical_bw, new_ewma));
 
     dev.ewma_bandwidth_bps.store(new_ewma, std::memory_order_relaxed);
-
     return Status::OK();
 }
 
@@ -522,6 +502,12 @@ double DeviceSelector::getAggregateEwmaBandwidth() const {
         total += dev.getEwmaBandwidth();
     }
     return total > 0.0 ? total : -1.0;
+}
+
+uint64_t DeviceSelector::getInflightBytes(int dev_id) const {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return 0;
+    return it->second.getInflightBytes();
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/quota.cpp
@@ -35,8 +35,9 @@ Status DeviceSelector::loadTopology(std::shared_ptr<Topology>& local_topology) {
         info.dev_id = dev_id;
         info.bw_gbps.store(0.0, std::memory_order_relaxed);  // unknown
         info.numa_id = entry->numa_node;
-        info.ewma_bandwidth_bps.store(theoreticalBandwidth(info),
-                                      std::memory_order_relaxed);
+        const double seed = theoreticalBandwidth(info);
+        info.ewma_bandwidth_bps.store(seed, std::memory_order_relaxed);
+        info.ewma_transmit_bps.store(seed, std::memory_order_relaxed);
     }
     // Initialize device base priorities after all devices are loaded
     fillDevicePriorities();
@@ -64,10 +65,11 @@ Status DeviceSelector::setDeviceBandwidth(int dev_id, double gbps) {
                      << ", assuming " << p.default_bandwidth_gbps << " Gbps";
     }
     dev.bw_gbps.store(gbps, std::memory_order_relaxed);
-    // A worker completing between these two stores clamps the old EWMA
-    // against the new rate once; the seed below overwrites it.
-    dev.ewma_bandwidth_bps.store(theoreticalBandwidth(dev),
-                                 std::memory_order_relaxed);
+    // A worker completing between these stores clamps the old EWMA against
+    // the new rate once; the seeds below overwrite it.
+    const double seed = theoreticalBandwidth(dev);
+    dev.ewma_bandwidth_bps.store(seed, std::memory_order_relaxed);
+    dev.ewma_transmit_bps.store(seed, std::memory_order_relaxed);
     return Status::OK();
 }
 
@@ -401,6 +403,129 @@ Status DeviceSelector::chargeDevice(int dev_id, uint64_t length) {
     return Status::OK();
 }
 
+void DeviceSelector::learnRate(const DeviceInfo& dev,
+                               std::atomic<double>& series, double alpha,
+                               double observed_bps) const {
+    // EWMA update: new = α × old + (1-α) × observed
+    // α = 0: always use observed (full adaptation)
+    // α = 1: never update (no learning)
+    // Clamped to [min_multiplier, max_multiplier] of theoretical bandwidth.
+    const double theoretical_bw = theoreticalBandwidth(dev);
+    const double current = series.load(std::memory_order_relaxed);
+    double updated = alpha * current + (1.0 - alpha) * observed_bps;
+    updated = std::max(
+        sched_params_.ewma_min_multiplier * theoretical_bw,
+        std::min(sched_params_.ewma_max_multiplier * theoretical_bw, updated));
+    series.store(updated, std::memory_order_relaxed);
+}
+
+void DeviceSelector::notePosted(int dev_id, uint64_t bytes, uint64_t now_ns) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return;
+    auto& dev = it->second;
+    // The read-modify-write picks exactly one thread to see each transition,
+    // so a busy stretch is opened once however many workers post at once.
+    if (dev.posted_bytes.fetch_add(bytes, std::memory_order_relaxed) == 0)
+        dev.busy_since.store(now_ns, std::memory_order_relaxed);
+}
+
+void DeviceSelector::notePostEnded(int dev_id, uint64_t bytes,
+                                   uint64_t now_ns) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return;
+    auto& dev = it->second;
+    if (dev.posted_bytes.fetch_sub(bytes, std::memory_order_relaxed) != bytes)
+        return;  // still busy
+    // Bank the stretch that just ended. A neighbour opening the next stretch
+    // between the subtraction above and this read would leave `since` ahead
+    // of `now_ns`; bank nothing rather than an underflowed interval. It
+    // costs one burst's busy time and reads the link fast, so it is bounded
+    // and the smoothing absorbs it.
+    const uint64_t since = dev.busy_since.load(std::memory_order_relaxed);
+    if (now_ns > since)
+        dev.busy_ns.fetch_add(now_ns - since, std::memory_order_relaxed);
+}
+
+uint64_t DeviceSelector::getBusyNs(int dev_id) const {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return 0;
+    return it->second.busy_ns.load(std::memory_order_relaxed);
+}
+
+uint64_t DeviceSelector::getPostedBytes(int dev_id) const {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return 0;
+    return it->second.getPostedBytes();
+}
+
+void DeviceSelector::noteCompleted(int dev_id, uint64_t bytes) {
+    auto it = devices_.find(dev_id);
+    if (it != devices_.end())
+        it->second.completed_bytes.fetch_add(bytes, std::memory_order_relaxed);
+}
+
+uint64_t DeviceSelector::busyNsAt(const DeviceInfo& dev, uint64_t now_ns) {
+    uint64_t busy = dev.busy_ns.load(std::memory_order_relaxed);
+    if (dev.posted_bytes.load(std::memory_order_relaxed) > 0) {
+        const uint64_t since = dev.busy_since.load(std::memory_order_relaxed);
+        if (now_ns > since) busy += now_ns - since;
+    }
+    return busy;
+}
+
+void DeviceSelector::resetTransmitMeter(int dev_id) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return;
+    // One store, so it cannot interleave with a sampler's two baseline
+    // exchanges: the next maybeSampleTransmit sees prev == 0, takes both
+    // baselines itself under its CAS, and learns nothing from them.
+    it->second.meter_ts.store(0, std::memory_order_relaxed);
+}
+
+void DeviceSelector::maybeSampleTransmit(int dev_id, uint64_t now_ns) {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return;
+    auto& dev = it->second;
+
+    uint64_t prev = dev.meter_ts.load(std::memory_order_relaxed);
+    // `now_ns <= prev`: a lane whose poll timestamp predates another lane's
+    // sample; letting it through would move the baseline backwards.
+    if (prev != 0 && (now_ns <= prev ||
+                      now_ns - prev < sched_params_.transmit_meter_interval_ns))
+        return;
+    // One sampler per interval: the loser leaves the counters alone.
+    if (!dev.meter_ts.compare_exchange_strong(
+            prev, now_ns, std::memory_order_acq_rel, std::memory_order_relaxed))
+        return;
+
+    const uint64_t completed =
+        dev.completed_bytes.load(std::memory_order_relaxed);
+    const uint64_t before =
+        dev.meter_completed.exchange(completed, std::memory_order_relaxed);
+
+    // Busy time up to now: what has been banked by the stretches that ended,
+    // plus the one still open. Charging the bytes to this instead of to
+    // elapsed wall time is what keeps a NIC that bursts and then waits from
+    // reading as a slow link -- the gap between bursts is not the link, and
+    // asking whether the NIC was busy when the interval opened cannot see it
+    // (a burst's first completion always has the rest of that burst behind
+    // it, so every interval opens busy).
+    const uint64_t busy = busyNsAt(dev, now_ns);
+    const uint64_t busy_before =
+        dev.meter_busy_ns.exchange(busy, std::memory_order_relaxed);
+
+    if (prev == 0) return;  // first sample: it only sets the baseline
+    // A sample spanning this much wall time describes a link too far back to
+    // attribute to the link as it is now, however busy it was.
+    if (now_ns - prev > sched_params_.transmit_meter_max_interval_ns) return;
+    if (completed <= before || busy <= busy_before) return;
+
+    learnRate(
+        dev, dev.ewma_transmit_bps,
+        sched_params_.transmit_bandwidth_learning_rate,
+        static_cast<double>(completed - before) / ((busy - busy_before) / 1e9));
+}
+
 Status DeviceSelector::release(int dev_id, uint64_t length, double latency) {
     auto it = devices_.find(dev_id);
     if (it == devices_.end())
@@ -416,22 +541,9 @@ Status DeviceSelector::release(int dev_id, uint64_t length, double latency) {
     // swept off a queue pair, or moved to another device -- learns nothing.
     if (latency <= 0.0) return Status::OK();
 
-    // Update EWMA bandwidth: new = α × old + (1-α) × observed
-    // α = 0: always use observed (full adaptation)
-    // α = 1: never update (no learning)
-    double observed_bw = static_cast<double>(length) / latency;
-    double current_ewma = dev.getEwmaBandwidth();
-
-    double alpha = sched_params_.bandwidth_learning_rate;
-    double new_ewma = alpha * current_ewma + (1.0 - alpha) * observed_bw;
-
-    // Clamp to [min_multiplier, max_multiplier] of theoretical bandwidth
-    double theoretical_bw = theoreticalBandwidth(dev);
-    new_ewma = std::max(
-        sched_params_.ewma_min_multiplier * theoretical_bw,
-        std::min(sched_params_.ewma_max_multiplier * theoretical_bw, new_ewma));
-
-    dev.ewma_bandwidth_bps.store(new_ewma, std::memory_order_relaxed);
+    learnRate(dev, dev.ewma_bandwidth_bps,
+              sched_params_.bandwidth_learning_rate,
+              static_cast<double>(length) / latency);
     return Status::OK();
 }
 
@@ -508,6 +620,21 @@ uint64_t DeviceSelector::getInflightBytes(int dev_id) const {
     auto it = devices_.find(dev_id);
     if (it == devices_.end()) return 0;
     return it->second.getInflightBytes();
+}
+
+double DeviceSelector::getTransmitBandwidth(int dev_id) const {
+    auto it = devices_.find(dev_id);
+    if (it == devices_.end()) return -1.0;
+    return it->second.getTransmitBandwidth();
+}
+
+double DeviceSelector::getAggregateTransmitBandwidth() const {
+    double total = 0.0;
+    for (const auto& [id, dev] : devices_) {
+        if (!dev.available.load(std::memory_order_relaxed)) continue;
+        total += dev.getTransmitBandwidth();
+    }
+    return total > 0.0 ? total : -1.0;
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -493,7 +493,6 @@ Status RdmaTransport::submitTransferTasks(
             (request.length + num_slices - 1) / num_slices, default_block_size);
 
         std::vector<int> slice_dev_ids;
-        std::vector<uint64_t> slice_charged_bytes;
         // Only if a single request is enough, we perform aggregated allocation
         if (num_slices >= max_slice_count / 2) {
             std::string source_location = kWildcardLocation;
@@ -507,7 +506,7 @@ Status RdmaTransport::submitTransferTasks(
                 auto status = device_selector->allocate(
                     request.length, static_cast<uint32_t>(num_slices),
                     block_size, source_location, slice_dev_ids,
-                    request.priority, batch->device_mask, &slice_charged_bytes);
+                    request.priority, batch->device_mask);
                 if (!status.ok() || slice_dev_ids.empty()) {
                     LOG(WARNING) << "Device quota allocation failed: "
                                  << status.message();
@@ -526,7 +525,8 @@ Status RdmaTransport::submitTransferTasks(
             slice->task = task;
             slice->retry_count = 0;
             slice->last_fallback_idx = -1;
-            slice->quota_charged = false;
+            slice->charged_dev = -1;
+            slice->counted_lane = -1;
             slice->ep_weak_ptr.reset();
             slice->word = PENDING;
             slice->next = nullptr;
@@ -536,14 +536,7 @@ Status RdmaTransport::submitTransferTasks(
             task->ref();  // Each slice holds a reference to the task
             if (slice_idx < slice_dev_ids.size()) {
                 slice->source_dev_id = slice_dev_ids[slice_idx];
-                slice->quota_charged = true;
-                slice->charged_dev_id = slice->source_dev_id;
-                // Remember the exact bytes charged so release is symmetric even
-                // when this slice's real length differs from the allocator's
-                // per-slice estimate.
-                slice->charged_bytes = slice_idx < slice_charged_bytes.size()
-                                           ? slice_charged_bytes[slice_idx]
-                                           : slice->length;
+                slice->charged_dev = slice->source_dev_id;
             }
             offset += length;
             int part_id = next_worker_idx % num_workers;

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rdma_transport.cpp
@@ -526,6 +526,7 @@ Status RdmaTransport::submitTransferTasks(
             slice->retry_count = 0;
             slice->last_fallback_idx = -1;
             slice->charged_dev = -1;
+            slice->posted_dev = -1;
             slice->counted_lane = -1;
             slice->ep_weak_ptr.reset();
             slice->word = PENDING;
@@ -947,7 +948,11 @@ double RdmaTransport::getEstimatedBandwidth() const {
     if (!workers_) return -1.0;
     auto* sel = workers_->getDeviceSelector();
     if (!sel) return -1.0;
-    return sel->getAggregateEwmaBandwidth();
+    // The transmit estimate, not the selection EWMA: the admission queue
+    // asks "how fast do bytes move once they are sent", and adds the wait
+    // behind earlier work itself (DeadlineMlu's bytes_ahead), so the rate
+    // must not fold that wait in the way the selection sample does.
+    return sel->getAggregateTransmitBandwidth();
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -288,6 +288,16 @@ Status Workers::submit(RdmaSliceList& slice_list, int worker_id) {
     }
     auto& worker = worker_context_[worker_id];
 
+    // This lane's set and counter now account for the slices, wherever they
+    // are later swept from. First entry only: a slice arriving here has
+    // never been counted, so there is nothing to move.
+    auto* owned = slice_list.first;
+    for (int i = 0; i < slice_list.num_slices && owned; ++i) {
+        owned->owner_worker.store(worker_id, std::memory_order_relaxed);
+        owned->counted_lane.store(worker_id, std::memory_order_relaxed);
+        owned = owned->next;
+    }
+
     // Get priority from first slice (all slices in list have same priority)
     int priority = PRIO_HIGH;
     if (slice_list.first && slice_list.first->task) {
@@ -317,6 +327,22 @@ void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
     if (slice && slice->task) {
         priority = slice->priority;
     }
+    // This lane's queue and counter are about to account for the slice, so
+    // move the count here before it is visible on the queue. With a shared
+    // queue pair the lane re-queueing the slice is the one that polled the
+    // completion, not necessarily the one that first enqueued it: whichever
+    // lane still counts it is paid back in the same exchange, so the slice
+    // is never in two counts or in none. A sweep that already discounted it
+    // left -1 behind and there is nothing to pay.
+    if (slice) {
+        const int lane = laneIndex(worker);
+        slice->owner_worker.store(lane, std::memory_order_relaxed);
+        const int prev =
+            slice->counted_lane.exchange(lane, std::memory_order_acq_rel);
+        if (prev >= 0 && prev != lane && prev < (int)num_workers_)
+            worker_context_[prev].inflight_slices.fetch_sub(1);
+        if (prev != lane) worker.inflight_slices.fetch_add(1);
+    }
     // The worker must never block on its own queue (issue #3637): a full
     // queue parks the slice in requeue_overflow and the next tick retries.
     // Either way it stays counted as inflight, which keeps the worker from
@@ -324,7 +350,6 @@ void Workers::submitFromTick(WorkerContext& worker, RdmaSlice* slice) {
     if (!worker.queues[priority].try_push(slice_list)) {
         worker.requeue_overflow.emplace_back(priority, slice_list);
     }
-    worker.inflight_slices.fetch_add(1);
 }
 
 Status Workers::cancel(RdmaTask* task) {
@@ -347,82 +372,125 @@ Status Workers::cancel(RdmaTask* task) {
     return Status::OK();
 }
 
-bool Workers::cancelUnpostedSlice(WorkerContext& worker, RdmaSlice* slice) {
-    if (!slice || !slice->task ||
+void Workers::rechargeSlice(RdmaSlice* slice, int dev_id) {
+    if (!device_selector_ || !slice || dev_id < 0) return;
+    if (slice->charged_dev.load(std::memory_order_relaxed) == dev_id) return;
+    if (auto status = device_selector_->chargeDevice(dev_id, slice->length);
+        !status.ok()) {
+        // A device the selector does not track (a topology/quota mismatch).
+        // The transfer can still go, so the slice is not failed; it keeps
+        // the charge it has, if any, so the release stays balanced -- but
+        // this NIC's load is under-counted, so say so (rate-limited).
+        LOG_EVERY_N(WARNING, 100)
+            << "rechargeSlice: device " << dev_id
+            << " is not tracked by DeviceSelector; slice " << slice
+            << " keeps its previous charge: " << status.ToString();
+        return;
+    }
+    // Charge the new device before letting go of the old one, so a release
+    // racing in between pays back whichever device is on record and never
+    // both, and never one that has not been charged. No latency sample --
+    // this is not a completion.
+    const int prev =
+        slice->charged_dev.exchange(dev_id, std::memory_order_acq_rel);
+    if (prev >= 0) device_selector_->release(prev, slice->length, 0.0);
+}
+
+bool Workers::dropUnpostableSlice(WorkerContext& worker, RdmaSlice* slice) {
+    if (!slice || !slice->task) return false;
+    // Two reasons not to post. The caller cancelled the transfer; or another
+    // lane already resolved this slice while it waited here for a re-post --
+    // with a shared queue pair that lane's timeout sweep can still reach it
+    // through a set entry it has not drained. Posting a resolved slice would
+    // move bytes for a transfer that is already over.
+    if (slice->word == PENDING &&
         !slice->task->cancel_requested.load(std::memory_order_acquire))
         return false;
-    if (slice->word == PENDING) {
-        releaseSliceQuota(device_selector_.get(), slice);
-        updateSliceStatus(slice, CANCELED);
-    }
-    worker.inflight_slices.fetch_sub(1);
+    // Retire it the way a sweep would -- charge, count and set entry all go
+    // back where they came from, each idempotently, since whichever path
+    // resolved the slice may already have run them -- and updateSliceStatus
+    // is a no-op once the slice is terminal.
+    retireSweptSlice(worker, slice, nullptr);
+    updateSliceStatus(slice, CANCELED);
     return true;
 }
 
-void Workers::releaseSliceQuota(DeviceSelector* selector, RdmaSlice* slice,
-                                double latency) {
-    if (!slice || !slice->quota_charged || !selector) return;
-    // Release against the device the bytes were actually charged on, and unwind
-    // exactly the bytes that were charged, not the current routing NIC or the
-    // slice length: a fallback re-route can leave source_dev_id pointing at a
-    // different device, and the allocator's per-slice estimate can differ from
-    // slice->length.
-    selector->release(slice->charged_dev_id, slice->charged_bytes, latency);
-    slice->quota_charged = false;
-    slice->charged_dev_id = -1;
-    slice->charged_bytes = 0;
+void Workers::releaseSliceQuota(RdmaSlice* slice, double latency) {
+    if (!slice || !device_selector_) return;
+    // The field names the device it was charged to, so the release goes
+    // there even if a fallback has since rewritten source_dev_id.
+    const int charged =
+        slice->charged_dev.exchange(-1, std::memory_order_acq_rel);
+    if (charged >= 0)
+        device_selector_->release(charged, slice->length, latency);
 }
 
-void Workers::chargeSliceQuota(DeviceSelector* selector, RdmaSlice* slice) {
-    // Reconcile the inflight charge so it lands on the device the slice will
-    // actually post on (slice->source_dev_id) and reflects the slice's real
-    // length. This keeps DeviceSelector's per-NIC inflight view both symmetric
-    // with releaseSliceQuota and an accurate load signal, across three paths
-    // that would otherwise skew local telemetry:
-    //   - initial allocate: the aggregated allocator charges a per-slice
-    //     estimate (ceil(total/num_slices)); convert it to the exact length so
-    //     inflight equals the bytes really put on the wire.
-    //   - fallback re-route: the charge was made on the originally selected NIC
-    //     but the slice now posts on a different one -> migrate the charge.
-    //   - retry: the previous attempt released the quota, so re-enter the
-    //     inflight view instead of running uncounted.
-    if (!selector || slice->source_dev_id < 0) return;
-    if (slice->quota_charged && slice->charged_dev_id == slice->source_dev_id &&
-        slice->charged_bytes == slice->length)
-        return;  // already charged exactly this slice's length on the right NIC
-    if (slice->quota_charged) {
-        // Stale device and/or estimate -> unwind exactly what was charged
-        // first. Order is deliberate: releasing before charging makes inflight
-        // dip slightly below reality for the instant between the two calls,
-        // whereas charging first would transiently double-count during a
-        // fallback migration. inflight is only a scoring signal (not an
-        // admission gate), so a momentary dip merely perturbs one selection,
-        // while a double-count would over-penalize the NIC -- the dip is the
-        // lesser, intended bias.
-        selector->release(slice->charged_dev_id, slice->charged_bytes, 0.0);
-        slice->quota_charged = false;
-        slice->charged_dev_id = -1;
-        slice->charged_bytes = 0;
+Workers::WorkerContext* Workers::ownerContext(const RdmaSlice* slice) {
+    if (!worker_context_ || !slice) return nullptr;
+    const int lane = slice->owner_worker.load(std::memory_order_relaxed);
+    if (lane < 0 || lane >= (int)num_workers_) return nullptr;
+    return &worker_context_[lane];
+}
+
+int Workers::laneIndex(const WorkerContext& worker) const {
+    if (!worker_context_) return -1;
+    return static_cast<int>(&worker - worker_context_);
+}
+
+bool Workers::routeSetRemoval(WorkerContext& self, RdmaSlice* slice) {
+    // Two sets can hold an entry for one slice: a retry re-queued by another
+    // lane moves ownership while the lane it left still holds the old
+    // entry. So this lane takes out whatever it holds itself, and the
+    // owning lane, if it is somebody else, is handed the slice regardless --
+    // a hand-over for an entry it does not hold costs one erase of nothing.
+    const bool mine = self.inflight_slice_set.count(slice) > 0;
+    auto* owner = ownerContext(slice);
+    if (owner && owner != &self) {
+        std::lock_guard<std::mutex> lock(owner->reclaim_mutex);
+        owner->reclaimed.push_back(slice);
     }
-    // Charge this slice's real length on the routing NIC. Only commit the
-    // bookkeeping if the charge actually succeeded, so a failed charge is never
-    // released later (which would underflow the counter).
-    Status status = selector->chargeDevice(slice->source_dev_id, slice->length);
-    if (status.ok()) {
-        slice->charged_dev_id = slice->source_dev_id;
-        slice->charged_bytes = slice->length;
-        slice->quota_charged = true;
-    } else {
-        // The routing NIC is not tracked by DeviceSelector (a topology/quota
-        // mismatch, e.g. a device that never entered devices_). The data
-        // transfer can still proceed, so we do not fail the slice, but the
-        // slice runs without inflight accounting -- surface it (rate-limited on
-        // the hot path) instead of silently under-counting the device's load.
-        LOG_EVERY_N(WARNING, 100)
-            << "chargeSliceQuota: source_dev_id " << slice->source_dev_id
-            << " is not tracked by DeviceSelector; slice " << slice
-            << " proceeds without inflight accounting: " << status.ToString();
+    return mine || !owner || owner == &self;
+}
+
+void Workers::retireSweptSlice(WorkerContext& self, RdmaSlice* slice,
+                               std::vector<RdmaSlice*>* deferred) {
+    if (!slice) return;
+    releaseSliceQuota(slice);
+    discountFromOwner(self, slice);
+    if (!routeSetRemoval(self, slice)) return;
+    if (deferred)
+        deferred->push_back(slice);
+    else
+        self.inflight_slice_set.erase(slice);
+}
+
+void Workers::discountFromOwner(WorkerContext& self, RdmaSlice* slice) {
+    if (!slice) return;
+    // Several paths can reach one slice -- its own completion, another
+    // lane's sweep of a shared queue pair, this lane's timeout pass -- and
+    // only the first of them takes it out of the count: the field says
+    // which lane's, and comes back -1 for everyone after.
+    const int lane =
+        slice->counted_lane.exchange(-1, std::memory_order_acq_rel);
+    if (lane < 0) return;
+    const bool known = worker_context_ && lane < (int)num_workers_;
+    (known ? worker_context_[lane] : self).inflight_slices.fetch_sub(1);
+}
+
+void Workers::drainReclaimed(WorkerContext& worker) {
+    std::vector<RdmaSlice*> taken;
+    {
+        std::lock_guard<std::mutex> lock(worker.reclaim_mutex);
+        if (worker.reclaimed.empty()) return;
+        taken.swap(worker.reclaimed);
     }
+    for (auto* slice : taken) worker.inflight_slice_set.erase(slice);
+}
+
+void Workers::markPosted(WorkerContext& worker, RdmaSlice* slice,
+                         uint64_t post_ts) {
+    slice->submit_ts = post_ts;
+    worker.inflight_slice_set.insert(slice);
 }
 
 std::shared_ptr<RdmaEndPoint> Workers::getEndpoint(Workers::PostPath path) {
@@ -532,7 +600,7 @@ void Workers::asyncPostSend() {
         if (slice_list.num_slices == 0) continue;
         auto slice = slice_list.first;
         for (int id = 0; id < slice_list.num_slices; ++id) {
-            if (cancelUnpostedSlice(worker, slice)) {
+            if (dropUnpostableSlice(worker, slice)) {
                 slice = slice->next;
                 continue;
             }
@@ -540,13 +608,13 @@ void Workers::asyncPostSend() {
             if (!status.ok()) {
                 LOG(ERROR) << "Failed to generate post path for slice " << slice
                            << ": " << status.ToString();
-                releaseSliceQuota(device_selector_.get(), slice);
+                releaseSliceQuota(slice);
                 updateSliceStatus(slice, slice->task->cancel_requested.load(
                                              std::memory_order_acquire)
                                              ? CANCELED
                                              : FAILED);
-                worker.inflight_slices.fetch_sub(1);
-            } else if (cancelUnpostedSlice(worker, slice)) {
+                discountFromOwner(worker, slice);
+            } else if (dropUnpostableSlice(worker, slice)) {
                 slice = slice->next;
                 continue;
             } else {
@@ -566,7 +634,7 @@ void Workers::asyncPostSend() {
         if (slices.empty()) continue;
         slices.erase(std::remove_if(slices.begin(), slices.end(),
                                     [&](RdmaSlice* slice) {
-                                        return cancelUnpostedSlice(worker,
+                                        return dropUnpostableSlice(worker,
                                                                    slice);
                                     }),
                      slices.end());
@@ -576,20 +644,20 @@ void Workers::asyncPostSend() {
             std::vector<RdmaSlice*> clone;
             slices.swap(clone);
             for (auto slice : clone) {
-                if (cancelUnpostedSlice(worker, slice)) continue;
+                if (dropUnpostableSlice(worker, slice)) continue;
                 slice->retry_count++;
+                releaseSliceQuota(slice);
                 if (slice->retry_count >=
                     transport_->params_->workers.max_retry_count) {
                     LOG(WARNING)
                         << "Slice " << slice << " failed: retry count exceeded";
                     disableEndpoint(slice);
-                    releaseSliceQuota(device_selector_.get(), slice);
                     updateSliceStatus(slice, FAILED);
+                    discountFromOwner(worker, slice);
                 } else {
-                    releaseSliceQuota(device_selector_.get(), slice);
+                    // The re-submit moves the count to the lane it lands on.
                     submitFromTick(worker, slice);
                 }
-                worker.inflight_slices.fetch_sub(1);
             }
             continue;
         }
@@ -636,31 +704,36 @@ void Workers::asyncPostSend() {
             }
         }
 
-        int num_submitted = endpoint->submitSlices(slices, tl_wid);
+        // Everything a completion's poller must find is written before the
+        // work request can reach the wire: with a shared queue pair another
+        // lane may poll the completion before submitSlices returns, and a
+        // poller that finds no set entry cannot route it home.
+        const uint64_t post_ts = getCurrentTimeInNano();
+        int num_submitted = endpoint->submitSlices(
+            slices, tl_wid,
+            [&](RdmaSlice* posted) { markPosted(worker, posted, post_ts); });
         for (int id = 0; id < num_submitted; ++id) {
             auto slice = slices[id];
-            if (slice->failed) {
-                releaseSliceQuota(device_selector_.get(), slice);
-                if (slice->task->cancel_requested.load(
-                        std::memory_order_acquire)) {
-                    updateSliceStatus(slice, CANCELED);
-                    worker.inflight_slices.fetch_sub(1);
-                    continue;
-                }
-                slice->retry_count++;
-                if (slice->retry_count >=
-                    transport_->params_->workers.max_retry_count) {
-                    LOG(WARNING)
-                        << "Slice " << slice << " failed: retry count exceeded";
-                    disableEndpoint(slice);
-                    updateSliceStatus(slice, FAILED);
-                } else {
-                    submitFromTick(worker, slice);
-                }
-                worker.inflight_slices.fetch_sub(1);
+            if (!slice->failed) continue;
+            // Rejected by the hardware: it never went on the wire, so take
+            // back what the hook put in place.
+            worker.inflight_slice_set.erase(slice);
+            releaseSliceQuota(slice);
+            if (slice->task->cancel_requested.load(std::memory_order_acquire)) {
+                updateSliceStatus(slice, CANCELED);
+                discountFromOwner(worker, slice);
+                continue;
+            }
+            slice->retry_count++;
+            if (slice->retry_count >=
+                transport_->params_->workers.max_retry_count) {
+                LOG(WARNING)
+                    << "Slice " << slice << " failed: retry count exceeded";
+                disableEndpoint(slice);
+                updateSliceStatus(slice, FAILED);
+                discountFromOwner(worker, slice);
             } else {
-                slice->submit_ts = getCurrentTimeInNano();
-                worker.inflight_slice_set.insert(slice);
+                submitFromTick(worker, slice);
             }
         }
 
@@ -734,38 +807,195 @@ void Workers::promoteTimedOutRequests(WorkerContext& worker) {
     promote_level(PRIO_LOW, PRIO_MEDIUM);
 }
 
+void Workers::expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns) {
+    drainReclaimed(worker);
+    std::vector<RdmaSlice*> slice_to_remove;
+    // Erasing from this lane's set has to wait until the loop below is done
+    // with it; slices belonging to another lane are handed over instead.
+    // One captured reference keeps the std::function inside its small-buffer
+    // storage, so a sweep does not allocate.
+    struct Sweep {
+        Workers* self;
+        WorkerContext* worker;
+        std::vector<RdmaSlice*>* deferred;
+    } sweep{this, &worker, &slice_to_remove};
+    auto retire = [&sweep](RdmaSlice* swept) {
+        sweep.self->retireSweptSlice(*sweep.worker, swept, sweep.deferred);
+    };
+    for (auto& slice : worker.inflight_slice_set) {
+        if (slice->word != PENDING) {
+            // Terminal but still counted here: an endpoint teardown cancels
+            // whatever is queued on it without going through a sweep, so
+            // nothing has given this lane its slice back. Do it now, or the
+            // charge, the NIC's posted bytes and this lane's count carry it
+            // for the life of the process.
+            retire(slice);
+            continue;
+        }
+        if (now_ns - slice->enqueue_ts > slice_timeout_ns_) {
+            auto ep = slice->ep_weak_ptr.lock();
+            LOG(WARNING) << "Slice " << slice
+                         << " failed: transfer timeout (software)";
+            // The slice turns terminal here, not on the CQ. Its flush
+            // completion may never be polled (acknowledge() zeroes wr_depth,
+            // so the endpoint destroys the QP and its unpolled CQEs), so
+            // return the selector charge now for it and every slice swept
+            // with it; releaseSliceQuota() is idempotent.
+            if (!ep) {
+                retire(slice);
+                updateSliceStatus(slice, TIMEOUT);
+                continue;
+            }
+            auto num_slices = ep->acknowledge(slice, TIMEOUT, retire);
+            disableEndpoint(slice);
+            if (num_slices == 0) {
+                // A neighbour's retry already popped it off the queue pair
+                // and discounted it there, so only its charge and its set
+                // entry are still outstanding.
+                releaseSliceQuota(slice);
+                if (routeSetRemoval(worker, slice))
+                    slice_to_remove.push_back(slice);
+                updateSliceStatus(slice, TIMEOUT);
+            }
+        }
+    }
+    for (auto& slice : slice_to_remove) worker.inflight_slice_set.erase(slice);
+}
+
+void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
+                               const ibv_wc& wc, uint64_t poll_ts) {
+    auto slice = (RdmaSlice*)wc.wr_id;
+    // What the acknowledge callbacks below need, behind one reference so
+    // the std::function stays in its small-buffer storage (no allocation
+    // per completion).
+    struct Sweep {
+        Workers* self;
+        WorkerContext* worker;
+    } sweep{this, &worker};
+    // The lane that enqueued this slice owns its set entry; with a
+    // shared queue pair that is not necessarily this one.
+    if (routeSetRemoval(worker, slice)) worker.inflight_slice_set.erase(slice);
+    auto ep = slice->ep_weak_ptr.lock();
+    double enqueue_lat = (slice->submit_ts - slice->enqueue_ts) / 1000.0;
+    double inflight_lat = (poll_ts - slice->submit_ts) / 1000.0;
+    // The selection EWMA learns only from a successful transfer, and only
+    // from this attempt's own post->completion time (#3511): the time since
+    // first enqueue folds in queueing and earlier failed attempts on other
+    // NICs. A failed or flushed work request, or a slice another path has
+    // already resolved, contributes no sample and only returns its charge.
+    const bool ewma_sample =
+        ep && slice->word == PENDING && wc.status == IBV_WC_SUCCESS;
+    const double sample_lat_sec =
+        ewma_sample ? (poll_ts - slice->submit_ts) / 1e9 : 0.0;
+    releaseSliceQuota(slice, sample_lat_sec);
+    if (slice->word != PENDING) {
+        // Resolved before its completion was polled -- swept off the queue
+        // pair by a neighbour, timed out, or cancelled by a teardown. The
+        // charge came back above; the lane count is settled here in case
+        // that path could not (idempotent, so a path that did is unharmed).
+        discountFromOwner(worker, slice);
+        return;
+    }
+    if (!ep) {
+        updateSliceStatus(slice, FAILED);
+        discountFromOwner(worker, slice);
+        return;
+    }
+    if (wc.status != IBV_WC_SUCCESS) {
+        if (wc.status != IBV_WC_WR_FLUSH_ERR) {
+            // TE handles them automatically
+            LOG(INFO) << "Detected error WQE for slice " << slice
+                      << " (opcode: " << slice->task->request.opcode
+                      << ", source_addr: " << (void*)slice->source_addr
+                      << ", dest_addr: " << (void*)slice->target_addr
+                      << ", length: " << slice->length
+                      << ", local_nic: " << context.name()
+                      << "): " << ibv_wc_status_str(wc.status);
+        }
+        // GPUDirect reachability learning: a protection/access error
+        // on a GPU buffer means the chosen NIC cannot P2P-DMA to that
+        // GPU (ibv_reg_mr succeeded but the PCIe path is unusable).
+        // Record it so selection avoids that NIC and converges onto a
+        // reachable rail instead of exhausting retries. The local side
+        // (source NIC -> source GPU) surfaces as LOC_PROT; the remote
+        // side (target NIC -> target GPU) as REM_ACCESS or, for a
+        // remote GDR-read failure, REM_OP (observed on strict fabrics).
+        bool local_gdr_err = (wc.status == IBV_WC_LOC_PROT_ERR);
+        bool remote_gdr_err = (wc.status == IBV_WC_REM_ACCESS_ERR ||
+                               wc.status == IBV_WC_REM_OP_ERR);
+        if (local_gdr_err && slice->source_gpu_ordinal >= 0 &&
+            slice->source_nic_name) {
+            GdrReachability::instance().reportLocalFailure(
+                slice->source_nic_name, slice->source_gpu_ordinal);
+        } else if (remote_gdr_err && slice->target_gpu_ordinal >= 0 &&
+                   slice->target_nic_name && slice->target_machine_id) {
+            GdrReachability::instance().reportRemoteFailure(
+                *slice->target_machine_id, slice->target_nic_name,
+                slice->target_gpu_ordinal);
+        }
+        slice->retry_count++;
+        if (slice->retry_count >=
+            transport_->params_->workers.max_retry_count) {
+            LOG(WARNING) << "Slice " << slice
+                         << " failed: retry count exceeded";
+            ep->acknowledge(slice, FAILED, [&sweep](RdmaSlice* swept) {
+                sweep.self->retireSweptSlice(*sweep.worker, swept, nullptr);
+            });
+            disableEndpoint(slice);
+        } else {
+            // Popped but still in flight: their work requests are
+            // live and their completions are still coming, so only
+            // the owning lane's count stops tracking them here.
+            ep->acknowledge(slice, PENDING, [&](RdmaSlice* swept) {
+                discountFromOwner(worker, swept);
+            });
+            disableEndpoint(slice);
+            if (slice->task->cancel_requested.load(std::memory_order_acquire)) {
+                updateSliceStatus(slice, CANCELED);
+            } else {
+                submitFromTick(worker, slice);
+            }
+        }
+    } else {
+        ep->acknowledge(slice, COMPLETED, [&sweep](RdmaSlice* swept) {
+            sweep.self->retireSweptSlice(*sweep.worker, swept, nullptr);
+        });
+        // A successful GPU transfer re-admits any learned GDR
+        // unreachability for the (GPU, NIC) pair(s) it used, so a
+        // transient exclusion (or a recovered path) heals. Skipped
+        // entirely until something has actually been excluded.
+        if (GdrReachability::hasAnyExclusion()) {
+            auto& gdr = GdrReachability::instance();
+            if (slice->source_gpu_ordinal >= 0 && slice->source_nic_name)
+                gdr.reportLocalSuccess(slice->source_nic_name,
+                                       slice->source_gpu_ordinal);
+            if (slice->target_gpu_ordinal >= 0 && slice->target_nic_name &&
+                slice->target_machine_id)
+                gdr.reportRemoteSuccess(*slice->target_machine_id,
+                                        slice->target_nic_name,
+                                        slice->target_gpu_ordinal);
+        }
+        // A successful transfer proves this rail is healthy; clear
+        // any accumulated error count so a previously-cooled-down
+        // rail can be used again without waiting for the full
+        // cooldown to expire. The monitor pointer is resolved once
+        // in generatePostPath, so no map lookup is needed here.
+        if (auto* rail = slice->rail_monitor; rail && rail->ready())
+            rail->markRecovered(slice->source_dev_id, slice->target_dev_id);
+        if (transport_->params_->workers.show_latency_info) {
+            worker.perf.inflight_lat.add(inflight_lat);
+            worker.perf.enqueue_lat.add(enqueue_lat);
+        }
+    }
+}
+
 void Workers::asyncPollCq() {
     auto& worker = worker_context_[tl_wid];
     const static size_t kPollCount = 64;
     int num_contexts = (int)transport_->context_set_.size();
     int num_cq_list = transport_->params_->device.num_cq_list;
-    int num_slices = 0;
 
-    uint64_t current_ts = getCurrentTimeInNano();
-    std::vector<RdmaSlice*> slice_to_remove;
-    for (auto& slice : worker.inflight_slice_set) {
-        if (slice->word != PENDING) continue;
-        if (current_ts - slice->enqueue_ts > slice_timeout_ns_) {
-            auto ep = slice->ep_weak_ptr.lock();
-            LOG(WARNING) << "Slice " << slice
-                         << " failed: transfer timeout (software)";
-            // A software timeout is terminal (no retry), so release the
-            // inflight charge here or it leaks on charged_dev_id forever. No
-            // latency sample: a timeout is not a valid bandwidth observation.
-            releaseSliceQuota(device_selector_.get(), slice);
-            if (!ep) {
-                updateSliceStatus(slice, TIMEOUT);
-                slice_to_remove.push_back(slice);
-                worker.inflight_slices.fetch_sub(1);
-                continue;
-            }
-            auto num_slices = ep->acknowledge(slice, TIMEOUT);
-            disableEndpoint(slice);
-            worker.inflight_slices.fetch_sub(num_slices);
-            slice_to_remove.push_back(slice);
-        }
-    }
-    for (auto& slice : slice_to_remove) worker.inflight_slice_set.erase(slice);
+    expireTimedOutSlices(worker, getCurrentTimeInNano());
 
     for (int index = 0; index < num_contexts; index++) {
         auto& context = transport_->context_set_[index];
@@ -775,115 +1005,8 @@ void Workers::asyncPollCq() {
         int nr_poll = cq->poll(kPollCount, wc);
         if (nr_poll < 0) continue;
         auto poll_ts = getCurrentTimeInNano();
-        for (int i = 0; i < nr_poll; ++i) {
-            auto slice = (RdmaSlice*)wc[i].wr_id;
-            worker.inflight_slice_set.erase(slice);
-            auto ep = slice->ep_weak_ptr.lock();
-            double enqueue_lat =
-                (slice->submit_ts - slice->enqueue_ts) / 1000.0;
-            double inflight_lat = (poll_ts - slice->submit_ts) / 1000.0;
-            // EWMA bandwidth must learn only from successful transfers, and
-            // only from the current NIC attempt's inflight time -- not the
-            // cumulative time since first enqueue, which folds in queueing
-            // delay and prior failed attempts on other NICs and would bias the
-            // estimate low. A failed/flushed WC or an already-resolved slice
-            // contributes no sample (latency 0), so releaseSliceQuota only
-            // frees the charge.
-            bool ewma_sample =
-                ep && slice->word == PENDING && wc[i].status == IBV_WC_SUCCESS;
-            double sample_lat_sec =
-                ewma_sample ? (poll_ts - slice->submit_ts) / 1e9 : 0.0;
-            releaseSliceQuota(device_selector_.get(), slice, sample_lat_sec);
-            if (slice->word != PENDING) continue;
-            if (!ep) {
-                updateSliceStatus(slice, FAILED);
-                num_slices++;
-                continue;
-            }
-            if (wc[i].status != IBV_WC_SUCCESS) {
-                if (wc[i].status != IBV_WC_WR_FLUSH_ERR) {
-                    // TE handles them automatically
-                    LOG(INFO) << "Detected error WQE for slice " << slice
-                              << " (opcode: " << slice->task->request.opcode
-                              << ", source_addr: " << (void*)slice->source_addr
-                              << ", dest_addr: " << (void*)slice->target_addr
-                              << ", length: " << slice->length
-                              << ", local_nic: " << context->name()
-                              << "): " << ibv_wc_status_str(wc[i].status);
-                }
-                // GPUDirect reachability learning: a protection/access error
-                // on a GPU buffer means the chosen NIC cannot P2P-DMA to that
-                // GPU (ibv_reg_mr succeeded but the PCIe path is unusable).
-                // Record it so selection avoids that NIC and converges onto a
-                // reachable rail instead of exhausting retries. The local side
-                // (source NIC -> source GPU) surfaces as LOC_PROT; the remote
-                // side (target NIC -> target GPU) as REM_ACCESS or, for a
-                // remote GDR-read failure, REM_OP (observed on strict fabrics).
-                bool local_gdr_err = (wc[i].status == IBV_WC_LOC_PROT_ERR);
-                bool remote_gdr_err = (wc[i].status == IBV_WC_REM_ACCESS_ERR ||
-                                       wc[i].status == IBV_WC_REM_OP_ERR);
-                if (local_gdr_err && slice->source_gpu_ordinal >= 0 &&
-                    slice->source_nic_name) {
-                    GdrReachability::instance().reportLocalFailure(
-                        slice->source_nic_name, slice->source_gpu_ordinal);
-                } else if (remote_gdr_err && slice->target_gpu_ordinal >= 0 &&
-                           slice->target_nic_name && slice->target_machine_id) {
-                    GdrReachability::instance().reportRemoteFailure(
-                        *slice->target_machine_id, slice->target_nic_name,
-                        slice->target_gpu_ordinal);
-                }
-                slice->retry_count++;
-                if (slice->retry_count >=
-                    transport_->params_->workers.max_retry_count) {
-                    LOG(WARNING)
-                        << "Slice " << slice << " failed: retry count exceeded";
-                    num_slices += ep->acknowledge(slice, FAILED);
-                    disableEndpoint(slice);
-                } else {
-                    num_slices += ep->acknowledge(slice, PENDING);
-                    disableEndpoint(slice);
-                    if (slice->task->cancel_requested.load(
-                            std::memory_order_acquire)) {
-                        updateSliceStatus(slice, CANCELED);
-                    } else {
-                        submitFromTick(worker, slice);
-                    }
-                }
-            } else {
-                num_slices += ep->acknowledge(slice, COMPLETED);
-                // A successful GPU transfer re-admits any learned GDR
-                // unreachability for the (GPU, NIC) pair(s) it used, so a
-                // transient exclusion (or a recovered path) heals. Skipped
-                // entirely until something has actually been excluded.
-                if (GdrReachability::hasAnyExclusion()) {
-                    auto& gdr = GdrReachability::instance();
-                    if (slice->source_gpu_ordinal >= 0 &&
-                        slice->source_nic_name)
-                        gdr.reportLocalSuccess(slice->source_nic_name,
-                                               slice->source_gpu_ordinal);
-                    if (slice->target_gpu_ordinal >= 0 &&
-                        slice->target_nic_name && slice->target_machine_id)
-                        gdr.reportRemoteSuccess(*slice->target_machine_id,
-                                                slice->target_nic_name,
-                                                slice->target_gpu_ordinal);
-                }
-                // A successful transfer proves this rail is healthy; clear
-                // any accumulated error count so a previously-cooled-down
-                // rail can be used again without waiting for the full
-                // cooldown to expire. The monitor pointer is resolved once
-                // in generatePostPath, so no map lookup is needed here.
-                if (auto* rail = slice->rail_monitor; rail && rail->ready())
-                    rail->markRecovered(slice->source_dev_id,
-                                        slice->target_dev_id);
-                if (transport_->params_->workers.show_latency_info) {
-                    worker.perf.inflight_lat.add(inflight_lat);
-                    worker.perf.enqueue_lat.add(enqueue_lat);
-                }
-            }
-        }
-    }
-    if (num_slices) {
-        worker.inflight_slices.fetch_sub(num_slices);
+        for (int i = 0; i < nr_poll; ++i)
+            handleCompletion(worker, *context, wc[i], poll_ts);
     }
 }
 
@@ -1183,11 +1306,7 @@ Status Workers::selectOptimalDevice(RouteHint& source, RouteHint& target,
         CHECK_STATUS(device_selector_->allocate(
             slice->length, source.buffer->location, slice->source_dev_id,
             slice->priority, slice->task->device_mask));
-        slice->quota_charged = true;
-        slice->charged_dev_id = slice->source_dev_id;
-        // Single-slice allocate charges exactly slice->length on the chosen
-        // device.
-        slice->charged_bytes = slice->length;
+        slice->charged_dev = slice->source_dev_id;
     }
 
     if (slice->source_dev_id < 0)
@@ -1380,6 +1499,11 @@ Status Workers::selectFallbackDevice(RouteHint& source, RouteHint& target,
             reachable = false;
 
         if (reachable) {
+            // A retry gets here after the failure path returned the slice's
+            // charge, so charge the device this attempt will actually use:
+            // otherwise the NIC's inflight bytes miss it and its completion
+            // teaches neither bandwidth estimate.
+            rechargeSlice(slice, sdev);
             slice->source_dev_id = sdev;
             slice->target_dev_id = tdev;
             // Keys are assigned by generatePostPath() once the device pair is
@@ -1418,10 +1542,6 @@ Status Workers::generatePostPath(RdmaSlice* slice) {
             "Selected device has no registered memory key" LOC_MARK);
     slice->source_lkey = lkeys[slice->source_dev_id];
     slice->target_rkey = rkeys[slice->target_dev_id];
-    // The routing NIC is now final for this (re)submit. Reconcile the inflight
-    // charge onto it so a fallback re-route or a retry does not leave the
-    // original NIC charged (residue) or run uncounted.
-    chargeSliceQuota(device_selector_.get(), slice);
     // Cache the RailMonitor pointer so asyncPollCq / disableEndpoint can
     // update rail state without a segment lookup or string-keyed map
     // lookup on the hot path.

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -123,6 +123,20 @@ Workers::Workers(RdmaTransport* transport)
     params.bandwidth_learning_rate =
         conf->get("transports/rdma/bandwidth_learning_rate", 0.01);
 
+    // Same convention for the transmit estimate the deadline predictors read
+    params.transmit_bandwidth_learning_rate =
+        conf->get("transports/rdma/transmit_bandwidth_learning_rate",
+                  params.transmit_bandwidth_learning_rate);
+
+    // How often that estimate is metered, and how stale an interval may be
+    // before it is re-baselined instead of learned from.
+    params.transmit_meter_interval_ns =
+        conf->get("transports/rdma/transmit_meter_interval_ns",
+                  params.transmit_meter_interval_ns);
+    params.transmit_meter_max_interval_ns =
+        conf->get("transports/rdma/transmit_meter_max_interval_ns",
+                  params.transmit_meter_max_interval_ns);
+
     // EWMA bounds as multipliers of theoretical bandwidth
     params.ewma_min_multiplier =
         conf->get("transports/rdma/ewma_min_bandwidth_multiplier", 0.1);
@@ -410,15 +424,20 @@ bool Workers::dropUnpostableSlice(WorkerContext& worker, RdmaSlice* slice) {
     // back where they came from, each idempotently, since whichever path
     // resolved the slice may already have run them -- and updateSliceStatus
     // is a no-op once the slice is terminal.
-    retireSweptSlice(worker, slice, nullptr);
+    retireSweptSlice(worker, slice, getCurrentTimeInNano(), nullptr);
     updateSliceStatus(slice, CANCELED);
     return true;
 }
 
-void Workers::releaseSliceQuota(RdmaSlice* slice, double latency) {
+void Workers::releaseSliceQuota(RdmaSlice* slice, uint64_t now_ns,
+                                double latency) {
     if (!slice || !device_selector_) return;
-    // The field names the device it was charged to, so the release goes
+    // Each field names the device it was charged to, so the release goes
     // there even if a fallback has since rewritten source_dev_id.
+    const int posted =
+        slice->posted_dev.exchange(-1, std::memory_order_acq_rel);
+    if (posted >= 0)
+        device_selector_->notePostEnded(posted, slice->length, now_ns);
     const int charged =
         slice->charged_dev.exchange(-1, std::memory_order_acq_rel);
     if (charged >= 0)
@@ -453,9 +472,18 @@ bool Workers::routeSetRemoval(WorkerContext& self, RdmaSlice* slice) {
 }
 
 void Workers::retireSweptSlice(WorkerContext& self, RdmaSlice* slice,
-                               std::vector<RdmaSlice*>* deferred) {
+                               uint64_t now_ns,
+                               std::vector<RdmaSlice*>* deferred,
+                               bool bytes_moved) {
     if (!slice) return;
-    releaseSliceQuota(slice);
+    const int posted_dev = slice->posted_dev.load(std::memory_order_relaxed);
+    releaseSliceQuota(slice, now_ns);
+    // A slice swept off with FAILED or TIMEOUT leaves the hardware without
+    // its bytes being counted, so the stretch it was part of cannot be
+    // divided into the next sample. One swept with COMPLETED did move them;
+    // its own completion, still to be polled, credits them.
+    if (posted_dev >= 0 && !bytes_moved && device_selector_)
+        device_selector_->resetTransmitMeter(posted_dev);
     discountFromOwner(self, slice);
     if (!routeSetRemoval(self, slice)) return;
     if (deferred)
@@ -487,9 +515,19 @@ void Workers::drainReclaimed(WorkerContext& worker) {
     for (auto* slice : taken) worker.inflight_slice_set.erase(slice);
 }
 
+void Workers::notePostedSlice(RdmaSlice* slice) {
+    if (!slice || !device_selector_) return;
+    int none = -1;
+    if (slice->posted_dev.compare_exchange_strong(none, slice->source_dev_id,
+                                                  std::memory_order_acq_rel))
+        device_selector_->notePosted(slice->source_dev_id, slice->length,
+                                     slice->submit_ts);
+}
+
 void Workers::markPosted(WorkerContext& worker, RdmaSlice* slice,
                          uint64_t post_ts) {
     slice->submit_ts = post_ts;
+    notePostedSlice(slice);
     worker.inflight_slice_set.insert(slice);
 }
 
@@ -608,7 +646,7 @@ void Workers::asyncPostSend() {
             if (!status.ok()) {
                 LOG(ERROR) << "Failed to generate post path for slice " << slice
                            << ": " << status.ToString();
-                releaseSliceQuota(slice);
+                releaseSliceQuota(slice, getCurrentTimeInNano());
                 updateSliceStatus(slice, slice->task->cancel_requested.load(
                                              std::memory_order_acquire)
                                              ? CANCELED
@@ -646,7 +684,7 @@ void Workers::asyncPostSend() {
             for (auto slice : clone) {
                 if (dropUnpostableSlice(worker, slice)) continue;
                 slice->retry_count++;
-                releaseSliceQuota(slice);
+                releaseSliceQuota(slice, getCurrentTimeInNano());
                 if (slice->retry_count >=
                     transport_->params_->workers.max_retry_count) {
                     LOG(WARNING)
@@ -707,7 +745,8 @@ void Workers::asyncPostSend() {
         // Everything a completion's poller must find is written before the
         // work request can reach the wire: with a shared queue pair another
         // lane may poll the completion before submitSlices returns, and a
-        // poller that finds no set entry cannot route it home.
+        // poller that finds no posted device on the slice would leave the
+        // device's backlog holding these bytes for good.
         const uint64_t post_ts = getCurrentTimeInNano();
         int num_submitted = endpoint->submitSlices(
             slices, tl_wid,
@@ -718,7 +757,7 @@ void Workers::asyncPostSend() {
             // Rejected by the hardware: it never went on the wire, so take
             // back what the hook put in place.
             worker.inflight_slice_set.erase(slice);
-            releaseSliceQuota(slice);
+            releaseSliceQuota(slice, post_ts);
             if (slice->task->cancel_requested.load(std::memory_order_acquire)) {
                 updateSliceStatus(slice, CANCELED);
                 discountFromOwner(worker, slice);
@@ -817,10 +856,12 @@ void Workers::expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns) {
     struct Sweep {
         Workers* self;
         WorkerContext* worker;
+        uint64_t now_ns;
         std::vector<RdmaSlice*>* deferred;
-    } sweep{this, &worker, &slice_to_remove};
+    } sweep{this, &worker, now_ns, &slice_to_remove};
     auto retire = [&sweep](RdmaSlice* swept) {
-        sweep.self->retireSweptSlice(*sweep.worker, swept, sweep.deferred);
+        sweep.self->retireSweptSlice(*sweep.worker, swept, sweep.now_ns,
+                                     sweep.deferred);
     };
     for (auto& slice : worker.inflight_slice_set) {
         if (slice->word != PENDING) {
@@ -852,7 +893,7 @@ void Workers::expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns) {
                 // A neighbour's retry already popped it off the queue pair
                 // and discounted it there, so only its charge and its set
                 // entry are still outstanding.
-                releaseSliceQuota(slice);
+                releaseSliceQuota(slice, now_ns);
                 if (routeSetRemoval(worker, slice))
                     slice_to_remove.push_back(slice);
                 updateSliceStatus(slice, TIMEOUT);
@@ -863,7 +904,8 @@ void Workers::expireTimedOutSlices(WorkerContext& worker, uint64_t now_ns) {
 }
 
 void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
-                               const ibv_wc& wc, uint64_t poll_ts) {
+                               const ibv_wc& wc, uint64_t poll_ts,
+                               bool last_in_pass) {
     auto slice = (RdmaSlice*)wc.wr_id;
     // What the acknowledge callbacks below need, behind one reference so
     // the std::function stays in its small-buffer storage (no allocation
@@ -871,7 +913,8 @@ void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
     struct Sweep {
         Workers* self;
         WorkerContext* worker;
-    } sweep{this, &worker};
+        uint64_t now_ns;
+    } sweep{this, &worker, poll_ts};
     // The lane that enqueued this slice owns its set entry; with a
     // shared queue pair that is not necessarily this one.
     if (routeSetRemoval(worker, slice)) worker.inflight_slice_set.erase(slice);
@@ -887,7 +930,33 @@ void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
         ep && slice->word == PENDING && wc.status == IBV_WC_SUCCESS;
     const double sample_lat_sec =
         ewma_sample ? (poll_ts - slice->submit_ts) / 1e9 : 0.0;
-    releaseSliceQuota(slice, sample_lat_sec);
+    const int dev_id = slice->source_dev_id;
+    const uint64_t moved = slice->length;
+    releaseSliceQuota(slice, poll_ts, sample_lat_sec);
+    // The transmit estimate is metered from bytes completed over the time
+    // the NIC spent busy, so it needs the release above to have taken this
+    // slice out of the backlog first -- that is what closes the stretch.
+    // Only successful bytes moved on the wire.
+    if (device_selector_) {
+        if (wc.status == IBV_WC_SUCCESS) {
+            device_selector_->noteCompleted(dev_id, moved);
+            // Only once the whole poll pass has been counted. Every work
+            // request it reaps carries the same timestamp, so a sample taken
+            // partway through would end its interval at that timestamp while
+            // leaving the rest of the pass's bytes to the next one -- which
+            // then gets them for free. The estimate is an average of
+            // per-interval rates, so the short interval that is paid twice
+            // and the long one that is paid once do not cancel: at 2 GB/s
+            // with sixteen-deep polling that read 8% high.
+            if (last_in_pass)
+                device_selector_->maybeSampleTransmit(dev_id, poll_ts);
+        } else {
+            // The bytes of a failed or flushed work request never moved, but
+            // the stretch the NIC held it for did. Start over here rather
+            // than divide that time into whatever completes next.
+            device_selector_->resetTransmitMeter(dev_id);
+        }
+    }
     if (slice->word != PENDING) {
         // Resolved before its completion was polled -- swept off the queue
         // pair by a neighbour, timed out, or cancelled by a teardown. The
@@ -939,7 +1008,8 @@ void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
             LOG(WARNING) << "Slice " << slice
                          << " failed: retry count exceeded";
             ep->acknowledge(slice, FAILED, [&sweep](RdmaSlice* swept) {
-                sweep.self->retireSweptSlice(*sweep.worker, swept, nullptr);
+                sweep.self->retireSweptSlice(*sweep.worker, swept, sweep.now_ns,
+                                             nullptr);
             });
             disableEndpoint(slice);
         } else {
@@ -958,7 +1028,8 @@ void Workers::handleCompletion(WorkerContext& worker, RdmaContext& context,
         }
     } else {
         ep->acknowledge(slice, COMPLETED, [&sweep](RdmaSlice* swept) {
-            sweep.self->retireSweptSlice(*sweep.worker, swept, nullptr);
+            sweep.self->retireSweptSlice(*sweep.worker, swept, sweep.now_ns,
+                                         nullptr, /*bytes_moved=*/true);
         });
         // A successful GPU transfer re-admits any learned GDR
         // unreachability for the (GPU, NIC) pair(s) it used, so a
@@ -1006,7 +1077,8 @@ void Workers::asyncPollCq() {
         if (nr_poll < 0) continue;
         auto poll_ts = getCurrentTimeInNano();
         for (int i = 0; i < nr_poll; ++i)
-            handleCompletion(worker, *context, wc[i], poll_ts);
+            handleCompletion(worker, *context, wc[i], poll_ts,
+                             i + 1 == nr_poll);
     }
 }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -38,12 +38,6 @@ namespace tent {
 thread_local int tl_wid = -1;
 
 namespace {
-struct ArbitrationEntry {
-    RdmaSlice* slice;
-    double mlu;
-    size_t order;
-};
-
 // Look up (or create) the RailMonitor for `machine_id` on this worker's
 // map. Returning a stable reference is safe because the map stores values
 // via unique_ptr -- rehashes move the pointer slot, not the RailMonitor.
@@ -386,6 +380,41 @@ Status Workers::cancel(RdmaTask* task) {
     return Status::OK();
 }
 
+void Workers::orderByDeadline(std::vector<RdmaSlice*>& slices, int dev_id,
+                              uint64_t now_ns) {
+    if (!device_selector_ || slices.size() < 2) return;
+    // This NIC's transmit estimate answers "how fast do these bytes move";
+    // <= 0 means nothing to predict from, so the order stays as it is.
+    const double bw_bps = device_selector_->getTransmitBandwidth(dev_id);
+    if (bw_bps <= 0.0) return;
+
+    thread_local std::vector<ArbFlow> flows;
+    flows.clear();
+    flows.reserve(slices.size());
+    bool any_deadline = false;
+    for (const RdmaSlice* s : slices) {
+        flows.push_back(s && s->task
+                            ? ArbFlow{s->task->request.deadline_ns, s->length}
+                            : ArbFlow{0, 0});
+        any_deadline |= flows.back().deadline_ns != 0;
+    }
+    // Without a deadline anywhere every MLU is 0 and the order would come
+    // out as it went in; skip the greedy pass rather than run it for that.
+    if (!any_deadline) return;
+
+    // What actually precedes these slices: bytes already posted to the NIC.
+    // None of the candidates is in it -- they are about to be posted -- and
+    // neither is work still sitting in a worker queue.
+    const size_t bytes_ahead = device_selector_->getPostedBytes(dev_id);
+    const auto order = OrderByUrgency(flows, now_ns, bw_bps, bytes_ahead);
+
+    thread_local std::vector<RdmaSlice*> ordered;
+    ordered.clear();
+    ordered.reserve(order.size());
+    for (size_t i : order) ordered.push_back(slices[i]);
+    std::copy(ordered.begin(), ordered.end(), slices.begin());
+}
+
 void Workers::rechargeSlice(RdmaSlice* slice, int dev_id) {
     if (!device_selector_ || !slice || dev_id < 0) return;
     if (slice->charged_dev.load(std::memory_order_relaxed) == dev_id) return;
@@ -707,39 +736,9 @@ void Workers::asyncPostSend() {
         // its deadline claims the shared NIC's QP slots ahead of looser flows.
         // Default (deadline_bw_arbitration_ == false) leaves order untouched,
         // so behavior is byte-identical to today's FIFO / equal split.
-        if (deadline_bw_arbitration_ && slices.size() > 1) {
-            const uint64_t now_ns = getCurrentTimeInNano();
-            const double bw_bps = device_selector_
-                                      ? device_selector_->getSchedulingParams()
-                                                .default_bandwidth_gbps *
-                                            1e9 / 8.0
-                                      : 0.0;
-            if (bw_bps > 0.0) {
-                thread_local std::vector<ArbitrationEntry> scratch;
-                scratch.clear();
-                scratch.reserve(slices.size());
-
-                for (size_t i = 0; i < slices.size(); ++i) {
-                    const RdmaSlice* s = slices[i];
-                    ArbFlow flow{0, 0};
-                    if (s && s->task) {
-                        flow = ArbFlow{s->task->request.deadline_ns, s->length};
-                    }
-                    scratch.push_back(ArbitrationEntry{
-                        slices[i], PredictedMlu(flow, now_ns, bw_bps), i});
-                }
-
-                std::sort(
-                    scratch.begin(), scratch.end(),
-                    [](const ArbitrationEntry& a, const ArbitrationEntry& b) {
-                        if (a.mlu > b.mlu) return true;
-                        if (a.mlu < b.mlu) return false;
-                        return a.order < b.order;
-                    });
-                for (size_t i = 0; i < scratch.size(); ++i) {
-                    slices[i] = scratch[i].slice;
-                }
-            }
+        if (deadline_bw_arbitration_) {
+            orderByDeadline(slices, path.local_device_id,
+                            getCurrentTimeInNano());
         }
 
         // Everything a completion's poller must find is written before the

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -432,8 +432,8 @@ target_include_directories(tent_rail_monitor_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_rail_monitor_test COMMAND tent_rail_monitor_test)
 
-# DeviceSelector inflight quota accounting: estimate->exact reconcile, fallback
-# migration, retry recharge, baseline no-underflow, EWMA gating, charge-failure.
+# DeviceSelector inflight quota accounting: per-slice charge/release balance,
+# chargeDevice, baseline no-underflow, EWMA gating, charge-failure.
 add_executable(tent_quota_accounting_test quota_accounting_test.cpp)
 target_link_libraries(tent_quota_accounting_test PRIVATE gtest gtest_main
                                                          tent_link_group)

--- a/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/admission_queue_test.cpp
@@ -586,6 +586,160 @@ TEST(AdmissionQueueTest, Step3DropsInfeasibleAndKeepsFeasible) {
     EXPECT_EQ(queue.outstandingBytes(), 16u);
 }
 
+// The deadline is absolute, so an owner dispatched now still has to wait
+// behind everything already dispatched and not yet completed. That wait is
+// an additive delay charged from the queue's own dispatch accounting, not a
+// slower bandwidth.
+TEST(AdmissionQueueTest, Step3DropCountsBytesAlreadyDispatched) {
+    LocalTransferAdmissionQueue queue(step3Limits(1.0));
+    // now = 1e9 ns; bandwidth 1e9 B/s: 1 MB takes 1 ms.
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    // owner 1: 1 MB, loose deadline; dispatched and still in flight.
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(1, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 1'000'000, 5'000'000'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    ASSERT_EQ(queue.pickForDispatch(4, 1 << 20), std::vector<QueueOwnerId>{1});
+
+    // owner 2: 16 B with a 500 us window. Alone it would take 16 ns
+    // (MLU ~3e-5); behind the 1 MB it completes at ~1 ms → MLU ~2 → drop.
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(2, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'500'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_TRUE(queue.pickForDispatch(4, 1 << 20, &dropped).empty());
+    EXPECT_EQ(dropped, std::vector<QueueOwnerId>{2});
+
+    // Once owner 1 completes nothing is ahead: the same request is feasible.
+    ASSERT_EQ(queue.complete(1, TransferStatusEnum::COMPLETED).code(),
+              Status::Code::kOk);
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(3, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'500'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    dropped.clear();
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{3});
+    EXPECT_TRUE(dropped.empty());
+}
+
+// Only provider-governed bytes wait ahead of an eligible owner: an owner on
+// another transport is neither counted when dispatched nor subtracted when
+// it completes.
+TEST(AdmissionQueueTest, Step3QueueAheadCountsOnlyProviderGovernedBytes) {
+    LocalTransferAdmissionQueue queue(step3Limits(1.0));
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    // owner 1: 1 MB, not eligible (not governed by the provider); dispatched.
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(
+                makeSubmit(
+                    1, 1, {makeOwnerWithDeadline(0, 1'000'000, 5'000'000'000)}),
+                ids)
+            .code(),
+        Status::Code::kOk);
+    ASSERT_EQ(queue.pickForDispatch(4, 1 << 20), std::vector<QueueOwnerId>{1});
+
+    // owner 2: 16 B with a 500 us window, eligible. Nothing ahead of it is
+    // on the NIC, so it is feasible.
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(2, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'500'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{2});
+    EXPECT_TRUE(dropped.empty());
+
+    // Completing the ungoverned owner must not disturb the count either:
+    // afterwards an eligible 1 MB owner still drops a tight owner behind it.
+    ASSERT_EQ(queue.complete(1, TransferStatusEnum::COMPLETED).code(),
+              Status::Code::kOk);
+    ASSERT_EQ(queue.complete(2, TransferStatusEnum::COMPLETED).code(),
+              Status::Code::kOk);
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(3, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 1'000'000, 5'000'000'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    dropped.clear();
+    ASSERT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped),
+              std::vector<QueueOwnerId>{3});
+    EXPECT_TRUE(dropped.empty());
+    ASSERT_EQ(
+        queue
+            .tryAdmit(makeSubmit(4, 1,
+                                 {makeDegradationEligibleOwnerWithDeadline(
+                                     0, 16, 1'000'500'000)}),
+                      ids)
+            .code(),
+        Status::Code::kOk);
+    dropped.clear();
+    EXPECT_TRUE(queue.pickForDispatch(4, 1 << 20, &dropped).empty());
+    EXPECT_EQ(dropped, std::vector<QueueOwnerId>{4});
+}
+
+// Within one pick, `bytes_ahead` for a later owner is exactly the eligible
+// bytes picked before it: an ungoverned owner ahead adds nothing, and an
+// eligible one is counted once (dispatching_bytes_ already grows as owners
+// are picked).
+TEST(AdmissionQueueTest, Step3QueueAheadWithinOnePickIsExact) {
+    LocalTransferAdmissionQueue queue(step3Limits(1.0));
+    // now = 1e9 ns; bandwidth 1e9 B/s: 1 MB takes 1 ms.
+    queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
+                               [] { return uint64_t{1'000'000'000}; });
+
+    // EDF order: N (400 KB, not eligible, 560 us), A (400 KB, eligible,
+    // 600 us), B (16 B, eligible, 640 us); 400 KB takes 400 us.
+    //   A: nothing governed ahead -> 400 / 600 = 0.67 -> dispatch
+    //      (counting N: 800 / 600 = 1.33 -> drop)
+    //   B: A ahead -> ~400 / 640 = 0.63 -> dispatch
+    //      (counting A twice: 800 / 640 = 1.25 -> drop)
+    std::vector<QueueOwnerId> ids;
+    ASSERT_EQ(
+        queue
+            .tryAdmit(
+                makeSubmit(1, 3,
+                           {makeOwnerWithDeadline(0, 400'000, 1'000'560'000),
+                            makeDegradationEligibleOwnerWithDeadline(
+                                1, 400'000, 1'000'600'000),
+                            makeDegradationEligibleOwnerWithDeadline(
+                                2, 16, 1'000'640'000)}),
+                ids)
+            .code(),
+        Status::Code::kOk);
+    std::vector<QueueOwnerId> dropped;
+    const std::vector<QueueOwnerId> all{1, 2, 3};
+    EXPECT_EQ(queue.pickForDispatch(4, 1 << 20, &dropped), all);
+    EXPECT_TRUE(dropped.empty());
+}
+
 TEST(AdmissionQueueTest, Step3DropsAlreadyExpiredDeadline) {
     LocalTransferAdmissionQueue queue(step3Limits(1.5));
     queue.setDegradationPolicy([] { return 1e9; }, DegradationHooks{},
@@ -642,6 +796,67 @@ TEST(AdmissionQueueTest, Step3NoDropWithoutBandwidthProvider) {
     auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
     ASSERT_EQ(picked.size(), 1u);
     EXPECT_TRUE(dropped.empty());
+}
+
+// A provider that cannot report bandwidth (<= 0, e.g. every RDMA NIC is
+// unavailable) disables the prediction outright: nothing is dropped, not
+// even an owner whose deadline has already passed, because "no estimate"
+// must not be read as "infeasible".
+TEST(AdmissionQueueTest, Step3NoDropWhenBandwidthIsUnknown) {
+    for (const double reported : {0.0, -1.0}) {
+        LocalTransferAdmissionQueue queue(step3Limits(1.5));
+        int hook_calls = 0;
+        DegradationHooks hooks;
+        hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
+        queue.setDegradationPolicy([reported] { return reported; }, hooks,
+                                   [] { return uint64_t{2'000'000'000}; });
+
+        std::vector<QueueOwnerId> admitted_ids;
+        // Deadline 1e9 is already behind now = 2e9.
+        ASSERT_EQ(
+            queue
+                .tryAdmit(makeSubmit(1, 1,
+                                     {makeDegradationEligibleOwnerWithDeadline(
+                                         0, 16, 1'000'000'000)}),
+                          admitted_ids)
+                .code(),
+            Status::Code::kOk);
+
+        std::vector<QueueOwnerId> dropped;
+        auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+        EXPECT_EQ(picked.size(), 1u) << "bandwidth " << reported;
+        EXPECT_TRUE(dropped.empty()) << "bandwidth " << reported;
+        EXPECT_EQ(hook_calls, 0) << "bandwidth " << reported;
+    }
+}
+
+// Drop enabled with a healthy bandwidth: an eligible owner that carries no
+// deadline has nothing to miss and is dispatched, whatever the threshold.
+TEST(AdmissionQueueTest, Step3NoDropWithoutDeadline) {
+    for (const double theta : {1.5, 1e-9}) {
+        LocalTransferAdmissionQueue queue(step3Limits(theta));
+        int hook_calls = 0;
+        DegradationHooks hooks;
+        hooks.on_local_decode_suggested = [&](const Request&) { ++hook_calls; };
+        queue.setDegradationPolicy([] { return 1e9; }, hooks,
+                                   [] { return uint64_t{1'000'000'000}; });
+
+        std::vector<QueueOwnerId> admitted_ids;
+        ASSERT_EQ(
+            queue
+                .tryAdmit(makeSubmit(1, 1,
+                                     {makeDegradationEligibleOwnerWithDeadline(
+                                         0, 1 << 20, /*deadline_ns=*/0)}),
+                          admitted_ids)
+                .code(),
+            Status::Code::kOk);
+
+        std::vector<QueueOwnerId> dropped;
+        auto picked = queue.pickForDispatch(4, 1 << 20, &dropped);
+        EXPECT_EQ(picked.size(), 1u) << "theta " << theta;
+        EXPECT_TRUE(dropped.empty()) << "theta " << theta;
+        EXPECT_EQ(hook_calls, 0) << "theta " << theta;
+    }
 }
 
 TEST(AdmissionQueueTest, Step3DynamicBandwidthProvider) {

--- a/mooncake-transfer-engine/tent/tests/bw_arbitration_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/bw_arbitration_test.cpp
@@ -15,10 +15,12 @@
 // Unit tests for the deadline-aware bandwidth arbitration ordering (#2792).
 
 #include "tent/transport/rdma/bw_arbitration.h"
+#include "tent/runtime/deadline_mlu.h"
 
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <limits>
 #include <vector>
 
 namespace mooncake {
@@ -31,6 +33,34 @@ constexpr double kBw = 1e9;               // 1 GB/s -> 16 B takes 16 ns
 // A flow whose window is `window_ns` from now, transferring `len` bytes.
 ArbFlow flow(uint64_t window_ns, size_t len) {
     return ArbFlow{kNow + window_ns, len};
+}
+
+// The admission queue's drop predictor and the NIC arbitration must compute
+// the same MLU from the same inputs; DeadlineMlu is that one definition.
+TEST(DeadlineMluTest, PredictedTimeOverWindow) {
+    // 16 B at 1 GB/s = 16 ns; a 32 ns window is half used.
+    EXPECT_DOUBLE_EQ(DeadlineMlu(0, 16, kNow + 32, kNow, kBw), 0.5);
+}
+
+// A deadline is absolute, so time spent behind bytes already in the pipeline
+// counts against the window: it is an additive delay, not a slower link.
+TEST(DeadlineMluTest, BytesAheadAddToPredictedTime) {
+    EXPECT_DOUBLE_EQ(DeadlineMlu(16, 16, kNow + 32, kNow, kBw), 1.0);
+    // Queueing alone can exhaust the window even for a tiny request.
+    EXPECT_DOUBLE_EQ(DeadlineMlu(64, 0, kNow + 32, kNow, kBw), 2.0);
+}
+
+TEST(DeadlineMluTest, NoDeadlineOrNoBandwidthIsNotUrgent) {
+    EXPECT_DOUBLE_EQ(DeadlineMlu(0, 16, 0, kNow, kBw), 0.0);
+    EXPECT_DOUBLE_EQ(DeadlineMlu(0, 16, kNow + 32, kNow, 0.0), 0.0);
+    EXPECT_DOUBLE_EQ(DeadlineMlu(0, 16, kNow + 32, kNow, -1.0), 0.0);
+}
+
+TEST(DeadlineMluTest, PastDeadlineIsInfinitelyUrgent) {
+    EXPECT_EQ(DeadlineMlu(0, 16, kNow, kNow, kBw),
+              std::numeric_limits<double>::max());
+    EXPECT_EQ(DeadlineMlu(0, 16, kNow - 1, kNow, kBw),
+              std::numeric_limits<double>::max());
 }
 
 TEST(BwArbitrationTest, TighterDeadlineSortsFirst) {

--- a/mooncake-transfer-engine/tent/tests/bw_arbitration_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/bw_arbitration_test.cpp
@@ -63,6 +63,50 @@ TEST(DeadlineMluTest, PastDeadlineIsInfinitelyUrgent) {
               std::numeric_limits<double>::max());
 }
 
+TEST(DeadlineMluTest, ArbitrationUsesTheSameDefinition) {
+    const ArbFlow f = flow(32, 16);
+    EXPECT_DOUBLE_EQ(PredictedMlu(f, kNow, kBw),
+                     DeadlineMlu(0, f.length, f.deadline_ns, kNow, kBw));
+    EXPECT_DOUBLE_EQ(PredictedMlu(f, kNow, kBw, 48),
+                     DeadlineMlu(48, f.length, f.deadline_ns, kNow, kBw));
+}
+
+TEST(BwArbitrationTest, BytesAheadFavorTheTighterWindow) {
+    std::vector<ArbFlow> flows = {
+        flow(100'000, 4096),  // idx0: 4.1us of 100us  -> MLU 0.041
+        flow(30'000, 1024),   // idx1: 1.0us of 30us   -> MLU 0.034
+    };
+    // On an idle NIC the bigger request is (slightly) more urgent...
+    auto idle = OrderByUrgency(flows, kNow, kBw);
+    EXPECT_EQ(idle[0], 0u);
+    // ...but behind 64 KiB already queued (65.5us) the 30us window is gone
+    // while the 100us one still has room, so the small flow must go first.
+    auto busy = OrderByUrgency(flows, kNow, kBw, 65536);
+    EXPECT_EQ(busy[0], 1u);
+    EXPECT_EQ(busy[1], 0u);
+}
+
+// Ordering is decided one slot at a time: once a flow takes a slot, the
+// flows still waiting sit behind its bytes too, so the queue-ahead term
+// grows as the order is built. Scoring everyone once against the same value
+// would miss that.
+TEST(BwArbitrationTest, EachSlotIsScoredBehindTheOnesBeforeIt) {
+    // 1 GB/s: 1 byte == 1 ns of wire time.
+    std::vector<ArbFlow> flows = {
+        flow(40'000, 100'000),  // idx0: 100us of a 40us window -> 2.50
+        flow(100'000, 20'000),  // idx1: 20us of a 100us window -> 0.20
+        flow(50'000, 5'000),    // idx2: 5us of a 50us window   -> 0.10
+    };
+    // Scored once, the order would be its own MLU ranking: 0, 1, 2.
+    // Behind idx0's 100us, though, idx2's 50us window is blown (105/50 =
+    // 2.10) while idx1 still fits (120/100 = 1.20), so idx2 goes first.
+    auto order = OrderByUrgency(flows, kNow, kBw);
+    ASSERT_EQ(order.size(), 3u);
+    EXPECT_EQ(order[0], 0u);
+    EXPECT_EQ(order[1], 2u);
+    EXPECT_EQ(order[2], 1u);
+}
+
 TEST(BwArbitrationTest, TighterDeadlineSortsFirst) {
     std::vector<ArbFlow> flows = {
         flow(1'000'000, 4096),  // idx0: loose (1ms window)

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -266,6 +267,80 @@ TEST(DeviceSelectorBandwidthTest, ReseedOnLinkSpeedChangeReleasesStaleClamp) {
     for (int i = 0; i < 64; ++i) observe(*sel, 3.1e9);
     // With the 400G clamp still in place this would sit at the 5 GB/s floor.
     EXPECT_NEAR(sel->getAggregateEwmaBandwidth(), 3.1e9, 3.1e9 * 0.02);
+}
+
+// What one device has been charged and not yet released.
+TEST(DeviceSelectorInflightTest, InflightBytesPerDevice) {
+    auto topo = oneRdmaNic();
+    Topology::MemEntry mem;
+    mem.name = "cpu:0";
+    mem.type = Topology::MEM_HOST;
+    mem.numa_node = 0;
+    mem.device_list[0].push_back(kDev);
+    topo->mem_list_.push_back(mem);
+    DeviceSelector sel;
+    ASSERT_TRUE(sel.loadTopology(topo).ok());
+
+    EXPECT_EQ(sel.getInflightBytes(kDev), 0u);
+    int chosen = -1;
+    ASSERT_TRUE(sel.allocate(kMiB, "cpu:0", chosen).ok());
+    ASSERT_EQ(chosen, kDev);
+    EXPECT_EQ(sel.getInflightBytes(kDev), kMiB);
+    EXPECT_EQ(sel.getInflightBytes(7), 0u);  // unknown device
+    ASSERT_TRUE(sel.release(kDev, kMiB, 0.0).ok());
+    EXPECT_EQ(sel.getInflightBytes(kDev), 0u);
+}
+
+// Smart-mode multi-path allocation must charge each device the bytes of the
+// slices it was assigned -- the caller cuts slices as min(block, remaining),
+// and release() returns exactly that -- not ceil(total / n) per slice, which
+// would drift per device (and wrap a device that receives less than it
+// released).
+TEST(DeviceSelectorInflightTest, MultiPathChargesActualSliceBytes) {
+    auto topo = oneRdmaNic();
+    Topology::NicEntry nic;
+    nic.name = "mlx5_1";
+    nic.type = Topology::NIC_RDMA;
+    nic.numa_node = 0;
+    topo->nic_list_.push_back(nic);
+    Topology::MemEntry mem;
+    mem.name = "cpu:0";
+    mem.type = Topology::MEM_HOST;
+    mem.numa_node = 0;
+    mem.device_list[0].push_back(0);
+    mem.device_list[0].push_back(1);
+    topo->mem_list_.push_back(mem);
+    DeviceSelector sel;
+    ASSERT_TRUE(sel.loadTopology(topo).ok());
+    DeviceSelector::SchedulingParams params;
+    params.score_jitter_range = 0.0;
+    sel.setSchedulingParams(params);
+
+    // 1,000,001 B in 64 KiB blocks: 15 full slices and one of 16,961 B;
+    // ceil(total / 16) = 62,501 would charge 1,000,016 in total.
+    constexpr uint64_t kTotal = 1'000'001;
+    constexpr uint64_t kBlock = 65536;
+    constexpr uint32_t kSlices = 16;
+    std::vector<int> ids;
+    ASSERT_TRUE(
+        sel.allocate(kTotal, kSlices, kBlock, "cpu:0", ids, PRIO_HIGH, ~0ULL)
+            .ok());
+    ASSERT_EQ(ids.size(), kSlices);
+
+    uint64_t expected[2] = {0, 0};
+    for (uint32_t i = 0; i < kSlices; ++i) {
+        ASSERT_TRUE(ids[i] == 0 || ids[i] == 1);
+        expected[ids[i]] += std::min<uint64_t>(kBlock, kTotal - i * kBlock);
+    }
+    EXPECT_EQ(sel.getInflightBytes(0), expected[0]);
+    EXPECT_EQ(sel.getInflightBytes(1), expected[1]);
+
+    for (uint32_t i = 0; i < kSlices; ++i) {
+        const uint64_t len = std::min<uint64_t>(kBlock, kTotal - i * kBlock);
+        ASSERT_TRUE(sel.release(ids[i], len, 0.0).ok());
+    }
+    EXPECT_EQ(sel.getInflightBytes(0), 0u);
+    EXPECT_EQ(sel.getInflightBytes(1), 0u);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -17,11 +17,13 @@
 
 #include "tent/transport/rdma/quota.h"
 
+
 #include <gtest/gtest.h>
 
-#include <algorithm>
 #include <memory>
+#include <sstream>
 #include <utility>
+#include <algorithm>
 #include <vector>
 
 namespace mooncake {
@@ -177,8 +179,11 @@ TEST(DeviceSelectorAvailabilityTest, DevicesStartAvailable) {
 TEST(DeviceSelectorAvailabilityTest, UnavailableDeviceLeavesAggregate) {
     auto sel = makeTwoNicSelector();
     EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 25e9);
+    EXPECT_DOUBLE_EQ(sel->getAggregateTransmitBandwidth(), 25e9);
     ASSERT_TRUE(sel->setDeviceAvailable(kDev1, false).ok());
     EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 12.5e9);
+    // The admission queue reads this series: a dead NIC must leave it too.
+    EXPECT_DOUBLE_EQ(sel->getAggregateTransmitBandwidth(), 12.5e9);
     ASSERT_TRUE(sel->setDeviceAvailable(kDev1, true).ok());
     EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 25e9);
 }
@@ -269,8 +274,56 @@ TEST(DeviceSelectorBandwidthTest, ReseedOnLinkSpeedChangeReleasesStaleClamp) {
     EXPECT_NEAR(sel->getAggregateEwmaBandwidth(), 3.1e9, 3.1e9 * 0.02);
 }
 
-// What one device has been charged and not yet released.
-TEST(DeviceSelectorInflightTest, InflightBytesPerDevice) {
+// ---------------------------------------------------------------------------
+// The transmit estimate: the series the admission queue's deadline-drop
+// predictor and the NIC arbitration read. It is metered from bytes completed
+// over the NIC's busy time -- never from a slice's own latency, which grows
+// with the batch it travelled in -- and smoothed hard enough that one odd
+// interval cannot flip a drop decision.
+// ---------------------------------------------------------------------------
+
+constexpr uint64_t kT0 = 1'000'000'000;  // 1s in ns
+
+// A selector whose meter samples on every call and adopts each sample
+// outright, so one interval is one observation. 25 Gbps seed = 3.125 GB/s.
+std::unique_ptr<DeviceSelector> makeMeteredSelector(double alpha = 0.0) {
+    DeviceSelector::SchedulingParams params;
+    params.transmit_bandwidth_learning_rate = alpha;
+    params.transmit_meter_interval_ns = 0;  // sample whenever asked
+    auto sel = makeSelector(params);
+    EXPECT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    return sel;
+}
+
+// Drive the meter the way the RDMA workers do: `n` slices of 1 MiB are
+// posted together (one submitSlices call, one timestamp), the NIC serves
+// them at `per_slice_ns` each, and completions are polled `poll_batch` at a
+// time (one poll pass timestamps its whole group alike).
+// Returns the timestamp of the last completion, so batches can be chained
+// on a clock that only moves forward (a sample whose timestamp is not past
+// the previous one is ignored, as the meter ignores it in production).
+uint64_t runBatch(DeviceSelector& sel, uint32_t n, uint64_t per_slice_ns,
+                  uint32_t poll_batch, uint64_t t0 = kT0) {
+    for (uint32_t i = 0; i < n; ++i) sel.notePosted(kDev, kMiB, t0);
+    sel.maybeSampleTransmit(kDev, t0);  // baseline: the NIC has a backlog
+    uint32_t done = 0;
+    uint64_t poll_ts = t0;
+    while (done < n) {
+        const uint32_t group = std::min(poll_batch, n - done);
+        poll_ts = t0 + (done + group) * per_slice_ns;
+        for (uint32_t i = 0; i < group; ++i) {
+            sel.notePostEnded(kDev, kMiB, poll_ts);
+            sel.noteCompleted(kDev, kMiB);
+        }
+        done += group;
+        sel.maybeSampleTransmit(kDev, poll_ts);
+    }
+    return poll_ts;
+}
+
+// The NIC arbitration needs "bytes already charged to this NIC" as the
+// queue-ahead term of its deadline prediction.
+TEST(DeviceSelectorTransmitTest, InflightBytesPerDevice) {
     auto topo = oneRdmaNic();
     Topology::MemEntry mem;
     mem.name = "cpu:0";
@@ -296,7 +349,7 @@ TEST(DeviceSelectorInflightTest, InflightBytesPerDevice) {
 // and release() returns exactly that -- not ceil(total / n) per slice, which
 // would drift per device (and wrap a device that receives less than it
 // released).
-TEST(DeviceSelectorInflightTest, MultiPathChargesActualSliceBytes) {
+TEST(DeviceSelectorTransmitTest, MultiPathChargesActualSliceBytes) {
     auto topo = oneRdmaNic();
     Topology::NicEntry nic;
     nic.name = "mlx5_1";
@@ -341,6 +394,522 @@ TEST(DeviceSelectorInflightTest, MultiPathChargesActualSliceBytes) {
     }
     EXPECT_EQ(sel.getInflightBytes(0), 0u);
     EXPECT_EQ(sel.getInflightBytes(1), 0u);
+}
+
+// A learning rate is a weight on the old value; anything outside [0, 1]
+// makes the EWMA update meaningless, so setSchedulingParams clamps both.
+TEST(DeviceSelectorTransmitTest, LearningRatesAreClampedToUnitInterval) {
+    DeviceSelector::SchedulingParams params;
+    params.bandwidth_learning_rate = 1.5;
+    params.transmit_bandwidth_learning_rate = -0.5;
+    params.transmit_meter_interval_ns = 0;
+    auto sel = makeSelector(params);
+    EXPECT_DOUBLE_EQ(sel->getSchedulingParams().bandwidth_learning_rate, 1.0);
+    EXPECT_DOUBLE_EQ(
+        sel->getSchedulingParams().transmit_bandwidth_learning_rate, 0.0);
+
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    ASSERT_TRUE(sel->release(kDev, kMiB, kMiB / 3.1e9).ok());
+    runBatch(*sel, 1, kMiB, 1);  // one interval at 1 GB/s
+    // alpha 1.0: the selection EWMA never learns; alpha 0.0: the transmit
+    // estimate adopts each interval outright.
+    EXPECT_DOUBLE_EQ(sel->getAggregateEwmaBandwidth(), 3.125e9);
+    EXPECT_NEAR(sel->getAggregateTransmitBandwidth(), 1e9, 1.0);
+}
+
+TEST(DeviceSelectorTransmitTest, SeededFromLinkSpeed) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 3.125e9);
+    EXPECT_DOUBLE_EQ(sel->getAggregateTransmitBandwidth(), 3.125e9);
+    EXPECT_LT(sel->getTransmitBandwidth(7), 0.0);  // unknown device
+}
+
+// The point of metering bytes over time rather than timing each slice: work
+// requested together is posted with one timestamp and completed under one
+// poll timestamp, so per-slice "post to completion" grows with the batch
+// while the NIC's rate does not.
+TEST(DeviceSelectorTransmitTest, RateIsIndependentOfBatchDepth) {
+    // 1 MiB every kMiB/8 nanoseconds == 8 bytes/ns == 8 GB/s. Even the
+    // 64-slice batch then fits well inside one meter window.
+    for (uint32_t n : {1u, 8u, 64u}) {
+        for (uint32_t poll_batch : {1u, 64u}) {
+            auto sel = makeMeteredSelector();
+            runBatch(*sel, n, kMiB / 8, poll_batch);
+            EXPECT_NEAR(sel->getTransmitBandwidth(kDev), 8e9, 1.0)
+                << "n=" << n << " poll_batch=" << poll_batch;
+        }
+    }
+}
+
+// Selection and transmit answer different questions from the same traffic:
+// each MiB queues on the NIC behind earlier work as long as it spends on
+// the wire.
+TEST(DeviceSelectorTransmitTest, SelectionKeepsQueueingThatTransmitDrops) {
+    auto sel = makeMeteredSelector();
+    const double wire_s = kMiB / 1e9;
+    for (int i = 0; i < 2000; ++i)
+        ASSERT_TRUE(sel->release(kDev, kMiB, 2.0 * wire_s).ok());
+    runBatch(*sel, 8, kMiB, 8);
+    // A backed-up NIC should look slow to device selection...
+    EXPECT_NEAR(sel->getAggregateEwmaBandwidth(), 0.5e9, 0.5e9 * 0.02);
+    // ...while the deadline predictors get the rate it moves bytes at.
+    EXPECT_NEAR(sel->getAggregateTransmitBandwidth(), 1e9, 1.0);
+}
+
+// The accumulator itself: time is banked only for stretches during which
+// something was posted, and a stretch already open is not restarted.
+TEST(DeviceSelectorTransmitTest, BusyTimeCountsOnlyStretchesWithWorkPosted) {
+    auto sel = makeSelector();
+    EXPECT_EQ(sel->getBusyNs(kDev), 0u);
+
+    sel->notePosted(kDev, kMiB, kT0);
+    sel->notePosted(kDev, kMiB, kT0 + 5);      // already busy: not a restart
+    sel->notePostEnded(kDev, kMiB, kT0 + 40);  // still busy
+    EXPECT_EQ(sel->getBusyNs(kDev), 0u);       // nothing banked until idle
+    sel->notePostEnded(kDev, kMiB, kT0 + 100);
+    EXPECT_EQ(sel->getBusyNs(kDev), 100u);
+
+    // The gap to the next stretch is not counted.
+    sel->notePosted(kDev, kMiB, kT0 + 1000);
+    sel->notePostEnded(kDev, kMiB, kT0 + 1010);
+    EXPECT_EQ(sel->getBusyNs(kDev), 110u);
+}
+
+// Two workers racing on one NIC can open the next stretch before the ending
+// one is banked, leaving busy_since ahead of the timestamp closing it. Bank
+// nothing rather than an underflowed interval.
+TEST(DeviceSelectorTransmitTest, OutOfOrderTransitionBanksNothing) {
+    auto sel = makeSelector();
+    sel->notePosted(kDev, kMiB, kT0 + 500);
+    sel->notePostEnded(kDev, kMiB, kT0 + 100);
+    EXPECT_EQ(sel->getBusyNs(kDev), 0u);
+}
+
+// An interval that opens with an empty queue pair still holds a usable
+// measurement: whatever the NIC did while it had work. Only the idle part is
+// dropped, not the whole interval.
+TEST(DeviceSelectorTransmitTest, OnlyTheBusyPartOfAnIntervalIsMeasured) {
+    auto sel = makeMeteredSelector();
+    sel->maybeSampleTransmit(kDev, kT0);  // opens idle
+    // Idle for 3 * kMiB ns, then 1 MiB moved in kMiB ns: 1 byte/ns.
+    sel->notePosted(kDev, kMiB, kT0 + 3 * kMiB);
+    sel->notePostEnded(kDev, kMiB, kT0 + 4 * kMiB);
+    sel->noteCompleted(kDev, kMiB);
+    sel->maybeSampleTransmit(kDev, kT0 + 4 * kMiB);
+    EXPECT_NEAR(sel->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// A sample spanning more wall time than transmit_meter_max_interval_ns is
+// dropped whatever its busy time says: the link it describes is too old to
+// attribute to the link as it is now.
+TEST(DeviceSelectorTransmitTest, StaleIntervalsAreNotSamples) {
+    auto sel = makeMeteredSelector();
+    sel->notePosted(kDev, kMiB, kT0);
+    sel->maybeSampleTransmit(kDev, kT0);
+    sel->notePostEnded(kDev, kMiB, kT0 + 1'000'000'000);
+    sel->noteCompleted(kDev, kMiB);
+    sel->maybeSampleTransmit(kDev, kT0 + 1'000'000'000);
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 3.125e9);
+}
+
+TEST(DeviceSelectorTransmitTest, MeterHonoursItsInterval) {
+    DeviceSelector::SchedulingParams params;
+    params.transmit_bandwidth_learning_rate = 0.0;
+    auto sel = makeSelector(params);  // default 10 ms interval
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+
+    sel->notePosted(kDev, 64 * kMiB, kT0);
+    sel->maybeSampleTransmit(kDev, kT0);
+    sel->noteCompleted(kDev, kMiB);
+    sel->maybeSampleTransmit(kDev, kT0 + 1'000'000);  // 1 ms: too soon
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 3.125e9);
+    sel->maybeSampleTransmit(kDev, kT0 + 10'000'000);  // 10 ms: sampled
+    EXPECT_NE(sel->getTransmitBandwidth(kDev), 3.125e9);
+}
+
+// One fast interval is one observation among many, not the new estimate.
+TEST(DeviceSelectorTransmitTest, SmoothsSingleOutlier) {
+    auto sel = makeMeteredSelector(0.9);  // the shipped learning rate
+    uint64_t t = kT0;
+    for (int i = 0; i < 200; ++i) t = runBatch(*sel, 8, kMiB, 8, t);
+    ASSERT_NEAR(sel->getTransmitBandwidth(kDev), 1e9, 1e9 * 0.02);
+
+    // An interval that moved 30x as fast moves the estimate by ~(1 - alpha).
+    sel->notePosted(kDev, kMiB, t);
+    sel->maybeSampleTransmit(kDev, t);
+    sel->notePostEnded(kDev, kMiB, t + kMiB / 30);
+    sel->noteCompleted(kDev, kMiB);
+    sel->maybeSampleTransmit(kDev, t + kMiB / 30);
+    EXPECT_LT(sel->getTransmitBandwidth(kDev), 5e9);
+    EXPECT_GT(sel->getTransmitBandwidth(kDev), 3e9);
+}
+
+// release() feeds the selection EWMA only; the transmit estimate has one
+// source, the meter.
+TEST(DeviceSelectorTransmitTest, ReleaseDoesNotFeedTheTransmitEstimate) {
+    auto sel = makeSelector();
+    ASSERT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    ASSERT_TRUE(sel->release(kDev, kMiB, kMiB / 1e9).ok());
+    EXPECT_NE(sel->getAggregateEwmaBandwidth(), 3.125e9);
+    EXPECT_DOUBLE_EQ(sel->getAggregateTransmitBandwidth(), 3.125e9);
+}
+
+TEST(DeviceSelectorTransmitTest, ClampScalesWithLinkSpeed) {
+    auto sel = makeMeteredSelector();
+    // 1 MiB in a nanosecond: capped at 10x the 3.125 GB/s link rate.
+    runBatch(*sel, 1, 1, 1);
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 31.25e9);
+    // 1 MiB in 40 ms: floored at 0.1x.
+    sel->notePosted(kDev, kMiB, kT0 + 1);
+    sel->maybeSampleTransmit(kDev, kT0 + 1);
+    sel->notePostEnded(kDev, kMiB, kT0 + 1 + 40'000'000);
+    sel->noteCompleted(kDev, kMiB);
+    sel->maybeSampleTransmit(kDev, kT0 + 1 + 40'000'000);
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 0.3125e9);
+}
+
+// ---------------------------------------------------------------------------
+// How closely the meter recovers a NIC's real rate in the SHIPPED
+// configuration -- 10 ms interval, alpha 0.9 -- rather than the
+// one-sample-per-call setup the mechanism tests above use. Each records the
+// figure it measured and pins it with a bound just above it, so a change in
+// what the meter is worth as a number shows up here rather than in
+// production. Every figure is the worst of ten readings taken over
+// successive stretches of the same traffic, not the value one run happened
+// to stop on.
+//
+//   steady 8 GB/s, polled 1, 16 or 64     4.8e-16, the last bit of a double
+//   steady 8 GB/s, 64 MiB slices          7.0e-13   (slice size cancels)
+//   steady 2 GB/s, polled 16 deep         5.8e-13   (one pass fills most of
+//                                                    a meter interval)
+//   bursty 4/12 GB/s, mean 8              1.2%      (the swing between the
+//                                                    halves, not an offset)
+//   21% duty cycle, 16 MiB per 10 ms      6.0e-16   (was -78% before the
+//                                                    meter charged busy time)
+//   8 -> 2 GB/s renegotiation             within 5% after 478 ms
+//   a real 50 GB/s wire                   pinned at 31.25 GB/s, the clamp
+//
+// Once the sample is taken at the end of a poll pass, how deep the polling
+// is does not enter the steady-state error at all. What it does change is
+// how often a sample can be taken, and therefore how fast the estimate
+// follows a change -- which is what the renegotiation figure measures.
+// ---------------------------------------------------------------------------
+
+// Default scheduling params (10 ms meter interval, alpha 0.9, 50 ms staleness
+// cut-off) over a 25 Gbps link: seed and clamp centre are 3.125 GB/s.
+std::unique_ptr<DeviceSelector> shippedSelector() {
+    auto sel = makeSelector();
+    EXPECT_TRUE(sel->setDeviceBandwidth(kDev, 25.0).ok());
+    return sel;
+}
+
+// A NIC transmitting steadily at `bytes_per_ns`, driven the way
+// handleCompletion drives the meter: a slice leaves the wire every
+// slice/rate nanoseconds, one poll pass picks up `poll_batch` of them and
+// stamps the whole group with a single timestamp, each completion offers the
+// meter a sample, and the queue pair is refilled so the NIC never goes idle.
+// Returns the estimate after `duration_ns` of traffic.
+double runWire(DeviceSelector& sel, double bytes_per_ns, uint64_t slice,
+               uint64_t poll_batch, uint64_t duration_ns, uint64_t& clock) {
+    const uint64_t per_slice_ns = static_cast<uint64_t>(slice / bytes_per_ns);
+    // Whole slices only, and the clock is advanced by exactly what was
+    // driven: a stretch left over at the end would be busy time with no
+    // completions in it, which is the harness lying to the meter rather
+    // than the meter being wrong.
+    const uint64_t n = duration_ns / per_slice_ns;
+    const uint64_t start_ns = clock;
+    for (uint64_t i = 0; i < poll_batch; ++i)
+        sel.notePosted(kDev, slice, start_ns);
+    sel.maybeSampleTransmit(kDev, start_ns);  // open an interval, NIC busy
+
+    uint64_t done = 0;
+    while (done < n) {
+        const uint64_t group = std::min<uint64_t>(poll_batch, n - done);
+        // One poll pass timestamps everything it reaps alike.
+        const uint64_t poll_ts = start_ns + (done + group) * per_slice_ns;
+        for (uint64_t i = 0; i < group; ++i) {
+            sel.notePostEnded(kDev, slice, poll_ts);
+            sel.noteCompleted(kDev, slice);
+            // Refill: the queue pair never drains, so the NIC stays busy.
+            sel.notePosted(kDev, slice, poll_ts);
+        }
+        sel.maybeSampleTransmit(kDev, poll_ts);  // once per pass, at its end
+        done += group;
+    }
+    clock = start_ns + n * per_slice_ns;
+    return sel.getTransmitBandwidth(kDev);
+}
+
+double relErr(double got, double want) { return std::abs(got - want) / want; }
+
+// The worst reading in a run, and where the readings sat. Each scenario is
+// judged over many meter intervals rather than at one endpoint: an estimate
+// that lands on the right number once but wanders between samples is not
+// worth what the deadline predictors spend it on.
+struct Spread {
+    double worst_rel_err = 0.0;
+    double lo = 0.0;
+    double hi = 0.0;
+
+    void add(double got, double want) {
+        if (lo == 0.0 || got < lo) lo = got;
+        if (got > hi) hi = got;
+        worst_rel_err = std::max(worst_rel_err, relErr(got, want));
+    }
+    std::string str() const {
+        std::ostringstream out;
+        out.precision(3);
+        out << "lo=" << std::fixed << lo << " hi=" << hi << std::scientific
+            << " worst_rel_err=" << worst_rel_err;
+        return out.str();
+    }
+};
+
+// A wire held at exactly 8 GB/s. Both ends of every meter interval are
+// completion timestamps, so each window measures the rate over a whole
+// number of slices -- there is no partial slice to misattribute, and the
+// EWMA of a constant is that constant. The residual is the poll group split
+// across an interval boundary, and it is ~1e-6 even at the deepest polling.
+TEST(DeviceSelectorTransmitAccuracyTest, SteadyRateIsRecovered) {
+    // Long enough for the seed to have washed out of the EWMA at every one
+    // of these depths: the deeper the polling the fewer samples a second of
+    // traffic offers, so a shorter warm-up leaves the shallowest converged
+    // and the deepest still on its way, which is a difference in how fast
+    // the estimate moves and not in what it settles on.
+    constexpr uint64_t kWarmUp = 8'000'000'000ull;
+    constexpr uint64_t kChunk = 200'000'000ull;  // ~20 meter intervals each
+    for (uint64_t poll_batch : {1ull, 16ull, 64ull}) {
+        auto sel = shippedSelector();
+        uint64_t at = kT0;
+        runWire(*sel, 8.0, kMiB, poll_batch, kWarmUp, at);
+        Spread spread;
+        for (int chunk = 0; chunk < 10; ++chunk)
+            spread.add(runWire(*sel, 8.0, kMiB, poll_batch, kChunk, at), 8e9);
+        RecordProperty("poll_batch_" + std::to_string(poll_batch),
+                       spread.str());
+        EXPECT_LT(spread.worst_rel_err, 1e-12)
+            << "poll_batch=" << poll_batch << " lo=" << spread.lo
+            << " hi=" << spread.hi;
+    }
+}
+
+// Slice size does not enter the error. 64 MiB slices leave barely one
+// completion per interval, but since an interval can only begin and end on a
+// completion, the window still holds whole slices: no phase error to average
+// out. This is what makes the estimate independent of how the caller carved
+// its transfer up.
+TEST(DeviceSelectorTransmitAccuracyTest, SliceSizeDoesNotSkewTheEstimate) {
+    auto sel = shippedSelector();  // 8 GB/s, an interval holds 76 MiB
+    uint64_t at = kT0;
+    runWire(*sel, 8.0, 64 * kMiB, 1, 4'000'000'000ull, at);
+    Spread spread;
+    for (int chunk = 0; chunk < 10; ++chunk)
+        spread.add(runWire(*sel, 8.0, 64 * kMiB, 1, 400'000'000ull, at), 8e9);
+    RecordProperty("estimate", spread.str());
+    EXPECT_LT(spread.worst_rel_err, 1e-9)
+        << "lo=" << spread.lo << " hi=" << spread.hi;
+}
+
+// The realistic case: the wire does not hold one rate. Alternating 5 ms
+// bursts of 4 and 12 GB/s carry the same bytes per 10 ms as a steady 8 GB/s
+// link, and each burst is short enough to fall inside a meter window. What
+// the estimate has to recover is the mean, not the burst it last saw.
+TEST(DeviceSelectorTransmitAccuracyTest, BurstyWireConvergesOnItsMean) {
+    auto sel = shippedSelector();
+    uint64_t at = kT0;
+    Spread spread;
+    for (int i = 0; i < 1200; ++i) {
+        runWire(*sel, (i % 2) ? 12.0 : 4.0, kMiB, 8, 5'000'000ull, at);
+        // Read it back on every burst boundary past the warm-up, so the
+        // swing between the fast and the slow half is inside the bound and
+        // not just the endpoint the run happens to stop on.
+        if (i >= 400) spread.add(sel->getTransmitBandwidth(kDev), 8e9);
+    }
+    RecordProperty("estimate", spread.str());
+    EXPECT_LT(spread.worst_rel_err, 0.015)
+        << "lo=" << spread.lo << " hi=" << spread.hi;
+}
+
+// A link that renegotiates down to a quarter of its rate. alpha 0.9 closes
+// 10% of the gap per SAMPLE, and ~39 samples are needed to get within 5%.
+// What that costs in wall time is set by how often a sample can be taken,
+// which is not the 10 ms interval but the poll rhythm: a sample only lands
+// on a completion timestamp, so the effective interval here is the first
+// poll pass at or after 10 ms. This measures the window in which the
+// admission queue's drop predicate still believes the old, faster link.
+TEST(DeviceSelectorTransmitAccuracyTest, FollowsALinkThatSlowsDown) {
+    auto sel = shippedSelector();
+    uint64_t at = kT0;
+    // Polled four at a time, so one pass is a fifth of a meter interval and
+    // the coarse-polling bias below stays out of the measurement.
+    ASSERT_LT(relErr(runWire(*sel, 8.0, kMiB, 4, 2'000'000'000ull, at), 8e9),
+              0.02);
+
+    constexpr uint64_t kStep = 10'000'000ull;  // 10 ms of traffic per step
+    const uint64_t slowdown_at = at;
+    while (relErr(sel->getTransmitBandwidth(kDev), 2e9) > 0.05 &&
+           at - slowdown_at < 5'000'000'000ull) {
+        runWire(*sel, 2.0, kMiB, 4, kStep, at);
+    }
+    const uint64_t elapsed_ns = at - slowdown_at;
+    RecordProperty("ms_to_within_5pct", std::to_string(elapsed_ns / 1'000'000));
+    // Both ends matter: too slow and the drop predicate believes the old
+    // link for longer, too fast and one odd interval could flip it.
+    EXPECT_GT(elapsed_ns, 300'000'000ull) << "ms=" << elapsed_ns / 1'000'000;
+    EXPECT_LT(elapsed_ns, 700'000'000ull) << "ms=" << elapsed_ns / 1'000'000;
+}
+
+// Nothing calls the meter while a NIC is idle: handleCompletion is its only
+// caller. A workload that bursts and then waits therefore does not close an
+// interval at the end of its burst -- it closes it at the NEXT burst, with
+// the idle gap inside the elapsed time. Drives only completions, the way
+// production does.
+double runDutyCycle(DeviceSelector& sel, double bytes_per_ns, uint64_t slice,
+                    uint64_t burst_slices, uint64_t period_ns, int bursts,
+                    uint64_t start_ns = kT0) {
+    const uint64_t per_slice_ns = static_cast<uint64_t>(slice / bytes_per_ns);
+    uint64_t at = start_ns;
+    for (int b = 0; b < bursts; ++b) {
+        for (uint64_t i = 0; i < burst_slices; ++i)
+            sel.notePosted(kDev, slice, at);
+        for (uint64_t i = 0; i < burst_slices; ++i) {
+            // One completion per poll pass here: the bursts are what is
+            // being measured, not the polling.
+            const uint64_t done_ts = at + (i + 1) * per_slice_ns;
+            sel.notePostEnded(kDev, slice, done_ts);
+            sel.noteCompleted(kDev, slice);
+            sel.maybeSampleTransmit(kDev, done_ts);
+        }
+        at += period_ns;
+    }
+    return sel.getTransmitBandwidth(kDev);
+}
+
+// A NIC that bursts and then waits. The gap between bursts is not the link
+// being slow, it is the link having nothing to do, so only the time the NIC
+// actually held work may be charged for the bytes it moved. Metered against
+// elapsed time this read 1.68 GB/s -- the period average, 4.8x below the
+// wire -- and the admission layer's absolute drop threshold was wrong by
+// that factor.
+TEST(DeviceSelectorTransmitAccuracyTest, IdleTimeIsNotChargedToTheLink) {
+    auto sel = shippedSelector();
+    // 16 MiB at 8 GB/s == 2 ms of wire time every 10 ms: 21% duty cycle.
+    uint64_t at = kT0;
+    runDutyCycle(*sel, 8.0, kMiB, 16, 10'000'000ull, 400, at);
+    at += 400ull * 10'000'000ull;
+    Spread spread;
+    for (int chunk = 0; chunk < 20; ++chunk) {
+        spread.add(runDutyCycle(*sel, 8.0, kMiB, 16, 10'000'000ull, 20, at),
+                   8e9);
+        at += 20ull * 10'000'000ull;
+    }
+    RecordProperty("estimate", spread.str());
+    EXPECT_LT(spread.worst_rel_err, 1e-6)
+        << "lo=" << spread.lo << " hi=" << spread.hi;
+}
+
+// Widen the gap past transmit_meter_max_interval_ns and the same workload is
+// rejected instead: the estimate keeps its seed. The protection is a cliff at
+// 50 ms, not a correction.
+TEST(DeviceSelectorTransmitAccuracyTest, DutyCyclePastTheCutOffIsRejected) {
+    auto sel = shippedSelector();
+    const double got = runDutyCycle(*sel, 8.0, kMiB, 16, 60'000'000ull, 100);
+    RecordProperty("estimate", std::to_string(got));
+    EXPECT_DOUBLE_EQ(got, 3.125e9);  // the 25 Gbps seed, never updated
+}
+
+// The worst case for the poll cadence: sixteen 1 MiB slices at 2 GB/s put one
+// pass at 8.4 ms against a 10 ms meter interval, so almost every interval
+// ends on the pass that fills it. Taking the sample at the end of a pass
+// rather than partway through is what makes this exact -- sampled from inside
+// a pass, the interval that closed lost the rest of the pass's bytes and the
+// next one got them for free, and since the estimate averages per-interval
+// rates over intervals of unequal length the two did not cancel: this read 8%
+// high and a 4x slowdown never converged at all.
+TEST(DeviceSelectorTransmitAccuracyTest, CoarsePollingDoesNotSkewTheEstimate) {
+    auto sel = shippedSelector();
+    uint64_t at = kT0;
+    runWire(*sel, 2.0, kMiB, 16, 4'000'000'000ull, at);
+    Spread spread;
+    for (int chunk = 0; chunk < 10; ++chunk)
+        spread.add(runWire(*sel, 2.0, kMiB, 16, 400'000'000ull, at), 2e9);
+    RecordProperty("estimate", spread.str());
+    EXPECT_LT(spread.worst_rel_err, 1e-9)
+        << "lo=" << spread.lo << " hi=" << spread.hi;
+}
+
+// The clamp is the hard ceiling on what can be measured at all: a link whose
+// real rate is more than ewma_max_multiplier times the seed reads as the
+// clamp, not as itself. Reachable when the seed came from
+// default_bandwidth_gbps because the port speed could not be read.
+TEST(DeviceSelectorTransmitAccuracyTest, RateAboveTheClampIsNotMeasurable) {
+    auto sel = shippedSelector();  // seed 3.125 GB/s, ceiling 31.25 GB/s
+    uint64_t at = kT0;
+    for (int chunk = 0; chunk < 10; ++chunk) {
+        const double got = runWire(*sel, 50.0, kMiB, 16, 200'000'000ull, at);
+        // Pinned at 10x, not the real 50 GB/s, and it stays pinned: more
+        // intervals of the same evidence never lift it past the clamp.
+        EXPECT_DOUBLE_EQ(got, 31.25e9) << "chunk=" << chunk;
+    }
+    RecordProperty("estimate", std::to_string(sel->getTransmitBandwidth(kDev)));
+}
+
+// A reset abandons the interval in progress without learning from it; the
+// sample after it rebuilds both baselines from scratch, so the bytes and
+// busy time it eventually divides come from the same window.
+TEST(DeviceSelectorTransmitTest, ResetStartsTheNextIntervalFresh) {
+    auto sel = makeMeteredSelector();
+    sel->notePosted(kDev, 2 * kMiB, kT0);  // one busy stretch, two slices
+    sel->maybeSampleTransmit(kDev, kT0);   // baseline
+    sel->noteCompleted(kDev, kMiB);
+    sel->resetTransmitMeter(kDev);
+    // Rebuilds the baselines (1 MiB done, 1 MiB ns busy) and learns nothing.
+    sel->maybeSampleTransmit(kDev, kT0 + kMiB);
+    EXPECT_DOUBLE_EQ(sel->getTransmitBandwidth(kDev), 3.125e9);
+    sel->noteCompleted(kDev, kMiB);
+    sel->notePostEnded(kDev, 2 * kMiB, kT0 + 2 * kMiB);
+    // 1 MiB over the 1 MiB ns of busy time since those baselines: 1 GB/s.
+    sel->maybeSampleTransmit(kDev, kT0 + 2 * kMiB);
+    EXPECT_NEAR(sel->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// The padding after each hot counter is only worth anything if the struct
+// itself starts on a cache line; otherwise two lanes' posts and completions
+// contend on the same line.
+TEST(DeviceSelectorLayoutTest, HotCountersSitOnTheirOwnCacheLines) {
+    DeviceSelector::DeviceInfo info;
+    const auto base = reinterpret_cast<uintptr_t>(&info);
+    auto line_of = [&](const void* p) {
+        return (reinterpret_cast<uintptr_t>(p) - base) / 64;
+    };
+    EXPECT_EQ(alignof(DeviceSelector::DeviceInfo), 64u);
+    EXPECT_EQ(sizeof(DeviceSelector::DeviceInfo) % 64, 0u);
+    const std::vector<const void*> hot = {
+        &info.inflight_bytes, &info.ewma_bandwidth_bps, &info.ewma_transmit_bps,
+        &info.total_bytes,    &info.posted_bytes,       &info.completed_bytes,
+        &info.meter_ts};
+    for (size_t i = 0; i < hot.size(); ++i) {
+        EXPECT_EQ((reinterpret_cast<uintptr_t>(hot[i]) - base) % 64, 0u)
+            << "field " << i;
+        for (size_t j = i + 1; j < hot.size(); ++j)
+            EXPECT_NE(line_of(hot[i]), line_of(hot[j])) << i << " vs " << j;
+    }
+}
+
+// The NIC's posted backlog is what a slice about to be posted waits behind:
+// charged when a WR reaches the hardware, returned when it leaves.
+TEST(DeviceSelectorTransmitTest, PostedBytesTrackTheHardwareBacklog) {
+    auto sel = makeSelector();
+    EXPECT_EQ(sel->getPostedBytes(kDev), 0u);
+    sel->notePosted(kDev, kMiB, kT0);
+    sel->notePosted(kDev, kMiB, kT0);
+    EXPECT_EQ(sel->getPostedBytes(kDev), 2 * kMiB);
+    sel->notePostEnded(kDev, kMiB, kT0);
+    EXPECT_EQ(sel->getPostedBytes(kDev), kMiB);
+    sel->notePostEnded(kDev, kMiB, kT0);
+    EXPECT_EQ(sel->getPostedBytes(kDev), 0u);
+    EXPECT_EQ(sel->getPostedBytes(7), 0u);  // unknown device
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/device_selector_test.cpp
@@ -17,6 +17,7 @@
 
 #include "tent/transport/rdma/quota.h"
 
+#include "tent/transport/rdma/bw_arbitration.h"
 
 #include <gtest/gtest.h>
 
@@ -817,6 +818,20 @@ TEST(DeviceSelectorTransmitAccuracyTest, DutyCyclePastTheCutOffIsRejected) {
     const double got = runDutyCycle(*sel, 8.0, kMiB, 16, 60'000'000ull, 100);
     RecordProperty("estimate", std::to_string(got));
     EXPECT_DOUBLE_EQ(got, 3.125e9);  // the 25 Gbps seed, never updated
+}
+
+// The ordering half of the estimate's job is immune to all of this: one
+// arbitration call scores every contender against the same bw, so scaling it
+// scales every MLU alike and the order is unchanged. Only the admission
+// layer's absolute threshold can be moved by a wrong rate.
+TEST(DeviceSelectorTransmitAccuracyTest, OrderingIsUnaffectedByARateError) {
+    const std::vector<ArbFlow> flows{
+        {kT0 + 40, 16}, {kT0 + 10, 8}, {kT0 + 80, 64}};
+    const auto truth = OrderByUrgency(flows, kT0, 8e9, 1024);
+    for (double wrong : {8e9 / 5, 8e9 / 2, 8e9 * 3}) {
+        EXPECT_EQ(OrderByUrgency(flows, kT0, wrong, 1024), truth)
+            << "bw=" << wrong;
+    }
 }
 
 // The worst case for the poll cadence: sixteen 1 MiB slices at 2 GB/s put one

--- a/mooncake-transfer-engine/tent/tests/quota_accounting_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/quota_accounting_test.cpp
@@ -12,24 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Unit tests for the TENT per-NIC inflight quota accounting: the DeviceSelector
-// charge/release primitives and the slice-level reconcile
-// (Workers::chargeSliceQuota / releaseSliceQuota). These lock in the invariants
-// behind the device-selector scheduling-accuracy fix:
-//   * allocate charges a per-slice estimate; the reconcile converts it to the
-//     slice's real length once the routing NIC is final;
-//   * same-NIC reconcile, A->B fallback, and retry all leave inflight at zero;
-//   * cancel/timeout/failed completions (latency <= 0) do not move EWMA, while
-//     a successful completion updates it with charged_bytes / attempt_latency;
+// Unit tests for the DeviceSelector's per-NIC inflight accounting, the
+// selector half of the charge/release contract the worker relies on:
+//   * allocate charges each slice exactly the bytes it carries, so release
+//     by slice length balances every NIC;
+//   * chargeDevice / release are a matched pair on the device named, and a
+//     charge against an untracked device fails without touching anything;
+//   * a completion with no latency sample (cancel, timeout, failed CQ) moves
+//     no EWMA; a successful one updates it with length / attempt latency;
 //   * baseline (round-robin) mode never touches inflight, so it cannot
-//   underflow;
-//   * a charge against an untracked device leaves the slice uncharged (the data
-//     transfer still proceeds) rather than corrupting the counter.
-//
-// The reconcile helpers are private static members of Workers (they only need a
-// DeviceSelector, not a Workers/RdmaTransport instance);
-// WorkersQuotaTestAccessor is a declared friend that forwards to them so the
-// reconcile logic can be exercised directly and hardware-independently.
+//     underflow.
+// The slice-level half -- which device a slice's charge follows across a
+// fallback or a retry -- lives in rdma_transport_test.cpp
+// (RdmaWorkersChargeTest), where a Workers can be built without hardware.
 
 #include <gtest/gtest.h>
 
@@ -42,27 +37,11 @@
 #include "tent/common/types.h"
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/quota.h"
-#include "tent/transport/rdma/slice.h"
-#include "tent/transport/rdma/workers.h"
 
 namespace mooncake {
 namespace tent {
-
-// Test-only shim: forwards to Workers' private static reconcile helpers (see
-// the friend declaration in workers.h).
-class WorkersQuotaTestAccessor {
-   public:
-    static void charge(DeviceSelector* sel, RdmaSlice* slice) {
-        Workers::chargeSliceQuota(sel, slice);
-    }
-    static void release(DeviceSelector* sel, RdmaSlice* slice, double latency) {
-        Workers::releaseSliceQuota(sel, slice, latency);
-    }
-};
-
 namespace {
 
-using Accessor = WorkersQuotaTestAccessor;
 constexpr uint64_t kNotFound = std::numeric_limits<uint64_t>::max();
 
 // Two RDMA NICs (dev 0, 1) reachable from host location "cpu:0".
@@ -117,102 +96,57 @@ double EwmaOf(DeviceSelector& sel, const std::string& name) {
     return -1.0;
 }
 
-// A slice already charged `charged` bytes of inflight against device `dev`,
-// i.e. the post-allocate state before the worker reconciles it in
-// generatePostPath.
-RdmaSlice ChargedSlice(DeviceSelector& sel, int dev, uint64_t charged,
-                       uint64_t length) {
-    EXPECT_TRUE(sel.chargeDevice(dev, charged).ok());
-    RdmaSlice slice;
-    slice.length = length;
-    slice.source_dev_id = dev;
-    slice.charged_dev_id = dev;
-    slice.charged_bytes = charged;
-    slice.quota_charged = true;
-    return slice;
-}
-
 }  // namespace
 
-// ---- allocate charges an estimate, reconcile converts it to real length ----
+// ---- allocate charges what each slice carries; release by length balances
 
-TEST(QuotaAccounting, AllocateChargesPerSliceEstimate) {
+TEST(QuotaAccounting, AllocateChargesEachSliceItsOwnLength) {
     auto sel = MakeSelector(/*smart=*/true);
     std::vector<int> dev_ids;
-    std::vector<uint64_t> charged;
-    // total 1000 over 4 slices -> estimate ceil(1000/4) = 250 per slice.
+    // 1000 bytes in 250-byte blocks: four slices of 250.
     ASSERT_TRUE(sel->allocate(1000, /*num_slices=*/4, /*slice_bytes=*/250,
-                              "cpu:0", dev_ids, PRIO_HIGH, ~0ULL, &charged)
+                              "cpu:0", dev_ids)
                     .ok());
     ASSERT_EQ(dev_ids.size(), 4u);
-    ASSERT_EQ(charged.size(), 4u);
-    for (uint64_t c : charged) EXPECT_EQ(c, 250u);  // estimate, not real length
-    EXPECT_EQ(TotalInflight(*sel), 1000u);          // charged == sum estimates
-}
+    EXPECT_EQ(TotalInflight(*sel), 1000u);
 
-TEST(QuotaAccounting, ReconcileConvertsEstimateToRealLengthSameNic) {
-    auto sel = MakeSelector(/*smart=*/true);
-    // Charged the 250-byte estimate on dev 0, but the slice is really 256
-    // bytes.
-    RdmaSlice slice = ChargedSlice(*sel, /*dev=*/0, /*charged=*/250,
-                                   /*length=*/256);
-    ASSERT_EQ(InflightOf(*sel, "mlx5_0"), 250u);
-
-    Accessor::charge(sel.get(), &slice);  // as generatePostPath would
-
-    EXPECT_EQ(slice.charged_bytes, 256u);  // now the real length
-    EXPECT_EQ(slice.charged_dev_id, 0);
-    EXPECT_TRUE(slice.quota_charged);
-    EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 256u);  // inflight == real length
-
-    Accessor::release(sel.get(), &slice, 0.0);
-    EXPECT_FALSE(slice.quota_charged);
+    for (int dev : dev_ids) ASSERT_TRUE(sel->release(dev, 250, 0.0).ok());
     EXPECT_EQ(TotalInflight(*sel), 0u);
 }
 
-// ---- the three reconcile paths all return inflight to zero ----
-
-TEST(QuotaAccounting, SameNicReconcileReturnsToZero) {
+TEST(QuotaAccounting, ATrailingShortSliceIsChargedItsRealLength) {
     auto sel = MakeSelector(/*smart=*/true);
-    RdmaSlice slice = ChargedSlice(*sel, 0, 250, 256);
-    Accessor::charge(sel.get(), &slice);
-    Accessor::release(sel.get(), &slice, 0.0);
+    std::vector<int> dev_ids;
+    // 1000 bytes in 300-byte blocks: 300, 300, 300 and a 100-byte tail.
+    ASSERT_TRUE(sel->allocate(1000, /*num_slices=*/4, /*slice_bytes=*/300,
+                              "cpu:0", dev_ids)
+                    .ok());
+    ASSERT_EQ(dev_ids.size(), 4u);
+    EXPECT_EQ(TotalInflight(*sel), 1000u);  // not 4 * 300
+
+    for (size_t i = 0; i < dev_ids.size(); ++i)
+        ASSERT_TRUE(sel->release(dev_ids[i], i == 3 ? 100 : 300, 0.0).ok());
     EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);
-    EXPECT_EQ(TotalInflight(*sel), 0u);
+    EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 0u);
 }
 
-TEST(QuotaAccounting, FallbackMigrationMovesChargeAndReturnsToZero) {
+// ---- chargeDevice / release are a matched pair on the device named ----
+
+TEST(QuotaAccounting, ChargeDeviceAndReleaseBalance) {
     auto sel = MakeSelector(/*smart=*/true);
-    // Charged on dev 0, but a fallback re-routed the slice to dev 1.
-    RdmaSlice slice = ChargedSlice(*sel, /*dev=*/0, /*charged=*/256,
-                                   /*length=*/256);
-    slice.source_dev_id = 1;  // fallback rewrote the routing NIC
-
-    Accessor::charge(sel.get(), &slice);
-    EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);    // original NIC unwound
-    EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 256u);  // migrated to fallback NIC
-    EXPECT_EQ(slice.charged_dev_id, 1);
-
-    Accessor::release(sel.get(), &slice, 0.0);
-    EXPECT_EQ(TotalInflight(*sel), 0u);
-}
-
-TEST(QuotaAccounting, RetryReEntersInflightThenReturnsToZero) {
-    auto sel = MakeSelector(/*smart=*/true);
-    RdmaSlice slice = ChargedSlice(*sel, 0, 256, 256);
-
-    // Retry path: the failed attempt releases the quota before resubmitting.
-    Accessor::release(sel.get(), &slice, 0.0);
-    EXPECT_FALSE(slice.quota_charged);
-    EXPECT_EQ(TotalInflight(*sel), 0u);  // not double-counted, not leaked
-
-    // Resubmit re-selects a NIC and reconciles -> re-enters the inflight view.
-    slice.source_dev_id = 1;
-    Accessor::charge(sel.get(), &slice);
-    EXPECT_TRUE(slice.quota_charged);
+    ASSERT_TRUE(sel->chargeDevice(1, 256).ok());
+    EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);
     EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 256u);
 
-    Accessor::release(sel.get(), &slice, 0.0);
+    ASSERT_TRUE(sel->release(1, 256, 0.0).ok());
+    EXPECT_EQ(TotalInflight(*sel), 0u);
+}
+
+TEST(QuotaAccounting, ChargeOnAnUntrackedDeviceFailsAndChangesNothing) {
+    auto sel = MakeSelector(/*smart=*/true);
+    EXPECT_FALSE(sel->chargeDevice(999, 4096).ok());
+    EXPECT_EQ(TotalInflight(*sel), 0u);
+    EXPECT_FALSE(sel->release(999, 4096, 0.0).ok());
     EXPECT_EQ(TotalInflight(*sel), 0u);
 }
 
@@ -221,10 +155,10 @@ TEST(QuotaAccounting, RetryReEntersInflightThenReturnsToZero) {
 TEST(QuotaAccounting, NonSuccessCompletionDoesNotMoveEwma) {
     auto sel = MakeSelector(/*smart=*/true);
     const double before = EwmaOf(*sel, "mlx5_0");
-    RdmaSlice slice = ChargedSlice(*sel, 0, 4096, 4096);
+    ASSERT_TRUE(sel->chargeDevice(0, 4096).ok());
 
     // cancel / timeout / failed CQ all release with latency <= 0.
-    Accessor::release(sel.get(), &slice, 0.0);
+    ASSERT_TRUE(sel->release(0, 4096, 0.0).ok());
 
     EXPECT_EQ(EwmaOf(*sel, "mlx5_0"), before);  // unchanged
     EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);
@@ -236,9 +170,9 @@ TEST(QuotaAccounting, SuccessUpdatesEwmaWithLengthOverLatency) {
 
     const uint64_t length = 100'000'000;  // 100 MB
     const double latency = 0.001;         // seconds (attempt latency)
-    RdmaSlice slice = ChargedSlice(*sel, 0, length, length);
+    ASSERT_TRUE(sel->chargeDevice(0, length).ok());
 
-    Accessor::release(sel.get(), &slice, latency);
+    ASSERT_TRUE(sel->release(0, length, latency).ok());
 
     // observed_bw = length / latency; EWMA = a*old + (1-a)*observed, a = 0.01.
     const double observed = static_cast<double>(length) / latency;  // 1e11 B/s
@@ -253,57 +187,16 @@ TEST(QuotaAccounting, SuccessUpdatesEwmaWithLengthOverLatency) {
 TEST(QuotaAccounting, BaselineModeKeepsInflightZero) {
     auto sel = MakeSelector(/*smart=*/false);
     std::vector<int> dev_ids;
-    std::vector<uint64_t> charged;
-    ASSERT_TRUE(sel->allocate(4096, 8, 512, "cpu:0", dev_ids, PRIO_HIGH, ~0ULL,
-                              &charged)
-                    .ok());
-    ASSERT_EQ(charged.size(), dev_ids.size());
-    for (uint64_t c : charged) EXPECT_EQ(c, 0u);  // baseline charges nothing
-    EXPECT_EQ(TotalInflight(*sel), 0u);
+    ASSERT_TRUE(sel->allocate(4096, 8, 512, "cpu:0", dev_ids).ok());
+    ASSERT_EQ(dev_ids.size(), 8u);
+    EXPECT_EQ(TotalInflight(*sel), 0u);  // baseline charges nothing
 
-    // Even the reconcile/release path must not move (or underflow) inflight.
-    RdmaSlice slice;
-    slice.length = 512;
-    slice.source_dev_id = 0;
-    Accessor::charge(sel.get(), &slice);
+    // Neither a re-charge nor a release moves (or underflows) inflight.
+    ASSERT_TRUE(sel->chargeDevice(0, 512).ok());
     EXPECT_EQ(TotalInflight(*sel), 0u);
-    Accessor::release(sel.get(), &slice, 0.001);
+    for (int dev : dev_ids) ASSERT_TRUE(sel->release(dev, 512, 0.001).ok());
     EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);  // not ~2^64 (no underflow)
     EXPECT_EQ(InflightOf(*sel, "mlx5_1"), 0u);
-}
-
-// ---- charge against an untracked device: proceed, but do not corrupt state
-// ----
-
-TEST(QuotaAccounting, ChargeFailureLeavesSliceUncharged) {
-    auto sel = MakeSelector(/*smart=*/true);
-    RdmaSlice slice;
-    slice.length = 4096;
-    slice.source_dev_id = 999;  // not present in the topology
-
-    Accessor::charge(sel.get(), &slice);
-
-    EXPECT_FALSE(slice.quota_charged);  // not marked charged
-    EXPECT_EQ(slice.charged_dev_id, -1);
-    EXPECT_EQ(slice.charged_bytes, 0u);
-    EXPECT_EQ(TotalInflight(*sel), 0u);
-
-    // A later release must be a harmless no-op (no crash, no underflow).
-    Accessor::release(sel.get(), &slice, 0.0);
-    EXPECT_EQ(TotalInflight(*sel), 0u);
-}
-
-TEST(QuotaAccounting,
-     MigrationToUntrackedDeviceUnwindsOriginalWithoutUnderflow) {
-    auto sel = MakeSelector(/*smart=*/true);
-    RdmaSlice slice = ChargedSlice(*sel, /*dev=*/0, 256, 256);
-    slice.source_dev_id = 999;  // fallback picked an untracked device
-
-    Accessor::charge(sel.get(), &slice);
-
-    EXPECT_EQ(InflightOf(*sel, "mlx5_0"), 0u);  // original NIC still unwound
-    EXPECT_FALSE(slice.quota_charged);  // new charge failed -> uncharged
-    EXPECT_EQ(TotalInflight(*sel), 0u);
 }
 
 }  // namespace tent

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -100,6 +100,12 @@ class RdmaTransportTestPeer {
                                                        endpoint_ready);
     }
 
+    static void orderByDeadline(Workers& workers,
+                                std::vector<RdmaSlice*>& slices, int dev_id,
+                                uint64_t now_ns) {
+        workers.orderByDeadline(slices, dev_id, now_ns);
+    }
+
     static void rechargeSlice(Workers& workers, RdmaSlice* slice, int dev_id) {
         workers.rechargeSlice(slice, dev_id);
     }
@@ -909,6 +915,123 @@ TEST_F(RdmaWorkersTimeoutTest, NotOnQueueStillReleasesSelectorInflightCharge) {
 
     expectTimedOutAndReleased();
     EXPECT_EQ(ctx_.inflight_slices.load(), 0);
+}
+
+// The selector charges every slice when it is allocated, before it reaches a
+// worker queue, so a NIC's inflight bytes already cover the slices being
+// ordered. What actually precedes them is what the NIC owes minus this
+// batch; each slice then also waits for the ones ordered ahead of it.
+class RdmaWorkersArbitrationTest : public ::testing::Test {
+   protected:
+    static constexpr int kDev = 0;
+    static constexpr uint64_t kNow = 1'000'000'000;
+
+    void SetUp() override {
+        auto topology = std::make_shared<Topology>();
+        ASSERT_TRUE(
+            topology
+                ->parse(
+                    R"({"nics":[{"name":"mc-absent-rnic-0","type":0,"numa_node":0}]})")
+                .ok());
+        Topology::MemEntry mem;
+        mem.name = "cpu:0";
+        mem.type = Topology::MEM_HOST;
+        mem.numa_node = 0;
+        mem.device_list[0].push_back(kDev);
+        topology->mem_list_.push_back(mem);
+
+        RdmaTransportTestPeer::bindTopology(transport_, topology);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_TRUE(selector_->setDeviceAvailable(kDev, true).ok());
+
+        // Pin the transmit estimate at exactly 1 GB/s, so one byte of
+        // queueing is one nanosecond of predicted time: one metered interval
+        // that moved 1 MiB in 1 MiB nanoseconds.
+        auto params = selector_->getSchedulingParams();
+        params.transmit_bandwidth_learning_rate = 0.0;  // adopt outright
+        params.transmit_meter_interval_ns = 0;          // sample on demand
+        selector_->setSchedulingParams(params);
+        ASSERT_TRUE(selector_->setDeviceBandwidth(kDev, 25.0).ok());
+        selector_->notePosted(kDev, 1 << 20, kNow);
+        selector_->maybeSampleTransmit(kDev, kNow);
+        selector_->notePostEnded(kDev, 1 << 20, kNow + (1 << 20));
+        selector_->noteCompleted(kDev, 1 << 20);
+        selector_->maybeSampleTransmit(kDev, kNow + (1 << 20));
+        ASSERT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+        ASSERT_EQ(selector_->getPostedBytes(kDev), 0u);
+    }
+
+    void TearDown() override {
+        for (auto* slice : slices_) RdmaSliceStorage::Get().deallocate(slice);
+        for (auto* task : tasks_) task->deref();
+    }
+
+    // A slice of `length` bytes due `window_ns` from kNow, charged to the NIC
+    // by the selector exactly as selectOptimalDevice() charges it.
+    RdmaSlice* makeSlice(uint64_t length, uint64_t window_ns) {
+        auto* task = RdmaTaskStorage::Get().allocate();
+        task->num_slices = 1;
+        task->status_word = PENDING;
+        task->first_error = PENDING;
+        task->ref();  // the batch's reference, dropped in TearDown
+        task->request.deadline_ns = kNow + window_ns;
+        auto* slice = RdmaSliceStorage::Get().allocate();
+        slice->task = task;
+        slice->length = length;
+        slice->word = PENDING;
+        slice->rail_monitor = nullptr;
+        int chosen = -1;
+        EXPECT_TRUE(selector_->allocate(length, "cpu:0", chosen).ok());
+        EXPECT_EQ(chosen, kDev);
+        slice->source_dev_id = chosen;
+        slice->charged_dev = chosen;
+        tasks_.push_back(task);
+        slices_.push_back(slice);
+        return slice;
+    }
+
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+    std::vector<RdmaTask*> tasks_;
+    std::vector<RdmaSlice*> slices_;
+};
+
+TEST_F(RdmaWorkersArbitrationTest, QueueAheadExcludesTheSlicesBeingOrdered) {
+    auto* big = makeSlice(40'000, 200'000);    // 40us of a 200us window: 0.20
+    auto* small = makeSlice(15'000, 100'000);  // 15us of a 100us window: 0.15
+    // Charged to the NIC by the selector, but not yet handed to hardware.
+    ASSERT_EQ(selector_->getInflightBytes(kDev), 55'000u);
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 0u);
+
+    std::vector<RdmaSlice*> slices{small, big};
+    RdmaTransportTestPeer::orderByDeadline(*workers_, slices, kDev, kNow);
+
+    // The NIC has nothing to move yet, so `big` is simply the more urgent of
+    // the two. Reading the allocation charge as queueing would count the
+    // batch's own 55'000 bytes and put `small`'s tighter window on top
+    // instead (0.70 vs 0.48).
+    EXPECT_EQ(slices[0], big);
+    EXPECT_EQ(slices[1], small);
+}
+
+TEST_F(RdmaWorkersArbitrationTest, QueueAheadCountsWorkOutsideTheBatch) {
+    auto* big = makeSlice(40'000, 200'000);
+    auto* small = makeSlice(15'000, 100'000);
+    // Another batch's slices, already posted to this NIC: 200us of work
+    // these two really do wait behind.
+    selector_->notePosted(kDev, 200'000, kNow);
+
+    std::vector<RdmaSlice*> slices{big, small};
+    RdmaTransportTestPeer::orderByDeadline(*workers_, slices, kDev, kNow);
+
+    // Behind it `small`'s 100us window is already gone (2.15) while `big`'s
+    // 200us one is not (1.20), so the order flips.
+    EXPECT_EQ(slices[0], small);
+    EXPECT_EQ(slices[1], big);
+    selector_->notePostEnded(kDev, 200'000, kNow);
 }
 
 // Two RDMA NICs, both reachable from the host buffer, and a Workers whose

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -105,15 +105,19 @@ class RdmaTransportTestPeer {
     }
 
     static void releaseSliceQuota(Workers& workers, RdmaSlice* slice,
-                                  double latency) {
-        workers.releaseSliceQuota(slice, latency);
+                                  uint64_t now_ns, double latency) {
+        workers.releaseSliceQuota(slice, now_ns, latency);
+    }
+
+    static void notePostedSlice(Workers& workers, RdmaSlice* slice) {
+        workers.notePostedSlice(slice);
     }
 
     static void handleCompletion(Workers& workers,
                                  Workers::WorkerContext& worker,
                                  RdmaContext& context, const ibv_wc& wc,
-                                 uint64_t poll_ts) {
-        workers.handleCompletion(worker, context, wc, poll_ts);
+                                 uint64_t poll_ts, bool last_in_pass = true) {
+        workers.handleCompletion(worker, context, wc, poll_ts, last_in_pass);
     }
 
     static void markPosted(Workers& workers, Workers::WorkerContext& worker,
@@ -137,8 +141,9 @@ class RdmaTransportTestPeer {
         return workers.worker_context_[i];
     }
     static void retireSweptSlice(Workers& workers, WorkerContext& self,
-                                 RdmaSlice* slice) {
-        workers.retireSweptSlice(self, slice, nullptr);
+                                 RdmaSlice* slice, uint64_t now_ns,
+                                 bool bytes_moved = false) {
+        workers.retireSweptSlice(self, slice, now_ns, nullptr, bytes_moved);
     }
     static void drainReclaimed(Workers& workers, WorkerContext& worker) {
         workers.drainReclaimed(worker);
@@ -979,7 +984,7 @@ class RdmaWorkersChargeTest : public ::testing::Test {
 // estimate, because the release is a no-op on an uncharged slice.
 TEST_F(RdmaWorkersChargeTest, RetryIsRechargedAndStillLearns) {
     // The error path hands the charge back and re-submits.
-    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kNow, 0.0);
     ASSERT_EQ(slice_->charged_dev, -1);
     ASSERT_EQ(selector_->getInflightBytes(0), 0u);
 
@@ -995,7 +1000,8 @@ TEST_F(RdmaWorkersChargeTest, RetryIsRechargedAndStillLearns) {
     // uncharged slice: the bytes would stay charged to nobody and the
     // sample would be lost.
     const double before = selector_->getAggregateEwmaBandwidth();
-    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kLen / 5e8);
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kNow + kLen,
+                                             kLen / 5e8);
     EXPECT_EQ(selector_->getInflightBytes(1), 0u);
     // Device 0 is untaught; device 1 adopted 0.5 GB/s in place of its seed.
     EXPECT_NEAR(selector_->getAggregateEwmaBandwidth(),
@@ -1014,7 +1020,7 @@ TEST_F(RdmaWorkersChargeTest, FallbackMovesTheChargeToTheNicItPostsOn) {
     EXPECT_EQ(selector_->getInflightBytes(0), 0u);
     EXPECT_EQ(selector_->getInflightBytes(1), kLen);
 
-    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kNow, 0.0);
     EXPECT_EQ(slice_->charged_dev, -1);
     EXPECT_EQ(selector_->getInflightBytes(0), 0u);
     EXPECT_EQ(selector_->getInflightBytes(1), 0u);
@@ -1029,7 +1035,7 @@ TEST_F(RdmaWorkersChargeTest, ChargeOnAnUntrackedDeviceKeepsTheOldOne) {
     EXPECT_EQ(slice_->charged_dev, 0);
     EXPECT_EQ(selector_->getInflightBytes(0), kLen);
 
-    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kNow, 0.0);
     EXPECT_EQ(slice_->charged_dev, -1);
     EXPECT_EQ(selector_->getInflightBytes(0), 0u);
 }
@@ -1081,15 +1087,18 @@ TEST(RdmaWorkersOwnershipTest, SweepByAnotherLaneIsRoutedToTheOwner) {
     ASSERT_TRUE(selector->allocate(kLen, "cpu:0", chosen).ok());
     slice->source_dev_id = chosen;
     slice->charged_dev = chosen;
+    RdmaTransportTestPeer::notePostedSlice(*workers, slice);
     lane_b.inflight_slice_set.insert(slice);
     lane_b.inflight_slices.store(1);
     // Lane A still holds an entry from an earlier attempt of the same slice
     // (a retry moved it to lane B before A's set was drained).
     lane_a.inflight_slice_set.insert(slice);
     ASSERT_EQ(selector->getInflightBytes(kDev), kLen);
+    ASSERT_EQ(selector->getPostedBytes(kDev), kLen);
 
     // Lane A sweeps it off the shared queue pair.
-    RdmaTransportTestPeer::retireSweptSlice(*workers, lane_a, slice);
+    RdmaTransportTestPeer::retireSweptSlice(*workers, lane_a, slice,
+                                            getCurrentTimeInNano());
 
     EXPECT_EQ(lane_a.inflight_slices.load(), 0);  // not lane A's to discount
     EXPECT_EQ(lane_b.inflight_slices.load(), 0);
@@ -1097,6 +1106,7 @@ TEST(RdmaWorkersOwnershipTest, SweepByAnotherLaneIsRoutedToTheOwner) {
     EXPECT_TRUE(lane_a.inflight_slice_set.empty());
     EXPECT_EQ(lane_b.inflight_slice_set.count(slice), 1u);  // owner erases it
     EXPECT_EQ(selector->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector->getPostedBytes(kDev), 0u);
 
     // ...on its own next pass.
     RdmaTransportTestPeer::drainReclaimed(*workers, lane_b);
@@ -1105,6 +1115,253 @@ TEST(RdmaWorkersOwnershipTest, SweepByAnotherLaneIsRoutedToTheOwner) {
     RdmaTransportTestPeer::destroyWorkerContexts(*workers);
     RdmaSliceStorage::Get().deallocate(slice);
     task->deref();
+}
+
+// What the completion path owes the NIC's accounting, driven with a
+// synthesized work completion: a successful one hands back the slice's
+// charge and its place in the backlog, then feeds the meter the bytes it
+// moved. An unsuccessful one returns the same accounting but teaches
+// nothing -- a flush burst must not drag the estimate down.
+class RdmaWorkersCompletionTest : public ::testing::Test {
+   protected:
+    static constexpr int kDev = 1;
+    static constexpr uint64_t kLen = 1 << 20;
+    static constexpr uint64_t kNow = 1'000'000'000;
+
+    void SetUp() override {
+        auto topology = std::make_shared<Topology>();
+        ASSERT_TRUE(topology
+                        ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                        .ok());
+        Topology::MemEntry mem;
+        mem.name = "cpu:0";
+        mem.type = Topology::MEM_HOST;
+        mem.numa_node = 0;
+        mem.device_list[0].push_back(kDev);
+        topology->mem_list_.push_back(mem);
+
+        RdmaTransportTestPeer::bindTopology(transport_, topology);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_TRUE(selector_->setDeviceAvailable(kDev, true).ok());
+        auto params = selector_->getSchedulingParams();
+        params.transmit_bandwidth_learning_rate = 0.0;  // adopt outright
+        params.transmit_meter_interval_ns = 0;          // sample on demand
+        selector_->setSchedulingParams(params);
+        ASSERT_TRUE(selector_->setDeviceBandwidth(kDev, 25.0).ok());
+
+        task_ = RdmaTaskStorage::Get().allocate();
+        task_->num_slices = 1;
+        task_->status_word = PENDING;
+        task_->first_error = PENDING;
+        task_->ref();  // the batch's reference
+        task_->ref();  // the slice's, dropped when it turns terminal
+        slice_ = RdmaSliceStorage::Get().allocate();
+        slice_->task = task_;
+        slice_->length = kLen;
+        slice_->word = PENDING;
+        slice_->rail_monitor = nullptr;
+        // Queued for a while before it was posted: the busy stretch must
+        // start at submit_ts, not enqueue_ts.
+        slice_->enqueue_ts = kNow - kLen;
+        slice_->submit_ts = kNow;
+        int chosen = -1;
+        ASSERT_TRUE(selector_->allocate(kLen, "cpu:0", chosen).ok());
+        ASSERT_EQ(chosen, kDev);
+        slice_->source_dev_id = chosen;
+        slice_->charged_dev = chosen;
+        // Posted to the hardware, and its endpoint is still around (never
+        // constructed, so acknowledge() sweeps nothing).
+        endpoint_ = std::make_shared<RdmaEndPoint>();
+        slice_->ep_weak_ptr = endpoint_;
+        RdmaTransportTestPeer::notePostedSlice(*workers_, slice_);
+        ASSERT_EQ(selector_->getPostedBytes(kDev), kLen);
+        // The meter's interval opens with the NIC holding this backlog.
+        selector_->maybeSampleTransmit(kDev, kNow);
+    }
+
+    void TearDown() override {
+        for (auto* slice : extra_slices_)
+            RdmaSliceStorage::Get().deallocate(slice);
+        for (auto* task : extra_tasks_) releaseTask(task);
+        if (slice_) RdmaSliceStorage::Get().deallocate(slice_);
+        if (task_) releaseTask(task_);
+    }
+
+    // The endpoint is never constructed, so acknowledge() sweeps nothing
+    // and a slice completed here never turns terminal; only the cancel
+    // paths drop the slice's reference. Drop whatever is left.
+    static void releaseTask(RdmaTask* task) {
+        for (int n = task->ref_count.load(); n > 0; --n) task->deref();
+    }
+
+    // Another slice on the same NIC, charged and posted at `submit_ts` the
+    // way asyncPostSend does it.
+    RdmaSlice* makeSlice(uint64_t submit_ts) {
+        auto* task = RdmaTaskStorage::Get().allocate();
+        task->num_slices = 1;
+        task->status_word = PENDING;
+        task->first_error = PENDING;
+        task->ref();  // the batch's reference
+        task->ref();  // the slice's, dropped when it turns terminal
+        auto* slice = RdmaSliceStorage::Get().allocate();
+        slice->task = task;
+        slice->length = kLen;
+        slice->word = PENDING;
+        slice->rail_monitor = nullptr;
+        slice->enqueue_ts = submit_ts - kLen;
+        slice->submit_ts = submit_ts;
+        int chosen = -1;
+        EXPECT_TRUE(selector_->allocate(kLen, "cpu:0", chosen).ok());
+        slice->source_dev_id = chosen;
+        slice->charged_dev = chosen;
+        slice->ep_weak_ptr = endpoint_;
+        RdmaTransportTestPeer::notePostedSlice(*workers_, slice);
+        extra_tasks_.push_back(task);
+        extra_slices_.push_back(slice);
+        return slice;
+    }
+
+    void completeAt(RdmaSlice* slice, ibv_wc_status status, uint64_t poll_ts,
+                    bool last_in_pass = true) {
+        ibv_wc wc{};
+        wc.wr_id = reinterpret_cast<uint64_t>(slice);
+        wc.status = status;
+        RdmaTransportTestPeer::handleCompletion(
+            *workers_, ctx_, *RdmaTransportTestPeer::contextSet(transport_)[0],
+            wc, poll_ts, last_in_pass);
+    }
+
+    void complete(ibv_wc_status status) {
+        completeAt(slice_, status, kNow + kLen);  // one byte per nanosecond
+    }
+
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+    RdmaTask* task_ = nullptr;
+    RdmaSlice* slice_ = nullptr;
+    std::shared_ptr<RdmaEndPoint> endpoint_;
+    RdmaTransportTestPeer::WorkerContext ctx_;
+    std::vector<RdmaTask*> extra_tasks_;
+    std::vector<RdmaSlice*> extra_slices_;
+};
+
+// One poll pass stamps every completion it reaps with the same timestamp.
+// Sampled at each of them, the first would divide its own bytes by the
+// busy time of the whole group, and the rest -- same timestamp, no later
+// than the baseline it just moved -- would be ignored: 0.5 GB/s for a
+// link that moved 2 MiB in 2 MiB ns. The pass samples once, at its end.
+TEST_F(RdmaWorkersCompletionTest, OnlyTheLastCompletionOfAPassSamples) {
+    auto* second = makeSlice(kNow);  // same burst: 2 MiB posted at kNow
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 2 * kLen);
+
+    completeAt(slice_, IBV_WC_SUCCESS, kNow + 2 * kLen, /*last_in_pass=*/false);
+    completeAt(second, IBV_WC_SUCCESS, kNow + 2 * kLen, /*last_in_pass=*/true);
+
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+TEST_F(RdmaWorkersCompletionTest, SuccessFeedsTheMeter) {
+    complete(IBV_WC_SUCCESS);
+
+    EXPECT_EQ(slice_->charged_dev, -1);
+    EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// The workers' half of the busy-time meter. Which stretches get charged for
+// the bytes is decided by the timestamps this layer hands down -- the
+// slice's submit_ts when it reaches the hardware, the poll timestamp when it
+// leaves -- and nothing else pins that wiring. Two bursts far apart, each
+// moved at one byte per nanosecond, have to read as one byte per nanosecond:
+// the wait between them is the NIC having nothing to do, not a slow link.
+TEST_F(RdmaWorkersCompletionTest, IdleBetweenBurstsIsNotChargedToTheLink) {
+    complete(IBV_WC_SUCCESS);  // kNow -> kNow + kLen
+    ASSERT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 0u);  // the NIC goes idle
+
+    // The next burst starts ten times its own wire time later.
+    const uint64_t start = kNow + 10 * kLen;
+    auto* second = makeSlice(start);
+    completeAt(second, IBV_WC_SUCCESS, start + kLen);
+
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// A slice that fails carries no wire time to learn from, but it does end a
+// busy stretch: the meter must not later charge its bytes-less span to the
+// next sample.
+TEST_F(RdmaWorkersCompletionTest, AFailedSliceEndsItsStretchWithoutTeaching) {
+    task_->cancel_requested.store(true);  // stop short of a re-submit
+    complete(IBV_WC_RETRY_EXC_ERR);
+    ASSERT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);  // seed
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 0u);
+
+    // The failure abandoned the meter's interval: the next completion only
+    // rebuilds the baselines, and its busy time -- not the failed slice's --
+    // is what the completion after that divides its bytes into.
+    const uint64_t start = kNow + 10 * kLen;
+    auto* second = makeSlice(start);
+    completeAt(second, IBV_WC_SUCCESS, start + kLen);
+    ASSERT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);
+
+    auto* third = makeSlice(start + kLen);
+    completeAt(third, IBV_WC_SUCCESS, start + 2 * kLen);  // one byte per ns
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// A slice resolved before its completion is polled -- timed out through a
+// stale entry on another lane, or cancelled by a teardown -- was re-counted
+// here when it was re-queued, and nothing but its completion is left to
+// take it out of this lane's count again.
+TEST_F(RdmaWorkersCompletionTest, ResolvedSliceStillLeavesTheLaneCount) {
+    slice_->word = TIMEOUT;
+    slice_->counted_lane = 0;
+    ctx_.inflight_slices.store(1);
+
+    complete(IBV_WC_SUCCESS);
+
+    EXPECT_EQ(ctx_.inflight_slices.load(), 0);
+    EXPECT_EQ(slice_->charged_dev, -1);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
+}
+
+// A predecessor swept along with a COMPLETED slice did move its bytes; its
+// own completion is still coming to credit them, so the meter's interval
+// must survive the sweep.
+TEST_F(RdmaWorkersCompletionTest, SweptAsCompletedKeepsTheMeterInterval) {
+    RdmaTransportTestPeer::retireSweptSlice(*workers_, ctx_, slice_,
+                                            kNow + kLen, /*bytes_moved=*/true);
+    selector_->noteCompleted(kDev, kLen);
+    selector_->maybeSampleTransmit(kDev, kNow + kLen);  // one byte per ns
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// One swept with FAILED or TIMEOUT did not: its busy time has nothing to be
+// divided into, so the next sample only rebuilds the baselines.
+TEST_F(RdmaWorkersCompletionTest, SweptAsFailedAbandonsTheMeterInterval) {
+    RdmaTransportTestPeer::retireSweptSlice(*workers_, ctx_, slice_,
+                                            kNow + kLen);
+    selector_->noteCompleted(kDev, kLen);
+    selector_->maybeSampleTransmit(kDev, kNow + kLen);
+    EXPECT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);  // seed
+}
+
+TEST_F(RdmaWorkersCompletionTest, FlushedCompletionTeachesNothing) {
+    // A queue pair reset flushes every posted work request at once; those
+    // completions carry no wire time.
+    task_->cancel_requested.store(true);  // stop short of a re-submit
+    complete(IBV_WC_WR_FLUSH_ERR);
+
+    EXPECT_EQ(slice_->charged_dev, -1);
+    EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
+    EXPECT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);  // seed
 }
 
 // A queue pair shared by two worker lanes (the qp_pools layout): the lane
@@ -1282,6 +1539,7 @@ TEST_F(RdmaWorkersSharedQpTest, TimeoutSweepGivesTheOtherLaneItsSliceBack) {
     auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
     auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
     ASSERT_EQ(selector_->getInflightBytes(kDev), 2 * kLen);
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 2 * kLen);
 
     RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);  // 1 ms
     RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane0,
@@ -1293,6 +1551,7 @@ TEST_F(RdmaWorkersSharedQpTest, TimeoutSweepGivesTheOtherLaneItsSliceBack) {
     EXPECT_EQ(ours->charged_dev, -1);
     EXPECT_EQ(theirs->charged_dev, -1);
     EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
 
     // Each lane's own count came back down, and lane 1's set entry is waiting
     // for lane 1 rather than having been erased from under it.
@@ -1315,6 +1574,7 @@ TEST_F(RdmaWorkersSharedQpTest, TeardownLeftoversAreReclaimedByTheirLane) {
     auto* ours = postSlice(/*lane=*/0, /*enqueue_ts=*/0);
     auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
     auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 2 * kLen);
 
     ASSERT_EQ(endpoint_->deconstruct(), 0);
     ASSERT_EQ(ours->word, CANCELED);
@@ -1327,6 +1587,7 @@ TEST_F(RdmaWorkersSharedQpTest, TeardownLeftoversAreReclaimedByTheirLane) {
                                                 /*now_ns=*/2'000'000);
 
     EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
     EXPECT_EQ(lane0.inflight_slices.load(), 0);
     EXPECT_EQ(lane1.inflight_slices.load(), 0);
     EXPECT_TRUE(lane0.inflight_slice_set.empty());
@@ -1339,8 +1600,14 @@ TEST_F(RdmaWorkersSharedQpTest, TeardownLeftoversAreReclaimedByTheirLane) {
 // next decrement has to come back with it. Otherwise the completion that
 // finally resolves the slice cannot take it out of the count again, and the
 // lane it belongs to never reaches zero: it stops suspending, and it looks
-// permanently loaded to submit()'s least-loaded-lane pick.
+// permanently loaded to submit()'s least-loaded-lane pick. The retry's
+// own completion is a transmit sample like any other.
 TEST_F(RdmaWorkersSharedQpTest, RetriedSliceIsStillCountedByItsLane) {
+    auto params = selector_->getSchedulingParams();
+    params.transmit_bandwidth_learning_rate = 0.0;  // adopt outright
+    params.transmit_meter_interval_ns = 0;          // sample on demand
+    selector_->setSchedulingParams(params);
+    ASSERT_TRUE(selector_->setDeviceBandwidth(kDev, 25.0).ok());
     constexpr uint64_t kPosted = 1'000'000;
 
     auto* slice = postSlice(/*lane=*/0, /*enqueue_ts=*/kPosted);
@@ -1352,14 +1619,56 @@ TEST_F(RdmaWorkersSharedQpTest, RetriedSliceIsStillCountedByItsLane) {
     ASSERT_EQ(slice->word, PENDING);
     ASSERT_EQ(slice->retry_count, 1);
     EXPECT_EQ(lane0.inflight_slices.load(), 1);  // queued again, still counted
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
 
-    // Second attempt reaches the hardware and succeeds.
+    // Second attempt reaches the hardware and succeeds. The failure ended
+    // the meter's interval, so the next sample only rebuilds its baselines:
+    // taken at the re-post, as a poll pass in between would, so that the
+    // retry's own 1 MiB over its own 1 MiB ns is what the completion
+    // measures.
     repost(slice, /*lane=*/0, kPosted + 2 * kLen);
+    selector_->maybeSampleTransmit(kDev, kPosted + 2 * kLen);
+    ASSERT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);
     completeWith(slice, IBV_WC_SUCCESS, kPosted + 3 * kLen);
 
     EXPECT_EQ(slice->word, COMPLETED);
     EXPECT_EQ(lane0.inflight_slices.load(), 0);
     EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(selector_->getPostedBytes(kDev), 0u);
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
+}
+
+// A completion sweeps everything posted before it on the queue pair off
+// with COMPLETED. Those bytes moved -- their own completions, still to be
+// polled, credit them -- so the sweep must not abandon the meter's
+// interval the way a FAILED or TIMEOUT sweep does. The completion samples
+// before it sweeps, so the evidence is the sample after: 1 MiB over the
+// next 1 MiB ns reads 1 GB/s, where a reset would have that sample rebuild
+// its baselines and learn nothing.
+TEST_F(RdmaWorkersSharedQpTest, CompletionSweepKeepsTheMeterInterval) {
+    auto params = selector_->getSchedulingParams();
+    params.transmit_bandwidth_learning_rate = 0.0;  // adopt outright
+    params.transmit_meter_interval_ns = 0;          // sample on demand
+    selector_->setSchedulingParams(params);
+    ASSERT_TRUE(selector_->setDeviceBandwidth(kDev, 25.0).ok());
+    constexpr uint64_t kPosted = 1'000'000;
+
+    auto* first = postSlice(/*lane=*/0, /*enqueue_ts=*/kPosted);
+    auto* second = postSlice(/*lane=*/0, /*enqueue_ts=*/kPosted);
+    selector_->maybeSampleTransmit(kDev, kPosted);  // baseline
+    ASSERT_DOUBLE_EQ(selector_->getTransmitBandwidth(kDev), 3.125e9);
+
+    // Its own sample, with `first` still posted: 1 MiB over 2 MiB ns.
+    completeWith(second, IBV_WC_SUCCESS, kPosted + 2 * kLen);
+    ASSERT_EQ(first->word, COMPLETED);
+    ASSERT_EQ(second->word, COMPLETED);
+    ASSERT_EQ(selector_->getPostedBytes(kDev), 0u);
+    ASSERT_NEAR(selector_->getTransmitBandwidth(kDev), 0.5e9, 1.0);
+
+    auto* third = postSlice(/*lane=*/0, /*enqueue_ts=*/kPosted + 2 * kLen);
+    completeWith(third, IBV_WC_SUCCESS, kPosted + 3 * kLen);
+
+    EXPECT_NEAR(selector_->getTransmitBandwidth(kDev), 1e9, 1.0);
 }
 
 // Same retry, on the layout this fixture exists for: lane 1 enqueued the

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -33,9 +33,12 @@
 #include "tent/transfer_engine.h"
 #include "tent/runtime/topology.h"
 #include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/endpoint.h"
+#include "tent/transport/rdma/endpoint_store.h"
 #include "tent/transport/rdma/params.h"
 #include "tent/transport/rdma/quota.h"
 #include "tent/transport/rdma/rdma_transport.h"
+#include "tent/transport/rdma/slice.h"
 #include "tent/transport/rdma/ibv_loader.h"
 #include "tent/transport/rdma/workers.h"
 
@@ -96,6 +99,68 @@ class RdmaTransportTestPeer {
         return RdmaTransport::classifyNotifyCompletion(status, endpoint_alive,
                                                        endpoint_ready);
     }
+
+    static void rechargeSlice(Workers& workers, RdmaSlice* slice, int dev_id) {
+        workers.rechargeSlice(slice, dev_id);
+    }
+
+    static void releaseSliceQuota(Workers& workers, RdmaSlice* slice,
+                                  double latency) {
+        workers.releaseSliceQuota(slice, latency);
+    }
+
+    static void handleCompletion(Workers& workers,
+                                 Workers::WorkerContext& worker,
+                                 RdmaContext& context, const ibv_wc& wc,
+                                 uint64_t poll_ts) {
+        workers.handleCompletion(worker, context, wc, poll_ts);
+    }
+
+    static void markPosted(Workers& workers, Workers::WorkerContext& worker,
+                           RdmaSlice* slice, uint64_t post_ts) {
+        workers.markPosted(worker, slice, post_ts);
+    }
+
+    using WorkerContext = Workers::WorkerContext;
+
+    // Stands in for start(): the lane array without any threads.
+    static void makeWorkerContexts(Workers& workers, size_t n) {
+        workers.worker_context_ = new WorkerContext[n];
+        workers.num_workers_ = n;
+    }
+    static void destroyWorkerContexts(Workers& workers) {
+        delete[] workers.worker_context_;
+        workers.worker_context_ = nullptr;
+        workers.num_workers_ = 0;
+    }
+    static WorkerContext& workerContext(Workers& workers, size_t i) {
+        return workers.worker_context_[i];
+    }
+    static void retireSweptSlice(Workers& workers, WorkerContext& self,
+                                 RdmaSlice* slice) {
+        workers.retireSweptSlice(self, slice, nullptr);
+    }
+    static void drainReclaimed(Workers& workers, WorkerContext& worker) {
+        workers.drainReclaimed(worker);
+    }
+    // Drop the handover list without touching the set, to model a lane that
+    // drained it just before another lane handed an entry over.
+    static void clearReclaimed(WorkerContext& worker) {
+        std::lock_guard<std::mutex> lock(worker.reclaim_mutex);
+        worker.reclaimed.clear();
+    }
+    static bool dropUnpostableSlice(Workers& workers, WorkerContext& worker,
+                                    RdmaSlice* slice) {
+        return workers.dropUnpostableSlice(worker, slice);
+    }
+
+    static void setSliceTimeout(Workers& workers, uint64_t ns) {
+        workers.slice_timeout_ns_ = ns;
+    }
+    static void expireTimedOutSlices(Workers& workers, WorkerContext& ctx,
+                                     uint64_t now_ns) {
+        workers.expireTimedOutSlices(ctx, now_ns);
+    }
 };
 
 // Friend accessor for RdmaContext: TENT reaches libibverbs through a table of
@@ -114,8 +179,41 @@ class RdmaContextTestPeer {
         context.params_ = std::move(params);
     }
 
+    // The rest of what enable() would build, for a test that only needs a
+    // context complete enough to construct endpoints on.
+    static void bindResources(RdmaContext& context, ibv_pd* pd,
+                              std::vector<RdmaCQ*> cqs, RdmaCQ* notify_cq) {
+        context.native_pd_ = pd;
+        context.cq_list_ = std::move(cqs);
+        context.notify_cq_ = notify_cq;
+        context.endpoint_store_ =
+            std::make_shared<SIEVEEndpointStore>(context, 16);
+    }
+
+    static void unbindResources(RdmaContext& context) {
+        context.native_pd_ = nullptr;
+        context.cq_list_.clear();
+        context.notify_cq_ = nullptr;
+        context.endpoint_store_.reset();
+    }
+
     static void unbindDevice(RdmaContext& context) {
         context.native_context_ = nullptr;
+    }
+};
+
+// Friend accessor for RdmaEndPoint. Posting is the one step in the data
+// path that does not go through the injectable verbs table (ibv_post_send is
+// an inline that dispatches through the queue pair), so a test stands in for
+// it and puts the slice on the queue pair the way submitSlices would.
+class RdmaEndPointTestPeer {
+   public:
+    static void pretendPosted(const std::shared_ptr<RdmaEndPoint>& endpoint,
+                              int qp_index, RdmaSlice* slice) {
+        ASSERT_TRUE(endpoint->reserveQuota(qp_index, 1));
+        slice->qp_index = qp_index;
+        slice->ep_weak_ptr = endpoint;
+        endpoint->slice_queue_[qp_index].push(slice);
     }
 };
 
@@ -703,6 +801,643 @@ TEST(RdmaContextEventChainTest, PortActiveReseedsOnlyWhenTheSpeedChanged) {
     EXPECT_TRUE(selector->isDeviceAvailable(kDev));
 
     RdmaContextTestPeer::unbindDevice(context);
+}
+
+// A slice that hits the software timeout turns terminal here, not on the CQ,
+// and its flush completion is not guaranteed to be polled, so the timeout
+// path must return the selector's inflight charge itself.
+class RdmaWorkersTimeoutTest : public ::testing::Test {
+   protected:
+    static constexpr int kDev = 1;
+    static constexpr uint64_t kLen = 1 << 20;
+
+    void SetUp() override {
+        auto topology = std::make_shared<Topology>();
+        ASSERT_TRUE(topology
+                        ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                        .ok());
+        Topology::MemEntry mem;
+        mem.name = "cpu:0";
+        mem.type = Topology::MEM_HOST;
+        mem.numa_node = 0;
+        mem.device_list[0].push_back(1);
+        topology->mem_list_.push_back(mem);
+
+        RdmaTransportTestPeer::bindTopology(transport_, topology);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_TRUE(selector_->setDeviceAvailable(kDev, true).ok());
+
+        // Charge the slice to the NIC exactly as selectOptimalDevice() does.
+        task_ = RdmaTaskStorage::Get().allocate();
+        task_->num_slices = 1;
+        task_->status_word = PENDING;
+        task_->first_error = PENDING;
+        task_->ref();  // the batch's reference
+        task_->ref();  // the slice's reference, dropped by updateSliceStatus()
+        slice_ = RdmaSliceStorage::Get().allocate();
+        slice_->task = task_;
+        slice_->length = kLen;
+        slice_->word = PENDING;
+        slice_->enqueue_ts = 0;  // enqueued at t=0
+        slice_->rail_monitor = nullptr;
+        int chosen = -1;
+        ASSERT_TRUE(selector_->allocate(kLen, "cpu:0", chosen).ok());
+        ASSERT_EQ(chosen, kDev);
+        slice_->source_dev_id = chosen;
+        slice_->charged_dev = chosen;
+        slice_->counted_lane = 0;  // as Workers::submit() marks it
+        ASSERT_EQ(selector_->getInflightBytes(kDev), kLen);
+
+        ctx_.inflight_slice_set.insert(slice_);
+        RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);  // 1 ms
+    }
+
+    void TearDown() override {
+        if (slice_) RdmaSliceStorage::Get().deallocate(slice_);
+        if (task_) task_->deref();  // drops the batch's reference; frees it
+    }
+
+    void expire() {
+        RdmaTransportTestPeer::expireTimedOutSlices(*workers_, ctx_,
+                                                    /*now_ns=*/2'000'000);
+    }
+
+    void expectTimedOutAndReleased() {
+        EXPECT_EQ(slice_->word, TIMEOUT);
+        EXPECT_TRUE(ctx_.inflight_slice_set.empty());
+        EXPECT_EQ(slice_->charged_dev, -1);
+        EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    }
+
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+    RdmaTask* task_ = nullptr;
+    RdmaSlice* slice_ = nullptr;
+    RdmaTransportTestPeer::WorkerContext ctx_;
+};
+
+TEST_F(RdmaWorkersTimeoutTest, EndpointGoneReleasesSelectorInflightCharge) {
+    slice_->ep_weak_ptr.reset();  // endpoint already gone
+    ctx_.inflight_slices.store(1);
+
+    expire();
+
+    expectTimedOutAndReleased();
+    EXPECT_EQ(ctx_.inflight_slices.load(), 0);
+}
+
+// The slice's endpoint is alive but no longer holds it (a neighbour's retry
+// popped it with PENDING and its count), so acknowledge() sweeps nothing;
+// the timeout path still has to fail it and return its charge.
+TEST_F(RdmaWorkersTimeoutTest, NotOnQueueStillReleasesSelectorInflightCharge) {
+    auto endpoint = std::make_shared<RdmaEndPoint>();  // never constructed
+    slice_->ep_weak_ptr = endpoint;
+    slice_->qp_index = 0;
+    ctx_.inflight_slices.store(0);  // already dropped with the neighbour's
+
+    expire();
+
+    expectTimedOutAndReleased();
+    EXPECT_EQ(ctx_.inflight_slices.load(), 0);
+}
+
+// Two RDMA NICs, both reachable from the host buffer, and a Workers whose
+// selector is set to adopt every selection sample outright.
+class RdmaWorkersChargeTest : public ::testing::Test {
+   protected:
+    static constexpr uint64_t kLen = 1 << 20;
+    static constexpr uint64_t kNow = 1'000'000'000;
+
+    void SetUp() override {
+        auto topology = std::make_shared<Topology>();
+        ASSERT_TRUE(topology
+                        ->parse(R"({"nics":[
+                        {"name":"mc-absent-rnic-0","type":0,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                        .ok());
+        Topology::MemEntry mem;
+        mem.name = "cpu:0";
+        mem.type = Topology::MEM_HOST;
+        mem.numa_node = 0;
+        mem.device_list[0].push_back(0);
+        mem.device_list[0].push_back(1);
+        topology->mem_list_.push_back(mem);
+
+        RdmaTransportTestPeer::bindTopology(transport_, topology);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        auto params = selector_->getSchedulingParams();
+        params.bandwidth_learning_rate = 0.0;  // adopt the sample
+        selector_->setSchedulingParams(params);
+        for (int dev : {0, 1}) {
+            ASSERT_TRUE(selector_->setDeviceAvailable(dev, true).ok());
+            ASSERT_TRUE(selector_->setDeviceBandwidth(dev, 25.0).ok());
+        }
+
+        task_ = RdmaTaskStorage::Get().allocate();
+        task_->num_slices = 1;
+        task_->status_word = PENDING;
+        task_->first_error = PENDING;
+        task_->ref();
+        slice_ = RdmaSliceStorage::Get().allocate();
+        slice_->task = task_;
+        slice_->length = kLen;
+        slice_->word = PENDING;
+        slice_->rail_monitor = nullptr;
+        // Allocated on NIC 0, as submitTransferTasks charges it.
+        int chosen = -1;
+        ASSERT_TRUE(
+            selector_->allocate(kLen, "cpu:0", chosen, PRIO_HIGH, 1ULL << 0)
+                .ok());
+        ASSERT_EQ(chosen, 0);
+        slice_->source_dev_id = chosen;
+        slice_->charged_dev = chosen;
+        ASSERT_EQ(selector_->getInflightBytes(0), kLen);
+    }
+
+    void TearDown() override {
+        RdmaSliceStorage::Get().deallocate(slice_);
+        task_->deref();
+    }
+
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+    RdmaTask* task_ = nullptr;
+    RdmaSlice* slice_ = nullptr;
+};
+
+// The CQ error path returns a slice's charge before re-submitting it, and
+// the retry picks its device again. Without a fresh charge the NIC's
+// inflight bytes miss the retry entirely and its completion teaches neither
+// estimate, because the release is a no-op on an uncharged slice.
+TEST_F(RdmaWorkersChargeTest, RetryIsRechargedAndStillLearns) {
+    // The error path hands the charge back and re-submits.
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    ASSERT_EQ(slice_->charged_dev, -1);
+    ASSERT_EQ(selector_->getInflightBytes(0), 0u);
+
+    // The retry settles on the fallback NIC.
+    RdmaTransportTestPeer::rechargeSlice(*workers_, slice_, 1);
+    slice_->source_dev_id = 1;  // as selectFallbackDevice does next
+    EXPECT_EQ(slice_->charged_dev, 1);
+    EXPECT_EQ(selector_->getInflightBytes(1), kLen);
+    EXPECT_EQ(selector_->getInflightBytes(0), 0u);
+
+    // Its completion returns the charge and teaches the selector the rate
+    // it saw. Without the recharge above the release would be a no-op on an
+    // uncharged slice: the bytes would stay charged to nobody and the
+    // sample would be lost.
+    const double before = selector_->getAggregateEwmaBandwidth();
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, kLen / 5e8);
+    EXPECT_EQ(selector_->getInflightBytes(1), 0u);
+    // Device 0 is untaught; device 1 adopted 0.5 GB/s in place of its seed.
+    EXPECT_NEAR(selector_->getAggregateEwmaBandwidth(),
+                before - 3.125e9 + 0.5e9, 1.0);
+}
+
+// A first attempt that falls back to another NIC is still charged to the
+// one the allocator picked. The charge moves with the routing: the fallback
+// NIC is charged first, then the original is paid back, so a release racing
+// in between finds one of them on record and never both.
+TEST_F(RdmaWorkersChargeTest, FallbackMovesTheChargeToTheNicItPostsOn) {
+    RdmaTransportTestPeer::rechargeSlice(*workers_, slice_, 1);
+    slice_->source_dev_id = 1;
+
+    EXPECT_EQ(slice_->charged_dev, 1);
+    EXPECT_EQ(selector_->getInflightBytes(0), 0u);
+    EXPECT_EQ(selector_->getInflightBytes(1), kLen);
+
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    EXPECT_EQ(slice_->charged_dev, -1);
+    EXPECT_EQ(selector_->getInflightBytes(0), 0u);
+    EXPECT_EQ(selector_->getInflightBytes(1), 0u);
+}
+
+// A device the selector does not track cannot be charged. The slice keeps
+// the charge it has rather than ending up charged to nobody, so the release
+// still balances the NIC that was charged and nothing underflows.
+TEST_F(RdmaWorkersChargeTest, ChargeOnAnUntrackedDeviceKeepsTheOldOne) {
+    RdmaTransportTestPeer::rechargeSlice(*workers_, slice_, 999);
+
+    EXPECT_EQ(slice_->charged_dev, 0);
+    EXPECT_EQ(selector_->getInflightBytes(0), kLen);
+
+    RdmaTransportTestPeer::releaseSliceQuota(*workers_, slice_, 0.0);
+    EXPECT_EQ(slice_->charged_dev, -1);
+    EXPECT_EQ(selector_->getInflightBytes(0), 0u);
+}
+
+// With qp_pools several worker lanes share a queue pair, so the lane that
+// sweeps a slice off it is often not the lane that enqueued it. The sweep
+// must give the accounting back to the owner: its set entry, its place in
+// its inflight count, and its selector charge.
+TEST(RdmaWorkersOwnershipTest, SweepByAnotherLaneIsRoutedToTheOwner) {
+    constexpr int kDev = 1;
+    constexpr uint64_t kLen = 1 << 20;
+    auto topology = std::make_shared<Topology>();
+    ASSERT_TRUE(topology
+                    ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                    .ok());
+    Topology::MemEntry mem;
+    mem.name = "cpu:0";
+    mem.type = Topology::MEM_HOST;
+    mem.numa_node = 0;
+    mem.device_list[0].push_back(kDev);
+    topology->mem_list_.push_back(mem);
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport), 0u);
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    auto* selector = workers->getDeviceSelector();
+    ASSERT_TRUE(selector->setDeviceAvailable(kDev, true).ok());
+    RdmaTransportTestPeer::makeWorkerContexts(*workers, 2);
+    auto& lane_a = RdmaTransportTestPeer::workerContext(*workers, 0);
+    auto& lane_b = RdmaTransportTestPeer::workerContext(*workers, 1);
+
+    // Lane B enqueued and posted the slice.
+    auto* task = RdmaTaskStorage::Get().allocate();
+    task->num_slices = 1;
+    task->status_word = PENDING;
+    task->first_error = PENDING;
+    task->ref();
+    auto* slice = RdmaSliceStorage::Get().allocate();
+    slice->task = task;
+    slice->length = kLen;
+    slice->word = PENDING;
+    slice->rail_monitor = nullptr;
+    slice->owner_worker = 1;
+    slice->counted_lane = 1;  // as Workers::submit() marks it
+    int chosen = -1;
+    ASSERT_TRUE(selector->allocate(kLen, "cpu:0", chosen).ok());
+    slice->source_dev_id = chosen;
+    slice->charged_dev = chosen;
+    lane_b.inflight_slice_set.insert(slice);
+    lane_b.inflight_slices.store(1);
+    // Lane A still holds an entry from an earlier attempt of the same slice
+    // (a retry moved it to lane B before A's set was drained).
+    lane_a.inflight_slice_set.insert(slice);
+    ASSERT_EQ(selector->getInflightBytes(kDev), kLen);
+
+    // Lane A sweeps it off the shared queue pair.
+    RdmaTransportTestPeer::retireSweptSlice(*workers, lane_a, slice);
+
+    EXPECT_EQ(lane_a.inflight_slices.load(), 0);  // not lane A's to discount
+    EXPECT_EQ(lane_b.inflight_slices.load(), 0);
+    // A took out its own stale entry; B's is handed over, not touched.
+    EXPECT_TRUE(lane_a.inflight_slice_set.empty());
+    EXPECT_EQ(lane_b.inflight_slice_set.count(slice), 1u);  // owner erases it
+    EXPECT_EQ(selector->getInflightBytes(kDev), 0u);
+
+    // ...on its own next pass.
+    RdmaTransportTestPeer::drainReclaimed(*workers, lane_b);
+    EXPECT_TRUE(lane_b.inflight_slice_set.empty());
+
+    RdmaTransportTestPeer::destroyWorkerContexts(*workers);
+    RdmaSliceStorage::Get().deallocate(slice);
+    task->deref();
+}
+
+// A queue pair shared by two worker lanes (the qp_pools layout): the lane
+// that sweeps a completion off it is not the lane that enqueued the slices,
+// so acknowledge() hands back slices belonging to somebody else. Everything
+// the sweep gives back has to land on the owner.
+class RdmaWorkersSharedQpTest : public ::testing::Test {
+   protected:
+    static constexpr int kDev = 1;
+    static constexpr uint64_t kLen = 1 << 20;
+
+    // Verbs stand-ins: enough for a context to hand out a protection domain
+    // and a completion queue, and for an endpoint to create its queue pairs.
+    struct FakeState {
+        ibv_context native{};
+        ibv_pd pd{};
+        ibv_cq cq{};
+        ibv_qp qp[8]{};
+        int next_qp = 0;
+        ibv_mr mr{};
+    };
+    static FakeState fake;
+
+    static ibv_cq* createCq(ibv_context*, int, void*, ibv_comp_channel*, int) {
+        return &fake.cq;
+    }
+    static int destroyCq(ibv_cq*) { return 0; }
+    static ibv_qp* createQp(ibv_pd*, ibv_qp_init_attr*) {
+        return &fake.qp[fake.next_qp++];
+    }
+    static int destroyQp(ibv_qp*) { return 0; }
+    static int modifyQp(ibv_qp*, ibv_qp_attr*, int) { return 0; }
+    static ibv_mr* regMr(ibv_pd*, void*, size_t, int) { return &fake.mr; }
+    static int deregMr(ibv_mr*) { return 0; }
+
+    void SetUp() override {
+        fake = FakeState{};
+        fake.native.num_comp_vectors = 1;
+
+        auto topology = std::make_shared<Topology>();
+        ASSERT_TRUE(topology
+                        ->parse(R"({"nics":[
+                        {"name":"mc-tcp-0","type":1,"numa_node":0},
+                        {"name":"mc-absent-rnic-1","type":0,"numa_node":0}]})")
+                        .ok());
+        Topology::MemEntry mem;
+        mem.name = "cpu:0";
+        mem.type = Topology::MEM_HOST;
+        mem.numa_node = 0;
+        mem.device_list[0].push_back(kDev);
+        topology->mem_list_.push_back(mem);
+        RdmaTransportTestPeer::bindTopology(transport_, topology);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+        selector_ = workers_->getDeviceSelector();
+        ASSERT_TRUE(selector_->setDeviceAvailable(kDev, true).ok());
+        RdmaTransportTestPeer::makeWorkerContexts(*workers_, 2);
+
+        // One queue pair for both lanes, the layout that makes the sweep
+        // cross lanes.
+        params_ = std::make_shared<RdmaParams>();
+        params_->device.num_cq_list = 1;
+        params_->endpoint.qp_mul_factor = 1;
+
+        context_ = RdmaTransportTestPeer::contextSet(transport_)[kDev];
+        auto& verbs = RdmaContextTestPeer::verbs(*context_);
+        verbs.ibv_create_cq = createCq;
+        verbs.ibv_destroy_cq = destroyCq;
+        verbs.ibv_create_qp = createQp;
+        verbs.ibv_destroy_qp = destroyQp;
+        verbs.ibv_modify_qp = modifyQp;
+        verbs.ibv_reg_mr_default = regMr;
+        verbs.ibv_dereg_mr = deregMr;
+        RdmaContextTestPeer::bindDevice(*context_, &fake.native, params_);
+        ASSERT_EQ(cq_.construct(context_.get(), 4096, 0), 0);
+        ASSERT_EQ(notify_cq_.construct(context_.get(), 4096, 0), 0);
+        RdmaContextTestPeer::bindResources(*context_, &fake.pd, {&cq_},
+                                           &notify_cq_);
+
+        endpoint_ = std::make_shared<RdmaEndPoint>();
+        ASSERT_EQ(
+            endpoint_->construct(context_.get(), &params_->endpoint, "peer:0"),
+            0);
+    }
+
+    void TearDown() override {
+        // The endpoint goes first: deconstruct() returns its work-request
+        // quota through the context's completion queue, which
+        // unbindResources takes away below.
+        endpoint_.reset();
+        for (auto* slice : slices_) RdmaSliceStorage::Get().deallocate(slice);
+        for (auto* task : tasks_) task->deref();
+        if (workers_) RdmaTransportTestPeer::destroyWorkerContexts(*workers_);
+        if (context_) {
+            RdmaContextTestPeer::unbindResources(*context_);
+            RdmaContextTestPeer::unbindDevice(*context_);
+        }
+    }
+
+    // A slice charged to the NIC, owned by `lane`, and posted on the shared
+    // queue pair.
+    RdmaSlice* postSlice(int lane, uint64_t enqueue_ts) {
+        auto* task = RdmaTaskStorage::Get().allocate();
+        task->num_slices = 1;
+        task->status_word = PENDING;
+        task->first_error = PENDING;
+        task->ref();  // the batch's reference
+        task->ref();  // the slice's, dropped by updateSliceStatus()
+        auto* slice = RdmaSliceStorage::Get().allocate();
+        slice->task = task;
+        slice->length = kLen;
+        slice->word = PENDING;
+        slice->rail_monitor = nullptr;
+        slice->enqueue_ts = enqueue_ts;
+        slice->owner_worker = lane;
+        int chosen = -1;
+        EXPECT_TRUE(selector_->allocate(kLen, "cpu:0", chosen).ok());
+        slice->source_dev_id = chosen;
+        slice->charged_dev = chosen;
+        slice->counted_lane = lane;  // as Workers::submit() marks it
+        auto& ctx = RdmaTransportTestPeer::workerContext(*workers_, lane);
+        ctx.inflight_slices.fetch_add(1);
+        // Posted straight away, as the hook inside submitSlices does it.
+        RdmaTransportTestPeer::markPosted(*workers_, ctx, slice, enqueue_ts);
+        RdmaEndPointTestPeer::pretendPosted(endpoint_, 0, slice);
+        tasks_.push_back(task);
+        slices_.push_back(slice);
+        return slice;
+    }
+
+    // Drive one completion for `slice` through lane 0's poll path.
+    void completeWith(RdmaSlice* slice, ibv_wc_status status,
+                      uint64_t poll_ts = 1'000'000) {
+        ibv_wc wc{};
+        wc.wr_id = reinterpret_cast<uint64_t>(slice);
+        wc.status = status;
+        RdmaTransportTestPeer::handleCompletion(
+            *workers_, RdmaTransportTestPeer::workerContext(*workers_, 0),
+            *context_, wc, poll_ts);
+    }
+
+    // What asyncPostSend does with a re-queued slice on its next pass, minus
+    // the routing it needs a live segment for: take it off the lane's queue,
+    // charge it again and put it back on the queue pair at `post_ts`.
+    void repost(RdmaSlice* slice, int lane, uint64_t post_ts = 1'000'000) {
+        auto& ctx = RdmaTransportTestPeer::workerContext(*workers_, lane);
+        std::vector<RdmaSliceList> drained;
+        ctx.queues[slice->priority].pop(drained);
+        ASSERT_EQ(drained.size(), 1u);
+        ASSERT_EQ(drained[0].first, slice);
+        RdmaTransportTestPeer::rechargeSlice(*workers_, slice, kDev);
+        RdmaTransportTestPeer::markPosted(*workers_, ctx, slice, post_ts);
+        RdmaEndPointTestPeer::pretendPosted(endpoint_, 0, slice);
+    }
+
+    RdmaTransport transport_;
+    std::shared_ptr<RdmaParams> params_;
+    std::shared_ptr<RdmaContext> context_;
+    RdmaCQ cq_;
+    RdmaCQ notify_cq_;
+    std::shared_ptr<RdmaEndPoint> endpoint_;
+    std::unique_ptr<Workers> workers_;
+    DeviceSelector* selector_ = nullptr;
+    std::vector<RdmaTask*> tasks_;
+    std::vector<RdmaSlice*> slices_;
+};
+
+RdmaWorkersSharedQpTest::FakeState RdmaWorkersSharedQpTest::fake;
+
+TEST_F(RdmaWorkersSharedQpTest, TimeoutSweepGivesTheOtherLaneItsSliceBack) {
+    // Lane 1 posted first, so lane 0's timeout sweeps it off the queue pair
+    // along with lane 0's own slice.
+    auto* theirs = postSlice(/*lane=*/1, /*enqueue_ts=*/0);
+    auto* ours = postSlice(/*lane=*/0, /*enqueue_ts=*/0);
+    auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
+    auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+    ASSERT_EQ(selector_->getInflightBytes(kDev), 2 * kLen);
+
+    RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);  // 1 ms
+    RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane0,
+                                                /*now_ns=*/2'000'000);
+
+    // Both are terminal and neither is charged to the NIC any more.
+    EXPECT_EQ(ours->word, TIMEOUT);
+    EXPECT_EQ(theirs->word, TIMEOUT);
+    EXPECT_EQ(ours->charged_dev, -1);
+    EXPECT_EQ(theirs->charged_dev, -1);
+    EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+
+    // Each lane's own count came back down, and lane 1's set entry is waiting
+    // for lane 1 rather than having been erased from under it.
+    EXPECT_EQ(lane0.inflight_slices.load(), 0);
+    EXPECT_EQ(lane1.inflight_slices.load(), 0);
+    EXPECT_TRUE(lane0.inflight_slice_set.empty());
+    EXPECT_EQ(lane1.inflight_slice_set.count(theirs), 1u);
+    RdmaTransportTestPeer::drainReclaimed(*workers_, lane1);
+    EXPECT_TRUE(lane1.inflight_slice_set.empty());
+}
+
+// Tearing an endpoint down cancels whatever is still queued on it without
+// going through a sweep, so each lane is left holding a slice that will
+// never complete. The owner's next pass has to take those out: otherwise
+// their NIC charge, their share of its posted backlog and their place in the
+// lane's count are held for the life of the process, and the lane never goes
+// idle again.
+TEST_F(RdmaWorkersSharedQpTest, TeardownLeftoversAreReclaimedByTheirLane) {
+    auto* theirs = postSlice(/*lane=*/1, /*enqueue_ts=*/0);
+    auto* ours = postSlice(/*lane=*/0, /*enqueue_ts=*/0);
+    auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
+    auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+
+    ASSERT_EQ(endpoint_->deconstruct(), 0);
+    ASSERT_EQ(ours->word, CANCELED);
+    ASSERT_EQ(theirs->word, CANCELED);
+
+    RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);
+    RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane0,
+                                                /*now_ns=*/2'000'000);
+    RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane1,
+                                                /*now_ns=*/2'000'000);
+
+    EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+    EXPECT_EQ(lane0.inflight_slices.load(), 0);
+    EXPECT_EQ(lane1.inflight_slices.load(), 0);
+    EXPECT_TRUE(lane0.inflight_slice_set.empty());
+    EXPECT_TRUE(lane1.inflight_slice_set.empty());
+}
+
+// A slice whose attempt fails with a transient error is swept off the queue
+// pair and put back on its lane's queue. The sweep takes it out of that
+// lane's count, so the re-submit puts it back in -- and whatever guards the
+// next decrement has to come back with it. Otherwise the completion that
+// finally resolves the slice cannot take it out of the count again, and the
+// lane it belongs to never reaches zero: it stops suspending, and it looks
+// permanently loaded to submit()'s least-loaded-lane pick.
+TEST_F(RdmaWorkersSharedQpTest, RetriedSliceIsStillCountedByItsLane) {
+    constexpr uint64_t kPosted = 1'000'000;
+
+    auto* slice = postSlice(/*lane=*/0, /*enqueue_ts=*/kPosted);
+    auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
+    ASSERT_EQ(lane0.inflight_slices.load(), 1);
+
+    // First attempt: a transient error, well short of max_retry_count.
+    completeWith(slice, IBV_WC_RETRY_EXC_ERR, kPosted + kLen);
+    ASSERT_EQ(slice->word, PENDING);
+    ASSERT_EQ(slice->retry_count, 1);
+    EXPECT_EQ(lane0.inflight_slices.load(), 1);  // queued again, still counted
+
+    // Second attempt reaches the hardware and succeeds.
+    repost(slice, /*lane=*/0, kPosted + 2 * kLen);
+    completeWith(slice, IBV_WC_SUCCESS, kPosted + 3 * kLen);
+
+    EXPECT_EQ(slice->word, COMPLETED);
+    EXPECT_EQ(lane0.inflight_slices.load(), 0);
+    EXPECT_EQ(selector_->getInflightBytes(kDev), 0u);
+}
+
+// Same retry, on the layout this fixture exists for: lane 1 enqueued the
+// slice, lane 0 polls the queue pair they share. The re-submit goes onto
+// lane 0's queue, so lane 0 is the lane counting it from then on and the
+// slice's ownership has to move with it. Left pointing at lane 1, the
+// completion that finally resolves it discounts a lane that is no longer
+// carrying it -- lane 1 goes negative and lane 0 never comes back down.
+TEST_F(RdmaWorkersSharedQpTest, RetryPolledByAnotherLaneMovesOwnership) {
+    auto* slice = postSlice(/*lane=*/1, /*enqueue_ts=*/0);
+    auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
+    auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+    ASSERT_EQ(lane1.inflight_slices.load(), 1);
+
+    completeWith(slice, IBV_WC_RETRY_EXC_ERR);  // polled by lane 0
+    ASSERT_EQ(slice->word, PENDING);
+    EXPECT_EQ(lane0.inflight_slices.load(), 1);  // lane 0 queued it
+    EXPECT_EQ(lane1.inflight_slices.load(), 0);
+
+    repost(slice, /*lane=*/0);
+    completeWith(slice, IBV_WC_SUCCESS);
+
+    EXPECT_EQ(slice->word, COMPLETED);
+    EXPECT_EQ(lane0.inflight_slices.load(), 0);
+    EXPECT_EQ(lane1.inflight_slices.load(), 0);
+    EXPECT_TRUE(lane0.inflight_slice_set.empty());
+}
+
+// The same retry seen from the lane the slice is leaving. Lane 1's set still
+// holds an entry for it: the handover goes through lane 1's reclaim list, and
+// until lane 1 drains that list its sweep can still walk onto the entry. What
+// decides whether a lane may take an entry out of its set is whether the entry
+// is in that set -- not whether the lane still owns the slice, which the retry
+// has just changed. Keyed on ownership, lane 1 hands its own entry to lane 0,
+// which does not have it, and lane 1 keeps walking a slice it no longer holds.
+TEST_F(RdmaWorkersSharedQpTest, StaleSetEntryIsTakenOutByTheLaneHoldingIt) {
+    auto* slice = postSlice(/*lane=*/1, /*enqueue_ts=*/0);
+    auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+
+    completeWith(slice, IBV_WC_RETRY_EXC_ERR);  // lane 0 retries it
+    ASSERT_EQ(lane1.inflight_slice_set.count(slice), 1u);
+
+    // Lane 1 drained just before lane 0 handed the entry over, so the entry
+    // is in its set with nothing queued to take it out.
+    RdmaTransportTestPeer::clearReclaimed(lane1);
+
+    RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);
+    RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane1,
+                                                /*now_ns=*/2'000'000);
+
+    EXPECT_TRUE(lane1.inflight_slice_set.empty());
+}
+
+// The other half of that window. While the slice waits on lane 0's queue for
+// its re-post, lane 1's sweep resolves it. Posting it now would move bytes for
+// a transfer that is already over, and its completion returns early at
+// `word != PENDING` -- before any discount -- so lane 0's count would never
+// come back down. The pre-post check has to drop an already-resolved slice the
+// same way it drops a cancelled one.
+TEST_F(RdmaWorkersSharedQpTest, SliceResolvedWhileQueuedIsDroppedNotPosted) {
+    auto* slice = postSlice(/*lane=*/1, /*enqueue_ts=*/0);
+    auto& lane0 = RdmaTransportTestPeer::workerContext(*workers_, 0);
+    auto& lane1 = RdmaTransportTestPeer::workerContext(*workers_, 1);
+
+    completeWith(slice, IBV_WC_RETRY_EXC_ERR);  // re-queued on lane 0
+    ASSERT_EQ(lane0.inflight_slices.load(), 1);
+
+    RdmaTransportTestPeer::clearReclaimed(lane1);
+    RdmaTransportTestPeer::setSliceTimeout(*workers_, 1'000'000);
+    RdmaTransportTestPeer::expireTimedOutSlices(*workers_, lane1,
+                                                /*now_ns=*/2'000'000);
+    ASSERT_EQ(slice->word, TIMEOUT);
+    ASSERT_FALSE(slice->task->cancel_requested.load());
+
+    // What lane 0's next pass does with it before generating a post path.
+    EXPECT_TRUE(
+        RdmaTransportTestPeer::dropUnpostableSlice(*workers_, lane0, slice));
+    EXPECT_EQ(lane0.inflight_slices.load(), 0);
 }
 
 TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {


### PR DESCRIPTION
## Description

Fixes #3750.

The admission queue's deadline-infeasible drop (RFC #2519 step 3) and the RDMA workers' bandwidth arbitration (RFC #2792) each computed "predicted MLU" from a different bandwidth: the drop from the sum of the selection EWMAs, the arbitration from the constant `default_bandwidth_gbps`. The selection EWMA is fed per-slice latency, so it folds queueing into a "bandwidth"; predicting an `N`-slice request from it multiplies that wait by `N` although the slices wait behind the same backlog concurrently, and one slow completion could flip an irreversible drop.

Both layers now predict completion time as `(bytes_ahead + length) / wire_rate` through one definition, `DeadlineMlu` (`tent/runtime/deadline_mlu.h`), restoring the in-flight term RFC #2519 specified. Review of the first version (thanks @alogfans, @catyans) found that neither input was what it claimed to be, and fixing that reached into the per-slice accounting. Three commits, each building and passing on its own:

1. `[Bugfix][TENT] Return every slice's charge and lane count to the counter that holds it` — the per-slice accounting below (retry re-charge, timeout release, shared-QP ownership), nothing the predictors read yet.
2. `[Bugfix][TENT] Meter the NIC's transmit rate and predict the admission drop from it and the bytes ahead` — `DeadlineMlu`, the transmit meter, `dispatching_bytes_`, `getEstimatedBandwidth()`.
3. `[TENT] Score each arbitration slot against the bytes actually posted ahead of it` — the arbitration reads the meter and the posted backlog, greedily per slot.

**Wire rate.** Each device gains a transmit estimate, `ewma_transmit_bps`, with the selection EWMA's update rule, clamp and link-speed seed, but fed from a **meter**: bytes completed over the time the NIC spent with work posted (`posted_bytes` / `busy_ns` / `busy_since`, `maybeSampleTransmit`), one sample per `transmit_meter_interval_ns` (10 ms), smoothed with `transmit_bandwidth_learning_rate` (0.9 ≈ 10 intervals). Per-completion latency cannot serve: work requests are posted in batches whose timestamps are effectively one and a poll pass stamps its completions alike, so a slice's own post→completion grows with batch depth (R, R/2, R/3, …). Busy time rather than elapsed time, because a workload that bursts and waits otherwise reads its duty cycle as the link rate; the sample is taken only on the last completion of a poll pass; a posted slice that ends without moving its bytes (failed, flushed, timed out) resets the interval. `getEstimatedBandwidth()` returns the aggregate transmit estimate; the arbitration reads the local NIC's. The selection EWMA is main's (#3511): a successful attempt's post→completion time.

**Bytes ahead.** The admission queue charges the bytes of drop-eligible owners it has dispatched and not yet completed (`dispatching_bytes_`, plus what the current pick already took); owners on other transports share the queue but not the NIC. The arbitration reads the NIC's **posted bytes** — what has reached the hardware — not the selector's allocation-time `inflight_bytes`, which already held the slices being ordered; `OrderByUrgency` then scores each slot behind the slots chosen before it (greedy for the first 64, one ranked pass for the rest).

**Per-slice accounting.** The meter and the arbitration only mean something if every charge comes back to the counter it was made on, and with `qp_pools` several worker lanes share a queue pair, so a completion or a timeout sweep on one lane routinely pops slices another lane enqueued. Every accounting a slice carries now names the counter it sits in — `charged_dev`, `posted_dev`, `counted_lane` (atomic, −1 = none) — and whichever path takes it out exchanges the field for −1 and pays back exactly what it read, so no path pays twice, none pays the wrong lane or device, and a fallback rewriting `source_dev_id` or a retry moving between lanes cannot misdirect a release. `owner_worker` routes set entries: a sweeper hands another lane's entry to that lane's reclaim list, drained on its next pass together with entries a teardown left behind. Retries are re-charged on the device they actually post on (`rechargeSlice`, charge-then-swap); a timeout returns the charge of the slice and of everything swept with it (`acknowledge` gained a per-slice callback); a slice resolved while it waited for a re-post is dropped rather than posted; everything a shared QP's poller must find (post timestamp, posted device, set entry) is written inside `submitSlices` before the WR reaches the wire. `selectMultiPath` charges each slice its real length, so release by length balances without a recorded charge size. `DeviceInfo` is 64-byte aligned with its hot counters on separate lines.

**Relation to #3511** (merged while this was in review): it fixed the retry/fallback charge with `charged_dev_id` + `charged_bytes` + a release-then-charge `chargeSliceQuota`. This PR keeps its own mechanism (the exchange discipline above is what a pooled QP's races need, and exact charging removes the need for `charged_bytes`) and follows #3511's semantics on the selection-EWMA sample and on baseline mode tracking no inflight. `quota_accounting_test.cpp` keeps #3511's selector-level cases; its slice-level cases live in `RdmaWorkersChargeTest`.

Known and deliberately left out: `submitSlices` and `acknowledge` hold only the endpoint's read guard, so on a pooled layout two lanes can reach one `BoundedSliceQueue` at once. That race predates this PR and needs a per-QP lock (noted in the `slice_queue_` comment); separate change.

No public API or wire-format changes. New config keys: `transports/rdma/transmit_bandwidth_learning_rate`, `transmit_meter_interval_ns`, `transmit_meter_max_interval_ns`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [x] Docs

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cd build
cmake --build . -j4
ctest -R 'tent_|admission_queue|bw_arbitration' --output-on-failure
```

**Test results:**
- [x] Unit tests pass — 47/47 in the selection above; full `ctest` 94/98, the 4 failures need NUMA sysfs / a network the container lacks and fail identically on `main` (Ubuntu 22.04 container, rdma-core 39, no RNIC)
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

All new tests run without hardware. Those that pin a specific line were checked by flipping it (the test then fails).

- `deadline_mlu` / `bw_arbitration_test`: `DeadlineMlu` edge cases; each greedy slot is scored behind the ones before it; bytes ahead favour the tighter window.
- `admission_queue_test`: an owner is dispatched on an idle queue, dropped behind 1 MB of eligible work in flight, dispatched again once it completes; other-transport owners do not count; no bandwidth / no deadline never drops.
- `tent_device_selector_test`: the estimate is independent of batch depth (1..64 slices at one timestamp) and slice size; busy time counts only stretches with work posted; idle gaps and stale intervals are not samples; a reset re-baselines. `DeviceSelectorTransmitAccuracyTest` pins the number over ten successive stretches: a steady wire exact, a bursty one within 0.4 %, a duty cycle to 1e-6, a 4x slowdown followed within 478 ms.
- `tent_quota_accounting_test` (#3511's, re-pointed at the selector API): per-slice charge/release balance incl. a short trailing slice, `chargeDevice`, baseline mode keeps inflight at zero, EWMA gating.
- `tent_rdma_transport_test`:
  - `RdmaWorkersArbitrationTest`: `orderByDeadline` with a live selector — allocated contenders are not counted as queue-ahead, posted work outside the batch is.
  - `RdmaWorkersChargeTest`: a retry is re-charged and its completion teaches the selector; a fallback moves the charge; a charge on an untracked device keeps the old one.
  - `RdmaWorkersCompletionTest` (synthesized `ibv_wc` through `handleCompletion`): success feeds the meter; idle between bursts is not charged; a failed slice ends its stretch without teaching; only the last completion of a pass samples; a resolved slice still leaves the lane count; a COMPLETED sweep keeps the interval, a FAILED one abandons it.
  - `RdmaWorkersSharedQpTest` (a real `RdmaEndPoint` on fake verbs, one QP shared by two lanes): a timeout sweep on lane 0 gives lane 1 its slice back with both sets, counters and charges balanced; teardown leftovers are reclaimed by their lane; a retried slice stays counted and its completion is a transmit sample; a retry polled by the other lane moves ownership; a stale set entry is taken out by the lane holding it; a slice resolved while queued is dropped, not posted; a completion sweep keeps the meter interval.
  - `RdmaWorkersTimeoutTest`: a timed-out slice returns its charge with its endpoint gone or no longer holding it.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (~1.1k LOC excluding tests; #3750 describes the change and the review comments above the rest — happy to file an RFC if wanted)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Claude Code was used for drafting code, tests and comments; every changed line was reviewed by the submitter.
