### PR TITLE
[Store] Stabilize HA under OpLog pressure

### DIFF
--- a/mooncake-common/etcd/etcd_wrapper.go
+++ b/mooncake-common/etcd/etcd_wrapper.go
@@ -324,7 +324,6 @@ func EtcdStoreResetClientWrapper(endpoints *C.char, errMsg **C.char) int {
 		return -1
 	}
 
-	cancelAllStoreKeepAlives()
 	closeAllStoreMaintenanceSessions()
 	cancelAllStoreWatches()
 	cancelAllStorePrefixWatches()
@@ -593,20 +592,6 @@ func cancelAndDeleteWatch(k string) int {
 	return -1
 }
 
-func cancelAllStoreKeepAlives() {
-	storeKeepAliveMutex.Lock()
-	cancels := make([]context.CancelFunc, 0, len(storeKeepAliveCtx))
-	for leaseId, cancel := range storeKeepAliveCtx {
-		cancels = append(cancels, cancel)
-		delete(storeKeepAliveCtx, leaseId)
-	}
-	storeKeepAliveMutex.Unlock()
-
-	for _, cancel := range cancels {
-		cancel()
-	}
-}
-
 func closeAllStoreMaintenanceSessions() {
 	storeMaintenanceMutex.Lock()
 	sessions := make([]*maintenanceSession, 0, len(storeMaintenanceSessions))
@@ -768,11 +753,19 @@ func hasKeepAliveContext(leaseId int64) bool {
 
 //export EtcdStoreKeepAliveWrapper
 func EtcdStoreKeepAliveWrapper(leaseId int64, errMsg **C.char) int {
-	cli := getStoreClient()
-	if cli == nil {
+	storeCli := getStoreClient()
+	if storeCli == nil {
 		*errMsg = C.CString("etcd client not initialized")
 		return -1
 	}
+	// Keep lease traffic separate from Store traffic. A Store client reset or
+	// a busy Store connection must not stop leadership keep-alive.
+	cli, err := clientv3.New(newStoreClientConfig(storeCli.Endpoints()))
+	if err != nil {
+		*errMsg = C.CString(err.Error())
+		return -1
+	}
+	defer cli.Close()
 
 	// Create a context with cancel function
 	ctx, cancel := context.WithCancel(context.Background())

--- a/mooncake-store/include/etcd_helper.h
+++ b/mooncake-store/include/etcd_helper.h
@@ -31,8 +31,9 @@ class EtcdHelper {
 
     /*
      * @brief Reset the global store etcd client and reconnect to the given
-     *        endpoints. This cancels active store watches/keepalives in the Go
-     *        wrapper and creates a fresh clientv3.Client.
+     *        endpoints. This cancels active store watches and maintenance
+     *        sessions. Each lease keep-alive uses an independent client and
+     *        continues.
      * @param etcd_endpoints: The endpoints of the etcd store client.
      * @return: Error code.
      */

--- a/mooncake-store/src/master_service.cpp
+++ b/mooncake-store/src/master_service.cpp
@@ -10287,6 +10287,11 @@ MasterService::EvictTenantMemoryForQuota(const TenantId& tenant_id,
 
 void MasterService::BatchEvict(double evict_ratio_target,
                                double evict_ratio_lowerbound) {
+    // Consume the allocation-pressure signal before this pass. A new failure
+    // during the pass remains visible to the next iteration.
+    const bool allocation_pressure =
+        need_mem_eviction_.exchange(false, std::memory_order_relaxed);
+
     if (evict_ratio_target < evict_ratio_lowerbound) {
         LOG(ERROR) << "evict_ratio_target=" << evict_ratio_target
                    << ", evict_ratio_lowerbound=" << evict_ratio_lowerbound
@@ -10490,7 +10495,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
         uint64_t freed_bytes{0};
         long evicted_objects{0};
         bool stop_scan{false};
-        ErrorCode error{ErrorCode::OK};
         // Set when the candidate was present but its re-validation failed
         // (lease still live, soft-pinned, or no evictable replica), so the
         // first pass can keep its lease timeout for the second-pass census.
@@ -10537,7 +10541,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 auto submission =
                     persist_evict_oplog_or_skip(tenant_id, key, metadata);
                 if (!submission) {
-                    return {.stop_scan = true, .error = submission.error()};
+                    return {.stop_scan = true};
                 }
                 uint64_t freed = try_evict_or_offload(
                     tenant_id, key, metadata, tenant_state, deferred_replicas);
@@ -10577,7 +10581,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             auto submission = persist_evict_oplog_or_skip(tenant_id, member_key,
                                                           member_metadata);
             if (!submission) {
-                return {.stop_scan = true, .error = submission.error()};
+                return {.stop_scan = true};
             }
             const uint64_t freed =
                 try_evict_or_offload(tenant_id, member_key, member_metadata,
@@ -10600,8 +10604,7 @@ void MasterService::BatchEvict(double evict_ratio_target,
             tenant_id, key, group_id, allow_soft_pinned, now, evict_one_member);
         EvictionResult result{.freed_bytes = group_result.freed_bytes,
                               .evicted_objects = group_result.evicted_objects,
-                              .stop_scan = group_result.stop_scan,
-                              .error = group_result.error};
+                              .stop_scan = group_result.stop_scan};
 
         // The callback erased every member except the trigger; re-look-up the
         // trigger to erase it if it is now invalid and to drop an emptied
@@ -10757,7 +10760,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
     }
 
     if (total_eviction_base == 0) {
-        need_mem_eviction_ = false;
         VLOG(1) << "[EVICT-DIAG] object_count=" << object_count
                 << " eviction_base=0 (no evictable memory objects)";
         return;
@@ -10872,7 +10874,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
     long evicted_count = 0;
     uint64_t total_freed_size = 0;
     bool stop_eviction_scan = false;
-    ErrorCode oplog_failure{ErrorCode::OK};
     std::vector<std::chrono::system_clock::time_point> no_pin_objects;
     std::vector<std::vector<Replica>> deferred_replicas;
     // Shards that actually evicted this cycle; their metadata maps are
@@ -10922,7 +10923,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
                 }
                 if (evict_result.stop_scan) {
                     stop_eviction_scan = true;
-                    oplog_failure = evict_result.error;
                 }
                 deferred_replicas.clear();
             }
@@ -11007,7 +11007,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         }
                         if (evict_result.stop_scan) {
                             stop_eviction_scan = true;
-                            oplog_failure = evict_result.error;
                         }
                     }
                 }
@@ -11064,7 +11063,6 @@ void MasterService::BatchEvict(double evict_ratio_target,
                         }
                         if (evict_result.stop_scan) {
                             stop_eviction_scan = true;
-                            oplog_failure = evict_result.error;
                         }
                     }
                 }
@@ -11098,13 +11096,9 @@ void MasterService::BatchEvict(double evict_ratio_target,
 
     const bool made_progress = evicted_count > 0 || released_discarded_cnt > 0;
     const bool success = made_progress || offload_deferred_count > 0;
-    if (stop_eviction_scan) {
-        need_mem_eviction_ =
-            oplog_failure == ErrorCode::TASK_PENDING_LIMIT_EXCEEDED;
-    } else if (success) {
-        need_mem_eviction_ = false;
-    } else if (total_eviction_base == 0) {
-        need_mem_eviction_ = false;
+    if (allocation_pressure && !stop_eviction_scan && !success &&
+        total_eviction_base > 0) {
+        need_mem_eviction_.store(true, std::memory_order_relaxed);
     }
 
     if (success) {

--- a/mooncake-store/tests/ha/leadership/high_availability_test.cpp
+++ b/mooncake-store/tests/ha/leadership/high_availability_test.cpp
@@ -692,6 +692,11 @@ TEST_F(HighAvailabilityTest, LeadershipMonitorReportsKeepAliveLoss) {
         });
     ASSERT_TRUE(monitor.has_value());
 
+    ASSERT_EQ(ErrorCode::OK,
+              EtcdHelper::ResetEtcdStoreClient(FLAGS_etcd_endpoints));
+    EXPECT_EQ(loss_future.wait_for(std::chrono::seconds(1)),
+              std::future_status::timeout);
+
     const auto lease_id =
         static_cast<EtcdLeaseId>(std::stoll(session.owner_token));
     ASSERT_EQ(ErrorCode::OK, EtcdHelper::CancelKeepAlive(lease_id));
@@ -738,7 +743,7 @@ TEST_F(HighAvailabilityTest, EtcdStoreClientResetKeepsBasicOperationsWorking) {
     ASSERT_EQ(ErrorCode::OK, EtcdHelper::RevokeLease(lease_id));
 }
 
-TEST_F(HighAvailabilityTest, EtcdStoreClientResetStopsOldKeepAlive) {
+TEST_F(HighAvailabilityTest, EtcdStoreClientResetKeepsOldKeepAlive) {
     if (auto skip_reason = GetEtcdSkipReason(); skip_reason.has_value()) {
         GTEST_SKIP() << *skip_reason;
     }
@@ -770,12 +775,20 @@ TEST_F(HighAvailabilityTest, EtcdStoreClientResetStopsOldKeepAlive) {
     }
     ASSERT_EQ(ErrorCode::OK, reset_err);
 
-    auto keep_alive_status = future.wait_for(std::chrono::seconds(5));
-    if (keep_alive_status != std::future_status::ready) {
+    auto keep_alive_status = future.wait_for(std::chrono::seconds(1));
+    if (keep_alive_status != std::future_status::timeout) {
+        keep_alive_thread.join();
+    }
+    ASSERT_EQ(keep_alive_status, std::future_status::timeout);
+
+    auto cancel_err = EtcdHelper::CancelKeepAlive(lease_id);
+    if (cancel_err != ErrorCode::OK) {
         cleanup_keep_alive();
     }
-    ASSERT_EQ(keep_alive_status, std::future_status::ready);
-    EXPECT_NE(ErrorCode::OK, future.get());
+    ASSERT_EQ(ErrorCode::OK, cancel_err);
+    ASSERT_EQ(future.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    EXPECT_EQ(ErrorCode::ETCD_CTX_CANCELLED, future.get());
     keep_alive_thread.join();
 
     EtcdLeaseId new_lease_id = 0;

--- a/mooncake-store/tests/ha/master_service_ha_test.cpp
+++ b/mooncake-store/tests/ha/master_service_ha_test.cpp
@@ -4509,7 +4509,8 @@ TEST_F(MasterServiceHATest, NoFBatchEvictReleasesNoFSpaceAfterDurable) {
 }
 #endif
 
-TEST_F(MasterServiceHATest, BatchEvictStopsAfterFirstOpLogReservationFailure) {
+TEST_F(MasterServiceHATest,
+       BatchEvictQueueSaturationDoesNotRequestAnotherPass) {
     const std::string cluster_id = "test_batch_evict_reservation_failure";
     auto backend = std::make_shared<FakeBatchHaKvBackend>();
     auto service_config = MasterServiceConfig::builder()
@@ -4556,7 +4557,7 @@ TEST_F(MasterServiceHATest, BatchEvictStopsAfterFirstOpLogReservationFailure) {
                   logs.find(warning, first_warning + warning.size()))
             << logs;
         EXPECT_NE(std::string::npos, logs.find("err=-1401")) << logs;
-        EXPECT_TRUE(NeedMemEvictionForTesting(service));
+        EXPECT_FALSE(NeedMemEvictionForTesting(service));
         EXPECT_EQ(1u,
                   ReplicaCountForTesting(service, kDefaultTenant, first_key));
         EXPECT_EQ(1u,


### PR DESCRIPTION
Related to #3808

## Why

Sustained OpLog pressure exposed two independent HA failures. OpLog queue
saturation could request repeated eviction passes. The leader also shared one
etcd client with Store traffic, so resetting that client closed the leadership
keep-alive stream.

## What

- Stop retrying a full eviction pass after OpLog queue saturation.
- Give each leadership lease keep-alive its own etcd client.
- Keep active lease streams alive when the general Store etcd client resets.
- Update HA tests to require reset isolation.

## How

Batch eviction consumes one pending allocation-pressure request. It restores
that request only when the pass made no progress, ended without an OpLog error,
and still found evictable objects.

The Go etcd wrapper creates one client for each blocking lease keep-alive.
General Store reset still replaces the Store client and cancels its watches and
maintenance sessions. It does not cancel leadership keep-alive. Explicit lease
cancel and coordinator shutdown remain the normal stop paths.

## Test

- The reset-isolation regression failed before the fix because Store client
  reset closed the keep-alive channel.
- The two focused leadership tests passed 20 consecutive runs.
- The full etcd HA test binary passed all 14 tests.
- Go tests with the race detector passed.
- The queue-saturation regression passed 20 consecutive runs.
- Eight related eviction tests passed.
- `MasterServiceTest.PutStartExpiringTest` passed.
- One full HA test run passed all 93 tests.
- Pre-commit and `git diff --check` passed.

A sustained downstream deployment test confirmed that the target cache
collapse did not recur. Active-master deletion promoted the standby, and the
replacement standby caught up. Environment, image, traffic, hardware, and
performance details are intentionally omitted.

The Ubuntu 22.04 wheel job failed in
`test_ssd_offload_in_evict.py::test_concurrent_stress`. The unchanged base
commit failed in the same job and test. All other CI jobs passed.

This PR does not address the separate durable mutation barrier in #3808. It
must not be treated as the complete production-readiness gate for that roadmap.

## Ablation

- Existing shared-client behavior failed because reset closed the lease stream.
- A dedicated client alone failed because reset still canceled the lease
  context.
- Removing reset cancellation alone failed because closing the shared client
  still closed the stream.
- The combined lease design passed the reset and leadership checks.
- Always clearing the eviction request stopped the retry, but it failed
  `PutStartExpiringTest`. Conditional restore passed that test and the
  queue-saturation test.

## Module

- [x] Mooncake Store
- [x] Common

## Type of change

- [x] Bug fix

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR
- [x] I have added tests to prove my changes are effective
- [x] The related roadmap issue is #3808

## AI assistance disclosure

- [x] AI tools were used. Codex helped diagnose the failure, implement the
  change, and run tests. The human submitter must review every changed line
  before merge.
