### PR TITLE
[PG] Fix CUDA enqueue-stream serialization

### DIFF
--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -68,6 +68,7 @@ struct TransferGroupMeta {
 
     bool* activeRanks;
     bool* activeRanksDevice;
+    int32_t* activeRanksMirrorDevice = nullptr;
     bool* maybeActivatable;
     RankState rankStates[kMaxNumRanks];  // per GlobalRank
     uint64_t rankEpochs[kMaxNumRanks];
@@ -112,6 +113,8 @@ class MooncakeWorker {
 
     void Start();
 
+    bool hasPendingActiveRanksMirrorUpdate(const TransferGroupMeta* meta) const;
+
     /**
      * @brief Waits for all active collective tasks for the given communicator
      * to complete.
@@ -150,6 +153,7 @@ class MooncakeWorker {
     int cpuTaskCount = 0;
     size_t cudaOpCount = 0;
     std::atomic<uint64_t> next_cuda_task_sequence_{1};
+    std::atomic<uint64_t> next_active_ranks_mirror_generation_{1};
     std::atomic<uint64_t> submitted_task_sequence_[kNumTasks_]{};
 
     std::thread worker_thread_;

--- a/mooncake-pg/include/mooncake_worker.cuh
+++ b/mooncake-pg/include/mooncake_worker.cuh
@@ -1,6 +1,7 @@
 #ifndef MOONCAKE_WORKER_CUH
 #define MOONCAKE_WORKER_CUH
 
+#include <array>
 #include <atomic>
 #include <functional>
 
@@ -130,21 +131,24 @@ class MooncakeWorker {
     void waitUntilTasksSubmitted(
         const std::vector<CudaTaskSubmissionToken>& tasks) const;
 
-    static constexpr size_t kNumTasks_ = 4;
+    static constexpr size_t kNumCpuTasks_ = 2;
+    static constexpr size_t kNumCudaTasks_ = 2;
+    static constexpr size_t kCudaTaskOffset_ = kNumCpuTasks_;
+    static constexpr size_t kNumTasks_ = kNumCpuTasks_ + kNumCudaTasks_;
 
     static constexpr size_t kDrainTasksTimeoutMs = 5000;  // 5s
 
     std::atomic<bool> running_{false};
     std::atomic<bool> started_{false};
     int cuda_device_index_;
-    std::optional<GpuStream> enqueue_stream_;
+    std::array<std::optional<GpuStream>, kNumCudaTasks_> enqueue_streams_;
 
     Task *tasks_, *tasks_device_;
     bool hasCallback_[kNumTasks_]{};
     std::function<void()> callbacks_[kNumTasks_]{};
 
     int cpuTaskCount = 0;
-    int cudaTaskCount = 0;
+    size_t cudaOpCount = 0;
     std::atomic<uint64_t> next_cuda_task_sequence_{1};
     std::atomic<uint64_t> submitted_task_sequence_[kNumTasks_]{};
 

--- a/mooncake-pg/include/mooncake_worker_kernels.cuh
+++ b/mooncake-pg/include/mooncake_worker_kernels.cuh
@@ -14,6 +14,10 @@ __global__
 #endif
     struct Task {
     volatile bool active = false;
+    // Host publishes a new request generation; the resident enqueue kernel
+    // publishes the generation only after the device mirror has been updated.
+    uint64_t activeRanksMirrorRequestGeneration = 0;
+    uint64_t activeRanksMirrorAppliedGeneration = 0;
     int opType =
         0;  // c10d::OpType as int, for ABI compatibility with kernel code
     size_t dataSize;  // In bytes
@@ -32,7 +36,9 @@ __global__ void enqueueTaskKernel(int opType, size_t dataSize,
                                   uint64_t submitSequence,
                                   int32_t* failedRanksHint,
                                   bool resetFailedRanksHint, void* meta,
-                                  Task* tasks, size_t taskId);
+                                  bool* activeRanks, int32_t* activeRanksMirror,
+                                  size_t activeRanksCount, Task* tasks,
+                                  size_t taskId);
 
 template <typename scalar_t>
 __global__ void reduceKernel(scalar_t* dst, const scalar_t* src,
@@ -49,7 +55,9 @@ __global__ void reduceKernel(scalar_t* dst, const scalar_t* src,
 void launchEnqueueTaskKernel(int opType, size_t dataSize, int64_t broadcastRoot,
                              int bufferOffset, uint64_t submitSequence,
                              int32_t* failedRanksHint,
-                             bool resetFailedRanksHint, void* meta, Task* tasks,
+                             bool resetFailedRanksHint, void* meta,
+                             bool* activeRanks, int32_t* activeRanksMirror,
+                             size_t activeRanksCount, Task* tasks,
                              size_t taskId, cudaStream_t stream);
 
 void launchReduceKernel_uint8(uint8_t* dst, const uint8_t* src,

--- a/mooncake-pg/src/CMakeLists.txt
+++ b/mooncake-pg/src/CMakeLists.txt
@@ -75,7 +75,7 @@ elseif(USE_MUSA OR USE_MACA)
                   "${_pg_platform_name} compiler (${_pg_device_compiler_name})")
   endif()
   list(APPEND _pg_device_flags "-DUSE_${_pg_platform_name}"
-       ${_pg_platform_device_flags})
+       "-DMOONCAKE_EP_USE_${_pg_platform_name}=1" ${_pg_platform_device_flags})
 
   add_custom_command(
     OUTPUT "${_pg_device_object}"

--- a/mooncake-pg/src/mooncake_communicator.cpp
+++ b/mooncake-pg/src/mooncake_communicator.cpp
@@ -505,6 +505,10 @@ PGResult<void> MooncakeCommunicator::initialize(
     meta_->engine = context_.engine;
     meta_->communicator = this;
     meta_->autoSyncOnFailure = config.auto_sync_on_failure;
+    if (active_ranks_mirror_ && active_ranks_mirror_is_device_ &&
+        active_ranks_mirror_device_index_ == device_index_) {
+        meta_->activeRanksMirrorDevice = active_ranks_mirror_;
+    }
     p2p_proxy_->bindMeta(meta_);
 
     // Active ranks will be filled by applyViewUpdate, so only allocate their
@@ -1350,6 +1354,10 @@ void MooncakeCommunicator::syncActiveRanksMirror() const {
     auto active_ranks = getActiveRanks();
     const size_t bytes = max_group_size_ * sizeof(int32_t);
     if (active_ranks_mirror_is_device_) {
+        if (meta_ && meta_->activeRanksMirrorDevice && worker_ &&
+            worker_->hasPendingActiveRanksMirrorUpdate(meta_.get())) {
+            return;
+        }
         const GpuDeviceGuard device_guard(active_ranks_mirror_device_index_);
         PG_ASSERT_CUDA(cudaMemcpyAsync(
             active_ranks_mirror_, active_ranks.data(), bytes,
@@ -1596,8 +1604,8 @@ void MooncakeCommunicator::applyViewUpdate(
         meta_->maybeActivatable[i] = activatable[i];
     }
 
-    // Keep the caller-visible active-ranks mirror in sync with the view.
-    // FIXME: potential deadlock?
+    // A failed CUDA task piggybacks same-device mirror update on its
+    // already-resident enqueue kernel. Other updates use a H2D copy.
     syncActiveRanksMirror();
 
     // Publish the rank-space extent after the corresponding data-plane state.

--- a/mooncake-pg/src/mooncake_worker.cu
+++ b/mooncake-pg/src/mooncake_worker.cu
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <type_traits>
+#include <transport/device/device_ops.cuh>
 
 #ifdef __MUSA__
 #include <musa_bf16.h>
@@ -20,7 +21,9 @@ __global__ void enqueueTaskKernel(int opType, size_t dataSize,
                                   uint64_t submitSequence,
                                   int32_t* failedRanksHint,
                                   bool resetFailedRanksHint, void* meta,
-                                  Task* tasks, size_t taskId) {
+                                  bool* activeRanks, int32_t* activeRanksMirror,
+                                  size_t activeRanksCount, Task* tasks,
+                                  size_t taskId) {
     // Copy task into slot
     tasks[taskId].opType = opType;
     tasks[taskId].dataSize = dataSize;
@@ -38,6 +41,20 @@ __global__ void enqueueTaskKernel(int opType, size_t dataSize,
     // Spin-wait until CPU proxy sets DONE
     while (tasks[taskId].active) {
         __threadfence_system();
+    }
+
+    const uint64_t mirrorUpdateGeneration = device::mc_ld_acquire_u64(
+        &tasks[taskId].activeRanksMirrorRequestGeneration);
+    const uint64_t appliedMirrorUpdateGeneration = device::mc_ld_acquire_u64(
+        &tasks[taskId].activeRanksMirrorAppliedGeneration);
+    if (activeRanksMirror &&
+        mirrorUpdateGeneration != appliedMirrorUpdateGeneration) {
+        for (size_t rank = 0; rank < activeRanksCount; ++rank) {
+            activeRanksMirror[rank] = activeRanks[rank] ? 1 : 0;
+        }
+        device::mc_st_release_u64(
+            &tasks[taskId].activeRanksMirrorAppliedGeneration,
+            mirrorUpdateGeneration);
     }
 }
 
@@ -137,11 +154,14 @@ namespace mooncake {
 void launchEnqueueTaskKernel(int opType, size_t dataSize, int64_t broadcastRoot,
                              int bufferOffset, uint64_t submitSequence,
                              int32_t* failedRanksHint,
-                             bool resetFailedRanksHint, void* meta, Task* tasks,
+                             bool resetFailedRanksHint, void* meta,
+                             bool* activeRanks, int32_t* activeRanksMirror,
+                             size_t activeRanksCount, Task* tasks,
                              size_t taskId, cudaStream_t stream) {
     enqueueTaskKernel<<<1, 1, 0, stream>>>(
         opType, dataSize, broadcastRoot, bufferOffset, submitSequence,
-        failedRanksHint, resetFailedRanksHint, meta, tasks, taskId);
+        failedRanksHint, resetFailedRanksHint, meta, activeRanks,
+        activeRanksMirror, activeRanksCount, tasks, taskId);
 }
 
 #define DEF_LAUNCH_REDUCE(scalar_t, suffix)                                   \

--- a/mooncake-pg/src/mooncake_worker_host.cpp
+++ b/mooncake-pg/src/mooncake_worker_host.cpp
@@ -158,6 +158,8 @@ MooncakeWorker::MooncakeWorker(int cuda_device_index)
 
     for (size_t i = 0; i < kNumTasks_; ++i) {
         tasks_[i].active = false;
+        tasks_[i].activeRanksMirrorRequestGeneration = 0;
+        tasks_[i].activeRanksMirrorAppliedGeneration = 0;
         tasks_[i].submitSequence = 0;
         tasks_[i].failedRanksHint = nullptr;
         tasks_[i].resetFailedRanksHint = false;
@@ -292,10 +294,11 @@ void MooncakeWorker::putTaskCuda(
 
         hasCallback_[taskId] = false;
 
-        launchEnqueueTaskKernel((int)opType, realSize, broadcastRoot,
-                                bufferOffset, taskSequence, failed_ranks_hint,
-                                pos == 0, meta.get(), tasks_device_, taskId,
-                                enq_stream.get());
+        launchEnqueueTaskKernel(
+            (int)opType, realSize, broadcastRoot, bufferOffset, taskSequence,
+            failed_ranks_hint, pos == 0, meta.get(), meta->activeRanksDevice,
+            meta->activeRanksMirrorDevice, meta->maxGroupSize, tasks_device_,
+            taskId, enq_stream.get());
         copyFromRecvBuffer(
             (void*)meta->segmentInfos[meta->rank].recv_buffer[bufferOffset],
             pos, realSize, enq_stream.get());

--- a/mooncake-pg/src/mooncake_worker_host.cpp
+++ b/mooncake-pg/src/mooncake_worker_host.cpp
@@ -151,7 +151,9 @@ MooncakeWorker::MooncakeWorker(int cuda_device_index)
     }
 
     if (cuda_device_index_ >= 0) {
-        enqueue_stream_ = GpuStream::createNonBlocking(cuda_device_index_);
+        for (auto& enqueue_stream : enqueue_streams_) {
+            enqueue_stream = GpuStream::createNonBlocking(cuda_device_index_);
+        }
     }
 
     for (size_t i = 0; i < kNumTasks_; ++i) {
@@ -255,34 +257,35 @@ void MooncakeWorker::putTaskCuda(
     const GpuDeviceGuard guard(cuda_device_index_);
     const auto issue_stream =
         GpuStream::borrow(issueStream, cuda_device_index_);
-    const auto& enq_stream = enqueue_stream_.value();
+    const size_t cudaTaskSlot = cudaOpCount % kNumCudaTasks_;
+    const size_t taskId = kCudaTaskOffset_ + cudaTaskSlot;
+    const auto& enq_stream = enqueue_streams_[cudaTaskSlot].value();
+    ++cudaOpCount;
+
     cudaStreamCaptureStatus issue_capture = cudaStreamCaptureStatusNone;
     cudaStreamCaptureStatus enq_capture = cudaStreamCaptureStatusNone;
     PG_ASSERT_CUDA(cudaStreamIsCapturing(issue_stream.get(), &issue_capture));
     PG_ASSERT_CUDA(cudaStreamIsCapturing(enq_stream.get(), &enq_capture));
     const bool is_capturing = issue_capture != cudaStreamCaptureStatusNone ||
                               enq_capture != cudaStreamCaptureStatusNone;
-    if (is_capturing) {
-        GpuEvent event_start(issue_stream.deviceIndex());
-        event_start.record(issue_stream);
-        enq_stream.waitEvent(event_start);
-    } else {
-        // Do not create an eager cross-stream cycle with the completion wait
-        // installed by the preceding collective on issue_stream.
-        PG_ASSERT_CUDA(cudaStreamSynchronize(issue_stream.get()));
-    }
+
+    GpuEvent event_start(issue_stream.deviceIndex());
+    event_start.record(issue_stream);
+    enq_stream.waitEvent(event_start);
+
     std::vector<CudaTaskSubmissionToken> submitted_tasks;
     submitted_tasks.reserve((tensorSize + chunkSize - 1) / chunkSize);
 
+    // Keep every chunk of one collective on the same task slot and enqueue
+    // stream. The next collective rotates to the other CUDA task slot.
     for (size_t pos = 0; pos < tensorSize; pos += chunkSize) {
         size_t realSize = std::min(tensorSize, pos + chunkSize) - pos;
-        int taskId = cudaTaskCount % 2 + 2;
         int bufferOffset = meta->taskCount % 2;
 
         const uint64_t taskSequence =
             next_cuda_task_sequence_.fetch_add(1, std::memory_order_relaxed);
         submitted_tasks.push_back(
-            {.task_id = static_cast<size_t>(taskId), .sequence = taskSequence});
+            {.task_id = taskId, .sequence = taskSequence});
         copyToSendBuffer(
             (void*)meta->segmentInfos[meta->rank].send_buffer[bufferOffset],
             pos, realSize, enq_stream.get());
@@ -297,25 +300,22 @@ void MooncakeWorker::putTaskCuda(
             (void*)meta->segmentInfos[meta->rank].recv_buffer[bufferOffset],
             pos, realSize, enq_stream.get());
 
-        ++cudaTaskCount;
         ++meta->taskCount;
     }
 
-    // With one enqueue stream per task slot, the worker can observe the
-    // enqueue kernel without waiting on an issue-stream event from another
-    // slot.  Retain this gate so the caller never advances while task
-    // metadata is still only queued on the GPU.
+    // Each CUDA task slot is paired with a dedicated enqueue stream. All chunks
+    // of one collective stay on that pair, and reusing the same slot is
+    // serialized by the stream. In eager mode, finish each chunk's host-worker
+    // submission step before installing the completion wait on issue_stream
+    // below. Captured enqueue kernels have not run yet, so capture skips this
+    // gate.
     if (!is_capturing) {
         waitUntilTasksSubmitted(submitted_tasks);
-        PG_ASSERT_CUDA(cudaStreamSynchronize(enq_stream.get()));
     }
 
     GpuEvent event_end(enq_stream.deviceIndex());
     event_end.record(enq_stream);
     issue_stream.waitEvent(event_end);
-    if (!is_capturing) {
-        PG_ASSERT_CUDA(cudaStreamSynchronize(issue_stream.get()));
-    }
 }
 
 }  // namespace mooncake

--- a/mooncake-pg/src/mooncake_worker_thread.cpp
+++ b/mooncake-pg/src/mooncake_worker_thread.cpp
@@ -27,6 +27,30 @@ void MooncakeWorker::Start() {
     }
 }
 
+bool MooncakeWorker::hasPendingActiveRanksMirrorUpdate(
+    const TransferGroupMeta* meta) const {
+    for (size_t i = kCudaTaskOffset_; i < kNumTasks_; ++i) {
+        auto& task = tasks_[i];
+        // The request generation is the publication token for this pending
+        // update. Keep this acquire before reading transferGroupMeta so the
+        // task-to-group association is observed after the request is
+        // published.
+        const uint64_t requested =
+            std::atomic_ref(task.activeRanksMirrorRequestGeneration)
+                .load(std::memory_order_acquire);
+        if (task.transferGroupMeta != meta) {
+            continue;
+        }
+        const uint64_t applied =
+            std::atomic_ref(task.activeRanksMirrorAppliedGeneration)
+                .load(std::memory_order_acquire);
+        if (requested != applied) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool MooncakeWorker::drainTasks(const TransferGroupMeta* meta) const {
     BackoffWaiter waiter;
     return waiter.wait_for(
@@ -370,6 +394,22 @@ void MooncakeWorker::startWorker() {
                                     failedRanks[i][rank];
                             }
                             active_failed_ranks_hint[i] = nullptr;
+                        }
+
+                        // Mark the resident-kernel mirror update as pending
+                        // before publishing the link event. The resulting
+                        // ViewUpdate must observe request != applied and skip
+                        // the host H2D path. The kernel consumes this request
+                        // and copies the updated active ranks.
+                        if (task_detected_failure[i] &&
+                            group->autoSyncOnFailure &&
+                            group->activeRanksMirrorDevice) {
+                            const uint64_t generation =
+                                next_active_ranks_mirror_generation_.fetch_add(
+                                    1, std::memory_order_relaxed);
+                            std::atomic_ref(
+                                task.activeRanksMirrorRequestGeneration)
+                                .store(generation, std::memory_order_release);
                         }
 
                         // Push link event via communicator's Agent.

--- a/mooncake-pg/tests/test_pg_collectives.py
+++ b/mooncake-pg/tests/test_pg_collectives.py
@@ -46,7 +46,9 @@ def _collective_payload(
         return {"value": int(tensor.cpu().item())}
 
     if case_name == "broadcast":
-        tensor = torch.tensor([111 if rank == 0 else -1], dtype=torch.int32, device=device)
+        tensor = torch.tensor(
+            [111 if rank == 0 else -1], dtype=torch.int32, device=device
+        )
         dist.broadcast(tensor, src=0)
         return {"value": int(tensor.cpu().item())}
 
@@ -73,7 +75,9 @@ def _collective_payload(
         if hasattr(dist, "reduce_scatter_tensor"):
             dist.reduce_scatter_tensor(output, input_buf, op=dist.ReduceOp.SUM)
         else:
-            dist.reduce_scatter(output, list(input_buf.chunk(world_size)), op=dist.ReduceOp.SUM)
+            dist.reduce_scatter(
+                output, list(input_buf.chunk(world_size)), op=dist.ReduceOp.SUM
+            )
         return {"value": output.cpu().tolist()}
 
     if case_name == "barrier":
@@ -140,19 +144,11 @@ def _async_ops_on_independent_streams_worker(
         rank_zero_submitted_both = allow_rank_one_to_start.wait(timeout=5.0)
 
     with torch.cuda.stream(stream_a):
-        tensor_a = torch.tensor(
-            [ctx.rank + 1], dtype=torch.int32, device=device
-        )
-        work_a = dist.all_reduce(
-            tensor_a, op=dist.ReduceOp.SUM, async_op=True
-        )
+        tensor_a = torch.tensor([ctx.rank + 1], dtype=torch.int32, device=device)
+        work_a = dist.all_reduce(tensor_a, op=dist.ReduceOp.SUM, async_op=True)
     with torch.cuda.stream(stream_b):
-        tensor_b = torch.tensor(
-            [(ctx.rank + 1) * 10], dtype=torch.int32, device=device
-        )
-        work_b = dist.all_reduce(
-            tensor_b, op=dist.ReduceOp.SUM, async_op=True
-        )
+        tensor_b = torch.tensor([(ctx.rank + 1) * 10], dtype=torch.int32, device=device)
+        work_b = dist.all_reduce(tensor_b, op=dist.ReduceOp.SUM, async_op=True)
 
     if ctx.rank == 0:
         # Rank 1 does not submit either operation until both calls on rank 0
@@ -173,7 +169,9 @@ def _async_ops_on_independent_streams_worker(
 
 class _CollectiveTestMixin:
     def test_world_init_without_pg_options(self) -> None:
-        rows = self.spawn_backend_and_collect(_collective_worker, "world_init_without_pg_options")
+        rows = self.spawn_backend_and_collect(
+            _collective_worker, "world_init_without_pg_options"
+        )
         self.assert_all_ok(rows)
 
         expected = sum(range(1, self.world_size + 1))
@@ -201,9 +199,11 @@ class _CollectiveTestMixin:
             self.assertEqual(row["value"], expected)
 
     def test_allreduce_product(self) -> None:
-        rows = self.spawn_backend_and_collect(_collective_worker, "allreduce", "product")
+        rows = self.spawn_backend_and_collect(
+            _collective_worker, "allreduce", "product"
+        )
         self.assert_all_ok(rows)
-        expected = 2 ** self.world_size
+        expected = 2**self.world_size
         for row in rows:
             self.assertEqual(row["value"], expected)
 
@@ -214,7 +214,9 @@ class _CollectiveTestMixin:
             self.assertEqual(row["value"], 111)
 
     def test_all_gather_into_tensor(self) -> None:
-        rows = self.spawn_backend_and_collect(_collective_worker, "all_gather_into_tensor")
+        rows = self.spawn_backend_and_collect(
+            _collective_worker, "all_gather_into_tensor"
+        )
         self.assert_all_ok(rows)
         expected = list(range(self.world_size))
         for row in rows:
@@ -232,7 +234,9 @@ class _CollectiveTestMixin:
         self.assert_all_ok(rows)
         for row in rows:
             rank = row["rank"]
-            expected = self.world_size * (self.world_size * (self.world_size - 1) // 2 + rank)
+            expected = self.world_size * (
+                self.world_size * (self.world_size - 1) // 2 + rank
+            )
             self.assertEqual(row["value"], [expected])
 
     def test_barrier(self) -> None:
@@ -267,7 +271,9 @@ class TestMooncakePGCollectivesCPU(_CollectiveTestMixin, MooncakePGCPUBackendTes
     world_size = 4
 
 
-class TestMooncakePGCollectivesCUDA(_CollectiveTestMixin, MooncakePGCUDABackendTestCase):
+class TestMooncakePGCollectivesCUDA(
+    _CollectiveTestMixin, MooncakePGCUDABackendTestCase
+):
     world_size = 2
 
     def test_async_ops_on_independent_streams(self) -> None:
@@ -288,7 +294,9 @@ class TestMooncakePGCollectivesCUDA(_CollectiveTestMixin, MooncakePGCUDABackendT
         )
 
 
-class TestMooncakePGCollectivesMUSA(_CollectiveTestMixin, MooncakePGMUSABackendTestCase):
+class TestMooncakePGCollectivesMUSA(
+    _CollectiveTestMixin, MooncakePGMUSABackendTestCase
+):
     world_size = 2
 
 

--- a/mooncake-pg/tests/test_pg_collectives.py
+++ b/mooncake-pg/tests/test_pg_collectives.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from pg_test_utils import (
     MooncakePGCPUBackendTestCase,
@@ -126,6 +127,50 @@ def _collective_worker(
     ctx.record_result(payload)
 
 
+def _async_ops_on_independent_streams_worker(
+    ctx: MooncakePGWorkerContext,
+    allow_rank_one_to_start,
+) -> None:
+    device = ctx.init_group()
+    stream_a = torch.cuda.Stream(device=device)
+    stream_b = torch.cuda.Stream(device=device)
+
+    rank_zero_submitted_both = True
+    if ctx.rank == 1:
+        rank_zero_submitted_both = allow_rank_one_to_start.wait(timeout=5.0)
+
+    with torch.cuda.stream(stream_a):
+        tensor_a = torch.tensor(
+            [ctx.rank + 1], dtype=torch.int32, device=device
+        )
+        work_a = dist.all_reduce(
+            tensor_a, op=dist.ReduceOp.SUM, async_op=True
+        )
+    with torch.cuda.stream(stream_b):
+        tensor_b = torch.tensor(
+            [(ctx.rank + 1) * 10], dtype=torch.int32, device=device
+        )
+        work_b = dist.all_reduce(
+            tensor_b, op=dist.ReduceOp.SUM, async_op=True
+        )
+
+    if ctx.rank == 0:
+        # Rank 1 does not submit either operation until both calls on rank 0
+        # return.
+        allow_rank_one_to_start.set()
+
+    work_a.wait()
+    work_b.wait()
+    stream_a.synchronize()
+    stream_b.synchronize()
+    ctx.record_result(
+        {
+            "rank_zero_submitted_both": rank_zero_submitted_both,
+            "values": [int(tensor_a.cpu().item()), int(tensor_b.cpu().item())],
+        }
+    )
+
+
 class _CollectiveTestMixin:
     def test_world_init_without_pg_options(self) -> None:
         rows = self.spawn_backend_and_collect(_collective_worker, "world_init_without_pg_options")
@@ -224,6 +269,23 @@ class TestMooncakePGCollectivesCPU(_CollectiveTestMixin, MooncakePGCPUBackendTes
 
 class TestMooncakePGCollectivesCUDA(_CollectiveTestMixin, MooncakePGCUDABackendTestCase):
     world_size = 2
+
+    def test_async_ops_on_independent_streams(self) -> None:
+        spawn_ctx = mp.get_context("spawn")
+        allow_rank_one_to_start = spawn_ctx.Event()
+        rows = self.spawn_backend_and_collect(
+            _async_ops_on_independent_streams_worker,
+            allow_rank_one_to_start,
+        )
+        self.assert_all_ok(rows)
+        for row in rows:
+            self.assertEqual(row["values"], [3, 30])
+
+        rank_one = next(row for row in rows if row["rank"] == 1)
+        self.assertTrue(
+            rank_one["rank_zero_submitted_both"],
+            "rank 0 blocked before submitting both async operations",
+        )
 
 
 class TestMooncakePGCollectivesMUSA(_CollectiveTestMixin, MooncakePGMUSABackendTestCase):


### PR DESCRIPTION
## Description

Reported by #3775.

Mooncake PG's CUDA worker has two CUDA task slots, but both slots previously shared a single enqueue stream. Because `enqueueTaskKernel` occupies the enqueue stream until the CPU worker completes the task, a kernel for the other task slot could remain queued behind it and could not set that slot's active flag. This introduced unintended serialization between asynchronous operations submitted even on separate CUDA streams.

This PR aligns enqueue-stream ownership with task-slot ownership:

- Pair each CUDA task slot with its own enqueue stream.
  
- Select the slot once per collective invocation, keeping all chunks of that collective on the same slot/stream pair.
  
- Alternate consecutive collective invocations between the two slots.
  
- Restore CUDA-event ordering between the caller's issue stream and the selected enqueue stream, removing eager-mode host synchronizations.
  
- Add a regression test.
  
Removing the eager-mode host synchronizations made collective submission genuinely asynchronous: `putTaskCuda` could now return while its enqueue kernel and CPU task were still in flight. This exposed a pre-existing deadlock in the fault-driven active-ranks mirror update, which had previously been masked by the host synchronization. A concurrent `ViewUpdate` could attempt the device-mirror H2D copy while the task that triggered it was still being completed. This PR avoids that deadlock by marking the update as pending and letting the resident enqueue kernel apply it after task completion.

The removed synchronizations were introduced in #3609. They are no longer required because each task slot now owns a separate enqueue stream, while CUDA events preserve stream ordering. CUDA-capture handling is retained. The TBO warmup scenario from #3609 was revalidated with SGLang's `test_mooncake_ep_small.py`.

 ### Review note

Commit [`e4eb4174`](https://github.com/kvcache-ai/Mooncake/commit/e4eb417445729c5225e9ea74fdc7dc46554b1647) contains formatting-only changes to `mooncake-pg/tests/test_pg_collectives.py` required by CI. It introduces no functional changes.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [x] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

- All unittests under `mooncake-pg/tests` passed.
- Manual tests in SGLang's `test_mooncake_ep_small.py` passed

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure


- [ ] No AI tools were used
- [x] AI tools were used (specify below)



Codex assisted with root-cause analysis, implementation, and regression-test development. The human submitter reviewed all the resulting changes and is responsible for them.