### PR TITLE
[Store] Fix snapshot test eviction race

### DIFF
--- a/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
+++ b/mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <sstream>
 #include <thread>
 #include <unordered_map>
@@ -165,6 +166,8 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
     // private members
     static tl::expected<void, SerializationError> CallPersistState(
         MasterService* service, const std::string& snapshot_id) {
+        std::unique_lock<std::shared_mutex> snapshot_lock(
+            service->snapshot_mutex_);
         // If snapshot_manager_ exists, use it; otherwise create a temporary one
         if (service->snapshot_manager_) {
             return service->snapshot_manager_->PersistState(snapshot_id);
@@ -826,6 +829,15 @@ class MasterServiceSnapshotTestBase : public ::testing::Test {
                "shadows the base class member. "
             << "Use 'service_.reset(new MasterService(...))' instead of "
                "'std::unique_ptr<MasterService> service_(...)'";
+
+        // Freeze the original service before snapshot/restore validation. The
+        // eviction worker can otherwise mutate replica metadata while the
+        // snapshot is being serialized, making the post-restore comparison
+        // compare two different points in time.
+        service_->eviction_running_ = false;
+        if (service_->eviction_thread_.joinable()) {
+            service_->eviction_thread_.join();
+        }
 
         // Some test configs may not enable snapshot/restore, so the backend
         // is not created in the constructor. We create it here for TearDown


### PR DESCRIPTION
## Description

Stop the MasterService eviction worker before snapshot/restore validation in
the shared snapshot test fixture, and serialize manual snapshot writes under
`snapshot_mutex_`. This prevents background eviction from changing replica
metadata while the test compares the original and restored services.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
ctest --test-dir /tmp/mooncake-build-fix \
  -R '^master_service_ssd_test_for_snapshot$' \
  --output-on-failure --repeat until-fail:2

/tmp/mooncake-build-fix/mooncake-store/tests/master_service_ssd_test_for_snapshot \
  --gtest_filter='MasterServiceSSDSnapshotTest.EvictObject'

ctest --test-dir /tmp/mooncake-build-fix \
  -R '^(master_service_test_for_snapshot|master_service_promotion_test_for_snapshot)$' \
  --output-on-failure

pre-commit run --files \
  mooncake-store/tests/ha/snapshot/master_service_test_for_snapshot_base.h
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (not applicable)
- [ ] Manual testing done (not applicable)

The SSD snapshot target passed twice, `EvictObject` passed ten consecutive
runs, and the other snapshot fixtures passed. Pre-commit passed all applicable
hooks.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (not applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue (not applicable)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (analysis and implementation assistance). The human
  submitter must review and defend every changed line end-to-end.