### PR TITLE
[Bugfix][TE] Use the only ADXL endpoint when dest has one engine

### DIFF
--- a/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
+++ b/mooncake-transfer-engine/src/transport/ascend_transport/ascend_direct_transport/transfer_executor_base.cpp
@@ -47,6 +47,12 @@ void markSlicesFailed(const std::vector<Transport::Slice*>& slice_list) {
 std::string EngineNameForDestAddr(
     const std::vector<TransferMetadata::BufferDesc>& buffers,
     const std::vector<std::string>& endpoints, uint64_t dest_addr) {
+    // A single-engine TE (embedded/standalone) publishes one endpoint at
+    // index 0, while buffer device_id is the logical NPU id and is often
+    // >= 1. That id is not an engine index.
+    if (endpoints.size() == 1) {
+        return endpoints.front();
+    }
     for (const auto& buf : buffers) {
         if (dest_addr < buf.addr || dest_addr - buf.addr >= buf.length) {
             continue;

--- a/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
+++ b/mooncake-transfer-engine/tests/ascend_direct_transport_test.cpp
@@ -2097,6 +2097,34 @@ TEST_F(AscendDirectTransportTest,
 }
 
 TEST_F(AscendDirectTransportTest,
+       Standalone_SingleEndpoint_IgnoresDestDeviceId) {
+    globalConfig().ascend_agent_mode = false;
+    unsetenv("HCCL_INTRA_ROCE_ENABLE");
+    constexpr int kDeviceCount = 4;
+    mock_acl::set_device_count(kDeviceCount);
+    g_device_id = 3;
+    auto transport = createTransport();
+    ASSERT_NE(transport, nullptr);
+    ASSERT_EQ(transport->registerLocalMemory(test_buffer_src_, kRegisterMemSize,
+                                             "cpu:0", true, true),
+              0);
+
+    std::vector<std::string> endpoints = {"127.0.0.1:7400"};
+    addMultiEndpointRemoteSegment(transport->meta(), 1, "single_endpoint",
+                                  "127.0.0.1", endpoints, /*dest_device_id=*/2,
+                                  0x10000, kTransferBufSize);
+
+    initTestData(kTransferBufSize);
+    auto result = runRemoteTransfer(transport.get(), test_buffer_src_, 1,
+                                    0x10000, kTransferBufSize);
+    ASSERT_TRUE(result.finished);
+    EXPECT_FALSE(result.failed);
+    EXPECT_EQ(adxl_mock::get_last_connect_target(), "127.0.0.1:7400")
+        << "A single remote endpoint is used as-is, even when dest "
+           "buffer device_id is not 0";
+}
+
+TEST_F(AscendDirectTransportTest,
        Standalone_FabricMem_SameHostSelectsDestBufferEngine) {
     // Fabric mem is a Store-TE feature, so the TE must be store-init for the
     // transport to capture use_fabric_mem_=true.


### PR DESCRIPTION
## Description

Ascend Direct routes by dest buffer `device_id` as an index into `rank_info.endpoints`. Embedded/standalone TEs publish a single endpoint at index 0, but stamp `device_id` with the logical NPU id (often `>= 1`). Every transfer then logs `device_id >= endpoint count 1, falling back to ...` even though the fallback is the only valid engine.

If the dest segment has exactly one endpoint, use `endpoints.front()` and skip the `device_id` lookup. Dest segments with multiple endpoints (agent-mode store) still select `endpoints[device_id]`.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
source ${ASCEND_HOME_PATH}/bin/setenv.bash
cd build
make ascend_direct_transport_test
./mooncake-transfer-engine/tests/ascend_direct_transport_test \
  --gtest_filter="*SingleEndpoint*:*Standalone_MissingDestBuffer*:*Standalone_RemoteHost*:*SameSegment_TwoDestBuffers*:*DummyReal_Roce_SameHostSelectsDestBufferEngine*"
./scripts/code_format.sh
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

Lima VM `hixl` with `USE_ASCEND_DIRECT=ON`: 6 filtered tests PASSED, including new `Standalone_SingleEndpoint_IgnoresDestDeviceId`. Multi-endpoint dest routing tests still pass. Integration / on-box session Not run (no NPU session workload in this VM).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor Grok assisted with the routing change, unit test, and PR text. The submitter reviewed the diff.


Made with [Cursor](https://cursor.com)