### PR TITLE
[TENT]: Map MOONCAKE_LOCAL_HOSTNAME to TENT rpc_server_hostname

### DIFF
--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -135,6 +135,7 @@ Status ConfigHelper::loadFromEnv(Config& config) {
     }
 
     // Legacy keys for backward compatibility (MC_* env vars)
+    setConfig(config, "MOONCAKE_LOCAL_HOSTNAME", "rpc_server_hostname");
     setConfig(config, "MC_RDMA_BIND_ADDRESS", "transports/rdma/bind_address");
     setConfig(config, "MC_NUM_CQ_PER_CTX",
               "transports/rdma/device/num_cq_list");

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -299,9 +299,8 @@ TEST(TransferEngineConfigOverrideTest,
 }
 
 TEST(TransferEngineConfigOverrideTest, LocalHostnameEnvOverridesMcTentConf) {
-    EnvVarGuard conf_guard(
-        "MC_TENT_CONF",
-        R"({"rpc_server_hostname":"10.0.0.1"})");
+    EnvVarGuard conf_guard("MC_TENT_CONF",
+                           R"({"rpc_server_hostname":"10.0.0.1"})");
     EnvVarGuard host_guard("MOONCAKE_LOCAL_HOSTNAME", "10.0.0.2");
 
     Config config;

--- a/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp
@@ -283,6 +283,35 @@ TEST(TransferEngineConfigOverrideTest,
     EXPECT_EQ(config.get("transports/rdma/bind_address", ""), "10.0.0.2");
 }
 
+// MOONCAKE_LOCAL_HOSTNAME is the classic Transfer Engine + store env var that
+// names the local host for RPC binding and segment identity. TENT must honor
+// the same env so a single MOONCAKE_LOCAL_HOSTNAME works across both engines;
+// otherwise TENT's auto-discovery can pick a container/CNI IP (e.g. 10.154.0.1)
+// instead of the RDMA-network IP, breaking cross-node RDMA handshake.
+TEST(TransferEngineConfigOverrideTest,
+     LocalHostnameEnvLoadsIntoRpcServerHostname) {
+    EnvVarGuard guard("MOONCAKE_LOCAL_HOSTNAME", "10.0.0.2");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    EXPECT_EQ(config.get("rpc_server_hostname", ""), "10.0.0.2");
+}
+
+TEST(TransferEngineConfigOverrideTest, LocalHostnameEnvOverridesMcTentConf) {
+    EnvVarGuard conf_guard(
+        "MC_TENT_CONF",
+        R"({"rpc_server_hostname":"10.0.0.1"})");
+    EnvVarGuard host_guard("MOONCAKE_LOCAL_HOSTNAME", "10.0.0.2");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+
+    // Legacy env must override MC_TENT_CONF, same precedence as
+    // MC_RDMA_BIND_ADDRESS (env wins so per-pod injection works).
+    EXPECT_EQ(config.get("rpc_server_hostname", ""), "10.0.0.2");
+}
+
 TEST(TransferEngineConfigOverrideTest,
      LegacyRdmaSliceAffinityLogEnvLoadsIntoTentConfig) {
     EnvVarGuard guard("MC_LOG_RDMA_SLICE_AFFINITY", "true");


### PR DESCRIPTION
## Description

`MOONCAKE_LOCAL_HOSTNAME` is the standard environment variable used by the
classic Transfer Engine and the store to specify the local RPC bind address
(read at store startup; sglang's `MooncakeStore` config reads it too). TENT
did not previously read it — the RPC bind address could only come from the
`rpc_server_hostname` field of the `MC_TENT_CONF` JSON or be passed
explicitly via the constructor. When neither is set, TENT falls back to
`discoverLocalIpAddress()` to auto-discover the local IP.

Under container / hostNetwork multi-NIC environments, `discoverLocalIpAddress`
takes the first non-lo IPv4 from `getifaddrs`, which can select a container
network IP (e.g. `10.154.0.1`) instead of the RDMA-network IP
(e.g. `10.15.56.196`). That IP is written into `SegmentDesc.rpc_server_addr`
and published to metadata, so the peer's RDMA handshake goes over the wrong
network and cross-node transfers time out / fail.

## Change

Map `MOONCAKE_LOCAL_HOSTNAME` to TENT's `rpc_server_hostname` in
`ConfigHelper::loadFromEnv`, consistent with how `MC_RDMA_BIND_ADDRESS` and
`MC_TE_FILTERS` reuse classic env vars:

```cpp
setConfig(config, "MOONCAKE_LOCAL_HOSTNAME", "rpc_server_hostname");
```

After the mapping, a single `MOONCAKE_LOCAL_HOSTNAME` works for both the
classic and TENT engines — no need to duplicate `rpc_server_hostname` in the
TENT JSON or maintain a separate env set for TENT.

## Precedence

`loadFromEnv` runs before `restoreExplicitTransferEngineConfig`; the store's
TENT branch in `TransferEngine::init` only passes `local_segment_name` /
`metadata_type` / `metadata_servers` explicitly, not `rpc_server_hostname`,
so the env-set value is not overwritten by restore. Same as
`MC_RDMA_BIND_ADDRESS`: env wins over `MC_TENT_CONF` JSON, which suits
per-pod injection.

## Tests

- `TransferEngineConfigOverrideTest.LocalHostnameEnvLoadsIntoRpcServerHostname`:
  sets `MOONCAKE_LOCAL_HOSTNAME` and asserts `rpc_server_hostname` is populated
- `TransferEngineConfigOverrideTest.LocalHostnameEnvOverridesMcTentConf`:
  JSON sets one value + env sets another; asserts env wins

## Files Changed

- `mooncake-transfer-engine/tent/src/common/config.cpp` — add `MOONCAKE_LOCAL_HOSTNAME` → `rpc_server_hostname` mapping in `loadFromEnv`
- `mooncake-transfer-engine/tent/tests/transfer_engine_config_override_test.cpp` — two regression tests

## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [X] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)