### PR TITLE
[Store] Assert HA restore state from domain state, not metrics

### DIFF
--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -804,6 +804,22 @@ class MasterServiceHATest : public ::testing::Test {
                    : allocators->front()->size();
     }
 
+    // Bytes held by replicas that were restored from a standby snapshot but
+    // whose segment is not mounted yet. Those replicas hang off
+    // DummyBufferAllocator, which is never attached to the segment usage
+    // tracker, so they are invisible to SegmentAllocatedSizeForTesting until
+    // ReMountSegment hands them over to a real allocator.
+    static uint64_t StandbyAccountedBytesForTesting(
+        const MasterService& service) {
+        uint64_t total = 0;
+        for (const auto& [segment, bytes] :
+             service.standby_accounted_memory_bytes_) {
+            (void)segment;
+            total += bytes;
+        }
+        return total;
+    }
+
     static void EraseObjectForTesting(MasterService& service,
                                       const TenantId& tenant_id,
                                       const std::string& key) {
@@ -1022,8 +1038,8 @@ TEST_F(MasterServiceHATest, RestoreFailureKeepsExistingState) {
                     .RestoreFromStandbySnapshot(
                         {existing}, 7, {MakeStandbyMemorySegment(endpoint)})
                     .has_value());
-    const auto metric_after_restore =
-        MasterMetricManager::instance().get_allocated_mem_size();
+    const auto accounted_after_restore =
+        StandbyAccountedBytesForTesting(service);
 
     auto invalid =
         MakeStandbyObject("standby_restore_invalid", "unknown_endpoint");
@@ -1038,8 +1054,8 @@ TEST_F(MasterServiceHATest, RestoreFailureKeepsExistingState) {
     EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant,
                                      "standby_restore_invalid"),
               0);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size(),
-              metric_after_restore);
+    EXPECT_EQ(StandbyAccountedBytesForTesting(service),
+              accounted_after_restore);
     ASSERT_TRUE(service.ReMountSegment({MakeSegment(endpoint)}, generate_uuid())
                     .has_value());
 }
@@ -1378,8 +1394,6 @@ TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
         MasterServiceConfig::builder().set_enable_ha(false).build());
 
     const std::string endpoint = "standby_remount_segment";
-    const auto metric_before =
-        MasterMetricManager::instance().get_allocated_mem_size();
     const std::string first_key = "standby_remount_first_key";
     const std::string second_key = "standby_remount_second_key";
     auto first_object = MakeStandbyObject(first_key, endpoint);
@@ -1395,9 +1409,7 @@ TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
             .RestoreFromStandbySnapshot({first_object, second_object}, 7,
                                         {MakeStandbyMemorySegment(endpoint)})
             .has_value());
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              2048);
+    EXPECT_EQ(StandbyAccountedBytesForTesting(service), 2048);
 
     auto before = service.GetReplicaList(first_key, kDefaultTenant);
     ASSERT_FALSE(before.has_value());
@@ -1437,9 +1449,8 @@ TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
                   .buffer_descriptor.buffer_address_,
               kDefaultSegmentBase + 4096);
     EXPECT_EQ(SegmentAllocatedSizeForTesting(service, endpoint), 2048);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              2048);
+    // The remount handed every restored byte over to the real allocator.
+    EXPECT_EQ(StandbyAccountedBytesForTesting(service), 0);
 
     const std::string new_key = "post_remount_allocation";
     PutObjectOnSegment(service, generate_uuid(), new_key, endpoint);
@@ -1450,14 +1461,10 @@ TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
                   .get_memory_descriptor()
                   .buffer_descriptor.buffer_address_,
               kDefaultSegmentBase + 1024);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              3072);
+    EXPECT_EQ(SegmentAllocatedSizeForTesting(service, endpoint), 3072);
 
     EraseObjectForTesting(service, kDefaultTenant, first_key);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              2048);
+    EXPECT_EQ(SegmentAllocatedSizeForTesting(service, endpoint), 2048);
     const std::string replacement_key = "post_remount_replacement";
     PutObjectOnSegment(service, generate_uuid(), replacement_key, endpoint);
     auto replacement =
