### PR TITLE
[Store] Add bounded standby promotion handoff

### DIFF
--- a/mooncake-store/benchmarks/CMakeLists.txt
+++ b/mooncake-store/benchmarks/CMakeLists.txt
@@ -52,6 +52,10 @@ target_link_libraries(
   batch_evict_bench PRIVATE mooncake_store cachelib_memory_allocator
                             gflags::gflags glog::glog pthread)
 
+add_executable(batch_oplog_promotion_bench batch_oplog_promotion_bench.cpp)
+target_link_libraries(batch_oplog_promotion_bench PRIVATE mooncake_store
+                                                          gflags::gflags)
+
 if(STORE_USE_ETCD)
   add_executable(oplog_batch_bench oplog_batch_bench.cpp)
   target_link_libraries(

--- a/mooncake-store/benchmarks/batch_oplog_promotion_bench.cpp
+++ b/mooncake-store/benchmarks/batch_oplog_promotion_bench.cpp
@@ -1,0 +1,84 @@
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include <chrono>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <string>
+
+#include "ha/snapshot/batch_oplog/promotion.h"
+#include "master_service.h"
+
+DEFINE_uint64(objects, 100000, "Synthetic standby object count");
+DEFINE_uint64(chunk_objects, 1000, "Objects drained per chunk");
+
+namespace {
+
+size_t PeakRssBytes() {
+    std::ifstream status("/proc/self/status");
+    std::string name;
+    size_t rss_kib = 0;
+    while (status >> name) {
+        if (name == "VmHWM:") {
+            status >> rss_kib;
+            break;
+        }
+        status.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    }
+    return rss_kib * 1024;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    google::InitGoogleLogging(argv[0]);
+    FLAGS_logtostderr = true;
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    if (FLAGS_objects == 0 || FLAGS_chunk_objects == 0 ||
+        FLAGS_objects == std::numeric_limits<uint64_t>::max() ||
+        FLAGS_chunk_objects > std::numeric_limits<size_t>::max()) {
+        std::cerr << "objects and chunk_objects must be non-zero\n";
+        return 1;
+    }
+
+    auto source_store = std::make_unique<mooncake::StandbyMetadataStore>();
+    for (uint64_t i = 0; i < FLAGS_objects; ++i) {
+        mooncake::StandbyObjectMetadata metadata;
+        metadata.size = 1;
+        mooncake::Replica::Descriptor replica;
+        replica.id = i + 1;
+        replica.status = mooncake::ReplicaStatus::COMPLETE;
+        replica.descriptor_variant = mooncake::DiskDescriptor{"bench", 1};
+        metadata.replicas.push_back(std::move(replica));
+        if (!source_store->PutMetadata("default", "bench-" + std::to_string(i),
+                                       metadata)) {
+            return 1;
+        }
+    }
+
+    mooncake::BatchOpLogPromotionHandoff handoff;
+    handoff.metadata_store = std::move(source_store);
+    handoff.applied_cursor = {.batch_id = 1, .last_seq = 1};
+    handoff.max_replica_id = FLAGS_objects;
+    mooncake::MasterService primary(
+        mooncake::MasterServiceConfig::builder().set_enable_ha(false).build());
+
+    const auto started = std::chrono::steady_clock::now();
+    auto restored = primary.RestoreFromBatchOpLogPromotion(
+        std::move(handoff), static_cast<size_t>(FLAGS_chunk_objects));
+    if (!restored) {
+        std::cerr << "restore failed: " << static_cast<int>(restored.error())
+                  << '\n';
+        return 1;
+    }
+    const auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - started);
+
+    std::cout << "objects=" << FLAGS_objects
+              << " source_store=StandbyMetadataStore"
+              << " chunk_objects=" << FLAGS_chunk_objects
+              << " restore_us=" << elapsed.count()
+              << " peak_rss_bytes=" << PeakRssBytes() << '\n';
+    return 0;
+}

--- a/mooncake-store/include/ha/snapshot/batch_oplog/promotion.h
+++ b/mooncake-store/include/ha/snapshot/batch_oplog/promotion.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "ha/oplog/oplog_batch_storage.h"
+#include "ha/standby_metadata_store.h"
+#include "metadata_store.h"
+#include "types.h"
+
+namespace mooncake {
+
+inline constexpr size_t kDefaultBatchOpLogPromotionChunkObjects = 1'000'000;
+
+struct BatchOpLogPromotionHandoff {
+    std::unique_ptr<StandbyMetadataStore> metadata_store;
+    std::vector<StandbySegmentInfo> segments;
+    DurablePrefix applied_cursor;
+    ViewVersionId producer_view_version{0};
+    ReplicaID max_replica_id{0};
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/ha/standby_controller.h
+++ b/mooncake-store/include/ha/standby_controller.h
@@ -8,6 +8,7 @@
 #include <ylt/util/tl/expected.hpp>
 
 #include "ha/ha_types.h"
+#include "ha/snapshot/batch_oplog/promotion.h"
 #include "master_config.h"
 #include "metadata_store.h"
 #include "types.h"
@@ -20,9 +21,19 @@ namespace ha {
  * Contains everything needed to restore primary's state.
  */
 struct PromotionContext {
+    PromotionContext() = default;
+    PromotionContext(PromotionContext&&) = default;
+    PromotionContext& operator=(PromotionContext&&) = default;
+    PromotionContext(const PromotionContext&) = delete;
+    PromotionContext& operator=(const PromotionContext&) = delete;
+
     uint64_t applied_seq_id{0};
     std::vector<StandbyObjectEntry> objects;
     std::vector<StandbySegmentInfo> segments;
+    std::unique_ptr<StandbyMetadataStore> metadata_store;
+    DurablePrefix applied_cursor;
+    ViewVersionId producer_view_version{0};
+    ReplicaID max_replica_id{0};
 };
 
 class StandbyController {

--- a/mooncake-store/include/ha/standby_metadata_store.h
+++ b/mooncake-store/include/ha/standby_metadata_store.h
@@ -66,6 +66,8 @@ class StandbyMetadataStore final : public MetadataStore {
     void Clear();
 
     void Snapshot(std::vector<StandbyObjectEntry>& out) const;
+    bool ValidateReplicaIds(ReplicaID& max_replica_id) const;
+    bool DrainChunk(size_t count, std::vector<StandbyObjectEntry>& out);
     // Mutations must remain frozen for the lifetime of the returned cursor.
     SnapshotCursor BeginSnapshotTraversal() const;
     bool CopyNextSnapshotChunk(size_t count, SnapshotCursor& cursor,

--- a/mooncake-store/include/hot_standby_service.h
+++ b/mooncake-store/include/hot_standby_service.h
@@ -17,6 +17,7 @@
 #include "ha/oplog/oplog_types.h"
 #include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
 #include "ha/snapshot/batch_oplog/capture.h"
+#include "ha/snapshot/batch_oplog/promotion.h"
 #include "ha/snapshot/snapshot_provider.h"
 #include "ha/standby_metadata_store.h"
 #include "standby_state_machine.h"
@@ -141,6 +142,10 @@ class HotStandbyService {
      */
     ErrorCode PromoteAndExportSnapshot(StandbySnapshot& out);
 
+    bool IsBatchOpLogSnapshotMode() const;
+    tl::expected<BatchOpLogPromotionHandoff, ErrorCode>
+    PromoteAndDetachBatchOpLogStore();
+
     /**
      * @brief Get the number of metadata entries in the local store
      */
@@ -236,11 +241,8 @@ class HotStandbyService {
     void NotifySnapshotPromotion();
     void NotifySnapshotStop();
 
-    // Shared body for Promote() and PromoteAndExportSnapshot(): runs the
-    // promotion sequence machine transitions + gap resolution + final
-    // catch-up + post catch-up gap check + success transition. Returns
-    // ErrorCode::OK on success or any fail-closed error code.
-    ErrorCode PromoteLockedInternal(uint64_t current_applied_seq_id);
+    ErrorCode PreparePromotionLocked(uint64_t current_applied_seq_id);
+    ErrorCode CompletePromotionLocked();
 
     void NotifySyncStatus();
 
@@ -266,6 +268,7 @@ class HotStandbyService {
     std::shared_ptr<HaKvBackend> batch_standby_kv_backend_;
     std::unique_ptr<OpLogBatchStandbyReader> batch_standby_reader_;
     std::optional<DurablePrefix> batch_snapshot_baseline_;
+    ViewVersionId batch_snapshot_producer_view_version_{0};
 
     std::shared_ptr<HaKvBackend> catch_up_batch_kv_backend_for_testing_;
 

--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -45,6 +45,7 @@
 #include "replica.h"
 #include "ha/ha_types.h"
 #include "ha/snapshot/object/snapshot_object_store.h"
+#include "ha/snapshot/batch_oplog/promotion.h"
 #include "task_manager.h"
 #include "kv_event/kv_event_publisher.h"
 #include "ha/oplog/oplog_types.h"
@@ -923,6 +924,9 @@ class MasterService {
         const std::vector<StandbyObjectEntry>& objects,
         uint64_t initial_oplog_sequence_id,
         const std::vector<StandbySegmentInfo>& segments);
+    tl::expected<void, ErrorCode> RestoreFromBatchOpLogPromotion(
+        BatchOpLogPromotionHandoff handoff,
+        size_t chunk_object_count = kDefaultBatchOpLogPromotionChunkObjects);
 
     /**
      * @brief Query the status of a task
@@ -965,6 +969,14 @@ class MasterService {
     void setHttpMetadataRemoteUrl(const std::string& metadata_connstring);
 
    private:
+    tl::expected<void, ErrorCode> RestoreFromStandbyState(
+        const std::vector<StandbyObjectEntry>* legacy_objects,
+        std::unique_ptr<StandbyMetadataStore> metadata_store,
+        uint64_t initial_oplog_sequence_id,
+        const std::vector<StandbySegmentInfo>& segments,
+        size_t chunk_object_count,
+        std::optional<ReplicaID> expected_max_replica_id);
+
     std::unique_ptr<ha::SnapshotCatalogStore> CreateSnapshotCatalogStore(
         const MasterServiceConfig& config);
 

--- a/mooncake-store/include/rpc_service.h
+++ b/mooncake-store/include/rpc_service.h
@@ -262,6 +262,9 @@ class WrappedMasterService {
         const std::vector<StandbyObjectEntry>& objects,
         uint64_t initial_oplog_sequence_id,
         const std::vector<StandbySegmentInfo>& segments);
+    tl::expected<void, ErrorCode> RestoreFromBatchOpLogPromotion(
+        BatchOpLogPromotionHandoff handoff,
+        size_t chunk_object_count = kDefaultBatchOpLogPromotionChunkObjects);
 
     tl::expected<UUID, ErrorCode> CreateCopyTask(
         const std::string& key, const std::string& tenant_id,

--- a/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
+++ b/mooncake-store/src/ha/leadership/master_service_supervisor.cpp
@@ -428,9 +428,21 @@ int RunSupervisorLoop(const HABackendSpec& spec,
         // Restore is the serving gate: do not register or expose a candidate
         // service until the complete promotion context has been applied.
         SetRuntimeState(admin_server, MasterRuntimeState::kRecovering);
-        auto restore_result = wrapped_master_service->RestoreFromStandby(
-            promotion_ctx->objects, promotion_ctx->applied_seq_id,
-            promotion_ctx->segments);
+        auto restore_result =
+            promotion_ctx->metadata_store
+                ? wrapped_master_service->RestoreFromBatchOpLogPromotion(
+                      BatchOpLogPromotionHandoff{
+                          .metadata_store =
+                              std::move(promotion_ctx->metadata_store),
+                          .segments = std::move(promotion_ctx->segments),
+                          .applied_cursor = promotion_ctx->applied_cursor,
+                          .producer_view_version =
+                              promotion_ctx->producer_view_version,
+                          .max_replica_id = promotion_ctx->max_replica_id,
+                      })
+                : wrapped_master_service->RestoreFromStandby(
+                      promotion_ctx->objects, promotion_ctx->applied_seq_id,
+                      promotion_ctx->segments);
         if (!restore_result) {
             LOG(ERROR) << "Standby restore failed: "
                        << toString(restore_result.error());

--- a/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
+++ b/mooncake-store/src/ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.cpp
@@ -128,28 +128,6 @@ void CopyRegistry(const StandbySegmentRegistry& source,
     }
 }
 
-tl::expected<ReplicaID, ErrorCode> ScanLiveReplicaIds(
-    const StandbyMetadataStore& metadata) {
-    auto cursor = metadata.BeginSnapshotTraversal();
-    ReplicaID max_replica_id = 0;
-    while (!cursor.done()) {
-        std::vector<StandbyObjectEntry> objects;
-        if (!metadata.CopyNextSnapshotChunk(1, cursor, objects)) {
-            return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
-        }
-        for (const auto& object : objects) {
-            std::unordered_set<ReplicaID> object_ids;
-            for (const auto& replica : object.metadata.replicas) {
-                if (replica.id == 0 || !object_ids.insert(replica.id).second) {
-                    return tl::make_unexpected(ErrorCode::DESERIALIZE_FAIL);
-                }
-                max_replica_id = std::max(max_replica_id, replica.id);
-            }
-        }
-    }
-    return max_replica_id;
-}
-
 AttemptResult ReplaySuffix(const std::string& cluster_id, HaKvBackend& backend,
                            OpLogApplier& applier,
                            const DurablePrefix* baseline) {
@@ -302,9 +280,9 @@ AttemptResult RestorePointer(
     if (suffix.disposition != AttemptDisposition::kSuccess) {
         return suffix;
     }
-    auto live_max_replica_id = ScanLiveReplicaIds(metadata);
-    if (!live_max_replica_id) {
-        return Invalid(live_max_replica_id.error());
+    ReplicaID live_max_replica_id = 0;
+    if (!metadata.ValidateReplicaIds(live_max_replica_id)) {
+        return Invalid(ErrorCode::DESERIALIZE_FAIL);
     }
     CopyRegistry(applier->GetSegmentRegistry(), registry);
     return {AttemptDisposition::kSuccess,
@@ -314,7 +292,7 @@ AttemptResult RestorePointer(
              .last_applied_seq = suffix.value.last_included_seq,
              .last_applied_batch_id = suffix.value.last_included_batch_id,
              .producer_view_version = descriptor.producer_view_version,
-             .max_replica_id = *live_max_replica_id}};
+             .max_replica_id = live_max_replica_id}};
 }
 
 AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
@@ -341,12 +319,12 @@ AttemptResult RestoreCompleteOpLog(const std::string& cluster_id,
     if (replay.disposition != AttemptDisposition::kSuccess) {
         return replay;
     }
-    auto max_replica_id = ScanLiveReplicaIds(metadata);
-    if (!max_replica_id) {
-        return Invalid(max_replica_id.error());
+    ReplicaID max_replica_id = 0;
+    if (!metadata.ValidateReplicaIds(max_replica_id)) {
+        return Invalid(ErrorCode::DESERIALIZE_FAIL);
     }
     CopyRegistry(applier->GetSegmentRegistry(), registry);
-    replay.value.max_replica_id = *max_replica_id;
+    replay.value.max_replica_id = max_replica_id;
     replay.value.last_applied_seq = replay.value.last_included_seq;
     replay.value.last_applied_batch_id = replay.value.last_included_batch_id;
     return replay;

--- a/mooncake-store/src/ha/standby_controller.cpp
+++ b/mooncake-store/src/ha/standby_controller.cpp
@@ -246,7 +246,37 @@ class CapabilityDrivenStandbyController final : public StandbyController {
             return tl::unexpected(promote_error);
         }
 
-        // Atomic promote + export (final catch-up happens inside)
+        if (standby_service_->IsBatchOpLogSnapshotMode()) {
+            auto handoff = standby_service_->PromoteAndDetachBatchOpLogStore();
+            if (!handoff) {
+                standby_service_->Stop();
+                {
+                    std::lock_guard<std::mutex> lock(state_mutex_);
+                    standby_running_ = false;
+                    last_standby_error_ = handoff.error();
+                }
+                NotifyRuntimeStateIfChanged();
+                return tl::unexpected(handoff.error());
+            }
+
+            {
+                std::lock_guard<std::mutex> lock(state_mutex_);
+                standby_running_ = false;
+                last_standby_error_ = ErrorCode::OK;
+            }
+            NotifyRuntimeStateIfChanged();
+
+            PromotionContext ctx;
+            ctx.applied_seq_id = handoff->applied_cursor.last_seq;
+            ctx.metadata_store = std::move(handoff->metadata_store);
+            ctx.segments = std::move(handoff->segments);
+            ctx.applied_cursor = handoff->applied_cursor;
+            ctx.producer_view_version = handoff->producer_view_version;
+            ctx.max_replica_id = handoff->max_replica_id;
+            return ctx;
+        }
+
+        // Atomic legacy promote + export (final catch-up happens inside).
         StandbySnapshot snapshot;
         ErrorCode err = standby_service_->PromoteAndExportSnapshot(snapshot);
         if (err != ErrorCode::OK) {

--- a/mooncake-store/src/ha/standby_metadata_store.cpp
+++ b/mooncake-store/src/ha/standby_metadata_store.cpp
@@ -1,5 +1,9 @@
 #include "ha/standby_metadata_store.h"
 
+#include <algorithm>
+#include <limits>
+#include <unordered_set>
+
 namespace mooncake {
 
 bool StandbyMetadataStore::PutMetadata(const std::string& tenant_id,
@@ -87,6 +91,48 @@ void StandbyMetadataStore::Snapshot(
             out.push_back({tenant_id, key, metadata});
         }
     }
+}
+
+bool StandbyMetadataStore::ValidateReplicaIds(ReplicaID& max_replica_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    max_replica_id = 0;
+    for (const auto& [tenant_id, objects] : store_) {
+        (void)tenant_id;
+        for (const auto& [key, metadata] : objects) {
+            (void)key;
+            std::unordered_set<ReplicaID> object_ids;
+            for (const auto& replica : metadata.replicas) {
+                if (replica.id == 0 ||
+                    replica.id == std::numeric_limits<ReplicaID>::max() ||
+                    !object_ids.insert(replica.id).second) {
+                    return false;
+                }
+                max_replica_id = std::max(max_replica_id, replica.id);
+            }
+        }
+    }
+    return true;
+}
+
+bool StandbyMetadataStore::DrainChunk(size_t count,
+                                      std::vector<StandbyObjectEntry>& out) {
+    out.clear();
+    if (count == 0) {
+        return false;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    out.reserve(count);
+    while (!store_.empty() && out.size() < count) {
+        auto tenant = store_.begin();
+        auto object = tenant->second.extract(tenant->second.begin());
+        out.push_back({tenant->first, std::move(object.key()),
+                       std::move(object.mapped())});
+        if (tenant->second.empty()) {
+            store_.erase(tenant);
+        }
+    }
+    return true;
 }
 
 StandbyMetadataStore::SnapshotCursor

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -83,6 +83,9 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     if (verification_thread_.joinable()) {
         verification_thread_.join();
     }
+    if (!metadata_store_) {
+        metadata_store_ = std::make_unique<StandbyMetadataStore>();
+    }
     batch_standby_reader_.reset();
     batch_standby_kv_backend_.reset();
     batch_snapshot_baseline_.reset();

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -724,13 +724,16 @@ ErrorCode HotStandbyService::PromoteAndExportSnapshot(StandbySnapshot& out) {
 
 bool HotStandbyService::IsBatchOpLogSnapshotMode() const {
     std::lock_guard<std::mutex> lock(mutex_);
-    return batch_oplog_snapshot_provider_ != nullptr;
+    return config_.enable_oplog_following &&
+           batch_oplog_snapshot_provider_ != nullptr &&
+           batch_standby_reader_ != nullptr;
 }
 
 tl::expected<BatchOpLogPromotionHandoff, ErrorCode>
 HotStandbyService::PromoteAndDetachBatchOpLogStore() {
     std::unique_lock<std::mutex> lock(mutex_);
-    if (!batch_oplog_snapshot_provider_) {
+    if (!batch_oplog_snapshot_provider_ || !config_.enable_oplog_following ||
+        !batch_standby_reader_) {
         return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
     }
     if (!IsReadyForPromotion()) {
@@ -750,10 +753,14 @@ HotStandbyService::PromoteAndDetachBatchOpLogStore() {
 
     const uint64_t latest_applied_seq_id =
         GetLocalLastAppliedSequenceIdLocked();
-    const auto applied_cursor =
+    auto applied_cursor =
         batch_standby_reader_
             ? batch_standby_reader_->GetLastAppliedDurablePrefix()
             : std::nullopt;
+    if (!applied_cursor && latest_applied_seq_id == 0 && metadata_store_ &&
+        metadata_store_->GetKeyCount() == 0) {
+        applied_cursor = DurablePrefix{};
+    }
     if (!metadata_store_ || !applied_cursor ||
         applied_cursor->last_seq != latest_applied_seq_id) {
         state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);

--- a/mooncake-store/src/hot_standby_service.cpp
+++ b/mooncake-store/src/hot_standby_service.cpp
@@ -86,6 +86,7 @@ ErrorCode HotStandbyService::Start(const std::string& primary_address,
     batch_standby_reader_.reset();
     batch_standby_kv_backend_.reset();
     batch_snapshot_baseline_.reset();
+    batch_snapshot_producer_view_version_ = 0;
     {
         std::lock_guard<std::mutex> cursor_lock(batch_snapshot_cursor_mutex_);
         last_applied_batch_snapshot_prefix_.reset();
@@ -283,6 +284,7 @@ ErrorCode HotStandbyService::LoadBatchOpLogSnapshotBaselineLocked(
     batch_snapshot_baseline_ =
         DurablePrefix{.batch_id = restored->last_applied_batch_id,
                       .last_seq = restored->last_applied_seq};
+    batch_snapshot_producer_view_version_ = restored->producer_view_version;
     applied_seq_id_.store(baseline_seq_id, std::memory_order_release);
     primary_seq_id_.store(baseline_seq_id, std::memory_order_release);
     return ErrorCode::OK;
@@ -495,7 +497,7 @@ bool HotStandbyService::IsReadyForPromotion() const {
             << "will be synced after promotion.";
     }
 
-    // NOTE: unresolved-gap check is deferred to PromoteLockedInternal, which
+    // NOTE: unresolved-gap check is deferred to PreparePromotionLocked, which
     // runs gap resolution + final catch-up first and only rejects promotion
     // when gaps remain after both attempts. Checking here would return a
     // misleading UNAVAILABLE_IN_CURRENT_STATUS before gap resolution runs.
@@ -532,29 +534,38 @@ ErrorCode HotStandbyService::FinalCatchUpBatchRecordsLocked(
             cluster_id_, backend, *oplog_applier_);
         reader = local_reader.get();
     }
-    const auto deadline =
-        std::chrono::steady_clock::now() + std::chrono::seconds(30);
     const auto initial_retry_delay =
         std::chrono::milliseconds(std::max(config_.oplog_poll_interval_ms, 1));
     const auto max_retry_delay =
         std::max(initial_retry_delay, std::chrono::milliseconds(1000));
+    const auto no_progress_timeout =
+        std::chrono::seconds(config_.batch_oplog_retry_timeout_sec);
+    auto last_progress = std::chrono::steady_clock::now();
     auto retry_delay = initial_retry_delay;
     auto wait_to_retry = [&] {
         const auto now = std::chrono::steady_clock::now();
-        if (now >= deadline) {
+        if (now - last_progress >= no_progress_timeout) {
             return false;
         }
         std::this_thread::sleep_for(std::min(
             retry_delay, std::chrono::duration_cast<std::chrono::milliseconds>(
-                             deadline - now)));
+                             no_progress_timeout - (now - last_progress))));
         retry_delay = std::min(retry_delay * 2, max_retry_delay);
         return true;
     };
     for (;;) {
-        if (std::chrono::steady_clock::now() >= deadline) {
-            return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
-        }
+        const uint64_t expected_before =
+            oplog_applier_->GetExpectedSequenceId();
+        const auto cursor_before = reader->GetLastAppliedDurablePrefix();
         auto result = reader->PollOnce();
+        const uint64_t expected_after = oplog_applier_->GetExpectedSequenceId();
+        const auto cursor_after = reader->GetLastAppliedDurablePrefix();
+        const bool made_progress =
+            expected_after > expected_before || cursor_after != cursor_before;
+        if (made_progress) {
+            last_progress = std::chrono::steady_clock::now();
+            retry_delay = initial_retry_delay;
+        }
         if (result.error != ErrorCode::OK) {
             if (result.disposition !=
                     OpLogBatchStandbyPollDisposition::RETRYABLE ||
@@ -563,7 +574,6 @@ ErrorCode HotStandbyService::FinalCatchUpBatchRecordsLocked(
             }
             continue;
         }
-        retry_delay = initial_retry_delay;
         if (!result.durable_prefix_present) {
             return GetLocalLastAppliedSequenceIdLocked() == 0
                        ? ErrorCode::OK
@@ -572,6 +582,9 @@ ErrorCode HotStandbyService::FinalCatchUpBatchRecordsLocked(
         if (GetLocalLastAppliedSequenceIdLocked() >=
             result.durable_prefix.last_seq) {
             return ErrorCode::OK;
+        }
+        if (!made_progress && !wait_to_retry()) {
+            return ErrorCode::INCOMPLETE_OPLOG_CATCH_UP;
         }
     }
 }
@@ -600,7 +613,11 @@ ErrorCode HotStandbyService::Promote() {
               << " entries"
               << ", state: " << StandbyStateToString(GetState());
 
-    auto internal_err = PromoteLockedInternal(current_applied_seq_id);
+    auto internal_err = PreparePromotionLocked(current_applied_seq_id);
+    if (internal_err != ErrorCode::OK) {
+        return internal_err;
+    }
+    internal_err = CompletePromotionLocked();
     if (internal_err != ErrorCode::OK) {
         return internal_err;
     }
@@ -617,7 +634,7 @@ ErrorCode HotStandbyService::Promote() {
     return ErrorCode::OK;
 }
 
-ErrorCode HotStandbyService::PromoteLockedInternal(
+ErrorCode HotStandbyService::PreparePromotionLocked(
     uint64_t current_applied_seq_id) {
     NotifySnapshotPromotion();
     StopReplicationLoop();
@@ -632,10 +649,15 @@ ErrorCode HotStandbyService::PromoteLockedInternal(
     applied_seq_id_.store(latest_applied_seq_id, std::memory_order_release);
     primary_seq_id_.store(latest_applied_seq_id, std::memory_order_release);
 
+    return ErrorCode::OK;
+}
+
+ErrorCode HotStandbyService::CompletePromotionLocked() {
     auto promotion_success =
         state_machine_.ProcessEvent(StandbyEvent::PROMOTION_SUCCESS);
     if (!promotion_success.allowed) {
         LOG(ERROR) << "Cannot finish promotion: " << promotion_success.reason;
+        state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
         return ErrorCode::INTERNAL_ERROR;
     }
     return ErrorCode::OK;
@@ -665,7 +687,11 @@ ErrorCode HotStandbyService::PromoteAndExportSnapshot(StandbySnapshot& out) {
               << " entries"
               << ", state: " << StandbyStateToString(GetState());
 
-    auto internal_err = PromoteLockedInternal(current_applied_seq_id);
+    auto internal_err = PreparePromotionLocked(current_applied_seq_id);
+    if (internal_err != ErrorCode::OK) {
+        return internal_err;
+    }
+    internal_err = CompletePromotionLocked();
     if (internal_err != ErrorCode::OK) {
         return internal_err;
     }
@@ -694,6 +720,78 @@ ErrorCode HotStandbyService::PromoteAndExportSnapshot(StandbySnapshot& out) {
         LOG(INFO) << "Standby promoted to Primary from snapshot baseline.";
     }
     return ErrorCode::OK;
+}
+
+bool HotStandbyService::IsBatchOpLogSnapshotMode() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return batch_oplog_snapshot_provider_ != nullptr;
+}
+
+tl::expected<BatchOpLogPromotionHandoff, ErrorCode>
+HotStandbyService::PromoteAndDetachBatchOpLogStore() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!batch_oplog_snapshot_provider_) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+    if (!IsReadyForPromotion()) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+
+    auto transition = state_machine_.ProcessEvent(StandbyEvent::PROMOTE);
+    if (!transition.allowed) {
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+
+    const uint64_t current_applied_seq_id = GetSyncStatus().applied_seq_id;
+    ErrorCode err = PreparePromotionLocked(current_applied_seq_id);
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    const uint64_t latest_applied_seq_id =
+        GetLocalLastAppliedSequenceIdLocked();
+    const auto applied_cursor =
+        batch_standby_reader_
+            ? batch_standby_reader_->GetLastAppliedDurablePrefix()
+            : std::nullopt;
+    if (!metadata_store_ || !applied_cursor ||
+        applied_cursor->last_seq != latest_applied_seq_id) {
+        state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+        return tl::make_unexpected(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP);
+    }
+
+    ReplicaID max_replica_id = 0;
+    if (!metadata_store_->ValidateReplicaIds(max_replica_id)) {
+        state_machine_.ProcessEvent(StandbyEvent::PROMOTION_FAILED);
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+
+    ViewVersionId producer_view_version = batch_snapshot_producer_view_version_;
+    ViewVersionId current_producer_view = 0;
+    if (batch_standby_reader_->ReadProducerView(current_producer_view) ==
+        ErrorCode::OK) {
+        producer_view_version = current_producer_view;
+    }
+
+    auto segments = oplog_applier_->GetSegmentRegistry().GetAllSegments();
+    err = CompletePromotionLocked();
+    if (err != ErrorCode::OK) {
+        return tl::make_unexpected(err);
+    }
+
+    BatchOpLogPromotionHandoff handoff{
+        .metadata_store = std::move(metadata_store_),
+        .segments = std::move(segments),
+        .applied_cursor = *applied_cursor,
+        .producer_view_version = producer_view_version,
+        .max_replica_id = max_replica_id,
+    };
+    batch_standby_reader_.reset();
+    oplog_applier_.reset();
+
+    lock.unlock();
+    Stop();
+    return handoff;
 }
 
 size_t HotStandbyService::GetMetadataCount() const {

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3114,10 +3114,37 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
     const std::vector<StandbyObjectEntry>& objects,
     uint64_t initial_oplog_sequence_id,
     const std::vector<StandbySegmentInfo>& segments) {
+    return RestoreFromStandbyState(&objects, nullptr, initial_oplog_sequence_id,
+                                   segments, objects.size(), std::nullopt);
+}
+
+tl::expected<void, ErrorCode> MasterService::RestoreFromBatchOpLogPromotion(
+    BatchOpLogPromotionHandoff handoff, size_t chunk_object_count) {
+    if (!handoff.metadata_store || chunk_object_count == 0 ||
+        ((handoff.applied_cursor.batch_id == 0) !=
+         (handoff.applied_cursor.last_seq == 0))) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    }
+    return RestoreFromStandbyState(nullptr, std::move(handoff.metadata_store),
+                                   handoff.applied_cursor.last_seq,
+                                   handoff.segments, chunk_object_count,
+                                   handoff.max_replica_id);
+}
+
+tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
+    const std::vector<StandbyObjectEntry>* legacy_objects,
+    std::unique_ptr<StandbyMetadataStore> metadata_store,
+    uint64_t initial_oplog_sequence_id,
+    const std::vector<StandbySegmentInfo>& segments, size_t chunk_object_count,
+    std::optional<ReplicaID> expected_max_replica_id) {
     if (enable_dfs_) {
         LOG(ERROR) << "RestoreFromStandbySnapshot: DFS allocator state "
                       "restoration is not supported";
         return tl::make_unexpected(ErrorCode::DFS_SERVICE_UNAVAILABLE);
+    }
+    if ((legacy_objects == nullptr) == (metadata_store == nullptr) ||
+        (metadata_store && chunk_object_count == 0)) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
     // The ordered writer initializes its sequence from durable_prefix.
     std::unique_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
@@ -3132,20 +3159,29 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
     };
 
     ReplicaID max_live_id = 0;
-    for (const auto& entry : objects) {
-        auto [tenant_id, user_key] = resolve_standby_object(entry);
-        std::unordered_set<ReplicaID> object_replica_ids;
-        for (const auto& desc : entry.metadata.replicas) {
-            if (desc.id == 0 ||
-                desc.id == std::numeric_limits<ReplicaID>::max() ||
-                !object_replica_ids.insert(desc.id).second) {
-                LOG(ERROR)
-                    << "RestoreFromStandbySnapshot: invalid or duplicate "
-                    << "replica id=" << desc.id
-                    << ", tenant=" << tenant_id.value() << ", key=" << user_key;
-                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+    if (metadata_store) {
+        if (!expected_max_replica_id ||
+            !metadata_store->ValidateReplicaIds(max_live_id) ||
+            max_live_id != *expected_max_replica_id) {
+            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        }
+    } else {
+        for (const auto& entry : *legacy_objects) {
+            auto [tenant_id, user_key] = resolve_standby_object(entry);
+            std::unordered_set<ReplicaID> object_replica_ids;
+            for (const auto& desc : entry.metadata.replicas) {
+                if (desc.id == 0 ||
+                    desc.id == std::numeric_limits<ReplicaID>::max() ||
+                    !object_replica_ids.insert(desc.id).second) {
+                    LOG(ERROR)
+                        << "RestoreFromStandbySnapshot: invalid or duplicate "
+                        << "replica id=" << desc.id
+                        << ", tenant=" << tenant_id.value()
+                        << ", key=" << user_key;
+                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                }
+                max_live_id = std::max(max_live_id, desc.id);
             }
-            max_live_id = std::max(max_live_id, desc.id);
         }
     }
 
@@ -3201,158 +3237,233 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
         std::string user_key;
         std::vector<Replica> replicas;
     };
-    std::unordered_map<size_t, std::vector<PreparedObject>> objects_by_shard;
-    std::unordered_set<std::string> object_ids;
-    std::unordered_map<const StandbySegmentInfo*,
-                       std::vector<std::pair<uintptr_t, uint64_t>>>
+    std::unordered_map<const StandbySegmentInfo*, std::map<uintptr_t, uint64_t>>
         memory_ranges;
     std::unordered_map<std::string, uint64_t> restored_accounted_memory_bytes;
+    size_t restored_object_count = 0;
 
-    for (const auto& entry : objects) {
-        auto [tenant_id, user_key] = resolve_standby_object(entry);
-        if (!tenant_id.IsValid()) {
-            LOG(ERROR) << "RestoreFromStandbySnapshot: invalid tenant_id="
-                       << entry.tenant_id << ", key=" << entry.key;
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-        }
-        if (!object_ids.insert(tenant_id.MakeScopedKey(user_key)).second) {
-            LOG(ERROR)
-                << "RestoreFromStandbySnapshot: duplicate object, tenant="
-                << tenant_id.value() << ", key=" << user_key;
-            return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-        }
-        const size_t existing_shard_idx = getShardIndex(tenant_id, user_key);
-        {
-            MetadataShardAccessorRO existing_shard(this, existing_shard_idx);
-            auto existing_tenant = existing_shard->tenants.find(tenant_id);
-            if (existing_tenant != existing_shard->tenants.end() &&
-                existing_tenant->second.metadata.contains(user_key)) {
-                LOG(ERROR)
-                    << "RestoreFromStandbySnapshot: object already exists, "
-                    << "tenant=" << tenant_id.value() << ", key=" << user_key;
-                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    const auto restore_chunk =
+        [&](const std::vector<StandbyObjectEntry>& objects)
+        -> tl::expected<void, ErrorCode> {
+        std::unordered_map<size_t, std::vector<PreparedObject>>
+            objects_by_shard;
+        std::unordered_set<std::string> chunk_object_ids;
+        for (const auto& entry : objects) {
+            auto [tenant_id, user_key] = resolve_standby_object(entry);
+            if (!tenant_id.IsValid()) {
+                LOG(ERROR) << "RestoreFromStandbySnapshot: invalid tenant_id="
+                           << entry.tenant_id << ", key=" << entry.key;
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
             }
-        }
-        const auto shard_idx = getShardIndex(tenant_id, user_key);
-        const auto& standby_meta = entry.metadata;
-        std::vector<Replica> replicas;
-        replicas.reserve(standby_meta.replicas.size());
-
-        for (const auto& desc : standby_meta.replicas) {
-            if (desc.is_memory_replica()) {
-                const auto& buffer =
-                    desc.get_memory_descriptor().buffer_descriptor;
-                auto segment_it =
-                    memory_segments_by_alias.find(buffer.transport_endpoint_);
-                if (segment_it == memory_segments_by_alias.end()) {
-                    LOG(ERROR) << "RestoreFromStandbySnapshot: unknown memory "
-                               << "endpoint=" << buffer.transport_endpoint_
-                               << ", tenant=" << tenant_id.value()
-                               << ", key=" << user_key;
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            if (!chunk_object_ids.insert(tenant_id.MakeScopedKey(user_key))
+                     .second) {
+                LOG(ERROR)
+                    << "RestoreFromStandbySnapshot: duplicate object, tenant="
+                    << tenant_id.value() << ", key=" << user_key;
+                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            const size_t shard_idx = getShardIndex(tenant_id, user_key);
+            {
+                MetadataShardAccessorRO existing_shard(this, shard_idx);
+                auto existing_tenant = existing_shard->tenants.find(tenant_id);
+                if (existing_tenant != existing_shard->tenants.end() &&
+                    existing_tenant->second.metadata.contains(user_key)) {
+                    LOG(ERROR)
+                        << "RestoreFromStandbySnapshot: object already exists, "
+                        << "tenant=" << tenant_id.value()
+                        << ", key=" << user_key;
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_ALREADY_EXISTS);
                 }
-                if (buffer.size_ != standby_meta.size || buffer.size_ == 0 ||
-                    buffer.buffer_address_ >
-                        std::numeric_limits<uintptr_t>::max() - buffer.size_) {
-                    LOG(ERROR) << "RestoreFromStandbySnapshot: invalid memory "
-                               << "descriptor, tenant=" << tenant_id.value()
-                               << ", key=" << user_key;
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                }
+            }
+            const auto& standby_meta = entry.metadata;
+            std::vector<Replica> replicas;
+            replicas.reserve(standby_meta.replicas.size());
 
-                const auto* segment = segment_it->second;
-                if (desc.status != ReplicaStatus::REMOVED &&
-                    desc.status != ReplicaStatus::FAILED) {
-                    auto& bytes =
-                        restored_accounted_memory_bytes[segment->segment_name];
-                    if (bytes > segment->capacity ||
-                        buffer.size_ > segment->capacity - bytes) {
+            for (const auto& desc : standby_meta.replicas) {
+                if (desc.is_memory_replica()) {
+                    const auto& buffer =
+                        desc.get_memory_descriptor().buffer_descriptor;
+                    auto segment_it = memory_segments_by_alias.find(
+                        buffer.transport_endpoint_);
+                    if (segment_it == memory_segments_by_alias.end()) {
                         LOG(ERROR)
-                            << "RestoreFromStandbySnapshot: memory descriptors "
-                            << "exceed segment capacity, segment="
-                            << segment->segment_name;
+                            << "RestoreFromStandbySnapshot: unknown memory "
+                            << "endpoint=" << buffer.transport_endpoint_
+                            << ", tenant=" << tenant_id.value()
+                            << ", key=" << user_key;
                         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                     }
-                    bytes += buffer.size_;
-                    memory_ranges[segment].emplace_back(buffer.buffer_address_,
-                                                        buffer.size_);
-                }
+                    if (buffer.size_ != standby_meta.size ||
+                        buffer.size_ == 0 ||
+                        buffer.buffer_address_ >
+                            std::numeric_limits<uintptr_t>::max() -
+                                buffer.size_) {
+                        LOG(ERROR)
+                            << "RestoreFromStandbySnapshot: invalid memory "
+                            << "descriptor, tenant=" << tenant_id.value()
+                            << ", key=" << user_key;
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    }
 
-                auto alloc = restored_allocators.at(buffer.transport_endpoint_);
-                replicas.push_back(Replica(
-                    desc.id, std::make_unique<AllocatedBuffer>(alloc, buffer),
-                    desc.status));
-            } else if (desc.is_nof_replica()) {
-                const auto& buffer =
-                    desc.get_nof_descriptor().buffer_descriptor;
-                if (buffer.size_ != standby_meta.size || buffer.size_ == 0) {
-                    LOG(ERROR) << "RestoreFromStandbySnapshot: invalid NoF "
-                               << "descriptor, tenant=" << tenant_id.value()
-                               << ", key=" << user_key;
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                }
-                auto& alloc = restored_allocators[buffer.transport_endpoint_];
-                if (!alloc) {
-                    alloc = std::make_shared<DummyBufferAllocator>(
-                        buffer.transport_endpoint_, buffer.transport_endpoint_);
-                }
-                replicas.push_back(Replica(
-                    desc.id, std::make_unique<AllocatedBuffer>(alloc, buffer),
-                    desc.status, ReplicaType::NOF_SSD));
-            } else if (desc.is_disk_replica()) {
-                const auto& disk_desc = desc.get_disk_descriptor();
-                if (disk_desc.object_size != standby_meta.size) {
-                    LOG(ERROR) << "RestoreFromStandbySnapshot: invalid disk "
-                               << "descriptor, tenant=" << tenant_id.value()
-                               << ", key=" << user_key;
-                    return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
-                }
-                replicas.push_back(Replica(desc.id, disk_desc.file_path,
-                                           disk_desc.object_size, desc.status));
-            } else if (desc.is_local_disk_replica()) {
-                const auto& local_disk_desc = desc.get_local_disk_descriptor();
-                if (local_disk_desc.object_size != standby_meta.size) {
+                    const auto* segment = segment_it->second;
+                    if (desc.status != ReplicaStatus::REMOVED &&
+                        desc.status != ReplicaStatus::FAILED) {
+                        auto& bytes =
+                            restored_accounted_memory_bytes[segment
+                                                                ->segment_name];
+                        if (bytes > segment->capacity ||
+                            buffer.size_ > segment->capacity - bytes) {
+                            LOG(ERROR)
+                                << "RestoreFromStandbySnapshot: memory "
+                                   "descriptors exceed segment capacity, "
+                                   "segment="
+                                << segment->segment_name;
+                            return tl::make_unexpected(
+                                ErrorCode::INVALID_PARAMS);
+                        }
+                        auto& ranges = memory_ranges[segment];
+                        auto next = ranges.lower_bound(buffer.buffer_address_);
+                        const uintptr_t end =
+                            buffer.buffer_address_ + buffer.size_;
+                        if ((next != ranges.end() && end > next->first) ||
+                            (next != ranges.begin() &&
+                             std::prev(next)->first + std::prev(next)->second >
+                                 buffer.buffer_address_)) {
+                            LOG(ERROR)
+                                << "RestoreFromStandbySnapshot: overlapping "
+                                   "memory descriptors";
+                            return tl::make_unexpected(
+                                ErrorCode::INVALID_PARAMS);
+                        }
+                        bytes += buffer.size_;
+                        ranges.emplace(buffer.buffer_address_, buffer.size_);
+                    }
+
+                    auto alloc =
+                        restored_allocators.at(buffer.transport_endpoint_);
+                    replicas.push_back(Replica(
+                        desc.id,
+                        std::make_unique<AllocatedBuffer>(alloc, buffer),
+                        desc.status));
+                } else if (desc.is_nof_replica()) {
+                    const auto& buffer =
+                        desc.get_nof_descriptor().buffer_descriptor;
+                    if (buffer.size_ != standby_meta.size ||
+                        buffer.size_ == 0) {
+                        LOG(ERROR) << "RestoreFromStandbySnapshot: invalid NoF "
+                                   << "descriptor, tenant=" << tenant_id.value()
+                                   << ", key=" << user_key;
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    }
+                    auto& alloc =
+                        restored_allocators[buffer.transport_endpoint_];
+                    if (!alloc) {
+                        alloc = std::make_shared<DummyBufferAllocator>(
+                            buffer.transport_endpoint_,
+                            buffer.transport_endpoint_);
+                    }
+                    replicas.push_back(Replica(
+                        desc.id,
+                        std::make_unique<AllocatedBuffer>(alloc, buffer),
+                        desc.status, ReplicaType::NOF_SSD));
+                } else if (desc.is_disk_replica()) {
+                    const auto& disk_desc = desc.get_disk_descriptor();
+                    if (disk_desc.object_size != standby_meta.size) {
+                        LOG(ERROR)
+                            << "RestoreFromStandbySnapshot: invalid disk "
+                            << "descriptor, tenant=" << tenant_id.value()
+                            << ", key=" << user_key;
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    }
+                    replicas.push_back(Replica(desc.id, disk_desc.file_path,
+                                               disk_desc.object_size,
+                                               desc.status));
+                } else if (desc.is_local_disk_replica()) {
+                    const auto& local_disk_desc =
+                        desc.get_local_disk_descriptor();
+                    if (local_disk_desc.object_size != standby_meta.size) {
+                        LOG(ERROR)
+                            << "RestoreFromStandbySnapshot: invalid local disk "
+                            << "descriptor, tenant=" << tenant_id.value()
+                            << ", key=" << user_key;
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    }
+                    replicas.push_back(Replica(
+                        desc.id, local_disk_desc.client_id,
+                        local_disk_desc.object_size,
+                        local_disk_desc.transport_endpoint, desc.status));
+                } else {
                     LOG(ERROR)
-                        << "RestoreFromStandbySnapshot: invalid local disk "
+                        << "RestoreFromStandbySnapshot: unsupported replica "
                         << "descriptor, tenant=" << tenant_id.value()
                         << ", key=" << user_key;
                     return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                 }
-                replicas.push_back(Replica(desc.id, local_disk_desc.client_id,
-                                           local_disk_desc.object_size,
-                                           local_disk_desc.transport_endpoint,
-                                           desc.status));
-            } else {
-                LOG(ERROR) << "RestoreFromStandbySnapshot: unsupported replica "
-                           << "descriptor, tenant=" << tenant_id.value()
-                           << ", key=" << user_key;
-                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+            }
+            objects_by_shard[shard_idx].push_back({&entry, std::move(tenant_id),
+                                                   std::move(user_key),
+                                                   std::move(replicas)});
+        }
+
+        for (const auto& [shard_idx, shard_objects] : objects_by_shard) {
+            MetadataShardAccessorRW shard(this, shard_idx);
+            for (const auto& object : shard_objects) {
+                auto tenant = shard->tenants.find(object.tenant_id);
+                if (tenant != shard->tenants.end() &&
+                    tenant->second.metadata.contains(object.user_key)) {
+                    return tl::make_unexpected(
+                        ErrorCode::OBJECT_ALREADY_EXISTS);
+                }
             }
         }
-        objects_by_shard[shard_idx].push_back({&entry, std::move(tenant_id),
-                                               std::move(user_key),
-                                               std::move(replicas)});
-    }
 
-    for (auto& [segment, ranges] : memory_ranges) {
-        (void)segment;
-        std::sort(ranges.begin(), ranges.end());
-        for (size_t i = 1; i < ranges.size(); ++i) {
-            if (ranges[i].first < ranges[i - 1].first + ranges[i - 1].second) {
-                LOG(ERROR) << "RestoreFromStandbySnapshot: overlapping memory "
-                           << "descriptors";
-                return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+        const auto now = std::chrono::system_clock::now();
+        for (auto& [shard_idx, shard_objects] : objects_by_shard) {
+            MetadataShardAccessorRW shard(this, shard_idx);
+            for (auto& object : shard_objects) {
+                const auto& standby_meta = object.entry->metadata;
+                auto& tenant_state =
+                    GetOrCreateTenantState(shard.get(), object.tenant_id);
+                auto [it, inserted] = tenant_state.metadata.emplace(
+                    std::piecewise_construct,
+                    std::forward_as_tuple(object.user_key),
+                    std::forward_as_tuple(
+                        standby_meta.client_id, now, standby_meta.size,
+                        std::move(object.replicas), std::nullopt,
+                        standby_meta.hard_pinned.value_or(false),
+                        standby_meta.data_type, standby_meta.group_id,
+                        object.tenant_id, object.user_key));
+                (void)inserted;
+                if (!standby_meta.group_id.empty()) {
+                    it->second.lease_ =
+                        RegisterGroupMember(object.tenant_id, object.user_key,
+                                            standby_meta.group_id);
+                }
+                tenant_state.processing_keys.erase(object.user_key);
             }
         }
-    }
+        restored_object_count += objects.size();
+        return {};
+    };
 
-    for (const auto& [shard_idx, shard_objects] : objects_by_shard) {
-        MetadataShardAccessorRW shard(this, shard_idx);
-        for (const auto& object : shard_objects) {
-            auto tenant = shard->tenants.find(object.tenant_id);
-            if (tenant != shard->tenants.end() &&
-                tenant->second.metadata.contains(object.user_key)) {
-                return tl::make_unexpected(ErrorCode::OBJECT_ALREADY_EXISTS);
+    if (legacy_objects) {
+        auto restored = restore_chunk(*legacy_objects);
+        if (!restored) {
+            return restored;
+        }
+    } else {
+        std::vector<StandbyObjectEntry> objects;
+        for (;;) {
+            if (!metadata_store->DrainChunk(chunk_object_count, objects)) {
+                return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
+            }
+            if (objects.empty()) {
+                break;
+            }
+            auto restored = restore_chunk(objects);
+            if (!restored) {
+                return restored;
             }
         }
     }
@@ -3371,31 +3482,6 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
     standby_allocator_keepalive_ = std::move(restored_allocators);
     invalid_replica_endpoints_ = std::move(restored_invalid_endpoints);
 
-    const auto now = std::chrono::system_clock::now();
-    for (auto& [shard_idx, shard_objects] : objects_by_shard) {
-        MetadataShardAccessorRW shard(this, shard_idx);
-        for (auto& object : shard_objects) {
-            const auto& standby_meta = object.entry->metadata;
-            auto& tenant_state =
-                GetOrCreateTenantState(shard.get(), object.tenant_id);
-            auto [it, inserted] = tenant_state.metadata.emplace(
-                std::piecewise_construct,
-                std::forward_as_tuple(object.user_key),
-                std::forward_as_tuple(
-                    standby_meta.client_id, now, standby_meta.size,
-                    std::move(object.replicas), std::nullopt,
-                    standby_meta.hard_pinned.value_or(false),
-                    standby_meta.data_type, standby_meta.group_id,
-                    object.tenant_id, object.user_key));
-            (void)inserted;
-            if (!standby_meta.group_id.empty()) {
-                it->second.lease_ = RegisterGroupMember(
-                    object.tenant_id, object.user_key, standby_meta.group_id);
-            }
-            tenant_state.processing_keys.erase(object.user_key);
-        }
-    }
-
     if (max_live_id != 0) {
         const ReplicaID desired_next_id = max_live_id + 1;
         ReplicaID current_next_id = Replica::next_id_.load();
@@ -3409,8 +3495,8 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbySnapshot(
         RebuildTenantQuotaUsageFromMetadata();
     }
 
-    LOG(INFO) << "Restored from standby: " << objects.size() << " objects, "
-              << segments.size()
+    LOG(INFO) << "Restored from standby: " << restored_object_count
+              << " objects, " << segments.size()
               << " segments, initial_seq_id=" << initial_oplog_sequence_id
               << ", invalid_endpoints=" << invalid_replica_endpoints_.size();
     return {};

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -3237,8 +3237,14 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
         std::string user_key;
         std::vector<Replica> replicas;
     };
+    const bool bounded_restore = metadata_store != nullptr;
+    // Batch restore spans chunks, so it needs an ordered cross-chunk index;
+    // legacy restore keeps its contiguous vector-and-sort validation path.
+    std::unordered_map<const StandbySegmentInfo*,
+                       std::vector<std::pair<uintptr_t, uint64_t>>>
+        legacy_memory_ranges;
     std::unordered_map<const StandbySegmentInfo*, std::map<uintptr_t, uint64_t>>
-        memory_ranges;
+        bounded_memory_ranges;
     std::unordered_map<std::string, uint64_t> restored_accounted_memory_bytes;
     size_t restored_object_count = 0;
 
@@ -3322,22 +3328,30 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
                             return tl::make_unexpected(
                                 ErrorCode::INVALID_PARAMS);
                         }
-                        auto& ranges = memory_ranges[segment];
-                        auto next = ranges.lower_bound(buffer.buffer_address_);
-                        const uintptr_t end =
-                            buffer.buffer_address_ + buffer.size_;
-                        if ((next != ranges.end() && end > next->first) ||
-                            (next != ranges.begin() &&
-                             std::prev(next)->first + std::prev(next)->second >
-                                 buffer.buffer_address_)) {
-                            LOG(ERROR)
-                                << "RestoreFromStandbySnapshot: overlapping "
-                                   "memory descriptors";
-                            return tl::make_unexpected(
-                                ErrorCode::INVALID_PARAMS);
+                        if (bounded_restore) {
+                            auto& ranges = bounded_memory_ranges[segment];
+                            auto next =
+                                ranges.lower_bound(buffer.buffer_address_);
+                            const uintptr_t end =
+                                buffer.buffer_address_ + buffer.size_;
+                            if ((next != ranges.end() && end > next->first) ||
+                                (next != ranges.begin() &&
+                                 std::prev(next)->first +
+                                         std::prev(next)->second >
+                                     buffer.buffer_address_)) {
+                                LOG(ERROR) << "RestoreFromStandbySnapshot: "
+                                              "overlapping "
+                                              "memory descriptors";
+                                return tl::make_unexpected(
+                                    ErrorCode::INVALID_PARAMS);
+                            }
+                            ranges.emplace(buffer.buffer_address_,
+                                           buffer.size_);
+                        } else {
+                            legacy_memory_ranges[segment].emplace_back(
+                                buffer.buffer_address_, buffer.size_);
                         }
                         bytes += buffer.size_;
-                        ranges.emplace(buffer.buffer_address_, buffer.size_);
                     }
 
                     auto alloc =
@@ -3414,6 +3428,22 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
                     tenant->second.metadata.contains(object.user_key)) {
                     return tl::make_unexpected(
                         ErrorCode::OBJECT_ALREADY_EXISTS);
+                }
+            }
+        }
+
+        if (!bounded_restore) {
+            for (auto& [segment, ranges] : legacy_memory_ranges) {
+                (void)segment;
+                std::sort(ranges.begin(), ranges.end());
+                for (size_t i = 1; i < ranges.size(); ++i) {
+                    if (ranges[i].first <
+                        ranges[i - 1].first + ranges[i - 1].second) {
+                        LOG(ERROR)
+                            << "RestoreFromStandbySnapshot: overlapping memory "
+                               "descriptors";
+                        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
+                    }
                 }
             }
         }

--- a/mooncake-store/src/rpc_service.cpp
+++ b/mooncake-store/src/rpc_service.cpp
@@ -1729,6 +1729,13 @@ tl::expected<void, ErrorCode> WrappedMasterService::RestoreFromStandby(
         objects, initial_oplog_sequence_id, segments);
 }
 
+tl::expected<void, ErrorCode>
+WrappedMasterService::RestoreFromBatchOpLogPromotion(
+    BatchOpLogPromotionHandoff handoff, size_t chunk_object_count) {
+    return master_service_.RestoreFromBatchOpLogPromotion(std::move(handoff),
+                                                          chunk_object_count);
+}
+
 void RegisterRpcService(
     coro_rpc::coro_rpc_server& server,
     mooncake::WrappedMasterService& wrapped_master_service) {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -196,6 +196,8 @@ add_ha_test(batch_oplog_snapshot_publisher_test
             ha/snapshot/batch_oplog/publisher_test.cpp)
 add_ha_test(batch_oplog_snapshot_coordinator_test
             ha/snapshot/batch_oplog/coordinator_test.cpp)
+add_ha_test(batch_oplog_snapshot_promotion_test
+            ha/snapshot/batch_oplog/promotion_test.cpp)
 add_store_test(master_service_test_for_snapshot
                ha/snapshot/master_service_test_for_snapshot.cpp)
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -703,6 +703,16 @@ class MasterServiceHATest : public ::testing::Test {
         return descriptors;
     }
 
+    static bool HasMetadataEntryForTesting(MasterService& service,
+                                           const TenantId& tenant_id,
+                                           const std::string& key) {
+        const auto shard_idx = service.getShardIndex(tenant_id, key);
+        MasterService::MetadataShardAccessorRO shard(&service, shard_idx);
+        auto tenant = shard->tenants.find(tenant_id);
+        return tenant != shard->tenants.end() &&
+               tenant->second.metadata.contains(key);
+    }
+
     static bool HasInvalidMemoryHandleForTesting(MasterService& service,
                                                  const TenantId& tenant_id,
                                                  const std::string& key) {
@@ -1035,6 +1045,82 @@ TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesReplicaIds) {
         ReplicaDescriptorsForTesting(service, kDefaultTenant, new_key);
     ASSERT_EQ(new_replicas.size(), 1);
     EXPECT_GE(new_replicas.front().id, 43);
+}
+
+TEST_F(MasterServiceHATest, BatchPromotionDrainsMultipleChunksAndPreservesIds) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+    const std::string endpoint = "batch_promotion_segment";
+
+    auto first = MakeStandbyObject("batch_promotion_first", endpoint);
+    first.metadata.replicas.front().id = 41;
+    first.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+    auto second = MakeStandbyObject("batch_promotion_second", endpoint);
+    second.tenant_id = "batch-promotion-tenant";
+    second.metadata.replicas.front().id = 42;
+    second.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase + 4096;
+
+    auto source = std::make_unique<StandbyMetadataStore>();
+    ASSERT_TRUE(
+        source->PutMetadata(first.tenant_id, first.key, first.metadata));
+    ASSERT_TRUE(
+        source->PutMetadata(second.tenant_id, second.key, second.metadata));
+    BatchOpLogPromotionHandoff handoff;
+    handoff.metadata_store = std::move(source);
+    handoff.segments = {MakeStandbyMemorySegment(endpoint)};
+    handoff.applied_cursor = {.batch_id = 7, .last_seq = 7};
+    handoff.max_replica_id = 42;
+
+    ASSERT_TRUE(service.RestoreFromBatchOpLogPromotion(std::move(handoff), 1)
+                    .has_value());
+    auto first_descriptors =
+        ReplicaDescriptorsForTesting(service, kDefaultTenant, first.key);
+    auto second_descriptors = ReplicaDescriptorsForTesting(
+        service, TenantId(second.tenant_id), second.key);
+    ASSERT_EQ(first_descriptors.size(), 1);
+    ASSERT_EQ(second_descriptors.size(), 1);
+    EXPECT_EQ(first_descriptors.front().id, 41);
+    EXPECT_EQ(second_descriptors.front().id, 42);
+}
+
+TEST_F(MasterServiceHATest, BatchPromotionRejectsCrossChunkOverlap) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+    const std::string endpoint = "batch_promotion_overlap_segment";
+    auto first = MakeStandbyObject("batch_promotion_overlap_first", endpoint);
+    first.metadata.replicas.front().id = 51;
+    first.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+    auto second = MakeStandbyObject("batch_promotion_overlap_second", endpoint);
+    second.metadata.replicas.front().id = 52;
+    second.metadata.replicas.front()
+        .get_memory_descriptor()
+        .buffer_descriptor.buffer_address_ = kDefaultSegmentBase;
+
+    auto source = std::make_unique<StandbyMetadataStore>();
+    ASSERT_TRUE(
+        source->PutMetadata(first.tenant_id, first.key, first.metadata));
+    ASSERT_TRUE(
+        source->PutMetadata(second.tenant_id, second.key, second.metadata));
+    BatchOpLogPromotionHandoff handoff;
+    handoff.metadata_store = std::move(source);
+    handoff.segments = {MakeStandbyMemorySegment(endpoint)};
+    handoff.applied_cursor = {.batch_id = 7, .last_seq = 7};
+    handoff.max_replica_id = 52;
+
+    auto result = service.RestoreFromBatchOpLogPromotion(std::move(handoff), 1);
+
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(ErrorCode::INVALID_PARAMS, result.error());
+    EXPECT_EQ(
+        HasMetadataEntryForTesting(service, kDefaultTenant, first.key) +
+            HasMetadataEntryForTesting(service, kDefaultTenant, second.key),
+        1);
 }
 
 TEST_F(MasterServiceHATest, RestoreRejectsInvalidReplicaIds) {

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
@@ -68,10 +68,11 @@ class MemoryBackend final : public HaKvBackend {
 
 std::unique_ptr<HotStandbyService> MakeBatchSnapshotStandby(
     const std::shared_ptr<MemoryBackend>& backend,
-    LocalFileSnapshotObjectStore& object_store) {
+    LocalFileSnapshotObjectStore& object_store,
+    bool enable_oplog_following = true) {
     HotStandbyConfig config;
     config.enable_snapshot_bootstrap = false;
-    config.enable_oplog_following = true;
+    config.enable_oplog_following = enable_oplog_following;
     config.enable_verification = false;
     config.oplog_poll_interval_ms = 1;
     config.batch_oplog_retry_timeout_sec = 0;
@@ -152,7 +153,7 @@ TEST(BatchOpLogPromotionTest, DetachesStoreWithFinalCursorAndProducerView) {
     EXPECT_FALSE(standby->ExportMetadataSnapshot(ignored));
 }
 
-TEST(BatchOpLogPromotionTest, MissingFinalCursorFailsBeforeDetach) {
+TEST(BatchOpLogPromotionTest, EmptyStoreWithoutDurablePrefixUsesZeroCursor) {
     auto backend = std::make_shared<MemoryBackend>();
     LocalFileSnapshotObjectStore object_store(
         "/tmp/mooncake-n07-promotion-missing-cursor");
@@ -161,11 +162,30 @@ TEST(BatchOpLogPromotionTest, MissingFinalCursorFailsBeforeDetach) {
 
     auto handoff = standby->PromoteAndDetachBatchOpLogStore();
 
-    ASSERT_FALSE(handoff.has_value());
-    EXPECT_EQ(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, handoff.error());
-    EXPECT_EQ(StandbyState::FAILED, standby->GetState());
+    ASSERT_TRUE(handoff.has_value());
+    EXPECT_EQ(DurablePrefix(), handoff->applied_cursor);
+    ASSERT_TRUE(handoff->metadata_store);
+    EXPECT_EQ(StandbyState::STOPPED, standby->GetState());
     std::vector<StandbyObjectEntry> retained;
-    EXPECT_TRUE(standby->ExportMetadataSnapshot(retained));
+    EXPECT_FALSE(standby->ExportMetadataSnapshot(retained));
+}
+
+TEST(BatchOpLogPromotionTest, SnapshotOnlyProviderFallsBackToLegacyExport) {
+    auto backend = std::make_shared<MemoryBackend>();
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n07-promotion-snapshot-only");
+    auto standby = MakeBatchSnapshotStandby(backend, object_store,
+                                            /*enable_oplog_following=*/false);
+    ASSERT_EQ(ErrorCode::OK, standby->Start("", "", "promotion-test"));
+
+    EXPECT_FALSE(standby->IsBatchOpLogSnapshotMode());
+    auto detach = standby->PromoteAndDetachBatchOpLogStore();
+    ASSERT_FALSE(detach.has_value());
+    EXPECT_EQ(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS, detach.error());
+    StandbySnapshot snapshot;
+    ASSERT_EQ(ErrorCode::OK, standby->PromoteAndExportSnapshot(snapshot));
+    EXPECT_EQ(0u, snapshot.oplog_sequence_id);
+    EXPECT_TRUE(snapshot.objects.empty());
 }
 
 TEST(BatchOpLogPromotionTest, EmptyStoreRestoresWithoutChunks) {

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
@@ -1,0 +1,182 @@
+#include "ha/snapshot/batch_oplog/promotion.h"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <mutex>
+#include <type_traits>
+
+#include "ha/kv/ha_kv_backend.h"
+#include "ha/oplog/oplog_batch_codec.h"
+#include "ha/oplog/oplog_batch_storage.h"
+#include "ha/snapshot/batch_oplog/batch_oplog_snapshot_provider.h"
+#include "ha/snapshot/object/backends/local/local_file_snapshot_object_store.h"
+#include "ha/standby_controller.h"
+#include "hot_standby_service.h"
+#include "master_service.h"
+
+namespace mooncake::test {
+namespace {
+
+class MemoryBackend final : public HaKvBackend {
+   public:
+    ErrorCode Get(std::string_view key, std::string& value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = values_.find(std::string(key));
+        if (it == values_.end()) {
+            return ErrorCode::ETCD_KEY_NOT_EXIST;
+        }
+        value = it->second;
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Put(std::string_view key, std::string_view value) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        values_[std::string(key)] = std::string(value);
+        return ErrorCode::OK;
+    }
+
+    ErrorCode Range(std::string_view begin, std::string_view end, size_t limit,
+                    std::vector<KvPair>& output) override {
+        std::lock_guard<std::mutex> lock(mutex_);
+        output.clear();
+        for (const auto& [key, value] : values_) {
+            if (key >= begin && key < end &&
+                (limit == 0 || output.size() < limit)) {
+                output.push_back({key, value});
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+    bool SupportsTxn() const override { return true; }
+
+    ErrorCode Txn(const KvTxn& txn) override {
+        for (const auto& put : txn.puts) {
+            auto error = Put(put.key, put.value);
+            if (error != ErrorCode::OK) {
+                return error;
+            }
+        }
+        return ErrorCode::OK;
+    }
+
+   private:
+    std::mutex mutex_;
+    std::map<std::string, std::string> values_;
+};
+
+std::unique_ptr<HotStandbyService> MakeBatchSnapshotStandby(
+    const std::shared_ptr<MemoryBackend>& backend,
+    LocalFileSnapshotObjectStore& object_store) {
+    HotStandbyConfig config;
+    config.enable_snapshot_bootstrap = false;
+    config.enable_oplog_following = true;
+    config.enable_verification = false;
+    config.oplog_poll_interval_ms = 1;
+    config.batch_oplog_retry_timeout_sec = 0;
+    auto standby = std::make_unique<HotStandbyService>(config);
+    standby->SetCatchUpBatchKvBackendForTesting(backend);
+    standby->SetBatchOpLogSnapshotProvider(
+        std::make_unique<BatchOpLogSnapshotProvider>(
+            "promotion-test", *backend, object_store, "snapshots"));
+    return standby;
+}
+
+StandbyObjectMetadata MakeMetadata(uint64_t size) {
+    StandbyObjectMetadata metadata;
+    metadata.size = size;
+    return metadata;
+}
+
+}  // namespace
+
+static_assert(std::is_move_constructible_v<BatchOpLogPromotionHandoff>);
+static_assert(!std::is_copy_constructible_v<BatchOpLogPromotionHandoff>);
+static_assert(std::is_move_constructible_v<ha::PromotionContext>);
+static_assert(!std::is_copy_constructible_v<ha::PromotionContext>);
+
+TEST(BatchOpLogPromotionTest, EmptyStoreHandoffIsMoveOnly) {
+    auto store = std::make_unique<StandbyMetadataStore>();
+    BatchOpLogPromotionHandoff handoff;
+    handoff.metadata_store = std::move(store);
+    handoff.applied_cursor = {.batch_id = 0, .last_seq = 0};
+
+    auto moved = std::move(handoff);
+    ASSERT_TRUE(moved.metadata_store);
+    EXPECT_EQ(0u, moved.metadata_store->GetKeyCount());
+
+    ha::PromotionContext context;
+    context.metadata_store = std::move(moved.metadata_store);
+    EXPECT_TRUE(context.metadata_store);
+}
+
+TEST(BatchOpLogPromotionTest, StoreDrainsBoundedChunksAcrossTenants) {
+    StandbyMetadataStore store;
+    ASSERT_TRUE(store.PutMetadata("tenant-a", "a1", MakeMetadata(1)));
+    ASSERT_TRUE(store.PutMetadata("tenant-a", "a2", MakeMetadata(2)));
+    ASSERT_TRUE(store.PutMetadata("tenant-b", "b1", MakeMetadata(3)));
+
+    std::vector<StandbyObjectEntry> chunk;
+    ASSERT_TRUE(store.DrainChunk(2, chunk));
+    EXPECT_EQ(2u, chunk.size());
+    EXPECT_EQ(1u, store.GetKeyCount());
+    ASSERT_TRUE(store.DrainChunk(2, chunk));
+    EXPECT_EQ(1u, chunk.size());
+    EXPECT_EQ(0u, store.GetKeyCount());
+    ASSERT_TRUE(store.DrainChunk(2, chunk));
+    EXPECT_TRUE(chunk.empty());
+    EXPECT_FALSE(store.DrainChunk(0, chunk));
+}
+
+TEST(BatchOpLogPromotionTest, DetachesStoreWithFinalCursorAndProducerView) {
+    auto backend = std::make_shared<MemoryBackend>();
+    ASSERT_EQ(
+        ErrorCode::OK,
+        backend->Put(BuildDurablePrefixKey("promotion-test"),
+                     EncodeDurablePrefix({.batch_id = 0, .last_seq = 0})));
+    ASSERT_EQ(ErrorCode::OK,
+              backend->Put(BuildProducerViewKey("promotion-test"), "7"));
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n07-promotion-success");
+    auto standby = MakeBatchSnapshotStandby(backend, object_store);
+    ASSERT_EQ(ErrorCode::OK, standby->Start("", "", "promotion-test"));
+
+    auto handoff = standby->PromoteAndDetachBatchOpLogStore();
+
+    ASSERT_TRUE(handoff.has_value());
+    ASSERT_TRUE(handoff->metadata_store);
+    EXPECT_EQ(DurablePrefix(), handoff->applied_cursor);
+    EXPECT_EQ(7, handoff->producer_view_version);
+    std::vector<StandbyObjectEntry> ignored;
+    EXPECT_FALSE(standby->ExportMetadataSnapshot(ignored));
+}
+
+TEST(BatchOpLogPromotionTest, MissingFinalCursorFailsBeforeDetach) {
+    auto backend = std::make_shared<MemoryBackend>();
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n07-promotion-missing-cursor");
+    auto standby = MakeBatchSnapshotStandby(backend, object_store);
+    ASSERT_EQ(ErrorCode::OK, standby->Start("", "", "promotion-test"));
+
+    auto handoff = standby->PromoteAndDetachBatchOpLogStore();
+
+    ASSERT_FALSE(handoff.has_value());
+    EXPECT_EQ(ErrorCode::INCOMPLETE_OPLOG_CATCH_UP, handoff.error());
+    EXPECT_EQ(StandbyState::FAILED, standby->GetState());
+    std::vector<StandbyObjectEntry> retained;
+    EXPECT_TRUE(standby->ExportMetadataSnapshot(retained));
+}
+
+TEST(BatchOpLogPromotionTest, EmptyStoreRestoresWithoutChunks) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+    BatchOpLogPromotionHandoff handoff;
+    handoff.metadata_store = std::make_unique<StandbyMetadataStore>();
+    handoff.applied_cursor = {.batch_id = 0, .last_seq = 0};
+
+    EXPECT_TRUE(service.RestoreFromBatchOpLogPromotion(std::move(handoff), 1)
+                    .has_value());
+}
+
+}  // namespace mooncake::test

--- a/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
+++ b/mooncake-store/tests/ha/snapshot/batch_oplog/promotion_test.cpp
@@ -188,6 +188,19 @@ TEST(BatchOpLogPromotionTest, SnapshotOnlyProviderFallsBackToLegacyExport) {
     EXPECT_TRUE(snapshot.objects.empty());
 }
 
+TEST(BatchOpLogPromotionTest, RecreatesStoreAfterBatchDetachOnRestart) {
+    auto backend = std::make_shared<MemoryBackend>();
+    LocalFileSnapshotObjectStore object_store(
+        "/tmp/mooncake-n07-promotion-restart");
+    auto standby = MakeBatchSnapshotStandby(backend, object_store);
+    ASSERT_EQ(ErrorCode::OK, standby->Start("", "", "promotion-test"));
+    ASSERT_TRUE(standby->PromoteAndDetachBatchOpLogStore().has_value());
+
+    ASSERT_EQ(ErrorCode::OK, standby->Start("", "", "promotion-test"));
+    EXPECT_EQ(StandbyState::WATCHING, standby->GetState());
+    EXPECT_EQ(0u, standby->GetMetadataCount());
+}
+
 TEST(BatchOpLogPromotionTest, EmptyStoreRestoresWithoutChunks) {
     MasterService service(
         MasterServiceConfig::builder().set_enable_ha(false).build());

--- a/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
+++ b/mooncake-store/tests/ha/standby/hot_standby_service_test.cpp
@@ -1013,6 +1013,8 @@ TEST_F(PromotionCatchUpTest, PaginatesBatchRecords) {
             batch_backend->Put(BuildBatchRecordKey(cluster_id_, id),
                                EncodeOpLogBatchRecord(MakeBatch(id, id, id))));
     }
+    config_.batch_oplog_retry_timeout_sec = 0;
+    service_ = std::make_unique<HotStandbyService>(config_);
     service_->SetCatchUpBatchKvBackendForTesting(batch_backend);
 
     auto err = service_->Start("", oplog_endpoints_, cluster_id_);


### PR DESCRIPTION
## Description

Depends on #3811.

Implement PR-N07 bounded standby promotion for the batch-OpLog snapshot path:

- move the complete `StandbyMetadataStore` into a move-only promotion context instead of exporting a second full object vector;
- carry the applied batch/sequence cursor, producer view, segments, and maximum live `ReplicaID` through the handoff;
- drain and install primary metadata in bounded object chunks while preserving cross-chunk validation and allocator accounting;
- use `batch_oplog_retry_timeout_sec` as a no-progress timeout during final catch-up instead of a fixed 30-second total deadline;
- keep the legacy snapshot vector path unchanged and keep RPC registration behind the complete restore gate.

GitHub cannot use `dev/oplog-ha-prs/I00` as the upstream base because that branch exists only in the contributor fork. #3811 is now merged into `main`; this branch has been rebased onto the resulting `main` and is N07-only. The N07 commit is [d3d418584](https://github.com/Icedcoco/Mooncake/commit/d3d418584c57538735b3fba89cb02a4c63fb5584).

#3806 also edits `RestoreFromStandbySnapshot`, but for different semantics: it tolerates and discards malformed objects. This PR bounds ownership and conversion memory while retaining the current R01 fail-closed behavior. If #3806 lands first, the shared restore implementation will need a semantic rebase rather than duplicating either path.

## Module

- [x] Mooncake Store (`mooncake-store`)

## Type of Change

- [x] New feature
- [x] Performance improvement

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build /tmp/mooncake-n07-build --target hot_standby_service_test hot_standby_snapshot_bootstrap_test standby_metadata_store_test batch_oplog_snapshot_provider_test batch_oplog_snapshot_promotion_test master_service_ha_test batch_oplog_promotion_bench -j8
ctest --test-dir /tmp/mooncake-n07-build --output-on-failure -R '(^hot_standby_service_test$|^hot_standby_snapshot_bootstrap_test$|^standby_metadata_store_test$|^batch_oplog_snapshot_provider_test$|^batch_oplog_snapshot_promotion_test$|^master_service_ha_test$)'
/tmp/mooncake-n07-build/mooncake-store/benchmarks/batch_oplog_promotion_bench --objects=10000 --chunk_objects=128
```

The build used `STORE_USE_ETCD=ON` so the final catch-up tests were compiled.

**Test results:**
- [x] Six related test targets passed, including the complete `master_service_ha_test` suite
- [x] Snapshot-only provider fallback and empty batch namespace promotion regressions passed
- [x] Eight `PromotionCatchUpTest` cases passed
- [x] Synthetic 10,000-object promotion completed in 108 ms with 70.9 MB peak RSS in this debug build
- [x] C++ formatting, whitespace, conflict, large-file, spelling, and CMake formatting hooks passed; unrelated pre-existing CMake reformatting was left out per `AGENTS.md`

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have formatted my code using the project formatter
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass (see the scoped CMake note above)
- [x] Documentation update is not applicable; N08 owns configuration and production wiring
- [x] I have added tests to prove my changes are effective
- [x] RFC #3167 covers this change

## AI Assistance Disclosure

- [x] AI tools were used (Codex implemented the change, tests, benchmark, and local verification)

The human submitter must review every changed line and be able to defend the change end-to-end before merge.

