### PR TITLE
[Store] Add batch OpLog snapshot coordinator

### DIFF
--- a/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <thread>
+
+#include "ha/oplog/oplog_batch_types.h"
+#include "types.h"
+
+namespace mooncake {
+
+inline constexpr uint64_t kDefaultBatchOpLogSnapshotIntervalSeconds = 600;
+
+class HaKvBackend;
+class HotStandbyService;
+class SnapshotMaintenanceLease;
+class SnapshotObjectStore;
+
+struct BatchOpLogSnapshotCoordinatorConfig {
+    uint64_t snapshot_interval_seconds{
+        kDefaultBatchOpLogSnapshotIntervalSeconds};
+    size_t chunk_object_count{1000000};
+    std::string snapshot_root;
+    std::function<std::chrono::steady_clock::time_point()> clock;
+};
+
+struct BatchOpLogSnapshotCoordinatorStatus {
+    bool running{false};
+    bool attempt_in_flight{false};
+    bool promotion_requested{false};
+    uint64_t attempts{0};
+    ErrorCode last_error{ErrorCode::OK};
+    std::optional<DurablePrefix> catch_up_target;
+};
+
+// Coordinates the opt-in batch-OpLog snapshot path. Construction alone does
+// not start a worker or change HotStandbyService behavior.
+class BatchOpLogSnapshotCoordinator final {
+   public:
+    using LeaseFactory =
+        std::function<std::unique_ptr<SnapshotMaintenanceLease>()>;
+
+    BatchOpLogSnapshotCoordinator(HotStandbyService& standby,
+                                  HaKvBackend& backend,
+                                  SnapshotObjectStore& object_store,
+                                  std::string cluster_id,
+                                  BatchOpLogSnapshotCoordinatorConfig config,
+                                  LeaseFactory lease_factory = {});
+    BatchOpLogSnapshotCoordinator(HotStandbyService& standby,
+                                  HaKvBackend& backend,
+                                  SnapshotObjectStore& object_store,
+                                  std::string cluster_id,
+                                  std::string snapshot_root,
+                                  uint64_t snapshot_interval_seconds =
+                                      kDefaultBatchOpLogSnapshotIntervalSeconds,
+                                  size_t chunk_object_count = 1000000);
+    ~BatchOpLogSnapshotCoordinator();
+
+    BatchOpLogSnapshotCoordinator(const BatchOpLogSnapshotCoordinator&) =
+        delete;
+    BatchOpLogSnapshotCoordinator& operator=(
+        const BatchOpLogSnapshotCoordinator&) = delete;
+
+    // Starts periodic scheduling. RunOnce() remains available for
+    // deterministic tests and callers that own the scheduling loop.
+    void Start();
+    void Stop();
+
+    // Executes at most one attempt. An ineligible cycle returns OK and leaves
+    // the standby OpLog apply loop untouched.
+    ErrorCode RunOnce();
+    ErrorCode PollOnce() { return RunOnce(); }
+
+    // Called by HotStandbyService before promotion/stop. Promotion keeps a
+    // fully uploaded candidate eligible for the background publish step.
+    void NotifyPromotion();
+    void OnPromotion() { NotifyPromotion(); }
+
+    BatchOpLogSnapshotCoordinatorStatus GetStatus() const;
+    bool IsRunning() const;
+    bool IsAttemptInFlight() const;
+    ErrorCode last_error() const;
+
+   private:
+    using Clock = std::chrono::steady_clock;
+
+    void SchedulerLoop();
+    ErrorCode RunAttempt();
+    std::optional<uint64_t> ReadLatestBatchId(ErrorCode& error) const;
+    bool CatchUpComplete(const DurablePrefix& target) const;
+    void FinishAttempt(ErrorCode error, bool count_attempt);
+    Clock::time_point Now() const;
+    void OnCaptureReleased();
+    std::optional<DurablePrefix> ReadDurablePrefix() const;
+    void RequestStop();
+
+    HotStandbyService& standby_;
+    HaKvBackend& backend_;
+    SnapshotObjectStore& object_store_;
+    std::string cluster_id_;
+    BatchOpLogSnapshotCoordinatorConfig config_;
+    LeaseFactory lease_factory_;
+
+    mutable std::mutex mutex_;
+    std::condition_variable cv_;
+    std::thread worker_;
+    bool running_{false};
+    bool stop_requested_{false};
+    bool attempt_in_flight_{false};
+    bool capture_active_{false};
+    bool promotion_requested_{false};
+    uint64_t attempts_{0};
+    ErrorCode last_error_{ErrorCode::OK};
+    std::optional<Clock::time_point> last_attempt_complete_;
+    std::optional<DurablePrefix> capture_cursor_;
+    std::optional<DurablePrefix> catch_up_target_;
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/snapshot/batch_oplog_snapshot_coordinator.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog_snapshot_coordinator.h
@@ -1,0 +1,5 @@
+#pragma once
+
+// Compatibility include; the batch-OpLog implementation lives in the
+// batch_oplog-specific directory.
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h"

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -291,6 +291,8 @@ class HotStandbyService {
     std::atomic<bool> replication_loop_running_{false};
     std::mutex replication_loop_mutex_;
     std::condition_variable replication_loop_cv_;
+    mutable std::mutex batch_snapshot_cursor_mutex_;
+    std::optional<DurablePrefix> last_applied_batch_snapshot_prefix_;
 
     std::shared_ptr<BatchOpLogSnapshotCapture::LeaseState>
         snapshot_capture_state_{

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -178,6 +178,17 @@ class HotStandbyService {
                                          std::vector<StandbyObjectEntry>& out);
     void EndBatchOpLogSnapshotCapture(BatchOpLogSnapshotCapture& capture);
 
+    // N06 coordinator seams. These stay inert unless a coordinator is
+    // explicitly constructed by the caller.
+    std::optional<DurablePrefix> GetLastAppliedBatchOpLogSnapshotPrefix() const;
+    void CancelBatchOpLogSnapshotCapture();
+    using SnapshotLifecycleCallback = std::function<void()>;
+    void SetBatchOpLogSnapshotCaptureReleasedCallback(
+        SnapshotLifecycleCallback callback);
+    void SetBatchOpLogSnapshotPromotionCallback(
+        SnapshotLifecycleCallback callback);
+    void SetBatchOpLogSnapshotStopCallback(SnapshotLifecycleCallback callback);
+
     // Inject a snapshot provider (from external snapshot implementation).
     void SetSnapshotProvider(std::unique_ptr<SnapshotProvider> provider);
 
@@ -222,6 +233,8 @@ class HotStandbyService {
     void HandleSnapshotCaptureRequest(
         const OpLogBatchStandbyPollResult& result);
     void CancelSnapshotCapture();
+    void NotifySnapshotPromotion();
+    void NotifySnapshotStop();
 
     // Shared body for Promote() and PromoteAndExportSnapshot(): runs the
     // promotion sequence machine transitions + gap resolution + final
@@ -287,7 +300,11 @@ class HotStandbyService {
     // Synchronization
     mutable std::mutex mutex_;
     mutable std::mutex sync_status_callback_mutex_;
+    mutable std::mutex snapshot_lifecycle_callback_mutex_;
     SyncStatusCallback sync_status_callback_;
+    SnapshotLifecycleCallback snapshot_capture_released_callback_;
+    SnapshotLifecycleCallback snapshot_promotion_callback_;
+    SnapshotLifecycleCallback snapshot_stop_callback_;
 };
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -43,6 +43,7 @@ set(MOONCAKE_STORE_MASTER_SOURCES
     ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
     ha/snapshot/batch_oplog/writer.cpp
     ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.cpp
+    ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp
     ha/snapshot/snapshot_maintenance_lease.cpp
     ha/snapshot/master_snapshot_codec.cpp
     ha/snapshot/local_ssd_codec.cpp

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp
@@ -344,16 +344,28 @@ ErrorCode BatchOpLogSnapshotCoordinator::RunAttempt() {
         return result;
     }
 
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        capture_active_ = true;
-    }
     auto capture = standby_.BeginBatchOpLogSnapshotCapture();
     {
         std::lock_guard<std::mutex> lock(mutex_);
         capture_active_ = capture.has_value();
+        if (capture && promotion_requested_) {
+            capture_active_ = false;
+        }
     }
     if (!capture || capture->last_included_batch_id <= *reread_latest) {
+        release_lease();
+        FinishAttempt(ErrorCode::OK, true);
+        return ErrorCode::OK;
+    }
+
+    bool cancel_after_promotion = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cancel_after_promotion = promotion_requested_;
+    }
+    if (cancel_after_promotion) {
+        standby_.CancelBatchOpLogSnapshotCapture();
+        standby_.EndBatchOpLogSnapshotCapture(*capture);
         release_lease();
         FinishAttempt(ErrorCode::OK, true);
         return ErrorCode::OK;

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp
@@ -1,0 +1,450 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h"
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <utility>
+
+#include <glog/logging.h>
+
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_storage.h"
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_publisher.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/batch_oplog/writer.h"
+#include "ha/snapshot/snapshot_maintenance_lease.h"
+#include "ha/snapshot/object/snapshot_object_store.h"
+#include "hot_standby_service.h"
+
+namespace mooncake {
+namespace {
+
+int64_t CurrentTimeMs() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+bool IsAtOrAfter(const DurablePrefix& current, const DurablePrefix& target) {
+    return !IsSequenceOlder(current.last_seq, target.last_seq) &&
+           current.batch_id >= target.batch_id;
+}
+
+}  // namespace
+
+BatchOpLogSnapshotCoordinator::BatchOpLogSnapshotCoordinator(
+    HotStandbyService& standby, HaKvBackend& backend,
+    SnapshotObjectStore& object_store, std::string cluster_id,
+    BatchOpLogSnapshotCoordinatorConfig config, LeaseFactory lease_factory)
+    : standby_(standby),
+      backend_(backend),
+      object_store_(object_store),
+      cluster_id_(std::move(cluster_id)),
+      config_(std::move(config)),
+      lease_factory_(std::move(lease_factory)) {
+    if (!config_.clock) {
+        config_.clock = [] { return Clock::now(); };
+    }
+    if (!lease_factory_) {
+        lease_factory_ = [this] {
+            return std::make_unique<SnapshotMaintenanceLease>(cluster_id_);
+        };
+    }
+    standby_.SetBatchOpLogSnapshotCaptureReleasedCallback(
+        [this] { OnCaptureReleased(); });
+    standby_.SetBatchOpLogSnapshotPromotionCallback(
+        [this] { NotifyPromotion(); });
+    standby_.SetBatchOpLogSnapshotStopCallback([this] { RequestStop(); });
+}
+
+BatchOpLogSnapshotCoordinator::BatchOpLogSnapshotCoordinator(
+    HotStandbyService& standby, HaKvBackend& backend,
+    SnapshotObjectStore& object_store, std::string cluster_id,
+    std::string snapshot_root, uint64_t snapshot_interval_seconds,
+    size_t chunk_object_count)
+    : BatchOpLogSnapshotCoordinator(
+          standby, backend, object_store, std::move(cluster_id),
+          BatchOpLogSnapshotCoordinatorConfig{
+              .snapshot_interval_seconds = snapshot_interval_seconds,
+              .chunk_object_count = chunk_object_count,
+              .snapshot_root = std::move(snapshot_root),
+              .clock = {}},
+          {}) {}
+
+BatchOpLogSnapshotCoordinator::~BatchOpLogSnapshotCoordinator() {
+    Stop();
+    standby_.SetBatchOpLogSnapshotCaptureReleasedCallback(nullptr);
+    standby_.SetBatchOpLogSnapshotPromotionCallback(nullptr);
+    standby_.SetBatchOpLogSnapshotStopCallback(nullptr);
+}
+
+void BatchOpLogSnapshotCoordinator::Start() {
+    std::thread stale_worker;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (running_) {
+            return;
+        }
+        stop_requested_ = true;
+        stale_worker = std::move(worker_);
+    }
+    cv_.notify_all();
+    if (stale_worker.joinable()) {
+        stale_worker.join();
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    stop_requested_ = false;
+    promotion_requested_ = false;
+    running_ = true;
+    worker_ = std::thread(&BatchOpLogSnapshotCoordinator::SchedulerLoop, this);
+}
+
+void BatchOpLogSnapshotCoordinator::Stop() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_requested_ = true;
+        running_ = false;
+    }
+    standby_.CancelBatchOpLogSnapshotCapture();
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [this] { return !attempt_in_flight_; });
+}
+
+void BatchOpLogSnapshotCoordinator::NotifyPromotion() {
+    bool cancel_capture = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        promotion_requested_ = true;
+        cancel_capture = capture_active_;
+    }
+    if (cancel_capture) {
+        standby_.CancelBatchOpLogSnapshotCapture();
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return !capture_active_; });
+    }
+    cv_.notify_all();
+}
+
+BatchOpLogSnapshotCoordinatorStatus BatchOpLogSnapshotCoordinator::GetStatus()
+    const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return {.running = running_,
+            .attempt_in_flight = attempt_in_flight_,
+            .promotion_requested = promotion_requested_,
+            .attempts = attempts_,
+            .last_error = last_error_,
+            .catch_up_target = catch_up_target_};
+}
+
+bool BatchOpLogSnapshotCoordinator::IsRunning() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return running_;
+}
+
+bool BatchOpLogSnapshotCoordinator::IsAttemptInFlight() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return attempt_in_flight_;
+}
+
+ErrorCode BatchOpLogSnapshotCoordinator::last_error() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return last_error_;
+}
+
+BatchOpLogSnapshotCoordinator::Clock::time_point
+BatchOpLogSnapshotCoordinator::Now() const {
+    return config_.clock ? config_.clock() : Clock::now();
+}
+
+void BatchOpLogSnapshotCoordinator::OnCaptureReleased() {
+    const auto prefix = ReadDurablePrefix();
+    std::lock_guard<std::mutex> lock(mutex_);
+    capture_active_ = false;
+    if (prefix) {
+        catch_up_target_ = *prefix;
+        if (capture_cursor_ && IsSequenceOlder(catch_up_target_->last_seq,
+                                               capture_cursor_->last_seq)) {
+            catch_up_target_ = *capture_cursor_;
+        }
+    } else if (capture_cursor_) {
+        catch_up_target_ = *capture_cursor_;
+    }
+    cv_.notify_all();
+}
+
+std::optional<DurablePrefix> BatchOpLogSnapshotCoordinator::ReadDurablePrefix()
+    const {
+    OpLogBatchStorage storage(cluster_id_, backend_);
+    DurablePrefix prefix;
+    if (storage.ReadDurablePrefix(prefix) != ErrorCode::OK) {
+        return std::nullopt;
+    }
+    return prefix;
+}
+
+std::optional<uint64_t> BatchOpLogSnapshotCoordinator::ReadLatestBatchId(
+    ErrorCode& error) const {
+    error = ErrorCode::OK;
+    uint64_t published_batch_id = 0;
+    for (const auto& key :
+         {ha::BuildBatchOpLogSnapshotLatestKey(cluster_id_),
+          ha::BuildBatchOpLogSnapshotFallbackKey(cluster_id_)}) {
+        std::string value;
+        const auto get_error = backend_.Get(key, value);
+        if (get_error == ErrorCode::ETCD_KEY_NOT_EXIST) {
+            continue;
+        }
+        if (get_error != ErrorCode::OK) {
+            error = get_error;
+            return std::nullopt;
+        }
+        auto descriptor = ha::DecodeBatchOpLogSnapshotDescriptor(value);
+        // Corrupt pointers are handled by the fenced publisher; they do not
+        // qualify a newer local cursor on their own.
+        if (descriptor) {
+            published_batch_id = std::max(published_batch_id,
+                                          descriptor->last_included_batch_id);
+        }
+    }
+    return published_batch_id;
+}
+
+bool BatchOpLogSnapshotCoordinator::CatchUpComplete(
+    const DurablePrefix& target) const {
+    const auto current = standby_.GetLastAppliedBatchOpLogSnapshotPrefix();
+    return current && IsAtOrAfter(*current, target);
+}
+
+void BatchOpLogSnapshotCoordinator::FinishAttempt(ErrorCode error,
+                                                  bool count_attempt) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (count_attempt) {
+        ++attempts_;
+        last_attempt_complete_ = Now();
+    }
+    last_error_ = error;
+    attempt_in_flight_ = false;
+    capture_active_ = false;
+    cv_.notify_all();
+}
+
+ErrorCode BatchOpLogSnapshotCoordinator::RunOnce() {
+    try {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (attempt_in_flight_) {
+                return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+            }
+            if (stop_requested_) {
+                return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+            }
+            if (last_attempt_complete_ &&
+                Now() - *last_attempt_complete_ <
+                    std::chrono::seconds(config_.snapshot_interval_seconds)) {
+                return ErrorCode::OK;
+            }
+            if (promotion_requested_) {
+                return ErrorCode::OK;
+            }
+        }
+        return RunAttempt();
+    } catch (const std::exception& e) {
+        LOG(ERROR) << "Batch snapshot coordinator failed: " << e.what();
+        FinishAttempt(ErrorCode::INTERNAL_ERROR, false);
+        return ErrorCode::INTERNAL_ERROR;
+    } catch (...) {
+        LOG(ERROR) << "Batch snapshot coordinator failed with unknown error";
+        FinishAttempt(ErrorCode::INTERNAL_ERROR, false);
+        return ErrorCode::INTERNAL_ERROR;
+    }
+}
+
+ErrorCode BatchOpLogSnapshotCoordinator::RunAttempt() {
+    if (config_.snapshot_root.empty() || config_.chunk_object_count == 0 ||
+        !NormalizeAndValidateClusterId(cluster_id_) || cluster_id_.empty()) {
+        FinishAttempt(ErrorCode::INVALID_PARAMS, false);
+        return ErrorCode::INVALID_PARAMS;
+    }
+
+    ErrorCode read_error = ErrorCode::OK;
+    const auto latest_batch_id = ReadLatestBatchId(read_error);
+    if (!latest_batch_id) {
+        FinishAttempt(read_error, false);
+        return read_error;
+    }
+    const auto local_prefix = standby_.GetLastAppliedBatchOpLogSnapshotPrefix();
+    if (!local_prefix || local_prefix->batch_id <= *latest_batch_id) {
+        FinishAttempt(ErrorCode::OK, false);
+        return ErrorCode::OK;
+    }
+    bool catch_up_blocked = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (attempt_in_flight_) {
+            return ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS;
+        }
+        catch_up_blocked = catch_up_target_.has_value();
+        attempt_in_flight_ = true;
+    }
+    if (catch_up_blocked) {
+        std::optional<DurablePrefix> target;
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            target = catch_up_target_;
+        }
+        if (target && !CatchUpComplete(*target)) {
+            FinishAttempt(ErrorCode::OK, false);
+            return ErrorCode::OK;
+        }
+    }
+
+    auto lease = lease_factory_();
+    if (!lease) {
+        // A factory may return null to represent a busy maintenance lease.
+        FinishAttempt(ErrorCode::OK, false);
+        return ErrorCode::OK;
+    }
+    const ErrorCode lease_error =
+        lease->IsHeld() ? ErrorCode::OK : lease->Acquire();
+    if (lease_error != ErrorCode::OK) {
+        // A busy maintenance lease is an ordinary skipped cycle.
+        const ErrorCode result = lease_error == ErrorCode::ETCD_TRANSACTION_FAIL
+                                     ? ErrorCode::OK
+                                     : lease_error;
+        FinishAttempt(result, false);
+        return result;
+    }
+
+    auto release_lease = [&] { (void)lease->Release(); };
+    bool cancel_before_capture = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        cancel_before_capture = stop_requested_ || promotion_requested_;
+    }
+    if (cancel_before_capture) {
+        release_lease();
+        FinishAttempt(ErrorCode::OK, true);
+        return ErrorCode::OK;
+    }
+
+    // Re-read both sides after fencing the maintenance lease.
+    const auto reread_latest = ReadLatestBatchId(read_error);
+    const auto reread_local = standby_.GetLastAppliedBatchOpLogSnapshotPrefix();
+    if (!reread_latest || !reread_local ||
+        reread_local->batch_id <= *reread_latest) {
+        const ErrorCode result =
+            read_error == ErrorCode::OK ? ErrorCode::OK : read_error;
+        release_lease();
+        FinishAttempt(result, true);
+        return result;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        capture_active_ = true;
+    }
+    auto capture = standby_.BeginBatchOpLogSnapshotCapture();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        capture_active_ = capture.has_value();
+    }
+    if (!capture || capture->last_included_batch_id <= *reread_latest) {
+        release_lease();
+        FinishAttempt(ErrorCode::OK, true);
+        return ErrorCode::OK;
+    }
+
+    const std::string snapshot_id =
+        std::to_string(capture->last_included_batch_id) + "-" +
+        lease->owner_token();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        capture_cursor_ =
+            DurablePrefix{.batch_id = capture->last_included_batch_id,
+                          .last_seq = capture->last_included_seq};
+    }
+    const std::string artifact_prefix =
+        ha::BuildBatchOpLogSnapshotArtifactPrefix(config_.snapshot_root,
+                                                  snapshot_id);
+
+    BatchOpLogSnapshotWriter writer(object_store_);
+    auto descriptor =
+        writer.Write(standby_, *capture, config_.snapshot_root, snapshot_id,
+                     config_.chunk_object_count, CurrentTimeMs());
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        capture_active_ = false;
+    }
+    if (!descriptor) {
+        release_lease();
+        FinishAttempt(ErrorCode::INTERNAL_ERROR, true);
+        return ErrorCode::INTERNAL_ERROR;
+    }
+
+    bool stop_before_publish = false;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_before_publish = stop_requested_ && !promotion_requested_;
+    }
+    if (stop_before_publish) {
+        auto cleanup = object_store_.DeleteObjectsWithPrefix(artifact_prefix);
+        if (!cleanup) {
+            LOG(WARNING) << "Failed to clean snapshot candidate after stop: "
+                         << cleanup.error();
+        }
+        release_lease();
+        FinishAttempt(ErrorCode::OK, true);
+        return ErrorCode::OK;
+    }
+
+    BatchOpLogSnapshotPublisher publisher(backend_, cluster_id_);
+    ErrorCode publish_error = publisher.Publish(*lease, *descriptor);
+    if (publish_error != ErrorCode::OK) {
+        auto cleanup = object_store_.DeleteObjectsWithPrefix(artifact_prefix);
+        if (!cleanup) {
+            LOG(WARNING) << "Failed to clean unpublished snapshot candidate: "
+                         << cleanup.error();
+        }
+    }
+    release_lease();
+    FinishAttempt(publish_error, true);
+    return publish_error;
+}
+
+void BatchOpLogSnapshotCoordinator::SchedulerLoop() {
+    while (true) {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            const auto delay =
+                std::chrono::seconds(config_.snapshot_interval_seconds == 0
+                                         ? 1
+                                         : config_.snapshot_interval_seconds);
+            if (cv_.wait_for(lock, delay, [this] { return stop_requested_; })) {
+                return;
+            }
+        }
+        if (RunOnce() == ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS) {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stop_requested_) {
+                return;
+            }
+        }
+    }
+}
+
+void BatchOpLogSnapshotCoordinator::RequestStop() {
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stop_requested_ = true;
+        running_ = false;
+    }
+    standby_.CancelBatchOpLogSnapshotCapture();
+    cv_.notify_all();
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -367,6 +367,9 @@ void HotStandbyService::Stop() {
         return;
     }
 
