### PR TITLE
[TransferEngine] Avoid zero-length WR depth allocation for zero-QP RDMA endpoints

### DIFF
--- a/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
+++ b/mooncake-transfer-engine/src/transport/rdma_transport/rdma_endpoint.cpp
@@ -128,6 +128,12 @@ int RdmaEndPoint::construct(ibv_cq *cq, size_t num_qp_list,
     max_sge_per_wr_ = max_sge_per_wr;
     max_inline_bytes_ = max_inline_bytes;
 
+    if (num_qp_list == 0) {
+        ready_wait_start_ts_.store(0, std::memory_order_relaxed);
+        status_.store(UNCONNECTED, std::memory_order_relaxed);
+        return 0;
+    }
+
     wr_depth_list_ = new std::atomic<int>[num_qp_list]();
     if (!wr_depth_list_) {
         LOG(ERROR) << "Failed to allocate memory for work request depth list";


### PR DESCRIPTION
## Description

Fixes the LeakSanitizer failure in `rdma_endpoint_state_test` for zero-QP test endpoints.

`RdmaEndPoint::construct()` previously allocated `wr_depth_list_` even when `num_qp_list == 0`. In C++, `new T[0]` may still return an allocation that must be freed, which showed up in CI as a deterministic 1-byte LeakSanitizer leak from zero-QP endpoints created by `installZeroQpEndpoint()`.

This change explicitly handles `num_qp_list == 0` before allocating `wr_depth_list_`. Zero-QP endpoints still transition to `UNCONNECTED`, but no zero-length allocation is performed.

Related: #3839

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build --target rdma_endpoint_state_test -j
./build/mooncake-transfer-engine/tests/rdma_endpoint_state_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

`rdma_endpoint_state_test` passed: 8 tests from 2 test suites.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [ ] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

Note: `pre-commit` is not installed in my local environment, so I could not run PR-scoped pre-commit.

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Used Codex to inspect the LeakSanitizer trace, implement the zero-QP guard, and run local verification.