### PR TITLE
[P2P-Store] Unregister buffers on GetReplica failure paths

### DIFF
--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -267,6 +267,9 @@ func (store *P2PStore) doGetReplica(ctx context.Context, payload *Payload, addrL
 		addr, size := addrList[i], sizeList[i]
 		err := store.memory.Add(addr, size, maxShardSize, "cpu:0")
 		if err != nil {
+			// Wait for transfers already started in earlier iterations:
+			// unregistering memory that in-flight transfers still use is unsafe.
+			wg.Wait()
 			store.unregisterBuffers(registered, maxShardSize)
 			return err
 		}
@@ -309,6 +312,15 @@ func buffersFromLists(addrList []uintptr, sizeList []uint64) []Buffer {
 		buffers = append(buffers, Buffer{addr: addrList[i], size: sizeList[i]})
 	}
 	return buffers
+}
+
+// unregisterBuffersTimes undoes `times` rounds of registration. Each successful
+// doGetReplica pass increments the refcount of every buffer once, so rollback
+// must unregister the same number of times to actually release them.
+func (store *P2PStore) unregisterBuffersTimes(bufferList []Buffer, maxShardSize uint64, times int) {
+	for i := 0; i < times; i++ {
+		store.unregisterBuffers(bufferList, maxShardSize)
+	}
 }
 
 func contains(slice []Location, value Location) bool {
@@ -355,14 +367,19 @@ func (store *P2PStore) GetReplica(ctx context.Context, name string, addrList []u
 	if payload == nil {
 		return ErrPayloadNotFound
 	}
+	replicaBuffers := buffersFromLists(addrList, sizeList)
+	successfulRounds := 0
 	for {
 		err = store.doGetReplica(ctx, payload, addrList, sizeList)
 		if err != nil {
+			// doGetReplica rolled back its own round; undo earlier rounds.
+			store.unregisterBuffersTimes(replicaBuffers, payload.MaxShardSize, successfulRounds)
 			return err
 		}
+		successfulRounds++
 		newPayload, recheckRevision, err := store.metadata.Get(ctx, name)
 		if err != nil {
-			store.unregisterBuffers(buffersFromLists(addrList, sizeList), payload.MaxShardSize)
+			store.unregisterBuffersTimes(replicaBuffers, payload.MaxShardSize, successfulRounds)
 			return err
 		}
 		if revision == recheckRevision {
@@ -374,7 +391,7 @@ func (store *P2PStore) GetReplica(ctx context.Context, name string, addrList []u
 	}
 	err = store.updatePayloadMetadata(ctx, name, addrList, sizeList, payload, revision)
 	if err != nil {
-		store.unregisterBuffers(buffersFromLists(addrList, sizeList), payload.MaxShardSize)
+		store.unregisterBuffersTimes(replicaBuffers, payload.MaxShardSize, successfulRounds)
 		return err
 	}
 	return nil

--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -261,13 +261,16 @@ func (store *P2PStore) doGetReplica(ctx context.Context, payload *Payload, addrL
 	var offset uint64 = 0
 	taskID := 0
 	maxShardSize := payload.MaxShardSize
+	var registered []Buffer
 
 	for i := 0; i < len(addrList); i++ {
 		addr, size := addrList[i], sizeList[i]
 		err := store.memory.Add(addr, size, maxShardSize, "cpu:0")
 		if err != nil {
+			store.unregisterBuffers(registered, maxShardSize)
 			return err
 		}
+		registered = append(registered, Buffer{addr: addr, size: size})
 		offset = 0
 		for ; offset < size; offset += maxShardSize {
 			source := addr + uintptr(offset)
@@ -292,11 +295,20 @@ func (store *P2PStore) doGetReplica(ctx context.Context, payload *Payload, addrL
 	select {
 	case err := <-errChan:
 		if err != nil {
+			store.unregisterBuffers(registered, maxShardSize)
 			return err
 		}
 	default:
 	}
 	return nil
+}
+
+func buffersFromLists(addrList []uintptr, sizeList []uint64) []Buffer {
+	buffers := make([]Buffer, 0, len(addrList))
+	for i := range addrList {
+		buffers = append(buffers, Buffer{addr: addrList[i], size: sizeList[i]})
+	}
+	return buffers
 }
 
 func contains(slice []Location, value Location) bool {
@@ -350,6 +362,7 @@ func (store *P2PStore) GetReplica(ctx context.Context, name string, addrList []u
 		}
 		newPayload, recheckRevision, err := store.metadata.Get(ctx, name)
 		if err != nil {
+			store.unregisterBuffers(buffersFromLists(addrList, sizeList), payload.MaxShardSize)
 			return err
 		}
 		if revision == recheckRevision {
@@ -359,7 +372,12 @@ func (store *P2PStore) GetReplica(ctx context.Context, name string, addrList []u
 			break
 		}
 	}
-	return store.updatePayloadMetadata(ctx, name, addrList, sizeList, payload, revision)
+	err = store.updatePayloadMetadata(ctx, name, addrList, sizeList, payload, revision)
+	if err != nil {
+		store.unregisterBuffers(buffersFromLists(addrList, sizeList), payload.MaxShardSize)
+		return err
+	}
+	return nil
 }
 
 func (store *P2PStore) performTransfer(ctx context.Context, source uintptr, shard Shard) error {


### PR DESCRIPTION
## Description

The replica-fetch path registers caller buffers with the transfer engine but never unregisters them on failure:

- In `doGetReplica`, if `memory.Add` fails partway through the buffer list, the buffers registered in earlier iterations stay registered. A transfer failure after all `Add` calls leaks every registration.
- In `GetReplica`, once `doGetReplica` has registered all buffers, a failure in the metadata recheck or in `updatePayloadMetadata` returns without any cleanup. `catalog.Add` only runs on full success, so a later `DeleteReplica` cannot release them either (`ErrPayloadNotOpened`).

`Register` already handles its own failure paths with `unregisterBuffers`; this PR applies the same pattern to the replica path: `doGetReplica` tracks what it registered and rolls back on its own failures, and `GetReplica` rolls back on post-transfer failures via a small `buffersFromLists` helper.

Note: this covers the error paths only. The pre-existing behavior where a repeated metadata recheck loop can bump registration refcounts more than once on success is unchanged and can be looked at separately if there is interest.

## Related Components

- [x] P2P Store (`mooncake-p2p-store`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cd mooncake-p2p-store/src/p2pstore
go build ./...
gofmt -l .
go vet ./...
```

**Test results:**
- [x] Manual testing done (describe below)

`go build` and `gofmt` clean; `go vet` shows only the three pre-existing `unsafe.Pointer` warnings in `transfer_engine.go` (identical on main). The package has no unit tests; the change adds rollback on error paths only, and the success path is untouched.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI assisted with the code audit and drafting. The submitter has reviewed, understands, and takes responsibility for all changes.