### PR TITLE
[Bugfix] Quarantine restored NoF replicas instead of dropping their handles

### DIFF
--- a/mooncake-store/include/master_service.h
+++ b/mooncake-store/include/master_service.h
@@ -3097,10 +3097,22 @@ class MasterService {
     // Client has successfully remounted them.
     std::unordered_set<std::string> invalid_replica_endpoints_;
 
+    // NoF endpoints quarantined by a standby restore. Held separately from
+    // invalid_replica_endpoints_ because ReMountSegment clears that set per
+    // remounted memory segment, so a NoF te_endpoint that collides with a
+    // memory segment alias would otherwise be un-quarantined by an unrelated
+    // memory remount.
+    std::unordered_set<std::string> invalid_nof_replica_endpoints_;
+
     // Keep DummyBufferAllocator alive after standby restore.
     // Key: transport_endpoint, Value: allocator.
     std::unordered_map<std::string, std::shared_ptr<BufferAllocatorBase>>
         standby_allocator_keepalive_;
+    // Same, for restored NoF replicas, and separate for the same reason:
+    // ReMountSegment erases standby_allocator_keepalive_ by endpoint, and a
+    // NoF placeholder must not be dropped by a memory remount.
+    std::unordered_map<std::string, std::shared_ptr<BufferAllocatorBase>>
+        standby_nof_allocator_keepalive_;
     std::vector<StandbySegmentInfo> standby_memory_segments_;
     std::unordered_map<std::string, uint64_t> standby_accounted_memory_bytes_;
 
@@ -3110,6 +3122,12 @@ class MasterService {
                                          Replica::Descriptor& descriptor) const;
     std::vector<Replica::Descriptor> GetReadableReplicaDescriptors(
         const ObjectMetadata& metadata) const;
+
+    // True when a standby restore quarantined this NoF namespace, i.e. the
+    // metadata still holds restored replicas whose (offset, size) ranges the
+    // fresh mount allocator would consider free. Caller holds snapshot_mutex_.
+    bool IsNoFSegmentQuarantined(const NoFSegment& segment) const;
+
     bool IsReplicaReadable(const Replica& replica) const;
     bool HasReadableReplica(const ObjectMetadata& metadata) const;
     bool IsEvictableMemoryReplica(const Replica& replica) const;

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -1003,6 +1003,19 @@ auto MasterService::MountNoFSegment(const NoFSegment& segment,
                << ", error=nof_pool_disabled";
     return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
 #else
+    // Lock order: snapshot_mutex_ (3) before segment_mutex_ (6).
+    std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+    if (IsNoFSegmentQuarantined(segment)) {
+        // A standby restore left replicas pointing into this namespace whose
+        // ranges this mount would treat as free. Fail closed: serving the
+        // mount would let a fresh allocation alias a live descriptor.
+        LOG(ERROR) << "NoF segment mount: client_id=" << client_id
+                   << ", segment_name=" << segment.name
+                   << ", endpoint=" << segment.te_endpoint
+                   << ", error=endpoint_quarantined_by_standby_restore";
+        return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+    }
+
     ScopedNoFSegmentAccess nof_segment_access =
         nof_segment_manager_.getNoFSegmentAccess();
 
@@ -1019,6 +1032,11 @@ auto MasterService::MountNoFSegment(const NoFSegment& segment,
     }
     return {};
 #endif
+}
+
+bool MasterService::IsNoFSegmentQuarantined(const NoFSegment& segment) const {
+    return invalid_nof_replica_endpoints_.contains(segment.te_endpoint) ||
+           invalid_nof_replica_endpoints_.contains(segment.name);
 }
 
 ErrorCode MasterService::ValidateStandbyRemountSegment(
@@ -1380,6 +1398,19 @@ auto MasterService::ReMountNoFSegment(const std::vector<NoFSegment>& segments,
                << ", error=nof_pool_disabled";
     return tl::make_unexpected(ErrorCode::UNAVAILABLE_IN_CURRENT_MODE);
 #else
+    // Lock order: snapshot_mutex_ (3) before segment_mutex_ (6).
+    std::shared_lock<std::shared_mutex> snapshot_lock(snapshot_mutex_);
+    for (const auto& segment : segments) {
+        if (IsNoFSegmentQuarantined(segment)) {
+            LOG(ERROR) << "NoF segment remount: client_id=" << client_id
+                       << ", segment_name=" << segment.name
+                       << ", endpoint=" << segment.te_endpoint
+                       << ", error=endpoint_quarantined_by_standby_restore";
+            return tl::make_unexpected(
+                ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+        }
+    }
+
     ScopedNoFSegmentAccess nof_segment_access =
         nof_segment_manager_.getNoFSegmentAccess();
     ErrorCode err = nof_segment_access.ReMountSegment(segments, client_id);
@@ -3529,6 +3560,9 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
     std::unordered_map<std::string, std::shared_ptr<BufferAllocatorBase>>
         restored_allocators;
     std::unordered_set<std::string> restored_invalid_endpoints;
+    std::unordered_map<std::string, std::shared_ptr<BufferAllocatorBase>>
+        restored_nof_allocators;
+    std::unordered_set<std::string> restored_invalid_nof_endpoints;
     for (const auto& seg : segments) {
         if (!seg.is_memory_segment) {
             continue;
@@ -3708,13 +3742,33 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
                                    << ", key=" << user_key;
                         return tl::make_unexpected(ErrorCode::INVALID_PARAMS);
                     }
+                    // A NoF descriptor points at a physical offset inside a
+                    // remote NVMe namespace, and the namespace allocator
+                    // state is not part of the snapshot. The next NoF mount
+                    // builds an empty allocator over the whole namespace and
+                    // would consider this offset free, so the restored replica
+                    // must not be served and the offset must not be handed out
+                    // again.
+                    //
+                    // Quarantine the endpoint rather than invalidating the
+                    // handle. The placeholder allocator is kept alive, so the
+                    // descriptor stays complete (including transport_endpoint_,
+                    // which get_descriptor() reads off the allocator) and
+                    // has_invalid_nof_handle() stays false, which keeps
+                    // ClearInvalidHandles from reaping the replica. Membership
+                    // in invalid_nof_replica_endpoints_ is what hides it from
+                    // every read path, and MountNoFSegment refuses to mount a
+                    // quarantined namespace, so nothing can alias the offset
+                    // while the descriptor survives for a later import.
                     auto& alloc =
-                        restored_allocators[buffer.transport_endpoint_];
+                        restored_nof_allocators[buffer.transport_endpoint_];
                     if (!alloc) {
                         alloc = std::make_shared<DummyBufferAllocator>(
                             buffer.transport_endpoint_,
                             buffer.transport_endpoint_);
                     }
+                    restored_invalid_nof_endpoints.insert(
+                        buffer.transport_endpoint_);
                     auto restored_buffer =
                         std::make_unique<AllocatedBuffer>(alloc, buffer);
                     replicas.push_back(
@@ -3850,7 +3904,9 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
         std::move(restored_accounted_memory_bytes);
     standby_memory_segments_ = std::move(restored_memory_segments);
     standby_allocator_keepalive_ = std::move(restored_allocators);
+    standby_nof_allocator_keepalive_ = std::move(restored_nof_allocators);
     invalid_replica_endpoints_ = std::move(restored_invalid_endpoints);
+    invalid_nof_replica_endpoints_ = std::move(restored_invalid_nof_endpoints);
     for (auto& [client_id, record] : new_known_owner_records) {
         client_liveness_records_.emplace(client_id, std::move(record));
         MasterMetricManager::instance().client_liveness_record_created();
@@ -3872,7 +3928,9 @@ tl::expected<void, ErrorCode> MasterService::RestoreFromStandbyState(
     LOG(INFO) << "Restored from standby: " << restored_object_count
               << " objects, " << segments.size()
               << " segments, initial_seq_id=" << initial_oplog_sequence_id
-              << ", invalid_endpoints=" << invalid_replica_endpoints_.size();
+              << ", invalid_endpoints=" << invalid_replica_endpoints_.size()
+              << ", quarantined_nof_endpoints="
+              << invalid_nof_replica_endpoints_.size();
     return {};
 }
 
@@ -4180,10 +4238,14 @@ bool MasterService::TryGetReadableReplicaDescriptor(
     } else if (descriptor.is_local_disk_replica()) {
         endpoint = descriptor.get_local_disk_descriptor().transport_endpoint;
     }
-    if (endpoint && invalid_replica_endpoints_.contains(*endpoint)) {
+    if (!endpoint) {
+        return true;
+    }
+    if (descriptor.is_nof_replica() &&
+        invalid_nof_replica_endpoints_.contains(*endpoint)) {
         return false;
     }
-    return true;
+    return !invalid_replica_endpoints_.contains(*endpoint);
 }
 
 std::vector<Replica::Descriptor> MasterService::GetReadableReplicaDescriptors(

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -581,6 +581,21 @@ class MasterServiceHATest : public ::testing::Test {
         return replica;
     }
 
+    Replica::Descriptor MakeStandbyNoFReplica(const std::string& endpoint,
+                                              uintptr_t offset,
+                                              size_t size = 1024) const {
+        Replica::Descriptor replica;
+        replica.id = 1;
+        replica.status = ReplicaStatus::COMPLETE;
+
+        NoFDescriptor nof_desc;
+        nof_desc.buffer_descriptor.transport_endpoint_ = endpoint;
+        nof_desc.buffer_descriptor.buffer_address_ = offset;
+        nof_desc.buffer_descriptor.size_ = size;
+        replica.descriptor_variant = std::move(nof_desc);
+        return replica;
+    }
+
     StandbyObjectEntry MakeStandbyObject(const std::string& key,
                                          const std::string& endpoint,
                                          size_t size = 1024) const {
@@ -588,6 +603,18 @@ class MasterServiceHATest : public ::testing::Test {
         metadata.client_id = generate_uuid();
         metadata.size = size;
         metadata.replicas.push_back(MakeStandbyMemoryReplica(endpoint, size));
+        return StandbyObjectEntry{"default", key, std::move(metadata)};
+    }
+
+    StandbyObjectEntry MakeStandbyNoFObject(const std::string& key,
+                                            const std::string& endpoint,
+                                            uintptr_t offset,
+                                            size_t size = 1024) const {
+        StandbyObjectMetadata metadata;
+        metadata.client_id = generate_uuid();
+        metadata.size = size;
+        metadata.replicas.push_back(
+            MakeStandbyNoFReplica(endpoint, offset, size));
         return StandbyObjectEntry{"default", key, std::move(metadata)};
     }
 
@@ -769,6 +796,22 @@ class MasterServiceHATest : public ::testing::Test {
         }
         for (const auto& replica : accessor.Get().GetAllReplicas()) {
             if (replica.has_invalid_mem_handle()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static bool HasInvalidNoFHandleForTesting(MasterService& service,
+                                              const TenantId& tenant_id,
+                                              const std::string& key) {
+        MasterService::MetadataAccessorRO accessor(
+            &service, MasterService::ObjectIdentity{tenant_id, key});
+        if (!accessor.Exists()) {
+            return true;
+        }
+        for (const auto& replica : accessor.Get().GetAllReplicas()) {
+            if (replica.has_invalid_nof_handle()) {
                 return true;
             }
         }
@@ -1146,6 +1189,85 @@ TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesMemoryBufferDescriptor) {
     EXPECT_EQ(restored.protocol_, "tcp");
     EXPECT_EQ(restored.transport_endpoint_, endpoint);
 }
+
+TEST_F(MasterServiceHATest, RestoreQuarantinesNoFReplicas) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+
+    const std::string key = "standby_nof_restore_key";
+    const std::string endpoint = "standby_nof_restore_endpoint";
+    constexpr uintptr_t offset = 4096;
+    constexpr size_t size = 1024;
+
+    ASSERT_TRUE(
+        service
+            .RestoreFromStandbySnapshot(
+                {MakeStandbyNoFObject(key, endpoint, offset, size)}, 7, {})
+            .has_value());
+
+    // The namespace allocator state is not part of the snapshot, so a later
+    // NoF mount would consider `offset` free. The restored replica must not
+    // be served while that is true.
+    auto get_result = service.GetReplicaList(key, kDefaultTenant);
+    ASSERT_FALSE(get_result.has_value());
+    EXPECT_EQ(get_result.error(), ErrorCode::REPLICA_IS_NOT_READY);
+
+    // But the descriptor is kept intact so a later import can rebuild the
+    // real allocator from it. In particular the handle stays valid, which is
+    // what keeps transport_endpoint_ readable and keeps the invalid-handle
+    // sweep from reclaiming the replica.
+    EXPECT_FALSE(HasInvalidNoFHandleForTesting(service, kDefaultTenant, key));
+    auto replicas = ReplicaDescriptorsForTesting(service, kDefaultTenant, key);
+    ASSERT_EQ(replicas.size(), 1);
+    ASSERT_TRUE(replicas.front().is_nof_replica());
+    const auto& buffer =
+        replicas.front().get_nof_descriptor().buffer_descriptor;
+    EXPECT_EQ(buffer.transport_endpoint_, endpoint);
+    EXPECT_EQ(buffer.buffer_address_, offset);
+    EXPECT_EQ(buffer.size_, size);
+
+    ClearInvalidHandlesForTesting(service);
+    EXPECT_EQ(ReplicaCountForTesting(service, kDefaultTenant, key), 1);
+    EXPECT_FALSE(service.GetReplicaList(key, kDefaultTenant).has_value());
+}
+
+#ifdef USE_NOF
+TEST_F(MasterServiceHATest, QuarantinedNoFEndpointCannotBeMounted) {
+    MasterService service(
+        MasterServiceConfig::builder().set_enable_ha(false).build());
+
+    const std::string key = "standby_nof_mount_gate_key";
+    const std::string endpoint = "standby_nof_mount_gate_endpoint";
+
+    ASSERT_TRUE(
+        service
+            .RestoreFromStandbySnapshot(
+                {MakeStandbyNoFObject(key, endpoint, 4096, 1024)}, 7, {})
+            .has_value());
+
+    // Mounting the quarantined namespace would build a fresh allocator over
+    // the whole range and could hand the restored offset to another object,
+    // so it is refused until an import can reconcile the restored ranges.
+    const UUID client_id = generate_uuid();
+    NoFSegment quarantined = MakeNoFSegment("mount_gate_segment", endpoint);
+    auto mounted = service.MountNoFSegment(quarantined, client_id);
+    ASSERT_FALSE(mounted.has_value());
+    EXPECT_EQ(mounted.error(), ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+
+    auto remounted = service.ReMountNoFSegment({quarantined}, client_id);
+    ASSERT_FALSE(remounted.has_value());
+    EXPECT_EQ(remounted.error(), ErrorCode::UNAVAILABLE_IN_CURRENT_STATUS);
+
+    // The restored replica is still hidden, and still intact.
+    EXPECT_FALSE(service.GetReplicaList(key, kDefaultTenant).has_value());
+    EXPECT_FALSE(HasInvalidNoFHandleForTesting(service, kDefaultTenant, key));
+
+    // An unrelated namespace is unaffected by the quarantine.
+    NoFSegment other =
+        MakeNoFSegment("mount_gate_other_segment", "mount_gate_other_endpoint");
+    EXPECT_TRUE(service.MountNoFSegment(other, client_id).has_value());
+}
+#endif
 
 TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesReplicaIds) {
     MasterService service(
@@ -2415,11 +2537,14 @@ TEST_F(MasterServiceHATest, RestoreFromStandbyPreservesNoFBufferDescriptor) {
     EXPECT_EQ(restored.protocol_, "nvmeof");
     EXPECT_EQ(restored.transport_endpoint_, endpoint);
 
+    // The descriptor is preserved, but the endpoint is quarantined until a
+    // mount can import these ranges, so the replica is not served yet. The
+    // snapshot carries no NoF allocator state, so serving it would race a
+    // fresh mount that considers `address` free (see #3826).
     auto public_replicas =
         service.GetReplicaList("standby_restore_nof_key", kDefaultTenant);
-    ASSERT_TRUE(public_replicas.has_value());
-    ASSERT_EQ(public_replicas->replicas.size(), 1);
-    EXPECT_TRUE(public_replicas->replicas.front().is_nof_replica());
+    ASSERT_FALSE(public_replicas.has_value());
+    EXPECT_EQ(public_replicas.error(), ErrorCode::REPLICA_IS_NOT_READY);
 }
 
 TEST_F(MasterServiceHATest, OplogDisabledByDefaultDoesNotCreateWriter) {


### PR DESCRIPTION
# Issue #3826 — NoF replicas restored from a standby snapshot can alias reallocated offsets

Revised after review. The first revision invalidated the restored handle; this one quarantines the endpoint instead. Discussion in the thread below.

## 1. Root cause

`MasterService::RestoreFromStandbySnapshot()` rebuilds in-memory `Replica` objects from the standby snapshot. For a NoF (NVMe-oF SSD) descriptor it created a `DummyBufferAllocator` and kept it alive in `standby_allocator_keepalive_`, so the replica's `weak_ptr` never expired and it looked like a live, `COMPLETE`, readable replica everywhere.

But `DummyBufferAllocator` holds no allocation state, and the snapshot carries no NoF segment registry: `MountNoFSegment` emits no `SEGMENT_MOUNT` oplog entry, and `StandbySegmentInfo` has no base-offset field. So when the namespace is later mounted, `ScopedNoFSegmentAccess::MountSegment()` builds a fresh, empty allocator over the whole `[base, base+size)` (`segment.cpp`, via `CreateBufferAllocator`). It considers the offsets held by restored replicas free and can hand them to a different `(tenant_id, user_key)`. Nothing validates that two keys map to the same physical range, so the old descriptor keeps reporting `COMPLETE` while the bytes underneath belong to another object: a silent wrong-data read.

Memory replicas already have both halves of the protection this needs. `ReMountSegment()` collects the restored descriptors for the remounted endpoint, calls `BuildRegionLiveAllocations()` + `ImportOffsetBufferAllocator()` / `ImportCachelibBufferAllocator()`, and swaps in an allocator that already owns those ranges via `ReplaceAllocators`. Until that import happens, restored replicas whose segment is absent are recorded in `invalid_replica_endpoints_` so they cannot be read. The NoF path had neither.

## 2. The fix

Quarantine the NoF endpoint, mirroring the memory path.

* **Keep the descriptor.** The placeholder allocator stays alive, in a NoF-specific keepalive map. `get_descriptor()` therefore still returns the complete descriptor including `transport_endpoint_` (which it reads off the allocator), and `has_invalid_nof_handle()` stays false, so `BuildStaleHandleCleanupPlan()` no longer classifies the replica as stale and `ClearInvalidHandles()` leaves it alone. The state a future import needs survives.
* **Hide it from reads.** The endpoint goes into `invalid_nof_replica_endpoints_`, which `IsReplicaReadable()` consults, so the replica is excluded from `GetReplicaList`, `GetReplicaListForAdmin`, `BatchGetReplicaList` and the eviction paths.
* **Block fresh allocation.** `MountNoFSegment()` and `ReMountNoFSegment()` refuse a namespace whose `te_endpoint` or `name` is quarantined, returning `UNAVAILABLE_IN_CURRENT_STATUS`. Nothing can alias the offset while the descriptor survives.

The NoF keepalive and quarantine sets are deliberately separate from `standby_allocator_keepalive_` and `invalid_replica_endpoints_`. `ReMountSegment()` erases both of those by endpoint when a memory segment comes back, so a NoF `te_endpoint` that collides with a memory segment alias would otherwise be un-quarantined, and its placeholder dropped, by an unrelated memory remount. NoF replicas are still checked against `invalid_replica_endpoints_` as before, so this is strictly additive on the read path.

Why not simply invalidate the handle, as the first revision did? It closes the read window, but `ClearInvalidHandles()` then permanently removes the replica and `get_descriptor()` loses the endpoint once the allocator expires, so the breadcrumbs a later remount needs are gone. Reaching "restored NoF data is disposable" through an expired weak pointer also decides a #3796 contract question by side effect rather than explicitly.

### Scope: this is the fail-closed half

Making the data readable again is the second half and is not in this PR. It needs a NoF analog of the memory import path, so that a mount can adopt the restored `(offset, size)` ranges, swap in an allocator that owns them, replace the buffers and lift the quarantine. Neither `replace_nof_buffer` nor a NoF `ReplaceAllocators` exists in the tree today. Happy to fold it in here instead if you would rather see them together.

Note this corrects a claim in the first revision of this description. I argued that rebuilding the allocator was not implementable because the snapshot carries no NoF base or capacity. That is true at restore time, but the gate belongs at mount time, where the real `NoFSegment` with `base`, `size` and `te_endpoint` is in hand. The snapshot gap does not block it.

## 3. Files changed

* `mooncake-store/include/master_service.h` — `invalid_nof_replica_endpoints_`, `standby_nof_allocator_keepalive_`, `IsNoFSegmentQuarantined()`.
* `mooncake-store/src/master_service.cpp` — quarantine on restore; `IsReplicaReadable()` honours it; `MountNoFSegment()` / `ReMountNoFSegment()` fail closed; restore summary logs the quarantine count.
* `mooncake-store/tests/ha/master_service_ha_test.cpp` — `RestoreQuarantinesNoFReplicas` (descriptor intact, endpoint preserved, not served, not reaped), `QuarantinedNoFEndpointCannotBeMounted` (`USE_NOF` only), and the updated `RestoreFromStandbyPreservesNoFBufferDescriptor` tail.

## 4. Risk and open questions

* **Availability cost, and the main thing worth your call.** While a NoF endpoint is quarantined, that whole namespace cannot be mounted at all, not just the restored ranges. After a promotion that had NoF replicas, NoF is unusable until the import path lands. That is what fail-closed means here, and it is bounded by the follow-up, but it is a real regression in availability traded for correctness. If you would rather have a narrower gate, or an operator escape hatch, say so and I will add it rather than guess.
* **Nothing lifts the quarantine yet.** Only a subsequent restore reassigns the set. Objects on a permanently gone endpoint stay in the metadata index, since nothing reaps a quarantined replica any more. Restored memory replicas behave the same way today, so I matched them rather than inventing a NoF-specific TTL, but if you want quarantine to expire that is a decision for you.
* **#3796 contract.** `RestoreFromStandbyPreservesNoFBufferDescriptor` keeps its descriptor assertions, which quarantine satisfies including `transport_endpoint_`. Only its tail, which asserted `GetReplicaList` serves the replica, is updated, because serving it is the aliasing window. That is the narrow part of the contract I believe has to change; if the project reads #3796 as promising readability, this needs a different answer.
* **CI coverage.** The restore side is compiled unconditionally and covered by `master_service_ha_test`. The mount gate is inside `USE_NOF`, and CI builds with `USE_NOF=OFF`, so `QuarantinedNoFEndpointCannotBeMounted` will not run there.
* **Lock order.** Both mount gates take `snapshot_mutex_` (3) before `segment_mutex_` (6), matching memory `MountSegment()`. Both are shared locks and the only callers are the RPC entry points, so there is no nesting.

## 5. How I verified it

* Traced the consumers this depends on: `IsReplicaReadable()` and the `VisitReplicas` filters, and `BuildStaleHandleCleanupPlan()` / `ClearStaleHandles()`, confirming the stale predicate keys only on `has_invalid_mem_handle() || has_invalid_nof_handle() || has_stale_local_disk_client()` and never consults the endpoint sets, which is what makes a quarantined replica survive the sweep.
* Confirmed `get_descriptor()` reads `transport_endpoint_` off the allocator, which is why the keepalive is what preserves it.
* Confirmed `MountSegment()` (memory) establishes the `snapshot_mutex_` before segment-access order the new gates follow.
* `clang-format --style=file` clean on all three files, with a pre-existing unrelated diff in the test file left untouched.
* **Not compiled or run.** This checkout has none of the C++ dependencies (no glog, gflags, boost, yalantinglibs, cachelib), so `scripts/run_ci_test.sh` cannot run here. `master_service_ha_test` needs to be built and run before this merges, and I would treat CI as the gate rather than my reading.