### PR TITLE
[Store] Structure TransferSubmitterConfig environment settings

### DIFF
--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -100,6 +100,12 @@ struct ReplicaSelectionEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MC_STORE_REPLICA_SCORING);
 };
 
+struct TransferSubmitterEnvironmentVariables {
+    // Keep the raw string to preserve the legacy token set, whitespace,
+    // invalid-value fallback, and warning behavior.
+    MC_DEFINE_ENV_VAR(std::string, MC_STORE_MEMCPY);
+};
+
 #undef MC_DEFINE_ENV_VAR
 
 }  // namespace mooncake

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -100,6 +100,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     config/local_hot_cache_config.cpp
     config/offset_allocator_backend_config.cpp
     config/replica_selection_config.cpp
+    config/transfer_submitter_config.cpp
     device/accelerator_device.cpp
     device/accelerator_registry.cpp
     device/runtime_accelerator.cpp

--- a/mooncake-store/src/config/transfer_submitter_config.cpp
+++ b/mooncake-store/src/config/transfer_submitter_config.cpp
@@ -1,0 +1,36 @@
+#include "transfer_submitter_config.h"
+
+#include <glog/logging.h>
+
+#include <algorithm>
+#include <cctype>
+
+#include "bool_parser.h"
+#include "environ.h"
+#include "environment_variables.h"
+
+namespace mooncake {
+
+TransferSubmitterConfig TransferSubmitterConfig::FromEnvironment() {
+    TransferSubmitterConfig config;
+    auto value =
+        Environ::Read(TransferSubmitterEnvironmentVariables::MC_STORE_MEMCPY);
+    if (!value.has_value()) {
+        return config;
+    }
+
+    std::transform(value->begin(), value->end(), value->begin(),
+                   [](unsigned char c) { return std::tolower(c); });
+    const auto parsed = TryParseBool(*value, {.trim_ascii_whitespace = false});
+    // Reject enable/disable, which only the shared parser accepts.
+    if (parsed.has_value() && *value != "enable" && *value != "disable") {
+        config.memcpy_enabled_override = *parsed;
+    } else {
+        LOG(WARNING) << "Invalid value for MC_STORE_MEMCPY: " << *value
+                     << ", defaulting to enabled";
+        config.memcpy_enabled_override = true;
+    }
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/config/transfer_submitter_config.h
+++ b/mooncake-store/src/config/transfer_submitter_config.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <optional>
+
+namespace mooncake {
+
+struct TransferSubmitterConfig {
+    // Unset leaves transport-dependent automatic selection to the submitter.
+    std::optional<bool> memcpy_enabled_override;
+
+    static TransferSubmitterConfig FromEnvironment();
+};
+
+}  // namespace mooncake

--- a/mooncake-store/src/transfer_task.cpp
+++ b/mooncake-store/src/transfer_task.cpp
@@ -12,6 +12,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include "config/transfer_submitter_config.h"
 #include "device/accelerator_registry.h"
 #include "transfer_engine.h"
 #include "transport/transport.h"
@@ -959,29 +960,15 @@ TransferSubmitter::TransferSubmitter(TransferEngine& engine,
     // When not set, auto-detect based on transport type:
     //   - TCP-only environment: enable memcpy (avoids TCP loopback overhead)
     //   - RDMA/other transports: disable memcpy (RDMA is more efficient)
-    const char* env_value = std::getenv("MC_STORE_MEMCPY");
-    if (env_value == nullptr) {
+    const auto config = TransferSubmitterConfig::FromEnvironment();
+    if (config.memcpy_enabled_override.has_value()) {
+        memcpy_enabled_ = *config.memcpy_enabled_override;
+    } else {
         memcpy_enabled_ = engine_.isTcpOnly();
         LOG(INFO) << "MC_STORE_MEMCPY not set, auto-detected: "
                   << (memcpy_enabled_ ? "TCP-only environment, memcpy enabled"
                                       : "non-TCP transport available, memcpy "
                                         "disabled");
-    } else {
-        std::string env_str(env_value);
-        // Convert to lowercase for case-insensitive comparison
-        std::transform(env_str.begin(), env_str.end(), env_str.begin(),
-                       [](unsigned char c) { return std::tolower(c); });
-        if (env_str == "false" || env_str == "0" || env_str == "no" ||
-            env_str == "off") {
-            memcpy_enabled_ = false;
-        } else if (env_str == "true" || env_str == "1" || env_str == "yes" ||
-                   env_str == "on") {
-            memcpy_enabled_ = true;
-        } else {
-            LOG(WARNING) << "Invalid value for MC_STORE_MEMCPY: " << env_str
-                         << ", defaulting to enabled";
-            memcpy_enabled_ = true;
-        }
     }
 
     VLOG(1) << "TransferSubmitter initialized with memcpy_enabled="

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -134,6 +134,8 @@ add_store_test(master_admin_server_test master_admin_server_test.cpp)
 add_store_test(posix_file_test posix_file_test.cpp)
 add_store_test(thread_pool_test thread_pool_test.cpp)
 add_store_test(transfer_task_test transfer_task_test.cpp)
+add_store_test(transfer_submitter_config_test
+               transfer_submitter_config_test.cpp)
 find_package(CUDAToolkit QUIET)
 if(CUDAToolkit_FOUND)
   target_compile_definitions(transfer_task_test PRIVATE MOONCAKE_TEST_CUDA_H2D)

--- a/mooncake-store/tests/transfer_submitter_config_test.cpp
+++ b/mooncake-store/tests/transfer_submitter_config_test.cpp
@@ -1,0 +1,116 @@
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include "../src/config/transfer_submitter_config.h"
+
+namespace mooncake {
+namespace {
+
+class TransferSubmitterConfigTest : public ::testing::Test {
+   protected:
+    void SetUp() override {
+        if (const char* value = std::getenv("MC_STORE_MEMCPY")) {
+            original_ = value;
+        }
+        google::InitGoogleLogging("TransferSubmitterConfigTest");
+        original_logtostderr_ = FLAGS_logtostderr;
+        FLAGS_logtostderr = true;
+        ASSERT_EQ(unsetenv("MC_STORE_MEMCPY"), 0);
+    }
+
+    void TearDown() override {
+        if (original_.has_value()) {
+            EXPECT_EQ(setenv("MC_STORE_MEMCPY", original_->c_str(), 1), 0);
+        } else {
+            EXPECT_EQ(unsetenv("MC_STORE_MEMCPY"), 0);
+        }
+        FLAGS_logtostderr = original_logtostderr_;
+        google::ShutdownGoogleLogging();
+    }
+
+   private:
+    std::optional<std::string> original_;
+    bool original_logtostderr_ = false;
+};
+
+TEST_F(TransferSubmitterConfigTest, UnsetMeansAutomatic) {
+    ::testing::internal::CaptureStderr();
+    const auto config = TransferSubmitterConfig::FromEnvironment();
+    const auto diagnostics = ::testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(config.memcpy_enabled_override.has_value());
+    EXPECT_TRUE(diagnostics.empty()) << diagnostics;
+}
+
+TEST_F(TransferSubmitterConfigTest, PreservesLegacyTokensAndFallbacks) {
+    struct Case {
+        const char* value;
+        bool expected;
+        bool expect_warning;
+    };
+    const Case cases[] = {
+        {"1", true, false},        {"true", true, false},
+        {"TRUE", true, false},     {"yes", true, false},
+        {"YeS", true, false},      {"on", true, false},
+        {"On", true, false},       {"0", false, false},
+        {"false", false, false},   {"FALSE", false, false},
+        {"no", false, false},      {"nO", false, false},
+        {"off", false, false},     {"Off", false, false},
+        {"", true, true},          {" true", true, true},
+        {"false ", true, true},    {"\t0\n", true, true},
+        {"enable", true, true},    {"disable", true, true},
+        {"ENABLE", true, true},    {"DISABLE", true, true},
+        {"2", true, true},         {"-1", true, true},
+        {"+0", true, true},        {"00", true, true},
+        {"falsejunk", true, true}, {"invalid", true, true},
+    };
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE(test_case.value);
+        ASSERT_EQ(setenv("MC_STORE_MEMCPY", test_case.value, 1), 0);
+        ::testing::internal::CaptureStderr();
+        const auto config = TransferSubmitterConfig::FromEnvironment();
+        const auto diagnostics = ::testing::internal::GetCapturedStderr();
+
+        EXPECT_EQ(config.memcpy_enabled_override,
+                  std::optional<bool>{test_case.expected});
+        if (test_case.expect_warning) {
+            EXPECT_NE(diagnostics.find("Invalid value for MC_STORE_MEMCPY:"),
+                      std::string::npos);
+        } else {
+            EXPECT_TRUE(diagnostics.empty()) << diagnostics;
+        }
+    }
+}
+
+TEST_F(TransferSubmitterConfigTest, InvalidValueWarningUsesLowercaseValue) {
+    ASSERT_EQ(setenv("MC_STORE_MEMCPY", "BAD", 1), 0);
+    ::testing::internal::CaptureStderr();
+    const auto config = TransferSubmitterConfig::FromEnvironment();
+    const auto diagnostics = ::testing::internal::GetCapturedStderr();
+
+    EXPECT_EQ(config.memcpy_enabled_override, std::optional<bool>{true});
+    EXPECT_NE(diagnostics.find("Invalid value for MC_STORE_MEMCPY: bad, "
+                               "defaulting to enabled"),
+              std::string::npos);
+}
+
+TEST_F(TransferSubmitterConfigTest, NewConfigsReadCurrentEnvironment) {
+    ASSERT_EQ(setenv("MC_STORE_MEMCPY", "0", 1), 0);
+    const auto first = TransferSubmitterConfig::FromEnvironment();
+    ASSERT_EQ(setenv("MC_STORE_MEMCPY", "1", 1), 0);
+    const auto second = TransferSubmitterConfig::FromEnvironment();
+    ASSERT_EQ(unsetenv("MC_STORE_MEMCPY"), 0);
+    const auto third = TransferSubmitterConfig::FromEnvironment();
+
+    EXPECT_EQ(first.memcpy_enabled_override, std::optional<bool>{false});
+    EXPECT_EQ(second.memcpy_enabled_override, std::optional<bool>{true});
+    EXPECT_FALSE(third.memcpy_enabled_override.has_value());
+}
+
+}  // namespace
+}  // namespace mooncake


### PR DESCRIPTION
## Description

Move `MC_STORE_MEMCPY` loading into a private `TransferSubmitterConfig` and add its definition to the grouped environment catalog. `TransferSubmitter` reads the config once per construction and keeps transport-dependent automatic selection when the variable is unset.

Preserve the existing accepted values, whitespace handling, warnings, and fallback. In particular, empty values and `enable`/`disable` remain invalid and warn before falling back to enabled. Local-copy eligibility and transfer execution are unchanged.

Part of #3809. This overlaps the `MC_STORE_MEMCPY` read in #1538, but uses the component-owned config layout adopted by the current series and does not include its other migrations.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -DBUILD_UNIT_TESTS=ON -DWITH_STORE_RUST=OFF \
  -DUSE_CUDA=OFF -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON \
  -DUSE_TENT=OFF -DUSE_NOF=OFF -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF -DSTORE_USE_REDIS=OFF
cmake --build build --target transfer_submitter_config_test transfer_task_test client_tcp_local_memcpy_test mooncake_client -j32
ctest --test-dir build -R '^(transfer_submitter_config|transfer_task|client_tcp_local_memcpy)_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

All 20 tests passed across the three CPU test targets; `mooncake_client` also builds. The four new config tests cover unset values, 28 valid/invalid input cases, warning behavior, and repeated config construction. Existing transfer and TCP local-copy tests passed before and after the change, including the same-process endpoint safety checks.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped implement the config extraction, add and run tests, and review the changes.