### PR TITLE
[CI] Keep Ascend mirror retry on actions/checkout

### DIFF
--- a/.github/workflows/ci_ascend.yml
+++ b/.github/workflows/ci_ascend.yml
@@ -45,12 +45,13 @@ jobs:
         fetch-depth: 1
         persist-credentials: false
 
-    - name: Retry checkout via GitHub mirror
+    # Mirror is only a git transport fallback. Keep retry on actions/checkout so
+    # pull_request_target fork checks still run; do not fetch with raw git.
+    - name: Configure GitHub mirror rewrite
       if: steps.checkout_code.outcome == 'failure'
       shell: bash
       env:
         ASCEND_GITHUB_MIRROR_URLS: 'https://ghfast.top/'
-        CHECKOUT_REF: ${{ inputs.checkout_ref || github.sha }}
       run: |
         set -euo pipefail
 
@@ -83,27 +84,21 @@ jobs:
 
         workdir="${GITHUB_WORKSPACE}"
         git config --global --add safe.directory "$workdir"
+        find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 
-        for base in "${candidates[@]}"; do
-          mirror_url="${base}https://github.com/${GITHUB_REPOSITORY}.git"
-          echo "Retrying checkout with ${mirror_url}"
+        # insteadOf only rewrites github.com fetches; checkout still runs
+        # assertSafePrCheckout before any git network I/O.
+        mirror_base="${candidates[0]}"
+        echo "Rewriting https://github.com/ to ${mirror_base}https://github.com/"
+        git config --global url."${mirror_base}https://github.com/".insteadOf "https://github.com/"
 
-          find "$workdir" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
-          git init "$workdir"
-          git -C "$workdir" remote add origin "$mirror_url"
-
-          if git -C "$workdir" fetch --depth=1 origin "$CHECKOUT_REF" && \
-             git -C "$workdir" checkout --force --detach FETCH_HEAD; then
-            echo "Mirror checkout succeeded via ${base}"
-            exit 0
-          fi
-
-          echo "Mirror checkout failed via ${base}"
-          rm -rf "$workdir/.git"
-        done
-
-        echo "Direct GitHub checkout failed and all mirror retries failed"
-        exit 1
+    - name: Retry checkout via GitHub mirror
+      if: steps.checkout_code.outcome == 'failure'
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.checkout_ref || github.sha }}
+        fetch-depth: 1
+        persist-credentials: false
 
     - name: Configure CMake
       shell: bash


### PR DESCRIPTION
## Description

`ci_ascend.yml` retries GitHub checkout via mirror when `actions/checkout@v4` fails. That fallback used raw `git fetch`, so it skipped checkout's `pull_request_target` fork check (`assertSafePrCheckout`) and could check out an untrusted PR head into a privileged self-hosted job.

This is a regression in failure meaning, not a change we made to the YAML trigger. Checkout `@v4` now refuses fork PR heads under `pull_request_target` (backported 2026-07-16). The mirror step treated that refusal as a network failure and rescued the SHA.

The retry now only rewrites `https://github.com/` with `url.<mirror>.insteadOf` and runs `actions/checkout@v4` again (no `continue-on-error`). Network failures still use the mirror; fork + `pull_request_target` is rejected again and the job fails. `allow-unsafe-pr-checkout` is not enabled.

Submodule mirror retry and the separate xxHash missing-package failure in `mooncake-hixl-ci:v5` are unchanged.

### Incompatible behavior

After this change, **fork PRs can no longer run `ascend-test` / `ci_ascend`**. Labeling `run-e2e-ci` on a fork PR will fail at checkout instead of building and testing the PR head.

That previously-working path was **out of spec**, not a supported feature. The mirror exists only to survive github.com instability on the self-hosted runner. It was never meant to bypass `actions/checkout` and execute untrusted fork code in a privileged job that inherits repository secrets. Same-repo PRs, nightly, and `workflow_dispatch` on in-tree SHAs are unchanged.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [x] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Workflow YAML change only; Ascend self-hosted jobs are not covered by `scripts/run_ci_test.sh`.

**Test commands:**
```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci_ascend.yml'))"
pre-commit run --files .github/workflows/ci_ascend.yml
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

YAML parse succeeded. pre-commit hooks on the touched file passed (trailing whitespace, EOF, check-yaml, merge conflict, large files, codespell).

Expected job behavior after merge:
- Nightly / same-repo SHA with github.com reachable: first checkout still succeeds
- Same, github.com unreachable: retry checkout via `insteadOf` + `actions/checkout@v4`
- Fork PR with `run-e2e-ci` (`pull_request_target`): both checkouts refuse; job fails instead of compiling untrusted code

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor drafted the workflow change and this PR. The submitter reviewed the checkout retry path, the `insteadOf` rewrite, and the intentional fork-PR failure behavior.


Made with [Cursor](https://cursor.com)