### PR TITLE
[Store] Structure FilePerKeyConfig environment settings

### DIFF
--- a/mooncake-common/include/environment_variables.h
+++ b/mooncake-common/include/environment_variables.h
@@ -38,6 +38,12 @@ struct FileStorageEnvironmentVariables {
     MC_DEFINE_ENV_VAR(std::string, MOONCAKE_USE_URING);
 };
 
+struct FilePerKeyEnvironmentVariables {
+    MC_DEFINE_ENV_VAR(std::string, MOONCAKE_OFFLOAD_FSDIR);
+    MC_DEFINE_ENV_VAR(bool, MOONCAKE_OFFLOAD_ENABLE_EVICTION);
+    MC_DEFINE_ENV_VAR(bool, ENABLE_EVICTION);
+};
+
 struct ClientAutoPortEnvironmentVariables {
     MC_DEFINE_ENV_VAR(int, MC_STORE_CLIENT_SETUP_RETRIES);
     MC_DEFINE_ENV_VAR(int, MC_STORE_CLIENT_MIN_PORT);

--- a/mooncake-store/include/config/file_per_key_config.h
+++ b/mooncake-store/include/config/file_per_key_config.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+
+namespace mooncake {
+
+struct FilePerKeyConfig {
+    std::string fsdir = "file_per_key_dir";  // Subdirectory name
+
+    bool enable_eviction = true;  // Enable eviction for storage
+
+    bool Validate() const;
+
+    static FilePerKeyConfig FromEnvironment();
+};
+
+}  // namespace mooncake

--- a/mooncake-store/include/storage_backend.h
+++ b/mooncake-store/include/storage_backend.h
@@ -15,6 +15,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "config/file_per_key_config.h"
 #include "config/offset_allocator_backend_config.h"
 #include "file_interface.h"
 #include "mutex.h"
@@ -171,16 +172,6 @@ enum class StorageBackendType {
 static constexpr size_t kKB = 1024;
 static constexpr size_t kMB = kKB * 1024;
 static constexpr size_t kGB = kMB * 1024;
-
-struct FilePerKeyConfig {
-    std::string fsdir = "file_per_key_dir";  // Subdirectory name
-
-    bool enable_eviction = true;  // Enable eviction for storage
-
-    bool Validate() const;
-
-    static FilePerKeyConfig FromEnvironment();
-};
 
 enum class BucketEvictionPolicy {
     NONE,  // No eviction (default)

--- a/mooncake-store/src/CMakeLists.txt
+++ b/mooncake-store/src/CMakeLists.txt
@@ -96,6 +96,7 @@ set(MOONCAKE_STORE_CLIENT_SOURCES
     file_storage.cpp
     config/client_metric_config.cpp
     config/file_storage_config.cpp
+    config/file_per_key_config.cpp
     config/client_auto_port_config.cpp
     config/local_hot_cache_config.cpp
     config/offset_allocator_backend_config.cpp

--- a/mooncake-store/src/config/file_per_key_config.cpp
+++ b/mooncake-store/src/config/file_per_key_config.cpp
@@ -1,0 +1,32 @@
+#include "config/file_per_key_config.h"
+
+#include <glog/logging.h>
+
+#include "environ.h"
+#include "environment_variables.h"
+
+namespace mooncake {
+
+bool FilePerKeyConfig::Validate() const {
+    if (fsdir.empty()) {
+        LOG(ERROR) << "FilePerKeyConfig: fsdir is invalid";
+        return false;
+    }
+    return true;
+}
+
+FilePerKeyConfig FilePerKeyConfig::FromEnvironment() {
+    FilePerKeyConfig config;
+    using Variables = FilePerKeyEnvironmentVariables;
+
+    config.fsdir =
+        Environ::ReadOr(Variables::MOONCAKE_OFFLOAD_FSDIR, config.fsdir);
+
+    config.enable_eviction = Environ::ReadOr(
+        Variables::MOONCAKE_OFFLOAD_ENABLE_EVICTION,
+        Environ::ReadOr(Variables::ENABLE_EVICTION, config.enable_eviction));
+
+    return config;
+}
+
+}  // namespace mooncake

--- a/mooncake-store/src/storage_backend.cpp
+++ b/mooncake-store/src/storage_backend.cpp
@@ -57,14 +57,6 @@ struct FdGuard {
 
 namespace mooncake {
 
-bool FilePerKeyConfig::Validate() const {
-    if (fsdir.empty()) {
-        LOG(ERROR) << "FilePerKeyConfig: fsdir is invalid";
-        return false;
-    }
-    return true;
-}
-
 bool BucketBackendConfig::Validate() const {
     if (bucket_keys_limit <= 0) {
         LOG(ERROR) << "BucketBackendConfig: bucket_keys_limit must > 0";
@@ -75,18 +67,6 @@ bool BucketBackendConfig::Validate() const {
         return false;
     }
     return true;
-}
-
-FilePerKeyConfig FilePerKeyConfig::FromEnvironment() {
-    FilePerKeyConfig config;
-
-    config.fsdir = Environ::GetString("MOONCAKE_OFFLOAD_FSDIR", config.fsdir);
-
-    config.enable_eviction = Environ::GetBool(
-        "MOONCAKE_OFFLOAD_ENABLE_EVICTION",
-        Environ::GetBool("ENABLE_EVICTION", config.enable_eviction));
-
-    return config;
 }
 
 BucketBackendConfig BucketBackendConfig::FromEnvironment() {

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -223,6 +223,7 @@ add_store_test(master_service_test_for_snapshot
 add_store_test(non_ha_reconnect_test non_ha_reconnect_test.cpp)
 add_store_test(nvme_kv_storage_backend_test nvme_kv_storage_backend_test.cpp)
 add_store_test(storage_backend_test storage_backend_test.cpp)
+add_store_test(file_per_key_config_test file_per_key_config_test.cpp)
 add_store_test(offset_allocator_backend_config_test
                offset_allocator_backend_config_test.cpp)
 add_store_test(client_storage_backend_test client_storage_backend_test.cpp)

--- a/mooncake-store/tests/file_per_key_config_test.cpp
+++ b/mooncake-store/tests/file_per_key_config_test.cpp
@@ -1,0 +1,231 @@
+#include "config/file_per_key_config.h"
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+namespace mooncake::test {
+namespace {
+
+class FilePerKeyConfigTest : public ::testing::Test {
+   protected:
+    static void SetUpTestSuite() {
+        google::InitGoogleLogging("FilePerKeyConfigTest");
+    }
+
+    static void TearDownTestSuite() { google::ShutdownGoogleLogging(); }
+
+    void SetUp() override {
+        original_logtostderr_ = FLAGS_logtostderr;
+        FLAGS_logtostderr = true;
+        for (size_t i = 0; i < kVariables.size(); ++i) {
+            if (const char* value = std::getenv(kVariables[i])) {
+                original_[i] = value;
+            }
+        }
+        for (const char* name : kVariables) {
+            ASSERT_EQ(unsetenv(name), 0);
+        }
+    }
+
+    void TearDown() override {
+        for (size_t i = 0; i < kVariables.size(); ++i) {
+            if (original_[i].has_value()) {
+                EXPECT_EQ(setenv(kVariables[i], original_[i]->c_str(), 1), 0);
+            } else {
+                EXPECT_EQ(unsetenv(kVariables[i]), 0);
+            }
+        }
+        FLAGS_logtostderr = original_logtostderr_;
+    }
+
+   private:
+    inline static constexpr std::array<const char*, 3> kVariables = {
+        "MOONCAKE_OFFLOAD_FSDIR", "MOONCAKE_OFFLOAD_ENABLE_EVICTION",
+        "ENABLE_EVICTION"};
+    std::array<std::optional<std::string>, 3> original_;
+    bool original_logtostderr_ = false;
+};
+
+TEST_F(FilePerKeyConfigTest, UnsetValuesKeepDefaults) {
+    testing::internal::CaptureStderr();
+    const auto config = FilePerKeyConfig::FromEnvironment();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    EXPECT_EQ(config.fsdir, "file_per_key_dir");
+    EXPECT_TRUE(config.enable_eviction);
+    EXPECT_TRUE(config.Validate());
+    EXPECT_TRUE(diagnostics.empty());
+}
+
+TEST_F(FilePerKeyConfigTest, ReadsDirectoryVerbatimWithoutValidation) {
+    for (const char* value : {"", "   ", "relative/subdir", " /data "}) {
+        SCOPED_TRACE(value);
+        ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_FSDIR", value, 1), 0);
+        testing::internal::CaptureStderr();
+        const auto config = FilePerKeyConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+
+        EXPECT_EQ(config.fsdir, value);
+        EXPECT_TRUE(diagnostics.empty());
+    }
+}
+
+TEST_F(FilePerKeyConfigTest, ValidateRejectsOnlyEmptyDirectory) {
+    FilePerKeyConfig config;
+    config.fsdir = "";
+    testing::internal::CaptureStderr();
+    const bool valid = config.Validate();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(valid);
+    EXPECT_NE(diagnostics.find("FilePerKeyConfig: fsdir is invalid"),
+              std::string::npos);
+    for (const char* value : {"   ", "relative/subdir", " /data "}) {
+        SCOPED_TRACE(value);
+        config.fsdir = value;
+        EXPECT_TRUE(config.Validate());
+    }
+}
+
+TEST_F(FilePerKeyConfigTest, BothEvictionNamesKeepBoolParsingAndWarnings) {
+    struct Case {
+        const char* value;
+        bool enabled;
+        bool warning;
+    };
+    const Case cases[] = {
+        {"1", true, false},
+        {"0", false, false},
+        {"true", true, false},
+        {"FALSE", false, false},
+        {"Yes", true, false},
+        {"nO", false, false},
+        {"on", true, false},
+        {"OFF", false, false},
+        {"enable", true, false},
+        {"DISABLE", false, false},
+        {" \tfalse\r\n", false, false},
+        {"", true, true},
+        {"   ", true, true},
+        {"2", true, true},
+        {"-1", true, true},
+        {"999999999999999999999999", true, true},
+        {"falsex", true, true},
+        {"invalid", true, true},
+    };
+    for (const char* name :
+         {"MOONCAKE_OFFLOAD_ENABLE_EVICTION", "ENABLE_EVICTION"}) {
+        SCOPED_TRACE(name);
+        for (const auto& entry : cases) {
+            SCOPED_TRACE(entry.value);
+            ASSERT_EQ(setenv(name, entry.value, 1), 0);
+            testing::internal::CaptureStderr();
+            const auto config = FilePerKeyConfig::FromEnvironment();
+            const auto diagnostics = testing::internal::GetCapturedStderr();
+
+            EXPECT_EQ(config.enable_eviction, entry.enabled);
+            const std::string expected =
+                entry.warning
+                    ? std::string("[Mooncake] Warning: invalid value '") +
+                          entry.value + "' for env " + name +
+                          ", using default 1\n"
+                    : "";
+            EXPECT_EQ(diagnostics, expected);
+        }
+        ASSERT_EQ(unsetenv(name), 0);
+    }
+}
+
+TEST_F(FilePerKeyConfigTest, PreferredEvictionNameOverridesLegacyValue) {
+    struct Case {
+        const char* legacy;
+        const char* preferred;
+        bool enabled;
+    };
+    const Case cases[] = {{"true", "false", false}, {"false", "true", true}};
+    for (const auto& entry : cases) {
+        SCOPED_TRACE(entry.preferred);
+        ASSERT_EQ(setenv("ENABLE_EVICTION", entry.legacy, 1), 0);
+        ASSERT_EQ(
+            setenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION", entry.preferred, 1), 0);
+        testing::internal::CaptureStderr();
+        const auto config = FilePerKeyConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+
+        EXPECT_EQ(config.enable_eviction, entry.enabled);
+        EXPECT_TRUE(diagnostics.empty());
+    }
+}
+
+TEST_F(FilePerKeyConfigTest, InvalidPreferredValueFallsBackToLegacyValue) {
+    ASSERT_EQ(setenv("ENABLE_EVICTION", "false", 1), 0);
+    for (const char* value : {"", "bad"}) {
+        SCOPED_TRACE(value);
+        ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION", value, 1), 0);
+        testing::internal::CaptureStderr();
+        const auto config = FilePerKeyConfig::FromEnvironment();
+        const auto diagnostics = testing::internal::GetCapturedStderr();
+
+        EXPECT_FALSE(config.enable_eviction);
+        EXPECT_EQ(diagnostics,
+                  std::string("[Mooncake] Warning: invalid value '") + value +
+                      "' for env MOONCAKE_OFFLOAD_ENABLE_EVICTION, using "
+                      "default 0\n");
+    }
+}
+
+TEST_F(FilePerKeyConfigTest, InvalidLegacyValueWarnsEvenWithValidPreferred) {
+    ASSERT_EQ(setenv("ENABLE_EVICTION", "bad", 1), 0);
+    ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION", "false", 1), 0);
+    testing::internal::CaptureStderr();
+    const auto config = FilePerKeyConfig::FromEnvironment();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(config.enable_eviction);
+    EXPECT_EQ(diagnostics,
+              "[Mooncake] Warning: invalid value 'bad' for env "
+              "ENABLE_EVICTION, using default 1\n");
+}
+
+TEST_F(FilePerKeyConfigTest, InvalidAliasesWarnInLegacyFirstOrder) {
+    ASSERT_EQ(setenv("ENABLE_EVICTION", "bad", 1), 0);
+    ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION", "bad", 1), 0);
+    testing::internal::CaptureStderr();
+    const auto config = FilePerKeyConfig::FromEnvironment();
+    const auto diagnostics = testing::internal::GetCapturedStderr();
+
+    EXPECT_TRUE(config.enable_eviction);
+    EXPECT_EQ(diagnostics,
+              "[Mooncake] Warning: invalid value 'bad' for env "
+              "ENABLE_EVICTION, using default 1\n"
+              "[Mooncake] Warning: invalid value 'bad' for env "
+              "MOONCAKE_OFFLOAD_ENABLE_EVICTION, using default 1\n");
+}
+
+TEST_F(FilePerKeyConfigTest, NewConfigsReadCurrentEnvironment) {
+    ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_FSDIR", "first", 1), 0);
+    ASSERT_EQ(setenv("ENABLE_EVICTION", "false", 1), 0);
+    const auto first = FilePerKeyConfig::FromEnvironment();
+    ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_FSDIR", "second", 1), 0);
+    ASSERT_EQ(setenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION", "true", 1), 0);
+    const auto second = FilePerKeyConfig::FromEnvironment();
+    ASSERT_EQ(unsetenv("MOONCAKE_OFFLOAD_FSDIR"), 0);
+    ASSERT_EQ(unsetenv("MOONCAKE_OFFLOAD_ENABLE_EVICTION"), 0);
+    ASSERT_EQ(unsetenv("ENABLE_EVICTION"), 0);
+    const auto third = FilePerKeyConfig::FromEnvironment();
+
+    EXPECT_EQ(first.fsdir, "first");
+    EXPECT_FALSE(first.enable_eviction);
+    EXPECT_EQ(second.fsdir, "second");
+    EXPECT_TRUE(second.enable_eviction);
+    EXPECT_EQ(third.fsdir, "file_per_key_dir");
+    EXPECT_TRUE(third.enable_eviction);
+}
+
+}  // namespace
+}  // namespace mooncake::test


### PR DESCRIPTION
## Description

Move the existing `FilePerKeyConfig` declaration into an independent config header and its environment loading and validation into `src/config`. Group its three environment-variable definitions in the common catalog and use the existing typed readers. Existing callers can still include `storage_backend.h`.

Preserve defaults, accepted values, empty-value handling, warnings, alias precedence, and per-config read timing. The legacy `ENABLE_EVICTION` value is still read before `MOONCAKE_OFFLOAD_ENABLE_EVICTION`, including its warnings when the preferred variable is valid. Storage initialization, file operations, and eviction behavior are unchanged.

Part of #3809.

## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [x] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake -S . -B build -DBUILD_UNIT_TESTS=ON -DWITH_STORE_RUST=OFF \
  -DUSE_CUDA=OFF -DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=ON \
  -DUSE_TENT=OFF -DUSE_NOF=OFF -DUSE_ETCD=OFF \
  -DSTORE_USE_ETCD=OFF -DSTORE_USE_REDIS=OFF
cmake --build build --target file_per_key_config_test storage_backend_test file_storage_test mooncake_client -j32
ctest --test-dir build -R '^(file_per_key_config|storage_backend|file_storage)_test$' --output-on-failure
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

All 124 tests passed across the three CPU test targets; `mooncake_client` also builds. The nine new config tests passed against the original implementation and after extraction. They cover defaults, verbatim directory values, validation, bool parsing through both variable names, alias precedence, warnings, and repeated config construction. The existing 115 storage tests passed before and after the change without modifications.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used (specify below)

Codex helped extract the config, add and run tests, and review the changes.