### PR TITLE
[Store] Add DFS read/write metrics and diagnostic logging

### DIFF
--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -653,6 +653,226 @@ struct SsdMetric {
     }
 };
 
+// DFS metrics. The DFS data plane is descriptor-addressed BatchWrite/BatchRead
+// against preallocated shard files and never passes through FileStorage, so
+// SsdMetric does not observe any of it; these counters are recorded in Client
+// instead. kSsdLatencyBucket is reused because DFS is 3fs/nfs backed and shares
+// the same 50us-30s latency envelope as the SSD offload path.
+struct DfsMetric {
+    // Failures are dimensioned by ErrorCode name so a scrape can tell
+    // DFS_SERVICE_UNAVAILABLE apart from FILE_WRITE_FAIL without log digging.
+    std::array<std::string, 1> error_label_names = {"error"};
+
+    explicit DfsMetric(std::map<std::string, std::string> labels = {})
+        : dfs_read_bytes("mooncake_dfs_read_bytes_total",
+                         "Total bytes read from DFS", labels),
+          dfs_write_bytes("mooncake_dfs_write_bytes_total",
+                          "Total bytes written to DFS", labels),
+          dfs_read_ops("mooncake_dfs_read_ops_total",
+                       "Total number of DFS read operations (key count)",
+                       labels),
+          dfs_write_ops("mooncake_dfs_write_ops_total",
+                        "Total number of DFS write operations (key count)",
+                        labels),
+          dfs_read_latency_us("mooncake_dfs_read_latency_us",
+                              "DFS BatchRead latency per batch (us)",
+                              kSsdLatencyBucket, labels),
+          dfs_write_latency_us(
+              "mooncake_dfs_write_latency_us",
+              "DFS BatchWrite latency per batch (us), excluding D2H staging",
+              kSsdLatencyBucket, labels),
+          dfs_write_staging_latency_us(
+              "mooncake_dfs_write_staging_latency_us",
+              "DFS device-to-host staging latency per batch (us)",
+              kSsdLatencyBucket, labels),
+          dfs_read_latency_summary("mooncake_dfs_read_latency_summary_us",
+                                   "DFS read latency quantiles (us)",
+                                   {0.5, 0.9, 0.99}, labels),
+          dfs_write_latency_summary("mooncake_dfs_write_latency_summary_us",
+                                    "DFS write latency quantiles (us)",
+                                    {0.5, 0.9, 0.99}, labels),
+          dfs_read_errors("mooncake_dfs_read_errors_total",
+                          "DFS read failures by error code (key count)", labels,
+                          error_label_names),
+          dfs_write_errors("mooncake_dfs_write_errors_total",
+                           "DFS write failures by error code (key count)",
+                           labels, error_label_names),
+          dfs_writes_skipped(
+              "mooncake_dfs_writes_skipped_total",
+              "DFS writes skipped without being attempted because a non-DFS "
+              "replica transfer failed first (key count)",
+              labels),
+          start_time_(std::chrono::steady_clock::now()) {}
+
+    ylt::metric::counter_t dfs_read_bytes;
+    ylt::metric::counter_t dfs_write_bytes;
+    ylt::metric::counter_t dfs_read_ops;
+    ylt::metric::counter_t dfs_write_ops;
+    ylt::metric::histogram_t dfs_read_latency_us;
+    ylt::metric::histogram_t dfs_write_latency_us;
+    ylt::metric::histogram_t dfs_write_staging_latency_us;
+    ylt::metric::summary_t dfs_read_latency_summary;
+    ylt::metric::summary_t dfs_write_latency_summary;
+    ylt::metric::hybrid_counter_1t dfs_read_errors;
+    ylt::metric::hybrid_counter_1t dfs_write_errors;
+    ylt::metric::counter_t dfs_writes_skipped;
+    std::chrono::steady_clock::time_point start_time_;
+
+    // One op is one key, matching the SsdMetric convention. Only successful
+    // keys are counted here; failures go to RecordReadErrors instead, so
+    // ops/bytes stay a clean measure of delivered work.
+    void ObserveRead(int64_t key_count, int64_t bytes, uint64_t latency_us) {
+        dfs_read_ops.inc(key_count);
+        dfs_read_bytes.inc(bytes);
+        dfs_read_latency_us.observe(latency_us);
+        dfs_read_latency_summary.observe(latency_us);
+    }
+
+    void ObserveWrite(int64_t key_count, int64_t bytes, uint64_t latency_us) {
+        dfs_write_ops.inc(key_count);
+        dfs_write_bytes.inc(bytes);
+        dfs_write_latency_us.observe(latency_us);
+        dfs_write_latency_summary.observe(latency_us);
+    }
+
+    // Staging is the GPU->host copy that precedes a DFS write. It is observed
+    // separately because it is neither DFS I/O nor attributable to the DFS
+    // backend, yet it sits inside the same put latency window.
+    void ObserveWriteStaging(uint64_t latency_us) {
+        dfs_write_staging_latency_us.observe(latency_us);
+    }
+
+    // error_name is the ErrorCode spelling from toString(); keeping it a string
+    // avoids pulling types.h into the metric header.
+    void RecordReadErrors(const std::string& error_name, int64_t count = 1) {
+        const std::array<std::string, 1> error_label = {error_name};
+        {
+            std::lock_guard<std::mutex> lock(observed_errors_mutex_);
+            observed_read_errors_.insert(error_name);
+        }
+        dfs_read_errors.inc(error_label, count);
+    }
+
+    void RecordWriteErrors(const std::string& error_name, int64_t count = 1) {
+        const std::array<std::string, 1> error_label = {error_name};
+        {
+            std::lock_guard<std::mutex> lock(observed_errors_mutex_);
+            observed_write_errors_.insert(error_name);
+        }
+        dfs_write_errors.inc(error_label, count);
+    }
+
+    void RecordSkippedWrites(int64_t count) { dfs_writes_skipped.inc(count); }
+
+    void serialize(std::string& str) {
+        dfs_read_bytes.serialize(str);
+        dfs_write_bytes.serialize(str);
+        dfs_read_ops.serialize(str);
+        dfs_write_ops.serialize(str);
+        dfs_read_latency_us.serialize(str);
+        dfs_write_latency_us.serialize(str);
+        dfs_write_staging_latency_us.serialize(str);
+        dfs_read_latency_summary.serialize(str);
+        dfs_write_latency_summary.serialize(str);
+        dfs_read_errors.serialize(str);
+        dfs_write_errors.serialize(str);
+        dfs_writes_skipped.serialize(str);
+    }
+
+    std::string summary_metrics() {
+        std::stringstream ss;
+        ss << "=== DFS Metrics Summary ===" << "\n";
+
+        const auto read_bytes = dfs_read_bytes.value();
+        const auto write_bytes = dfs_write_bytes.value();
+        const auto read_ops = dfs_read_ops.value();
+        const auto write_ops = dfs_write_ops.value();
+        const auto elapsed_s = std::chrono::duration<double>(
+                                   std::chrono::steady_clock::now() -
+                                   start_time_)
+                                   .count();
+
+        ss << format_io_line("DFS Read", read_bytes, read_ops, elapsed_s);
+        ss << format_io_line("DFS Write", write_bytes, write_ops, elapsed_s);
+        ss << "DFS Writes Skipped: " << dfs_writes_skipped.value() << "\n";
+        ss << format_error_line("DFS Read Errors", observed_read_errors_,
+                                dfs_read_errors);
+        ss << format_error_line("DFS Write Errors", observed_write_errors_,
+                                dfs_write_errors);
+
+        ss << "\n" << "=== DFS Latency Summary (microseconds) ===" << "\n";
+        ss << "Read: " << format_percentiles(dfs_read_latency_summary) << "\n";
+        ss << "Write: " << format_percentiles(dfs_write_latency_summary)
+           << "\n";
+
+        return ss.str();
+    }
+
+   private:
+    std::mutex observed_errors_mutex_;
+    std::unordered_set<std::string> observed_read_errors_;
+    std::unordered_set<std::string> observed_write_errors_;
+
+    // Reads the label values seen so far so the text summary can enumerate the
+    // hybrid counter, mirroring TransferOperationMetric::snapshot_operations.
+    std::string format_error_line(
+        const std::string& label,
+        const std::unordered_set<std::string>& observed,
+        ylt::metric::hybrid_counter_1t& counter) {
+        std::vector<std::string> names;
+        {
+            std::lock_guard<std::mutex> lock(observed_errors_mutex_);
+            names.assign(observed.begin(), observed.end());
+        }
+        if (names.empty()) {
+            return "";
+        }
+        std::sort(names.begin(), names.end());
+
+        std::stringstream ss;
+        ss << label << ":";
+        for (const auto& name : names) {
+            const std::array<std::string, 1> error_label = {name};
+            ss << " " << name << "=" << counter.value(error_label);
+        }
+        ss << "\n";
+        return ss.str();
+    }
+
+    std::string format_io_line(const std::string& label, int64_t bytes,
+                               int64_t ops, double elapsed_s) {
+        std::stringstream ss;
+        ss << label << ": " << byte_size_to_string(bytes) << ", ops=" << ops;
+        if (elapsed_s > 0 && bytes > 0) {
+            ss << ", throughput="
+               << byte_size_to_string(static_cast<int64_t>(bytes / elapsed_s))
+               << "/s";
+            ss << ", IOPS=" << std::fixed << std::setprecision(1)
+               << (ops / elapsed_s);
+        }
+        ss << "\n";
+        return ss.str();
+    }
+
+    std::string format_percentiles(ylt::metric::summary_t& summary) {
+        double sum = 0;
+        uint64_t count = 0;
+        auto rates = summary.get_rates(sum, count);
+        if (count == 0) {
+            return "No data";
+        }
+
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(1);
+        ss << "count=" << count;
+        if (rates.size() >= 1) ss << ", p50=" << rates[0] << "us";
+        if (rates.size() >= 2) ss << ", p90=" << rates[1] << "us";
+        if (rates.size() >= 3) ss << ", p99=" << rates[2] << "us";
+        ss << ", avg=" << (sum / count) << "us";
+        return ss.str();
+    }
+};
+
 struct ClientMetricConfig {
     bool enabled = true;
     std::chrono::milliseconds reporting_interval{0};
@@ -666,6 +886,7 @@ struct ClientMetric {
     MasterClientMetric master_client_metric;
     TransferOperationMetric transfer_operation_metric;
     SsdMetric ssd_metric;
+    DfsMetric dfs_metric;
     // Prometheus "info" pattern: the value carries no meaning and is always 1,
     // the version strings ride along as static labels next to any caller
     // supplied labels so a scrape can attribute samples to a concrete build.

--- a/mooncake-store/include/client_metric.h
+++ b/mooncake-store/include/client_metric.h
@@ -787,10 +787,10 @@ struct DfsMetric {
         const auto write_bytes = dfs_write_bytes.value();
         const auto read_ops = dfs_read_ops.value();
         const auto write_ops = dfs_write_ops.value();
-        const auto elapsed_s = std::chrono::duration<double>(
-                                   std::chrono::steady_clock::now() -
-                                   start_time_)
-                                   .count();
+        const auto elapsed_s =
+            std::chrono::duration<double>(std::chrono::steady_clock::now() -
+                                          start_time_)
+                .count();
 
         ss << format_io_line("DFS Read", read_bytes, read_ops, elapsed_s);
         ss << format_io_line("DFS Write", write_bytes, write_ops, elapsed_s);

--- a/mooncake-store/include/client_service.h
+++ b/mooncake-store/include/client_service.h
@@ -637,6 +637,10 @@ class Client {
         return metrics_ ? &metrics_->ssd_metric : nullptr;
     }
 
+    DfsMetric* GetDfsMetricPtr() {
+        return metrics_ ? &metrics_->dfs_metric : nullptr;
+    }
+
     [[nodiscard]] std::string GetTransportEndpoint() {
         return transfer_engine_->getLocalIpAndPort();
     }

--- a/mooncake-store/include/metadata_store.h
+++ b/mooncake-store/include/metadata_store.h
@@ -35,7 +35,7 @@ struct StandbyObjectMetadata {
     // state; promoted objects resume as ordinary cache.
     std::string group_id;  // Tenant group identifier
     ObjectDataType data_type{
-        ObjectDataType::UNKNOWN};  // Data type classification
+        ObjectDataType::UNKNOWN};                  // Data type classification
     struct_pack::compatible<bool, 1> hard_pinned;  // Eviction protection
 
     StandbyObjectMetadata() = default;

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -29,6 +29,7 @@ ClientMetric::ClientMetric(uint64_t interval_seconds,
       master_client_metric(labels),
       transfer_operation_metric(labels),
       ssd_metric(labels),
+      dfs_metric(labels), 
       build_info("mooncake_build_info",
                  "Build version of the running client; the value is always 1 "
                  "and the version strings are carried by the labels",
@@ -79,6 +80,7 @@ void ClientMetric::serialize(std::string& str) {
     }
     transfer_operation_metric.serialize(str);
     ssd_metric.serialize(str);
+    dfs_metric.serialize(str);
     build_info.serialize(str);
 }
 
@@ -98,6 +100,8 @@ std::string ClientMetric::summary_metrics() {
     ss << transfer_operation_metric.summary_metrics();
     ss << "\n";
     ss << ssd_metric.summary_metrics();
+    ss << "\n";
+    ss << dfs_metric.summary_metrics();
     return ss.str();
 }
 

--- a/mooncake-store/src/client_metric.cpp
+++ b/mooncake-store/src/client_metric.cpp
@@ -29,7 +29,7 @@ ClientMetric::ClientMetric(uint64_t interval_seconds,
       master_client_metric(labels),
       transfer_operation_metric(labels),
       ssd_metric(labels),
-      dfs_metric(labels), 
+      dfs_metric(labels),
       build_info("mooncake_build_info",
                  "Build version of the running client; the value is always 1 "
                  "and the version strings are carried by the labels",

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1685,6 +1685,10 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
         if (replica.is_dfs_replica()) {
             if (!dfs_storage_backend_) {
                 LOG(ERROR) << "DFS backend is not initialized";
+                if (auto* dfs_metric = GetDfsMetricPtr()) {
+                    dfs_metric->RecordReadErrors(
+                        toString(ErrorCode::DFS_SERVICE_UNAVAILABLE));
+                }
                 results[i] = tl::unexpected(ErrorCode::DFS_SERVICE_UNAVAILABLE);
                 continue;
             }
@@ -1726,7 +1730,12 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
     }
 
     if (!dfs_read_requests.empty()) {
+        auto* dfs_metric = GetDfsMetricPtr();
+        const auto dfs_read_start = std::chrono::steady_clock::now();
         auto dfs_results = dfs_storage_backend_->BatchRead(dfs_read_requests);
+        const auto dfs_read_latency_us = elapsed_us_since(dfs_read_start);
+        int64_t dfs_success_keys = 0;
+        uint64_t dfs_success_bytes = 0;
         if (dfs_results.size() != dfs_read_requests.size()) {
             LOG(ERROR) << "DFS BatchRead response size mismatch: expected "
                        << dfs_read_requests.size() << ", got "
@@ -1734,24 +1743,59 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
             for (size_t index : dfs_read_indices) {
                 results[index] = tl::unexpected(ErrorCode::INTERNAL_ERROR);
             }
+            if (dfs_metric) {
+                dfs_metric->RecordReadErrors(
+                    toString(ErrorCode::INTERNAL_ERROR),
+                    static_cast<int64_t>(dfs_read_indices.size()));
+            }
         } else {
             for (size_t i = 0; i < dfs_results.size(); ++i) {
                 const size_t index = dfs_read_indices[i];
                 const auto& request = dfs_read_requests[i];
                 if (!dfs_results[i]) {
+                    LOG(WARNING)
+                        << "DFS read failed, action=batch_read, key="
+                        << request.key
+                        << ", offset=" << request.descriptor.offset
+                        << ", size=" << request.descriptor.object_size
+                        << ", error=" << dfs_results[i].error();
+                    if (dfs_metric) {
+                        dfs_metric->RecordReadErrors(
+                            toString(dfs_results[i].error()));
+                    }
                     results[index] = tl::unexpected(dfs_results[i].error());
                     continue;
                 }
+                // The I/O itself delivered these bytes, so they count even if
+                // the checksum below rejects the payload; a checksum mismatch
+                // is additionally recorded as an error so the two are
+                // distinguishable.
+                ++dfs_success_keys;
+                dfs_success_bytes += request.descriptor.object_size;
                 auto checksum_result = VerifyObjectChecksum(
                     request.key, request.slices, request.descriptor.object_size,
                     query_results[index].object_checksum);
                 if (!checksum_result) {
+                    if (dfs_metric) {
+                        dfs_metric->RecordReadErrors(
+                            toString(checksum_result.error()));
+                    }
                     results[index] = tl::unexpected(checksum_result.error());
                     continue;
                 }
                 results[index] = {};
             }
         }
+    if (dfs_metric && dfs_success_keys > 0) {
+            dfs_metric->ObserveRead(dfs_success_keys,
+                                    static_cast<int64_t>(dfs_success_bytes),
+                                    dfs_read_latency_us);
+        }
+    VLOG(1) << "DFS batch read finished, action=batch_read, requested="
+            << dfs_read_requests.size()
+            << ", succeeded=" << dfs_success_keys
+            << ", bytes=" << dfs_success_bytes
+            << ", latency_us=" << dfs_read_latency_us;
     }
 
     // Wait for all transfers to complete
@@ -2618,27 +2662,47 @@ std::vector<ErrorCode> Client::WriteDfsReplicas(
     }
     if (!dfs_storage_backend_) {
         LOG(ERROR) << "DFS backend is unavailable for synchronous write";
+        if (auto* dfs_metric = GetDfsMetricPtr()) {
+            dfs_metric->RecordWriteErrors(
+                toString(ErrorCode::DFS_SERVICE_UNAVAILABLE),
+                static_cast<int64_t>(keys.size()));
+        }
         return std::vector<ErrorCode>(keys.size(),
                                       ErrorCode::DFS_SERVICE_UNAVAILABLE);
     }
 
+    auto* dfs_metric = GetDfsMetricPtr();
     std::vector<ErrorCode> results(keys.size(), ErrorCode::OK);
     std::vector<DfsWriteRequest> requests;
     std::vector<size_t> request_indices;
+    // Bytes per request, so the success accounting after BatchWrite does not
+    // have to walk the slice lists a second time.
+    std::vector<uint64_t> request_bytes;
     std::vector<PinnedBufferPool::Buffer> staging_buffers;
     requests.reserve(keys.size());
     request_indices.reserve(keys.size());
-
+    request_bytes.reserve(keys.size());
+    
+    // Staging is the device-to-host copy below; it is timed separately from the
+    // BatchWrite call so a slow put can be attributed to the right side of the
+    // boundary between them.
+    const auto staging_start = std::chrono::steady_clock::now();
+    bool staging_performed = false;
     auto runtime_accelerator =
         device::GetAcceleratorRegistry().RuntimeAccelerators();
     for (size_t i = 0; i < keys.size(); ++i) {
         if (slice_lists[i] == nullptr) {
             results[i] = ErrorCode::INVALID_PARAMS;
+            if (dfs_metric) {
+                dfs_metric->RecordWriteErrors(
+                    toString(ErrorCode::INVALID_PARAMS));
+            }
             continue;
         }
 
         std::vector<Slice> host_slices;
         host_slices.reserve(slice_lists[i]->size());
+        uint64_t key_bytes = 0;
         bool staging_succeeded = true;
         for (const auto& slice : *slice_lists[i]) {
             device::PointerInfo info{};
@@ -2647,46 +2711,89 @@ std::vector<ErrorCode> Client::WriteDfsReplicas(
                                : runtime_accelerator.FindDeviceForPointer(
                                      slice.ptr, &info);
             if (device == nullptr) {
+                key_bytes += slice.size;
                 host_slices.push_back(slice);
                 continue;
             }
 
+            staging_performed = true;
             device->SetContext(info.device_id);
             auto buffer = pinned_buffer_pool_->Acquire(slice.size);
             if (!device->Copy(buffer.data, slice.ptr, slice.size,
                               device::CopyDirection::kDeviceToHost)) {
-                LOG(ERROR) << "DFS D2H staging failed for key " << keys[i];
+                LOG(ERROR) << "DFS D2H staging failed, action=stage, key="
+                           << keys[i] << ", size=" << slice.size
+                           << ", device_id=" << info.device_id;
                 pinned_buffer_pool_->Release(std::move(buffer));
                 results[i] = ErrorCode::TRANSFER_FAIL;
                 staging_succeeded = false;
                 break;
             }
+            key_bytes += slice.size;
             host_slices.emplace_back(Slice{buffer.data, slice.size});
             staging_buffers.push_back(std::move(buffer));
         }
         if (!staging_succeeded) {
+            // Counted as a DFS write failure: the key was destined for DFS and
+            // never got there, even though the backend was never reached.
+            if (dfs_metric) {
+                dfs_metric->RecordWriteErrors(
+                    toString(ErrorCode::TRANSFER_FAIL));
+            }
             continue;
         }
 
         requests.push_back(
             DfsWriteRequest{keys[i], descriptors[i], std::move(host_slices)});
         request_indices.push_back(i);
+        request_bytes.push_back(key_bytes);
+    }
+    if (dfs_metric && staging_performed) {
+        dfs_metric->ObserveWriteStaging(elapsed_us_since(staging_start));
     }
 
+    const auto write_start = std::chrono::steady_clock::now();
     auto write_results = dfs_storage_backend_->BatchWrite(requests);
+    const auto write_latency_us = elapsed_us_since(write_start);
+    int64_t success_keys = 0;
+    uint64_t success_bytes = 0;
     if (write_results.size() != requests.size()) {
         LOG(ERROR) << "DFS BatchWrite response size mismatch: expected "
                    << requests.size() << ", got " << write_results.size();
         for (size_t index : request_indices) {
             results[index] = ErrorCode::INTERNAL_ERROR;
         }
+        if (dfs_metric && !request_indices.empty()) {
+            dfs_metric->RecordWriteErrors(
+                toString(ErrorCode::INTERNAL_ERROR),
+                static_cast<int64_t>(request_indices.size()));
+        }
     } else {
         for (size_t i = 0; i < write_results.size(); ++i) {
             results[request_indices[i]] =
                 write_results[i] ? ErrorCode::OK : write_results[i].error();
+            if (write_results[i]) {
+                ++success_keys;
+                success_bytes += request_bytes[i];
+            } else if (dfs_metric) {
+                dfs_metric->RecordWriteErrors(
+                    toString(write_results[i].error()));
+            }
         }
     }
-
+    // Latency is per batch, so it is only observed when the batch delivered
+    // something; a fully failed batch would otherwise pollute the histogram
+    // with error-path timings.
+    if (dfs_metric && success_keys > 0) {
+        dfs_metric->ObserveWrite(success_keys,
+                                 static_cast<int64_t>(success_bytes),
+                                 write_latency_us);
+    }
+    VLOG(1) << "DFS batch write finished, action=write, requested="
+            << requests.size() << ", succeeded=" << success_keys
+            << ", bytes=" << success_bytes
+            << ", latency_us=" << write_latency_us;
+    
     for (auto& buffer : staging_buffers) {
         pinned_buffer_pool_->Release(std::move(buffer));
     }
@@ -2698,12 +2805,22 @@ void Client::SubmitDfsWrites(std::vector<PutOperation>& ops) {
     std::vector<const std::vector<Slice>*> slice_lists;
     std::vector<DistributedFSDescriptor> descriptors;
     std::vector<size_t> op_indices;
+    auto* dfs_metric = GetDfsMetricPtr();
+    int64_t skipped_writes = 0;
 
     for (size_t i = 0; i < ops.size(); ++i) {
         auto& op = ops[i];
         if (op.IsResolved() ||
-            op.transfer_summary.allocated_dfs_replicas == 0 ||
-            !NonDfsTransfersSucceeded(op.transfer_summary)) {
+            op.transfer_summary.allocated_dfs_replicas == 0) {
+            continue;
+        }
+        // A DFS replica was allocated but is abandoned because a peer replica
+        // failed first. Without this counter the write simply disappears: no
+        // error is recorded against DFS and no I/O is attempted.
+        if (!NonDfsTransfersSucceeded(op.transfer_summary)) {
+            ++skipped_writes;
+            VLOG(1) << "Skipping DFS write, action=skip, key=" << op.key
+                    << ", reason=non_dfs_transfer_failed";
             continue;
         }
 
@@ -2715,12 +2832,19 @@ void Client::SubmitDfsWrites(std::vector<PutOperation>& ops) {
             op.transfer_summary.RecordFailure(ReplicaType::DFS,
                                               ErrorCode::INVALID_REPLICA);
             op.AppendFailureContext("Allocated DFS replica has no descriptor");
+            if (dfs_metric) {
+                dfs_metric->RecordWriteErrors(
+                    toString(ErrorCode::INVALID_REPLICA));
+            }
             continue;
         }
         keys.push_back(op.key);
         slice_lists.push_back(&op.slices);
         descriptors.push_back(dfs_it->get_dfs_descriptor());
         op_indices.push_back(i);
+    }
+    if (dfs_metric && skipped_writes > 0) {
+        dfs_metric->RecordSkippedWrites(skipped_writes);
     }
 
     auto results = WriteDfsReplicas(keys, slice_lists, descriptors);
@@ -4536,21 +4660,44 @@ ErrorCode Client::ReadDfsReplica(const std::string& key,
     }
     if (!dfs_storage_backend_) {
         LOG(ERROR) << "DFS backend is not initialized";
+        if (auto* dfs_metric = GetDfsMetricPtr()) {
+            dfs_metric->RecordReadErrors(
+                toString(ErrorCode::DFS_SERVICE_UNAVAILABLE));
+        }
         return ErrorCode::DFS_SERVICE_UNAVAILABLE;
     }
 
+    auto* dfs_metric = GetDfsMetricPtr();
     const auto& desc = replica_descriptor.get_dfs_descriptor();
     std::vector<DfsReadRequest> requests{DfsReadRequest{key, desc, slices}};
+    const auto read_start = std::chrono::steady_clock::now();
     auto results = dfs_storage_backend_->BatchRead(requests);
+    const auto read_latency_us = elapsed_us_since(read_start);
     if (results.size() != 1) {
         LOG(ERROR) << "DFS BatchRead response size mismatch for key " << key;
+        if (dfs_metric) {
+            dfs_metric->RecordReadErrors(toString(ErrorCode::INTERNAL_ERROR));
+        }
         return ErrorCode::INTERNAL_ERROR;
     }
     if (!results[0]) {
-        LOG(ERROR) << "DFS read failed for key " << key << ": "
-                   << results[0].error();
+        LOG(ERROR) << "DFS read failed, action=read, key=" << key
+                   << ", offset=" << desc.offset
+                   << ", size=" << desc.object_size
+                   << ", latency_us=" << read_latency_us
+                   << ", error=" << results[0].error();
+        if (dfs_metric) {
+            dfs_metric->RecordReadErrors(toString(results[0].error()));
+        }
         return results[0].error();
     }
+    if (dfs_metric) {
+        dfs_metric->ObserveRead(1, static_cast<int64_t>(desc.object_size),
+                                read_latency_us);
+    }
+    VLOG(1) << "DFS read finished, action=read, key=" << key
+            << ", offset=" << desc.offset << ", size=" << desc.object_size
+            << ", latency_us=" << read_latency_us;
     return ErrorCode::OK;
 }
 

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1753,12 +1753,11 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
                 const size_t index = dfs_read_indices[i];
                 const auto& request = dfs_read_requests[i];
                 if (!dfs_results[i]) {
-                    LOG(WARNING)
-                        << "DFS read failed, action=batch_read, key="
-                        << request.key
-                        << ", offset=" << request.descriptor.offset
-                        << ", size=" << request.descriptor.object_size
-                        << ", error=" << dfs_results[i].error();
+                    LOG(WARNING) << "DFS read failed, action=batch_read, key="
+                                 << request.key
+                                 << ", offset=" << request.descriptor.offset
+                                 << ", size=" << request.descriptor.object_size
+                                 << ", error=" << dfs_results[i].error();
                     if (dfs_metric) {
                         dfs_metric->RecordReadErrors(
                             toString(dfs_results[i].error()));
@@ -1786,16 +1785,16 @@ std::vector<tl::expected<void, ErrorCode>> Client::BatchGet(
                 results[index] = {};
             }
         }
-    if (dfs_metric && dfs_success_keys > 0) {
+        if (dfs_metric && dfs_success_keys > 0) {
             dfs_metric->ObserveRead(dfs_success_keys,
                                     static_cast<int64_t>(dfs_success_bytes),
                                     dfs_read_latency_us);
         }
-    VLOG(1) << "DFS batch read finished, action=batch_read, requested="
-            << dfs_read_requests.size()
-            << ", succeeded=" << dfs_success_keys
-            << ", bytes=" << dfs_success_bytes
-            << ", latency_us=" << dfs_read_latency_us;
+        VLOG(1) << "DFS batch read finished, action=batch_read, requested="
+                << dfs_read_requests.size()
+                << ", succeeded=" << dfs_success_keys
+                << ", bytes=" << dfs_success_bytes
+                << ", latency_us=" << dfs_read_latency_us;
     }
 
     // Wait for all transfers to complete
@@ -2682,7 +2681,7 @@ std::vector<ErrorCode> Client::WriteDfsReplicas(
     requests.reserve(keys.size());
     request_indices.reserve(keys.size());
     request_bytes.reserve(keys.size());
-    
+
     // Staging is the device-to-host copy below; it is timed separately from the
     // BatchWrite call so a slow put can be attributed to the right side of the
     // boundary between them.
@@ -2793,7 +2792,7 @@ std::vector<ErrorCode> Client::WriteDfsReplicas(
             << requests.size() << ", succeeded=" << success_keys
             << ", bytes=" << success_bytes
             << ", latency_us=" << write_latency_us;
-    
+
     for (auto& buffer : staging_buffers) {
         pinned_buffer_pool_->Release(std::move(buffer));
     }

--- a/mooncake-store/src/client_service.cpp
+++ b/mooncake-store/src/client_service.cpp
@@ -1396,6 +1396,11 @@ tl::expected<void, ErrorCode> Client::Get(const std::string& object_key,
         VerifyObjectChecksum(object_key, slices, calculate_total_size(replica),
                              query_result.object_checksum);
     if (!checksum_result) {
+        // add checksum err for single-key
+        auto* dfs_metric = GetDfsMetricPtr();
+        if (replica.is_dfs_replica() && dfs_metric) {
+            dfs_metric->RecordReadErrors(toString(checksum_result.error()));
+        }
         return tl::unexpected(checksum_result.error());
     }
 
@@ -1998,6 +2003,16 @@ tl::expected<void, ErrorCode> Client::Put(const ObjectKey& key,
                 transfer_summary.RecordFailure(ReplicaType::DFS, dfs_result);
             }
         }
+    } else if (transfer_summary.allocated_dfs_replicas > 0) {
+        // A DFS replica was allocated but is abandoned because a peer replica
+        // failed first. Without this counter the write simply disappears: no
+        // error is recorded against DFS and no I/O is attempted. Counted per
+        // key, matching SubmitDfsWrites.
+        VLOG(1) << "Skipping DFS write, action=skip, key=" << key
+                << ", reason=non_dfs_transfer_failed";
+        if (auto* dfs_metric = GetDfsMetricPtr()) {
+            dfs_metric->RecordSkippedWrites(1);
+        }
     }
 
     auto us_put = std::chrono::duration_cast<std::chrono::microseconds>(
@@ -2135,6 +2150,15 @@ tl::expected<void, ErrorCode> Client::Upsert(const ObjectKey& key,
             } else {
                 transfer_summary.RecordFailure(ReplicaType::DFS, dfs_result);
             }
+        }
+    } else if (transfer_summary.allocated_dfs_replicas > 0) {
+        // Same abandoned-write case as in Put: the DFS replica was allocated
+        // but a peer replica failed first, so no I/O is attempted and no DFS
+        // error is recorded. Counted per key, matching SubmitDfsWrites.
+        VLOG(1) << "Skipping DFS write, action=skip, key=" << key
+                << ", reason=non_dfs_transfer_failed";
+        if (auto* dfs_metric = GetDfsMetricPtr()) {
+            dfs_metric->RecordSkippedWrites(1);
         }
     }
 

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -332,9 +332,8 @@ std::vector<tl::expected<void, ErrorCode>> DistributedStorageBackend::BatchRead(
             request.slices.size() >
                 static_cast<size_t>(std::numeric_limits<int>::max())) {
             LOG(ERROR) << "DFS read request exceeds platform limits for key "
-                       << request.key
-                       << ", object_size=" << desc.object_size
-                       << ", slice_count=" << request.slices.size();           
+                       << request.key << ", object_size=" << desc.object_size
+                       << ", slice_count=" << request.slices.size();
             results.emplace_back(
                 tl::make_unexpected(ErrorCode::INVALID_PARAMS));
             continue;

--- a/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
+++ b/mooncake-store/src/storage/distributed/distributed_storage_backend.cpp
@@ -331,6 +331,10 @@ std::vector<tl::expected<void, ErrorCode>> DistributedStorageBackend::BatchRead(
         if (desc.object_size > std::numeric_limits<size_t>::max() ||
             request.slices.size() >
                 static_cast<size_t>(std::numeric_limits<int>::max())) {
+            LOG(ERROR) << "DFS read request exceeds platform limits for key "
+                       << request.key
+                       << ", object_size=" << desc.object_size
+                       << ", slice_count=" << request.slices.size();           
             results.emplace_back(
                 tl::make_unexpected(ErrorCode::INVALID_PARAMS));
             continue;

--- a/mooncake-store/tests/CMakeLists.txt
+++ b/mooncake-store/tests/CMakeLists.txt
@@ -163,10 +163,13 @@ add_store_test(dfs_posix_test dfs_posix_test.cpp)
 add_store_test(distributed_storage_config_test
                distributed_storage_config_test.cpp)
 add_store_test(dfs_sync_client_test dfs_sync_client_test.cpp)
-add_test(NAME dfs_batch_read_checksum_test
-         COMMAND dfs_sync_client_test
-                 --gtest_filter=DfsSyncClientTest.BatchGetVerifiesDfsChecksum)
-set_tests_properties(dfs_batch_read_checksum_test
+add_test(
+  NAME dfs_read_checksum_test
+  COMMAND
+    dfs_sync_client_test
+    "--gtest_filter=DfsSyncClientTest.BatchGetVerifiesDfsChecksum:DfsSyncClientTest.GetVerifiesDfsChecksumAndRecordsError"
+)
+set_tests_properties(dfs_read_checksum_test
                      PROPERTIES ENVIRONMENT "MOONCAKE_STORE_CHECKSUM=1")
 if(USE_3FS)
   add_store_test(dfs_hf3fs_test dfs_hf3fs_test.cpp)

--- a/mooncake-store/tests/dfs_sync_client_test.cpp
+++ b/mooncake-store/tests/dfs_sync_client_test.cpp
@@ -435,9 +435,8 @@ TEST_F(DfsSyncClientTest, DfsMetricsRecordUnavailableBackend) {
 
     std::string value(4096, 'T');
     std::vector<Slice> slices{{value.data(), value.size()}};
-    auto result =
-        client_without_backend->Put("dfs_metric_no_backend", slices,
-                                    DfsConfig());
+    auto result = client_without_backend->Put("dfs_metric_no_backend", slices,
+                                              DfsConfig());
     ASSERT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::DFS_SERVICE_UNAVAILABLE);
     EXPECT_EQ(metric->dfs_write_errors.value(unavailable_label), 1);

--- a/mooncake-store/tests/dfs_sync_client_test.cpp
+++ b/mooncake-store/tests/dfs_sync_client_test.cpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include <array>
 
 #include <unistd.h>
 
@@ -358,6 +359,111 @@ TEST_F(DfsSyncClientTest, BatchGetVerifiesDfsChecksum) {
     ASSERT_EQ(results.size(), 1);
     ASSERT_FALSE(results[0].has_value());
     EXPECT_EQ(results[0].error(), ErrorCode::CHECKSUM_MISMATCH);
+}
+
+TEST_F(DfsSyncClientTest, DfsMetricsCountSuccessfulWriteAndRead) {
+    auto* metric = writer_->GetDfsMetricPtr();
+    if (metric == nullptr) {
+        GTEST_SKIP() << "Client metrics are disabled";
+    }
+    const int64_t base_write_ops = metric->dfs_write_ops.value();
+    const int64_t base_write_bytes = metric->dfs_write_bytes.value();
+    const int64_t base_read_ops = metric->dfs_read_ops.value();
+    const int64_t base_read_bytes = metric->dfs_read_bytes.value();
+
+    const std::string key = "dfs_metric_success";
+    std::string value(4096, 'Q');
+    std::vector<Slice> write_slices{{value.data(), value.size()}};
+    ASSERT_TRUE(writer_->Put(key, write_slices, DfsConfig()).has_value());
+
+    EXPECT_EQ(metric->dfs_write_ops.value(), base_write_ops + 1);
+    EXPECT_EQ(metric->dfs_write_bytes.value(),
+              base_write_bytes + static_cast<int64_t>(value.size()));
+
+    auto query = QueryDfsOnly(key);
+    ASSERT_TRUE(query.has_value());
+    std::vector<char> output(value.size());
+    std::vector<Slice> read_slices{{output.data(), output.size()}};
+    ASSERT_TRUE(writer_->Get(key, *query, read_slices).has_value());
+
+    EXPECT_EQ(metric->dfs_read_ops.value(), base_read_ops + 1);
+    EXPECT_EQ(metric->dfs_read_bytes.value(),
+              base_read_bytes + static_cast<int64_t>(value.size()));
+    // Host-resident slices never go through the D2H staging path.
+    EXPECT_EQ(metric->dfs_writes_skipped.value(), 0);
+}
+
+TEST_F(DfsSyncClientTest, DfsMetricsCountWriteFailureSeparatelyFromOps) {
+    auto* metric = writer_->GetDfsMetricPtr();
+    if (metric == nullptr) {
+        GTEST_SKIP() << "Client metrics are disabled";
+    }
+    const std::array<std::string, 1> write_fail_label{
+        toString(ErrorCode::FILE_WRITE_FAIL)};
+    const int64_t base_write_ops = metric->dfs_write_ops.value();
+    const int64_t base_errors =
+        metric->dfs_write_errors.value(write_fail_label);
+
+    std::vector<std::string> keys{"dfs_metric_ok", "dfs_metric_fail"};
+    std::vector<std::string> values{std::string(4096, 'R'),
+                                    std::string(4096, 'S')};
+    auto slices = MakeSlices(values);
+    adapter_->FailWriteCall(adapter_->WriteCalls() + 2);
+
+    auto results = writer_->BatchPut(keys, slices, DfsConfig());
+    ASSERT_EQ(results.size(), keys.size());
+    ASSERT_TRUE(results[0].has_value());
+    ASSERT_FALSE(results[1].has_value());
+
+    // The failed key must not inflate ops/bytes; it lands in the error family
+    // instead, keyed by the ErrorCode name.
+    EXPECT_EQ(metric->dfs_write_ops.value(), base_write_ops + 1);
+    EXPECT_EQ(metric->dfs_write_errors.value(write_fail_label),
+              base_errors + 1);
+}
+
+TEST_F(DfsSyncClientTest, DfsMetricsRecordUnavailableBackend) {
+    auto client_without_backend = CreateClient("127.0.0.1:18104");
+    ASSERT_NE(client_without_backend, nullptr);
+    auto* metric = client_without_backend->GetDfsMetricPtr();
+    if (metric == nullptr) {
+        GTEST_SKIP() << "Client metrics are disabled";
+    }
+    const std::array<std::string, 1> unavailable_label{
+        toString(ErrorCode::DFS_SERVICE_UNAVAILABLE)};
+    ASSERT_EQ(metric->dfs_write_errors.value(unavailable_label), 0);
+
+    std::string value(4096, 'T');
+    std::vector<Slice> slices{{value.data(), value.size()}};
+    auto result =
+        client_without_backend->Put("dfs_metric_no_backend", slices,
+                                    DfsConfig());
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::DFS_SERVICE_UNAVAILABLE);
+    EXPECT_EQ(metric->dfs_write_errors.value(unavailable_label), 1);
+    EXPECT_EQ(metric->dfs_write_ops.value(), 0);
+}
+
+TEST_F(DfsSyncClientTest, DfsMetricsAppearInSerializedOutput) {
+    auto* metric = writer_->GetDfsMetricPtr();
+    if (metric == nullptr) {
+        GTEST_SKIP() << "Client metrics are disabled";
+    }
+    const std::string key = "dfs_metric_serialize";
+    std::string value(4096, 'U');
+    std::vector<Slice> write_slices{{value.data(), value.size()}};
+    ASSERT_TRUE(writer_->Put(key, write_slices, DfsConfig()).has_value());
+
+    auto serialized = writer_->SerializeMetrics();
+    ASSERT_TRUE(serialized.has_value());
+    EXPECT_NE(serialized->find("mooncake_dfs_write_bytes_total"),
+              std::string::npos);
+    EXPECT_NE(serialized->find("mooncake_dfs_write_ops_total"),
+              std::string::npos);
+
+    auto summary = writer_->GetSummaryMetrics();
+    ASSERT_TRUE(summary.has_value());
+    EXPECT_NE(summary->find("=== DFS Metrics Summary ==="), std::string::npos);
 }
 
 }  // namespace mooncake::test

--- a/mooncake-store/tests/dfs_sync_client_test.cpp
+++ b/mooncake-store/tests/dfs_sync_client_test.cpp
@@ -361,6 +361,48 @@ TEST_F(DfsSyncClientTest, BatchGetVerifiesDfsChecksum) {
     EXPECT_EQ(results[0].error(), ErrorCode::CHECKSUM_MISMATCH);
 }
 
+TEST_F(DfsSyncClientTest, GetVerifiesDfsChecksumAndRecordsError) {
+    const char* checksum_enabled = std::getenv("MOONCAKE_STORE_CHECKSUM");
+    if (checksum_enabled == nullptr || std::string(checksum_enabled) != "1") {
+        GTEST_SKIP() << "MOONCAKE_STORE_CHECKSUM is not enabled";
+    }
+    auto* metric = writer_->GetDfsMetricPtr();
+    if (metric == nullptr) {
+        GTEST_SKIP() << "Client metrics are disabled";
+    }
+
+    const std::string key = "dfs_single_checksum";
+    std::string value(4096, 'V');
+    std::vector<Slice> write_slices{{value.data(), value.size()}};
+    ASSERT_TRUE(writer_->Put(key, write_slices, DfsConfig()).has_value());
+
+    auto query = QueryDfsOnly(key);
+    ASSERT_TRUE(query.has_value());
+    ASSERT_TRUE(query->object_checksum.has_value());
+
+    const std::array<std::string, 1> mismatch_label{
+        toString(ErrorCode::CHECKSUM_MISMATCH)};
+    const int64_t base_read_ops = metric->dfs_read_ops.value();
+    const int64_t base_errors = metric->dfs_read_errors.value(mismatch_label);
+
+    const std::optional<uint64_t> bad_checksum(*query->object_checksum ^
+                                               uint64_t{1});
+    std::vector<Replica::Descriptor> replicas = query->replicas;
+    QueryResult corrupted(std::move(replicas), query->lease_timeout,
+                          bad_checksum);
+
+    std::vector<char> output(value.size());
+    std::vector<Slice> read_slices{{output.data(), output.size()}};
+    auto result = writer_->Get(key, corrupted, read_slices);
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ErrorCode::CHECKSUM_MISMATCH);
+
+    // The I/O completed, so it still counts as a read op, exactly as in the
+    // batch path; the rejection lands in the error family instead.
+    EXPECT_EQ(metric->dfs_read_ops.value(), base_read_ops + 1);
+    EXPECT_EQ(metric->dfs_read_errors.value(mismatch_label), base_errors + 1);
+}
+
 TEST_F(DfsSyncClientTest, DfsMetricsCountSuccessfulWriteAndRead) {
     auto* metric = writer_->GetDfsMetricPtr();
     if (metric == nullptr) {

--- a/mooncake-store/tests/dfs_sync_client_test.cpp
+++ b/mooncake-store/tests/dfs_sync_client_test.cpp
@@ -15,6 +15,7 @@
 #include <unistd.h>
 
 #include "client_service.h"
+#include "environ.h"
 #include "storage/distributed/dfs_global_allocator.h"
 #include "storage/distributed/distributed_storage_backend.h"
 #include "storage/distributed/posix_fs_adapter.h"
@@ -333,8 +334,7 @@ TEST_F(DfsSyncClientTest, BatchGetUsesExplicitDfsDescriptors) {
 }
 
 TEST_F(DfsSyncClientTest, BatchGetVerifiesDfsChecksum) {
-    const char* checksum_enabled = std::getenv("MOONCAKE_STORE_CHECKSUM");
-    if (checksum_enabled == nullptr || std::string(checksum_enabled) != "1") {
+    if (!Environ::Get().GetStoreChecksumEnabled()) {
         GTEST_SKIP() << "MOONCAKE_STORE_CHECKSUM is not enabled";
     }
 
@@ -362,8 +362,7 @@ TEST_F(DfsSyncClientTest, BatchGetVerifiesDfsChecksum) {
 }
 
 TEST_F(DfsSyncClientTest, GetVerifiesDfsChecksumAndRecordsError) {
-    const char* checksum_enabled = std::getenv("MOONCAKE_STORE_CHECKSUM");
-    if (checksum_enabled == nullptr || std::string(checksum_enabled) != "1") {
+    if (!Environ::Get().GetStoreChecksumEnabled()) {
         GTEST_SKIP() << "MOONCAKE_STORE_CHECKSUM is not enabled";
     }
     auto* metric = writer_->GetDfsMetricPtr();


### PR DESCRIPTION
## Description


We are currently using mooncake based on the DFS POSIX backend, but have found that the DFS data metrics is effectively unobservable. Due to the different read/write paths, the existing ```SsdMetric``` cannot record DFS read and write operations. In addition, I refined several log points on the DFS read/write path to improve observability and make issue diagnosis easier. 

This PR mainly includes two parts:
- Add DFS data metrics, integrated into ```client_metric.h```. The overall design follows the existing SsdMetric impl. In total, 12 metrics have been added, covering read/write latency, read/write bytes, read/write ops, and related indicators. The latency metrics reuse the ```kSsdLatencyBucket ```.
- Refine logging on several critical paths, so that more detailed information is now printed to facilitate finer-grained diagnosis and troubleshooting.

I have tested this in our environment, and the data can be queried through the following interfaces:
```
curl -s http://<ip:port>/metrics
curl -s http://<ip:port>/metrics/summary
```
## Module

- [ ] Transfer Engine (`mooncake-transfer-engine`)
- [x] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?
I have added new test cases in ```mooncake-store/tests/dfs_sync_client_test.cpp```, executed them, and all tests have passed, validating the proposed changes.



**Test commands:**
```bash
cmake --build build --target dfs_sync_client_test
./build/mooncake-store/tests/dfs_sync_client_test
```

**Test results:**
- [x] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing done (describe below)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [ ] I have updated the documentation (if applicable)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure



- [ ] No AI tools were used
- [x] AI tools were used (specify below)