+    if (current_state != StandbyState::PROMOTED) {
+        NotifySnapshotStop();
+    }
     state_machine_.ProcessEvent(StandbyEvent::STOP);
     StopReplicationLoop();
 
@@ -377,6 +380,59 @@ void HotStandbyService::Stop() {
 
     LOG(INFO) << "HotStandbyService stopped, final_state="
               << StandbyStateToString(GetState());
+}
+
+std::optional<DurablePrefix>
+HotStandbyService::GetLastAppliedBatchOpLogSnapshotPrefix() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!batch_standby_reader_) {
+        return std::nullopt;
+    }
+    return batch_standby_reader_->GetLastAppliedDurablePrefix();
+}
+
+void HotStandbyService::CancelBatchOpLogSnapshotCapture() {
+    CancelSnapshotCapture();
+}
+
+void HotStandbyService::SetBatchOpLogSnapshotCaptureReleasedCallback(
+    SnapshotLifecycleCallback callback) {
+    std::lock_guard<std::mutex> lock(snapshot_lifecycle_callback_mutex_);
+    snapshot_capture_released_callback_ = std::move(callback);
+}
+
+void HotStandbyService::SetBatchOpLogSnapshotPromotionCallback(
+    SnapshotLifecycleCallback callback) {
+    std::lock_guard<std::mutex> lock(snapshot_lifecycle_callback_mutex_);
+    snapshot_promotion_callback_ = std::move(callback);
+}
+
+void HotStandbyService::SetBatchOpLogSnapshotStopCallback(
+    SnapshotLifecycleCallback callback) {
+    std::lock_guard<std::mutex> lock(snapshot_lifecycle_callback_mutex_);
+    snapshot_stop_callback_ = std::move(callback);
+}
+
+void HotStandbyService::NotifySnapshotPromotion() {
+    SnapshotLifecycleCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(snapshot_lifecycle_callback_mutex_);
+        callback = snapshot_promotion_callback_;
+    }
+    if (callback) {
+        callback();
+    }
+}
+
+void HotStandbyService::NotifySnapshotStop() {
+    SnapshotLifecycleCallback callback;
+    {
+        std::lock_guard<std::mutex> lock(snapshot_lifecycle_callback_mutex_);
+        callback = snapshot_stop_callback_;
+    }
+    if (callback) {
+        callback();
+    }
 }
 
 StandbySyncStatus HotStandbyService::GetSyncStatus() const {
@@ -560,6 +616,7 @@ ErrorCode HotStandbyService::Promote() {
 
 ErrorCode HotStandbyService::PromoteLockedInternal(
     uint64_t current_applied_seq_id) {
+    NotifySnapshotPromotion();
     StopReplicationLoop();
     ErrorCode catch_up_err =
         FinalCatchUpForPromotionLocked(current_applied_seq_id);
@@ -735,6 +792,15 @@ void HotStandbyService::EndBatchOpLogSnapshotCapture(
     BatchOpLogSnapshotCapture& capture) {
     if (capture.lease_state_ == snapshot_capture_state_) {
         capture.Release();
+        SnapshotLifecycleCallback callback;
+        {
+            std::lock_guard<std::mutex> lock(
+                snapshot_lifecycle_callback_mutex_);
+            callback = snapshot_capture_released_callback_;
+        }
+        if (callback) {
+            callback();
+        }
     }
 }
 

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -86,6 +86,10 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     batch_standby_reader_.reset();
     batch_standby_kv_backend_.reset();
     batch_snapshot_baseline_.reset();
+    {
+        std::lock_guard<std::mutex> cursor_lock(batch_snapshot_cursor_mutex_);
+        last_applied_batch_snapshot_prefix_.reset();
+    }
 
     last_error_.store(ErrorCode::OK, std::memory_order_release);
 
@@ -300,6 +304,8 @@ ErrorCode HotStandbyService::StartOplogFollowingLocked(
         if (cursor_error != ErrorCode::OK) {
             return cursor_error;
         }
+        std::lock_guard<std::mutex> cursor_lock(batch_snapshot_cursor_mutex_);
+        last_applied_batch_snapshot_prefix_ = *batch_snapshot_baseline_;
     }
 
     state_machine_.ProcessEvent(StandbyEvent::SYNC_COMPLETE);
@@ -384,11 +390,8 @@ void HotStandbyService::Stop() {
 
 std::optional<DurablePrefix>
 HotStandbyService::GetLastAppliedBatchOpLogSnapshotPrefix() const {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!batch_standby_reader_) {
-        return std::nullopt;
-    }
-    return batch_standby_reader_->GetLastAppliedDurablePrefix();
+    std::lock_guard<std::mutex> lock(batch_snapshot_cursor_mutex_);
+    return last_applied_batch_snapshot_prefix_;
 }
 
 void HotStandbyService::CancelBatchOpLogSnapshotCapture() {
@@ -904,6 +907,12 @@ void HotStandbyService::ReplicationLoop() {
             const uint64_t expected_before =
                 oplog_applier_->GetExpectedSequenceId();
             auto result = batch_standby_reader_->PollOnce();
+            {
+                std::lock_guard<std::mutex> cursor_lock(
+                    batch_snapshot_cursor_mutex_);
+                last_applied_batch_snapshot_prefix_ =
+                    batch_standby_reader_->GetLastAppliedDurablePrefix();
+            }
             HandleSnapshotCaptureRequest(result);
             if (result.durable_prefix_present) {
                 const uint64_t current_primary = primary_seq_id_.load();

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -188,6 +188,8 @@ add_ha_test(batch_oplog_snapshot_provider_test
             ha/snapshot/batch_oplog/provider_test.cpp)
 add_ha_test(batch_oplog_snapshot_publisher_test
             ha/snapshot/batch_oplog/publisher_test.cpp)
+add_ha_test(batch_oplog_snapshot_coordinator_test
+            ha/snapshot/batch_oplog/coordinator_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/coordinator_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/coordinator_test.cpp
@@ -1,0 +1,306 @@
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_codec.h"
+#include "ha/oplog/oplog_types.h"
+#include "ha/snapshot/batch_oplog/metadata.h"
+#include "ha/snapshot/snapshot_maintenance_lease.h"
+#include "ha/snapshot/object/snapshot_object_store.h"
+#include "hot_standby_service.h"
+
+namespace mooncake::test {
+namespace {
+
+class EmptyBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        auto it = values.find(std::string(key));
+        if (it == values.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        values[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view, std::string_view, size_t,
+                    std::vector<KvPair>& output) override {
+        output.clear();
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+    ErrorCode Txn(const KvTxn&) override { return ErrorCode::OK; }
+
+    std::map<std::string, std::string> values;
+};
+
+class UnusedObjectStore final : public SnapshotObjectStore {
+   public:
+    tl::expected<void, std::string> UploadBuffer(
+        const std::string&, const std::vector<uint8_t>&) override {
+        return {};
+    }
+    tl::expected<void, std::string> DownloadBuffer(
+        const std::string&, std::vector<uint8_t>&) override {
+        return tl::make_unexpected("unused");
+    }
+    tl::expected<void, std::string> UploadString(const std::string&,
+                                                 const std::string&) override {
+        return {};
+    }
+    tl::expected<void, std::string> DownloadString(const std::string&,
+                                                   std::string&) override {
+        return tl::make_unexpected("unused");
+    }
+    tl::expected<void, std::string> DeleteObjectsWithPrefix(
+        const std::string&) override {
+        return {};
+    }
+    tl::expected<void, std::string> ListObjectsWithPrefix(
+        const std::string&, std::vector<std::string>& output) override {
+        output.clear();
+        return {};
+    }
+    std::string GetConnectionInfo() const override { return "unused"; }
+};
+
+class RecordingBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const std::string owned_key(key);
+        values_[owned_key] = std::string(value);
+        create_revisions_.try_emplace(owned_key, next_revision_++);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view begin, std::string_view end, size_t limit,
+                    std::vector<KvPair>& output) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        output.clear();
+        for (const auto& [key, value] : values_) {
+            if (key >= begin && key < end &&
+                (limit == 0 || output.size() < limit)) {
+                output.push_back({key, value});
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+
+    ErrorCode Txn(const KvTxn& txn) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        for (const auto& compare : txn.compares) {
+            auto it = values_.find(compare.key);
+            if (compare.kind == KvCompareKind::kKeyNotExists) {
+                if (it != values_.end())
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+            } else if (compare.kind == KvCompareKind::kCreateRevisionEquals) {
+                auto revision = create_revisions_.find(compare.key);
+                if (revision == create_revisions_.end() ||
+                    revision->second != compare.expected_revision) {
+                    return ErrorCode::ETCD_TRANSACTION_FAIL;
+                }
+            } else if (it == values_.end() ||
+                       it->second != compare.expected_value) {
+                return ErrorCode::ETCD_TRANSACTION_FAIL;
+            }
+        }
+        for (const auto& put : txn.puts) {
+            values_[put.key] = put.value;
+            create_revisions_.try_emplace(put.key, next_revision_++);
+        }
+        return ErrorCode::OK;
+    }
+
+    bool Contains(std::string_view key) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return values_.contains(std::string(key));
+    }
+
+   private:
+    mutable std::mutex mutex_;
+    std::map<std::string, std::string> values_;
+    std::map<std::string, EtcdRevisionId> create_revisions_;
+    EtcdRevisionId next_revision_{1};
+};
+
+class RecordingObjectStore final : public SnapshotObjectStore {
+   public:
+    tl::expected<void, std::string> UploadBuffer(
+        const std::string& key, const std::vector<uint8_t>& buffer) override {
+        objects_[key] = buffer;
+        return {};
+    }
+    tl::expected<void, std::string> DownloadBuffer(
+        const std::string& key, std::vector<uint8_t>& buffer) override {
+        auto it = objects_.find(key);
+        if (it == objects_.end()) return tl::make_unexpected("not found");
+        buffer = it->second;
+        return {};
+    }
+    tl::expected<void, std::string> UploadString(
+        const std::string& key, const std::string& value) override {
+        objects_[key] = std::vector<uint8_t>(value.begin(), value.end());
+        return {};
+    }
+    tl::expected<void, std::string> DownloadString(
+        const std::string& key, std::string& value) override {
+        std::vector<uint8_t> bytes;
+        auto result = DownloadBuffer(key, bytes);
+        if (!result) return result;
+        value.assign(bytes.begin(), bytes.end());
+        return {};
+    }
+    tl::expected<void, std::string> DeleteObjectsWithPrefix(
+        const std::string& prefix) override {
+        for (auto it = objects_.begin(); it != objects_.end();) {
+            if (it->first.starts_with(prefix))
+                it = objects_.erase(it);
+            else
+                ++it;
+        }
+        return {};
+    }
+    tl::expected<void, std::string> ListObjectsWithPrefix(
+        const std::string& prefix, std::vector<std::string>& output) override {
+        output.clear();
+        for (const auto& [key, value] : objects_) {
+            (void)value;
+            if (key.starts_with(prefix)) output.push_back(key);
+        }
+        return {};
+    }
+    tl::expected<SnapshotObjectInspection, std::string> InspectObject(
+        const std::string& key) override {
+        auto it = objects_.find(key);
+        if (it == objects_.end()) return tl::make_unexpected("not found");
+        return SnapshotObjectInspection{.stored_size = it->second.size(),
+                                        .crc32c = std::nullopt};
+    }
+    std::string GetConnectionInfo() const override { return "recording"; }
+
+   private:
+    std::map<std::string, std::vector<uint8_t>> objects_;
+};
+
+OpLogBatchRecord MakeBatch() {
+    OpLogEntry entry;
+    entry.sequence_id = 1;
+    entry.op_type = OpType::REMOVE;
+    entry.tenant_id = "tenant";
+    entry.object_key = "key";
+    entry.checksum = ComputeOpLogChecksum(entry.payload);
+    OpLogBatchRecord batch;
+    batch.batch_id = 1;
+    batch.first_seq = 1;
+    batch.last_seq = 1;
+    batch.entries.push_back(std::move(entry));
+    return batch;
+}
+
+}  // namespace
+
+TEST(BatchOpLogSnapshotCoordinatorTest, EmptyStandbySkipsWithoutLease) {
+    HotStandbyConfig standby_config;
+    standby_config.enable_verification = false;
+    HotStandbyService standby(standby_config);
+    EmptyBackend backend;
+    UnusedObjectStore object_store;
+    size_t lease_factory_calls = 0;
+    BatchOpLogSnapshotCoordinatorConfig config;
+    config.snapshot_root = "snapshots";
+    config.clock = [] { return std::chrono::steady_clock::now(); };
+    BatchOpLogSnapshotCoordinator coordinator(
+        standby, backend, object_store, "cluster", std::move(config), [&] {
+            ++lease_factory_calls;
+            return std::unique_ptr<SnapshotMaintenanceLease>();
+        });
+
+    EXPECT_EQ(ErrorCode::OK, coordinator.RunOnce());
+    EXPECT_EQ(0u, lease_factory_calls);
+    EXPECT_FALSE(coordinator.IsAttemptInFlight());
+    EXPECT_EQ(0u, coordinator.GetStatus().attempts);
+
+    coordinator.Start();
+    EXPECT_TRUE(coordinator.IsRunning());
+    coordinator.Stop();
+    EXPECT_FALSE(coordinator.IsRunning());
+}
+
+TEST(BatchOpLogSnapshotCoordinatorTest, PublishesAfterCaptureAndResumesApply) {
+    auto backend = std::make_shared<RecordingBackend>();
+    ASSERT_EQ(ErrorCode::OK, backend->Put(BuildBatchRecordKey("cluster", 1),
+                                          EncodeOpLogBatchRecord(MakeBatch())));
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey("cluster"),
+                     EncodeDurablePrefix({.batch_id = 1, .last_seq = 1})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildProducerViewKey("cluster"), "7"));
+    const auto maintenance_key =
+        ha::BuildBatchOpLogSnapshotMaintenanceKey("cluster");
+    ASSERT_EQ(ErrorCode::OK, backend->Put(maintenance_key, "101"));
+
+    HotStandbyConfig standby_config;
+    standby_config.enable_verification = false;
+    standby_config.oplog_poll_interval_ms = 1;
+    HotStandbyService standby(standby_config);
+    standby.SetCatchUpBatchKvBackendForTesting(backend);
+    ASSERT_EQ(ErrorCode::OK, standby.Start("", "", "cluster"));
+
+    const auto deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto prefix = standby.GetLastAppliedBatchOpLogSnapshotPrefix();
+        if (prefix && prefix->batch_id == 1) break;
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    RecordingObjectStore object_store;
+    BatchOpLogSnapshotCoordinatorConfig config;
+    config.snapshot_root = "snapshots";
+    config.snapshot_interval_seconds = 0;
+    BatchOpLogSnapshotCoordinator coordinator(
+        standby, *backend, object_store, "cluster", std::move(config), [] {
+            return SnapshotMaintenanceLease::MakeForTesting("cluster", "101",
+                                                            4);
+        });
+
+    EXPECT_EQ(ErrorCode::OK, coordinator.RunOnce());
+    EXPECT_TRUE(
+        backend->Contains(ha::BuildBatchOpLogSnapshotLatestKey("cluster")));
+    EXPECT_EQ(1u, coordinator.GetStatus().attempts);
+    EXPECT_TRUE(coordinator.GetStatus().catch_up_target.has_value());
+    standby.Stop();
+}
+
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

PR-N06 adds the standalone `BatchOpLogSnapshotCoordinator` for the new batch OpLog standby snapshot path. It composes the existing N02 capture, N03 artifact writer, N04 maintenance lease/publisher, and N05 standby cursor state into one coordinator with periodic scheduling and explicit lifecycle state.

The coordinator is inert when only `HotStandbyService` is constructed. It is not wired into public configuration or the default production path; N08 will perform that integration after the complete snapshot mode is ready.

### Scheduling and lifecycle

- Uses the existing 600-second default snapshot interval.
- Starts only when the local durable batch cursor is newer than the published latest/fallback cursor, the previous catch-up target has been applied, and no attempt is already running.
- Acquires the N04 maintenance lease, then re-reads the published pointer and local cursor before capture. A busy lease skips the cycle without stopping OpLog apply.
- Generates an immutable `<batch-id>-<lease-id>` candidate prefix and reuses the existing chunk writer and fenced publisher.
- Records the durable prefix observed when capture releases standby state, so the next attempt waits for that catch-up target.
- Cancels capture on promotion/stop. Once capture has released standby state, promotion does not cancel the remaining artifact verification or publish work.
- Object-store failures and worker exceptions are contained in the coordinator; they do not terminate the OpLog apply loop or publish an invalid pointer.

### Compatibility

- Legacy snapshot provider/manager and public master configuration are unchanged.
- All new snapshot headers, implementation, and tests live under the `ha/snapshot/batch_oplog/` namespace, with only a compatibility include at the snapshot root.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] New feature
- [x] Refactor

## How Has This Been Tested?

**Test commands:**

```bash
cmake --build /tmp/mooncake-n06-build \
  --target batch_oplog_snapshot_coordinator_test \
  -j32

/tmp/mooncake-n06-build/mooncake-store/tests/batch_oplog_snapshot_coordinator_test \
  --gtest_color=no

/tmp/mooncake-n06-build/mooncake-store/tests/batch_oplog_snapshot_writer_test \
  --gtest_color=no
/tmp/mooncake-n06-build/mooncake-store/tests/batch_oplog_snapshot_provider_test \
  --gtest_color=no
/tmp/mooncake-n06-build/mooncake-store/tests/batch_oplog_snapshot_publisher_test \
  --gtest_color=no
/tmp/mooncake-n06-build/mooncake-store/tests/hot_standby_service_test \
  --gtest_color=no

pre-commit run --files \
  mooncake-store/include/hot_standby_service.h \
  mooncake-store/src/CMakeLists.txt \
  mooncake-store/src/hot_standby_service.cpp \
  mooncake-store/tests/CMakeLists.txt \
  mooncake-store/include/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.h \
  mooncake-store/include/ha/snapshot/batch_oplog_snapshot_coordinator.h \
  mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_coordinator.cpp \
  mooncake-store/tests/ha/snapshot/batch_oplog/coordinator_test.cpp
```

**Test results:**

- [x] Unit tests pass
- [ ] Integration tests pass (not applicable; N08 owns production/E2E wiring)
- [ ] Manual testing done

The coordinator test passed 2/2 tests. Existing batch snapshot writer passed 6/6, provider 5/5, publisher 12/13 with the real-etcd case skipped because no local etcd endpoint was available, and HotStandbyService passed 31 tests with 14 existing etcd-dependent cases skipped.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable; production wiring is intentionally deferred to N08)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

The implementation follows the PR-N06 snapshot coordinator design spec; add the corresponding RFC/issue link here if the maintainer requires one for this development branch.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (implementation and test drafting assistance)

The human submitter must review every changed line and be able to explain and defend the coordinator lifecycle, promotion/stop behavior, lease fencing, and test coverage.