### PR TITLE
[TENT]: Deduplicate TentMetrics singleton via shared tent_metrics library

### DIFF
--- a/mooncake-integration/CMakeLists.txt
+++ b/mooncake-integration/CMakeLists.txt
@@ -240,6 +240,15 @@ endif()
 if(WITH_TE)
   install(TARGETS engine asio_shared
           LIBRARY DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR} COMPONENT python)
+  # Co-locate libtent_metrics.so with the python C extensions so engine.so and
+  # store.so resolve it via $ORIGIN RPATH. The shared TentMetrics singleton
+  # must be loadable wherever the extensions are installed; otherwise
+  # `import mooncake.engine` / `mooncake.store` fails with a missing library.
+  if(TARGET tent_metrics)
+    install(TARGETS tent_metrics
+            LIBRARY DESTINATION ${MOONCAKE_PYTHON_INSTALL_DIR}
+            COMPONENT python)
+  endif()
 endif()
 
 if(WITH_EP)

--- a/mooncake-transfer-engine/rust/build.rs
+++ b/mooncake-transfer-engine/rust/build.rs
@@ -176,7 +176,6 @@ fn main() {
             build_dir.join("mooncake-common/src"),
             build_dir.join("mooncake-common/etcd"),
             build_dir.join("mooncake-transfer-engine/tent/src"),
-            build_dir.join("mooncake-transfer-engine/tent/src/metrics"),
             build_dir.join("src"),
             build_dir.join("src/common/base"),
         ] {
@@ -201,7 +200,6 @@ fn main() {
         manifest_dir.join("../../build/mooncake-common"),
         manifest_dir.join("../../build/mooncake-common/etcd"),
         manifest_dir.join("../../build/mooncake-transfer-engine/tent/src"),
-        manifest_dir.join("../../build/mooncake-transfer-engine/tent/src/metrics"),
         manifest_dir.join("../tent/build/src"),
     ] {
         push_dir(&mut search_dirs, dir);

--- a/mooncake-transfer-engine/rust/build.rs
+++ b/mooncake-transfer-engine/rust/build.rs
@@ -176,6 +176,11 @@ fn main() {
             build_dir.join("mooncake-common/src"),
             build_dir.join("mooncake-common/etcd"),
             build_dir.join("mooncake-transfer-engine/tent/src"),
+            // libtent_metrics.so is a SHARED lib built under tent/src/metrics.
+            // collect_tent_archives skips it (only .a), and has_library's
+            // /usr/local/lib fallback only gates the -l emit, not the -L search
+            // path — so the linker still needs this directory explicitly.
+            build_dir.join("mooncake-transfer-engine/tent/src/metrics"),
             build_dir.join("src"),
             build_dir.join("src/common/base"),
         ] {
@@ -200,6 +205,7 @@ fn main() {
         manifest_dir.join("../../build/mooncake-common"),
         manifest_dir.join("../../build/mooncake-common/etcd"),
         manifest_dir.join("../../build/mooncake-transfer-engine/tent/src"),
+        manifest_dir.join("../../build/mooncake-transfer-engine/tent/src/metrics"),
         manifest_dir.join("../tent/build/src"),
     ] {
         push_dir(&mut search_dirs, dir);

--- a/mooncake-transfer-engine/rust/build.rs
+++ b/mooncake-transfer-engine/rust/build.rs
@@ -176,6 +176,7 @@ fn main() {
             build_dir.join("mooncake-common/src"),
             build_dir.join("mooncake-common/etcd"),
             build_dir.join("mooncake-transfer-engine/tent/src"),
+            build_dir.join("mooncake-transfer-engine/tent/src/metrics"),
             build_dir.join("src"),
             build_dir.join("src/common/base"),
         ] {
@@ -200,6 +201,7 @@ fn main() {
         manifest_dir.join("../../build/mooncake-common"),
         manifest_dir.join("../../build/mooncake-common/etcd"),
         manifest_dir.join("../../build/mooncake-transfer-engine/tent/src"),
+        manifest_dir.join("../../build/mooncake-transfer-engine/tent/src/metrics"),
         manifest_dir.join("../tent/build/src"),
     ] {
         push_dir(&mut search_dirs, dir);
@@ -268,6 +270,9 @@ fn main() {
         }
         if has_mooncake_common {
             println!("cargo:rustc-link-arg=-lmooncake_common");
+        }
+        if has_library(&search_dirs, "tent_metrics") {
+            println!("cargo:rustc-link-arg=-ltent_metrics");
         }
         println!("cargo:rustc-link-arg=-Wl,--end-group");
         println!("cargo:rustc-link-lib=dl");

--- a/mooncake-transfer-engine/tent/src/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/CMakeLists.txt
@@ -131,6 +131,7 @@ target_link_libraries(tent PUBLIC tent_runtime tent_interface)
 
 add_library(tent_shared SHARED ${TENT_ENGINE_SOURCES})
 target_link_libraries(tent_shared PUBLIC tent_runtime tent_interface)
+set_target_properties(tent_shared PROPERTIES INSTALL_RPATH "$ORIGIN")
 
 add_library(tent_link_group INTERFACE)
 target_link_libraries(tent_link_group INTERFACE "-Wl,--start-group" tent)

--- a/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
@@ -1,6 +1,18 @@
 # TENT_METRICS_ENABLED option is declared in tent/CMakeLists.txt.
 file(GLOB TENT_METRICS_SOURCES "*.cpp")
-add_library(tent_metrics STATIC ${TENT_METRICS_SOURCES})
+# Build as a SHARED library so the TentMetrics singleton (the function-local
+# `static TentMetrics instance` in TentMetrics::instance()) is not duplicated
+# across DSOs. When statically linked, the metrics code is copied into every
+# consumer .so (engine.so and store.so), giving each its own TentMetrics
+# instance: a process that loads both modules ends up with two independent
+# metrics singletons, two periodic report threads ("TENT Metrics:" logged
+# twice per interval), and a metrics HTTP port clash (both default to 9100,
+# so only one binds and the other silently degrades to log-only). As a shared
+# library, both modules take a single DT_NEEDED on libtent_metrics.so and
+# share the one process-wide singleton. PIC is already on for the whole tent
+# tree (tent/CMakeLists.txt sets CMAKE_POSITION_INDEPENDENT_CODE ON), so the
+# tent_common OBJECT dependency links cleanly into the shared object.
+add_library(tent_metrics SHARED ${TENT_METRICS_SOURCES})
 # Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers +
 # transitive deps). ODR safety: yalantinglibs bundles ASIO headers but does NOT
 # compile ASIO inline because ASIO_SEPARATE_COMPILATION is set globally. All
@@ -20,3 +32,13 @@ else()
   target_compile_definitions(tent_metrics PUBLIC TENT_METRICS_ENABLED=0)
   message(STATUS "TENT metrics: DISABLED (zero overhead)")
 endif()
+
+# Install to lib/ for libtent_shared.so / system consumers. The python C
+# extensions (engine.so, store.so) resolve it via $ORIGIN, so a second
+# install lands libtent_metrics.so next to them — see
+# mooncake-integration/CMakeLists.txt.
+install(
+  TARGETS tent_metrics
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
@@ -13,9 +13,15 @@ file(GLOB TENT_METRICS_SOURCES "*.cpp")
 # tree (tent/CMakeLists.txt sets CMAKE_POSITION_INDEPENDENT_CODE ON), so the
 # tent_common OBJECT dependency links cleanly into the shared object.
 add_library(tent_metrics SHARED ${TENT_METRICS_SOURCES})
-set_target_properties(
-  tent_metrics
-  PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_WITH_INSTALL_RPATH TRUE)
+# Installed libtent_metrics.so sits next to libasio.so / libtent_common.so in
+# lib/, so $ORIGIN resolves its sibling dependencies at runtime regardless of
+# install prefix. Do NOT set BUILD_WITH_INSTALL_RPATH here: that would replace
+# CMake's build-tree RPATH (which records full paths to the build-tree siblings
+# like libasio.so) with $ORIGIN alone, and ctest would fail to load
+# libtent_metrics.so before `cmake --install` (libasio.so lives in a different
+# build subdir). CMake falls back to INSTALL_RPATH automatically at install
+# time, mirroring asio_shared in mooncake-common/src/CMakeLists.txt.
+set_target_properties(tent_metrics PROPERTIES INSTALL_RPATH "$ORIGIN")
 # Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers +
 # transitive deps). ODR safety: yalantinglibs bundles ASIO headers but does NOT
 # compile ASIO inline because ASIO_SEPARATE_COMPILATION is set globally. All
@@ -42,6 +48,4 @@ endif()
 # mooncake-integration/CMakeLists.txt.
 install(
   TARGETS tent_metrics
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin)
+  LIBRARY DESTINATION lib)

--- a/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt
@@ -13,6 +13,9 @@ file(GLOB TENT_METRICS_SOURCES "*.cpp")
 # tree (tent/CMakeLists.txt sets CMAKE_POSITION_INDEPENDENT_CODE ON), so the
 # tent_common OBJECT dependency links cleanly into the shared object.
 add_library(tent_metrics SHARED ${TENT_METRICS_SOURCES})
+set_target_properties(
+  tent_metrics
+  PROPERTIES INSTALL_RPATH "$ORIGIN" BUILD_WITH_INSTALL_RPATH TRUE)
 # Link yalantinglibs::yalantinglibs for metrics and HTTP server (ylt headers +
 # transitive deps). ODR safety: yalantinglibs bundles ASIO headers but does NOT
 # compile ASIO inline because ASIO_SEPARATE_COMPILATION is set globally. All

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -49,6 +49,19 @@ target_include_directories(tent_metrics_recording_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_metrics_recording_test COMMAND tent_metrics_recording_test)
 
+# Regression guard: tent_metrics must remain a SHARED dependency so the
+# TentMetrics singleton is shared across DSOs (engine.so / store.so) rather than
+# statically duplicated. Asserts libtent_shared.so imports TentMetrics::instance
+# (undefined, U) from libtent_metrics.so instead of defining it (T). See
+# check_tent_metrics_shared.cmake and docs/tent-metrics-shared-singleton.md.
+if(TARGET tent_shared AND TARGET tent_metrics)
+  add_test(
+    NAME tent_metrics_shared_singleton_check
+    COMMAND ${CMAKE_COMMAND}
+            -DTENT_SHARED_LIB=$<TARGET_FILE:tent_shared>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/check_tent_metrics_shared.cmake)
+endif()
+
 add_executable(admission_queue_test admission_queue_test.cpp
                                     ../src/runtime/admission_queue.cpp)
 target_link_libraries(admission_queue_test PRIVATE tent_common gtest gtest_main)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -49,19 +49,6 @@ target_include_directories(tent_metrics_recording_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_metrics_recording_test COMMAND tent_metrics_recording_test)
 
-# Regression guard: tent_metrics must remain a SHARED dependency so the
-# TentMetrics singleton is shared across DSOs (engine.so / store.so) rather than
-# statically duplicated. Asserts libtent_shared.so imports TentMetrics::instance
-# (undefined, U) from libtent_metrics.so instead of defining it (T). See
-# check_tent_metrics_shared.cmake and docs/tent-metrics-shared-singleton.md.
-if(TARGET tent_shared AND TARGET tent_metrics)
-  add_test(
-    NAME tent_metrics_shared_singleton_check
-    COMMAND ${CMAKE_COMMAND}
-            -DTENT_SHARED_LIB=$<TARGET_FILE:tent_shared>
-            -P ${CMAKE_CURRENT_SOURCE_DIR}/check_tent_metrics_shared.cmake)
-endif()
-
 add_executable(admission_queue_test admission_queue_test.cpp
                                     ../src/runtime/admission_queue.cpp)
 target_link_libraries(admission_queue_test PRIVATE tent_common gtest gtest_main)


### PR DESCRIPTION
## Description

`TentMetrics` is a process-wide singleton — `TentMetrics::instance()` holds a function-local `static TentMetrics instance`, and `initialized_` is guarded by `compare_exchange_strong` so each process initializes it at most once and starts a single 30s periodic report thread (`metric_report_thread_`, the source of the recurring `TENT Metrics: ...` log line).

`tent_metrics` was previously a **STATIC** library: it was packaged into the static `transfer_engine`, which was then **copied** into both the `engine.so` and `store.so` pybind extensions at link time. The result was two mutually invisible `static TentMetrics instance` objects plus two `initialized_` guards in the same process. When sglang `import mooncake.engine` (TENT KV migration) and `import mooncake.store` (`--hicache-storage-backend mooncake`) together, each scheduler process would:

1. start **two** report threads, logging `TENT Metrics:` twice per interval  (TP4 = 8 lines/interval instead of 4);
2. have both singletons bind the default HTTP port `9100` — **only one succeeds**; the other logs `HTTP endpoint unavailable ... continuing with log-only metrics` and silently degrades, so Prometheus scrapes only one engine's metrics and the other is lost.

## Trigger conditions

The duplicate-singleton problem only appears when all three hold:

1. **`TENT_METRICS_ENABLED=ON`** (compile time). An OFF build strips the entire metrics code path via `#if`; record macros are no-ops and no HTTP server is created, so there is no double-thread / port issue to begin with.
2. **`USE_TENT=ON`**. `transfer_engine` links `tent_metrics` only under this flag; non-TENT `engine.so` / `store.so` carry no metrics code and are unaffected.
3. **The same process loads both `mooncake.engine` and `mooncake.store` pybind extensions**. Each `.so` statically embeds its own `TentMetrics`; the singleton guard only prevents re-entry into the *same* instance, not the *other* copy.

The typical trigger is sglang with hierarchical cache backed by mooncake:

```
python -m sglang.launch_server --tp 4 \
  --enable-hierarchical-cache \
  --hicache-storage-backend mooncake \
  --hicache-storage-backend-extra-config '{"master_server_address": "etcd://...", ...}'
```

`mooncake.engine` serves TENT KV migration and `mooncake.store` serves the `--hicache-storage-backend mooncake` storage backend; both are imported inside the same scheduler process, so each rank ends up with two metrics instances.

**Does not trigger**: loading only `mooncake.engine` (TENT migration without a mooncake storage backend) or only `mooncake.store`; `TENT_METRICS_ENABLED=OFF`; `USE_TENT=OFF`. These deployments load metrics code once, so the singleton is naturally unique.

## Root-cause evidence

`nm -D` shows `engine.so` and `store.so` **each export** their own `TentMetrics::instance` (different addresses), confirming the static code was duplicated:

```
engine.so  00000000005043c0 T _ZN8mooncake4tent11TentMetrics8instanceEv
store.so   0000000000e0d0b0 T _ZN8mooncake4tent11TentMetrics8instanceEv
```

Mapping TID → PID (`ps -eLo pid,tid,comm`) shows 4 scheduler processes with 2 report threads each, not 8 processes — ruling out "multiple sglang instances" and confirming "two singletons in one process".

## Change

Switch `tent_metrics` from STATIC to SHARED:

```cmake
add_library(tent_metrics SHARED ${TENT_METRICS_SOURCES})
```

As a shared library, `engine.so` / `store.so` no longer embed the metrics code; they take a single `DT_NEEDED` dependency on `libtent_metrics.so`. The dynamic loader loads that library once (by soname), so both `.so`s reference the same mapping and share the one process-wide `TentMetrics` singleton — 8 threads collapse back to 4, the port clash disappears, and Prometheus sees the full picture.

## Mechanism

- **PIC**: `tent/CMakeLists.txt` sets `CMAKE_POSITION_INDEPENDENT_CODE ON` globally, so OBJECT libraries such as `tent_common` are already compiled PIC and link into the shared object with no extra change.
- **Symbol visibility**: after the fix, `TentMetrics::instance` is exported by `libtent_metrics.so` (`T`) and appears as `U` (undefined, resolved at load time from `DT_NEEDED`) inside `engine.so` / `store.so` / `libtent_shared.so`.
- **RPATH**: `engine.so` / `store.so` use `INSTALL_RPATH "$ORIGIN"`, so installing `libtent_metrics.so` alongside them makes it discoverable — the same pattern `asio_shared` already uses (installed to both `lib/` and the python package directory).

## Guards

- `transfer_engine` links `tent_link_group` (which includes `tent_metrics`) only under `if(USE_TENT)`, so `engine.so` / `store.so` depend on `libtent_metrics.so` only when `USE_TENT` is on.
- The install is guarded by `if(TARGET tent_metrics)`, aligning naturally with `USE_TENT`; non-TENT builds produce no `libtent_metrics.so` and incur no such dependency.

## Tests

- **Symbol check** (root cause): `nm -D engine.so` / `store.so` shows `TentMetrics::instance` as `T` (defined) before the fix and `U` (imported from `libtent_metrics.so`) after.
- **Runtime**: before the fix each scheduler process had 2 report threads (TP4 = 8 lines/interval); after, 1 (4 lines/interval). The `HTTP endpoint unavailable` warning disappears and port 9100 binds uniquely.
- **Existing tests**: `metrics_config_loader_test` / `tent_metrics_http_server_test` / `tent_metrics_recording_test` link `tent_metrics` directly; the SHARED switch does not change their behavior and they keep passing.

## Files Changed

- `mooncake-transfer-engine/tent/src/metrics/CMakeLists.txt` — switch `tent_metrics` from STATIC to SHARED and install it to `lib/`.
- `mooncake-integration/CMakeLists.txt` — install `libtent_metrics.so` to the python package directory (`MOONCAKE_PYTHON_INSTALL_DIR`) alongside `engine.so` / `store.so` for `$ORIGIN` resolution.


## Module

- [X] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [ ] AI tools were used (specify below)