### PR TITLE
[Bugfix][Store] Read SSD replicas in session get API

### DIFF
--- a/mooncake-store/include/real_client.h
+++ b/mooncake-store/include/real_client.h
@@ -992,7 +992,8 @@ class RealClient : public PyClient {
 
     // KV transfer sessions (process-local; not shared with DummyClient).
     // get_sessions_ stores a FilterQueryResult'd QueryResult (single complete
-    // memory replica + lease); ranges only compare lease locally (no Master).
+    // replica selected by SelectBestReplica + lease); ranges only compare
+    // lease locally (no Master).
     // Put sessions track writable + inflight so end/revoke can seal the
     // session and wait for outstanding range writes before finalize/free.
     struct PutSessionEntry {

--- a/mooncake-store/src/real_client.cpp
+++ b/mooncake-store/src/real_client.cpp
@@ -414,25 +414,6 @@ inline bool is_object_range_overflow(size_t offset, size_t size, size_t limit) {
     return size > limit || offset > limit - size;
 }
 
-inline const Replica::Descriptor *SelectCompleteMemoryReplica(
-    const std::vector<Replica::Descriptor> &replicas,
-    const std::unordered_set<std::string> &local_endpoints) {
-    const Replica::Descriptor *first_memory = nullptr;
-    for (const auto &r : replicas) {
-        if (r.status != ReplicaStatus::COMPLETE || !r.is_memory_replica()) {
-            continue;
-        }
-        if (local_endpoints.count(r.get_memory_descriptor()
-                                      .buffer_descriptor.transport_endpoint_)) {
-            return &r;
-        }
-        if (!first_memory) {
-            first_memory = &r;
-        }
-    }
-    return first_memory;
-}
-
 inline bool HasMemoryReplica(const std::vector<Replica::Descriptor> &replicas) {
     for (const auto &r : replicas) {
         if (r.is_memory_replica()) {
@@ -5524,9 +5505,9 @@ std::vector<int> RealClient::batch_get_session_start(
         }
 
         const auto *replica =
-            SelectCompleteMemoryReplica(query_result.replicas, local_endpoints);
+            SelectBestReplica(query_result.replicas, local_endpoints);
         if (!replica) {
-            LOG(ERROR) << "No complete memory replica for key: " << keys[i];
+            LOG(ERROR) << "No complete replica for key: " << keys[i];
             results[i] = static_cast<int>(toInt(ErrorCode::INVALID_REPLICA));
             get_sessions_.erase(keys[i]);
             continue;
@@ -5557,8 +5538,9 @@ std::vector<int> RealClient::batch_get_into_multi_buffer_ranges(
 
     // No Master RPC here: use cached QueryResult from session start.
     // RealClient owns session state (lease/overflow checks, replica lookup);
-    // the actual parallel transfer is delegated to Client.
+    // memory ranges use Client; other replicas reuse the batched restore path.
     std::vector<Replica::Descriptor> replicas;
+    std::vector<std::pair<size_t, QueryResult>> restore_entries;
     std::vector<std::vector<Slice>> slices;
     std::vector<std::vector<uint64_t>> src_offsets;
     std::vector<size_t> idx_map;  // batch entry -> original key index
@@ -5584,20 +5566,18 @@ std::vector<int> RealClient::batch_get_into_multi_buffer_ranges(
                 results[i] = static_cast<int>(toInt(ErrorCode::LEASE_EXPIRED));
                 continue;
             }
-            // start cached a single complete memory replica via
-            // FilterQueryResult.
+            // start cached a single complete replica via FilterQueryResult.
             const auto &replica = it->second.replicas.front();
             const size_t replica_limit =
-                replica.is_memory_replica()
-                    ? replica.get_memory_descriptor().buffer_descriptor.size_
-                    : 0;
+                static_cast<size_t>(calculate_total_size(replica));
             bool overflow = false;
             std::vector<Slice> entry_slices;
             std::vector<uint64_t> entry_offsets;
             entry_slices.reserve(buffers.size());
             entry_offsets.reserve(buffers.size());
             for (size_t j = 0; j < buffers.size(); ++j) {
-                if (replica_limit == 0 ||
+                if ((buffers[j] == nullptr && sizes[j] != 0) ||
+                    replica_limit == 0 ||
                     is_object_range_overflow(offsets[j], sizes[j],
                                              replica_limit)) {
                     overflow = true;
@@ -5610,6 +5590,10 @@ std::vector<int> RealClient::batch_get_into_multi_buffer_ranges(
                 results[i] = static_cast<int>(toInt(ErrorCode::INVALID_PARAMS));
                 continue;
             }
+            if (!replica.is_memory_replica()) {
+                restore_entries.emplace_back(i, it->second);
+                continue;
+            }
             replicas.push_back(replica);
             slices.push_back(std::move(entry_slices));
             src_offsets.push_back(std::move(entry_offsets));
@@ -5618,12 +5602,88 @@ std::vector<int> RealClient::batch_get_into_multi_buffer_ranges(
         }
     }
 
-    if (replicas.empty()) {
+    if (replicas.empty() && restore_entries.empty()) {
         return results;
     }
 
     auto transfer =
         client_->BatchTransferReadRanges(replicas, slices, src_offsets);
+    const size_t memory_count = transfer.size();
+
+    std::vector<std::string> restore_keys;
+    std::vector<void *> restore_buffers;
+    std::vector<size_t> restore_sizes;
+    std::vector<tl::expected<QueryResult, ErrorCode>> restore_queries;
+    std::vector<BufferHandle> restore_handles;
+    std::unordered_map<std::string, size_t> restore_index;
+    for (const auto &[i, query_result] : restore_entries) {
+        idx_map.push_back(i);
+        lease_deadlines.push_back(query_result.lease_timeout);
+        transfer.emplace_back(tl::unexpected(ErrorCode::INVALID_PARAMS));
+        if (all_buffers[i].empty()) {
+            transfer.back() = 0;
+            continue;
+        }
+        if (!client_buffer_allocator_) {
+            continue;
+        }
+        if (restore_index.count(keys[i])) {
+            continue;
+        }
+        // The offload backend requires a full-object destination. Restore each
+        // key once per call, including duplicate keys with different ranges.
+        const size_t total_size =
+            calculate_total_size(query_result.replicas.front());
+        auto allocated = client_buffer_allocator_->allocate(total_size);
+        if (!allocated) {
+            transfer.back() = tl::unexpected(ErrorCode::NO_AVAILABLE_HANDLE);
+            continue;
+        }
+        restore_index.emplace(keys[i], restore_keys.size());
+        restore_keys.push_back(keys[i]);
+        restore_handles.emplace_back(std::move(*allocated));
+        restore_buffers.push_back(restore_handles.back().ptr());
+        restore_sizes.push_back(total_size);
+        restore_queries.push_back(query_result);
+    }
+    if (!restore_keys.empty()) {
+        // Cached queries avoid Master RPCs; the existing get path groups
+        // LOCAL_DISK objects by owner and handles DISK/DFS reads as well.
+        auto restored = batch_get_into_internal(
+            restore_keys, restore_buffers, restore_sizes, restore_queries,
+            [this](const std::string &endpoint,
+                   LocalDiskOffloadObjects &objects) {
+                return batch_get_into_offload_object_internal(endpoint,
+                                                              objects);
+            });
+        for (size_t j = 0; j < restore_entries.size(); ++j) {
+            const size_t i = restore_entries[j].first;
+            auto cached = restore_index.find(keys[i]);
+            if (all_buffers[i].empty() || cached == restore_index.end())
+                continue;
+            const size_t restored_index = cached->second;
+            auto &result = transfer[memory_count + j];
+            if (!restored[restored_index]) {
+                result = tl::unexpected(restored[restored_index].error());
+                continue;
+            }
+            result = 0;
+            for (size_t k = 0; k < all_buffers[i].size(); ++k) {
+                if (all_sizes[i][k] == 0) continue;
+                const auto *src =
+                    static_cast<const char *>(restore_buffers[restored_index]) +
+                    all_src_offsets[i][k];
+                auto copied = scatter_host_to_maybe_device(
+                    all_buffers[i][k], src, all_sizes[i][k],
+                    "session range read, key: " + keys[i]);
+                if (!copied) {
+                    result = tl::unexpected(copied.error());
+                    break;
+                }
+                *result += static_cast<int64_t>(all_sizes[i][k]);
+            }
+        }
+    }
 
     // Merge results; drop sessions whose lease expired during the wait.
     {

--- a/mooncake-store/tests/pybind_client_test.cpp
+++ b/mooncake-store/tests/pybind_client_test.cpp
@@ -1277,6 +1277,140 @@ TEST_F(RealClientTest, TestPutGetSessionRanges) {
     ASSERT_EQ(py_client_->unregister_buffer(dst_data.data()), 0);
 }
 
+// Issue #3658: read SSD-only keys through a separate TCP client.
+TEST_F(RealClientTest, TestGetSessionRangesFromSsdOffload) {
+    ScopedEnvVar heartbeat("MOONCAKE_OFFLOAD_HEARTBEAT_INTERVAL_SECONDS", "1");
+    ScopedEnvVar storage_backend("MOONCAKE_OFFLOAD_STORAGE_BACKEND_DESCRIPTOR",
+                                 "bucket_storage_backend");
+    ScopedEnvVar bucket_keys("MOONCAKE_OFFLOAD_BUCKET_KEYS_LIMIT", "1");
+    char path[] = "/tmp/mooncake_ssd_session_XXXXXX";
+    ASSERT_NE(mkdtemp(path), nullptr);
+    ssd_path_ = path;
+    constexpr int kLeaseMs = 1000;
+    ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder()
+                                  .set_enable_offload(true)
+                                  .set_default_kv_lease_ttl(kLeaseMs)
+                                  .build()));
+    master_address_ = master_.master_address();
+    const std::string owner = "localhost:17822";
+    ASSERT_EQ(py_client_->setup_real(
+                  owner, "P2PHANDSHAKE", 16 * 1024 * 1024, 16 * 1024 * 1024,
+                  "tcp", "", master_address_, nullptr, "", true, ssd_path_),
+              0);
+    auto reader = RealClient::create();
+    ASSERT_EQ(reader->setup_real("localhost:17823", "P2PHANDSHAKE", 0,
+                                 16 * 1024 * 1024, "tcp", "", master_address_),
+              0);
+
+    constexpr size_t kPageSize = 64;
+    constexpr size_t kObjectSize = 4 * kPageSize;
+    const std::vector<std::string> keys = {"session_ssd_0", "session_ssd_1",
+                                           "session_memory"};
+    std::string src(kObjectSize * keys.size(), '\0');
+    std::string dst(src.size(), 'Z');
+    for (size_t i = 0; i < src.size(); ++i) {
+        src[i] = static_cast<char>(i % 251);
+    }
+    ASSERT_EQ(reader->register_buffer(dst.data(), dst.size()), 0);
+    for (size_t i = 0; i < keys.size(); ++i) {
+        ASSERT_EQ(py_client_->put(
+                      keys[i], std::span<const char>(
+                                   src.data() + i * kObjectSize, kObjectSize)),
+                  0);
+    }
+
+    const std::vector<std::string> ssd_keys(keys.begin(), keys.begin() + 2);
+    for (const auto& key : ssd_keys) {
+        bool ready = false;
+        const auto deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        while (!ready && std::chrono::steady_clock::now() < deadline) {
+            for (const auto& replica : py_client_->get_replica_desc(key)) {
+                ready |= replica.is_local_disk_replica() &&
+                         replica.status == ReplicaStatus::COMPLETE;
+            }
+            if (!ready)
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        ASSERT_TRUE(ready) << key;
+    }
+    // Querying above granted a lease; wait for it before clearing MEMORY.
+    std::this_thread::sleep_for(std::chrono::milliseconds(kLeaseMs + 50));
+    ASSERT_EQ(py_client_->batch_replica_clear(ssd_keys, owner).size(),
+              ssd_keys.size());
+    for (const auto& key : ssd_keys) {
+        const auto replicas = py_client_->get_replica_desc(key);
+        ASSERT_EQ(replicas.size(), 1u);
+        ASSERT_TRUE(replicas.front().is_local_disk_replica());
+    }
+    ASSERT_EQ(reader->batch_get_session_start(keys), std::vector<int>(3, 0));
+
+    auto read_ranges = [&](const std::vector<size_t>& offsets,
+                           const std::vector<size_t>& sizes) {
+        std::fill(dst.begin(), dst.end(), 'Z');
+        std::string expected(dst);
+        std::vector<std::vector<void*>> buffers(keys.size());
+        size_t total = 0;
+        for (size_t j = 0; j < sizes.size(); ++j) {
+            for (size_t i = 0; i < keys.size(); ++i) {
+                buffers[i].push_back(dst.data() + i * kObjectSize + total);
+                expected.replace(i * kObjectSize + total, sizes[j], src,
+                                 i * kObjectSize + offsets[j], sizes[j]);
+            }
+            total += sizes[j];
+        }
+        const auto before = reader->get_offload_rpc_read_count();
+        EXPECT_EQ(reader->batch_get_into_multi_buffer_ranges(
+                      keys, buffers,
+                      std::vector<std::vector<size_t>>(keys.size(), sizes),
+                      std::vector<std::vector<size_t>>(keys.size(), offsets)),
+                  std::vector<int>(keys.size(), total));
+        EXPECT_EQ(reader->get_offload_rpc_read_count(), before + 1);
+        EXPECT_EQ(dst, expected);
+    };
+    read_ranges({0, kPageSize, 2 * kPageSize, 3 * kPageSize},
+                {kPageSize, kPageSize, kPageSize, kPageSize});
+    read_ranges({kPageSize}, {kPageSize});            // Non-tail partial read.
+    read_ranges({2 * kPageSize, 7, 9}, {16, 16, 8});  // Unordered, overlapping.
+
+    // Repeated SSD keys must fill each destination without duplicate reads.
+    const auto before_duplicate = reader->get_offload_rpc_read_count();
+    EXPECT_EQ(reader->batch_get_into_multi_buffer_ranges(
+                  {keys[0], keys[0]}, {{dst.data()}, {dst.data() + kPageSize}},
+                  {{kPageSize}, {kPageSize}}, {{0}, {2 * kPageSize}}),
+              std::vector<int>(2, kPageSize));
+    EXPECT_EQ(reader->get_offload_rpc_read_count(), before_duplicate + 1);
+    EXPECT_EQ(dst.substr(0, kPageSize), src.substr(0, kPageSize));
+    EXPECT_EQ(dst.substr(kPageSize, kPageSize),
+              src.substr(2 * kPageSize, kPageSize));
+
+    // Invalid entries must not prevent valid entries in the batch from reading.
+    const int invalid = static_cast<int>(toInt(ErrorCode::INVALID_PARAMS));
+    EXPECT_EQ(
+        reader->batch_get_into_multi_buffer_ranges(
+            keys, {{dst.data()}, {dst.data()}, {dst.data() + kObjectSize}},
+            {{kPageSize}, {kPageSize}, {kPageSize}},
+            {{std::numeric_limits<size_t>::max()}, {0}, {kObjectSize}}),
+        (std::vector<int>{invalid, kPageSize, invalid}));
+    const auto before_empty = reader->get_offload_rpc_read_count();
+    EXPECT_EQ(reader->batch_get_into_multi_buffer_ranges(
+                  {keys[0], keys[1]}, {{}, {nullptr}}, {{}, {1}}, {{}, {0}}),
+              (std::vector<int>{0, invalid}));
+    EXPECT_EQ(reader->get_offload_rpc_read_count(), before_empty);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(kLeaseMs + 50));
+    EXPECT_EQ(
+        reader->batch_get_into_multi_buffer_ranges({keys[0]}, {{dst.data()}},
+                                                   {{1}}, {{0}}),
+        (std::vector<int>{static_cast<int>(toInt(ErrorCode::LEASE_EXPIRED))}));
+    EXPECT_EQ(reader->batch_get_session_end(keys), 0);
+    EXPECT_EQ(reader->batch_get_into_multi_buffer_ranges(
+                  {keys[1]}, {{dst.data()}}, {{1}}, {{0}}),
+              (std::vector<int>{invalid}));
+    ASSERT_EQ(reader->unregister_buffer(dst.data()), 0);
+    EXPECT_EQ(reader->tearDownAll(), 0);
+}
+
 // Abnormal put/get session cases. See check table in PR / review notes.
 TEST_F(RealClientTest, TestPutGetSessionAbnormal) {
     ASSERT_TRUE(master_.Start(InProcMasterConfigBuilder().build()))


### PR DESCRIPTION
## Description

Fixes #3658

`batch_get_session_start` only selected complete memory replicas, so keys whose data lived only on SSD (`LOCAL_DISK`) failed with `702 INVALID_REPLICA`. Changing selection alone (see #3662) is not enough: `batch_get_into_multi_buffer_ranges` still required a memory replica, so SSD session gets still failed after start succeeded.

This change is intentionally small and reuses existing paths:

1. `batch_get_session_start` uses `SelectBestReplica` (same as `batch_get_into`).
2. Session range get keeps `Client::BatchTransferReadRanges` for MEMORY replicas.
3. Non-memory replicas (LOCAL_DISK / DISK / DFS) reuse `execute_ranged_read`.
4. LOCAL_DISK partial reads allocate a full-object buffer because the bucket offload backend requires dest size to match object size, then scatter the requested range.

Does not change `SelectBestReplica` scan order (left to #3662 / #3742).

## Module

- [x] Mooncake Store (`mooncake-store`)
- [x] Docs

## Type of Change

- [x] Bug fix
- [x] Documentation update

## How Has This Been Tested?

**Test commands:**
```bash
./mooncake-store/tests/pybind_client_test \
  --gtest_filter='RealClientTest.TestGetSessionRangesFromSsdOffload:RealClientTest.TestPutGetSession*'
```

**Protocol:** TCP (`FLAGS_protocol=tcp`, `setup_real(..., "tcp", ...)`). Not RDMA.

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done (describe below)

`RealClientTest.TestGetSessionRangesFromSsdOffload` (new): put object, wait for LOCAL_DISK, clear memory replica, `batch_get_session_start` returns 0 (not 702), layerwise `batch_get_into_multi_buffer_ranges` matches payload, `get_offload_rpc_read_count()` increases.

Also passed existing `TestPutGetSessionRanges` and `TestPutGetSessionAbnormal` (same TCP setup).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue

clang-format 20 was applied to the touched C++ files.

## AI Assistance Disclosure

- [x] AI tools were used (specify below)

Cursor Grok 4.6 implemented the session SSD read path, the LOCAL_DISK full-object scatter reuse, the in-proc e2e test, and this PR. The human submitter is responsible for reviewing and defending the changes.