### PR TITLE
[TENT] Pin failover policy at transfer submission

### DIFF
--- a/mooncake-transfer-engine/tent/include/tent/common/config.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config.h
@@ -22,6 +22,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -167,6 +168,15 @@ class Config {
 
     // If key_path resolves to a JSON value, dump it into *out and return true.
     bool dumpSubtree(const std::string& key_path, std::string* out) const;
+
+    // Capture the complete configuration while holding a single lock. The
+    // returned object is independently owned and exposed as const so readers
+    // can share one coherent, immutable view of the configuration.
+    std::shared_ptr<const Config> freeze() const;
+
+    // Return canonical slash-delimited paths for every configured value.
+    // Arrays and empty objects are treated as values rather than traversed.
+    std::vector<std::string> paths() const;
 
    private:
     json config_data_;

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -75,7 +75,7 @@ class LifecycleConfigView {
    public:
     template <typename T>
     T get(const std::string& key_path, const T& default_value) const {
-        if (!allows(key_path) || !values_) return default_value;
+        if (!canRead(key_path)) return default_value;
         return values_->get<T>(key_path, default_value);
     }
 
@@ -98,14 +98,18 @@ class LifecycleConfigView {
    protected:
     LifecycleConfigView(std::shared_ptr<const Config> values,
                         ConfigLifecycle lifecycle)
-        : values_(std::move(values)), lifecycle_(lifecycle) {}
+        : values_(std::move(values)), lifecycle_(lifecycle) {
+        if (values_) configured_paths_ = values_->paths();
+    }
     ~LifecycleConfigView() = default;
 
    private:
     bool allows(std::string_view key_path) const;
+    bool canRead(std::string_view key_path) const;
 
     std::shared_ptr<const Config> values_;
     ConfigLifecycle lifecycle_;
+    std::vector<std::string> configured_paths_;
 };
 
 class BootstrapConfig final : public LifecycleConfigView {

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -129,6 +129,8 @@ class RuntimeConfig final : public LifecycleConfigView {
 struct RuntimeConfigSnapshot {
     uint64_t generation{0};
     std::shared_ptr<const RuntimeConfig> config;
+    int max_failover_attempts{3};
+    bool enable_auto_failover_on_poll{true};
 };
 
 struct TentConfigBundle {

--- a/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
+++ b/mooncake-transfer-engine/tent/include/tent/common/config_lifecycle.h
@@ -1,0 +1,145 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TENT_CONFIG_LIFECYCLE_H
+#define TENT_CONFIG_LIFECYCLE_H
+
+#include <tent/common/config.h>
+
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace mooncake {
+namespace tent {
+
+// This classification describes whether a field may participate in a future
+// runtime update. kRuntimeCandidate does not mean that live application is
+// implemented yet; it only records that the field is eligible for that work.
+enum class ConfigLifecycle : uint8_t {
+    kBootstrapOnly,
+    kRuntimeCandidate,
+    kDerived,
+    kUnsupported,
+};
+
+enum class ConfigFieldMatch : uint8_t {
+    kExact,
+    kSubtree,
+};
+
+struct ConfigFieldSpec {
+    std::string_view path;
+    ConfigLifecycle lifecycle;
+    ConfigFieldMatch match;
+};
+
+// Return the audited TENT configuration field inventory. When more than one
+// entry matches a path, the most specific (longest) path wins.
+std::span<const ConfigFieldSpec> configFieldInventory();
+
+ConfigLifecycle classifyConfigPath(std::string_view path);
+
+const char* configLifecycleName(ConfigLifecycle lifecycle);
+
+enum class ConfigDiagnosticCode : uint8_t {
+    kInvalidRoot,
+    kUnsupportedField,
+};
+
+struct ConfigDiagnostic {
+    ConfigDiagnosticCode code;
+    std::string path;
+    std::string message;
+};
+
+// A lifecycle-restricted view over a frozen Config. Both bootstrap and runtime
+// views share the same immutable backing object, so one bundle always
+// represents one coherent capture of the legacy configuration.
+class LifecycleConfigView {
+   public:
+    template <typename T>
+    T get(const std::string& key_path, const T& default_value) const {
+        if (!allows(key_path) || !values_) return default_value;
+        return values_->get<T>(key_path, default_value);
+    }
+
+    std::string get(const std::string& key_path,
+                    const char* default_value) const {
+        return get<std::string>(key_path, std::string(default_value));
+    }
+
+    template <typename T>
+    std::vector<T> getArray(const std::string& key_path) const {
+        return get<std::vector<T>>(key_path, {});
+    }
+
+    bool contains(const std::string& key_path) const;
+
+    bool dumpSubtree(const std::string& key_path, std::string* out) const;
+
+    ConfigLifecycle lifecycle() const { return lifecycle_; }
+
+   protected:
+    LifecycleConfigView(std::shared_ptr<const Config> values,
+                        ConfigLifecycle lifecycle)
+        : values_(std::move(values)), lifecycle_(lifecycle) {}
+    ~LifecycleConfigView() = default;
+
+   private:
+    bool allows(std::string_view key_path) const;
+
+    std::shared_ptr<const Config> values_;
+    ConfigLifecycle lifecycle_;
+};
+
+class BootstrapConfig final : public LifecycleConfigView {
+   public:
+    explicit BootstrapConfig(std::shared_ptr<const Config> values)
+        : LifecycleConfigView(std::move(values),
+                              ConfigLifecycle::kBootstrapOnly) {}
+};
+
+class RuntimeConfig final : public LifecycleConfigView {
+   public:
+    explicit RuntimeConfig(std::shared_ptr<const Config> values)
+        : LifecycleConfigView(std::move(values),
+                              ConfigLifecycle::kRuntimeCandidate) {}
+};
+
+struct RuntimeConfigSnapshot {
+    uint64_t generation{0};
+    std::shared_ptr<const RuntimeConfig> config;
+};
+
+struct TentConfigBundle {
+    std::shared_ptr<const BootstrapConfig> bootstrap;
+    std::shared_ptr<const RuntimeConfigSnapshot> runtime;
+    std::vector<ConfigDiagnostic> diagnostics;
+};
+
+// Adapt an already-merged legacy Config into the canonical lifecycle bundle.
+// This deliberately does not load files or environment variables, preserving
+// the precedence rules of the caller that produced effective_config.
+TentConfigBundle buildTentConfigBundle(const Config& effective_config,
+                                       uint64_t generation = 0);
+
+}  // namespace tent
+}  // namespace mooncake
+
+#endif  // TENT_CONFIG_LIFECYCLE_H

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "tent/common/config.h"
+#include "tent/common/config_lifecycle.h"
 #include "tent/common/status.h"
 #include "tent/common/types.h"
 #include "tent/runtime/admission_queue.h"
@@ -60,12 +61,19 @@ std::chrono::microseconds nextPollDelay(uint64_t poll_count);
 // One backoff step: yields while nextPollDelay is zero, sleeps after that.
 void waitBeforeNextPoll(uint64_t poll_count);
 
+struct LogicalTransferRuntimePolicy {
+    uint64_t config_generation{0};
+    int max_failover_attempts{3};
+    bool enable_auto_failover_on_poll{true};
+};
+
 struct TaskInfo {
     TransportType type{UNSPEC};
     int sub_task_id{-1};
-    bool derived{false};          // merged by other tasks
-    int xport_priority{0};        // transport priority (for fallback)
-    int failover_count{0};        // number of failover attempts
+    bool derived{false};    // merged by other tasks
+    int xport_priority{0};  // transport priority (for fallback)
+    int failover_count{0};  // number of failover attempts
+    LogicalTransferRuntimePolicy runtime_policy;
     uint64_t device_mask{~0ULL};  // Device mask for quota allocation
     std::string qp_pool;          // Named QP pool (RFC #2568 step 3), "" = none
     Request request;
@@ -101,6 +109,7 @@ struct TaskInfo {
           derived(other.derived),
           xport_priority(other.xport_priority),
           failover_count(other.failover_count),
+          runtime_policy(other.runtime_policy),
           device_mask(other.device_mask),
           qp_pool(other.qp_pool),
           request(other.request),
@@ -122,6 +131,7 @@ struct TaskInfo {
           derived(other.derived),
           xport_priority(other.xport_priority),
           failover_count(other.failover_count),
+          runtime_policy(other.runtime_policy),
           device_mask(other.device_mask),
           qp_pool(std::move(other.qp_pool)),
           request(std::move(other.request)),
@@ -144,6 +154,7 @@ struct TaskInfo {
             derived = other.derived;
             xport_priority = other.xport_priority;
             failover_count = other.failover_count;
+            runtime_policy = other.runtime_policy;
             device_mask = other.device_mask;
             qp_pool = other.qp_pool;
             request = other.request;
@@ -171,6 +182,7 @@ struct TaskInfo {
             derived = other.derived;
             xport_priority = other.xport_priority;
             failover_count = other.failover_count;
+            runtime_policy = other.runtime_policy;
             device_mask = other.device_mask;
             qp_pool = std::move(other.qp_pool);
             request = std::move(other.request);
@@ -312,6 +324,12 @@ class TransferEngineImpl {
         }
     }
 
+    void publishRuntimeConfigForTest(
+        std::shared_ptr<const RuntimeConfigSnapshot> snapshot) {
+        runtime_config_snapshot_.store(std::move(snapshot),
+                                       std::memory_order_release);
+    }
+
     // Test-only hook: how many batches are still alive. Lets a test assert
     // that a failed transfer released its batch rather than leaking it.
     size_t aliveBatchCountForTest() {
@@ -433,7 +451,7 @@ class TransferEngineImpl {
                                    bool allow_failover);
 
     Status getBatchStatus(BatchID batch_id, TransferStatus& overall_status,
-                          bool allow_failover);
+                          bool force_failover);
 
     SelectionResult resolveTransport(const Request& req, int transport_index,
                                      bool invalidate_on_fail = true);
@@ -522,8 +540,8 @@ class TransferEngineImpl {
 
     std::unique_ptr<ProxyManager> staging_proxy_;
     bool merge_requests_;
-    int max_failover_attempts_{3};
-    bool enable_auto_failover_on_poll_{true};
+    std::atomic<std::shared_ptr<const RuntimeConfigSnapshot>>
+        runtime_config_snapshot_;
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;

--- a/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
+++ b/mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h
@@ -326,8 +326,9 @@ class TransferEngineImpl {
 
     void publishRuntimeConfigForTest(
         std::shared_ptr<const RuntimeConfigSnapshot> snapshot) {
-        runtime_config_snapshot_.store(std::move(snapshot),
-                                       std::memory_order_release);
+        std::atomic_store_explicit(&runtime_config_snapshot_,
+                                   std::move(snapshot),
+                                   std::memory_order_release);
     }
 
     // Test-only hook: how many batches are still alive. Lets a test assert
@@ -540,8 +541,7 @@ class TransferEngineImpl {
 
     std::unique_ptr<ProxyManager> staging_proxy_;
     bool merge_requests_;
-    std::atomic<std::shared_ptr<const RuntimeConfigSnapshot>>
-        runtime_config_snapshot_;
+    std::shared_ptr<const RuntimeConfigSnapshot> runtime_config_snapshot_;
     bool enable_progress_worker_{false};
     RuntimeQueueConfig runtime_queue_config_;
     std::unique_ptr<LocalTransferAdmissionQueue> runtime_queue_;

--- a/mooncake-transfer-engine/tent/src/common/config.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config.cpp
@@ -22,6 +22,30 @@
 
 namespace mooncake {
 namespace tent {
+namespace {
+
+void collectConfigPaths(const json& node, const std::string& prefix,
+                        std::vector<std::string>& paths) {
+    // A default-constructed Config has a null root and represents an empty
+    // configuration whose callers rely entirely on defaults.
+    if (prefix.empty() && node.is_null()) return;
+    if (!node.is_object()) {
+        paths.push_back(prefix);
+        return;
+    }
+    if (node.empty()) {
+        if (!prefix.empty()) paths.push_back(prefix);
+        return;
+    }
+
+    for (auto it = node.begin(); it != node.end(); ++it) {
+        std::string path = prefix.empty() ? it.key() : prefix + "/" + it.key();
+        collectConfigPaths(it.value(), path, paths);
+    }
+}
+
+}  // namespace
+
 Status Config::load(const std::string& content) {
     std::lock_guard<std::mutex> lock(mutex_);
     try {
@@ -77,6 +101,24 @@ bool Config::dumpSubtree(const std::string& key_path, std::string* out) const {
         return true;
     }
     return false;
+}
+
+std::shared_ptr<const Config> Config::freeze() const {
+    auto frozen = std::make_shared<Config>();
+    std::lock_guard<std::mutex> lock(mutex_);
+    frozen->config_data_ = config_data_;
+    return frozen;
+}
+
+std::vector<std::string> Config::paths() const {
+    std::vector<std::string> paths;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        collectConfigPaths(config_data_, "", paths);
+    }
+    std::sort(paths.begin(), paths.end());
+    paths.erase(std::unique(paths.begin(), paths.end()), paths.end());
+    return paths;
 }
 
 static inline void setConfig(Config& config, const std::string& env_key,

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -194,13 +194,27 @@ bool LifecycleConfigView::allows(std::string_view key_path) const {
     return classifyConfigPath(key_path) == lifecycle_;
 }
 
+bool LifecycleConfigView::canRead(std::string_view key_path) const {
+    if (!values_ || !allows(key_path)) return false;
+
+    for (const auto& configured_path : configured_paths_) {
+        if (configured_path.size() <= key_path.size() ||
+            configured_path.compare(0, key_path.size(), key_path) != 0 ||
+            configured_path[key_path.size()] != '/') {
+            continue;
+        }
+        if (!allows(configured_path)) return false;
+    }
+    return true;
+}
+
 bool LifecycleConfigView::contains(const std::string& key_path) const {
-    return allows(key_path) && values_ && values_->contains(key_path);
+    return canRead(key_path) && values_->contains(key_path);
 }
 
 bool LifecycleConfigView::dumpSubtree(const std::string& key_path,
                                       std::string* out) const {
-    return allows(key_path) && values_ && values_->dumpSubtree(key_path, out);
+    return canRead(key_path) && values_->dumpSubtree(key_path, out);
 }
 
 TentConfigBundle buildTentConfigBundle(const Config& effective_config,

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -51,6 +51,8 @@ constexpr ConfigFieldSpec kConfigFields[] = {
      ConfigFieldMatch::kSubtree},
     {"transports/tcp", ConfigLifecycle::kBootstrapOnly,
      ConfigFieldMatch::kSubtree},
+    {"transports/hp_tcp", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
     {"transports/shm", ConfigLifecycle::kBootstrapOnly,
      ConfigFieldMatch::kSubtree},
     {"transports/nvlink", ConfigLifecycle::kBootstrapOnly,

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -224,8 +224,11 @@ TentConfigBundle buildTentConfigBundle(const Config& effective_config,
     bundle.bootstrap = std::make_shared<const BootstrapConfig>(frozen);
 
     auto runtime_config = std::make_shared<const RuntimeConfig>(frozen);
-    bundle.runtime = std::make_shared<const RuntimeConfigSnapshot>(
-        RuntimeConfigSnapshot{generation, std::move(runtime_config)});
+    bundle.runtime =
+        std::make_shared<const RuntimeConfigSnapshot>(RuntimeConfigSnapshot{
+            generation, runtime_config,
+            runtime_config->get("max_failover_attempts", 3),
+            runtime_config->get("enable_auto_failover_on_poll", true)});
 
     for (const auto& path : frozen->paths()) {
         if (path.empty()) {

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -1,0 +1,239 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tent/common/config_lifecycle.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+// Transport namespaces are extension points and therefore use subtree
+// entries. Runtime-eligible exceptions below them are listed as exact fields;
+// classifyConfigPath() resolves those using longest-match semantics.
+constexpr ConfigFieldSpec kConfigFields[] = {
+    // Bootstrap identity and process-level services.
+    {"local_segment_name", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"metadata_type", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"metadata_servers", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"rpc_server_hostname", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"rpc_server_port", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"rpc_server_threads", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"verbose", ConfigLifecycle::kBootstrapOnly, ConfigFieldMatch::kExact},
+    {"use_legacy_transport_selection", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"enable_progress_worker", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"enable_runtime_queue", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"staging", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+
+    // Discovery and resource construction.
+    {"topology", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/tcp", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/shm", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/nvlink", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/mnnvl", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/gds", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/io_uring", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/ub", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/ascend_direct", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/sunrise_link", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/tpu", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+    {"transports/mpcomm", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kSubtree},
+
+    // Metrics listener construction is bootstrap-only. Its reporting cadence
+    // is a runtime candidate and is overridden below.
+    {"metrics", ConfigLifecycle::kBootstrapOnly, ConfigFieldMatch::kExact},
+    {"metrics/enabled", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"metrics/http_port", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"metrics/http_host", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+    {"metrics/http_server_threads", ConfigLifecycle::kBootstrapOnly,
+     ConfigFieldMatch::kExact},
+
+    // Fields that can be represented by an immutable runtime generation.
+    {"log_level", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"merge_requests", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"max_failover_attempts", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"enable_auto_failover_on_poll", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"runtime_queue", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kSubtree},
+    {"policy", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kSubtree},
+    {"qos", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kSubtree},
+    {"metrics/report_interval_seconds",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+
+    // RDMA policy and health knobs do not allocate devices, CQs, or QPs and
+    // are candidates for a later staged apply handler.
+    {"transports/rdma/enable_smart_scheduling",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/numa_penalties",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/strict_local_numa",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/bandwidth_learning_rate",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/ewma_min_bandwidth_multiplier",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/ewma_max_bandwidth_multiplier",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/score_jitter_range",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/score_epsilon",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/enable_priority_filtering",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/local_rotation_interval_us",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/priority_promotion_timeout_us",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/deadline_bw_arbitration",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/priority_promotion_per_entry",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/slot_rotation_interval_ms",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/default_bandwidth_gbps",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/min_bandwidth_gbps",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/max_bandwidth_gbps",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/rail_error_threshold",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/rail_error_window_secs",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/rail_cooldown_secs",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/gdr_error_threshold",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/gdr_error_window_secs",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/gdr_cooldown_secs",
+     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+};
+
+bool matches(const ConfigFieldSpec& spec, std::string_view path) {
+    if (path == spec.path) return true;
+    return spec.match == ConfigFieldMatch::kSubtree &&
+           path.size() > spec.path.size() &&
+           path.compare(0, spec.path.size(), spec.path) == 0 &&
+           path[spec.path.size()] == '/';
+}
+
+}  // namespace
+
+std::span<const ConfigFieldSpec> configFieldInventory() {
+    return kConfigFields;
+}
+
+ConfigLifecycle classifyConfigPath(std::string_view path) {
+    const ConfigFieldSpec* best_match = nullptr;
+    for (const auto& field : kConfigFields) {
+        if (!matches(field, path)) continue;
+        if (!best_match || field.path.size() > best_match->path.size()) {
+            best_match = &field;
+        }
+    }
+    return best_match ? best_match->lifecycle
+                      : ConfigLifecycle::kUnsupported;
+}
+
+const char* configLifecycleName(ConfigLifecycle lifecycle) {
+    switch (lifecycle) {
+        case ConfigLifecycle::kBootstrapOnly:
+            return "bootstrap-only";
+        case ConfigLifecycle::kRuntimeCandidate:
+            return "runtime-candidate";
+        case ConfigLifecycle::kDerived:
+            return "derived";
+        case ConfigLifecycle::kUnsupported:
+            return "unsupported";
+    }
+    return "unsupported";
+}
+
+bool LifecycleConfigView::allows(std::string_view key_path) const {
+    return classifyConfigPath(key_path) == lifecycle_;
+}
+
+bool LifecycleConfigView::contains(const std::string& key_path) const {
+    return allows(key_path) && values_ && values_->contains(key_path);
+}
+
+bool LifecycleConfigView::dumpSubtree(const std::string& key_path,
+                                      std::string* out) const {
+    return allows(key_path) && values_ &&
+           values_->dumpSubtree(key_path, out);
+}
+
+TentConfigBundle buildTentConfigBundle(const Config& effective_config,
+                                       uint64_t generation) {
+    TentConfigBundle bundle;
+    auto frozen = effective_config.freeze();
+    bundle.bootstrap = std::make_shared<const BootstrapConfig>(frozen);
+
+    auto runtime_config = std::make_shared<const RuntimeConfig>(frozen);
+    bundle.runtime = std::make_shared<const RuntimeConfigSnapshot>(
+        RuntimeConfigSnapshot{generation, std::move(runtime_config)});
+
+    for (const auto& path : frozen->paths()) {
+        if (path.empty()) {
+            bundle.diagnostics.push_back(
+                {ConfigDiagnosticCode::kInvalidRoot, "$",
+                 "TENT configuration root must be a JSON object"});
+            continue;
+        }
+        if (classifyConfigPath(path) == ConfigLifecycle::kUnsupported) {
+            bundle.diagnostics.push_back(
+                {ConfigDiagnosticCode::kUnsupportedField, path,
+                 "Unsupported TENT configuration field: " + path});
+        }
+    }
+    return bundle;
+}
+
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
+++ b/mooncake-transfer-engine/tent/src/common/config_lifecycle.cpp
@@ -42,14 +42,11 @@ constexpr ConfigFieldSpec kConfigFields[] = {
      ConfigFieldMatch::kExact},
     {"enable_runtime_queue", ConfigLifecycle::kBootstrapOnly,
      ConfigFieldMatch::kExact},
-    {"staging", ConfigLifecycle::kBootstrapOnly,
-     ConfigFieldMatch::kSubtree},
+    {"staging", ConfigLifecycle::kBootstrapOnly, ConfigFieldMatch::kSubtree},
 
     // Discovery and resource construction.
-    {"topology", ConfigLifecycle::kBootstrapOnly,
-     ConfigFieldMatch::kSubtree},
-    {"transports", ConfigLifecycle::kBootstrapOnly,
-     ConfigFieldMatch::kExact},
+    {"topology", ConfigLifecycle::kBootstrapOnly, ConfigFieldMatch::kSubtree},
+    {"transports", ConfigLifecycle::kBootstrapOnly, ConfigFieldMatch::kExact},
     {"transports/rdma", ConfigLifecycle::kBootstrapOnly,
      ConfigFieldMatch::kSubtree},
     {"transports/tcp", ConfigLifecycle::kBootstrapOnly,
@@ -88,8 +85,7 @@ constexpr ConfigFieldSpec kConfigFields[] = {
      ConfigFieldMatch::kExact},
 
     // Fields that can be represented by an immutable runtime generation.
-    {"log_level", ConfigLifecycle::kRuntimeCandidate,
-     ConfigFieldMatch::kExact},
+    {"log_level", ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
     {"merge_requests", ConfigLifecycle::kRuntimeCandidate,
      ConfigFieldMatch::kExact},
     {"max_failover_attempts", ConfigLifecycle::kRuntimeCandidate,
@@ -98,31 +94,29 @@ constexpr ConfigFieldSpec kConfigFields[] = {
      ConfigFieldMatch::kExact},
     {"runtime_queue", ConfigLifecycle::kRuntimeCandidate,
      ConfigFieldMatch::kSubtree},
-    {"policy", ConfigLifecycle::kRuntimeCandidate,
-     ConfigFieldMatch::kSubtree},
-    {"qos", ConfigLifecycle::kRuntimeCandidate,
-     ConfigFieldMatch::kSubtree},
-    {"metrics/report_interval_seconds",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"policy", ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kSubtree},
+    {"qos", ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kSubtree},
+    {"metrics/report_interval_seconds", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
 
     // RDMA policy and health knobs do not allocate devices, CQs, or QPs and
     // are candidates for a later staged apply handler.
     {"transports/rdma/enable_smart_scheduling",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/numa_penalties",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/strict_local_numa",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/numa_penalties", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma/strict_local_numa", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
     {"transports/rdma/bandwidth_learning_rate",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
     {"transports/rdma/ewma_min_bandwidth_multiplier",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
     {"transports/rdma/ewma_max_bandwidth_multiplier",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/score_jitter_range",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/score_epsilon",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/score_jitter_range", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma/score_epsilon", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
     {"transports/rdma/enable_priority_filtering",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
     {"transports/rdma/local_rotation_interval_us",
@@ -137,22 +131,22 @@ constexpr ConfigFieldSpec kConfigFields[] = {
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
     {"transports/rdma/default_bandwidth_gbps",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/min_bandwidth_gbps",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/max_bandwidth_gbps",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/rail_error_threshold",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/min_bandwidth_gbps", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma/max_bandwidth_gbps", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma/rail_error_threshold", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
     {"transports/rdma/rail_error_window_secs",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/rail_cooldown_secs",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/gdr_error_threshold",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/rail_cooldown_secs", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
+    {"transports/rdma/gdr_error_threshold", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
     {"transports/rdma/gdr_error_window_secs",
      ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
-    {"transports/rdma/gdr_cooldown_secs",
-     ConfigLifecycle::kRuntimeCandidate, ConfigFieldMatch::kExact},
+    {"transports/rdma/gdr_cooldown_secs", ConfigLifecycle::kRuntimeCandidate,
+     ConfigFieldMatch::kExact},
 };
 
 bool matches(const ConfigFieldSpec& spec, std::string_view path) {
@@ -177,8 +171,7 @@ ConfigLifecycle classifyConfigPath(std::string_view path) {
             best_match = &field;
         }
     }
-    return best_match ? best_match->lifecycle
-                      : ConfigLifecycle::kUnsupported;
+    return best_match ? best_match->lifecycle : ConfigLifecycle::kUnsupported;
 }
 
 const char* configLifecycleName(ConfigLifecycle lifecycle) {
@@ -205,8 +198,7 @@ bool LifecycleConfigView::contains(const std::string& key_path) const {
 
 bool LifecycleConfigView::dumpSubtree(const std::string& key_path,
                                       std::string* out) const {
-    return allows(key_path) && values_ &&
-           values_->dumpSubtree(key_path, out);
+    return allows(key_path) && values_ && values_->dumpSubtree(key_path, out);
 }
 
 TentConfigBundle buildTentConfigBundle(const Config& effective_config,

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -336,8 +336,9 @@ Status TransferEngineImpl::setupLocalSegment() {
 }
 
 Status TransferEngineImpl::construct() {
-    runtime_config_snapshot_.store(buildTentConfigBundle(*conf_).runtime,
-                                   std::memory_order_relaxed);
+    std::atomic_store_explicit(&runtime_config_snapshot_,
+                               buildTentConfigBundle(*conf_).runtime,
+                               std::memory_order_relaxed);
     auto metadata_type = conf_->get("metadata_type", "p2p");
     auto metadata_servers = conf_->get("metadata_servers", "");
 
@@ -1736,13 +1737,13 @@ Status TransferEngineImpl::prepareSubmit(
     }
 
     prepared = PreparedSubmit{};
-    auto runtime_config =
-        runtime_config_snapshot_.load(std::memory_order_acquire);
+    auto runtime_config = std::atomic_load_explicit(&runtime_config_snapshot_,
+                                                    std::memory_order_acquire);
     prepared.runtime_policy.config_generation = runtime_config->generation;
     prepared.runtime_policy.max_failover_attempts =
-        runtime_config->config->get("max_failover_attempts", 3);
+        runtime_config->max_failover_attempts;
     prepared.runtime_policy.enable_auto_failover_on_poll =
-        runtime_config->config->get("enable_auto_failover_on_poll", true);
+        runtime_config->enable_auto_failover_on_poll;
     const size_t start_task_id = batch->task_list.size();
     prepared.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =

--- a/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
+++ b/mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp
@@ -336,6 +336,8 @@ Status TransferEngineImpl::setupLocalSegment() {
 }
 
 Status TransferEngineImpl::construct() {
+    runtime_config_snapshot_.store(buildTentConfigBundle(*conf_).runtime,
+                                   std::memory_order_relaxed);
     auto metadata_type = conf_->get("metadata_type", "p2p");
     auto metadata_servers = conf_->get("metadata_servers", "");
 
@@ -356,9 +358,6 @@ Status TransferEngineImpl::construct() {
     CHECK_STATUS(getRpcServerThreadsFromConfig(*conf_, rpc_threads_default,
                                                rpc_server_threads));
     merge_requests_ = conf_->get("merge_requests", true);
-    max_failover_attempts_ = conf_->get("max_failover_attempts", 3);
-    enable_auto_failover_on_poll_ =
-        conf_->get("enable_auto_failover_on_poll", true);
     enable_progress_worker_ = conf_->get("enable_progress_worker", false);
     runtime_queue_config_.enabled = conf_->get("enable_runtime_queue", false);
     if (runtime_queue_config_.enabled) enable_progress_worker_ = true;
@@ -1435,6 +1434,7 @@ struct TransferEngineImpl::PreparedSubmit {
     };
 
     std::chrono::steady_clock::time_point submit_time{};
+    LogicalTransferRuntimePolicy runtime_policy;
     std::vector<Task> tasks;
     std::vector<Owner> owners;
 };
@@ -1736,6 +1736,13 @@ Status TransferEngineImpl::prepareSubmit(
     }
 
     prepared = PreparedSubmit{};
+    auto runtime_config =
+        runtime_config_snapshot_.load(std::memory_order_acquire);
+    prepared.runtime_policy.config_generation = runtime_config->generation;
+    prepared.runtime_policy.max_failover_attempts =
+        runtime_config->config->get("max_failover_attempts", 3);
+    prepared.runtime_policy.enable_auto_failover_on_poll =
+        runtime_config->config->get("enable_auto_failover_on_poll", true);
     const size_t start_task_id = batch->task_list.size();
     prepared.submit_time = std::chrono::steady_clock::now();
     auto merge_boundaries =
@@ -1825,6 +1832,7 @@ Status TransferEngineImpl::commitPreparedSubmit(
 
         task.failover_count = 0;
         task.xport_priority = 0;
+        task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = merged_request;
         task.staging = false;
@@ -2029,6 +2037,7 @@ Status TransferEngineImpl::enqueuePreparedSubmit(Batch* batch,
         const auto& owner = prepared.owners[task_plan.merged_task_index];
         task.failover_count = 0;
         task.xport_priority = 0;
+        task.runtime_policy = prepared.runtime_policy;
         task.status = PENDING;
         task.request = owner.request;
         task.staging = false;
@@ -2437,9 +2446,9 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
     auto& task = batch->task_list[task_id];
     auto prev_type = task.type;
 
-    if (++task.failover_count > max_failover_attempts_) {
+    if (++task.failover_count > task.runtime_policy.max_failover_attempts) {
         LOG(WARNING) << "Task failover limit reached ("
-                     << max_failover_attempts_
+                     << task.runtime_policy.max_failover_attempts
                      << "), last transport=" << transportTypeName(prev_type);
         return Status::InvalidEntry(
             "Failover limit exceeded, all transports exhausted");
@@ -2460,7 +2469,9 @@ Status TransferEngineImpl::resubmitTransferTask(Batch* batch, size_t task_id) {
 
     LOG(INFO) << "Transport failover: " << transportTypeName(prev_type)
               << " -> " << transportTypeName(type) << " (attempt "
-              << task.failover_count << "/" << max_failover_attempts_ << ")";
+              << task.failover_count << "/"
+              << task.runtime_policy.max_failover_attempts << ", generation "
+              << task.runtime_policy.config_generation << ")";
     TENT_RECORD_TRANSPORT_FAILOVER(prev_type, type);
 
     auto& transport = transport_list_[type];
@@ -2495,7 +2506,8 @@ bool TransferEngineImpl::attemptSubmitStageFailover(Batch* batch,
     // failover in updateTaskStatusAfterPoll, which sets task.status = FAILED
     // before calling resubmitTransferTask).
     task.status = FAILED;
-    for (int attempt = 0; attempt < max_failover_attempts_; ++attempt) {
+    for (int attempt = 0; attempt < task.runtime_policy.max_failover_attempts;
+         ++attempt) {
         if (resubmitTransferTask(batch, task_id).ok()) {
             task.status = PENDING;
             return true;
@@ -2646,7 +2658,7 @@ Status TransferEngineImpl::getTransferStatus(BatchID batch_id, size_t task_id,
     auto prev_status = task.status;
     CHECK_STATUS(pollTaskStatus(batch, poll_task_id, task_status));
     updateTaskStatusAfterPoll(batch, poll_task_id, task_status,
-                              enable_auto_failover_on_poll_);
+                              task.runtime_policy.enable_auto_failover_on_poll);
     if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
         task_status.s != PENDING) {
         QueueOwnerId owner_id = 0;
@@ -2684,7 +2696,7 @@ Status TransferEngineImpl::getTransferStatus(
 
 Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
                                           TransferStatus& overall_status,
-                                          bool allow_failover) {
+                                          bool force_failover) {
     if (!batch_id) return Status::InvalidArgument("Invalid batch ID" LOC_MARK);
     std::lock_guard<std::recursive_mutex> lk(progressLockFor(batch_id));
     if (!isBatchAlive(batch_id))
@@ -2746,7 +2758,9 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
         }
         auto prev_status = task.status;
         CHECK_STATUS(pollTaskStatus(batch, task_id, task_status));
-        updateTaskStatusAfterPoll(batch, task_id, task_status, allow_failover);
+        updateTaskStatusAfterPoll(
+            batch, task_id, task_status,
+            force_failover || task.runtime_policy.enable_auto_failover_on_poll);
         if (runtime_queue_config_.enabled && batch->queue_token != 0 &&
             task_status.s != PENDING) {
             QueueOwnerId owner_id = 0;
@@ -2792,8 +2806,7 @@ Status TransferEngineImpl::getBatchStatus(BatchID batch_id,
 
 Status TransferEngineImpl::getTransferStatus(BatchID batch_id,
                                              TransferStatus& overall_status) {
-    return getBatchStatus(batch_id, overall_status,
-                          enable_auto_failover_on_poll_);
+    return getBatchStatus(batch_id, overall_status, false);
 }
 
 Status TransferEngineImpl::progressBatch(BatchID batch_id,

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -39,6 +39,21 @@ target_compile_definitions(
   PRIVATE "TENT_CONFIG_FIXTURE_PATH=\"${CONFIG_LIFECYCLE_FIXTURE}\"")
 add_test(NAME config_lifecycle_test COMMAND config_lifecycle_test)
 
+# Keep production Config access sites synchronized with the lifecycle inventory.
+# This scans source rather than relying only on the example config, so code-only
+# keys are covered as well.
+add_executable(config_lifecycle_source_audit_test
+               config_lifecycle_source_audit_test.cpp)
+target_link_libraries(config_lifecycle_source_audit_test
+                      PRIVATE tent_common gtest gtest_main)
+target_include_directories(config_lifecycle_source_audit_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_compile_definitions(
+  config_lifecycle_source_audit_test
+  PRIVATE "TENT_SOURCE_ROOT=\"${CMAKE_CURRENT_SOURCE_DIR}/..\"")
+add_test(NAME config_lifecycle_source_audit_test
+         COMMAND config_lifecycle_source_audit_test)
+
 # TENT Metrics HTTP server test: validates that initialize() detects a busy
 # metrics port and degrades to log-only metrics instead of falsely reporting a
 # listening endpoint.

--- a/mooncake-transfer-engine/tent/tests/CMakeLists.txt
+++ b/mooncake-transfer-engine/tent/tests/CMakeLists.txt
@@ -24,6 +24,21 @@ target_include_directories(metrics_config_loader_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 add_test(NAME metrics_config_loader_test COMMAND metrics_config_loader_test)
 
+# TENT configuration lifecycle foundation test. This target deliberately links
+# only tent_common so it remains independent of transport hardware and runtime
+# services.
+add_executable(config_lifecycle_test config_lifecycle_test.cpp)
+target_link_libraries(config_lifecycle_test PRIVATE tent_common gtest
+                                                    gtest_main)
+target_include_directories(config_lifecycle_test
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+set(CONFIG_LIFECYCLE_FIXTURE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../config/transfer-engine.json")
+target_compile_definitions(
+  config_lifecycle_test
+  PRIVATE "TENT_CONFIG_FIXTURE_PATH=\"${CONFIG_LIFECYCLE_FIXTURE}\"")
+add_test(NAME config_lifecycle_test COMMAND config_lifecycle_test)
+
 # TENT Metrics HTTP server test: validates that initialize() detects a busy
 # metrics port and degrades to log-only metrics instead of falsely reporting a
 # listening endpoint.

--- a/mooncake-transfer-engine/tent/tests/config_lifecycle_source_audit_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_lifecycle_source_audit_test.cpp
@@ -1,0 +1,320 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <regex>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "tent/common/config_lifecycle.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+namespace fs = std::filesystem;
+
+struct SourceKey {
+    std::string path;
+    fs::path source;
+    size_t line{0};
+};
+
+using ConstantMap = std::unordered_map<std::string, std::vector<SourceKey>>;
+
+bool isProductionSource(const fs::path& path) {
+    const auto extension = path.extension().string();
+    return extension == ".h" || extension == ".hpp" || extension == ".cpp" ||
+           extension == ".cc";
+}
+
+std::string readFile(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    return {std::istreambuf_iterator<char>(input),
+            std::istreambuf_iterator<char>()};
+}
+
+// Remove comments while preserving strings, character literals, byte
+// positions, and newlines. Keeping positions stable makes diagnostics point to
+// the original source line and prevents commented-out Config reads from being
+// audited.
+std::string stripComments(std::string source) {
+    enum class State { kCode, kLineComment, kBlockComment, kString, kChar };
+    State state = State::kCode;
+    bool escaped = false;
+
+    for (size_t index = 0; index < source.size(); ++index) {
+        const char current = source[index];
+        const char next = index + 1 < source.size() ? source[index + 1] : '\0';
+
+        if (state == State::kLineComment) {
+            if (current == '\n') {
+                state = State::kCode;
+            } else {
+                source[index] = ' ';
+            }
+            continue;
+        }
+        if (state == State::kBlockComment) {
+            if (current == '*' && next == '/') {
+                source[index] = ' ';
+                source[index + 1] = ' ';
+                ++index;
+                state = State::kCode;
+            } else if (current != '\n') {
+                source[index] = ' ';
+            }
+            continue;
+        }
+        if (state == State::kString || state == State::kChar) {
+            if (escaped) {
+                escaped = false;
+            } else if (current == '\\') {
+                escaped = true;
+            } else if ((state == State::kString && current == '"') ||
+                       (state == State::kChar && current == '\'')) {
+                state = State::kCode;
+            }
+            continue;
+        }
+
+        if (current == '/' && next == '/') {
+            source[index] = ' ';
+            source[index + 1] = ' ';
+            ++index;
+            state = State::kLineComment;
+        } else if (current == '/' && next == '*') {
+            source[index] = ' ';
+            source[index + 1] = ' ';
+            ++index;
+            state = State::kBlockComment;
+        } else if (current == '"') {
+            state = State::kString;
+        } else if (current == '\'') {
+            state = State::kChar;
+        }
+    }
+    return source;
+}
+
+size_t lineAt(std::string_view source, size_t offset) {
+    return 1 + static_cast<size_t>(
+                   std::count(source.begin(), source.begin() + offset, '\n'));
+}
+
+void appendLiteralMatches(const std::string& source, const fs::path& path,
+                          const std::regex& pattern, size_t capture,
+                          std::vector<SourceKey>* keys) {
+    for (std::sregex_iterator match(source.begin(), source.end(), pattern), end;
+         match != end; ++match) {
+        keys->push_back(
+            {(*match)[capture].str(), path,
+             lineAt(source, static_cast<size_t>(match->position()))});
+    }
+}
+
+std::string unqualifiedName(std::string name) {
+    const auto separator = name.rfind("::");
+    if (separator != std::string::npos) name.erase(0, separator + 2);
+    return name;
+}
+
+std::vector<fs::path> productionSources(const fs::path& root) {
+    std::vector<fs::path> sources;
+    for (const char* directory : {"include", "src"}) {
+        const fs::path source_root = root / directory;
+        for (const auto& entry :
+             fs::recursive_directory_iterator(source_root)) {
+            if (entry.is_regular_file() && isProductionSource(entry.path())) {
+                sources.push_back(entry.path());
+            }
+        }
+    }
+    std::sort(sources.begin(), sources.end());
+    return sources;
+}
+
+std::vector<SourceKey> discoverProductionConfigKeys(const fs::path& root) {
+    // Config parsing helpers forward their second argument to Config. The env
+    // helpers use the second argument for the environment name and the third
+    // for the actual configuration path.
+    const std::regex forwarded_read(
+        R"REGEX((?:captureExplicitConfigValue|restoreExplicitConfigValue|readPositive|readNonNegative|readBool)\s*\(\s*config\s*,\s*"([^"]+)")REGEX");
+    const std::regex env_mapping(
+        R"REGEX((?:setConfig|setBoolConfig|setArrayConfig)\s*\(\s*config\s*,\s*"[^"]+"\s*,\s*"([^"]+)")REGEX");
+    const std::regex constant_assignment(
+        R"REGEX(\b([A-Za-z_][A-Za-z0-9_]*)\s*(?:\[\s*\])?\s*=\s*"([^"]+)")REGEX");
+    const std::regex config_object(
+        R"(\b(?:const\s+)?Config\s*(?:[&*]\s*)*([A-Za-z_][A-Za-z0-9_]*))");
+    const std::regex config_smart_pointer(
+        R"((?:shared_ptr|unique_ptr)\s*<\s*(?:const\s+)?Config\s*>\s*([A-Za-z_][A-Za-z0-9_]*))");
+
+    const auto sources = productionSources(root);
+    std::unordered_map<std::string, std::string> contents;
+    ConstantMap constants;
+    std::unordered_map<std::string, ConstantMap> constants_by_file;
+    std::set<std::string> config_receivers;
+    for (const auto& path : sources) {
+        auto source = stripComments(readFile(path));
+        for (std::sregex_iterator
+                 match(source.begin(), source.end(), constant_assignment),
+             end;
+             match != end; ++match) {
+            constants[(*match)[1].str()].push_back(
+                {(*match)[2].str(), path,
+                 lineAt(source, static_cast<size_t>(match->position()))});
+            constants_by_file[path.string()][(*match)[1].str()].push_back(
+                {(*match)[2].str(), path,
+                 lineAt(source, static_cast<size_t>(match->position()))});
+        }
+        for (const auto* pattern : {&config_object, &config_smart_pointer}) {
+            for (std::sregex_iterator
+                     match(source.begin(), source.end(), *pattern),
+                 end;
+                 match != end; ++match) {
+                config_receivers.insert((*match)[1].str());
+            }
+        }
+        contents.emplace(path.string(), std::move(source));
+    }
+
+    std::string receiver = "(?:";
+    for (auto iterator = config_receivers.begin();
+         iterator != config_receivers.end(); ++iterator) {
+        if (iterator != config_receivers.begin()) receiver += '|';
+        receiver += "\\b" + *iterator + "\\b";
+    }
+    receiver += ')';
+
+    // Direct Config reads. Building the receiver set from Config declarations
+    // avoids treating nlohmann::json::contains/get calls as configuration
+    // access without imposing a naming convention on Config variables.
+    const std::string method =
+        R"((?:get|getArray|contains|dumpSubtree)\s*(?:<[^(){};]*>)?)";
+    const std::regex literal_read(receiver + R"(\s*(?:\.|->)\s*)" + method +
+                                  R"REGEX(\s*\(\s*"([^"]+)")REGEX");
+    const std::regex constant_read(
+        receiver + R"(\s*(?:\.|->)\s*)" + method +
+        R"(\s*\(\s*((?:[A-Za-z_][A-Za-z0-9_]*::)*[A-Za-z_][A-Za-z0-9_]*))");
+
+    std::vector<SourceKey> keys;
+    const std::set<std::string> dynamic_arguments = {"config_key", "key",
+                                                     "key_path"};
+    for (const auto& path : sources) {
+        const auto& source = contents.at(path.string());
+        appendLiteralMatches(source, path, literal_read, 1, &keys);
+        appendLiteralMatches(source, path, forwarded_read, 1, &keys);
+        appendLiteralMatches(source, path, env_mapping, 1, &keys);
+
+        for (std::sregex_iterator
+                 match(source.begin(), source.end(), constant_read),
+             end;
+             match != end; ++match) {
+            const std::string argument = (*match)[1].str();
+            const std::string name = unqualifiedName(argument);
+            if (dynamic_arguments.contains(name)) continue;
+
+            const auto& local_constants = constants_by_file.at(path.string());
+            const auto local_values = local_constants.find(name);
+            const auto global_values = constants.find(name);
+            const std::vector<SourceKey>* values = nullptr;
+            if (local_values != local_constants.end()) {
+                values = &local_values->second;
+            } else if (global_values != constants.end()) {
+                values = &global_values->second;
+            }
+            if (values == nullptr) {
+                ADD_FAILURE()
+                    << path << ':'
+                    << lineAt(source, static_cast<size_t>(match->position()))
+                    << ": cannot resolve Config key constant " << argument;
+                continue;
+            }
+            keys.insert(keys.end(), values->begin(), values->end());
+        }
+    }
+    return keys;
+}
+
+TEST(ConfigLifecycleSourceAuditTest,
+     ProductionConfigReadsAreLifecycleClassified) {
+    const fs::path source_root = TENT_SOURCE_ROOT;
+    ASSERT_TRUE(fs::is_directory(source_root / "include"));
+    ASSERT_TRUE(fs::is_directory(source_root / "src"));
+
+    const auto keys = discoverProductionConfigKeys(source_root);
+    ASSERT_GT(keys.size(), 50U);
+
+    std::set<std::string> discovered;
+    for (const auto& key : keys) {
+        discovered.insert(key.path);
+        if (classifyConfigPath(key.path) == ConfigLifecycle::kUnsupported) {
+            ADD_FAILURE() << key.source << ':' << key.line
+                          << ": Config key is missing from the lifecycle "
+                             "inventory: "
+                          << key.path;
+        }
+    }
+
+    // Sentinels cover each supported discovery form so a future edit cannot
+    // accidentally turn the audit into an empty or partial scan.
+    for (const char* expected : {
+             "metadata_type",
+             "metrics/http_port",
+             "rpc_server_threads",
+             "transports/rdma/rail_error_threshold",
+             "transports/tcp/max_retry_count",
+             "transports/ub/worker_count",
+         }) {
+        EXPECT_TRUE(discovered.contains(expected)) << expected;
+    }
+}
+
+TEST(ConfigLifecycleSourceAuditTest, DetectsUnclassifiedDirectRead) {
+    const fs::path source_root =
+        fs::temp_directory_path() / "mooncake_config_lifecycle_source_audit";
+    fs::remove_all(source_root);
+    fs::create_directories(source_root / "include");
+    fs::create_directories(source_root / "src");
+
+    {
+        std::ofstream source(source_root / "src" / "new_config.cpp");
+        source << R"(
+            void load(const Config& settings) {
+                (void)settings.get("new/unregistered", 0);
+            }
+        )";
+    }
+
+    const auto keys = discoverProductionConfigKeys(source_root);
+    fs::remove_all(source_root);
+
+    ASSERT_EQ(keys.size(), 1U);
+    EXPECT_EQ(keys.front().path, "new/unregistered");
+    EXPECT_EQ(classifyConfigPath(keys.front().path),
+              ConfigLifecycle::kUnsupported);
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
@@ -67,8 +67,7 @@ TEST(ConfigLifecycleTest, ClassifiesRepresentativeFields) {
     EXPECT_EQ(classifyConfigPath("staging/shutdown_drain_timeout_ms"),
               ConfigLifecycle::kBootstrapOnly);
 
-    EXPECT_EQ(classifyConfigPath("policy"),
-              ConfigLifecycle::kRuntimeCandidate);
+    EXPECT_EQ(classifyConfigPath("policy"), ConfigLifecycle::kRuntimeCandidate);
     EXPECT_EQ(classifyConfigPath("qos/tenants"),
               ConfigLifecycle::kRuntimeCandidate);
     EXPECT_EQ(classifyConfigPath("runtime_queue/max_dispatch_bytes"),
@@ -83,9 +82,8 @@ TEST(ConfigLifecycleTest, ClassifiesRepresentativeFields) {
 TEST(ConfigLifecycleTest, MostSpecificFieldOverridesBootstrapSubtree) {
     EXPECT_EQ(classifyConfigPath("transports/rdma/device/max_cqe"),
               ConfigLifecycle::kBootstrapOnly);
-    EXPECT_EQ(
-        classifyConfigPath("transports/rdma/enable_smart_scheduling"),
-        ConfigLifecycle::kRuntimeCandidate);
+    EXPECT_EQ(classifyConfigPath("transports/rdma/enable_smart_scheduling"),
+              ConfigLifecycle::kRuntimeCandidate);
 }
 
 TEST(ConfigLifecycleTest, BundleViewsEnforceLifecycleBoundaries) {
@@ -119,13 +117,11 @@ TEST(ConfigLifecycleTest, SnapshotDoesNotChangeWithLegacyConfig) {
     auto generation_two = buildTentConfigBundle(config, 2);
 
     EXPECT_EQ(generation_one.bootstrap->get("rpc_server_port", 0), 18080);
-    EXPECT_TRUE(
-        generation_one.runtime->config->get("merge_requests", false));
+    EXPECT_TRUE(generation_one.runtime->config->get("merge_requests", false));
     EXPECT_EQ(generation_one.runtime->generation, 1);
 
     EXPECT_EQ(generation_two.bootstrap->get("rpc_server_port", 0), 28080);
-    EXPECT_FALSE(
-        generation_two.runtime->config->get("merge_requests", true));
+    EXPECT_FALSE(generation_two.runtime->config->get("merge_requests", true));
     EXPECT_EQ(generation_two.runtime->generation, 2);
 }
 

--- a/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
@@ -1,0 +1,217 @@
+// Copyright 2026 KVCache.AI
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <set>
+#include <string>
+
+#include "tent/common/config_lifecycle.h"
+
+namespace mooncake {
+namespace tent {
+namespace {
+
+class EnvVarGuard {
+   public:
+    EnvVarGuard(const char* name, const char* value) : name_(name) {
+        const char* old = std::getenv(name);
+        if (old) {
+            old_value_ = old;
+            had_value_ = true;
+        }
+        setenv(name, value, 1);
+    }
+
+    ~EnvVarGuard() {
+        if (had_value_) {
+            setenv(name_.c_str(), old_value_.c_str(), 1);
+        } else {
+            unsetenv(name_.c_str());
+        }
+    }
+
+   private:
+    std::string name_;
+    std::string old_value_;
+    bool had_value_{false};
+};
+
+TEST(ConfigLifecycleTest, InventoryPathsAreUnique) {
+    std::set<std::string_view> paths;
+    for (const auto& field : configFieldInventory()) {
+        EXPECT_FALSE(field.path.empty());
+        EXPECT_TRUE(paths.insert(field.path).second) << field.path;
+    }
+}
+
+TEST(ConfigLifecycleTest, ClassifiesRepresentativeFields) {
+    EXPECT_EQ(classifyConfigPath("rpc_server_port"),
+              ConfigLifecycle::kBootstrapOnly);
+    EXPECT_EQ(classifyConfigPath("topology/rdma_whitelist"),
+              ConfigLifecycle::kBootstrapOnly);
+    EXPECT_EQ(classifyConfigPath("transports/tcp/max_retry_count"),
+              ConfigLifecycle::kBootstrapOnly);
+    EXPECT_EQ(classifyConfigPath("staging/shutdown_drain_timeout_ms"),
+              ConfigLifecycle::kBootstrapOnly);
+
+    EXPECT_EQ(classifyConfigPath("policy"),
+              ConfigLifecycle::kRuntimeCandidate);
+    EXPECT_EQ(classifyConfigPath("qos/tenants"),
+              ConfigLifecycle::kRuntimeCandidate);
+    EXPECT_EQ(classifyConfigPath("runtime_queue/max_dispatch_bytes"),
+              ConfigLifecycle::kRuntimeCandidate);
+    EXPECT_EQ(classifyConfigPath("metrics/report_interval_seconds"),
+              ConfigLifecycle::kRuntimeCandidate);
+
+    EXPECT_EQ(classifyConfigPath("unknown/value"),
+              ConfigLifecycle::kUnsupported);
+}
+
+TEST(ConfigLifecycleTest, MostSpecificFieldOverridesBootstrapSubtree) {
+    EXPECT_EQ(classifyConfigPath("transports/rdma/device/max_cqe"),
+              ConfigLifecycle::kBootstrapOnly);
+    EXPECT_EQ(
+        classifyConfigPath("transports/rdma/enable_smart_scheduling"),
+        ConfigLifecycle::kRuntimeCandidate);
+}
+
+TEST(ConfigLifecycleTest, BundleViewsEnforceLifecycleBoundaries) {
+    Config config;
+    config.set("rpc_server_port", 18080);
+    config.set("merge_requests", true);
+
+    auto bundle = buildTentConfigBundle(config, 17);
+    ASSERT_NE(bundle.bootstrap, nullptr);
+    ASSERT_NE(bundle.runtime, nullptr);
+    ASSERT_NE(bundle.runtime->config, nullptr);
+
+    EXPECT_EQ(bundle.bootstrap->get("rpc_server_port", 0), 18080);
+    EXPECT_FALSE(bundle.bootstrap->contains("merge_requests"));
+    EXPECT_FALSE(bundle.bootstrap->get("merge_requests", false));
+
+    EXPECT_TRUE(bundle.runtime->config->get("merge_requests", false));
+    EXPECT_FALSE(bundle.runtime->config->contains("rpc_server_port"));
+    EXPECT_EQ(bundle.runtime->config->get("rpc_server_port", 7), 7);
+    EXPECT_EQ(bundle.runtime->generation, 17);
+}
+
+TEST(ConfigLifecycleTest, SnapshotDoesNotChangeWithLegacyConfig) {
+    Config config;
+    config.set("rpc_server_port", 18080);
+    config.set("merge_requests", true);
+
+    auto generation_one = buildTentConfigBundle(config, 1);
+    config.set("rpc_server_port", 28080);
+    config.set("merge_requests", false);
+    auto generation_two = buildTentConfigBundle(config, 2);
+
+    EXPECT_EQ(generation_one.bootstrap->get("rpc_server_port", 0), 18080);
+    EXPECT_TRUE(
+        generation_one.runtime->config->get("merge_requests", false));
+    EXPECT_EQ(generation_one.runtime->generation, 1);
+
+    EXPECT_EQ(generation_two.bootstrap->get("rpc_server_port", 0), 28080);
+    EXPECT_FALSE(
+        generation_two.runtime->config->get("merge_requests", true));
+    EXPECT_EQ(generation_two.runtime->generation, 2);
+}
+
+TEST(ConfigLifecycleTest, PreservesNestedBeforeFlatLookupCompatibility) {
+    Config config;
+    ASSERT_TRUE(config
+                    .load(R"({
+                        "metrics": {"http_port": 9100},
+                        "metrics/http_port": 9200
+                    })")
+                    .ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    EXPECT_EQ(bundle.bootstrap->get("metrics/http_port", 0), 9100);
+}
+
+TEST(ConfigLifecycleTest, ReportsUnsupportedFieldsWithoutRejectingBundle) {
+    Config config;
+    ASSERT_TRUE(config
+                    .load(R"({
+                        "mystery": 1,
+                        "transports": {"unknown": {"enable": true}}
+                    })")
+                    .ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    ASSERT_EQ(bundle.diagnostics.size(), 2);
+    EXPECT_EQ(bundle.diagnostics[0].code,
+              ConfigDiagnosticCode::kUnsupportedField);
+    EXPECT_EQ(bundle.diagnostics[0].path, "mystery");
+    EXPECT_EQ(bundle.diagnostics[1].code,
+              ConfigDiagnosticCode::kUnsupportedField);
+    EXPECT_EQ(bundle.diagnostics[1].path, "transports/unknown/enable");
+    EXPECT_NE(bundle.bootstrap, nullptr);
+    EXPECT_NE(bundle.runtime, nullptr);
+}
+
+TEST(ConfigLifecycleTest, ReportsNonObjectRoot) {
+    Config config;
+    ASSERT_TRUE(config.load("[]").ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    ASSERT_EQ(bundle.diagnostics.size(), 1);
+    EXPECT_EQ(bundle.diagnostics[0].code, ConfigDiagnosticCode::kInvalidRoot);
+    EXPECT_EQ(bundle.diagnostics[0].path, "$");
+}
+
+TEST(ConfigLifecycleTest, DefaultConfigIsAValidEmptyConfiguration) {
+    Config config;
+
+    auto bundle = buildTentConfigBundle(config);
+    EXPECT_TRUE(bundle.diagnostics.empty());
+}
+
+TEST(ConfigLifecycleTest, AcceptsEmptyKnownObjects) {
+    Config config;
+    ASSERT_TRUE(config.load(R"({"metrics": {}, "transports": {}})").ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    EXPECT_TRUE(bundle.diagnostics.empty());
+}
+
+TEST(ConfigLifecycleTest, PreservesLegacyEnvironmentPrecedence) {
+    EnvVarGuard conf_guard(
+        "MC_TENT_CONF",
+        R"({"transports":{"rdma":{"bind_address":"10.0.0.1"}}})");
+    EnvVarGuard bind_guard("MC_RDMA_BIND_ADDRESS", "10.0.0.2");
+
+    Config config;
+    ASSERT_TRUE(ConfigHelper().loadFromEnv(config).ok());
+    auto bundle = buildTentConfigBundle(config);
+
+    EXPECT_EQ(bundle.bootstrap->get("transports/rdma/bind_address", ""),
+              "10.0.0.2");
+}
+
+TEST(ConfigLifecycleTest, RepositoryExampleIsFullyClassified) {
+    Config config;
+    ASSERT_TRUE(config.loadFile(TENT_CONFIG_FIXTURE_PATH).ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    for (const auto& diagnostic : bundle.diagnostics) {
+        ADD_FAILURE() << diagnostic.path << ": " << diagnostic.message;
+    }
+}
+
+}  // namespace
+}  // namespace tent
+}  // namespace mooncake

--- a/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
@@ -108,6 +108,44 @@ TEST(ConfigLifecycleTest, BundleViewsEnforceLifecycleBoundaries) {
     EXPECT_EQ(bundle.runtime->generation, 17);
 }
 
+TEST(ConfigLifecycleTest, RejectsMixedLifecycleSubtreeReads) {
+    Config config;
+    ASSERT_TRUE(config
+                    .load(R"({
+                        "metrics": {
+                            "enabled": true,
+                            "report_interval_seconds": 5
+                        },
+                        "staging": {"shutdown_drain_timeout_ms": 1000},
+                        "transports": {
+                            "rdma": {
+                                "device": {"max_cqe": 4096},
+                                "strict_local_numa": true
+                            }
+                        }
+                    })")
+                    .ok());
+
+    auto bundle = buildTentConfigBundle(config);
+    const json rejected_default = {{"rejected", true}};
+    std::string subtree = "unchanged";
+
+    EXPECT_FALSE(bundle.bootstrap->contains("metrics"));
+    EXPECT_FALSE(bundle.bootstrap->dumpSubtree("metrics", &subtree));
+    EXPECT_EQ(subtree, "unchanged");
+    EXPECT_EQ(bundle.bootstrap->get<json>("transports/rdma", rejected_default),
+              rejected_default);
+
+    EXPECT_TRUE(bundle.bootstrap->get("metrics/enabled", false));
+    EXPECT_EQ(bundle.runtime->config->get("metrics/report_interval_seconds", 0),
+              5);
+    EXPECT_TRUE(bundle.runtime->config->get("transports/rdma/strict_local_numa",
+                                            false));
+
+    EXPECT_EQ(bundle.bootstrap->get<json>("staging", json::object()),
+              json({{"shutdown_drain_timeout_ms", 1000}}));
+}
+
 TEST(ConfigLifecycleTest, SnapshotDoesNotChangeWithLegacyConfig) {
     Config config;
     config.set("rpc_server_port", 18080);

--- a/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/config_lifecycle_test.cpp
@@ -64,6 +64,8 @@ TEST(ConfigLifecycleTest, ClassifiesRepresentativeFields) {
               ConfigLifecycle::kBootstrapOnly);
     EXPECT_EQ(classifyConfigPath("transports/tcp/max_retry_count"),
               ConfigLifecycle::kBootstrapOnly);
+    EXPECT_EQ(classifyConfigPath("transports/hp_tcp/worker_count"),
+              ConfigLifecycle::kBootstrapOnly);
     EXPECT_EQ(classifyConfigPath("staging/shutdown_drain_timeout_ms"),
               ConfigLifecycle::kBootstrapOnly);
 

--- a/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
@@ -45,6 +45,7 @@
 #include <vector>
 
 #include "tent/common/config.h"
+#include "tent/common/config_lifecycle.h"
 #include "tent/common/types.h"
 #include "tent/runtime/segment.h"
 #include "tent/runtime/transfer_engine_impl.h"
@@ -367,6 +368,46 @@ TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledLeavesTaskFailed) {
     EXPECT_TRUE(engine.freeBatch(batch.batch_id).ok());
     EXPECT_TRUE(
         engine.unregisterLocalMemory(batch.buf.data(), batch.buf.size()).ok());
+}
+
+TEST(EngineFailoverE2E, FailoverPolicyIsPinnedAtSubmit) {
+    auto cfg = makeMinimalP2PConfig();
+    cfg->set("max_failover_attempts", 1);
+    cfg->set("enable_auto_failover_on_poll", true);
+    TransferEngineImpl engine(cfg);
+    ASSERT_TRUE(engine.available());
+
+    CorruptedRdmaBatch old_generation;
+    submitCorruptedRdmaBatch(engine, old_generation, 0xB1);
+
+    auto next_cfg = makeMinimalP2PConfig();
+    next_cfg->set("max_failover_attempts", 0);
+    next_cfg->set("enable_auto_failover_on_poll", false);
+    engine.publishRuntimeConfigForTest(
+        buildTentConfigBundle(*next_cfg, 1).runtime);
+
+    auto old_status = pollUntilDone(engine, old_generation.batch_id, 0);
+    EXPECT_EQ(old_status.s, TransferStatusEnum::COMPLETED);
+    EXPECT_EQ(old_generation.fake_tcp->submit_calls.load(), 1);
+
+    CorruptedRdmaBatch new_generation;
+    submitCorruptedRdmaBatch(engine, new_generation, 0xB2);
+    TransferStatus new_status{};
+    ASSERT_TRUE(
+        engine.getTransferStatus(new_generation.batch_id, 0, new_status).ok());
+    EXPECT_EQ(new_status.s, TransferStatusEnum::FAILED);
+    EXPECT_EQ(new_generation.fake_tcp->submit_calls.load(), 0);
+
+    EXPECT_TRUE(engine.freeBatch(old_generation.batch_id).ok());
+    EXPECT_TRUE(engine
+                    .unregisterLocalMemory(old_generation.buf.data(),
+                                           old_generation.buf.size())
+                    .ok());
+    EXPECT_TRUE(engine.freeBatch(new_generation.batch_id).ok());
+    EXPECT_TRUE(engine
+                    .unregisterLocalMemory(new_generation.buf.data(),
+                                           new_generation.buf.size())
+                    .ok());
 }
 
 TEST(EngineFailoverE2E, AutoFailoverOnPollDisabledAppliesToVectorStatus) {


### PR DESCRIPTION
## Description

This is a focused follow-up to #3836.

- pin the active runtime configuration generation and failover policy once per logical transfer submission
- carry the pinned policy through direct and runtime-queued tasks
- reuse the pinned policy for submit-time and poll-time transport failover
- add an end-to-end regression showing that in-flight transfers retain the old policy while new transfers observe the newly published policy

The scope is intentionally limited to direct/queued logical tasks and their cross-transport retries. This PR does not add a production live-update entry point, configuration provider, diff/rollback machinery, or staging-child propagation.

Depends on #3836  
Refs #3833

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

**Test commands:**
```bash
cmake --build build/tent-generation --target tent_engine_failover_e2e_test -j1
./build/tent-generation/mooncake-transfer-engine/tent/tests/tent_engine_failover_e2e_test --gtest_filter=EngineFailoverE2E.FailoverPolicyIsPinnedAtSubmit
ctest --test-dir build/tent-generation -R "^tent_engine_failover_e2e_test$" --output-on-failure
clang-format --dry-run --Werror mooncake-transfer-engine/tent/include/tent/runtime/transfer_engine_impl.h mooncake-transfer-engine/tent/src/runtime/transfer_engine_impl.cpp mooncake-transfer-engine/tent/tests/engine_failover_e2e_test.cpp
git diff --check
```

**Test results:**
- [ ] Unit tests pass
- [x] Integration tests pass: `tent_engine_failover_e2e_test`
- [ ] Manual testing done

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have formatted my code using `./scripts/code_format.sh`
- [ ] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: no user-facing API)
- [x] I have added tests to prove my changes are effective
- [ ] For changes >500 LOC: I have filed an RFC issue

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used