### PR TITLE
[Store] Structure ReplicaSelectionConfig environment settings

### DIFF
--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -66,7 +66,7 @@ struct ClientMetricEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MC_STORE_CLIENT_METRIC_INTERVAL);
     MC_DEFINE_ENV_VAR(std::string, MC_STORE_CLIENT_METRIC_BANDWIDTH);
 };
-  
+
 struct DistributedStorageEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DFS_ROOT_DIR);
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DISTRIBUTED_ROOT_DIR);
@@ -82,6 +82,11 @@ struct DistributedStorageEnvironmentVariables {
     MC_DEFINE_ENV_VAR(double, MOONCAKE_DFS_EVICTION_LOW_WATERMARK);
     MC_DEFINE_ENV_VAR(int, MOONCAKE_DFS_DEFERRED_FREE_SECONDS);
     MC_DEFINE_ENV_VAR(int, MOONCAKE_DFS_EVICTION_CHECK_INTERVAL);
+};
+
+struct ReplicaSelectionEnvironmentVariables {
+    // Only the exact string "1" enables scoring, unlike canonical bool parsing.
+    MC_DEFINE_ENV_VAR(std::string, MC_STORE_REPLICA_SCORING);
 };
 
 #undef MC_DEFINE_ENV_VAR

--- a/mooncake-store/include/config/replica_selection_config.h
+++ b/mooncake-store/include/config/replica_selection_config.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace mooncake {
+
+struct ReplicaSelectionConfig {
+    bool remote_scoring_enabled = false;
+
+    static ReplicaSelectionConfig FromEnvironment();
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/replica_selection.h
+++ b/mooncake-store/include/replica_selection.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-#include <cstdlib>
 #include <functional>
 #include <limits>
 #include <mutex>
@@ -30,6 +29,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "config/replica_selection_config.h"
 #include "replica.h"
 
 namespace mooncake {
@@ -82,11 +82,8 @@ inline double BuiltinRemoteReplicaScore(const Replica::Descriptor &r) {
 // scorer has been injected. Env is read once; the injected-scorer check is
 // live so tests / late injection take effect.
 inline bool RemoteReplicaScoringEnabled() {
-    static const bool env_enabled = [] {
-        const char *env = std::getenv("MC_STORE_REPLICA_SCORING");
-        return env && std::string(env) == "1";
-    }();
-    if (env_enabled) return true;
+    static const auto config = ReplicaSelectionConfig::FromEnvironment();
+    if (config.remote_scoring_enabled) return true;
     std::shared_lock lk(detail::ScorerMutex());
     return static_cast<bool>(detail::ScorerStorage());
 }

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -96,6 +96,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     config/file_storage_config.cpp
     config/client_auto_port_config.cpp
     config/local_hot_cache_config.cpp
+    config/replica_selection_config.cpp
     device/accelerator_device.cpp
     device/accelerator_registry.cpp
     device/runtime_accelerator.cpp

--- a/mooncake-store/src/config/replica_selection_config.cpp
+++ b/mooncake-store/src/config/replica_selection_config.cpp
@@ -1,0 +1,16 @@
+#include "config/replica_selection_config.h"
+
+#include "environ.h"
+#include "environment_variables.h"
+
+namespace mooncake {
+
+ReplicaSelectionConfig ReplicaSelectionConfig::FromEnvironment() {
+    ReplicaSelectionConfig config;
+    const auto value = Environ::Read(
+        ReplicaSelectionEnvironmentVariables::MC_STORE_REPLICA_SCORING);
+    config.remote_scoring_enabled = value.has_value() && *value == "1";
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -41,10 +41,15 @@ add_store_test(runtime_accelerator_test runtime_accelerator_test.cpp)
 add_store_test(registered_pinned_memory_test registered_pinned_memory_test.cpp)
 add_store_test(allocation_strategy_test allocation_strategy_test.cpp)
 add_store_test(replica_selection_test replica_selection_test.cpp)
+add_store_test(replica_selection_config_test replica_selection_config_test.cpp)
+set_tests_properties(replica_selection_test
+                     PROPERTIES ENVIRONMENT "MC_STORE_REPLICA_SCORING=0")
 add_test(
   NAME replica_selection_env_opt_in_test
-  COMMAND replica_selection_test
-          --gtest_filter=ReplicaSelectionTest.EnvironmentOptInUsesBuiltinScorer)
+  COMMAND
+    replica_selection_test
+    --gtest_filter=ReplicaSelectionTest.EnvironmentOptInUsesBuiltinScorer:ReplicaSelectionTest.EnvironmentIsCachedButInjectedScorerRemainsLive
+)
 set_tests_properties(replica_selection_env_opt_in_test
                      PROPERTIES ENVIRONMENT "MC_STORE_REPLICA_SCORING=1")
 add_store_test(eviction_strategy_test eviction_strategy_test.cpp)

--- a/mooncake-store/tests/replica_selection_config_test.cpp
+++ b/mooncake-store/tests/replica_selection_config_test.cpp
@@ -1,0 +1,72 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include "config/replica_selection_config.h"
+
+namespace mooncake {
+namespace {
+
+class ReplicaSelectionConfigTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        if (const char* value = std::getenv("MC_STORE_REPLICA_SCORING")) {
+            original_ = value;
+        }
+        ASSERT_EQ(unsetenv("MC_STORE_REPLICA_SCORING"), 0);
+    }
+
+    void TearDown() override {
+        if (original_.has_value()) {
+            EXPECT_EQ(setenv("MC_STORE_REPLICA_SCORING", original_->c_str(), 1),
+                      0);
+        } else {
+            EXPECT_EQ(unsetenv("MC_STORE_REPLICA_SCORING"), 0);
+        }
+    }
+
+   private:
+    std::optional<std::string> original_;
+};
+
+TEST_F(ReplicaSelectionConfigTest, UnsetDisablesScoring) {
+    EXPECT_FALSE(
+        ReplicaSelectionConfig::FromEnvironment().remote_scoring_enabled);
+}
+
+TEST_F(ReplicaSelectionConfigTest, OnlyExactOneEnablesScoring) {
+    struct Case {
+        const char* value;
+        bool enabled;
+    };
+    for (const auto& test_case :
+         {Case{"1", true}, Case{"", false}, Case{"0", false},
+          Case{"true", false}, Case{"TRUE", false}, Case{"yes", false},
+          Case{"on", false}, Case{"false", false}, Case{"-1", false},
+          Case{"2", false}, Case{"01", false}, Case{"+1", false},
+          Case{" 1", false}, Case{"1 ", false}, Case{"1\n", false},
+          Case{"1suffix", false}}) {
+        SCOPED_TRACE(test_case.value);
+        ASSERT_EQ(setenv("MC_STORE_REPLICA_SCORING", test_case.value, 1), 0);
+        testing::internal::CaptureStderr();
+        const auto config = ReplicaSelectionConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+        EXPECT_EQ(config.remote_scoring_enabled, test_case.enabled);
+        EXPECT_TRUE(diagnostics.empty());
+    }
+}
+
+TEST_F(ReplicaSelectionConfigTest, NewConfigsReadTheCurrentEnvironment) {
+    ASSERT_EQ(setenv("MC_STORE_REPLICA_SCORING", "1", 1), 0);
+    const auto enabled_config = ReplicaSelectionConfig::FromEnvironment();
+
+    ASSERT_EQ(unsetenv("MC_STORE_REPLICA_SCORING"), 0);
+    EXPECT_FALSE(
+        ReplicaSelectionConfig::FromEnvironment().remote_scoring_enabled);
+    EXPECT_TRUE(enabled_config.remote_scoring_enabled);
+}
+
+}  // namespace
+}  // namespace mooncake

--- a/mooncake-store/tests/replica_selection_test.cpp
+++ b/mooncake-store/tests/replica_selection_test.cpp
@@ -10,6 +10,8 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <cstdlib>
+#include <optional>
 #include <string>
 #include <thread>
 #include <unordered_set>
@@ -75,11 +77,29 @@ Replica::Descriptor MakeDfs(const std::string& path) {
     return d;
 }
 
-// A test fixture that guarantees scoring state is reset between tests, since
-// the enable flag / injected scorer are process-wide.
+// Restore the environment and injected scorer between tests. The cached
+// environment setting intentionally remains fixed for the process lifetime.
 class ReplicaSelectionTest : public ::testing::Test {
    protected:
-    void TearDown() override { SetRemoteReplicaScorer(nullptr); }
+    void SetUp() override {
+        if (const char* value = std::getenv("MC_STORE_REPLICA_SCORING")) {
+            original_env_ = value;
+        }
+    }
+
+    void TearDown() override {
+        SetRemoteReplicaScorer(nullptr);
+        if (original_env_.has_value()) {
+            EXPECT_EQ(
+                setenv("MC_STORE_REPLICA_SCORING", original_env_->c_str(), 1),
+                0);
+        } else {
+            EXPECT_EQ(unsetenv("MC_STORE_REPLICA_SCORING"), 0);
+        }
+    }
+
+   private:
+    std::optional<std::string> original_env_;
 };
 
 // --- Base policy (scoring off): behaviour must be unchanged --------------
@@ -178,6 +198,19 @@ TEST_F(ReplicaSelectionTest, EnvironmentOptInUsesBuiltinScorer) {
     const auto* sel = SelectBestReplica(reps, local);
     ASSERT_NE(sel, nullptr);
     EXPECT_EQ(sel->get_memory_descriptor().buffer_descriptor.protocol_, "rdma");
+}
+
+TEST_F(ReplicaSelectionTest, EnvironmentIsCachedButInjectedScorerRemainsLive) {
+    const bool initially_enabled = RemoteReplicaScoringEnabled();
+    ASSERT_EQ(
+        setenv("MC_STORE_REPLICA_SCORING", initially_enabled ? "0" : "1", 1),
+        0);
+    EXPECT_EQ(RemoteReplicaScoringEnabled(), initially_enabled);
+
+    SetRemoteReplicaScorer(BuiltinRemoteReplicaScore);
+    EXPECT_TRUE(RemoteReplicaScoringEnabled());
+    SetRemoteReplicaScorer(nullptr);
+    EXPECT_EQ(RemoteReplicaScoringEnabled(), initially_enabled);
 }
 
 TEST_F(ReplicaSelectionTest, ScorerTieKeepsMasterOrder) {


### PR DESCRIPTION
## Description

Part of #3809. Move `MC_STORE_REPLICA_SCORING` into the grouped environment catalog and load it through `ReplicaSelectionConfig::FromEnvironment()` under `src/config`.

Keep the existing behavior: only the exact value `"1"` enables scoring, other values silently leave it disabled, and the result is cached on the first scoring-policy check. Injected scorers still take effect at runtime. Replica selection policy and locking are unchanged.

This overlaps the replica-scoring environment read in #1538. This PR handles only that setting using the component-owned config layout tracked by #3809, rather than adding a setting-specific getter to `Environ`.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target replica_selection_config_test replica_selection_test -j32
cmake --build build --target mooncake_client -j32
ctest --test-dir build -R '^replica_selection(_config|_env_opt_in)?_test$' --output-on-failure
MC_STORE_REPLICA_SCORING=1 ctest --test-dir build -R '^replica_selection(_config|_env_opt_in)?_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

All three CTest entries pass in both runs. The new config tests cover unset, empty, exact `"1"`, rejected values, silent parsing, and fresh config reads. The selection tests cover first-use caching with both environment settings and live scorer injection. The existing environment opt-in test still checks that selection uses the built-in scorer.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Used Codex to extract the config, add behavior-preservation tests, and review and validate the changes.