### PR TITLE
[TENT] Route HP TCP lanes across configured rails

### DIFF
--- a/docs/source/design/tent/hp-tcp.md
+++ b/docs/source/design/tent/hp-tcp.md
@@ -2,8 +2,8 @@
 
 `hp_tcp` is a standalone TENT transport for CPU DRAM transfers over
 data-center TCP. Standard `tcp` remains the RPC-based compatibility path.
-The first version intentionally excludes GPU memory, TLS, multi-endpoint
-routing, multi-NIC striping, transparent replay after an ambiguous WRITE and
+The first version intentionally excludes GPU memory, TLS, per-transfer
+striping, rail failover, transparent replay after an ambiguous WRITE and
 dynamic lane scheduling.
 
 ## Architecture
@@ -24,6 +24,20 @@ thread per historical connection.
 TENT request -> bounded admission -> owner worker -> persistent lane
              -> versioned TCP protocol -> registered remote buffer
 ```
+
+### Static multi-rail routing
+
+`rail_addresses` optionally assigns persistent lanes across an ordered set of
+local and remote TCP addresses. Each entry must be a numeric address assigned
+to the local host; when the list is non-empty it supplies the published
+endpoints instead of `advertise_address`. Lane `i` uses rail
+`i % rail_count`, binds its socket to the matching local address, and keeps the
+existing peer-and-lane worker ownership. Both peers must configure the same
+non-zero rail count; multiple local rails require a wildcard listener.
+
+Routing is deliberately static. A transfer stays on one persistent lane and
+therefore one rail: `hp_tcp` does not stripe a transfer, rebalance traffic, or
+fail over between rails.
 
 ## Protocol and memory safety
 
@@ -84,12 +98,14 @@ The transport is configured under `transports.hp_tcp`:
 | --- | --- |
 | `enable` | Enable `hp_tcp`; set `transports.tcp.enable` to `false`. The two transports cannot be enabled together because control-plane notification ownership is singular. |
 | `bind_address`, `advertise_address`, `port` | Listener and published endpoint. |
+| `rail_addresses` | Ordered local source addresses for static lane-to-rail routing. The list must be unique, no longer than `connections_per_peer`, and have the same length on both peers. Multiple rails require `bind_address` to be empty or `0.0.0.0`. |
 | `worker_count` | ASIO event-loop threads. |
 | `connections_per_peer` | Persistent lanes per peer. |
 | `max_outstanding_tasks`, `max_outstanding_bytes` | Global admission bounds. |
 | `max_transfer_bytes` | Maximum request size. I/O progress is tracked in fixed internal steps. |
 | `connect_timeout_ms`, `progress_timeout_ms` | Connection and I/O deadlines. |
 
-Tests cover wire validation, admission, buffer leases, connection reuse,
-session reaping, client/server timeout, stale-registration recovery, ambiguous
-WRITE completion and a two-process READ/WRITE smoke test.
+Tests cover wire validation, rail metadata and source binding, admission,
+buffer leases, connection reuse, session reaping, client/server timeout,
+stale-registration recovery, ambiguous WRITE completion and a two-process
+READ/WRITE smoke test.

--- a/mooncake-transfer-engine/tent/config/transfer-engine.json
+++ b/mooncake-transfer-engine/tent/config/transfer-engine.json
@@ -86,6 +86,7 @@
             "enable": false,
             "bind_address": "",
             "advertise_address": "",
+            "rail_addresses": [],
             "port": 0,
             "worker_count": 16,
             "connections_per_peer": 4,

--- a/mooncake-transfer-engine/tent/include/tent/runtime/hp_tcp_transport_config.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/hp_tcp_transport_config.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "tent/common/config.h"
 
@@ -13,6 +14,8 @@ namespace mooncake::tent {
 struct HighPerformanceTcpParams {
     std::string bind_address;
     std::string advertise_address;
+    // Ordered local rail addresses; peers must publish the same rail count.
+    std::vector<std::string> rail_addresses;
     uint16_t port{0};
     size_t worker_count{16};
     size_t connections_per_peer{4};

--- a/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_client.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_client.h
@@ -40,6 +40,7 @@ class HighPerformanceTcpClient {
         SegmentID peer_id{0};
         std::string incarnation;
         std::string host;
+        std::string local_host;
         uint16_t port{0};
         uint32_t lane_id{0};
         uint64_t registration_id{0};

--- a/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_protocol.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/hp_tcp/hp_tcp_protocol.h
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "tent/common/status.h"
 #include "tent/common/types.h"
@@ -61,10 +62,14 @@ EncodeHighPerformanceTcpResponse(const HighPerformanceTcpResponseFrame& frame);
 Status DecodeHighPerformanceTcpResponse(const uint8_t* bytes, size_t size,
                                         HighPerformanceTcpResponseFrame* frame);
 
-struct HighPerformanceTcpEndpointAttr {
-    std::string incarnation;
+struct HighPerformanceTcpEndpoint {
     std::string host;
     uint16_t port{0};
+};
+
+struct HighPerformanceTcpEndpointAttr {
+    std::string incarnation;
+    std::vector<HighPerformanceTcpEndpoint> endpoints;
     uint64_t max_transfer_bytes{0};
 };
 

--- a/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/hp_tcp_transport_config.cpp
@@ -49,6 +49,24 @@ Status ReadString(const json& object, std::string_view key,
     return Status::OK();
 }
 
+Status ReadStringList(const json& object, std::string_view key,
+                      std::vector<std::string>* output) {
+    auto it = object.find(std::string(key));
+    if (it == object.end()) return Status::OK();
+    if (!it->is_array()) {
+        return Invalid("transports/hp_tcp/" + std::string(key),
+                       "must be an array of strings");
+    }
+    for (const auto& item : *it) {
+        if (!item.is_string()) {
+            return Invalid("transports/hp_tcp/" + std::string(key),
+                           "must be an array of strings");
+        }
+        output->push_back(item.get<std::string>());
+    }
+    return Status::OK();
+}
+
 }  // namespace
 
 Status ParseHpTcpTransportConfig(const Config& config,
@@ -86,6 +104,8 @@ Status ParseHpTcpTransportConfig(const Config& config,
         ReadString(hp_tcp, "bind_address", &parsed.params.bind_address));
     CHECK_STATUS(ReadString(hp_tcp, "advertise_address",
                             &parsed.params.advertise_address));
+    CHECK_STATUS(ReadStringList(hp_tcp, "rail_addresses",
+                                &parsed.params.rail_addresses));
     CHECK_STATUS(ReadUnsigned(hp_tcp, "port", &parsed.params.port));
     CHECK_STATUS(
         ReadUnsigned(hp_tcp, "worker_count", &parsed.params.worker_count));
@@ -111,7 +131,6 @@ Status ParseHpTcpTransportConfig(const Config& config,
         return Invalid("transports/hp_tcp",
                        "contains zero or inconsistent limits");
     }
-
     if (parsed.enabled && config.get("transports/tcp/enable", true)) {
         return Invalid("transports",
                        "tcp and hp_tcp cannot be enabled together");

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_client.cpp
@@ -145,23 +145,54 @@ class HighPerformanceTcpClient::Lane
                  asio::ip::tcp::resolver::results_type results) {
         std::error_code ignored;
         socket_.close(ignored);
+        if (!current_->local_host.empty()) {
+            if (results.empty()) {
+                finishIoError(asio::error::host_not_found);
+                return;
+            }
+            std::error_code error;
+            socket_.open(results.begin()->endpoint().protocol(), error);
+            if (error) {
+                finishIoError(error);
+                return;
+            }
+            const auto source =
+                asio::ip::make_address(current_->local_host, error);
+            if (error) {
+                finishIoError(error);
+                return;
+            }
+            socket_.bind(asio::ip::tcp::endpoint(source, 0), error);
+            if (error) {
+                finishIoError(error);
+                return;
+            }
+        }
         auto self = shared_from_this();
-        asio::async_connect(
-            socket_, results,
-            [self, epoch](const std::error_code& error,
-                          const asio::ip::tcp::endpoint&) {
-                self->runHandler(epoch, [&] {
-                    if (self->finishForcedIfAny()) return;
-                    if (error) {
-                        self->finishIoError(error);
-                        return;
-                    }
-                    self->cancelTimer();
-                    self->parent_->connections_created_.fetch_add(
-                        1, std::memory_order_relaxed);
-                    self->writeHeader(epoch);
-                });
+        const auto connected = [self, epoch](const std::error_code& error) {
+            self->runHandler(epoch, [&] {
+                if (self->finishForcedIfAny()) return;
+                if (error) {
+                    self->finishIoError(error);
+                    return;
+                }
+                self->cancelTimer();
+                self->parent_->connections_created_.fetch_add(
+                    1, std::memory_order_relaxed);
+                self->writeHeader(epoch);
             });
+        };
+        if (!current_->local_host.empty()) {
+            // The endpoint-range overload closes and reopens the socket while
+            // trying endpoints, which discards the source bind above.
+            socket_.async_connect(results.begin()->endpoint(), connected);
+        } else {
+            asio::async_connect(socket_, results,
+                                [connected](const std::error_code& error,
+                                            const asio::ip::tcp::endpoint&) {
+                                    connected(error);
+                                });
+        }
     }
 
     void writeHeader(uint64_t epoch) {

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_protocol.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_protocol.cpp
@@ -201,19 +201,23 @@ const char* HighPerformanceTcpPermissionName(Permission permission) {
 Status EncodeHighPerformanceTcpEndpointAttr(
     const HighPerformanceTcpEndpointAttr& attr, std::string* encoded) {
     if (encoded == nullptr || !IsHex128(attr.incarnation) ||
-        attr.host.empty() || attr.port == 0 || attr.max_transfer_bytes == 0) {
+        attr.endpoints.empty() || attr.max_transfer_bytes == 0) {
         return InvalidAttr("endpoint");
     }
 
-    json object = {
-        {"protocol", "tent_hp_tcp"},
-        {"version", kHighPerformanceTcpVersion},
-        {"incarnation", attr.incarnation},
-        {"endpoints",
-         json::array({{{"host", attr.host}, {"port", attr.port}}})},
-        {"max_transfer_bytes", attr.max_transfer_bytes},
-    };
-    *encoded = object.dump();
+    json endpoints = json::array();
+    for (const auto& endpoint : attr.endpoints) {
+        if (endpoint.host.empty() || endpoint.port == 0) {
+            return InvalidAttr("endpoint");
+        }
+        endpoints.push_back({{"host", endpoint.host}, {"port", endpoint.port}});
+    }
+    *encoded = json{{"protocol", "tent_hp_tcp"},
+                    {"version", kHighPerformanceTcpVersion},
+                    {"incarnation", attr.incarnation},
+                    {"endpoints", std::move(endpoints)},
+                    {"max_transfer_bytes", attr.max_transfer_bytes}}
+                   .dump();
     return Status::OK();
 }
 
@@ -230,20 +234,27 @@ Status DecodeHighPerformanceTcpEndpointAttr(
         const std::string incarnation = object.value("incarnation", "");
         const auto endpoints = object.find("endpoints");
         if (!IsHex128(incarnation) || endpoints == object.end() ||
-            !endpoints->is_array() || endpoints->size() != 1 ||
-            !(*endpoints)[0].is_object())
+            !endpoints->is_array() || endpoints->empty())
             return InvalidAttr("endpoint identity/list");
-        const json& endpoint = (*endpoints)[0];
-        const std::string host = endpoint.value("host", "");
-        uint64_t port = 0;
+
+        std::vector<HighPerformanceTcpEndpoint> decoded_endpoints;
+        decoded_endpoints.reserve(endpoints->size());
+        for (const auto& endpoint : *endpoints) {
+            if (!endpoint.is_object()) return InvalidAttr("endpoint address");
+            const std::string host = endpoint.value("host", "");
+            uint64_t port = 0;
+            if (host.empty() || !ReadPositiveUint64(endpoint, "port", &port) ||
+                port > 65535) {
+                return InvalidAttr("endpoint address");
+            }
+            decoded_endpoints.push_back({host, static_cast<uint16_t>(port)});
+        }
+
         uint64_t max_transfer_bytes = 0;
-        if (host.empty() || !ReadPositiveUint64(endpoint, "port", &port) ||
-            port > 65535 ||
-            !ReadPositiveUint64(object, "max_transfer_bytes",
+        if (!ReadPositiveUint64(object, "max_transfer_bytes",
                                 &max_transfer_bytes))
             return InvalidAttr("endpoint address/limit");
-        *attr = {incarnation, host, static_cast<uint16_t>(port),
-                 max_transfer_bytes};
+        *attr = {incarnation, std::move(decoded_endpoints), max_transfer_bytes};
         return Status::OK();
     } catch (const std::exception& error) {
         return Status::MalformedJson(

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_transport.cpp
@@ -127,6 +127,27 @@ Status HighPerformanceTcpTransport::validateParams() const {
         return Status::InvalidArgument(
             "invalid high-performance TCP limits" LOC_MARK);
     }
+    if (!params_.rail_addresses.empty()) {
+        if (params_.rail_addresses.size() > params_.connections_per_peer ||
+            (params_.rail_addresses.size() > 1 &&
+             !params_.bind_address.empty() &&
+             params_.bind_address != "0.0.0.0")) {
+            return Status::InvalidArgument(
+                "HP TCP rails require one lane per address and a wildcard "
+                "listener" LOC_MARK);
+        }
+        for (size_t i = 0; i < params_.rail_addresses.size(); ++i) {
+            if (params_.rail_addresses[i].empty() ||
+                std::find(params_.rail_addresses.begin() + i + 1,
+                          params_.rail_addresses.end(),
+                          params_.rail_addresses[i]) !=
+                    params_.rail_addresses.end()) {
+                return Status::InvalidArgument(
+                    "HP TCP rail addresses must be non-empty and "
+                    "unique" LOC_MARK);
+            }
+        }
+    }
     return Status::OK();
 }
 
@@ -246,17 +267,25 @@ Status HighPerformanceTcpTransport::install(
     }
 
     const SegmentDescRef local = metadata_->segmentManager().getLocal();
-    const std::string host = params_.advertise_address.empty()
-                                 ? HostFromRpc(local->rpc_server_addr)
-                                 : params_.advertise_address;
-    if (host.empty()) {
+    std::vector<HighPerformanceTcpEndpoint> endpoints;
+    if (!params_.rail_addresses.empty()) {
+        for (const auto& address : params_.rail_addresses) {
+            endpoints.push_back({address, bound_port});
+        }
+    } else {
+        const std::string host = params_.advertise_address.empty()
+                                     ? HostFromRpc(local->rpc_server_addr)
+                                     : params_.advertise_address;
+        if (!host.empty()) endpoints.push_back({host, bound_port});
+    }
+    if (endpoints.empty()) {
         status = Status::InvalidArgument(
             "unable to derive HP TCP advertise address" LOC_MARK);
     } else {
         const std::string incarnation = makeIncarnation();
         std::string encoded;
         status = EncodeHighPerformanceTcpEndpointAttr(
-            {incarnation, host, bound_port, params_.max_transfer_bytes},
+            {incarnation, std::move(endpoints), params_.max_transfer_bytes},
             &encoded);
         if (status.ok()) {
             status = metadata_->segmentManager().updateLocal(
@@ -512,6 +541,15 @@ Status HighPerformanceTcpTransport::planTask(const Request& request,
     }
     const uint32_t lane_id = static_cast<uint32_t>(
         request_id % static_cast<uint64_t>(params_.connections_per_peer));
+    const size_t endpoint_count =
+        params_.rail_addresses.empty() ? 1 : params_.rail_addresses.size();
+    if (endpoint_attr.endpoints.size() != endpoint_count) {
+        return Status::InvalidArgument(
+            "HP TCP local and remote rail counts differ" LOC_MARK);
+    }
+    const uint32_t endpoint_id =
+        static_cast<uint32_t>(lane_id % endpoint_count);
+    const auto& endpoint = endpoint_attr.endpoints[endpoint_id];
     const size_t owner_worker =
         workers_->affinityOwner(request.target_id, lane_id);
 
@@ -523,8 +561,11 @@ Status HighPerformanceTcpTransport::planTask(const Request& request,
     HighPerformanceTcpClient::Operation operation;
     operation.peer_id = request.target_id;
     operation.incarnation = endpoint_attr.incarnation;
-    operation.host = endpoint_attr.host;
-    operation.port = endpoint_attr.port;
+    operation.host = endpoint.host;
+    if (!params_.rail_addresses.empty()) {
+        operation.local_host = params_.rail_addresses[endpoint_id];
+    }
+    operation.port = endpoint.port;
     operation.lane_id = lane_id;
     operation.registration_id = buffer_attr.registration_id;
     operation.remote_addr = request.target_offset;

--- a/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_workers.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/hp_tcp/hp_tcp_workers.cpp
@@ -186,8 +186,7 @@ size_t HighPerformanceTcpWorkers::affinityOwner(uint64_t peer,
         hash ^= value + static_cast<size_t>(0x9e3779b97f4a7c15ULL) +
                 (hash << 6U) + (hash >> 2U);
     };
-    // HP TCP v1 has one endpoint. Keep its zero index in the hash so this
-    // interface simplification does not change the existing worker mapping.
+    // A lane keeps the same worker owner regardless of its rail.
     mix(std::hash<uint32_t>{}(0));
     mix(std::hash<uint32_t>{}(lane));
     return config_.worker_count == 0 ? 0 : hash % config_.worker_count;

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_e2e_test.cpp
@@ -67,7 +67,7 @@ class ChildProcessGuard {
     int stop_fd_;
 };
 
-std::shared_ptr<Config> MakeHpConfig() {
+std::shared_ptr<Config> MakeHpConfig(bool multi_rail) {
     auto config = std::make_shared<Config>();
     config->set("metadata_type", "p2p");
     config->set("metadata_servers", "P2PHANDSHAKE");
@@ -83,6 +83,11 @@ std::shared_ptr<Config> MakeHpConfig() {
     config->set("transports/hp_tcp/max_transfer_bytes", 8ULL << 20);
     config->set("transports/hp_tcp/connect_timeout_ms", 2000);
     config->set("transports/hp_tcp/progress_timeout_ms", 5000);
+    if (multi_rail) {
+        config->set("transports/hp_tcp/bind_address", "");
+        config->set("transports/hp_tcp/rail_addresses",
+                    std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
+    }
     config->set("transports/rdma/enable", false);
     config->set("transports/shm/enable", false);
     config->set("rpc_server_threads", 1);
@@ -103,7 +108,7 @@ bool WaitBatchDone(TransferEngine& engine, BatchID batch) {
     return false;
 }
 
-void RunWriteThenReadAcrossProcesses(size_t task_count) {
+void RunWriteThenReadAcrossProcesses(size_t task_count, bool multi_rail) {
     const size_t remote_buffer_length = task_count * kDataLength;
     const size_t local_buffer_length = 2 * remote_buffer_length;
 
@@ -120,7 +125,7 @@ void RunWriteThenReadAcrossProcesses(size_t task_count) {
 
         int exit_code = 0;
         {
-            TransferEngine server(MakeHpConfig());
+            TransferEngine server(MakeHpConfig(multi_rail));
             if (!server.available()) {
                 exit_code = 2;
             } else {
@@ -178,7 +183,7 @@ void RunWriteThenReadAcrossProcesses(size_t task_count) {
     }
     close(ready_pipe[0]);
 
-    TransferEngine client(MakeHpConfig());
+    TransferEngine client(MakeHpConfig(multi_rail));
     ASSERT_TRUE(client.available());
     std::vector<uint8_t> local(local_buffer_length, 0);
     for (size_t task = 0; task < task_count; ++task) {
@@ -256,7 +261,11 @@ void RunWriteThenReadAcrossProcesses(size_t task_count) {
 }
 
 TEST(HighPerformanceTcpE2eTest, WriteThenReadConcurrency16) {
-    RunWriteThenReadAcrossProcesses(16);
+    RunWriteThenReadAcrossProcesses(16, false);
+}
+
+TEST(HighPerformanceTcpE2eTest, WriteThenReadAcrossTwoRails) {
+    RunWriteThenReadAcrossProcesses(16, true);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_protocol_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_protocol_test.cpp
@@ -55,16 +55,17 @@ TEST(HighPerformanceTcpProtocolTest, RejectsMalformedWireFrames) {
 }
 
 TEST(HighPerformanceTcpProtocolTest, MetadataAttributesRoundTrip) {
-    HighPerformanceTcpEndpointAttr endpoint{"00112233445566778899aabbccddeeff",
-                                            "127.0.0.1", 1234, 4096};
+    HighPerformanceTcpEndpointAttr endpoint{
+        "00112233445566778899aabbccddeeff", {{"127.0.0.1", 1234}}, 4096};
     std::string encoded;
     ASSERT_TRUE(EncodeHighPerformanceTcpEndpointAttr(endpoint, &encoded).ok());
     HighPerformanceTcpEndpointAttr decoded_endpoint;
     ASSERT_TRUE(
         DecodeHighPerformanceTcpEndpointAttr(encoded, &decoded_endpoint).ok());
     EXPECT_EQ(decoded_endpoint.incarnation, endpoint.incarnation);
-    EXPECT_EQ(decoded_endpoint.host, endpoint.host);
-    EXPECT_EQ(decoded_endpoint.port, endpoint.port);
+    ASSERT_EQ(decoded_endpoint.endpoints.size(), 1U);
+    EXPECT_EQ(decoded_endpoint.endpoints[0].host, "127.0.0.1");
+    EXPECT_EQ(decoded_endpoint.endpoints[0].port, 1234);
 
     ASSERT_TRUE(
         EncodeHighPerformanceTcpBufferAttr({42, "global_read_write"}, &encoded)
@@ -87,6 +88,21 @@ TEST(HighPerformanceTcpProtocolTest, MetadataAttributesRoundTrip) {
     EXPECT_FALSE(
         DecodeHighPerformanceTcpEndpointAttr("not-json", &decoded_endpoint)
             .ok());
+}
+
+TEST(HighPerformanceTcpProtocolTest, MultiRailMetadataRoundTrip) {
+    HighPerformanceTcpEndpointAttr endpoint{
+        "00112233445566778899aabbccddeeff",
+        {{"127.0.0.1", 1234}, {"127.0.0.2", 1234}},
+        4096};
+    std::string encoded;
+    ASSERT_TRUE(EncodeHighPerformanceTcpEndpointAttr(endpoint, &encoded).ok());
+    HighPerformanceTcpEndpointAttr decoded;
+    ASSERT_TRUE(DecodeHighPerformanceTcpEndpointAttr(encoded, &decoded).ok());
+    ASSERT_EQ(decoded.endpoints.size(), 2U);
+    EXPECT_EQ(decoded.endpoints[0].host, "127.0.0.1");
+    EXPECT_EQ(decoded.endpoints[1].host, "127.0.0.2");
+    EXPECT_EQ(decoded.endpoints[1].port, 1234);
 }
 
 }  // namespace

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_socket_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_socket_test.cpp
@@ -272,6 +272,47 @@ TEST(HighPerformanceTcpSocketTest, ClientProgressTimeoutCompletesTask) {
     peer.join();
 }
 
+TEST(HighPerformanceTcpSocketTest, ClientBindsConfiguredSourceAddress) {
+    asio::io_context peer_io;
+    asio::ip::tcp::acceptor acceptor(peer_io,
+                                     {asio::ip::make_address("127.0.0.1"), 0});
+    std::string peer_address;
+    std::thread peer([&] {
+        asio::ip::tcp::socket socket(peer_io);
+        acceptor.accept(socket);
+        peer_address = socket.remote_endpoint().address().to_string();
+        std::array<uint8_t, kHighPerformanceTcpRequestSize> request{};
+        asio::read(socket, asio::buffer(request));
+        const uint8_t payload = 0x5a;
+        asio::write(socket, asio::buffer(&payload, 1));
+    });
+
+    HighPerformanceTcpWorkers workers({.worker_count = 1});
+    ASSERT_TRUE(workers.start().ok());
+    HighPerformanceTcpClient client({4096, 128, 1000, 1000, 1}, &workers);
+    std::array<uint8_t, 1> local{};
+    Completion completion;
+    auto operation = Operation(local.data(), local.size(), 0x1000, 1, 4,
+                               HighPerformanceTcpOpcode::kRead, &completion,
+                               acceptor.local_endpoint().port());
+    operation.local_host = "127.0.0.2";
+    std::vector<HighPerformanceTcpWorkers::Command> commands;
+    commands.push_back({.worker_id = 0,
+                        .run =
+                            [&](size_t) mutable {
+                                client.enqueueOnOwner(0, std::move(operation));
+                            },
+                        .cancel = {}});
+    ASSERT_TRUE(workers.tryCommitBatch(commands, nullptr, 0, 0, [] {}).ok());
+    ASSERT_TRUE(completion.wait());
+    EXPECT_EQ(completion.status, COMPLETED);
+    EXPECT_EQ(local[0], 0x5a);
+    EXPECT_TRUE(client.cancelAll().ok());
+    EXPECT_TRUE(workers.stop().ok());
+    peer.join();
+    EXPECT_EQ(peer_address, "127.0.0.2");
+}
+
 TEST(HighPerformanceTcpSocketTest,
      WriteWithoutCompletionAckMarksRemoteOutcomeUnknown) {
     asio::io_context peer_io;

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_config_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_config_test.cpp
@@ -48,6 +48,19 @@ TEST(HpTcpTransportConfigTest, ParsesAndValidatesLimits) {
     EXPECT_TRUE(ParseHpTcpTransportConfig(config, &parsed).IsInvalidArgument());
 }
 
+TEST(HpTcpTransportConfigTest, ParsesRailAddresses) {
+    Config config;
+    ASSERT_TRUE(
+        config
+            .load(
+                R"({"transports":{"tcp":{"enable":false},"hp_tcp":{"enable":true,"connections_per_peer":4,"rail_addresses":["10.0.0.1","10.1.0.1"]}}})")
+            .ok());
+    HpTcpTransportConfig parsed;
+    ASSERT_TRUE(ParseHpTcpTransportConfig(config, &parsed).ok());
+    ASSERT_EQ(parsed.params.rail_addresses.size(), 2U);
+    EXPECT_EQ(parsed.params.rail_addresses[1], "10.1.0.1");
+}
+
 TEST(HpTcpTransportConfigTest, AcceptsFullWidthUnsignedLimit) {
     Config config;
     ASSERT_TRUE(

--- a/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/hp_tcp_transport_test.cpp
@@ -145,7 +145,10 @@ TEST(HighPerformanceTcpTransportTest, UnknownWriteOutcomeIsPermanent) {
 TEST(HighPerformanceTcpTransportTest,
      PublishesEndpointAndSeparatesLocalOnlyCapabilities) {
     auto metadata = MakeLocalMetadata();
-    HighPerformanceTcpTransport transport(MakeParams());
+    auto params = MakeParams();
+    params.bind_address.clear();
+    params.rail_addresses = {"127.0.0.1", "127.0.0.2"};
+    HighPerformanceTcpTransport transport(std::move(params));
     std::string segment_name = "hp_transport_test";
     ASSERT_TRUE(
         transport.install(segment_name, metadata, nullptr, nullptr).ok());
@@ -157,8 +160,11 @@ TEST(HighPerformanceTcpTransportTest,
     HighPerformanceTcpEndpointAttr endpoint;
     ASSERT_TRUE(
         DecodeHighPerformanceTcpEndpointAttr(attr_it->second, &endpoint).ok());
-    EXPECT_EQ(endpoint.host, "127.0.0.1");
-    EXPECT_NE(endpoint.port, 0);
+    ASSERT_EQ(endpoint.endpoints.size(), 2U);
+    EXPECT_EQ(endpoint.endpoints[0].host, "127.0.0.1");
+    EXPECT_EQ(endpoint.endpoints[1].host, "127.0.0.2");
+    EXPECT_NE(endpoint.endpoints[0].port, 0);
+    EXPECT_EQ(endpoint.endpoints[0].port, endpoint.endpoints[1].port);
 
     std::array<uint8_t, 64> local_only_storage{};
     BufferDesc local_only;


### PR DESCRIPTION
## Description

Follow-up to #3689 and related to the multi-rail TCP roadmap in #1058.

This change lets `hp_tcp` route its existing persistent lanes across an ordered set of configured TCP rail addresses:

- `rail_addresses` publishes one endpoint per rail and binds each outgoing lane to the matching local source address.
- Lane `i` uses rail `i % rail_count`.
- The existing peer-and-lane worker affinity is preserved, so adding endpoints does not collapse or reshuffle worker ownership.
- Connections remain persistent and are reused exactly as in the single-endpoint path.
- Both peers must expose the same rail count. Multiple rails require a wildcard listener.

The default remains unchanged: an empty `rail_addresses` list publishes and consumes the existing singleton endpoint metadata. Multi-rail mode requires both peers to run the updated implementation and use matching ordered rail lists.

This is deliberately static lane routing. It does **not** add per-transfer striping, adaptive load balancing, rail failover, socket tuning, GPU/CANN support, QoS, or NUMA-aware scheduling. Unlike the striped-transfer prototype in #1633, each request stays on one persistent lane and one rail.

### Why

On multi-NIC hosts, increasing worker or connection counts alone does not select multiple data paths. The client must bind each persistent lane to a specific local address and connect it to the corresponding remote endpoint. This patch adds only that missing mapping while retaining the correctness and lifecycle guarantees introduced by #3689.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [x] Documentation update
- [x] Performance improvement
- [ ] Other

## How Has This Been Tested?

The branch adds focused coverage for:

- singleton and multi-endpoint metadata round trips;
- `rail_addresses` configuration parsing;
- client source-address binding;
- endpoint publication;
- a two-process `TransferEngine` READ/WRITE test over two loopback rails with full payload comparison.

Prior dual-host validation of the same routing logic used four matched NIC/address pairs, observed connections on all four rails, and completed HP_TCP READ/WRITE payload-consistency checks for both small and large buffers. Exploratory 64 MiB measurements showed modest, testbed-specific throughput gains over the single-endpoint setup; this PR does not claim linear scaling or guaranteed gains on every topology.

**Validation completed locally:**

- `git diff --check`
- clang-format 20
- independent full-diff and data-path review

**Pending:**

- GitHub CI on the post-#3689 squash-merge branch
- final human line-by-line review before marking ready

## Checklist

- [ ] I have performed a final human self-review of every changed line
- [x] I have formatted my code using `./scripts/code_format.sh` / clang-format 20
- [ ] I have run the complete pre-commit hook set on the final branch
- [x] I have updated the documentation
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: not applicable; the production change is below this threshold

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used

OpenAI Codex assisted with porting the focused multi-rail diff onto the squash-merged #3689 baseline, implementation review, test construction, and documentation. The PR is opened as a draft so the human submitter can complete the required line-by-line review and inspect the final CI results before requesting review.