### PR TITLE
[Bugfix][TENT] Return an error for unregistered application RPC IDs

### DIFF
--- a/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
+++ b/mooncake-transfer-engine/tent/src/rpc/rpc.cpp
@@ -16,6 +16,8 @@
 #include <glog/logging.h>
 #include <async_simple/executors/SimpleExecutor.h>
 
+#include <stdexcept>
+
 #include "transfer_engine_rpc_client_io_context.h"
 #include "tent/common/utils/ip.h"
 #include "tent/common/utils/random.h"
@@ -174,7 +176,10 @@ Status CoroRpcAgent::stop() {
 Lazy<void> CoroRpcAgent::process(int func_id) {
     auto* ctx = co_await coro_rpc::get_context_in_coro();
     auto it = func_map_.find(func_id);
-    if (it == func_map_.end()) co_return;
+    if (it == func_map_.end()) {
+        throw std::runtime_error("Unknown TENT RPC function: " +
+                                 std::to_string(func_id));
+    }
     const auto handler = it->second;
 
     auto request = ctx->get_request_attachment();

--- a/mooncake-transfer-engine/tent/tests/rpc_handler_isolation_test.cpp
+++ b/mooncake-transfer-engine/tent/tests/rpc_handler_isolation_test.cpp
@@ -158,6 +158,12 @@ TEST_F(RpcHandlerIsolationTest, OffloadedHandlerExceptionReachesTheCaller) {
     EXPECT_FALSE(client.call(addr_, kThrowingFunc, "", response).ok());
 }
 
+TEST_F(RpcHandlerIsolationTest, UnknownFunctionReturnsAnError) {
+    CoroRpcAgent client;
+    std::string response;
+    EXPECT_FALSE(client.call(addr_, 0x7fffffff, "", response).ok());
+}
+
 }  // namespace
 }  // namespace tent
 }  // namespace mooncake


### PR DESCRIPTION
## Description

TENT exposes one coro-rpc method, `CoroRpcAgent::process(int)`, and dispatches the application-level function ID through `func_map_`. When that ID is absent, `process()` currently returns normally, so the caller receives `Status::OK()` with an empty response even though no handler ran.

This change throws for an unregistered application RPC ID and uses the existing RPC exception path to return a non-OK `RpcServiceError`. A focused loopback regression test covers the behavior.

This is complementary to #3498: that PR registers and routes supported legacy wire IDs during rolling upgrades; this PR handles IDs with no registered mapping.

## Module

- [x] Transfer Engine (`mooncake-transfer-engine`)
- [ ] Mooncake Store (`mooncake-store`)
- [ ] Reshard (`mooncake-reshard`)
- [ ] Mooncake EP (`mooncake-ep`)
- [ ] Mooncake PG (`mooncake-pg`)
- [ ] Integration (`mooncake-integration`)
- [ ] P2P Store (`mooncake-p2p-store`)
- [ ] Python Wheel (`mooncake-wheel`)
- [ ] Common (`mooncake-common`)
- [ ] Mooncake RL (`mooncake-rl`)
- [ ] CI/CD
- [ ] Docs
- [ ] Other

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Other

## How Has This Been Tested?

The new regression test fails on the parent revision because the unknown call returns OK, and passes with this change.

**Test commands:**
```bash
cmake -S . -B build/pr-release -G Ninja -DCMAKE_BUILD_TYPE=Release -DWITH_TE=ON -DWITH_STORE=OFF -DWITH_STORE_RUST=OFF -DWITH_P2P_STORE=OFF -DWITH_EP=OFF -DUSE_TENT=ON -DUSE_CUDA=OFF -DUSE_HIP=OFF -DBUILD_BENCHMARK=OFF -DBUILD_UNIT_TESTS=ON -DBUILD_EXAMPLES=OFF
cmake --build build/pr-release --target tent_rpc_handler_isolation_test tent_tcp_transport_test tent_tcp_datapath_roundtrip_test -j4
ctest --test-dir build/pr-release --output-on-failure -R 'tent_(rpc_handler_isolation|tcp_(transport|datapath_roundtrip))'
pre-commit run --files mooncake-transfer-engine/tent/src/rpc/rpc.cpp mooncake-transfer-engine/tent/tests/rpc_handler_isolation_test.cpp
```

**Test results:**
- [x] Unit tests pass
- [x] Integration tests pass (if applicable)
- [x] Manual testing done
  - 4/4 selected CTest entries passed, covering the handler-isolation cases and TCP transport/datapath round trips.
  - The unknown application ID returns a non-OK status after the change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have formatted my code using `./scripts/code_format.sh`
- [x] I have run pre-commit on the files changed in this PR and all hooks pass
- [x] I have updated the documentation (not applicable: no user-facing interface or setup changed)
- [x] I have added tests to prove my changes are effective
- [x] For changes >500 LOC: I have filed an RFC issue (not applicable: this is a 12-insertion, 1-deletion fix)

## AI Assistance Disclosure

- [ ] No AI tools were used
- [x] AI tools were used 