### PR TITLE
[TransferEngine] Add deadline-safe scatter operation lifecycle

### DIFF
--- a/docs/source/design/transfer-engine/deadline-safe-scatter.md
+++ b/docs/source/design/transfer-engine/deadline-safe-scatter.md
@@ -1,0 +1,82 @@
+# Deadline-safe scatter lifecycle
+
+`TransferEngine::ScatterTransferOperation` separates a caller's logical
+deadline from the physical lifetime of submitted I/O. This distinction matters
+for RDMA, DMA, and staged transfers: returning a timeout does not prove that a
+device has stopped accessing the local buffer or its memory registration.
+
+## Operation states
+
+An operation reports one of these states through `snapshot()`:
+
+```text
+SUBMITTED -> IN_PROGRESS -> SUCCEEDED
+                         -> FAILED
+
+SUBMITTED/IN_PROGRESS -> TIMED_OUT
+TIMED_OUT             -> CANCEL_REQUESTED -> DRAINING -> DRAINED
+                                                  `-> QUARANTINED
+QUARANTINED           -> DRAINING -> DRAINED
+```
+
+`SUCCEEDED`, `FAILED`, and `DRAINED` are physically complete states. A buffer
+may be reused only when `snapshot().buffer_reusable` is true. `DRAINED` records
+resource safety after a logical failure; it does not convert that failure into
+success.
+
+`QUARANTINED` is a bounded caller-visible state for work whose physical
+termination could not be established before the drain deadline. Keep the
+operation alive and do not reuse the buffer. Destroying the operation preserves
+the original safe behavior and waits for physical completion.
+
+## Deadlines and drain
+
+Use `waitUntil()` when several transfers share one total deadline. Unlike
+repeated relative waits, an absolute `std::chrono::steady_clock` deadline cannot
+accidentally grant every fragment a new timeout budget.
+
+When the deadline expires:
+
+- the first timeout is preserved as the logical result;
+- pending fragment callbacks receive that result exactly once;
+- physical work remains owned and tracked;
+- a late physical completion updates the snapshot without invoking callbacks a
+  second time.
+
+`cancelAndDrainUntil()` dispatches best-effort cancellation to backends that
+support it and then polls for physical completion. Backends without generic
+cancellation drain naturally. If the drain deadline expires, the operation
+becomes quarantined rather than claiming the buffer is safe.
+
+## Buffer ownership
+
+Scatter ranges still accept caller-managed raw buffer addresses. Callers that
+need a bounded return path may also pass `ScatterTransferOptions` containing
+opaque `std::shared_ptr<void>` lifetime anchors that own the local allocations
+and/or registrations. Transfer Engine retains the anchors until physical
+completion, including while the operation is quarantined.
+
+The anchor does not register or validate memory and does not replace the
+caller's normal memory-registration API. It only makes the required lifetime
+explicit and mechanically retainable.
+
+## Integration boundary
+
+Transfer Engine reports per-operation status, physical completion, first
+failure, bytes, fragments, timeout/cancel/drain/quarantine events, late
+completions, and completion latency. It does not coordinate tensor-parallel
+ranks or commit framework state.
+
+A multi-rank KV restore should therefore:
+
+1. transfer each rank's temporary shard independently;
+2. validate every rank;
+3. commit only after all ranks succeed;
+4. abort all temporary shards after any failure;
+5. drain or quarantine unresolved operations before local recomputation reuses
+   their staging memory.
+
+Large-object windowing belongs above the transfer lifecycle. A Store-level
+bounded retrieve should limit in-flight bytes, fragments, and operations and
+must not recycle a staging window until its transfer snapshot reports that the
+buffer is reusable.

--- a/docs/source/design/transfer-engine/index.md
+++ b/docs/source/design/transfer-engine/index.md
@@ -166,6 +166,10 @@ For a complete C++ API reference, see [Transfer Engine C++ API Reference](../../
 ### Data Transfer
 Transfer Engine provides batch-based read/write transfers between segments (DRAM/VRAM/NVMeof). A typical flow is: register local memory, open a target segment, submit a batch, and poll status. Detailed function signatures and usage are documented in the C++ API reference.
 
+For asynchronous scatter transfers that must respect a caller deadline without
+reusing buffers still owned by DMA or RDMA, see
+[Deadline-safe scatter lifecycle](deadline-safe-scatter.md).
+
 ### Multi-Transport Management
 
 The `TransferEngine` class internally manages multiple backend `Transport` classes.
@@ -521,6 +525,14 @@ For advanced users, TransferEngine provides the following advanced runtime optio
 ## C++ API Reference
 
 For the complete C++ API reference, see [Transfer Engine C++ API](../../api-reference/cpp/index).
+
+## Deadline-safe Operations
+
+:::{toctree}
+:maxdepth: 1
+
+deadline-safe-scatter
+:::
 
 ## Supported Protocols
 

--- a/mooncake-transfer-engine/benchmark/CMakeLists.txt
+++ b/mooncake-transfer-engine/benchmark/CMakeLists.txt
@@ -26,6 +26,8 @@ else()
 endif()
 
 file(GLOB TEBENCH_SOURCES "*.cpp")
+list(REMOVE_ITEM TEBENCH_SOURCES
+     "${CMAKE_CURRENT_SOURCE_DIR}/scatter_lifecycle_bench.cpp")
 # The TENT backend is only available when USE_TENT is enabled; drop its
 # translation unit (which pulls in tent/ headers) from non-TENT builds.
 if(NOT USE_TENT)
@@ -36,6 +38,11 @@ if(NOT USE_TENT)
 endif()
 add_executable(tebench ${TEBENCH_SOURCES})
 target_link_libraries(tebench PUBLIC transfer_engine)
+
+# Hardware-free control-plane benchmark for the deadline-safe scatter lifecycle.
+# It uses a scripted transport and does not report data-plane throughput.
+add_executable(scatter_lifecycle_bench scatter_lifecycle_bench.cpp)
+target_link_libraries(scatter_lifecycle_bench PUBLIC transfer_engine)
 if(USE_TENT)
   target_compile_definitions(tebench PRIVATE USE_TENT)
   # tent_link_group's interface brings in the tent/ header search path.

--- a/mooncake-transfer-engine/benchmark/scatter_lifecycle_bench.cpp
+++ b/mooncake-transfer-engine/benchmark/scatter_lifecycle_bench.cpp
@@ -1,0 +1,254 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "transfer_engine.h"
+#include "transfer_engine_impl.h"
+
+namespace mooncake {
+
+class TransferEngineImplTestPeer {
+   public:
+    static void replaceTransport(TransferEngine& engine,
+                                 std::shared_ptr<Transport> transport) {
+        auto& impl = *engine.impl_;
+        impl.multi_transports_->transport_map_.clear();
+        impl.multi_transports_->transport_map_.emplace("scripted",
+                                                       std::move(transport));
+    }
+
+    static TransferEngineImpl& implementation(TransferEngine& engine) {
+        return *engine.impl_;
+    }
+};
+
+class ScriptedBenchmarkTransport : public Transport {
+   public:
+    void setStatus(TransferStatusEnum status) { status_.store(status); }
+
+    Status submitTransfer(BatchID,
+                          const std::vector<TransferRequest>&) override {
+        return Status::OK();
+    }
+
+    Status submitTransferTask(const std::vector<TransferTask*>&) override {
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus& status) override {
+        const auto current = status_.load();
+        status.s = current;
+        status.transferred_bytes = 0;
+        if (current != TransferStatusEnum::WAITING &&
+            current != TransferStatusEnum::PENDING) {
+            auto* batch = reinterpret_cast<BatchDesc*>(batch_id);
+            if (task_id >= batch->task_list.size())
+                return Status::InvalidArgument("scripted task out of range");
+            batch->task_list[task_id].is_finished = true;
+        }
+        return Status::OK();
+    }
+
+   private:
+    int registerLocalMemory(void*, size_t, const std::string&, bool,
+                            bool) override {
+        return 0;
+    }
+
+    int unregisterLocalMemory(void*, bool) override { return 0; }
+
+    int registerLocalMemoryBatch(const std::vector<BufferEntry>&,
+                                 const std::string&) override {
+        return 0;
+    }
+
+    int unregisterLocalMemoryBatch(const std::vector<void*>&) override {
+        return 0;
+    }
+
+    const char* getName() const override { return "scripted-benchmark"; }
+
+    std::atomic<TransferStatusEnum> status_{TransferStatusEnum::COMPLETED};
+};
+
+struct Summary {
+    int64_t median_ns;
+    int64_t p95_ns;
+};
+
+Summary summarize(std::vector<int64_t> samples) {
+    std::sort(samples.begin(), samples.end());
+    const size_t median = samples.size() / 2;
+    const size_t p95 = (samples.size() - 1) * 95 / 100;
+    return {.median_ns = samples[median], .p95_ns = samples[p95]};
+}
+
+size_t parseSize(int argc, char** argv, std::string_view prefix,
+                 size_t default_value) {
+    for (int i = 1; i < argc; ++i) {
+        std::string_view argument(argv[i]);
+        if (argument.starts_with(prefix))
+            return std::strtoull(argv[i] + prefix.size(), nullptr, 10);
+    }
+    return default_value;
+}
+
+}  // namespace mooncake
+
+int main(int argc, char** argv) {
+    using Clock = std::chrono::steady_clock;
+    using namespace mooncake;
+
+    const size_t iterations = parseSize(argc, argv, "--iterations=", 1000);
+    const size_t fragments = parseSize(argc, argv, "--fragments=", 16);
+    if (iterations == 0 || fragments == 0) {
+        std::cerr << "iterations and fragments must be non-zero\n";
+        return 2;
+    }
+
+    TransferEngine engine(false);
+    if (engine.init(P2PHANDSHAKE, "127.0.0.1:12345") != 0) return 1;
+    auto transport = std::make_shared<ScriptedBenchmarkTransport>();
+    TransferEngineImplTestPeer::replaceTransport(engine, transport);
+    auto& impl = TransferEngineImplTestPeer::implementation(engine);
+
+    constexpr SegmentID kSegmentId = 91;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "benchmark-remote";
+    descriptor->protocol = "scripted";
+    impl.getMetadata()->addLocalSegment(kSegmentId, "benchmark-remote",
+                                        std::move(descriptor));
+
+    auto buffer = std::make_shared<std::vector<char>>(fragments);
+    std::vector<size_t> offsets(fragments);
+    std::vector<size_t> lengths(fragments, 1);
+    for (size_t i = 0; i < fragments; ++i) offsets[i] = i;
+    TransferEngine::ScatterTransferRange range{
+        .opcode = TransferRequest::READ,
+        .remote_segment = "benchmark-remote",
+        .remote_base_offset = 0,
+        .remote_size = buffer->size(),
+        .local_buffer = buffer->data(),
+        .local_capacity = buffer->size(),
+        .local_offsets = offsets,
+        .remote_offsets = offsets,
+        .lengths = lengths,
+        .on_fragment_complete = {},
+    };
+    TransferEngine::ScatterTransferOptions options{
+        .local_lifetimes = {buffer},
+    };
+
+    std::vector<int64_t> baseline_samples;
+    std::vector<int64_t> lifecycle_samples;
+    baseline_samples.reserve(iterations);
+    lifecycle_samples.reserve(iterations);
+
+    auto run_baseline = [&]() {
+        const auto started = Clock::now();
+        auto operation = engine.submitScatter({range});
+        if (!operation.wait().ok()) return int64_t{-1};
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+                   Clock::now() - started)
+            .count();
+    };
+    auto run_lifecycle = [&]() {
+        const auto started = Clock::now();
+        auto operation = engine.submitScatter({range}, options);
+        if (!operation.wait().ok()) return int64_t{-1};
+        if (!operation.snapshot().buffer_reusable) return int64_t{-1};
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+                   Clock::now() - started)
+            .count();
+    };
+
+    const size_t warmups = std::min<size_t>(iterations, 100);
+    for (size_t i = 0; i < warmups; ++i) {
+        if (run_baseline() < 0 || run_lifecycle() < 0) return 1;
+    }
+    for (size_t i = 0; i < iterations; ++i) {
+        int64_t baseline_ns;
+        int64_t lifecycle_ns;
+        if (i % 2 == 0) {
+            baseline_ns = run_baseline();
+            lifecycle_ns = run_lifecycle();
+        } else {
+            lifecycle_ns = run_lifecycle();
+            baseline_ns = run_baseline();
+        }
+        if (baseline_ns < 0 || lifecycle_ns < 0) return 1;
+        baseline_samples.push_back(baseline_ns);
+        lifecycle_samples.push_back(lifecycle_ns);
+    }
+
+    transport->setStatus(TransferStatusEnum::WAITING);
+    std::vector<int64_t> quarantine_samples;
+    std::vector<int64_t> late_drain_samples;
+    quarantine_samples.reserve(iterations);
+    late_drain_samples.reserve(iterations);
+    for (size_t i = 0; i < iterations; ++i) {
+        size_t callback_count = 0;
+        range.on_fragment_complete = [&](size_t, const Status&) {
+            ++callback_count;
+        };
+        auto operation = engine.submitScatter({range}, options);
+        const auto started = Clock::now();
+        if (!operation.waitUntil(started).IsClock()) return 1;
+        if (!operation.cancelAndDrainUntil(started).IsClock()) return 1;
+        const auto quarantined = Clock::now();
+        if (operation.snapshot().state !=
+            TransferEngine::ScatterTransferState::QUARANTINED)
+            return 1;
+        quarantine_samples.push_back(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(quarantined -
+                                                                 started)
+                .count());
+
+        transport->setStatus(TransferStatusEnum::COMPLETED);
+        if (!operation.wait().IsClock()) return 1;
+        if (callback_count != fragments ||
+            operation.snapshot().late_completions != fragments)
+            return 1;
+        late_drain_samples.push_back(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
+                                                                 quarantined)
+                .count());
+        transport->setStatus(TransferStatusEnum::WAITING);
+    }
+
+    const auto baseline = summarize(std::move(baseline_samples));
+    const auto lifecycle = summarize(std::move(lifecycle_samples));
+    const auto quarantine = summarize(std::move(quarantine_samples));
+    const auto late_drain = summarize(std::move(late_drain_samples));
+    std::cout << "{\"iterations\":" << iterations
+              << ",\"fragments\":" << fragments
+              << ",\"baseline_median_ns\":" << baseline.median_ns
+              << ",\"baseline_p95_ns\":" << baseline.p95_ns
+              << ",\"lifecycle_median_ns\":" << lifecycle.median_ns
+              << ",\"lifecycle_p95_ns\":" << lifecycle.p95_ns
+              << ",\"quarantine_median_ns\":" << quarantine.median_ns
+              << ",\"quarantine_p95_ns\":" << quarantine.p95_ns
+              << ",\"late_drain_median_ns\":" << late_drain.median_ns
+              << ",\"late_drain_p95_ns\":" << late_drain.p95_ns << "}\n";
+    return 0;
+}

--- a/mooncake-transfer-engine/include/transfer_engine.h
+++ b/mooncake-transfer-engine/include/transfer_engine.h
@@ -147,6 +147,44 @@ class TransferEngine {
         std::function<void(size_t, const Status&)> on_fragment_complete;
     };
 
+    struct ScatterTransferOptions {
+        // Optional ownership anchors for local buffers and their memory
+        // registrations. The operation retains these objects until every
+        // submitted transfer is physically complete.
+        std::vector<std::shared_ptr<void>> local_lifetimes;
+    };
+
+    enum class ScatterTransferState : uint8_t {
+        SUBMITTED,
+        IN_PROGRESS,
+        SUCCEEDED,
+        FAILED,
+        TIMED_OUT,
+        CANCEL_REQUESTED,
+        DRAINING,
+        DRAINED,
+        QUARANTINED,
+    };
+
+    struct ScatterTransferSnapshot {
+        ScatterTransferState state = ScatterTransferState::FAILED;
+        Status first_failure =
+            Status::InvalidArgument("invalid scatter transfer operation");
+        size_t total_bytes = 0;
+        size_t in_flight_bytes = 0;
+        size_t quarantined_bytes = 0;
+        size_t total_fragments = 0;
+        size_t completed_fragments = 0;
+        size_t deadline_timeouts = 0;
+        size_t cancel_requests = 0;
+        size_t drain_attempts = 0;
+        size_t quarantine_events = 0;
+        size_t late_completions = 0;
+        std::chrono::nanoseconds submit_to_physical_completion{};
+        bool physical_complete = false;
+        bool buffer_reusable = false;
+    };
+
     class ScatterTransferOperation {
        public:
         ScatterTransferOperation(ScatterTransferOperation&&) noexcept;
@@ -168,6 +206,22 @@ class TransferEngine {
         // its CPU/GPU buffers alive until a later wait reaches completion.
         Status waitFor(std::chrono::nanoseconds timeout);
 
+        // Wait against one absolute deadline. On timeout, pending callbacks
+        // are completed exactly once with a clock error, but physical work is
+        // still owned by this operation and the buffers are not reusable.
+        Status waitUntil(std::chrono::steady_clock::time_point deadline);
+
+        // Request best-effort cancellation and drain submitted work until the
+        // absolute deadline. A timeout leaves the operation quarantined: keep
+        // it alive and do not reuse its buffers until snapshot() reports
+        // buffer_reusable=true.
+        Status cancelAndDrainUntil(
+            std::chrono::steady_clock::time_point deadline);
+
+        // Return a single-consumer lifecycle snapshot. Do not call this
+        // concurrently with a wait method or from a fragment callback.
+        ScatterTransferSnapshot snapshot() const;
+
        private:
         class Impl;
         explicit ScatterTransferOperation(std::unique_ptr<Impl> impl);
@@ -177,6 +231,9 @@ class TransferEngine {
 
     ScatterTransferOperation submitScatter(
         const std::vector<ScatterTransferRange>& ranges);
+    ScatterTransferOperation submitScatter(
+        const std::vector<ScatterTransferRange>& ranges,
+        const ScatterTransferOptions& options);
     Status transferScatter(const std::vector<ScatterTransferRange>& ranges);
 
     Status submitTransferWithNotify(BatchID batch_id,

--- a/mooncake-transfer-engine/src/transfer_engine.cpp
+++ b/mooncake-transfer-engine/src/transfer_engine.cpp
@@ -960,6 +960,8 @@ std::string TransferEngine::showLinks(bool json) const {
 namespace mooncake {
 
 class TransferEngine::ScatterTransferOperation::Impl {
+    using Clock = std::chrono::steady_clock;
+
    public:
     struct Backend {
         std::shared_ptr<TransferEngineImpl> legacy;
@@ -969,14 +971,18 @@ class TransferEngine::ScatterTransferOperation::Impl {
     };
 
     Impl(TransferEngine& engine, Backend backend,
-         const std::vector<ScatterTransferRange>& ranges)
-        : backend_(std::move(backend)) {
+         const std::vector<ScatterTransferRange>& ranges,
+         const ScatterTransferOptions& options)
+        : backend_(std::move(backend)),
+          lifetime_anchors_(options.local_lifetimes),
+          submitted_at_(Clock::now()) {
         callbacks_.reserve(ranges.size());
         size_t fragment_count = 0;
         for (const auto& range : ranges) {
             callbacks_.push_back(range.on_fragment_complete);
-            fragment_count += range.lengths.size();
+            fragment_count += range.local_offsets.size();
         }
+        total_fragments_ = fragment_count;
         requests_.reserve(fragment_count);
         request_fragments_.reserve(fragment_count);
         build(engine, ranges);
@@ -985,6 +991,8 @@ class TransferEngine::ScatterTransferOperation::Impl {
     ~Impl() { wait(); }
 
     Status wait() {
+        if (state_ == ScatterTransferState::QUARANTINED)
+            state_ = ScatterTransferState::DRAINING;
         while (!completed_) {
             poll();
             if (!completed_) std::this_thread::sleep_for(kPollInterval);
@@ -1012,6 +1020,79 @@ class TransferEngine::ScatterTransferOperation::Impl {
             std::this_thread::sleep_for(kPollInterval);
         }
         return aggregate_status_;
+    }
+
+    Status waitUntil(Clock::time_point deadline) {
+        while (!completed_) {
+            poll();
+            if (completed_) break;
+            if (Clock::now() >= deadline) {
+                const auto status =
+                    Status::Clock("scatter transfer deadline exceeded");
+                remember(status);
+                publishPendingCallbacks(status);
+                logical_terminal_published_ = true;
+                if (state_ == ScatterTransferState::SUBMITTED ||
+                    state_ == ScatterTransferState::IN_PROGRESS) {
+                    state_ = ScatterTransferState::TIMED_OUT;
+                    ++deadline_timeouts_;
+                }
+                return aggregate_status_;
+            }
+            std::this_thread::sleep_for(kPollInterval);
+        }
+        return aggregate_status_;
+    }
+
+    Status cancelAndDrainUntil(Clock::time_point deadline) {
+        if (completed_) return aggregate_status_;
+
+        ++drain_attempts_;
+        const auto cancel_status =
+            Status::Clock("scatter transfer cancellation requested");
+        remember(cancel_status);
+        publishPendingCallbacks(cancel_status);
+        logical_terminal_published_ = true;
+        state_ = ScatterTransferState::CANCEL_REQUESTED;
+        if (!cancel_requested_) {
+            cancel_requested_ = true;
+            ++cancel_requests_;
+        }
+        requestAbort(cancel_status);
+        state_ = ScatterTransferState::DRAINING;
+
+        while (!completed_) {
+            poll();
+            if (completed_) break;
+            if (Clock::now() >= deadline) {
+                state_ = ScatterTransferState::QUARANTINED;
+                ++quarantine_events_;
+                return aggregate_status_;
+            }
+            std::this_thread::sleep_for(kPollInterval);
+        }
+        return aggregate_status_;
+    }
+
+    ScatterTransferSnapshot snapshot() const {
+        ScatterTransferSnapshot result;
+        result.state = state_;
+        result.first_failure = aggregate_status_;
+        result.total_bytes = total_bytes_;
+        result.in_flight_bytes = in_flight_bytes_;
+        result.quarantined_bytes =
+            state_ == ScatterTransferState::QUARANTINED ? in_flight_bytes_ : 0;
+        result.total_fragments = total_fragments_;
+        result.completed_fragments = completed_fragments_;
+        result.deadline_timeouts = deadline_timeouts_;
+        result.cancel_requests = cancel_requests_;
+        result.drain_attempts = drain_attempts_;
+        result.quarantine_events = quarantine_events_;
+        result.late_completions = late_completions_;
+        result.submit_to_physical_completion = physical_completion_latency_;
+        result.physical_complete = completed_;
+        result.buffer_reusable = completed_;
+        return result;
     }
 
    private:
@@ -1078,18 +1159,29 @@ class TransferEngine::ScatterTransferOperation::Impl {
 
     void finish() {
         aggregate_status_ = closeSegments(aggregate_status_);
+        const bool drained = state_ == ScatterTransferState::TIMED_OUT ||
+                             state_ == ScatterTransferState::CANCEL_REQUESTED ||
+                             state_ == ScatterTransferState::DRAINING ||
+                             state_ == ScatterTransferState::QUARANTINED;
         completed_ = true;
+        state_ = drained                  ? ScatterTransferState::DRAINED
+                 : aggregate_status_.ok() ? ScatterTransferState::SUCCEEDED
+                                          : ScatterTransferState::FAILED;
+        physical_completion_latency_ =
+            std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now() -
+                                                                 submitted_at_);
         callbacks_.clear();
+        lifetime_anchors_.clear();
         requests_.clear();
         request_fragments_.clear();
         done_.clear();
+        callback_done_.clear();
         task_sizes_.clear();
         backend_ = {};
     }
 
-    void complete(size_t range_index, size_t fragment_index,
-                  const Status& status) {
-        remember(status);
+    void invokeCallback(size_t range_index, size_t fragment_index,
+                        const Status& status) {
         const auto& callback = callbacks_[range_index];
         if (!callback) return;
         try {
@@ -1100,11 +1192,34 @@ class TransferEngine::ScatterTransferOperation::Impl {
         }
     }
 
+    void completeUnsubmitted(size_t range_index, size_t fragment_index,
+                             const Status& status) {
+        remember(status);
+        ++completed_fragments_;
+        invokeCallback(range_index, fragment_index, status);
+    }
+
     void completeRequest(size_t request_index, const Status& status) {
         const auto [range_index, fragment_index] =
             request_fragments_[request_index];
         done_[request_index] = true;
-        complete(range_index, fragment_index, status);
+        remember(status);
+        ++completed_fragments_;
+        in_flight_bytes_ -= requests_[request_index].length;
+        if (logical_terminal_published_) ++late_completions_;
+        if (!callback_done_[request_index]) {
+            callback_done_[request_index] = true;
+            invokeCallback(range_index, fragment_index, status);
+        }
+    }
+
+    void publishPendingCallbacks(const Status& status) {
+        for (size_t i = 0; i < request_fragments_.size(); ++i) {
+            if (callback_done_[i]) continue;
+            callback_done_[i] = true;
+            const auto [range_index, fragment_index] = request_fragments_[i];
+            invokeCallback(range_index, fragment_index, status);
+        }
     }
 
     void failPending(const Status& status) {
@@ -1145,7 +1260,7 @@ class TransferEngine::ScatterTransferOperation::Impl {
                     Status::InvalidArgument("invalid scatter transfer range");
                 remember(status);
                 for (size_t i = 0; i < fragment_count; ++i)
-                    complete(range_index, i, status);
+                    completeUnsubmitted(range_index, i, status);
                 continue;
             }
 
@@ -1163,14 +1278,16 @@ class TransferEngine::ScatterTransferOperation::Impl {
                         std::numeric_limits<uint64_t>::max() - remote_offset ||
                     length > std::numeric_limits<uint64_t>::max() -
                                  (range.remote_base_offset + remote_offset)) {
-                    complete(range_index, fragment_index,
-                             Status::InvalidArgument(
-                                 "invalid scatter transfer fragment"));
+                    completeUnsubmitted(
+                        range_index, fragment_index,
+                        Status::InvalidArgument(
+                            "invalid scatter transfer fragment"));
                     continue;
                 }
 
                 if (length == 0) {
-                    complete(range_index, fragment_index, Status::OK());
+                    completeUnsubmitted(range_index, fragment_index,
+                                        Status::OK());
                     continue;
                 }
 
@@ -1185,9 +1302,10 @@ class TransferEngine::ScatterTransferOperation::Impl {
                 }
                 if (*segment_handle ==
                     static_cast<SegmentHandle>(ERR_INVALID_ARGUMENT)) {
-                    complete(range_index, fragment_index,
-                             Status::InvalidArgument(
-                                 "failed to open scatter transfer segment"));
+                    completeUnsubmitted(
+                        range_index, fragment_index,
+                        Status::InvalidArgument(
+                            "failed to open scatter transfer segment"));
                     continue;
                 }
 
@@ -1201,6 +1319,7 @@ class TransferEngine::ScatterTransferOperation::Impl {
                     .task_group_id = 1,
                 });
                 request_fragments_.emplace_back(range_index, fragment_index);
+                total_bytes_ += length;
             }
         }
 
@@ -1210,6 +1329,8 @@ class TransferEngine::ScatterTransferOperation::Impl {
         }
 
         done_.assign(requests_.size(), false);
+        callback_done_.assign(requests_.size(), false);
+        in_flight_bytes_ = total_bytes_;
         Status submit_status = Status::OK();
         if (useTent()) {
             task_sizes_.assign(requests_.size(), 1);
@@ -1267,6 +1388,8 @@ class TransferEngine::ScatterTransferOperation::Impl {
     }
 
     void poll() {
+        if (state_ == ScatterTransferState::SUBMITTED)
+            state_ = ScatterTransferState::IN_PROGRESS;
         size_t request_index = 0;
         for (size_t task_id = 0; task_id < task_sizes_.size(); ++task_id) {
             const size_t request_start = request_index;
@@ -1340,13 +1463,29 @@ class TransferEngine::ScatterTransferOperation::Impl {
     std::vector<TransferRequest> requests_;
     std::vector<std::pair<size_t, size_t>> request_fragments_;
     std::vector<std::function<void(size_t, const Status&)>> callbacks_;
+    std::vector<std::shared_ptr<void>> lifetime_anchors_;
     std::unordered_map<std::string, SegmentHandle> segment_handles_;
     std::vector<uint8_t> done_;
+    std::vector<uint8_t> callback_done_;
     std::vector<size_t> task_sizes_;
     BatchID batch_id_ = INVALID_BATCH_ID;
     size_t remaining_ = 0;
+    size_t total_bytes_ = 0;
+    size_t in_flight_bytes_ = 0;
+    size_t total_fragments_ = 0;
+    size_t completed_fragments_ = 0;
+    size_t deadline_timeouts_ = 0;
+    size_t cancel_requests_ = 0;
+    size_t drain_attempts_ = 0;
+    size_t quarantine_events_ = 0;
+    size_t late_completions_ = 0;
     Status aggregate_status_;
+    Clock::time_point submitted_at_;
+    std::chrono::nanoseconds physical_completion_latency_{};
+    ScatterTransferState state_ = ScatterTransferState::SUBMITTED;
     bool abort_requested_ = false;
+    bool cancel_requested_ = false;
+    bool logical_terminal_published_ = false;
     bool completed_ = false;
 };
 
@@ -1376,8 +1515,33 @@ Status TransferEngine::ScatterTransferOperation::waitFor(
                : Status::InvalidArgument("invalid scatter transfer operation");
 }
 
+Status TransferEngine::ScatterTransferOperation::waitUntil(
+    std::chrono::steady_clock::time_point deadline) {
+    return impl_
+               ? impl_->waitUntil(deadline)
+               : Status::InvalidArgument("invalid scatter transfer operation");
+}
+
+Status TransferEngine::ScatterTransferOperation::cancelAndDrainUntil(
+    std::chrono::steady_clock::time_point deadline) {
+    return impl_
+               ? impl_->cancelAndDrainUntil(deadline)
+               : Status::InvalidArgument("invalid scatter transfer operation");
+}
+
+TransferEngine::ScatterTransferSnapshot
+TransferEngine::ScatterTransferOperation::snapshot() const {
+    return impl_ ? impl_->snapshot() : ScatterTransferSnapshot{};
+}
+
 TransferEngine::ScatterTransferOperation TransferEngine::submitScatter(
     const std::vector<ScatterTransferRange>& ranges) {
+    return submitScatter(ranges, ScatterTransferOptions{});
+}
+
+TransferEngine::ScatterTransferOperation TransferEngine::submitScatter(
+    const std::vector<ScatterTransferRange>& ranges,
+    const ScatterTransferOptions& options) {
     ScatterTransferOperation::Impl::Backend backend;
     backend.legacy = impl_;
 #ifdef USE_TENT
@@ -1386,7 +1550,7 @@ TransferEngine::ScatterTransferOperation TransferEngine::submitScatter(
 
     return ScatterTransferOperation(
         std::make_unique<ScatterTransferOperation::Impl>(
-            *this, std::move(backend), ranges));
+            *this, std::move(backend), ranges, options));
 }
 
 Status TransferEngine::transferScatter(

--- a/mooncake-transfer-engine/tests/transport_uint_test.cpp
+++ b/mooncake-transfer-engine/tests/transport_uint_test.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <condition_variable>
 #include <cstdlib>
 #include <fstream>
@@ -269,6 +270,38 @@ class PartialFailureSubmissionTransport : public BatchResultTransport {
 
    private:
     bool extra_slice_ = false;
+};
+
+class ScriptedScatterTransport : public BatchResultTransport {
+   public:
+    void setStatus(TransferStatusEnum status) { status_.store(status); }
+
+    Status submitTransferTask(
+        const std::vector<TransferTask*>& tasks) override {
+        submitted_tasks_.fetch_add(tasks.size());
+        return Status::OK();
+    }
+
+    Status getTransferStatus(BatchID batch_id, size_t task_id,
+                             TransferStatus& status) override {
+        auto current = status_.load();
+        status.s = current;
+        status.transferred_bytes = 0;
+        if (current != TransferStatusEnum::WAITING &&
+            current != TransferStatusEnum::PENDING) {
+            auto* batch = reinterpret_cast<BatchDesc*>(batch_id);
+            if (task_id >= batch->task_list.size())
+                return Status::InvalidArgument("scripted task out of range");
+            batch->task_list[task_id].is_finished = true;
+        }
+        return Status::OK();
+    }
+
+    size_t submittedTasks() const { return submitted_tasks_.load(); }
+
+   private:
+    std::atomic<TransferStatusEnum> status_{TransferStatusEnum::WAITING};
+    std::atomic<size_t> submitted_tasks_{0};
 };
 
 class TransportTest : public ::testing::Test {
@@ -692,6 +725,183 @@ TEST_F(TransportTest, ScatterSubmitFailurePreservesCompletedFragments) {
     EXPECT_EQ(transport->request_counts, (std::vector<size_t>{2}));
     transport->addExtraSlice();
     EXPECT_EQ(run(), (std::vector<bool>{false, false}));
+}
+
+TEST_F(TransportTest, ScatterLifecycleReportsPhysicalSuccess) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<ScriptedScatterTransport>();
+    transport->setStatus(TransferStatusEnum::COMPLETED);
+    auto& impl = TransferEngineImplTestPeer::implementation(engine);
+    TransferEngineImplTestPeer::replaceTransports(impl,
+                                                  {{"scripted", transport}});
+
+    constexpr SegmentID kSegmentId = 13;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "remote";
+    descriptor->protocol = "scripted";
+    impl.getMetadata()->addLocalSegment(kSegmentId, "remote",
+                                        std::move(descriptor));
+
+    std::array<char, 2> buffer{};
+    std::array<size_t, 2> offsets{0, 1};
+    std::array<size_t, 2> lengths{1, 1};
+    TransferEngine::ScatterTransferRange range{
+        .opcode = TransferRequest::READ,
+        .remote_segment = "remote",
+        .remote_base_offset = 0,
+        .remote_size = buffer.size(),
+        .local_buffer = buffer.data(),
+        .local_capacity = buffer.size(),
+        .local_offsets = offsets,
+        .remote_offsets = offsets,
+        .lengths = lengths,
+        .on_fragment_complete = {},
+    };
+
+    auto operation = engine.submitScatter({range});
+    EXPECT_TRUE(operation.wait().ok());
+    const auto snapshot = operation.snapshot();
+    EXPECT_EQ(snapshot.state, TransferEngine::ScatterTransferState::SUCCEEDED);
+    EXPECT_TRUE(snapshot.first_failure.ok());
+    EXPECT_EQ(snapshot.total_bytes, 2);
+    EXPECT_EQ(snapshot.in_flight_bytes, 0);
+    EXPECT_EQ(snapshot.total_fragments, 2);
+    EXPECT_EQ(snapshot.completed_fragments, 2);
+    EXPECT_EQ(snapshot.late_completions, 0);
+    EXPECT_TRUE(snapshot.physical_complete);
+    EXPECT_TRUE(snapshot.buffer_reusable);
+    EXPECT_GT(snapshot.submit_to_physical_completion.count(), 0);
+    EXPECT_EQ(transport->submittedTasks(), 2);
+}
+
+TEST_F(TransportTest, ScatterLifecycleQuarantinesLateCompletion) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<ScriptedScatterTransport>();
+    auto& impl = TransferEngineImplTestPeer::implementation(engine);
+    TransferEngineImplTestPeer::replaceTransports(impl,
+                                                  {{"scripted", transport}});
+
+    constexpr SegmentID kSegmentId = 14;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "remote";
+    descriptor->protocol = "scripted";
+    impl.getMetadata()->addLocalSegment(kSegmentId, "remote",
+                                        std::move(descriptor));
+
+    auto buffer = std::make_shared<std::array<char, 1>>();
+    std::weak_ptr<std::array<char, 1>> weak_buffer = buffer;
+    std::array<size_t, 1> offsets{0};
+    std::array<size_t, 1> lengths{1};
+    size_t callback_count = 0;
+    bool callback_timed_out = false;
+    TransferEngine::ScatterTransferRange range{
+        .opcode = TransferRequest::READ,
+        .remote_segment = "remote",
+        .remote_base_offset = 0,
+        .remote_size = buffer->size(),
+        .local_buffer = buffer->data(),
+        .local_capacity = buffer->size(),
+        .local_offsets = offsets,
+        .remote_offsets = offsets,
+        .lengths = lengths,
+        .on_fragment_complete =
+            [&](size_t, const Status& status) {
+                ++callback_count;
+                callback_timed_out = status.IsClock();
+            },
+    };
+
+    TransferEngine::ScatterTransferOptions options{
+        .local_lifetimes = {buffer},
+    };
+    auto operation = engine.submitScatter({range}, options);
+    options.local_lifetimes.clear();
+    buffer.reset();
+
+    auto status = operation.waitUntil(std::chrono::steady_clock::now());
+    EXPECT_TRUE(status.IsClock());
+    auto snapshot = operation.snapshot();
+    const auto first_failure = snapshot.first_failure.ToString();
+    EXPECT_EQ(snapshot.state, TransferEngine::ScatterTransferState::TIMED_OUT);
+    EXPECT_TRUE(snapshot.first_failure.IsClock());
+    EXPECT_EQ(snapshot.in_flight_bytes, 1);
+    EXPECT_EQ(snapshot.completed_fragments, 0);
+    EXPECT_EQ(snapshot.deadline_timeouts, 1);
+    EXPECT_FALSE(snapshot.physical_complete);
+    EXPECT_FALSE(snapshot.buffer_reusable);
+    EXPECT_EQ(callback_count, 1);
+    EXPECT_TRUE(callback_timed_out);
+    EXPECT_FALSE(weak_buffer.expired());
+
+    status = operation.cancelAndDrainUntil(std::chrono::steady_clock::now());
+    EXPECT_TRUE(status.IsClock());
+    EXPECT_EQ(status.ToString(), first_failure);
+    snapshot = operation.snapshot();
+    EXPECT_EQ(snapshot.state,
+              TransferEngine::ScatterTransferState::QUARANTINED);
+    EXPECT_EQ(snapshot.quarantined_bytes, 1);
+    EXPECT_EQ(snapshot.cancel_requests, 1);
+    EXPECT_EQ(snapshot.drain_attempts, 1);
+    EXPECT_EQ(snapshot.quarantine_events, 1);
+    EXPECT_FALSE(snapshot.buffer_reusable);
+    EXPECT_EQ(snapshot.first_failure.ToString(), first_failure);
+    EXPECT_FALSE(weak_buffer.expired());
+
+    transport->setStatus(TransferStatusEnum::COMPLETED);
+    EXPECT_TRUE(operation.wait().IsClock());
+    snapshot = operation.snapshot();
+    EXPECT_EQ(snapshot.state, TransferEngine::ScatterTransferState::DRAINED);
+    EXPECT_EQ(snapshot.in_flight_bytes, 0);
+    EXPECT_EQ(snapshot.quarantined_bytes, 0);
+    EXPECT_EQ(snapshot.completed_fragments, 1);
+    EXPECT_EQ(snapshot.late_completions, 1);
+    EXPECT_TRUE(snapshot.physical_complete);
+    EXPECT_TRUE(snapshot.buffer_reusable);
+    EXPECT_EQ(callback_count, 1);
+    EXPECT_TRUE(weak_buffer.expired());
+}
+
+TEST_F(TransportTest, ScatterLifecyclePreservesFirstPhysicalFailure) {
+    TransferEngine engine(false);
+    ASSERT_EQ(engine.init(P2PHANDSHAKE, "127.0.0.1:12345"), 0);
+    auto transport = std::make_shared<ScriptedScatterTransport>();
+    transport->setStatus(TransferStatusEnum::FAILED);
+    auto& impl = TransferEngineImplTestPeer::implementation(engine);
+    TransferEngineImplTestPeer::replaceTransports(impl,
+                                                  {{"scripted", transport}});
+
+    constexpr SegmentID kSegmentId = 15;
+    auto descriptor = std::make_shared<TransferMetadata::SegmentDesc>();
+    descriptor->name = "remote";
+    descriptor->protocol = "scripted";
+    impl.getMetadata()->addLocalSegment(kSegmentId, "remote",
+                                        std::move(descriptor));
+
+    std::array<char, 1> buffer{};
+    std::array<size_t, 1> offsets{0};
+    std::array<size_t, 1> lengths{1};
+    TransferEngine::ScatterTransferRange range{
+        .opcode = TransferRequest::READ,
+        .remote_segment = "remote",
+        .remote_base_offset = 0,
+        .remote_size = buffer.size(),
+        .local_buffer = buffer.data(),
+        .local_capacity = buffer.size(),
+        .local_offsets = offsets,
+        .remote_offsets = offsets,
+        .lengths = lengths,
+        .on_fragment_complete = {},
+    };
+
+    auto operation = engine.submitScatter({range});
+    EXPECT_FALSE(operation.wait().ok());
+    const auto snapshot = operation.snapshot();
+    EXPECT_EQ(snapshot.state, TransferEngine::ScatterTransferState::FAILED);
+    EXPECT_TRUE(snapshot.first_failure.IsSocket());
+    EXPECT_TRUE(snapshot.physical_complete);
+    EXPECT_TRUE(snapshot.buffer_reusable);
 }
 
 #ifdef USE_EVENT_DRIVEN_COMPLETION


### PR DESCRIPTION
## Description

This PR introduces a deadline-safe lifecycle for scatter transfer operations. It is the Transfer Engine foundation for bounded remote retrieval; Store windowing and framework-specific tensor-parallel commit barriers are intentionally out of scope.

The motivating problem is that a logical wait timeout does not prove that DMA/RDMA has physically stopped. Releasing or reusing a staging buffer after such a timeout can therefore be unsafe, and a late completion must not publish a second logical result.

The change adds:

- absolute-deadline `waitUntil()` semantics;
- explicit operation states from submission through drain or quarantine;
- best-effort `cancelAndDrainUntil()`;
- retained local lifetime anchors until physical completion;
- idempotent late-completion accounting and first-failure preservation;
- snapshots for bytes, fragments, timeouts, cancellation, drain, quarantine, and physical-completion latency;
- documentation, fault-injection unit tests, and a control-plane microbenchmark.

Existing scatter submission and `waitFor()` call sites remain source-compatible. Background research motivation: https://arxiv.org/abs/2608.17826

Related upstream lifecycle context includes #3000, #3310, #2887, #2881, #2916, #2917, and #3523.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## Design boundary

This PR does not make Mooncake responsible for a serving framework's scheduler or tensor-parallel atomic commit. An integration can use the exposed physical-completion and buffer-reuse state to implement prepare-all / commit-all / abort-all across ranks.

A follow-up Store PR is expected to add bounded bytes, fragments, and operations per retrieve window under one total deadline.

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B <build-dir> -G Ninja \
  -DWITH_STORE=OFF \
  -DWITH_STORE_RUST=OFF \
  -DBUILD_UNIT_TESTS=ON \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_BENCHMARK=ON \
  -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build <build-dir> --target transport_uint_test scatter_lifecycle_bench -j2
<build-dir>/mooncake-transfer-engine/tests/transport_uint_test
./scripts/code_format.sh --base upstream/main --changed-lines --check
git diff --check upstream/main...HEAD
```

**Test results:**
- [x] Unit tests pass: 27/27 on Ubuntu 24.04 arm64, GCC 13.3
- [ ] Integration tests pass (not applicable to this Transfer Engine lifecycle primitive)
- [x] Manual testing done: benchmark target builds and starts successfully
- [x] ASAN/UBSAN lifecycle run passed before the conflict-free rebase
- [x] TENT-enabled compile/link validation passed before the conflict-free rebase

The post-rebase full pre-commit rerun was blocked while fetching hook environments by a GitHub TLS failure. The repository's changed-line clang-format 20 check, `git diff --check`, merge-marker check, and added-file size check pass locally. The earlier full hook run passed on the same three-patch series.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## Known limitations

- Classic transport has no generic physical-cancel primitive; unresolved operations drain or quarantine.
- This minimum PR does not add an engine-global quarantine reaper.
- Process-wide metrics export and Store bounded retrieve remain follow-up work.
- Real RDMA never-CQE and link-flap tests require hardware validation.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

OpenAI Codex assisted with public-API investigation, implementation, test drafting, documentation, formatting checks, and audit preparation. The human submitter remains responsible for reviewing, understanding, and defending the change.