### PR TITLE
[Bugfix][TransferEngine] Free wr_depth_list_ of zero-QP endpoints in ~RdmaEndPoint

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -101,10 +101,12 @@ RdmaEndPoint::RdmaEndPoint(RdmaContext &context)
       cq_outstanding_(nullptr) {}
 
 RdmaEndPoint::~RdmaEndPoint() {
-    if (!qp_list_.empty()) {
-        // In normal flow, beginDestroy()+finishDestroy() should have been
-        // called already via endpoint_store. This is a fallback for abnormal
-        // shutdown (e.g., process exit).
+    // In normal flow, beginDestroy()+finishDestroy() should have been
+    // called already via endpoint_store. This is a fallback for abnormal
+    // shutdown (e.g., process exit). Keyed on wr_depth_list_ as well:
+    // construct() allocates it even for a zero-QP endpoint, whose qp_list_
+    // is empty, and skipping deconstructLocked() would leak it.
+    if (!qp_list_.empty() || wr_depth_list_) {
         RWSpinlock::WriteGuard guard(lock_);
         deconstructLocked();
     }


### PR DESCRIPTION
## Description

Fixes #3839. Also clears the identical rdma_endpoint_state_test leg of #3824.

## Summary

The nightly-coverage lane has failed `rdma_endpoint_state_test` since 2026-09-01: every test passes, then LeakSanitizer fails the binary at exit with a 1-byte direct leak out of `RdmaEndPoint::construct`.

## Root cause

`construct(cq, num_qp_list)` always allocates `wr_depth_list_ = new std::atomic<int>[num_qp_list]()`, which is a real allocation even for `num_qp_list == 0`. The destructor's abnormal-shutdown fallback only runs `deconstructLocked()` when `!qp_list_.empty()`, so a constructed zero-QP endpoint that is destroyed without an explicit `deconstruct()` (as `installZeroQpEndpoint` in the lifecycle-gate tests does via the endpoint store shared_ptr) never frees `wr_depth_list_`.

## Changes

One condition in `~RdmaEndPoint`: also enter the cleanup fallback when `wr_depth_list_` is non-null. `deconstructLocked()` already handles the empty-`qp_list_` case and nulls the pointer, so a double call stays safe.

## Validation

Reproduced and verified in a Ubuntu 22.04 / gcc 11 container with `-DENABLE_ASAN=ON`:

- Unpatched: all 8 tests pass, then `LeakSanitizer: detected memory leaks` with `SUMMARY: AddressSanitizer: 3 byte(s) leaked in 3 allocation(s)` (1-byte direct leaks out of `RdmaEndPoint::construct` via `installZeroQpEndpoint`), exit code 1. Same signature as both nightly logs.
- Patched: 20/20 consecutive runs report `[  PASSED  ] 8 tests.` with no LeakSanitizer output, exit code 0.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake -B build -DENABLE_ASAN=ON -DBUILD_UNIT_TESTS=ON ...
ninja -C build rdma_endpoint_state_test
./build/mooncake-transfer-engine/tests/rdma_endpoint_state_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective (the existing zero-QP lifecycle tests are the regression test; they fail under ASan without this fix)
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Written with Claude Code (Claude, Anthropic); I reviewed every changed line and can defend the change end to end.