### PR TITLE
[P2P-Store] Back off transfer status polling after a spin budget

### DIFF
--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"time"
 )
 
 // When the data size larger than MAX_CHUNK_SIZE bytes, we split them into multiple buffers and registered separately.
@@ -475,34 +476,63 @@ func performTransferOnce(ctx context.Context, transport batchTransport, source u
 		return STATUS_FAILED, err
 	}
 
-	for isTransferInFlight(status) {
-		select {
-		case <-ctx.Done():
-			if _, drainErr := drainTransfer(transport, batchID); drainErr != nil {
-				return STATUS_FAILED, drainErr
-			}
-			return STATUS_FAILED, ctx.Err()
-		default:
-			status, _, err = transport.getTransferStatus(batchID, 0)
-			if err != nil {
-				return STATUS_FAILED, err
-			}
-		}
+	status, err = waitTransfer(ctx, transport, batchID)
+	if err != nil {
+		return STATUS_FAILED, err
 	}
-
 	return status, nil
 }
 
-// drainTransfer polls the batch until its task reaches a terminal state so
-// the batch can be freed.
-func drainTransfer(transport batchTransport, batchID BatchID) (int, error) {
+// Polling schedule for waitTransfer. The first pollSpinBudget polls run
+// back-to-back so short transfers still complete with no added latency;
+// after that the poller backs off exponentially from pollMinInterval to
+// pollMaxInterval. The cap stays small because some transports (for example
+// the NVLink async transport) only advance completion state when polled.
+const (
+	pollSpinBudget  = 128
+	pollMinInterval = 100 * time.Microsecond
+	pollMaxInterval = time.Millisecond
+)
+
+// waitTransfer polls task 0 of batchID until it reaches a terminal state.
+// On context cancellation it keeps polling until the task is terminal
+// (the engine refuses to free a batch with in-flight tasks) and then
+// returns ctx.Err().
+//
+// doGetReplica starts one goroutine per shard, so for a checkpoint-sized
+// payload hundreds of pollers may be active at once. Spinning them all at
+// full speed for a transfer that takes seconds buys nothing in completion
+// latency and saturates cores; the spin budget plus backoff keeps the
+// fast path for small transfers while bounding CPU on large ones.
+func waitTransfer(ctx context.Context, transport batchTransport, batchID BatchID) (int, error) {
 	status := STATUS_WAITING
-	for isTransferInFlight(status) {
+	interval := pollMinInterval
+	cancelled := false
+	for polls := 0; ; polls++ {
 		var err error
 		status, _, err = transport.getTransferStatus(batchID, 0)
 		if err != nil {
 			return STATUS_FAILED, err
 		}
+		if !isTransferInFlight(status) {
+			break
+		}
+		if !cancelled && ctx.Err() != nil {
+			cancelled = true
+		}
+		if polls < pollSpinBudget {
+			continue
+		}
+		time.Sleep(interval)
+		if interval < pollMaxInterval {
+			interval *= 2
+			if interval > pollMaxInterval {
+				interval = pollMaxInterval
+			}
+		}
+	}
+	if cancelled {
+		return STATUS_FAILED, ctx.Err()
 	}
 	return status, nil
 }

--- a/mooncake-p2p-store/src/p2pstore/core.go
+++ b/mooncake-p2p-store/src/p2pstore/core.go
@@ -494,10 +494,15 @@ const (
 	pollMaxInterval = time.Millisecond
 )
 
+// sleepFn is the sleep used between polls. Tests replace it to observe the
+// backoff schedule without depending on wall-clock timing.
+var sleepFn = time.Sleep
+
 // waitTransfer polls task 0 of batchID until it reaches a terminal state.
-// On context cancellation it keeps polling until the task is terminal
-// (the engine refuses to free a batch with in-flight tasks) and then
-// returns ctx.Err().
+// The task is always driven to a terminal state, even if ctx is cancelled
+// (the engine refuses to free a batch with in-flight tasks). Cancellation
+// is then authoritative: if ctx is done by the time the task is terminal,
+// ctx.Err() is returned regardless of the observed status.
 //
 // doGetReplica starts one goroutine per shard, so for a checkpoint-sized
 // payload hundreds of pollers may be active at once. Spinning them all at
@@ -507,7 +512,6 @@ const (
 func waitTransfer(ctx context.Context, transport batchTransport, batchID BatchID) (int, error) {
 	status := STATUS_WAITING
 	interval := pollMinInterval
-	cancelled := false
 	for polls := 0; ; polls++ {
 		var err error
 		status, _, err = transport.getTransferStatus(batchID, 0)
@@ -517,13 +521,10 @@ func waitTransfer(ctx context.Context, transport batchTransport, batchID BatchID
 		if !isTransferInFlight(status) {
 			break
 		}
-		if !cancelled && ctx.Err() != nil {
-			cancelled = true
-		}
 		if polls < pollSpinBudget {
 			continue
 		}
-		time.Sleep(interval)
+		sleepFn(interval)
 		if interval < pollMaxInterval {
 			interval *= 2
 			if interval > pollMaxInterval {
@@ -531,8 +532,8 @@ func waitTransfer(ctx context.Context, transport batchTransport, batchID BatchID
 			}
 		}
 	}
-	if cancelled {
-		return STATUS_FAILED, ctx.Err()
+	if err := ctx.Err(); err != nil {
+		return STATUS_FAILED, err
 	}
 	return status, nil
 }

--- a/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
+++ b/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
@@ -120,18 +120,27 @@ func TestPerformTransferOnceSubmitErrorFreesBatch(t *testing.T) {
 	}
 }
 
+// recordSleeps swaps sleepFn for a recorder so tests can assert the exact
+// backoff schedule instead of measuring wall-clock time.
+func recordSleeps(t *testing.T) *[]time.Duration {
+	t.Helper()
+	var slept []time.Duration
+	prev := sleepFn
+	sleepFn = func(d time.Duration) { slept = append(slept, d) }
+	t.Cleanup(func() { sleepFn = prev })
+	return &slept
+}
+
 // TestWaitTransferBacksOffAfterSpinBudget checks the polling schedule: within
-// the spin budget polls are back-to-back, after it the poller sleeps with
-// exponential backoff capped at pollMaxInterval, so a long transfer costs a
-// bounded number of status calls instead of one per scheduler slot.
+// the spin budget polls are back-to-back, after it every in-flight poll is
+// followed by one sleep, growing 100µs, 200µs, 400µs, 800µs, then capped at 1ms.
 func TestWaitTransferBacksOffAfterSpinBudget(t *testing.T) {
 	const extraPolls = 40
+	slept := recordSleeps(t)
 	fake := &fakeBatchTransport{pollsUntilDone: pollSpinBudget + extraPolls, finalStatus: STATUS_COMPLETED}
 	fake.submitted = true
 
-	start := time.Now()
 	status, err := waitTransfer(context.Background(), fake, BatchID(1))
-	elapsed := time.Since(start)
 	if err != nil || status != STATUS_COMPLETED {
 		t.Fatalf("status=%d err=%v", status, err)
 	}
@@ -139,11 +148,11 @@ func TestWaitTransferBacksOffAfterSpinBudget(t *testing.T) {
 	if fake.polls != pollSpinBudget+extraPolls {
 		t.Fatalf("polls = %d, want %d", fake.polls, pollSpinBudget+extraPolls)
 	}
-	// One sleep per in-flight poll past the budget: 100µs,200,400,800,1ms,1ms,...
-	var want time.Duration
+
+	var want []time.Duration
 	interval := pollMinInterval
 	for i := 0; i < extraPolls-1; i++ {
-		want += interval
+		want = append(want, interval)
 		if interval < pollMaxInterval {
 			interval *= 2
 			if interval > pollMaxInterval {
@@ -151,22 +160,48 @@ func TestWaitTransferBacksOffAfterSpinBudget(t *testing.T) {
 			}
 		}
 	}
-	if elapsed < want {
-		t.Fatalf("elapsed %v shorter than the scheduled backoff %v", elapsed, want)
+	if len(*slept) != len(want) {
+		t.Fatalf("sleep count = %d, want %d: %v", len(*slept), len(want), *slept)
 	}
-	if elapsed > want*4+50*time.Millisecond {
-		t.Fatalf("elapsed %v far exceeds the scheduled backoff %v", elapsed, want)
+	for i := range want {
+		if (*slept)[i] != want[i] {
+			t.Fatalf("sleep[%d] = %v, want %v (schedule %v)", i, (*slept)[i], want[i], *slept)
+		}
+	}
+	if (*slept)[len(*slept)-1] != pollMaxInterval {
+		t.Fatalf("backoff did not reach the cap: last sleep %v", (*slept)[len(*slept)-1])
 	}
 }
 
 func TestWaitTransferWithinSpinBudgetDoesNotSleep(t *testing.T) {
+	slept := recordSleeps(t)
 	fake := &fakeBatchTransport{pollsUntilDone: pollSpinBudget / 2, finalStatus: STATUS_COMPLETED}
 	fake.submitted = true
-	start := time.Now()
 	if _, err := waitTransfer(context.Background(), fake, BatchID(1)); err != nil {
 		t.Fatal(err)
 	}
-	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
-		t.Fatalf("spin-budget path took %v, should not sleep", elapsed)
+	if len(*slept) != 0 {
+		t.Fatalf("spin-budget path slept %d time(s): %v", len(*slept), *slept)
+	}
+}
+
+// TestWaitTransferCancelledContextWinsOverTerminalStatus pins the edge case
+// where ctx is already cancelled and the very first poll reports a terminal
+// status: cancellation is authoritative and ctx.Err() is returned.
+func TestWaitTransferCancelledContextWinsOverTerminalStatus(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fake := &fakeBatchTransport{pollsUntilDone: 0, finalStatus: STATUS_COMPLETED}
+	fake.submitted = true
+
+	status, err := waitTransfer(ctx, fake, BatchID(1))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if status != STATUS_FAILED {
+		t.Fatalf("status = %d, want STATUS_FAILED", status)
+	}
+	if fake.polls != 1 {
+		t.Fatalf("polls = %d, want 1 (terminal on first poll)", fake.polls)
 	}
 }

--- a/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
+++ b/mooncake-p2p-store/src/p2pstore/perform_transfer_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 var errBatchBusy = errors.New("BatchID cannot be freed until all tasks are done")
@@ -116,5 +117,56 @@ func TestPerformTransferOnceSubmitErrorFreesBatch(t *testing.T) {
 	}
 	if !fake.freed {
 		t.Fatal("batch ID leaked on submit failure")
+	}
+}
+
+// TestWaitTransferBacksOffAfterSpinBudget checks the polling schedule: within
+// the spin budget polls are back-to-back, after it the poller sleeps with
+// exponential backoff capped at pollMaxInterval, so a long transfer costs a
+// bounded number of status calls instead of one per scheduler slot.
+func TestWaitTransferBacksOffAfterSpinBudget(t *testing.T) {
+	const extraPolls = 40
+	fake := &fakeBatchTransport{pollsUntilDone: pollSpinBudget + extraPolls, finalStatus: STATUS_COMPLETED}
+	fake.submitted = true
+
+	start := time.Now()
+	status, err := waitTransfer(context.Background(), fake, BatchID(1))
+	elapsed := time.Since(start)
+	if err != nil || status != STATUS_COMPLETED {
+		t.Fatalf("status=%d err=%v", status, err)
+	}
+	// The fake reports terminal state on poll number pollsUntilDone.
+	if fake.polls != pollSpinBudget+extraPolls {
+		t.Fatalf("polls = %d, want %d", fake.polls, pollSpinBudget+extraPolls)
+	}
+	// One sleep per in-flight poll past the budget: 100µs,200,400,800,1ms,1ms,...
+	var want time.Duration
+	interval := pollMinInterval
+	for i := 0; i < extraPolls-1; i++ {
+		want += interval
+		if interval < pollMaxInterval {
+			interval *= 2
+			if interval > pollMaxInterval {
+				interval = pollMaxInterval
+			}
+		}
+	}
+	if elapsed < want {
+		t.Fatalf("elapsed %v shorter than the scheduled backoff %v", elapsed, want)
+	}
+	if elapsed > want*4+50*time.Millisecond {
+		t.Fatalf("elapsed %v far exceeds the scheduled backoff %v", elapsed, want)
+	}
+}
+
+func TestWaitTransferWithinSpinBudgetDoesNotSleep(t *testing.T) {
+	fake := &fakeBatchTransport{pollsUntilDone: pollSpinBudget / 2, finalStatus: STATUS_COMPLETED}
+	fake.submitted = true
+	start := time.Now()
+	if _, err := waitTransfer(context.Background(), fake, BatchID(1)); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(start); elapsed > 20*time.Millisecond {
+		t.Fatalf("spin-budget path took %v, should not sleep", elapsed)
 	}
 }


### PR DESCRIPTION
## Description

`doGetReplica` starts one goroutine per shard, and each one polled `getTransferStatus` in a tight loop until its transfer finished. For a checkpoint-sized payload that means tens to hundreds of pollers spinning at full speed for the whole transfer: fetching a 2 GB replica kept 8 to 11 cores busy on a 16-core host, and the CPU cost grew with the shard count. Since #3770, `drainTransfer` on the cancellation path spun the same way.

This PR replaces both loops with `waitTransfer`: the first `pollSpinBudget` (128) polls run back-to-back so short transfers keep their fast path, after that the poller sleeps with exponential backoff from 100µs to a 1ms cap. The cap is kept small because some transports (for example the NVLink async transport) only advance completion state when polled. Cancellation semantics are unchanged: on `ctx.Done()` the task is still driven to a terminal state before the batch is freed, and `ctx.Err()` is returned.

Why this is specific to P2P Store rather than a general Transfer Engine change: the Python `transfer_sync` also spins, but it is a single caller moving latency-sensitive KV cache where microseconds matter. P2P Store moves checkpoints in shards of tens of MB with N concurrent pollers, where the completion-latency gain from spinning is unmeasurable and the CPU cost is not.

## Related Components

- [x] P2P Store (`mooncake-p2p-store`)

## Type of Change

- [x] Performance improvement

## How Has This Been Tested?

**Unit tests** (`perform_transfer_test.go`, fake `batchTransport`):
- `TestWaitTransferWithinSpinBudgetDoesNotSleep`: transfers completing inside the budget add no sleep
- `TestWaitTransferBacksOffAfterSpinBudget`: after the budget, elapsed time matches the 100µs → 1ms schedule
- The three #3770 regressions (cancellation frees the batch, completion, submit error) still pass

```bash
cd mooncake-p2p-store/src/p2pstore
go build ./... && gofmt -l . && go test ./...   # locally with CGO_LDFLAGS="-Wl,-undefined,dynamic_lookup"
```

**Benchmark**: Ubuntu 24.04, 16 vCPU, kernel 6.8, main @6957e76 vs this branch, TCP transport, etcd metadata, trainer and inferencer on the same host. Trainer registers a 2 GB anonymous buffer; inferencer runs `GetReplica` repeatedly, measuring wall time and process CPU (`getrusage` delta) per call. Medians:

| shards (pollers) | branch | rounds | wall ms | CPU ms | avg cores busy | Gbps |
|---|---|---|---|---|---|---|
| 16 | main | 5 | 1362 | 11133 | 8.40 | 12.6 |
| 16 | this PR | 5 | 1375 | 1150 | 0.84 | 12.5 |
| 64 | main | 10 | 1622 | 17246 | 10.68 | 10.6 |
| 64 | this PR | 10 | 1569 | 1477 | 0.98 | 11.0 |
| 256 | main | 5 | 1630 | 18444 | 11.18 | 10.5 |
| 256 | this PR | 5 | 1435 | 1389 | 0.96 | 12.0 |

CPU time drops 10x to 13x and no longer scales with shard count (the remaining ~1 core is the TCP I/O thread). Wall time is within noise at 16 and 64 shards (+1%, -3%) and 12% faster at 256 shards, where the pollers had been competing with the I/O thread for CPU.

**RDMA** (added 2026-09-10): two OCI BM.Optimized3.36 nodes in a compute cluster, 100 Gbps RoCE v2 (`mlx5`, ~92 Gbps achieved across nodes), trainer on node A and inferencer on node B, same harness with `nic_priority_matrix`. Medians:

| workload | branch | rounds | wall ms | CPU ms | avg cores busy | Gbps |
|---|---|---|---|---|---|---|
| 2 GB / 16 shards | main | 10 | 185.6 | 2657 | 14.3 | 92.5 |
| | this PR | 10 | 186.9 (+0.6%) | 700 (**-74%**) | 3.8 | 91.9 |
| 2 GB / 64 shards | main | 10 | 187.2 | 6259 | 33.4 | 91.8 |
| | this PR | 10 | 186.9 (-0.2%) | 1422 (**-77%**) | 7.7 | 92.0 |
| 2 GB / 256 shards | main | 10 | 186.7 | 7180 | 38.6 | 92.1 |
| | this PR | 10 | 186.9 (+0.2%) | 1600 (**-78%**) | 8.6 | 91.9 |
| 64 MB single shard (worst case) | main | 20 | 8.7 | 25 | 2.9 | 61.8 |
| | this PR | 20 | 9.1 (+5%, +0.4 ms) | 20 (-20%) | 2.2 | 58.5 |

On RDMA the pollers burn even more (up to 39 cores for a 2 GB fetch) because transfers finish faster. Checkpoint-sized payloads: no wall-time change within noise. Single 64 MB shard: +0.4 ms median, p90/max unchanged, no tail amplification. A 200 µs cap variant was identical on the single shard and 15-25% more CPU on sharded runs, so the 1 ms cap stays.

**Test results:**
- [x] Unit tests pass
- [x] Manual testing done (benchmark above)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

AI assisted with the code audit, benchmark harness, and drafting. The submitter has reviewed, understands, and takes responsibility for all changes.
