### PR TITLE
[Bugfix][TENT] Keep RailMonitor state across COW topology refreshes

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/transport/rdma/rail_monitor.h
+++ b/mooncake-transfer-engine/tent/include/tent/transport/rdma/rail_monitor.h
@@ -57,6 +57,9 @@ class RailMonitor {
     // conf: optional Config pointer; when non-null, overrides the default
     //   error_threshold / error_window_secs / cooldown_secs values via
     //   kCfgErrorThreshold / kCfgErrorWindowSecs / kCfgCooldownSecs.
+    // A later call with the same NIC/memory layout only refreshes the pins
+    // (segment COW snapshots); it does not rebuild rail_states_ or reprint
+    // the config banner.
     Status load(std::shared_ptr<const Topology> local,
                 std::shared_ptr<const Topology> remote,
                 const std::string &rail_topo_json = "",

--- a/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
+++ b/mooncake-transfer-engine/tent/src/transport/rdma/rail_monitor.cpp
@@ -17,10 +17,58 @@
 namespace mooncake {
 namespace tent {
 
+namespace {
+
+bool sameNicLayout(const Topology::NicEntry& a, const Topology::NicEntry& b) {
+    return a.name == b.name && a.pci_bus_id == b.pci_bus_id &&
+           a.type == b.type && a.numa_node == b.numa_node;
+}
+
+bool sameMemLayout(const Topology::MemEntry& a, const Topology::MemEntry& b) {
+    if (a.name != b.name || a.pci_bus_id != b.pci_bus_id || a.type != b.type ||
+        a.numa_node != b.numa_node)
+        return false;
+    for (size_t rank = 0; rank < Topology::DevicePriorityRanks; ++rank) {
+        if (a.device_list[rank] != b.device_list[rank]) return false;
+    }
+    return true;
+}
+
+// True when two snapshots describe the same NIC/memory wiring. Segment
+// metadata is copy-on-write, so a buffer register publishes a new Topology*
+// even when the rail map is unchanged. Comparing layout (not pointer
+// identity) lets load() refresh pins without rebuilding rail_states_.
+bool sameRailLayout(const Topology* a, const Topology* b) {
+    if (a == b) return true;
+    if (!a || !b) return false;
+    const size_t nic_count = a->getNicCount();
+    const size_t mem_count = a->getMemCount();
+    if (nic_count != b->getNicCount() || mem_count != b->getMemCount())
+        return false;
+    for (size_t i = 0; i < nic_count; ++i) {
+        auto* ea = a->getNicEntry(static_cast<int>(i));
+        auto* eb = b->getNicEntry(static_cast<int>(i));
+        if (!ea || !eb || !sameNicLayout(*ea, *eb)) return false;
+    }
+    for (size_t i = 0; i < mem_count; ++i) {
+        auto* ea = a->getMemEntry(static_cast<int>(i));
+        auto* eb = b->getMemEntry(static_cast<int>(i));
+        if (!ea || !eb || !sameMemLayout(*ea, *eb)) return false;
+    }
+    return true;
+}
+
+}  // namespace
+
 Status RailMonitor::load(std::shared_ptr<const Topology> local,
                          std::shared_ptr<const Topology> remote,
                          const std::string& rail_topo_json,
                          const Config* conf) {
+    const bool first_load = !ready_;
+    const bool same_layout = ready_ &&
+                             sameRailLayout(local_.get(), local.get()) &&
+                             sameRailLayout(remote_.get(), remote.get());
+
     local_ = std::move(local);
     remote_ = std::move(remote);
     if (conf) {
@@ -29,10 +77,15 @@ Status RailMonitor::load(std::shared_ptr<const Topology> local,
             conf->get(kCfgErrorWindowSecs, (int)error_window_.count()));
         cooldown_ = std::chrono::seconds(
             conf->get(kCfgCooldownSecs, (int)cooldown_.count()));
-        LOG(INFO) << "RailMonitor: error_threshold=" << error_threshold_
-                  << " error_window=" << error_window_.count() << "s"
-                  << " cooldown=" << cooldown_.count() << "s";
+        // Config is identical on every COW snapshot refresh. Log once per
+        // monitor so PD/e2e does not reprint the banner per slice/worker.
+        if (first_load) {
+            LOG(INFO) << "RailMonitor: error_threshold=" << error_threshold_
+                      << " error_window=" << error_window_.count() << "s"
+                      << " cooldown=" << cooldown_.count() << "s";
+        }
     }
+    if (same_layout) return Status::OK();
     if (!rail_topo_json.empty()) {
         auto status = loadFromJson(rail_topo_json);
         if (status.ok()) return status;

--- a/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rail_monitor_test.cpp
@@ -316,6 +316,43 @@ TEST(RailMonitorRecoverTest, FindBestAfterRecovery) {
 // pause would expire in ~2s.
 // ---------------------------------------------------------------------------
 
+// Segment metadata is copy-on-write: a new Topology object with the same
+// NIC/memory wiring must not rebuild rail_states_ (that would reset
+// error_count) and must not treat the reload as a first-time config log.
+TEST(RailMonitorLoadTest, SameLayoutReloadPreservesErrorCount) {
+    auto local1 = makeSingleNicTopology("mlx5_0");
+    auto remote1 = makeSingleNicTopology("mlx5_1");
+    auto local2 = makeSingleNicTopology("mlx5_0");
+    auto remote2 = makeSingleNicTopology("mlx5_1");
+    Config cfg;
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local1, remote1, "", &cfg).ok());
+
+    rail.markFailed(0, 0);
+    rail.markFailed(0, 0);
+    EXPECT_TRUE(rail.available(0, 0))
+        << "Two failures are below the default threshold of 3";
+
+    ASSERT_TRUE(rail.load(local2, remote2, "", &cfg).ok());
+    rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0))
+        << "COW snapshot refresh must not reset rail error_count";
+}
+
+TEST(RailMonitorLoadTest, DifferentLayoutRebuildsMapping) {
+    auto local = makeSingleNicTopology("mlx5_0");
+    auto remote_old = makeSingleNicTopology("mlx5_1");
+    auto remote_new = makeSingleNicTopology("mlx5_2");
+    RailMonitor rail;
+    ASSERT_TRUE(rail.load(local, remote_old).ok());
+    for (int i = 0; i < 3; ++i) rail.markFailed(0, 0);
+    EXPECT_FALSE(rail.available(0, 0));
+
+    ASSERT_TRUE(rail.load(local, remote_new).ok());
+    EXPECT_TRUE(rail.available(0, 0))
+        << "A real topology change must rebuild rails from a clean state";
+}
+
 TEST(RailMonitorRecoverTest, CooldownDoesNotCarryOverAfterRecovery) {
     auto local = makeSingleNicTopology("mlx5_0");
     auto remote = makeSingleNicTopology("mlx5_1");


### PR DESCRIPTION
## Description

Segment metadata is copy-on-write. Buffer / CUDA-graph register publishes a
new `Topology*`, so `RailMonitor::load()` treated every snapshot as a full
rebuild: it reprinted `RailMonitor: error_threshold=...` and called
`loadDefault()`, wiping `rail_states_` (error counts / pause). PD/e2e logs
showed thousands of banners with no real rail errors.

`load()` now compares NIC/memory layout (name, PCI, type, NUMA, device_list
ranks), not pointer identity. Same layout only refreshes the local/remote
pins. The config banner logs on first load of that monitor. A real layout
change still rebuilds.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build-rail-test --target tent_rail_monitor_test
./build-rail-test/mooncake-transfer-engine/tent/tests/tent_rail_monitor_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`tent_rail_monitor_test`: 10/10 PASSED, including
`RailMonitorLoadTest.SameLayoutReloadPreservesErrorCount` and
`RailMonitorLoadTest.DifferentLayoutRebuildsMapping`. Config banner only
appears on first load in the cooldown case, not on same-layout reload.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor (Grok 4.6) helped implement the same-layout short-circuit in
`RailMonitor::load()`, add the two `RailMonitorLoadTest` cases, and prepare
this PR. The human submitter reviewed the change end-to-end.

Made with [Cursor](https://cursor.com)