### PR TITLE
[Bugfix][TENT] Drain the async event queue and recover contexts whose PORT_ACTIVE was lost

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/context.h
@@ -123,6 +123,15 @@ class RdmaContext {
     // open or the query fails.
     int refreshPortAttributes();
 
+    // Read the port's current state from the hardware. The monitor thread
+    // polls this for paused contexts so a link that came back without a
+    // usable IBV_EVENT_PORT_ACTIVE is still noticed. Deliberately leaves the
+    // cached speed/width alone: refreshLinkSpeed() diffs against them, so
+    // refreshing here would hide a renegotiated rate from the selector.
+    // Returns -1 and leaves *state untouched if no device is open or the
+    // query fails.
+    int queryPortState(ibv_port_state *state) const;
+
     int eventFd() const { return event_fd_; }
 
     RdmaCQ *cq(int index);

--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/workers.h
@@ -84,6 +84,9 @@ class Workers {
 
     // dev_id is the NicID (context_set_ index), which is also the
     // DeviceSelector id, so port events can flip that device's availability.
+    // Drains the whole async event queue: the async fd is edge-triggered and
+    // ibv_get_async_event() dequeues one record per call, so an event left
+    // behind waits for an unrelated later event to release it.
     int handleContextEvents(int dev_id, std::shared_ptr<RdmaContext>& context);
 
     // The decision half of handleContextEvents, kept apart from
@@ -94,10 +97,23 @@ class Workers {
     void applyContextEvent(int dev_id, RdmaContext& context,
                            const ibv_async_event& event);
 
+    // Everything a recovered port needs: resume the context, re-seed its
+    // bandwidth and make it selectable again. Shared by the
+    // IBV_EVENT_PORT_ACTIVE path and by resumePausedContexts().
+    void activateContext(int dev_id, RdmaContext& context);
+
     // Re-read the link speed after a port event and re-seed the selector if
     // it changed; a link that returns at the same speed keeps what it
     // learned.
     void refreshLinkSpeed(int dev_id, RdmaContext& context);
+
+    // 1 Hz heartbeat from monitorThread(): safety net for a lost
+    // IBV_EVENT_PORT_ACTIVE. Nothing else ever leaves DEVICE_PAUSED, so a
+    // context whose recovery event was dropped (edge-triggered fd, event
+    // queue overflow, ...) would fail every transfer on that NIC forever.
+    // Polls the port state of paused contexts and activates the ones the
+    // hardware reports as up.
+    void resumePausedContexts();
 
     Status generatePostPath(RdmaSlice* slice);
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -880,6 +880,21 @@ int RdmaContext::refreshPortAttributes() {
     return 0;
 }
 
+int RdmaContext::queryPortState(ibv_port_state* state) const {
+    if (!state || !native_context_ || !params_) return -1;
+    ibv_port_attr port_attr;
+    if (verbs_.ibv_query_port_default(native_context_, params_->device.port,
+                                      &port_attr)) {
+        PLOG(WARNING) << "Failed to query state of port "
+                      << static_cast<int>(params_->device.port) << " on "
+                      << device_name_;
+        return -1;
+    }
+    // No recordPortSpeed() here on purpose -- see the header.
+    *state = port_attr.state;
+    return 0;
+}
+
 double RdmaContext::linkSpeedGbps() const {
     return ibLinkSpeedGbps(active_speed_.load(std::memory_order_relaxed),
                            active_width_.load(std::memory_order_relaxed));

--- a/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/context.cpp
@@ -895,6 +895,8 @@ int RdmaContext::queryPortState(ibv_port_state* state) const {
     // No recordPortSpeed() here on purpose -- see the header.
     *state = port_attr.state;
     return 0;
+}
+
 void RdmaContext::queryEffectiveSpeed() {
     if (!native_context_ || !verbs_.ibv_query_port_speed) {
         effective_speed_mbps_.store(0, std::memory_order_relaxed);

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -879,9 +879,15 @@ int Workers::handleContextEvents(int dev_id,
                         << context->name();
             return -1;
         }
-        LOG(WARNING) << "Received context async event "
-                     << ibv_event_type_str(event.event_type) << " for context "
-                     << context->name();
+        if (event.event_type == IBV_EVENT_COMM_EST) {
+            VLOG(1) << "Received context async event "
+                    << ibv_event_type_str(event.event_type)
+                    << " for context " << context->name();
+        } else {
+            LOG(WARNING) << "Received context async event "
+                         << ibv_event_type_str(event.event_type)
+                         << " for context " << context->name();
+        }
         applyContextEvent(dev_id, *context, event);
         ibv_ack_async_event(&event);
     }

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cerrno>
 #include <fstream>
 #include <sstream>
 
@@ -861,14 +862,29 @@ void Workers::workerThread(int thread_id) {
 
 int Workers::handleContextEvents(int dev_id,
                                  std::shared_ptr<RdmaContext>& context) {
-    ibv_async_event event;
-    if (ibv_get_async_event(context->nativeContext(), &event) < 0) return -1;
-    LOG(WARNING) << "Received context async event "
-                 << ibv_event_type_str(event.event_type) << " for context "
-                 << context->name();
-    applyContextEvent(dev_id, *context, event);
-    ibv_ack_async_event(&event);
-    return 0;
+    // The async fd is non-blocking and edge-triggered
+    // (joinNonblockingPollList), and ibv_get_async_event() dequeues one record
+    // per call, so every queued event has to be consumed here: epoll only
+    // reports readiness again once a *new* event arrives. Bursts are routine
+    // (IBV_EVENT_COMM_EST fires once per connection), and a PORT_ACTIVE
+    // stranded behind one keeps the context paused until some unrelated event
+    // happens to release it -- which may be never.
+    while (true) {
+        ibv_async_event event;
+        errno = 0;
+        if (ibv_get_async_event(context->nativeContext(), &event) < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return 0;  // drained
+            if (errno == EINTR) continue;
+            PLOG(ERROR) << "ibv_get_async_event for context "
+                        << context->name();
+            return -1;
+        }
+        LOG(WARNING) << "Received context async event "
+                     << ibv_event_type_str(event.event_type) << " for context "
+                     << context->name();
+        applyContextEvent(dev_id, *context, event);
+        ibv_ack_async_event(&event);
+    }
 }
 
 void Workers::applyContextEvent(int dev_id, RdmaContext& context,
@@ -909,12 +925,7 @@ void Workers::applyContextEvent(int dev_id, RdmaContext& context,
                 device_selector_->setDeviceAvailable(dev_id, false);
                 LOG(WARNING) << "Action: " << context.name() << " down";
             } else {
-                context.resume();
-                // The link may have renegotiated while down: re-seed before
-                // the device becomes selectable so no worker scores it on
-                // the old rate.
-                refreshLinkSpeed(dev_id, context);
-                device_selector_->setDeviceAvailable(dev_id, true);
+                activateContext(dev_id, context);
                 LOG(WARNING) << "Action: " << context.name() << " up";
             }
             break;
@@ -931,6 +942,14 @@ void Workers::applyContextEvent(int dev_id, RdmaContext& context,
         default:
             break;
     }
+}
+
+void Workers::activateContext(int dev_id, RdmaContext& context) {
+    context.resume();
+    // The link may have renegotiated while down: re-seed before the device
+    // becomes selectable so no worker scores it on the old rate.
+    refreshLinkSpeed(dev_id, context);
+    if (device_selector_) device_selector_->setDeviceAvailable(dev_id, true);
 }
 
 void Workers::refreshLinkSpeed(int dev_id, RdmaContext& context) {
@@ -956,6 +975,27 @@ void Workers::reclaimEndpoints() {
     }
 }
 
+void Workers::resumePausedContexts() {
+    for (size_t dev_id = 0; dev_id < transport_->context_set_.size();
+         ++dev_id) {
+        auto& context = transport_->context_set_[dev_id];
+        // Only a paused context is waiting for a recovery event; this also
+        // filters out inert slots, which never leave DEVICE_UNINIT.
+        if (!context || context->status() != RdmaContext::DEVICE_PAUSED)
+            continue;
+        ibv_port_state state;
+        if (context->queryPortState(&state) != 0) continue;  // already logged
+        // Only a fully active port carries traffic. Intermediate states
+        // (INIT/ARMED/ACTIVE_DEFER) mean the link is still settling, so leave
+        // the context paused and re-check on the next tick.
+        if (state != IBV_PORT_ACTIVE) continue;
+        LOG(WARNING) << "Action: " << context->name()
+                     << " up (port reports ACTIVE without an "
+                        "IBV_EVENT_PORT_ACTIVE event)";
+        activateContext(static_cast<int>(dev_id), *context);
+    }
+}
+
 void Workers::monitorThread() {
     // Track time for periodic endpoint reclaim (1 Hz heartbeat)
     auto last_reclaim_time = std::chrono::steady_clock::now();
@@ -971,6 +1011,8 @@ void Workers::monitorThread() {
 
         if (time_since_last_reclaim >= 1000) {  // 1 second = 1000 ms
             reclaimEndpoints();
+            // Safety net for a recovery event that never reached us.
+            resumePausedContexts();
             last_reclaim_time = current_time;
         }
 

--- a/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/workers.cpp
@@ -881,8 +881,8 @@ int Workers::handleContextEvents(int dev_id,
         }
         if (event.event_type == IBV_EVENT_COMM_EST) {
             VLOG(1) << "Received context async event "
-                    << ibv_event_type_str(event.event_type)
-                    << " for context " << context->name();
+                    << ibv_event_type_str(event.event_type) << " for context "
+                    << context->name();
         } else {
             LOG(WARNING) << "Received context async event "
                          << ibv_event_type_str(event.event_type)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -283,6 +283,26 @@ target_include_directories(tent_rdma_transport_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME tent_rdma_transport_test COMMAND tent_rdma_transport_test)
 
+# Regression test for the edge-triggered async event fd: one epoll wakeup must
+# drain the whole queue. Wraps ibv_get_async_event to script the event source,
+# so it needs no RDMA device. -Wl,--wrap is a GNU ld / lld feature that Apple's
+# linker lacks, and the test is meaningless without it, so skip the target
+# there rather than build one that calls the real symbols.
+if(UNIX AND NOT APPLE)
+  add_executable(tent_rdma_async_event_drain_test
+                 rdma_async_event_drain_test.cpp)
+  target_link_libraries(
+    tent_rdma_async_event_drain_test PRIVATE gtest gtest_main tent_link_group
+                                             ibverbs)
+  target_include_directories(tent_rdma_async_event_drain_test
+                             PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+  target_link_options(
+    tent_rdma_async_event_drain_test PRIVATE "-Wl,--wrap=ibv_get_async_event"
+    "-Wl,--wrap=ibv_ack_async_event")
+  add_test(NAME tent_rdma_async_event_drain_test
+           COMMAND tent_rdma_async_event_drain_test)
+endif()
+
 if(USE_HIP)
   find_package(HIP REQUIRED)
   add_executable(tent_rocm_platform_test rocm_platform_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
-# TENT Tests and Examples
-# tent_metrics_example and deadline_promotion_bench are not add_test targets.
-# tent/benchmark/hip_bandwidth_bench.cpp is a standalone hipcc program.
+# TENT Tests and Examples tent_metrics_example and deadline_promotion_bench are
+# not add_test targets. tent/benchmark/hip_bandwidth_bench.cpp is a standalone
+# hipcc program.
 
 # TENT Metrics Example
 add_executable(tent_metrics_example tent_metrics_example.cpp)
@@ -125,9 +125,9 @@ add_test(NAME tent_ip_utils_test COMMAND tent_ip_utils_test)
 # values with embedded NULs. Only built when hiredis is available.
 if(TARGET metastore_redis)
   add_executable(tent_redis_metastore_test redis_metastore_test.cpp)
-  target_link_libraries(tent_redis_metastore_test
-                        PRIVATE metastore_redis tent_common gtest gtest_main
-                                glog)
+  target_link_libraries(
+    tent_redis_metastore_test PRIVATE metastore_redis tent_common gtest
+                                      gtest_main glog)
   target_include_directories(tent_redis_metastore_test
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   add_test(NAME tent_redis_metastore_test COMMAND tent_redis_metastore_test)
@@ -286,14 +286,13 @@ add_test(NAME tent_rdma_transport_test COMMAND tent_rdma_transport_test)
 # Regression test for the edge-triggered async event fd: one epoll wakeup must
 # drain the whole queue. Wraps ibv_get_async_event to script the event source,
 # so it needs no RDMA device. -Wl,--wrap is a GNU ld / lld feature that Apple's
-# linker lacks, and the test is meaningless without it, so skip the target
-# there rather than build one that calls the real symbols.
+# linker lacks, and the test is meaningless without it, so skip the target there
+# rather than build one that calls the real symbols.
 if(UNIX AND NOT APPLE)
   add_executable(tent_rdma_async_event_drain_test
                  rdma_async_event_drain_test.cpp)
-  target_link_libraries(
-    tent_rdma_async_event_drain_test PRIVATE gtest gtest_main tent_link_group
-                                             ibverbs)
+  target_link_libraries(tent_rdma_async_event_drain_test
+                        PRIVATE gtest gtest_main tent_link_group ibverbs)
   target_include_directories(tent_rdma_async_event_drain_test
                              PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
   target_link_options(
@@ -577,9 +576,9 @@ if(USE_TPU)
   add_test(NAME tent_tpu_transport_test COMMAND tent_tpu_transport_test)
 endif()
 
-# NOT registered via add_test: the test needs a real CUDA device (it exports
-# a real CUDA IPC handle), so it must be run manually on a GPU host. Only
-# built when CUDA is enabled: the test includes CUDA headers directly.
+# NOT registered via add_test: the test needs a real CUDA device (it exports a
+# real CUDA IPC handle), so it must be run manually on a GPU host. Only built
+# when CUDA is enabled: the test includes CUDA headers directly.
 if(USE_CUDA)
   add_executable(tent_nvlink_ipc_handle_sharing_test
                  nvlink_ipc_handle_sharing_test.cpp)

--- a/mooncake-transfer-engine/tent/tests/rdma_async_event_drain_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_async_event_drain_test.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Workers::handleContextEvents() must empty the async event fd on every call:
+// the fd is edge-triggered, so anything left queued is stranded until an
+// unrelated later event releases it -- and a stranded IBV_EVENT_PORT_ACTIVE
+// leaves its context paused, silently failing every transfer on that NIC.
+// These tests replace the event source with a scripted queue via linker
+// wrapping, so no RDMA device is needed.
+
+#include <gtest/gtest.h>
+#include <infiniband/verbs.h>
+
+#include <cerrno>
+#include <cstring>
+#include <deque>
+#include <memory>
+
+#include "tent/runtime/topology.h"
+#include "tent/transport/rdma/context.h"
+#include "tent/transport/rdma/params.h"
+#include "tent/transport/rdma/rdma_transport.h"
+#include "tent/transport/rdma/workers.h"
+
+namespace {
+
+// Stands in for the kernel's async event queue behind async_fd.
+struct AsyncEventScript {
+    std::deque<ibv_event_type> pending;
+    // Reported once `pending` runs dry. EAGAIN mimics a drained non-blocking
+    // fd; anything else mimics a real read failure.
+    int drained_errno = EAGAIN;
+    // Fail this many reads with EINTR before serving the queue.
+    int pending_eintr = 0;
+    int get_calls = 0;
+    int ack_calls = 0;
+};
+
+AsyncEventScript g_script;
+
+}  // namespace
+
+extern "C" int __wrap_ibv_get_async_event(struct ibv_context* context,
+                                          struct ibv_async_event* event) {
+    (void)context;  // Never dereferenced by the code under test.
+    g_script.get_calls++;
+    if (g_script.pending_eintr > 0) {
+        g_script.pending_eintr--;
+        errno = EINTR;
+        return -1;
+    }
+    if (g_script.pending.empty()) {
+        errno = g_script.drained_errno;
+        return -1;
+    }
+    memset(event, 0, sizeof(*event));
+    event->event_type = g_script.pending.front();
+    g_script.pending.pop_front();
+    return 0;
+}
+
+extern "C" void __wrap_ibv_ack_async_event(struct ibv_async_event* event) {
+    (void)event;
+    g_script.ack_calls++;
+}
+
+namespace mooncake {
+namespace tent {
+
+// Friend accessor for driving the event loop without a full install().
+class RdmaTransportTestPeer {
+   public:
+    static void bindTopology(RdmaTransport& transport,
+                             std::shared_ptr<Topology> topology) {
+        transport.local_topology_ = topology;
+        transport.local_buffer_manager_.setTopology(topology);
+        transport.params_ = std::make_shared<RdmaParams>();
+        transport.conf_ = std::make_shared<Config>();
+    }
+
+    static size_t initializeContexts(RdmaTransport& transport) {
+        return transport.initializeContexts();
+    }
+
+    static std::unique_ptr<Workers> makeWorkers(RdmaTransport& transport) {
+        return std::make_unique<Workers>(&transport);
+    }
+
+    static int handleContextEvents(Workers& workers, int dev_id,
+                                   std::shared_ptr<RdmaContext>& context) {
+        return workers.handleContextEvents(dev_id, context);
+    }
+
+    static RdmaContextSet& contextSet(RdmaTransport& transport) {
+        return transport.context_set_;
+    }
+};
+
+namespace {
+
+// Event types whose handlers touch nothing a device-less context lacks.
+// IBV_EVENT_COMM_EST falls through applyContextEvent()'s default label;
+// IBV_EVENT_PORT_ACTIVE takes the recovery path, where resume() is a no-op on
+// an inert context and the link-speed refresh declines without a device.
+// Together they cover a handled and an unhandled event.
+constexpr ibv_event_type kUnhandledEvent = IBV_EVENT_COMM_EST;
+constexpr ibv_event_type kHandledEvent = IBV_EVENT_PORT_ACTIVE;
+
+class AsyncEventDrainTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        topology_ = std::make_shared<Topology>();
+        // No device is named "mc-absent-rnic-0" on any host, so the context
+        // stays inert: construct() still builds the endpoint store, but no
+        // real async fd is ever opened and only the scripted queue answers.
+        ASSERT_TRUE(
+            topology_
+                ->parse(
+                    R"({"nics":[{"name":"mc-absent-rnic-0","type":0,"numa_node":0}]})")
+                .ok());
+        RdmaTransportTestPeer::bindTopology(transport_, topology_);
+        ASSERT_EQ(RdmaTransportTestPeer::initializeContexts(transport_), 0u);
+        workers_ = RdmaTransportTestPeer::makeWorkers(transport_);
+
+        g_script = AsyncEventScript{};
+    }
+
+    int drain() {
+        auto& context = RdmaTransportTestPeer::contextSet(transport_)[kDev];
+        return RdmaTransportTestPeer::handleContextEvents(*workers_, kDev,
+                                                          context);
+    }
+
+    static constexpr int kDev = 0;
+    std::shared_ptr<Topology> topology_;
+    RdmaTransport transport_;
+    std::unique_ptr<Workers> workers_;
+};
+
+// The regression: a burst arriving between two epoll wakeups must be consumed
+// in full, not one event at a time.
+TEST_F(AsyncEventDrainTest, DrainsEveryQueuedEvent) {
+    constexpr int kBurst = 5;
+    for (int i = 0; i < kBurst; ++i)
+        g_script.pending.push_back(kUnhandledEvent);
+
+    EXPECT_EQ(drain(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty())
+        << "one epoll wakeup must drain the whole async event queue; "
+        << g_script.pending.size() << " event(s) were left stranded";
+    // kBurst reads plus the trailing EAGAIN that ends the drain.
+    EXPECT_EQ(g_script.get_calls, kBurst + 1);
+    EXPECT_EQ(g_script.ack_calls, kBurst);
+}
+
+// A PORT_ACTIVE queued behind a burst is the case that wedged a NIC for good,
+// so it must be reached and acked like any other event.
+TEST_F(AsyncEventDrainTest, ReachesHandledEventQueuedBehindOthers) {
+    g_script.pending.push_back(kUnhandledEvent);
+    g_script.pending.push_back(kUnhandledEvent);
+    g_script.pending.push_back(kHandledEvent);
+
+    EXPECT_EQ(drain(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty());
+    EXPECT_EQ(g_script.get_calls, 4);
+    EXPECT_EQ(g_script.ack_calls, 3);
+}
+
+// A wakeup with nothing pending is a drained fd, not a failure.
+TEST_F(AsyncEventDrainTest, EmptyQueueIsNotAnError) {
+    EXPECT_EQ(drain(), 0);
+
+    EXPECT_EQ(g_script.get_calls, 1);
+    EXPECT_EQ(g_script.ack_calls, 0);
+}
+
+// A signal must not end the drain early, or the events behind it are stranded
+// exactly as they were before the fix.
+TEST_F(AsyncEventDrainTest, InterruptedReadIsRetried) {
+    g_script.pending.push_back(kUnhandledEvent);
+    g_script.pending.push_back(kUnhandledEvent);
+    g_script.pending_eintr = 1;
+
+    EXPECT_EQ(drain(), 0);
+
+    EXPECT_TRUE(g_script.pending.empty());
+    // One EINTR, two reads, one trailing EAGAIN.
+    EXPECT_EQ(g_script.get_calls, 4);
+    EXPECT_EQ(g_script.ack_calls, 2);
+}
+
+// A genuine read failure still aborts and propagates, so the loop cannot spin
+// forever on a broken fd.
+TEST_F(AsyncEventDrainTest, RealReadErrorStopsTheDrain) {
+    g_script.pending.push_back(kUnhandledEvent);
+    g_script.drained_errno = EIO;
+
+    EXPECT_EQ(drain(), -1);
+
+    EXPECT_EQ(g_script.get_calls, 2);
+    EXPECT_EQ(g_script.ack_calls, 1);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rdma_transport_test.cpp
@@ -75,6 +75,12 @@ class RdmaTransportTestPeer {
         workers.applyContextEvent(dev_id, context, event);
     }
 
+    // Runs the monitorThread() 1 Hz safety net for contexts whose
+    // IBV_EVENT_PORT_ACTIVE never arrived, without starting any threads.
+    static void resumePausedContexts(Workers& workers) {
+        workers.resumePausedContexts();
+    }
+
     static const RdmaContextSet& contextSet(const RdmaTransport& transport) {
         return transport.context_set_;
     }
@@ -485,6 +491,75 @@ TEST(RdmaContextPortSpeedTest, RefreshOnInertContextIsRejected) {
     ASSERT_EQ(context.status(), RdmaContext::DEVICE_UNINIT);
     EXPECT_EQ(context.refreshPortAttributes(), -1);
     EXPECT_DOUBLE_EQ(context.linkSpeedGbps(), 0.0);
+}
+
+// The 1 Hz recovery poll only reactivates contexts that are actually paused.
+// An inert slot never opened a device, so there is no port to consult and
+// nothing to hand back to the selector.
+TEST_F(RdmaContextEventTest, RecoveryPollLeavesInertContextsAlone) {
+    fire(IBV_EVENT_PORT_ERR, ourPort());
+    ASSERT_FALSE(selector_->isDeviceAvailable(kDev));
+    ASSERT_EQ(context().status(), RdmaContext::DEVICE_UNINIT);
+
+    RdmaTransportTestPeer::resumePausedContexts(*workers_);
+
+    EXPECT_FALSE(selector_->isDeviceAvailable(kDev));
+}
+
+TEST(RdmaContextPortStateTest, QueryOnInertContextIsRejected) {
+    RdmaTransport transport;
+    RdmaContext context(transport);
+    ASSERT_EQ(context.status(), RdmaContext::DEVICE_UNINIT);
+
+    ibv_port_state state = IBV_PORT_DOWN;
+    EXPECT_EQ(context.queryPortState(&state), -1);
+    EXPECT_EQ(state, IBV_PORT_DOWN) << "a failed query must not invent a state";
+    EXPECT_EQ(context.queryPortState(nullptr), -1);
+}
+
+// A context paused by IBV_EVENT_PORT_ERR whose IBV_EVENT_PORT_ACTIVE never
+// arrives (the async fd is edge-triggered, so a queued event can be stranded)
+// used to stay DEVICE_PAUSED for the rest of the process' life, failing every
+// transfer routed to that NIC. The monitor thread's poll must notice that the
+// hardware reports the port as up and reactivate the context.
+TEST(RdmaPausedContextRecoveryTest, PollActivatesPausedContextWithLivePort) {
+    if (!hasRdmaDevice()) GTEST_SKIP() << "no RDMA device detected";
+
+    int count = 0;
+    ibv_device** devices = ibv_get_device_list(&count);
+    ASSERT_NE(devices, nullptr);
+    ASSERT_GT(count, 0);
+    const std::string device_name = ibv_get_device_name(devices[0]);
+    ibv_free_device_list(devices);
+
+    auto topology = std::make_shared<Topology>();
+    const std::string spec = R"({"nics":[{"name":")" + device_name +
+                             R"(","type":0,"numa_node":0}]})";
+    ASSERT_TRUE(topology->parse(spec).ok());
+
+    RdmaTransport transport;
+    RdmaTransportTestPeer::bindTopology(transport, topology);
+    RdmaTransportTestPeer::initializeContexts(transport);
+    const auto& contexts = RdmaTransportTestPeer::contextSet(transport);
+    ASSERT_EQ(contexts.size(), 1u);
+    RdmaContext& context = *contexts[0];
+    if (context.status() != RdmaContext::DEVICE_ENABLED)
+        GTEST_SKIP() << device_name << " has no usable active port";
+
+    auto workers = RdmaTransportTestPeer::makeWorkers(transport);
+    auto* selector = workers->getDeviceSelector();
+    ASSERT_NE(selector, nullptr);
+
+    // Exactly the state IBV_EVENT_PORT_ERR leaves behind, minus the event
+    // that would have undone it.
+    context.pause();
+    ASSERT_EQ(context.status(), RdmaContext::DEVICE_PAUSED);
+    ASSERT_TRUE(selector->setDeviceAvailable(0, false).ok());
+
+    RdmaTransportTestPeer::resumePausedContexts(*workers);
+
+    EXPECT_EQ(context.status(), RdmaContext::DEVICE_ENABLED);
+    EXPECT_TRUE(selector->isDeviceAvailable(0));
 }
 
 TEST(RdmaTransportIntegrationTest, WriteThenReadAcrossProcesses) {


### PR DESCRIPTION
## Description

**Problem**
Issue #3523 defect C. A TENT RDMA context that was paused by IBV_EVENT_PORT_ERR only ever leaves DEVICE_PAUSED from one place: the IBV_EVENT_PORT_ACTIVE branch of Workers::applyContextEvent(). Nothing revalidates the port afterwards, so if that one event is missed the context stays paused for the rest of the process' life, Workers::getEndpoint() rejects every transfer on that NIC, and no log line ever explains why.

That event is easy to miss. joinNonblockingPollList() registers the async fd with EPOLLIN | EPOLLET, while monitorThread() calls epoll_wait(..., maxevents=1, 100) and handleContextEvents() consumed exactly one ibv_async_event per wakeup. Under edge-triggered semantics epoll does not report readiness again until a new event arrives, so anything queued behind the event that woke us is stranded. Bursts are routine — IBV_EVENT_COMM_EST fires once per connection — so a PORT_ACTIVE sitting behind one waits for an unrelated future event that may never come. The classic engine hit exactly this and fixed it in WorkerPool::doProcessContextEvents(); TENT still had the one-event-per-wakeup read.

**Fix**
Workers::handleContextEvents() now drains the queue: loop until EAGAIN/EWOULDBLOCK, retry on EINTR, and propagate a genuine read error instead of spinning on a broken fd. Mirrors the classic engine.
Workers::resumePausedContexts() is a safety net on monitorThread()'s existing 1 Hz tick: for contexts in DEVICE_PAUSED it reads the port state and, when the hardware reports IBV_PORT_ACTIVE, runs the same recovery the event path runs. Intermediate states (INIT/ARMED/ACTIVE_DEFER) are left alone and re-checked on the next tick.
The recovery actions (resume() + re-seed bandwidth + setDeviceAvailable) are factored into Workers::activateContext() so the event path and the poll cannot drift apart.
New RdmaContext::queryPortState() reads the port state without touching the cached speed/width, because refreshLinkSpeed() diffs against them — refreshing there would hide a renegotiated link rate from the selector.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Tests**
New tent/tests/rdma_async_event_drain_test.cpp (5 cases), scripting the event source with -Wl,--wrap=ibv_get_async_event, so it needs no RDMA device: full drain of a burst, a handled event queued behind unhandled ones, empty queue is not an error, EINTR is retried, a real read error aborts. All 5 fail on main and pass with this change.
tent/tests/rdma_transport_test.cpp: RecoveryPollLeavesInertContextsAlone (the poll must not hand an inert slot back to the selector), QueryOnInertContextIsRejected, and PollActivatesPausedContextWithLivePort — the regression itself, on a real NIC (skipped when no device is present).


**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)

I use AI tools to help summarise the PR content, assist and review on my code.