@@ -1467,9 +1474,7 @@ TEST_F(MasterServiceHATest, RemountMakesRestoredMemoryReplicaReady) {
                   .get_memory_descriptor()
                   .buffer_descriptor.buffer_address_,
               kDefaultSegmentBase);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              3072);
+    EXPECT_EQ(SegmentAllocatedSizeForTesting(service, endpoint), 3072);
 }
 
 TEST_F(MasterServiceHATest, RemountRestoresCachelibMemoryReplica) {
@@ -1480,8 +1485,6 @@ TEST_F(MasterServiceHATest, RemountRestoresCachelibMemoryReplica) {
             .build());
 
     const std::string endpoint = "standby_cachelib_remount_segment";
-    const auto metric_before =
-        MasterMetricManager::instance().get_allocated_mem_size();
     const std::string key = "standby_cachelib_remount_key";
     auto object = MakeStandbyObject(key, endpoint, 64);
     object.metadata.replicas.front()
@@ -1494,9 +1497,7 @@ TEST_F(MasterServiceHATest, RemountRestoresCachelibMemoryReplica) {
                     .RestoreFromStandbySnapshot(
                         {object}, 7, {MakeStandbyMemorySegment(endpoint)})
                     .has_value());
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              64);
+    EXPECT_EQ(StandbyAccountedBytesForTesting(service), 64);
 
     auto single_before = service.GetReplicaList(key, kDefaultTenant);
     ASSERT_FALSE(single_before.has_value());
@@ -1519,9 +1520,8 @@ TEST_F(MasterServiceHATest, RemountRestoresCachelibMemoryReplica) {
                   .buffer_descriptor.protocol_,
               "rdma");
     EXPECT_EQ(SegmentAllocatedSizeForTesting(service, endpoint), 64);
-    EXPECT_EQ(MasterMetricManager::instance().get_allocated_mem_size() -
-                  metric_before,
-              64);
+    // The remount handed every restored byte over to the real allocator.
+    EXPECT_EQ(StandbyAccountedBytesForTesting(service), 0);
 
     PutObjectOnSegment(service, generate_uuid(), "cachelib_after_remount",
                        endpoint, 64);


### PR DESCRIPTION
## Description

The standby restore and remount tests in `master_service_ha_test.cpp` read
`master_allocated_mem_size` to verify how many bytes each step accounted for.
That makes an observability gauge the oracle for business state, which
[RFC #3158](https://github.com/kvcache-ai/Mooncake/issues/3158) explicitly
rules out, and it pins the tests to the legacy incremental metric writes
rather than to the authoritative state those writes describe.

This replaces all 11 such assertions with assertions on the authoritative
owners. The gauge is the sum of two distinct things, and the tests were
conflating them:

- Bytes restored from a standby snapshot live in
  `MasterService::standby_accounted_memory_bytes_` until `ReMountSegment`
  hands them to a real allocator. Before the remount these replicas hang off
  `DummyBufferAllocator`, which is never attached to the segment usage
  tracker, so they are invisible to the allocator-side view.
- Bytes owned by a mounted segment live in that segment's allocator, already
  reachable via the existing `SegmentAllocatedSizeForTesting` helper.

Splitting the assertions along that boundary also lets each remount test
state that the handoff drained the standby ledger
(`StandbyAccountedBytesForTesting(service) == 0`), which the single aggregate
gauge could not express.

This is a prerequisite for removing the legacy DRAM gauge writers: those
tests would otherwise be the only thing keeping the incremental writes alive.

No production code and no production behavior changes.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

Test-only change, scoped to `master_service_ha_test.cpp`. The affected tests
are `RestoreFailureKeepsExistingState`,
`RemountMakesRestoredMemoryReplicaReady` and
`RemountRestoresCachelibMemoryReplica`.

**Test commands:**
```bash
bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Not yet verified locally: the development machine has no cmake,
clang-format or pre-commit available, so this branch has not been compiled,
run or formatted locally and relies on PR CI for all of that. Every added
line was checked by hand against the 80-column limit.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor was used to locate the gauge-based assertions, trace the standby
accounting lifecycle through `RestoreFromStandbySnapshot` and
`ReMountSegment`, and draft the replacement assertions.

Made with [Cursor](https://cursor.com)