### PR TITLE
[Store] Make NoF storage gauges projection-only

### DIFF
--- a/mooncake-store/include/master_metric_manager.h
+++ b/mooncake-store/include/master_metric_manager.h
@@ -50,14 +50,6 @@ class MasterMetricManager {
     void inc_valid_get_nums(int64_t val = 1);
     void inc_total_get_nums(int64_t val = 1);
 
-    // NoF segment Metrics
-    void inc_allocated_nof_size(const std::string& segment, int64_t val = 1);
-    void dec_allocated_nof_size(const std::string& segment, int64_t val = 1);
-    void reset_allocated_nof_size();
-    void inc_total_nof_capacity(const std::string& segment, int64_t val = 1);
-    void dec_total_nof_capacity(const std::string& segment, int64_t val = 1);
-    void reset_total_nof_capacity();
-
     /**
      * @brief Refresh storage gauges from authoritative allocator snapshots.
      *
@@ -102,13 +94,12 @@ class MasterMetricManager {
     // followed by client expiry / reaper cleanup).
     void remove_segment_metrics(const std::string& segment);
 
-    // NoF segment Metrics
+    // NoF segment Metrics. Write-only from project_storage_usage(); business
+    // code reads NoFSegmentManager::GetUsage() instead.
     int64_t get_allocated_nof_size();
     int64_t get_total_nof_capacity();
     int64_t get_segment_allocated_nof_size(const std::string& segment);
     int64_t get_segment_total_nof_capacity(const std::string& segment);
-    // Remove all per-segment NoF metric labels for the given segment.
-    void remove_nof_segment_metrics(const std::string& segment);
 
     // File Storage Metrics
     void inc_allocated_file_size(int64_t val = 1);

--- a/mooncake-store/include/segment.h
+++ b/mooncake-store/include/segment.h
@@ -264,15 +264,13 @@ class ScopedNoFSegmentAccess {
     /**
      * @brief Prepare to unmount a segment by deleting its allocator
      */
-    ErrorCode PrepareUnmountSegment(const UUID& segment_id,
-                                    size_t& metrics_dec_capacity);
+    ErrorCode PrepareUnmountSegment(const UUID& segment_id);
 
     /**
      * @brief Deleting the segment to complete the unmounting operation
      */
     ErrorCode CommitUnmountSegment(const UUID& segment_id,
-                                   const UUID& client_id,
-                                   const size_t& metrics_dec_capacity);
+                                   const UUID& client_id);
 
     /**
      * @brief Get all the segments of a client

--- a/mooncake-store/src/allocator.cpp
+++ b/mooncake-store/src/allocator.cpp
@@ -219,9 +219,6 @@ CachelibBufferAllocator::~CachelibBufferAllocator() {
     if (replica_type_ == ReplicaType::MEMORY) {
         MasterMetricManager::instance().dec_allocated_mem_size(segment_name_,
                                                                size());
-    } else if (replica_type_ == ReplicaType::NOF_SSD) {
-        MasterMetricManager::instance().dec_allocated_nof_size(segment_name_,
-                                                               size());
     }
 };
 
@@ -251,9 +248,6 @@ std::unique_ptr<AllocatedBuffer> CachelibBufferAllocator::allocate(
     if (replica_type_ == ReplicaType::MEMORY) {
         MasterMetricManager::instance().inc_allocated_mem_size(segment_name_,
                                                                size);
-    } else if (replica_type_ == ReplicaType::NOF_SSD) {
-        MasterMetricManager::instance().inc_allocated_nof_size(segment_name_,
-                                                               size);
     }
     return std::make_unique<AllocatedBuffer>(shared_from_this(), buffer, size);
 }
@@ -271,9 +265,6 @@ void CachelibBufferAllocator::deallocate(AllocatedBuffer* handle) {
         if (replica_type_ == ReplicaType::MEMORY) {
             MasterMetricManager::instance().dec_allocated_mem_size(
                 segment_name_, freed_size);
-        } else if (replica_type_ == ReplicaType::NOF_SSD) {
-            MasterMetricManager::instance().dec_allocated_nof_size(
-                segment_name_, freed_size);
         }
         VLOG(1) << "deallocation_succeeded address=" << handle->buffer_ptr_
                 << " size=" << freed_size << " segment=" << segment_name_;
@@ -289,9 +280,6 @@ std::unique_ptr<AllocatedBuffer> CachelibBufferAllocator::adoptImportedBuffer(
     RecordAllocation(allocation.requested_size);
     if (replica_type_ == ReplicaType::MEMORY) {
         MasterMetricManager::instance().inc_allocated_mem_size(
-            segment_name_, allocation.requested_size);
-    } else if (replica_type_ == ReplicaType::NOF_SSD) {
-        MasterMetricManager::instance().inc_allocated_nof_size(
             segment_name_, allocation.requested_size);
     }
     return std::make_unique<AllocatedBuffer>(
@@ -388,9 +376,6 @@ OffsetBufferAllocator::~OffsetBufferAllocator() {
     if (replica_type_ == ReplicaType::MEMORY) {
         MasterMetricManager::instance().dec_allocated_mem_size(segment_name_,
                                                                size());
-    } else if (replica_type_ == ReplicaType::NOF_SSD) {
-        MasterMetricManager::instance().dec_allocated_nof_size(segment_name_,
-                                                               size());
     }
 };
 
@@ -432,9 +417,6 @@ std::unique_ptr<AllocatedBuffer> OffsetBufferAllocator::allocate(size_t size) {
     if (replica_type_ == ReplicaType::MEMORY) {
         MasterMetricManager::instance().inc_allocated_mem_size(segment_name_,
                                                                size);
-    } else if (replica_type_ == ReplicaType::NOF_SSD) {
-        MasterMetricManager::instance().inc_allocated_nof_size(segment_name_,
-                                                               size);
     }
     return allocated_buffer;
 }
@@ -448,9 +430,6 @@ void OffsetBufferAllocator::deallocate(AllocatedBuffer* handle) {
         RecordDeallocation(freed_size);
         if (replica_type_ == ReplicaType::MEMORY) {
             MasterMetricManager::instance().dec_allocated_mem_size(
-                segment_name_, freed_size);
-        } else if (replica_type_ == ReplicaType::NOF_SSD) {
-            MasterMetricManager::instance().dec_allocated_nof_size(
                 segment_name_, freed_size);
         }
         VLOG(1) << "deallocation_succeeded address=" << handle->data()

--- a/mooncake-store/src/master_metric_manager.cpp
+++ b/mooncake-store/src/master_metric_manager.cpp
@@ -718,38 +718,6 @@ void MasterMetricManager::remove_segment_metrics(const std::string& segment) {
 }
 
 // NoF segment Metrics
-void MasterMetricManager::inc_allocated_nof_size(const std::string& segment,
-                                                 int64_t val) {
-    nof_allocated_size_.inc(val);
-    if (!segment.empty()) nof_allocated_size_per_segment_.inc({segment}, val);
-}
-
-void MasterMetricManager::dec_allocated_nof_size(const std::string& segment,
-                                                 int64_t val) {
-    nof_allocated_size_.dec(val);
-    if (!segment.empty()) nof_allocated_size_per_segment_.dec({segment}, val);
-}
-
-void MasterMetricManager::reset_allocated_nof_size() {
-    nof_allocated_size_.reset();
-}
-
-void MasterMetricManager::inc_total_nof_capacity(const std::string& segment,
-                                                 int64_t val) {
-    nof_total_capacity_.inc(val);
-    if (!segment.empty()) nof_total_capacity_per_segment_.inc({segment}, val);
-}
-
-void MasterMetricManager::dec_total_nof_capacity(const std::string& segment,
-                                                 int64_t val) {
-    nof_total_capacity_.dec(val);
-    if (!segment.empty()) nof_total_capacity_per_segment_.dec({segment}, val);
-}
-
-void MasterMetricManager::reset_total_nof_capacity() {
-    nof_total_capacity_.reset();
-}
-
 int64_t MasterMetricManager::get_allocated_nof_size() {
     return nof_allocated_size_.value();
 }
@@ -806,12 +774,6 @@ int64_t MasterMetricManager::get_segment_allocated_nof_size(
 int64_t MasterMetricManager::get_segment_total_nof_capacity(
     const std::string& segment) {
     return nof_total_capacity_per_segment_.value({segment});
-}
-
-void MasterMetricManager::remove_nof_segment_metrics(
-    const std::string& segment) {
-    nof_allocated_size_per_segment_.remove_label_value({{"segment", segment}});
-    nof_total_capacity_per_segment_.remove_label_value({{"segment", segment}});
 }
 
 // File Storage Metrics

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -2857,8 +2857,6 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
                << ", error=nof_pool_disabled";
     return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
 #else
-    size_t metrics_dec_capacity = 0;  // to update the metrics
-
     std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
     std::shared_lock<std::shared_mutex> shared_lock(snapshot_mutex_);
     auto alive_clients = ok_client_;
@@ -2868,8 +2866,7 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
     {
         ScopedNoFSegmentAccess segment_access =
             nof_segment_manager_.getNoFSegmentAccess();
-        ErrorCode err = segment_access.PrepareUnmountSegment(
-            segment_id, metrics_dec_capacity);
+        ErrorCode err = segment_access.PrepareUnmountSegment(segment_id);
         if (err == ErrorCode::SEGMENT_NOT_FOUND) {
             // Return OK because this is an idempotent operation
             return {};
@@ -2886,8 +2883,7 @@ auto MasterService::UnmountNoFSegment(const UUID& segment_id,
     // 3. Commit the unmount operation
     ScopedNoFSegmentAccess segment_access =
         nof_segment_manager_.getNoFSegmentAccess();
-    auto err = segment_access.CommitUnmountSegment(segment_id, client_id,
-                                                   metrics_dec_capacity);
+    auto err = segment_access.CommitUnmountSegment(segment_id, client_id);
     if (err != ErrorCode::OK) {
         return tl::make_unexpected(err);
     }
@@ -11282,15 +11278,14 @@ bool MasterService::ProbeNoFSegment(const std::string& te_endpoint,
 bool MasterService::TryUnmountNoFSegmentByHeartbeat(
     const MountedNoFSegmentSnapshot& snapshot,
     const std::string& error_reason) {
-    size_t metrics_dec_capacity = 0;
     std::shared_lock<std::shared_mutex> client_lock(client_mutex_);
     std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
     auto alive_clients = ok_client_;
     client_lock.unlock();
     {
         auto nof_segment_access = nof_segment_manager_.getNoFSegmentAccess();
-        ErrorCode err = nof_segment_access.PrepareUnmountSegment(
-            snapshot.segment_id, metrics_dec_capacity);
+        ErrorCode err =
+            nof_segment_access.PrepareUnmountSegment(snapshot.segment_id);
         if (err == ErrorCode::SEGMENT_NOT_FOUND ||
             err == ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS) {
             std::lock_guard<std::mutex> lock(nof_heartbeat_mutex_);
@@ -11315,7 +11310,7 @@ bool MasterService::TryUnmountNoFSegmentByHeartbeat(
     {
         auto nof_segment_access = nof_segment_manager_.getNoFSegmentAccess();
         ErrorCode err = nof_segment_access.CommitUnmountSegment(
-            snapshot.segment_id, snapshot.client_id, metrics_dec_capacity);
+            snapshot.segment_id, snapshot.client_id);
         if (err != ErrorCode::OK && err != ErrorCode::SEGMENT_NOT_FOUND) {
             LOG(ERROR) << "segment_id=" << snapshot.segment_id
                        << ", segment_name=" << snapshot.segment.name

--- a/mooncake-store/src/segment.cpp
+++ b/mooncake-store/src/segment.cpp
@@ -1212,7 +1212,6 @@ ErrorCode ScopedNoFSegmentAccess::MountSegment(const NoFSegment& segment,
     nof_segment_manager_->mounted_segments_[segment.id] = {
         segment, client_id, SegmentStatus::OK, std::move(allocator)};
     nof_segment_manager_->client_by_name_[segment.name] = client_id;
-    MasterMetricManager::instance().inc_total_nof_capacity(segment.name, size);
 
     return ErrorCode::OK;
 }
@@ -1243,7 +1242,7 @@ ErrorCode ScopedNoFSegmentAccess::ReMountSegment(
 }
 
 ErrorCode ScopedNoFSegmentAccess::PrepareUnmountSegment(
-    const UUID& segment_id, size_t& metrics_dec_capacity) {
+    const UUID& segment_id) {
     auto it = nof_segment_manager_->mounted_segments_.find(segment_id);
     if (it == nof_segment_manager_->mounted_segments_.end()) {
         LOG(WARNING) << "NoF segment unmount: segment_id=" << segment_id
@@ -1258,7 +1257,6 @@ ErrorCode ScopedNoFSegmentAccess::PrepareUnmountSegment(
 
     auto& mounted_segment = it->second;
     auto& segment = mounted_segment.segment;
-    metrics_dec_capacity = segment.size;
 
     std::shared_ptr<BufferAllocatorBase> allocator =
         mounted_segment.buf_allocator;
@@ -1274,8 +1272,7 @@ ErrorCode ScopedNoFSegmentAccess::PrepareUnmountSegment(
 }
 
 ErrorCode ScopedNoFSegmentAccess::CommitUnmountSegment(
-    const UUID& segment_id, const UUID& client_id,
-    const size_t& metrics_dec_capacity) {
+    const UUID& segment_id, const UUID& client_id) {
     bool found_in_client_segments = false;
     auto client_it = nof_segment_manager_->client_segments_.find(client_id);
     if (client_it != nof_segment_manager_->client_segments_.end()) {
@@ -1303,9 +1300,6 @@ ErrorCode ScopedNoFSegmentAccess::CommitUnmountSegment(
     }
 
     nof_segment_manager_->mounted_segments_.erase(segment_id);
-    MasterMetricManager::instance().dec_total_nof_capacity(
-        segment_name, metrics_dec_capacity);
-    MasterMetricManager::instance().remove_nof_segment_metrics(segment_name);
 
     return ErrorCode::OK;
 }

--- a/mooncake-store/tests/segment_test.cpp
+++ b/mooncake-store/tests/segment_test.cpp
@@ -461,9 +461,12 @@ TEST_F(SegmentTest, NoFUsageSnapshotSurvivesMetricsReset) {
     EXPECT_EQ(usage.capacity_bytes, kSegmentSize);
     EXPECT_DOUBLE_EQ(usage.used_ratio(), 0.25);
 
+    // Zero the gauges the way a standby transition does, by projecting an
+    // empty snapshot. Nothing needs to be restored afterwards: the gauges no
+    // longer track allocator activity, so teardown emits no decrements that
+    // could underflow them.
     auto& metrics = MasterMetricManager::instance();
-    metrics.reset_allocated_nof_size();
-    metrics.reset_total_nof_capacity();
+    metrics.project_storage_usage({});
     EXPECT_EQ(metrics.get_allocated_nof_size(), 0);
     EXPECT_EQ(metrics.get_total_nof_capacity(), 0);
 
@@ -476,24 +479,76 @@ TEST_F(SegmentTest, NoFUsageSnapshotSurvivesMetricsReset) {
     EXPECT_EQ(usage.capacity_bytes, kSegmentSize);
     EXPECT_DOUBLE_EQ(usage.used_ratio(), 0.25);
 
-    // Restore global gauges before teardown because allocator and segment
-    // cleanup still emit their matching decrements.
-    metrics.inc_allocated_nof_size("", kAllocationSize);
-    metrics.inc_total_nof_capacity("", kSegmentSize);
     buffer.reset();
     {
         auto segment_access = segment_manager.getNoFSegmentAccess();
-        size_t metrics_dec_capacity = 0;
-        ASSERT_EQ(segment_access.PrepareUnmountSegment(segment.id,
-                                                       metrics_dec_capacity),
+        ASSERT_EQ(segment_access.PrepareUnmountSegment(segment.id),
                   ErrorCode::OK);
-        ASSERT_EQ(segment_access.CommitUnmountSegment(segment.id, client_id,
-                                                      metrics_dec_capacity),
+        ASSERT_EQ(segment_access.CommitUnmountSegment(segment.id, client_id),
                   ErrorCode::OK);
     }
     allocator.reset();
     EXPECT_EQ(segment_manager.GetUsage().used_bytes, 0u);
     EXPECT_EQ(segment_manager.GetUsage().capacity_bytes, 0u);
+}
+
+// The NoF gauges are a projection: only project_storage_usage() writes them.
+// Mounting a segment and allocating from it must leave the previously
+// projected values untouched until the next projection runs.
+TEST_F(SegmentTest, NoFGaugesMoveOnlyWhenProjected) {
+    NoFSegmentManager segment_manager(BufferAllocatorType::OFFSET);
+    constexpr size_t kSegmentSize = 16 * 1024 * 1024;
+    constexpr size_t kAllocationSize = 4 * 1024 * 1024;
+    constexpr int64_t kProjectedUsed = 111;
+    constexpr int64_t kProjectedCapacity = 222;
+
+    auto& metrics = MasterMetricManager::instance();
+    TieredStorageUsageSnapshot projected;
+    projected.nof.used_bytes = static_cast<size_t>(kProjectedUsed);
+    projected.nof.capacity_bytes = static_cast<size_t>(kProjectedCapacity);
+    metrics.project_storage_usage(projected);
+    ASSERT_EQ(metrics.get_allocated_nof_size(), kProjectedUsed);
+    ASSERT_EQ(metrics.get_total_nof_capacity(), kProjectedCapacity);
+
+    NoFSegment segment;
+    segment.id = generate_uuid();
+    segment.name = "nof_projection_only_segment";
+    segment.size = kSegmentSize;
+    segment.base = 0x340000000;
+    segment.te_endpoint = "nof_projection_only_endpoint";
+    UUID client_id = generate_uuid();
+    {
+        auto segment_access = segment_manager.getNoFSegmentAccess();
+        ASSERT_EQ(segment_access.MountSegment(segment, client_id),
+                  ErrorCode::OK);
+    }
+    auto allocator = GetNoFAllocatorForTesting(segment_manager, segment.id);
+    ASSERT_NE(allocator, nullptr);
+    auto buffer = allocator->allocate(kAllocationSize);
+    ASSERT_NE(buffer, nullptr);
+
+    // Domain state moved; the gauges did not.
+    EXPECT_EQ(segment_manager.GetUsage().used_bytes, kAllocationSize);
+    EXPECT_EQ(metrics.get_allocated_nof_size(), kProjectedUsed);
+    EXPECT_EQ(metrics.get_total_nof_capacity(), kProjectedCapacity);
+
+    projected.nof = segment_manager.GetUsageSnapshot();
+    metrics.project_storage_usage(projected);
+    EXPECT_EQ(metrics.get_allocated_nof_size(),
+              static_cast<int64_t>(kAllocationSize));
+    EXPECT_EQ(metrics.get_total_nof_capacity(),
+              static_cast<int64_t>(kSegmentSize));
+
+    buffer.reset();
+    {
+        auto segment_access = segment_manager.getNoFSegmentAccess();
+        ASSERT_EQ(segment_access.PrepareUnmountSegment(segment.id),
+                  ErrorCode::OK);
+        ASSERT_EQ(segment_access.CommitUnmountSegment(segment.id, client_id),
+                  ErrorCode::OK);
+    }
+    allocator.reset();
+    metrics.project_storage_usage({});
 }
 
 // MountSegmentDuplicate Tests:


### PR DESCRIPTION
## Description

Since the storage metrics projection landed in #3385, the NoF gauges have
had two writers with incompatible semantics. `project_storage_usage()` sets
absolute values from the authoritative `NoFSegmentManager` snapshot, while
`allocate`, `deallocate`, `MountSegment` and `CommitUnmountSegment` still
applied relative increments. The two agree only as long as every increment
is paired correctly, so a single missed decrement makes the exported value
jump the next time the projection runs, and every NoF allocation pays for
gauge bookkeeping it no longer needs.

This drops the incremental writers and lets the projection own the NoF
gauges, following the direction in
[RFC #3158](https://github.com/kvcache-ai/Mooncake/issues/3158).

The read side is unchanged. The same gauge names and per-segment labels are
still exported, now refreshed from `NoFSegmentManager::GetUsageSnapshot()`.
Two things make this behavior-preserving for consumers:

- `MasterAdminServer::RefreshStorageMetrics()` runs before every externally
  visible read (`/metrics` scrape, metrics summary, and the periodic
  reporting loop), so no consumer can observe a stale gauge.
- `project_storage_usage()` already drops per-segment labels for segments
  absent from the snapshot via `projected_nof_segments_`, which is what
  `remove_nof_segment_metrics()` used to do on unmount.

The NoF unmount API carried a `metrics_dec_capacity` out-parameter whose only
purpose was handing the segment size from `PrepareUnmountSegment` to
`CommitUnmountSegment` for that decrement, so it goes away with the decrement
it fed. The DRAM path has a separate copy of that parameter and keeps it
until its own writers are removed.

Scoped to the NoF tier deliberately. NoF and DRAM have independent gauges,
managers and allocator paths, so removing one tier's writers is atomic and
leaves no half-migrated state. The DRAM tier is larger and carries three
design decisions of its own (standby accounting, the `CxlRegionDriver`
capacity-gauge-as-refcount, and the `ApplySnapshotState` metric rebuild); it
will follow separately.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

`NoFUsageSnapshotSurvivesMetricsReset` no longer has to re-inflate the gauges
before teardown, because teardown no longer decrements them; it now zeroes
them the way a standby transition does, by projecting an empty snapshot.

Added `NoFGaugesMoveOnlyWhenProjected`, which pins the new contract:
allocating from a mounted NoF segment moves domain state while the previously
projected gauge values stay put, and only the next projection brings them
back in sync.

**Test commands:**
```bash
bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

Not yet verified locally: the development machine has no cmake,
clang-format or pre-commit available, so this branch has not been compiled,
run or formatted locally and relies on PR CI for all of that. Every added
line was checked by hand against the 80-column limit, and the repository was
swept for remaining references to the removed APIs.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Cursor was used to enumerate the legacy write call sites, confirm the
projection already covers per-segment label cleanup and the refresh-before-read
paths, and apply the removals.

Made with [Cursor](https://cursor.com)