### PR TITLE
[Bugfix][Store] Honor batch-get destination buffer capacities

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -2934,7 +2934,9 @@ List[int]
 **Parameters:**
 - `keys` (List[str]): List of object identifiers
 - `all_buffer_ptrs` (List[int]): List of memory addresses
-- `all_sizes` (List[int]): List of buffer sizes
+- `all_sizes` (List[int]): List of destination buffer capacities. For each key,
+  the capacities must sum to at least the object size; only the object-sized
+  prefix is written.
 
 **Returns:**
 - `List[int]`: List of bytes read for each operation (positive = success, negative = error)

--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -164,7 +164,9 @@ class RealClient : public PyClient {
      * @param keys Vector of keys of the objects to get
      * @param all_buffers Vector of vectors of pointers to the pre-allocated
      * buffers
-     * @param all_sizes Vector of vectors of sizes of the buffers
+     * @param all_sizes Vector of vectors of destination buffer capacities. For
+     * each key, the capacities must cover the object; bytes beyond the object
+     * size are not written.
      * @return Vector of integers, where each element is the number of bytes
      * read on success, or a negative value on error
      * @note The buffer addresses must resolve to Store-managed registered

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -6192,8 +6192,7 @@ RealClient::batch_get_into_multi_buffers_internal(
         std::string key;
         size_t original_index;
         QueryResult query_result;
-        std::vector<void *> buffers;
-        std::vector<size_t> sizes;
+        std::vector<Slice> slices;
         uint64_t total_size;
         Replica::Descriptor replica;
         bool is_local_disk;  // true=LOCAL_DISK (offload RPC), false=DISK/DFS
@@ -6235,29 +6234,34 @@ RealClient::batch_get_into_multi_buffers_internal(
         }
         const auto replica = *best_replica;
         uint64_t total_size = calculate_total_size(replica);
-        const auto &sizes = all_sizes[i];
-        uint64_t dst_total_size = 0;
-        for (auto &size : sizes) {
-            dst_total_size += size;
-        }
-        if (dst_total_size < total_size) {
-            LOG(ERROR) << "Buffer too small for key '" << key
-                       << "': required=" << total_size
-                       << ", available=" << dst_total_size;
+        if (all_buffers[i].size() != all_sizes[i].size()) {
+            LOG(ERROR) << "Buffer and size count mismatch for key '" << key
+                       << "': buffers=" << all_buffers[i].size()
+                       << ", sizes=" << all_sizes[i].size();
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
             continue;
         }
-        // Create slices for this key's buffer
+        const auto &sizes = all_sizes[i];
         const auto &buffers = all_buffers[i];
-        std::vector<Slice> key_slices;
-        key_slices.reserve(buffers.size());
-        if (replica.is_memory_replica() || replica.is_nof_replica()) {
-            // MEMORY / NOF: RDMA directly to the user buffers.
-            for (size_t j = 0; j < buffers.size(); ++j) {
-                key_slices.emplace_back(Slice{buffers[j], sizes[j]});
-            }
-        } else if (replica.is_local_disk_replica() ||
-                   replica.is_disk_replica() || replica.is_dfs_replica()) {
+        std::vector<Slice> destination_slices;
+        destination_slices.reserve(buffers.size());
+        uint64_t remaining = total_size;
+        for (size_t j = 0; j < buffers.size() && remaining > 0; ++j) {
+            const size_t slice_size = static_cast<size_t>(
+                std::min<uint64_t>(sizes[j], remaining));
+            if (slice_size == 0) continue;
+            destination_slices.emplace_back(buffers[j], slice_size);
+            remaining -= slice_size;
+        }
+        if (remaining != 0) {
+            LOG(ERROR) << "Buffer too small for key '" << key
+                       << "': required=" << total_size
+                       << ", missing=" << remaining;
+            results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
+            continue;
+        }
+        if (replica.is_local_disk_replica() || replica.is_disk_replica() ||
+            replica.is_dfs_replica()) {
             // LOCAL_DISK: GPU buffers passed directly as scatter-gather slices
             // (zero-copy). DISK/DFS use a contiguous temp buffer at read time.
             valid_local_disk_ops.emplace(
@@ -6265,24 +6269,26 @@ RealClient::batch_get_into_multi_buffers_internal(
                 DiskKeyInfo{.key = key,
                             .original_index = i,
                             .query_result = std::move(query_result_values),
-                            .buffers = all_buffers[i],
-                            .sizes = all_sizes[i],
+                            .slices = std::move(destination_slices),
                             .total_size = total_size,
                             .replica = replica,
                             .is_local_disk = replica.is_local_disk_replica()});
             results.emplace_back(static_cast<int64_t>(total_size));
             continue;
-        } else {
+        }
+        if (!replica.is_memory_replica() && !replica.is_nof_replica()) {
             LOG(ERROR) << "Unsupported replica type for key: " << key;
             results.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
             continue;
         }
 
+        // MEMORY / NOF: RDMA directly to the object-sized prefix of the user
+        // buffers.
         valid_operations.push_back(
             {.key = key,
              .original_index = i,
              .query_result = FilterQueryResult(query_result_values, replica),
-             .slices = std::move(key_slices),
+             .slices = std::move(destination_slices),
              .total_size = total_size});
         // Set success result (actual bytes transferred)
         results.emplace_back(static_cast<int64_t>(total_size));
@@ -6343,24 +6349,9 @@ RealClient::batch_get_into_multi_buffers_internal(
                         tl::make_unexpected(ErrorCode::INVALID_REPLICA);
                     continue;
                 }
-                std::vector<Slice> user_slices;
-                user_slices.reserve(op.buffers.size());
-                size_t slice_total = 0;
-                for (size_t j = 0; j < op.buffers.size(); ++j) {
-                    user_slices.push_back(Slice{op.buffers[j], op.sizes[j]});
-                    slice_total += op.sizes[j];
-                }
-                if (slice_total < op.total_size) {
-                    LOG(ERROR) << "Slice size too small for key " << key
-                               << ": slices=" << slice_total
-                               << ", total=" << op.total_size;
-                    results[op.original_index] =
-                        tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                    continue;
-                }
                 offload_objects[replica.get_local_disk_descriptor()
                                     .transport_endpoint]
-                    .emplace(key, std::move(user_slices));
+                    .emplace(key, std::move(op.slices));
             }
 
             for (auto &[endpoint, objects] : offload_objects) {
@@ -6403,16 +6394,11 @@ RealClient::batch_get_into_multi_buffers_internal(
             auto scatter_to_buffers = [&](const std::string &key, char *src,
                                           const DiskKeyInfo &op) -> bool {
                 size_t offset = 0;
-                for (size_t j = 0; j < op.buffers.size(); ++j) {
-                    if (offset >= op.total_size) break;
-                    size_t sz =
-                        std::min(op.sizes[j],
-                                 static_cast<size_t>(op.total_size - offset));
-                    void *dst = op.buffers[j];
+                for (const auto &slice : op.slices) {
                     const char *replica_type =
                         op.replica.is_dfs_replica() ? "DFS" : "DISK";
                     if (auto r = scatter_host_to_maybe_device(
-                            dst, src + offset, sz,
+                            slice.ptr, src + offset, slice.size,
                             std::string(replica_type) +
                                 " scatter, key: " + key);
                         !r) {
@@ -6420,7 +6406,7 @@ RealClient::batch_get_into_multi_buffers_internal(
                             tl::make_unexpected(r.error());
                         return false;
                     }
-                    offset += sz;
+                    offset += slice.size;
                 }
                 return true;
             };

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -249,6 +249,125 @@ TEST_F(RealClientTest, BatchGetIntoUsesSelectedLocalDiskEndpoint) {
     }
 }
 
+TEST_F(RealClientTest, BatchGetIntoMultiBuffersAcceptsLargerDestination) {
+    StartMasterAndSetupClient();
+
+    constexpr size_t kObjectSize = 100;
+    constexpr size_t kFirstBufferCapacity = 64;
+    constexpr size_t kSecondBufferCapacity = 64;
+    constexpr size_t kBufferCapacity =
+        kFirstBufferCapacity + kSecondBufferCapacity;
+    const std::string key = "batch_get_larger_destination";
+    std::vector<char> source(kObjectSize, 'A');
+    std::vector<char> destination(kBufferCapacity, 'Z');
+    std::fill(source.begin() + kFirstBufferCapacity, source.end(), 'B');
+
+    ReplicateConfig config;
+    config.replica_num = 1;
+    ASSERT_EQ(py_client_->put(key, source, config), 0);
+    ASSERT_EQ(
+        py_client_->register_buffer(destination.data(), destination.size()), 0);
+
+    const auto results = py_client_->batch_get_into_multi_buffers(
+        {key},
+        {{destination.data(), destination.data() + kFirstBufferCapacity}},
+        {{kFirstBufferCapacity, kSecondBufferCapacity}}, false);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0], static_cast<int>(kObjectSize));
+    EXPECT_TRUE(std::equal(source.begin(), source.begin() + kFirstBufferCapacity,
+                           destination.begin()));
+    EXPECT_TRUE(std::equal(source.begin() + kFirstBufferCapacity, source.end(),
+                           destination.begin() + kFirstBufferCapacity));
+    EXPECT_TRUE(std::all_of(destination.begin() + kObjectSize,
+                            destination.end(),
+                            [](char value) { return value == 'Z'; }));
+    ASSERT_EQ(py_client_->unregister_buffer(destination.data()), 0);
+}
+
+TEST_F(RealClientTest,
+       BatchGetIntoMultiBuffersAcceptsLargerDestinationFromLocalDisk) {
+    ScopedEnvVar local_memcpy("MC_STORE_MEMCPY", "1");
+    ScopedEnvVar heartbeat("MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS", "1");
+    ScopedEnvVar storage_backend("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+                                 "bucket_storage_backend");
+    ScopedEnvVar bucket_keys("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "1");
+
+    char path[] = "/tmp/mooncake_batch_get_capacity_XXXXXX";
+    const char* created = mkdtemp(path);
+    ASSERT_NE(created, nullptr);
+    ssd_path_ = created;
+
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
+                                  .set_enable_offload(true)
+                                  .set_default_kv_lease_ttl(10)
+                                  .build()));
+    master_address_ = master_.master_address();
+    ASSERT_EQ(
+        py_client_->setup_real("localhost:17813", "P2PHANDSHAKE",
+                               16 * 1024 * 1024, 16 * 1024 * 1024, "tcp", "",
+                               master_address_, nullptr, "", true, ssd_path_),
+        0);
+
+    constexpr size_t kObjectSize = 100;
+    constexpr size_t kFirstBufferCapacity = 64;
+    constexpr size_t kSecondBufferCapacity = 64;
+    constexpr size_t kBufferCapacity =
+        kFirstBufferCapacity + kSecondBufferCapacity;
+    const std::string key = "batch_get_larger_destination_from_local_disk";
+    std::vector<char> source(kObjectSize, 'A');
+    std::vector<char> destination(kBufferCapacity, 'Z');
+    std::fill(source.begin() + kFirstBufferCapacity, source.end(), 'B');
+    ASSERT_EQ(py_client_->put(key, source), 0);
+
+    bool disk_ready = false;
+    const auto offload_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (std::chrono::steady_clock::now() < offload_deadline && !disk_ready) {
+        for (const auto& replica : py_client_->get_replica_desc(key)) {
+            if (replica.is_local_disk_replica()) disk_ready = true;
+        }
+        if (!disk_ready)
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    ASSERT_TRUE(disk_ready);
+
+    bool memory_cleared = false;
+    const auto clear_deadline =
+        std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < clear_deadline) {
+        if (py_client_->batch_replica_clear({key}, "localhost:17813").size() ==
+            1) {
+            memory_cleared = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(memory_cleared);
+
+    const auto replicas = py_client_->get_replica_desc(key);
+    ASSERT_EQ(replicas.size(), 1);
+    ASSERT_TRUE(replicas.front().is_local_disk_replica());
+    ASSERT_EQ(
+        py_client_->register_buffer(destination.data(), destination.size()), 0);
+
+    const auto results = py_client_->batch_get_into_multi_buffers(
+        {key},
+        {{destination.data(), destination.data() + kFirstBufferCapacity}},
+        {{kFirstBufferCapacity, kSecondBufferCapacity}}, false);
+
+    ASSERT_EQ(results.size(), 1);
+    EXPECT_EQ(results[0], static_cast<int>(kObjectSize));
+    EXPECT_TRUE(std::equal(source.begin(), source.begin() + kFirstBufferCapacity,
+                           destination.begin()));
+    EXPECT_TRUE(std::equal(source.begin() + kFirstBufferCapacity, source.end(),
+                           destination.begin() + kFirstBufferCapacity));
+    EXPECT_TRUE(std::all_of(destination.begin() + kObjectSize,
+                            destination.end(),
+                            [](char value) { return value == 'Z'; }));
+    ASSERT_EQ(py_client_->unregister_buffer(destination.data()), 0);
+}
+
 #ifdef MOONCAKE_TEST_CUDA_H2D
 TEST_F(RealClientTest, PinnedSsdRestoreReadsNonTailRangeIntoGpu) {
     int device_count = 0;


### PR DESCRIPTION
# [Bugfix][Store] Honor batch-get destination buffer capacities

## Description

`batch_get_into_multi_buffers` accepts per-buffer destination capacities. For
each key, the aggregate capacity may exceed the object size; only insufficient
capacity is invalid. Before this change, the MEMORY/NoF path forwarded every
capacity unchanged to `Client::BatchGet`, whose slices must add up to the exact
object length. A valid oversized destination therefore failed deterministically
with `INVALID_PARAMS`.

For example, reading a 100-byte object into two 64-byte buffers passes the
public capacity check (`128 >= 100`), but previously sent 128 bytes of slices
for a 100-byte replica. This is production-reachable whenever callers reuse
fixed-capacity or size-class buffers. Existing exact-size callers, including
the common current vLLM allocation path, retain the same behavior.

This change:

- builds one canonical object-sized destination prefix before dispatching to
  MEMORY, NoF, LOCAL_DISK, DISK, or DFS;
- consumes the required object length incrementally instead of summing
  capacities, avoiding overflow in the capacity check;
- rejects per-key buffer/size rows with different element counts instead of
  indexing mismatched vectors; and
- documents that `all_sizes` contains destination capacities and that bytes
  beyond the object-sized prefix are not written.

The transfer remains zero-copy for MEMORY, NoF, and LOCAL_DISK. Exact-size
calls produce the same slices as before. Oversized calls only shorten the final
exposed slice, so no backend can read or write beyond the object boundary.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Two end-to-end regressions start an in-process master and a real TCP Store
client, write a 100-byte object, and read it into two registered 64-byte
buffers:

1. The default MEMORY path exercises `Client::BatchGet`.
2. The LOCAL_DISK path waits for SSD offload, clears the memory replica, checks
   that only the local-disk replica remains, and reads through the offload RPC.

Both tests verify the 100-byte return value, the complete object contents, and
that the unused 28-byte destination tail retains its sentinel value.

**Test commands:**

```bash
cmake --build build --target pybind_client_test -j "$(nproc)"

./build/mooncake-store/tests/pybind_client_test \
  --gtest_filter='RealClientTest.BatchGetIntoMultiBuffersAcceptsLargerDestination:RealClientTest.BatchGetIntoMultiBuffersAcceptsLargerDestinationFromLocalDisk'

./build/mooncake-store/tests/pybind_client_test \
  --gtest_filter='-RealClientTest.PinnedSsdRestoreReadsNonTailRangeIntoGpu'

pre-commit run --files \
  docs/source/api-reference/python/mooncake-store.md \
  mooncake-store/include/real_client.h \
  mooncake-store/src/real_client.cpp \
  mooncake-store/tests/pybind_client_test.cpp

make -C docs html
```

**Test results:**

- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (described below)

- Targeted real-client MEMORY and LOCAL_DISK regressions: 2/2 passed.
- Applicable `pybind_client_test` suite: 65/65 passed.
- PR-scoped pre-commit hooks: all passed.
- The documentation build was not completed because the test environment does
  not provide the configured `sphinx_copybutton` extension. Sphinx stopped
  while loading extensions, before processing the changed page.

Manual assertions in both regressions confirm that only the object-sized
prefix is written and excess destination capacity remains untouched.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable (158 added lines, 49 deleted lines)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

OpenAI Codex was used to implement the fix and add regression
tests.