### PR TITLE
[Store] Support multiple DFS roots (#3815)

### DIFF
--- a/docs/source/api-reference/python/mooncake-store.md
+++ b/docs/source/api-reference/python/mooncake-store.md
@@ -1147,8 +1147,9 @@ the positional overload.
   Defaults to `False`.
 - `ssd_offload_path` (str): FileStorage directory. When provided, it overrides
   `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH`. With the distributed backend, DFS shard
-  data is stored under `MOONCAKE_DFS_ROOT_DIR`, but this separate directory is
-  still validated during FileStorage initialization.
+  data is stored under `MOONCAKE_DFS_ROOT_DIRS` when configured, otherwise
+  under `MOONCAKE_DFS_ROOT_DIR`, but this separate directory is still validated
+  during FileStorage initialization.
 - `tenant_id` (str): Tenant namespace for object keys. Defaults to `"default"`.
 - `enable_client_http_server` (bool): Enable the client-local `/health`, `/metrics`, `/metrics/summary`, and `/version` HTTP endpoints. Defaults to `False`.
 - `client_http_port` (int): Port for the client-local HTTP endpoints. Defaults to `9300`.

--- a/docs/source/deployment/mooncake-store-deployment-guide.md
+++ b/docs/source/deployment/mooncake-store-deployment-guide.md
@@ -742,8 +742,8 @@ limitations below.
 
 #### Master configuration
 
-Enable the DFS allocator in the master process and select a shared root and
-shard layout. For example, to use HF3FS:
+Enable the DFS allocator in the master process and select the shared root or
+roots and shard layout. For example, to use HF3FS with one root:
 
 ```bash
 export MOONCAKE_ENABLE_DFS=1
@@ -767,13 +767,28 @@ The `hf3fs` adapter requires Mooncake to be built with `USE_3FS=ON`. Use
 `MOONCAKE_DFS_FS_ADAPTER=posix` for development and integration testing on a
 regular shared filesystem.
 
+The POSIX adapter can stripe shard files across multiple pre-mounted roots. All
+roots must already exist and be absolute, unique directory paths:
+
+```bash
+export MOONCAKE_DFS_ROOT_DIRS=/mnt/mooncake/nfs0,/mnt/mooncake/nfs1
+export MOONCAKE_DFS_FS_ADAPTER=posix
+```
+
+Shard `i` is placed under root `i % root_count`. The ordered root list is part
+of the storage layout: configure the same count, ordering, and local mount paths
+on the master and every client. Changing the list after shard files have been
+created is unsupported. `MOONCAKE_DFS_ROOT_DIRS` is not supported by the
+`hf3fs` adapter.
+
 #### Client configuration
 
 Every client that may read or write a DFS replica must initialize
-`FileStorage` and select the distributed backend. Use an absolute DFS root path;
-the root string, shard count, shard capacity, and alignment must match the
-master configuration. Select an adapter that can access the same underlying
-shared files; the examples use the same adapter in every process.
+`FileStorage` and select the distributed backend. Use an absolute DFS root path
+or ordered root list; the root configuration, shard count, shard capacity, and
+alignment must match the master configuration. Select an adapter that can
+access the same underlying shared files; the examples use the same adapter in
+every process.
 
 ```bash
 export MOONCAKE_OFFLOAD_ENABLED=true
@@ -797,9 +812,10 @@ backend-specific `MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR` and
 supplied as Python arguments. The
 `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` directory must already exist and be an
 absolute, writable, non-symlink directory. DFS shard data is stored under
+`MOONCAKE_DFS_ROOT_DIRS` when configured, otherwise under
 `MOONCAKE_DFS_ROOT_DIR`; the FileStorage path is still required for client
 initialization because the shared `FileStorageConfig` validates it even when
-the selected backend stores data in the DFS root.
+the selected backend stores data in the DFS roots.
 
 Native C++ clients must initialize a `DistributedStorageBackend` with the same
 DFS layout and attach it to the client with `SetDfsStorageBackend()` before
@@ -812,6 +828,7 @@ is required.
 | Variable | Scope | Default | Description |
 |----------|-------|---------|-------------|
 | `MOONCAKE_ENABLE_DFS` | Master | `false` | Enable master-side DFS allocation. `MOONCAKE_DFS_ENABLED` is accepted as a compatibility fallback. |
+| `MOONCAKE_DFS_ROOT_DIRS` | Master and clients | unset | Ordered, comma-separated POSIX shard roots. Each path must be absolute, unique, and already exist. Shard `i` uses root `i % root_count`. Takes precedence over `MOONCAKE_DFS_ROOT_DIR`; unsupported with `hf3fs`. |
 | `MOONCAKE_DFS_ROOT_DIR` | Master and clients | `/mnt/3fs/mooncake` | Absolute shared shard root; use the same path string in every process. Falls back to `MOONCAKE_DISTRIBUTED_ROOT_DIR`. |
 | `MOONCAKE_DFS_FS_ADAPTER` | Master and clients | `hf3fs` | Filesystem adapter: `hf3fs` or `posix`. Falls back to `MOONCAKE_DISTRIBUTED_FS_TYPE`. |
 | `MOONCAKE_DFS_SHARD_COUNT` | Master and clients | `64` | Number of DFS shard files. |
@@ -982,7 +999,7 @@ Arguments of `MooncakeDistributedStore.setup(...)`:
 | `master_server_addr` | str | required | Master `host:port`. **Keyword is `master_server_addr`, not `master_server_address`** |
 | `engine` | TransferEngine | `None` | *(advanced)* Reuse an existing Transfer Engine instance instead of creating one |
 | `enable_ssd_offload` | bool | `false` | *(advanced)* Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
-| `ssd_offload_path` | str | empty | *(advanced)* FileStorage path; with the distributed backend, DFS data uses `MOONCAKE_DFS_ROOT_DIR` |
+| `ssd_offload_path` | str | empty | *(advanced)* FileStorage path; with the distributed backend, DFS data uses `MOONCAKE_DFS_ROOT_DIRS` when set, otherwise `MOONCAKE_DFS_ROOT_DIR` |
 | `tenant_id` | str | `default` | *(advanced)* Tenant identifier |
 | `enable_client_http_server` | bool | `false` | Enable the client-side HTTP `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `client_http_port` | int | `9300` | Client-side HTTP endpoint port, used only when `enable_client_http_server=true` |
@@ -1013,7 +1030,7 @@ The store service CLI only accepts `--config`, `-D/--define`, `--port`, and `--m
 | `MOONCAKE_LOCAL_BUFFER_SIZE` | `local_buffer_size` | `1073741824` (1 GiB) | Transfer Engine buffer; same parsing as above |
 | `MOONCAKE_LOCAL_HOSTNAME` | `local_hostname` | `localhost` | |
 | `MOONCAKE_OFFLOAD_ENABLED` | `enable_ssd_offload` | `false` | Initialize client-side `FileStorage`; required for SSD offload and descriptor-based DFS |
-| `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | FileStorage path; DFS shard data uses `MOONCAKE_DFS_ROOT_DIR` with the distributed backend |
+| `MOONCAKE_OFFLOAD_FILE_STORAGE_PATH` | `ssd_offload_path` | empty | FileStorage path; DFS shard data uses `MOONCAKE_DFS_ROOT_DIRS` when set, otherwise `MOONCAKE_DFS_ROOT_DIR` |
 | `MOONCAKE_TENANT_ID` | `tenant_id` | `default` | Tenant identifier |
 | `MOONCAKE_ENABLE_CLIENT_HTTP_SERVER` | `enable_client_http_server` | `false` | Enable client-side `/health`, `/metrics`, `/metrics/summary`, and `/version` endpoints |
 | `MOONCAKE_CLIENT_HTTP_PORT` | `client_http_port` | `9300` | Client-side HTTP endpoint port |

--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -68,6 +68,7 @@ struct ClientMetricEnvironmentVariables {
 };
 
 struct DistributedStorageEnvironmentVariables {
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DFS_ROOT_DIRS);
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DFS_ROOT_DIR);
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DISTRIBUTED_ROOT_DIR);
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_DFS_FS_ADAPTER);

--- a/mooncake-store/include/config/distributed_storage_config.h
+++ b/mooncake-store/include/config/distributed_storage_config.h
@@ -1,13 +1,18 @@
 #pragma once
 
 #include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace mooncake {
 
 struct DistributedStorageConfig {
     std::string fsdir = "/mnt/3fs/mooncake";
+    // An explicitly configured, ordered list of POSIX roots. When empty,
+    // fsdir remains the backward-compatible single-root configuration.
+    std::vector<std::string> root_dirs;
     std::string fs_adapter_type = "hf3fs";
     bool enable_health_check = false;
     int shard_count = 64;
@@ -22,6 +27,7 @@ struct DistributedStorageConfig {
 
     bool Validate() const;
     bool ValidateForAllocator() const;
+    const std::string& RootForShard(size_t shard_idx) const;
     static DistributedStorageConfig FromEnvironment();
     std::string FormatStr() const;
 };

--- a/mooncake-store/include/storage/distributed/dfs_global_allocator.h
+++ b/mooncake-store/include/storage/distributed/dfs_global_allocator.h
@@ -149,7 +149,7 @@ class DfsGlobalAllocator {
     int SelectShard(const std::string& key) const;
     uint64_t AlignSize(uint64_t size) const;
 
-    std::string mount_path_;
+    std::vector<std::string> shard_paths_;
     int shard_count_ = 0;
     uint64_t alignment_ = 4096;
     std::vector<std::unique_ptr<ShardState>> shards_;

--- a/mooncake-store/include/storage/distributed/distributed_storage_backend.h
+++ b/mooncake-store/include/storage/distributed/distributed_storage_backend.h
@@ -100,7 +100,6 @@ class DistributedStorageBackend : public StorageBackendInterface {
     std::unique_ptr<FileSystemAdapter> fs_adapter_;
     std::unique_ptr<ObjectStorageAdapter> object_storage_adapter_;
     DistributedStorageConfig distributed_config_;
-    std::string root_dir_;
     std::vector<std::unique_ptr<ShardFile>> shard_files_;
     DistributedStorageMode storage_mode_ = DistributedStorageMode::kFileSystem;
     bool initialized_ = false;

--- a/mooncake-store/src/config/distributed_storage_config.cpp
+++ b/mooncake-store/src/config/distributed_storage_config.cpp
@@ -4,27 +4,82 @@
 #include <chrono>
 #include <filesystem>
 #include <sstream>
+#include <string_view>
+#include <unordered_set>
 
+#include "ascii_string.h"
 #include "environ.h"
 #include "environment_variables.h"
 
 namespace mooncake {
 
-bool DistributedStorageConfig::Validate() const {
-    if (fsdir.empty()) {
-        LOG(ERROR) << "DistributedStorageConfig: fsdir is empty";
-        return false;
+namespace {
+
+std::vector<std::string> ParseRootDirs(std::string_view value) {
+    std::vector<std::string> roots;
+    size_t begin = 0;
+    for (size_t end = value.find(',', begin); end != std::string_view::npos;
+         end = value.find(',', begin)) {
+        const std::string_view root = value.substr(begin, end - begin);
+        roots.emplace_back(TrimAsciiWhitespace(root));
+        begin = end + 1;
     }
-    if (!std::filesystem::path(fsdir).is_absolute()) {
-        LOG(ERROR)
-            << "DistributedStorageConfig: fsdir must be an absolute path: "
-            << fsdir;
-        return false;
+    roots.emplace_back(TrimAsciiWhitespace(value.substr(begin)));
+    return roots;
+}
+
+}  // namespace
+
+bool DistributedStorageConfig::Validate() const {
+    if (root_dirs.empty()) {
+        if (fsdir.empty()) {
+            LOG(ERROR) << "DistributedStorageConfig: fsdir is empty";
+            return false;
+        }
+        if (!std::filesystem::path(fsdir).is_absolute()) {
+            LOG(ERROR)
+                << "DistributedStorageConfig: fsdir must be an absolute path: "
+                << fsdir;
+            return false;
+        }
     }
     if (fs_adapter_type != "hf3fs" && fs_adapter_type != "posix") {
         LOG(ERROR) << "DistributedStorageConfig: unsupported fs_adapter_type: "
                    << fs_adapter_type;
         return false;
+    }
+    if (!root_dirs.empty()) {
+        if (fs_adapter_type != "posix") {
+            LOG(ERROR) << "DistributedStorageConfig: multiple DFS roots are "
+                          "supported only by the posix adapter";
+            return false;
+        }
+
+        std::unordered_set<std::string> canonical_roots;
+        for (const auto& root : root_dirs) {
+            const std::filesystem::path root_path(root);
+            if (root.empty() || !root_path.is_absolute()) {
+                LOG(ERROR) << "DistributedStorageConfig: every DFS root must "
+                              "be a non-empty absolute path: "
+                           << root;
+                return false;
+            }
+
+            std::error_code ec;
+            const auto canonical_root =
+                std::filesystem::canonical(root_path, ec);
+            if (ec || !std::filesystem::is_directory(canonical_root, ec)) {
+                LOG(ERROR) << "DistributedStorageConfig: DFS root must be an "
+                              "existing directory: "
+                           << root;
+                return false;
+            }
+            if (!canonical_roots.insert(canonical_root.string()).second) {
+                LOG(ERROR) << "DistributedStorageConfig: duplicate DFS root: "
+                           << root;
+                return false;
+            }
+        }
     }
     if (shard_count <= 0) {
         LOG(ERROR) << "DistributedStorageConfig: shard_count must > 0";
@@ -48,6 +103,12 @@ bool DistributedStorageConfig::Validate() const {
         return false;
     }
     return true;
+}
+
+const std::string& DistributedStorageConfig::RootForShard(
+    size_t shard_idx) const {
+    if (root_dirs.empty()) return fsdir;
+    return root_dirs[shard_idx % root_dirs.size()];
 }
 
 bool DistributedStorageConfig::ValidateForAllocator() const {
@@ -85,7 +146,9 @@ DistributedStorageConfig DistributedStorageConfig::FromEnvironment() {
         Environ::ReadOr(Variables::MOONCAKE_DISTRIBUTED_ROOT_DIR, config.fsdir);
     config.fsdir =
         Environ::ReadOr(Variables::MOONCAKE_DFS_ROOT_DIR, legacy_root_dir);
-    if (!std::filesystem::path(config.fsdir).is_absolute()) {
+    if (const auto roots = Environ::Read(Variables::MOONCAKE_DFS_ROOT_DIRS)) {
+        config.root_dirs = ParseRootDirs(*roots);
+    } else if (!std::filesystem::path(config.fsdir).is_absolute()) {
         config.fsdir = std::filesystem::absolute(config.fsdir).string();
     }
 
@@ -127,7 +190,16 @@ DistributedStorageConfig DistributedStorageConfig::FromEnvironment() {
 
 std::string DistributedStorageConfig::FormatStr() const {
     std::ostringstream oss;
-    oss << "fsdir=" << fsdir << ", fs_adapter_type=" << fs_adapter_type
+    oss << "fsdir=" << fsdir;
+    if (!root_dirs.empty()) {
+        oss << ", root_dirs=[";
+        for (size_t i = 0; i < root_dirs.size(); ++i) {
+            if (i != 0) oss << ',';
+            oss << root_dirs[i];
+        }
+        oss << ']';
+    }
+    oss << ", fs_adapter_type=" << fs_adapter_type
         << ", enable_health_check=" << enable_health_check
         << ", shard_count=" << shard_count
         << ", shard_capacity=" << shard_capacity << ", alignment=" << alignment

--- a/mooncake-store/src/storage/distributed/dfs_global_allocator.cpp
+++ b/mooncake-store/src/storage/distributed/dfs_global_allocator.cpp
@@ -40,11 +40,12 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    mount_path_ = config.fsdir;
     shard_count_ = config.shard_count;
     alignment_ = config.alignment;
     shards_.clear();
     shards_.resize(shard_count_);
+    shard_paths_.clear();
+    shard_paths_.reserve(shard_count_);
 
     eviction_enabled_ = config.eviction_enabled;
     eviction_high_watermark_ = config.eviction_high_watermark;
@@ -52,12 +53,15 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
     deferred_free_duration_ = config.deferred_free_duration;
     eviction_check_interval_ = config.eviction_check_interval;
 
-    std::error_code ec;
-    std::filesystem::create_directories(mount_path_, ec);
-    if (ec) {
-        LOG(ERROR) << "Failed to create DFS mount path " << mount_path_ << ": "
-                   << ec.message();
-        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    const auto& primary_root = config.RootForShard(0);
+    if (config.root_dirs.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(primary_root, ec);
+        if (ec) {
+            LOG(ERROR) << "Failed to create DFS mount path " << primary_root
+                       << ": " << ec.message();
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
     }
 
     if (config.fs_adapter_type == "posix") {
@@ -73,18 +77,20 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
 #endif
     }
 
-    auto adapter_init = fs_adapter_->Init(mount_path_);
+    auto adapter_init = fs_adapter_->Init(primary_root);
     if (!adapter_init) {
         LOG(ERROR) << "Failed to initialize DFS fs adapter "
                    << config.fs_adapter_type
-                   << " for mount_path=" << mount_path_
+                   << " for mount_path=" << primary_root
                    << ", error=" << adapter_init.error();
         return tl::make_unexpected(adapter_init.error());
     }
 
     for (int i = 0; i < shard_count_; ++i) {
-        std::string path = mount_path_ + "/dfs_shard_" +
-                           FormatShardIdx(i, shard_count_) + ".data";
+        std::string path =
+            (std::filesystem::path(config.RootForShard(i)) /
+             ("dfs_shard_" + FormatShardIdx(i, shard_count_) + ".data"))
+                .string();
         auto prealloc =
             fs_adapter_->PreallocateFile(path, config.shard_capacity);
         if (!prealloc) {
@@ -107,6 +113,7 @@ tl::expected<void, ErrorCode> DfsGlobalAllocator::Init(
                        << i;
             return tl::make_unexpected(ErrorCode::INTERNAL_ERROR);
         }
+        shard_paths_.push_back(std::move(path));
         shards_[i] = std::move(shard);
     }
 
@@ -145,14 +152,8 @@ tl::expected<DistributedFSDescriptor, ErrorCode> DfsGlobalAllocator::Allocate(
                                             reserved_bytes};
     handle_lock.unlock();
 
-    return DistributedFSDescriptor{
-        mount_path_ + "/dfs_shard_" + FormatShardIdx(shard_idx, shard_count_) +
-            ".data",
-        alloc_offset,
-        size,
-        aligned_size,
-        shard_idx,
-    };
+    return DistributedFSDescriptor{shard_paths_[shard_idx], alloc_offset, size,
+                                   aligned_size, shard_idx};
 }
 
 void DfsGlobalAllocator::Free(uint64_t offset, uint64_t /*aligned_size*/,

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -48,8 +48,7 @@ DistributedStorageBackend::DistributedStorageBackend(
     : StorageBackendInterface(file_storage_config),
       fs_adapter_(std::move(fs_adapter)),
       object_storage_adapter_(std::move(object_storage_adapter)),
-      distributed_config_(distributed_config),
-      root_dir_(distributed_config.fsdir) {
+      distributed_config_(distributed_config) {
     CHECK((fs_adapter_ != nullptr) != (object_storage_adapter_ != nullptr))
         << "DistributedStorageBackend: exactly one I/O adapter is required";
     if (object_storage_adapter_) {
@@ -82,23 +81,33 @@ tl::expected<void, ErrorCode> DistributedStorageBackend::Init() {
         return {};
     }
 
-    std::error_code ec;
-    std::filesystem::create_directories(root_dir_, ec);
-    if (ec) {
-        LOG(ERROR) << "Failed to create DFS root directory " << root_dir_
-                   << ": " << ec.message();
-        return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+    if (!distributed_config_.Validate()) {
+        return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
     }
 
-    auto init_result = fs_adapter_->Init(root_dir_);
+    const auto& primary_root = distributed_config_.RootForShard(0);
+    if (distributed_config_.root_dirs.empty()) {
+        std::error_code ec;
+        std::filesystem::create_directories(primary_root, ec);
+        if (ec) {
+            LOG(ERROR) << "Failed to create DFS root directory " << primary_root
+                       << ": " << ec.message();
+            return tl::make_unexpected(ErrorCode::FILE_WRITE_FAIL);
+        }
+    }
+
+    auto init_result = fs_adapter_->Init(primary_root);
     if (!init_result) return init_result;
 
     shard_files_.reserve(distributed_config_.shard_count);
     for (int i = 0; i < distributed_config_.shard_count; ++i) {
-        std::string path = root_dir_ + "/dfs_shard_" +
-                           DfsGlobalAllocator::FormatShardIdx(
-                               i, distributed_config_.shard_count) +
-                           ".data";
+        std::string path =
+            (std::filesystem::path(distributed_config_.RootForShard(i)) /
+             ("dfs_shard_" +
+              DfsGlobalAllocator::FormatShardIdx(
+                  i, distributed_config_.shard_count) +
+              ".data"))
+                .string();
         auto fd_result = fs_adapter_->OpenFile(path);
         if (!fd_result) {
             LOG(ERROR) << "Failed to open DFS shard " << path << ": "

--- a/mooncake-store/tests/dfs_posix_test.cpp
+++ b/mooncake-store/tests/dfs_posix_test.cpp
@@ -61,6 +61,7 @@ class EnvGuard {
         Save("MOONCAKE_DFS_EVICTION_LOW_WATERMARK");
         Save("MOONCAKE_DFS_DEFERRED_FREE_SECONDS");
         Save("MOONCAKE_DFS_EVICTION_CHECK_INTERVAL");
+        Save("MOONCAKE_DFS_ROOT_DIRS");
         Save("MOONCAKE_DFS_ROOT_DIR");
         Save("MOONCAKE_DFS_SHARD_COUNT");
         Save("MOONCAKE_DFS_SHARD_CAPACITY");
@@ -79,6 +80,7 @@ class EnvGuard {
     }
 
     void Set(const char* key, const char* value) { ::setenv(key, value, 1); }
+    void Unset(const char* key) { ::unsetenv(key); }
 
    private:
     void Save(const std::string& key) {
@@ -118,6 +120,7 @@ class AlignedBuffer {
 };
 
 void ConfigurePosixDfs(EnvGuard& env) {
+    env.Unset("MOONCAKE_DFS_ROOT_DIRS");
     env.Set("MOONCAKE_DFS_FS_ADAPTER", "posix");
     env.Set("MOONCAKE_DFS_SINGLE_TENANT", "1");
     env.Set("MOONCAKE_DFS_EVICTION_ENABLED", "0");
@@ -329,6 +332,40 @@ TEST(DfsGlobalAllocatorTest, AllocateFreeAndFormatShardIdx) {
     EXPECT_EQ(DfsGlobalAllocator::FormatShardIdx(10, 64), "10");
     EXPECT_EQ(DfsGlobalAllocator::FormatShardIdx(63, 64), "63");
     EXPECT_EQ(DfsGlobalAllocator::FormatShardIdx(100, 1000), "100");
+}
+
+TEST(DfsGlobalAllocatorTest, PlacesShardsRoundRobinAcrossRoots) {
+    EnvGuard env;
+    ConfigurePosixDfs(env);
+    TempDir root0("dfs_alloc_root0");
+    TempDir root1("dfs_alloc_root1");
+
+    auto config = MakeAllocatorConfig(root0.path(), 4, 1024 * 1024, 4096);
+    config.root_dirs = {root0.path(), root1.path()};
+
+    DfsGlobalAllocator allocator;
+    ASSERT_TRUE(allocator.Init(config));
+
+    for (int shard_idx = 0; shard_idx < config.shard_count; ++shard_idx) {
+        const TempDir& expected_root = shard_idx % 2 == 0 ? root0 : root1;
+        const std::string file_name =
+            "dfs_shard_" +
+            DfsGlobalAllocator::FormatShardIdx(shard_idx, config.shard_count) +
+            ".data";
+        EXPECT_TRUE(std::filesystem::exists(expected_root.file(file_name)))
+            << "shard_idx=" << shard_idx;
+    }
+
+    auto descriptor = allocator.Allocate("multi-root-key", 100);
+    ASSERT_TRUE(descriptor);
+    EXPECT_EQ(
+        descriptor->file_path,
+        (std::filesystem::path(config.RootForShard(descriptor->shard_idx)) /
+         ("dfs_shard_" +
+          DfsGlobalAllocator::FormatShardIdx(descriptor->shard_idx,
+                                             config.shard_count) +
+          ".data"))
+            .string());
 }
 
 TEST(DfsGlobalAllocatorTest, InitReturnsSpecificErrors) {
@@ -1100,6 +1137,65 @@ TEST_F(DfsBackendTest, FailurePaths) {
         adapter.ReadFile(tmp_->file("does_not_exist"), buf, sizeof(buf));
     ASSERT_FALSE(read.has_value());
     EXPECT_EQ(read.error(), ErrorCode::FILE_NOT_FOUND);
+}
+
+TEST(DfsStorageBackendTest, OpensAndUsesShardsAcrossRoots) {
+    TempDir root0("dfs_backend_root0");
+    TempDir root1("dfs_backend_root1");
+
+    FileStorageConfig file_config;
+    file_config.storage_backend_type = StorageBackendType::kDistributed;
+    file_config.storage_filepath = root0.path();
+
+    DistributedStorageConfig config;
+    config.fsdir = root0.path();
+    config.root_dirs = {root0.path(), root1.path()};
+    config.fs_adapter_type = "posix";
+    config.shard_count = 2;
+    config.shard_capacity = 1024 * 1024;
+    config.alignment = 4096;
+
+    DistributedStorageBackend backend(file_config, config,
+                                      std::make_unique<PosixFsAdapter>());
+    ASSERT_TRUE(backend.Init());
+
+    const std::string shard0 = root0.file(
+        "dfs_shard_" + DfsGlobalAllocator::FormatShardIdx(0, 2) + ".data");
+    const std::string shard1 = root1.file(
+        "dfs_shard_" + DfsGlobalAllocator::FormatShardIdx(1, 2) + ".data");
+    ASSERT_TRUE(std::filesystem::exists(shard0));
+    ASSERT_TRUE(std::filesystem::exists(shard1));
+
+    AlignedBuffer input0(4096);
+    AlignedBuffer input1(4096);
+    ASSERT_NE(input0.data(), nullptr);
+    ASSERT_NE(input1.data(), nullptr);
+    input0.Fill('A');
+    input1.Fill('B');
+
+    const DistributedFSDescriptor descriptor0{shard0, 0, input0.size(),
+                                              input0.size(), 0};
+    const DistributedFSDescriptor descriptor1{shard1, 0, input1.size(),
+                                              input1.size(), 1};
+    auto write_results = backend.BatchWrite(
+        {{"key0", descriptor0, {{input0.data(), input0.size()}}},
+         {"key1", descriptor1, {{input1.data(), input1.size()}}}});
+    ASSERT_EQ(write_results.size(), 2);
+    ASSERT_TRUE(write_results[0]);
+    ASSERT_TRUE(write_results[1]);
+
+    AlignedBuffer output0(4096);
+    AlignedBuffer output1(4096);
+    ASSERT_NE(output0.data(), nullptr);
+    ASSERT_NE(output1.data(), nullptr);
+    auto read_results = backend.BatchRead(
+        {{"key0", descriptor0, {{output0.data(), output0.size()}}},
+         {"key1", descriptor1, {{output1.data(), output1.size()}}}});
+    ASSERT_EQ(read_results.size(), 2);
+    ASSERT_TRUE(read_results[0]);
+    ASSERT_TRUE(read_results[1]);
+    EXPECT_EQ(std::memcmp(input0.data(), output0.data(), input0.size()), 0);
+    EXPECT_EQ(std::memcmp(input1.data(), output1.data(), input1.size()), 0);
 }
 
 TEST(DfsStorageFactoryTest, CreatesDistributedBackendWithPosixAdapter) {

--- a/mooncake-store/tests/distributed_storage_config_test.cpp
+++ b/mooncake-store/tests/distributed_storage_config_test.cpp
@@ -1,8 +1,11 @@
 #include <gtest/gtest.h>
+#include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <optional>
 #include <string>
@@ -43,7 +46,35 @@ class ScopedEnvVar {
     std::optional<std::string> original_;
 };
 
+class TempDir {
+   public:
+    explicit TempDir(const std::string& prefix) {
+        static std::atomic<int64_t> counter{0};
+        path_ = std::filesystem::temp_directory_path() /
+                (prefix + "_" + std::to_string(::getpid()) + "_" +
+                 std::to_string(++counter));
+        path_str_ = path_.string();
+        std::filesystem::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        std::filesystem::remove_all(path_, ec);
+    }
+
+    const std::string& path() const { return path_str_; }
+
+    std::string file(const std::string& name) const {
+        return (path_ / name).string();
+    }
+
+   private:
+    std::filesystem::path path_;
+    std::string path_str_;
+};
+
 struct DistributedStorageEnvironment {
+    ScopedEnvVar root_dirs{"MOONCAKE_DFS_ROOT_DIRS"};
     ScopedEnvVar root_dir{"MOONCAKE_DFS_ROOT_DIR"};
     ScopedEnvVar legacy_root_dir{"MOONCAKE_DISTRIBUTED_ROOT_DIR"};
     ScopedEnvVar fs_adapter{"MOONCAKE_DFS_FS_ADAPTER"};
@@ -64,6 +95,7 @@ struct DistributedStorageEnvironment {
 
 void ExpectDefaultConfig(const DistributedStorageConfig& config) {
     EXPECT_EQ(config.fsdir, "/mnt/3fs/mooncake");
+    EXPECT_TRUE(config.root_dirs.empty());
     EXPECT_EQ(config.fs_adapter_type, "hf3fs");
     EXPECT_FALSE(config.enable_health_check);
     EXPECT_EQ(config.shard_count, 64);
@@ -158,6 +190,51 @@ TEST_F(DistributedStorageConfigTest, PreservesAliasPrecedence) {
     const auto preferred = DistributedStorageConfig::FromEnvironment();
     EXPECT_EQ(preferred.fsdir, "/tmp/preferred-dfs");
     EXPECT_EQ(preferred.fs_adapter_type, "hf3fs");
+}
+
+TEST_F(DistributedStorageConfigTest, ReadsAndSelectsExplicitRootDirs) {
+    TempDir root0("dfs_config_root0");
+    TempDir root1("dfs_config_root1");
+    const std::string root_list =
+        "  " + root0.path() + ", " + root1.path() + "  ";
+
+    env.root_dirs.Set(root_list.c_str());
+    env.root_dir.Set("");
+    env.fs_adapter.Set("posix");
+
+    const auto config = DistributedStorageConfig::FromEnvironment();
+
+    EXPECT_EQ(config.root_dirs,
+              (std::vector<std::string>{root0.path(), root1.path()}));
+    EXPECT_EQ(config.RootForShard(0), root0.path());
+    EXPECT_EQ(config.RootForShard(1), root1.path());
+    EXPECT_EQ(config.RootForShard(2), root0.path());
+    EXPECT_TRUE(config.Validate());
+    EXPECT_NE(config.FormatStr().find("root_dirs=[" + root0.path() + "," +
+                                      root1.path() + "]"),
+              std::string::npos);
+}
+
+TEST_F(DistributedStorageConfigTest, RejectsEmptyExplicitRootList) {
+    env.root_dirs.Set("");
+    env.fs_adapter.Set("posix");
+
+    const auto config = DistributedStorageConfig::FromEnvironment();
+
+    ASSERT_EQ(config.root_dirs.size(), 1);
+    EXPECT_TRUE(config.root_dirs.front().empty());
+    EXPECT_FALSE(config.Validate());
+}
+
+TEST_F(DistributedStorageConfigTest, PreservesEmptyExplicitRootEntries) {
+    env.root_dirs.Set("/tmp/root0,,/tmp/root1,");
+    env.fs_adapter.Set("posix");
+
+    const auto config = DistributedStorageConfig::FromEnvironment();
+
+    EXPECT_EQ(config.root_dirs,
+              (std::vector<std::string>{"/tmp/root0", "", "/tmp/root1", ""}));
+    EXPECT_FALSE(config.Validate());
 }
 
 TEST_F(DistributedStorageConfigTest, EmptyPreferredRootOverridesAlias) {
@@ -257,6 +334,37 @@ TEST(DistributedStorageConfigValidationTest, RejectsInvalidBaseSettings) {
         mutate(config);
         EXPECT_FALSE(config.Validate());
     }
+}
+
+TEST(DistributedStorageConfigValidationTest, ValidatesExplicitRootDirectories) {
+    TempDir root0("dfs_validation_root0");
+    TempDir root1("dfs_validation_root1");
+    auto config = ValidConfig();
+    config.fsdir.clear();
+    config.root_dirs = {root0.path(), root1.path()};
+    ASSERT_TRUE(config.Validate());
+
+    auto hf3fs = config;
+    hf3fs.fs_adapter_type = "hf3fs";
+    EXPECT_FALSE(hf3fs.Validate());
+
+    auto relative = config;
+    relative.root_dirs = {"relative/root"};
+    EXPECT_FALSE(relative.Validate());
+
+    auto missing = config;
+    missing.root_dirs = {root0.file("missing")};
+    EXPECT_FALSE(missing.Validate());
+
+    const std::string file_path = root0.file("not_a_directory");
+    std::ofstream(file_path) << "data";
+    auto regular_file = config;
+    regular_file.root_dirs = {file_path};
+    EXPECT_FALSE(regular_file.Validate());
+
+    auto duplicate = config;
+    duplicate.root_dirs = {root0.path(), root0.file(".")};
+    EXPECT_FALSE(duplicate.Validate());
 }
 
 TEST(DistributedStorageConfigValidationTest, RejectsInvalidAllocatorSettings) {


### PR DESCRIPTION
## Description

- Support ordered POSIX DFS roots through `MOONCAKE_DFS_ROOT_DIRS`.
- Distribute shards across roots using round-robin placement.
- Preserve compatibility with the existing single-root configuration.
- Add validation, tests, and documentation.
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [x] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?



**Test commands:**
```bash
# Example: bash scripts/run_ci_test.sh
```

**Test results:**
- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)